### PR TITLE
feat: the Descartes engine never falls back

### DIFF
--- a/HexRealRootsMathlib.lean
+++ b/HexRealRootsMathlib.lean
@@ -39,6 +39,9 @@ to the abstract development; `Separation`/`Discr`/`Hadamard` supply the Mahler
 separation bound; `Isolations` and `Drivers` prove isolation soundness, run
 completeness, driver completeness, and refinement; `SimpleRealRoot` proves the
 root-identity theorems (overlap classes are the real roots); and `TwoCircle`
-states the single deferred theorem — Descartes-engine termination — behind its
-Obreshkoff two-circle prerequisite, the one intentional `sorry` in the library.
+proves Descartes-engine termination (`isolateDescartes?_isSome`) behind its
+Obreshkoff two-circle prerequisite (the λ-graded sector bound in
+`TwoCircleSector`, the region geometry in `TwoCircleRegion`, and the Descartes
+parity in `DescartesParity`). Every theorem in the library is now proven; there
+are no `sorry`s.
 -/

--- a/HexRealRootsMathlib/Drivers.lean
+++ b/HexRealRootsMathlib/Drivers.lean
@@ -65,7 +65,7 @@ variable {p : Hex.ZPoly}
 /-! ### Dyadic midpoint arithmetic -/
 
 /-- Dyadic order coincides with the order of the real values. -/
-private theorem toReal_lt_toReal_iff {a b : Dyadic} :
+theorem toReal_lt_toReal_iff {a b : Dyadic} :
     Dyadic.toReal a < Dyadic.toReal b ↔ a < b := by
   unfold Dyadic.toReal
   rw [Rat.cast_lt, Dyadic.toRat_lt_toRat_iff]
@@ -97,19 +97,19 @@ private theorem toReal_sub (a b : Dyadic) :
   unfold Dyadic.toReal; rw [Dyadic.toRat_sub]; push_cast; ring
 
 /-- The real value of an interval's dyadic midpoint. -/
-private theorem toReal_midpoint (I : Hex.DyadicInterval) :
+theorem toReal_midpoint (I : Hex.DyadicInterval) :
     Dyadic.toReal I.midpoint = (Dyadic.toReal I.lower + Dyadic.toReal I.upper) / 2 := by
   unfold Hex.DyadicInterval.midpoint
   rw [toReal_shiftRight_one, toReal_add]
 
 /-- The midpoint is strictly above the lower endpoint. -/
-private theorem lower_lt_midpoint (I : Hex.DyadicInterval) : I.lower < I.midpoint := by
+theorem lower_lt_midpoint (I : Hex.DyadicInterval) : I.lower < I.midpoint := by
   rw [← toReal_lt_toReal_iff, toReal_midpoint]
   have := toReal_lt_toReal_iff.mpr I.lt
   linarith
 
 /-- The midpoint is strictly below the upper endpoint. -/
-private theorem midpoint_lt_upper (I : Hex.DyadicInterval) : I.midpoint < I.upper := by
+theorem midpoint_lt_upper (I : Hex.DyadicInterval) : I.midpoint < I.upper := by
   rw [← toReal_lt_toReal_iff, toReal_midpoint]
   have := toReal_lt_toReal_iff.mpr I.lt
   linarith
@@ -278,7 +278,7 @@ private theorem rootBound_pos (p : Hex.ZPoly) : 0 < Dyadic.toReal (Hex.rootBound
     · rw [Hex.rootBound_of_degree?_pos hd, toReal_twoPow]; positivity
 
 /-- `-rootBound p < rootBound p`, so the initial interval is nonempty. -/
-private theorem neg_rootBound_lt_rootBound (p : Hex.ZPoly) :
+theorem neg_rootBound_lt_rootBound (p : Hex.ZPoly) :
     -(Hex.rootBound p) < Hex.rootBound p := by
   rw [← toReal_lt_toReal_iff, toReal_neg]
   have := rootBound_pos p; linarith
@@ -288,7 +288,7 @@ difference between `-rootBound p` and `rootBound p` counts the real roots of `p`
 in `(-R, R]`, which is *every* real root (Cauchy bound), i.e. `rootCount p`. This
 is a statement about `p`'s roots only — the chain elements' own (possibly larger)
 zeros never enter, so there is no `±R`-versus-`±∞` gap. -/
-private theorem sturmVar_neg_pos_sub (hdeg : 1 ≤ (p.degree?).getD 0)
+theorem sturmVar_neg_pos_sub (hdeg : 1 ≤ (p.degree?).getD 0)
     (hp : Hex.ZPoly.SquareFreeRat p) :
     (Hex.sturmVarAt (Hex.ZPoly.sturmChain p) (-(Hex.rootBound p)) : ℤ)
       - Hex.sturmVarAt (Hex.ZPoly.sturmChain p) (Hex.rootBound p)
@@ -344,7 +344,7 @@ private theorem toReal_le_two_pow_ceilLog2Dyadic (x : Dyadic) (hx : 0 < Dyadic.t
 /-- **The initial interval's width fits the depth budget.** For positive-degree
 `p`, `2 · rootBound p ≤ 2 ^ (isolationDepth p − sepPrec p)`, which is the
 depth-sufficiency hypothesis the `sturmVisit` induction consumes at the top. -/
-private theorem initial_width_le (p : Hex.ZPoly) (hdeg : 1 ≤ (p.degree?).getD 0) :
+theorem initial_width_le (p : Hex.ZPoly) (hdeg : 1 ≤ (p.degree?).getD 0) :
     Dyadic.toReal (Hex.rootBound p) - Dyadic.toReal (-(Hex.rootBound p))
       ≤ (2 : ℝ) ^ ((Hex.isolationDepth p : ℤ) - (Hex.sepPrec p : ℤ)) := by
   obtain ⟨d, hd⟩ : ∃ d, p.degree? = some (d + 1) := by
@@ -374,21 +374,21 @@ private theorem initial_width_le (p : Hex.ZPoly) (hdeg : 1 ≤ (p.degree?).getD 
 
 /-- Dyadic `≤` is reflexive (routed through `toRat`, staying in the core
 instances that `DyadicInterval` uses). -/
-private theorem dle_refl (a : Dyadic) : a ≤ a :=
+theorem dle_refl (a : Dyadic) : a ≤ a :=
   Dyadic.toRat_le_toRat_iff.mp (le_refl _)
 
 /-- Dyadic `<` implies `≤`. -/
-private theorem dle_of_lt {a b : Dyadic} (h : a < b) : a ≤ b :=
+theorem dle_of_lt {a b : Dyadic} (h : a < b) : a ≤ b :=
   Dyadic.toRat_le_toRat_iff.mp (le_of_lt (Dyadic.toRat_lt_toRat_iff.mpr h))
 
 /-- Transitivity of the core dyadic `≤`. -/
-private theorem dle_trans {a b c : Dyadic} (h1 : a ≤ b) (h2 : b ≤ c) : a ≤ c :=
+theorem dle_trans {a b c : Dyadic} (h1 : a ≤ b) (h2 : b ≤ c) : a ≤ c :=
   Dyadic.toRat_le_toRat_iff.mp
     (le_trans (Dyadic.toRat_le_toRat_iff.mpr h1) (Dyadic.toRat_le_toRat_iff.mpr h2))
 
 /-- `sturmVarAt` is antitone in the point: the count over `(a, b]` is a
 nonnegative cardinality, so the variation at `b` is at most the one at `a`. -/
-private theorem sturmVarAt_le (hdeg : 1 ≤ (p.degree?).getD 0)
+theorem sturmVarAt_le (hdeg : 1 ≤ (p.degree?).getD 0)
     (hp : Hex.ZPoly.SquareFreeRat p) {a b : Dyadic} (hab : a < b) :
     Hex.sturmVarAt (Hex.ZPoly.sturmChain p) b
       ≤ Hex.sturmVarAt (Hex.ZPoly.sturmChain p) a := by
@@ -400,7 +400,7 @@ private theorem sturmVarAt_le (hdeg : 1 ≤ (p.degree?).getD 0)
   omega
 
 /-- A real root of the real cast is a complex root of the complex cast. -/
-private theorem isRoot_toPolyℂ {r : ℝ} (hr : (toPolyℝ p).IsRoot r) :
+theorem isRoot_toPolyℂ {r : ℝ} (hr : (toPolyℝ p).IsRoot r) :
     (toPolyℂ p).IsRoot (r : ℂ) := by
   have hcomp : (algebraMap ℝ ℂ).comp (Int.castRingHom ℝ) = Int.castRingHom ℂ :=
     RingHom.ext_int _ _
@@ -416,7 +416,7 @@ private theorem isRoot_toPolyℂ {r : ℝ} (hr : (toPolyℝ p).IsRoot r) :
 holds at most one real root of a positive-degree squarefree `p` (two distinct
 real roots are more than `4·2^(−sepPrec p)` apart by `sepPrec_separates'`), so
 its exact Sturm count is at most `1`. -/
-private theorem sturmCount_le_one (hdeg : 1 ≤ (p.degree?).getD 0)
+theorem sturmCount_le_one (hdeg : 1 ≤ (p.degree?).getD 0)
     (hp : Hex.ZPoly.SquareFreeRat p) (J : Hex.DyadicInterval)
     (hw : Dyadic.toReal J.upper - Dyadic.toReal J.lower
       ≤ (2 : ℝ) ^ (-(Hex.sepPrec p : ℤ))) :
@@ -658,7 +658,7 @@ private theorem sturmVisit_spec (hdeg : 1 ≤ (p.degree?).getD 0)
           · exact hRhi I h
 
 /-- The final assembly step succeeds once its two invariants are witnessed. -/
-private theorem assemble?_isSome {chain : Array Hex.ZPoly}
+theorem assemble?_isSome {chain : Array Hex.ZPoly}
     (hchain : chain = Hex.ZPoly.sturmChain p) (arr : Array (Hex.RealRootIsolation p))
     (hord : ∀ i j : Fin arr.size, i < j → arr[i].interval.upper ≤ arr[j].interval.lower)
     (hsize : arr.size = Hex.sturmVarNegInf chain - Hex.sturmVarPosInf chain) :

--- a/HexRealRootsMathlib/MobiusCorrespond.lean
+++ b/HexRealRootsMathlib/MobiusCorrespond.lean
@@ -64,6 +64,19 @@ theorem mobiusPoly_eq_reflect_comp {R : Type*} [CommRing R] (n : ℕ) (a b : R)
       = (Polynomial.reflect n (mobiusInner a b P)).comp (Polynomial.X + Polynomial.C 1) :=
   rfl
 
+/-- **Ring-hom commutation.** The Möbius transform commutes with mapping along a
+ring homomorphism `φ`: every stage (`X + C` shift, `C (a-b) * X` dilation,
+`reflect`, the final `X + C 1` shift) is built from `comp`, `reflect`, `C`, `X`,
+`+`, `*`, `-`, which all commute with `Polynomial.map φ`. This is the bridge from
+the real transform to its complex-root picture (`φ = algebraMap ℝ ℂ`). -/
+theorem mobiusPoly_map {R S : Type*} [CommRing R] [CommRing S] (φ : R →+* S)
+    (n : ℕ) (a b : R) (P : Polynomial R) :
+    (mobiusPoly n a b P).map φ = mobiusPoly n (φ a) (φ b) (P.map φ) := by
+  simp only [mobiusPoly_eq_reflect_comp, mobiusInner, Polynomial.map_comp,
+    Polynomial.map_add, Polynomial.map_sub, Polynomial.map_mul, Polynomial.map_X,
+    Polynomial.map_C, map_sub, Polynomial.C_1, Polynomial.map_one,
+    ← Polynomial.reflect_map]
+
 /-- The inner Möbius polynomial has degree at most that of `P`: composing with
 the degree-one shift `X + C b` preserves degree, and composing with the (at
 most) degree-one dilation `C (a-b) * X` cannot raise it. Proved without

--- a/HexRealRootsMathlib/TwoCircle.lean
+++ b/HexRealRootsMathlib/TwoCircle.lean
@@ -7,78 +7,638 @@ Authors: Kim Morrison
 module
 
 public import Mathlib
+public import HexRealRootsMathlib.MobiusCorrespond
+public import HexRealRootsMathlib.DescartesParity
+public import HexRealRootsMathlib.TwoCircleRegion
+public import HexRealRootsMathlib.TwoCircleSector
+public import HexRealRootsMathlib.Drivers
 public import HexRealRoots.IsolateDescartes
+-- `import all` on the executable modules so the non-`@[expose]` bodies of
+-- `descartesVisit`, `isolateDescartes?`, `mobiusTransform`, `descartesVar`,
+-- `sturmVarAt`, `sturmChain`, `evalDyadic`, `dyadicSign`, `rootBound`,
+-- `sepPrec`, `isolationDepth`, and `assemble?` unfold here.
+import all HexRealRootsMathlib.Separation
+import all HexRealRoots.Basic
+import all HexRealRoots.Chain
+import all HexRealRoots.Var
+import all HexRealRoots.Mobius
+import all HexRealRoots.Prec
+import all HexRealRoots.IsolateDescartes
 
 public section
 
 /-!
-# Deferred: Descartes engine termination (the two-circle theorem)
+# The Descartes engine never falls back (the two-circle termination theorem)
 
-This module states the one deferred theorem of `HexRealRootsMathlib` and names
-its prerequisite. It is the **only intentional `sorry` in the library** — every
-other theorem (isolation soundness, run completeness, driver completeness for
-the Sturm engine, refinement, and root identity) is complete without it.
+This module proves `isolateDescartes?_isSome`: the *Descartes* isolation engine
+alone returns `some` on every nonzero square-free input, so the runtime never
+needs the Sturm fallback. It is the last theorem of `HexRealRootsMathlib`, and
+with it the companion is fully `sorry`-free.
 
-`isolateDescartes?_isSome` says the *Descartes* engine alone never falls back to
-`none` on nonzero square-free input. The Sturm engine's termination
-(`isolateSturm?_isSome`) and hence the top-level driver (`isolate?_isSome`) are
-already proven, so nothing downstream — including hex-rcf's decision procedure —
-waits on this statement. Its value is to retire the Sturm fallback from the
-trusted runtime story.
+## What the two-circle theorem actually says
 
-## Prerequisite: the Obreshkoff two-circle theorem
+The classical statement is **not** a general count bound. It is *λ-graded*
+(Obreschkoff 1963; modern treatments Krandick–Mehlhorn 2006, Eigenwillig 2008):
+if all but `λ` complex roots of a real polynomial lie in the open sector of
+half-angle `π/(λ+2)` about the positive real axis (equivalently, at most `λ`
+roots lie outside), then the coefficient sequence has at most `λ` sign
+variations. The naive reading "variation count ≤ number of roots in the
+two-circle region" is **false**: `(X²+X+1)·(X²−(3/2)X+1)` has four sign
+variations while only two of its roots lie outside the sector (the
+counterexample recorded in `TwoCircleSector.lean`).
 
-For an interval `(a, b)`, the variation count of the Möbius-transformed
-polynomial is at least the number of roots in the one-circle region (the open
-disc with diameter `(a, b)`) and at most the number of roots in the two-circle
-region (the union of the two discs through `a` and `b` whose centres lie at
-`(a+b)/2 ± i·(b−a)/(2√3)`), counted with multiplicity. Consequences: a short
-interval far from all roots has count `0`, and a short interval whose two-circle
-region contains one simple real root has count `1`, so at `isolationDepth p` the
-Descartes worklist drains and every candidate certifies.
+We need only the two lowest graded cases, `λ ∈ {0, 1}`, and both are already
+proven: `Polynomial.signVariations_le_one_of_sector` (`TwoCircleSector.lean`) is
+the `λ = 1` sector bound via Hoggar log-concavity, and its `λ = 0` corollary.
 
-Unlike the Sturm termination argument, the Descartes variation counts are also
-disturbed by nearby *non-real* roots, which is exactly why this statement needs
-the two-circle theorem rather than the real-gap separation bound.
+## The proof route
 
-## Status and boundaries (from the SPEC)
+At a node `(lo, hi]` write `V` for the Descartes variation count of the Möbius
+transform. `descartesVar_mobiusTransform` identifies `V` with
+`signVariations (mobiusPoly n a b (toPolyℝ p))` (`n = deg p`,
+`a = toReal lo`, `b = toReal hi`); `countP_roots_mobiusPoly` turns the count of
+*positive* transform-roots into the count of `p`-roots in the open interval
+`(a, b)`; and the Descartes parity exports pin that count exactly when `V ∈
+{0, 1}`. Together with the exact endpoint test `p(b) = 0`
+(`sign_dyadicSign`/`toReal_evalDyadic`), the half-open Sturm count on `(a, b]` is
+computed exactly, so every candidate row certifies (Sturm count `1`) and every
+discard row emits `#[]` (Sturm count `0`) — *node truthfulness*, needing no width
+budget.
 
-- The two-circle theorem has no formalisation in any proof assistant that we
-  know of. The classical proof (Obreschkoff 1963; modern treatment in
-  Krandick-Mehlhorn 2006 and Eigenwillig 2008) is an induction on multiplying in
-  linear and conjugate-quadratic factors, with sector inequalities on
-  coefficient sequences. Elementary but long, and the effort is genuinely
-  uncertain.
-- **Nothing else waits for it.** `isolate?_isSome`, all soundness theorems, and
-  hex-rcf's decision procedure are complete without it.
-- Like the Sturm slice, it should be developed against `Polynomial ℝ` (and `ℂ`
-  for the regions) with no `HexRealRoots` dependence, as a Mathlib contribution
-  in its own right.
+At the depth budget (interval width `≤ 2^{−sepPrec p}`) the two bisecting rows
+are refuted:
 
-## Conformance-deletion obligation
+* `V = 1 ∧ p(b) = 0` would put two real roots — one interior, plus `b` — in
+  `(a, b]`, a Sturm count of `2`, contradicting `sturmCount_le_one`.
+* `V ≥ 2` triggers the sector bound: `≥ 2` transform-roots lie outside the
+  sector, hence (`roots_mobiusPoly` on `ℂ`, `not_inTwoCircle_iff_mem_sector`)
+  `≥ 2` distinct roots of `p` lie inside the two-circle region, which is enclosed
+  in a ball of radius `√3·(b−a)/2` (`dist_le`); two such roots are within
+  `√3·2^{−sepPrec p} < 4·2^{−sepPrec p}`, contradicting the Mahler separation
+  bound `sepPrec_separates'`. Square-freeness (`separable_toPolyℝ` ⇒ nodup)
+  supplies distinctness.
 
-The PR that discharges this `sorry` **must delete the Descartes stand-in
-assertions** in `conformance/HexRealRoots/Conformance.lean` in the same change.
-Those assertions — `(isolateDescartes? p).isSome` and
-`endpoints (isolateDescartes? p) = endpoints (isolate? p)` per fixture — are the
-SPEC-mandated executable stand-in for this theorem (see
-[hex-real-roots.md](../SPEC/Libraries/hex-real-roots.md) §"Conformance
-fixtures" and the deletion note in that conformance module). Once the theorem
-carries the claim, the stand-in is redundant and is retired.
+The worklist therefore drains at `isolationDepth p`, mirroring the Sturm engine's
+`sturmVisit_spec`/`isolateSturm?_isSome` in `Drivers.lean`.
 -/
 
 namespace HexRealRootsMathlib
 
-/-- **The Descartes engine succeeds on nonzero square-free input (deferred).**
-`isolateDescartes? p ≠ none` for nonzero `p` passing the executable
-`SquareFreeRat` test.
+open Polynomial
 
-Deferred pending the Obreshkoff two-circle theorem (see the module docstring):
-at `isolationDepth p` the Descartes worklist drains because each short interval's
-Möbius variation count is pinned to the number of roots in its two-circle
-region, which is `0` far from the roots and `1` around a single simple real
-root. This is the sole intentional `sorry` in `HexRealRootsMathlib`. -/
+noncomputable section
+
+variable {p : Hex.ZPoly}
+
+/-! ### The exact endpoint test -/
+
+/-- The executable endpoint test `dyadicSign (p(hi)) == 0` decides whether `hi`
+is a real root of `toPolyℝ p`: the exact dyadic evaluation has the same sign as
+the real evaluation (`sign_dyadicSign`, `toReal_evalDyadic`), so it is zero
+exactly at a root. -/
+theorem bZero_iff (hi : Dyadic) :
+    (Hex.dyadicSign (p.evalDyadic hi) == 0) = true
+      ↔ (toPolyℝ p).IsRoot (Dyadic.toReal hi) := by
+  rw [beq_iff_eq]
+  have hs : SignType.sign ((Hex.dyadicSign (p.evalDyadic hi) : ℝ))
+      = SignType.sign (Dyadic.toReal (p.evalDyadic hi)) := sign_dyadicSign _
+  constructor
+  · intro h
+    rw [h] at hs
+    simp only [Int.cast_zero, sign_zero] at hs
+    have h0 : Dyadic.toReal (p.evalDyadic hi) = 0 := sign_eq_zero_iff.mp hs.symm
+    rw [toReal_evalDyadic] at h0
+    exact h0
+  · intro h
+    have h0 : Dyadic.toReal (p.evalDyadic hi) = 0 := by rw [toReal_evalDyadic]; exact h
+    rw [h0] at hs
+    simp only [sign_zero] at hs
+    have : ((Hex.dyadicSign (p.evalDyadic hi) : Int) : ℝ) = 0 := sign_eq_zero_iff.mp hs
+    exact_mod_cast this
+
+/-! ### The exact node count -/
+
+/-- **Node count.** For positive-degree square-free `p` and `lo < hi`, the exact
+Sturm count on `(lo, hi]` splits as the number of positive roots of the Möbius
+transform (= the `p`-roots in the open interval `(a, b)`) plus the endpoint
+indicator `[p(hi) = 0]`. No width budget is needed: the count is exact. -/
+theorem descartes_node_count (hdeg : 1 ≤ (p.degree?).getD 0)
+    (hp : Hex.ZPoly.SquareFreeRat p) {lo hi : Dyadic} (hlt : lo < hi) :
+    (Hex.sturmVarAt (Hex.ZPoly.sturmChain p) lo : Int)
+        - Hex.sturmVarAt (Hex.ZPoly.sturmChain p) hi
+      = ((mobiusPoly ((p.degree?).getD 0) (Dyadic.toReal lo) (Dyadic.toReal hi)
+            (toPolyℝ p)).roots.countP (0 < ·) : Int)
+        + (if (toPolyℝ p).IsRoot (Dyadic.toReal hi) then 1 else 0) := by
+  classical
+  have hp0 : p ≠ 0 := by
+    intro hh; rw [hh] at hdeg; simp only [Hex.DensePoly.degree?_zero_getD] at hdeg; omega
+  have hP0 : toPolyℝ p ≠ 0 := fun h => hp0 (toPolyℝ_eq_zero_iff.mp h)
+  have hab : Dyadic.toReal lo < Dyadic.toReal hi := toReal_lt_toReal_iff.mpr hlt
+  have hdeg' : (toPolyℝ p).natDegree ≤ (p.degree?).getD 0 := le_of_eq (natDegree_toPolyℝ p)
+  have hsep : (toPolyℝ p).Separable := separable_toPolyℝ p ((squareFreeRat_iff p hp0).mp hp)
+  have hnodup : (toPolyℝ p).roots.Nodup := nodup_roots hsep
+  set a := Dyadic.toReal lo with ha
+  set b := Dyadic.toReal hi with hb
+  -- The half-open Sturm count is the card of the filtered root multiset.
+  have hd : (Hex.sturmVarAt (Hex.ZPoly.sturmChain p) lo : Int)
+      - Hex.sturmVarAt (Hex.ZPoly.sturmChain p) hi
+      = (((toPolyℝ p).roots.filter (fun r => a < r ∧ r ≤ b)).card : ℤ) :=
+    sturmCount_eq_card_roots p hdeg hp ⟨lo, hi, hlt⟩
+  rw [hd, countP_roots_mobiusPoly hab hP0 hdeg', Multiset.countP_eq_card_filter]
+  -- Split the half-open filter into the open filter plus the `{b}` filter.
+  have hend : ((toPolyℝ p).roots.filter (fun r => r = b)).card
+      = if (toPolyℝ p).IsRoot b then 1 else 0 := by
+    rw [Multiset.filter_eq', Multiset.card_replicate]
+    by_cases hbroot : (toPolyℝ p).IsRoot b
+    · rw [if_pos hbroot,
+        Multiset.count_eq_one_of_mem hnodup (Polynomial.mem_roots'.mpr ⟨hP0, hbroot⟩)]
+    · rw [if_neg hbroot, Multiset.count_eq_zero.mpr
+        (fun hm => hbroot (Polynomial.mem_roots'.mp hm).2)]
+  have hsplit : ((toPolyℝ p).roots.filter (fun r => a < r ∧ r ≤ b)).card
+      = ((toPolyℝ p).roots.filter (fun r => a < r ∧ r < b)).card
+        + (if (toPolyℝ p).IsRoot b then 1 else 0) := by
+    have hadd := Multiset.filter_add_filter
+        (fun r : ℝ => r = b) (toPolyℝ p).roots (p := fun r : ℝ => a < r ∧ r < b)
+    have e1 : (toPolyℝ p).roots.filter (fun r => (a < r ∧ r < b) ∨ r = b)
+        = (toPolyℝ p).roots.filter (fun r => a < r ∧ r ≤ b) := by
+      refine Multiset.filter_congr (fun r _ => ?_)
+      constructor
+      · rintro (⟨h1, h2⟩ | rfl)
+        · exact ⟨h1, le_of_lt h2⟩
+        · exact ⟨hab, le_refl _⟩
+      · rintro ⟨h1, h2⟩
+        rcases lt_or_eq_of_le h2 with h | h
+        · exact Or.inl ⟨h1, h⟩
+        · exact Or.inr h
+    have e2 : (toPolyℝ p).roots.filter (fun r => (a < r ∧ r < b) ∧ r = b) = 0 := by
+      rw [Multiset.filter_eq_nil]
+      rintro r _ ⟨⟨_, hlt'⟩, rfl⟩
+      exact lt_irrefl _ hlt'
+    rw [e1, e2, add_zero] at hadd
+    have hcard := congrArg Multiset.card hadd
+    rw [Multiset.card_add, hend] at hcard
+    omega
+  rw [hsplit]
+  push_cast
+  ring
+
+/-! ### Node truthfulness -/
+
+/-- The Descartes dispatch Boolean at a node. -/
+private def dispatchC (p : Hex.ZPoly) (lo hi : Dyadic) (hlt : lo < hi) : Bool :=
+  (Hex.descartesVar (Hex.mobiusTransform p ⟨lo, hi, hlt⟩) == 0
+      && (Hex.dyadicSign (p.evalDyadic hi) == 0))
+    || (Hex.descartesVar (Hex.mobiusTransform p ⟨lo, hi, hlt⟩) == 1
+      && !(Hex.dyadicSign (p.evalDyadic hi) == 0))
+
+/-- **Candidate rows certify.** When the dispatch Boolean is `true` (either
+`V = 0 ∧ p(hi) = 0` or `V = 1 ∧ p(hi) ≠ 0`) the exact Sturm count is `1`, so the
+node's certification guard succeeds. -/
+private theorem node_candidate (hdeg : 1 ≤ (p.degree?).getD 0)
+    (hp : Hex.ZPoly.SquareFreeRat p) {lo hi : Dyadic} (hlt : lo < hi)
+    (hC : dispatchC p lo hi hlt = true) :
+    (Hex.sturmVarAt (Hex.ZPoly.sturmChain p) lo : Int)
+      - Hex.sturmVarAt (Hex.ZPoly.sturmChain p) hi = 1 := by
+  have hp0 : p ≠ 0 := by
+    intro hh; rw [hh] at hdeg; simp only [Hex.DensePoly.degree?_zero_getD] at hdeg; omega
+  have hP0 : toPolyℝ p ≠ 0 := fun h => hp0 (toPolyℝ_eq_zero_iff.mp h)
+  have hab : Dyadic.toReal lo < Dyadic.toReal hi := toReal_lt_toReal_iff.mpr hlt
+  set M := mobiusPoly ((p.degree?).getD 0) (Dyadic.toReal lo) (Dyadic.toReal hi) (toPolyℝ p) with hM
+  have hMne : M ≠ 0 := mobiusPoly_ne_zero_of_ne (ne_of_lt hab) hP0
+  have hV : Hex.descartesVar (Hex.mobiusTransform p ⟨lo, hi, hlt⟩) = Polynomial.signVariations M :=
+    descartesVar_mobiusTransform p ⟨lo, hi, hlt⟩ hdeg
+  have hcnt := descartes_node_count hdeg hp hlt
+  rw [← hM] at hcnt
+  unfold dispatchC at hC
+  simp only [Bool.or_eq_true, Bool.and_eq_true] at hC
+  rcases hC with ⟨hV0, hbz⟩ | ⟨hV1, hbz⟩
+  · have hSV0 : Polynomial.signVariations M = 0 := by rw [← hV]; simpa using hV0
+    have hcp := Polynomial.countP_pos_eq_zero_of_signVariations_eq_zero hMne hSV0
+    have hroot : (toPolyℝ p).IsRoot (Dyadic.toReal hi) := (bZero_iff hi).mp hbz
+    rw [hcnt, hcp, if_pos hroot]; norm_num
+  · have hSV1 : Polynomial.signVariations M = 1 := by rw [← hV]; simpa using hV1
+    have hcp := Polynomial.countP_pos_eq_one_of_signVariations_eq_one hMne hSV1
+    have hbzf : (Hex.dyadicSign (p.evalDyadic hi) == 0) = false := by simpa using hbz
+    have hnroot : ¬ (toPolyℝ p).IsRoot (Dyadic.toReal hi) := fun hr => by
+      rw [(bZero_iff hi).mpr hr] at hbzf; exact absurd hbzf (by decide)
+    rw [hcnt, hcp, if_neg hnroot]; norm_num
+
+/-- **Discard rows are truthful.** When the dispatch Boolean is `false` with
+`V = 0` (so `p(hi) ≠ 0`), the exact Sturm count is `0`, so the node's emitted
+`#[]` matches. -/
+private theorem node_discard (hdeg : 1 ≤ (p.degree?).getD 0)
+    (hp : Hex.ZPoly.SquareFreeRat p) {lo hi : Dyadic} (hlt : lo < hi)
+    (hC : dispatchC p lo hi hlt = false)
+    (hV0 : Hex.descartesVar (Hex.mobiusTransform p ⟨lo, hi, hlt⟩) = 0) :
+    (Hex.sturmVarAt (Hex.ZPoly.sturmChain p) lo : Int)
+      - Hex.sturmVarAt (Hex.ZPoly.sturmChain p) hi = 0 := by
+  have hp0 : p ≠ 0 := by
+    intro hh; rw [hh] at hdeg; simp only [Hex.DensePoly.degree?_zero_getD] at hdeg; omega
+  have hP0 : toPolyℝ p ≠ 0 := fun h => hp0 (toPolyℝ_eq_zero_iff.mp h)
+  have hab : Dyadic.toReal lo < Dyadic.toReal hi := toReal_lt_toReal_iff.mpr hlt
+  set M := mobiusPoly ((p.degree?).getD 0) (Dyadic.toReal lo) (Dyadic.toReal hi) (toPolyℝ p) with hM
+  have hMne : M ≠ 0 := mobiusPoly_ne_zero_of_ne (ne_of_lt hab) hP0
+  have hV : Hex.descartesVar (Hex.mobiusTransform p ⟨lo, hi, hlt⟩) = Polynomial.signVariations M :=
+    descartesVar_mobiusTransform p ⟨lo, hi, hlt⟩ hdeg
+  have hcnt := descartes_node_count hdeg hp hlt
+  rw [← hM] at hcnt
+  -- `V = 0` collapses the dispatch to `bZero`, and `hC = false` forces `bZero = false`.
+  have hbzf : (Hex.dyadicSign (p.evalDyadic hi) == 0) = false := by
+    unfold dispatchC at hC
+    rw [hV0] at hC
+    simpa using hC
+  have hnroot : ¬ (toPolyℝ p).IsRoot (Dyadic.toReal hi) := fun hr => by
+    rw [(bZero_iff hi).mpr hr] at hbzf; exact absurd hbzf (by decide)
+  have hSV0 : Polynomial.signVariations M = 0 := by rw [← hV]; exact hV0
+  have hcp := Polynomial.countP_pos_eq_zero_of_signVariations_eq_zero hMne hSV0
+  rw [hcnt, hcp, if_neg hnroot]; norm_num
+
+/-! ### Depth-budget refutation of the bisecting rows -/
+
+/-- The real cast of `toPolyℝ p` to `ℂ` is `toPolyℂ p`. -/
+private theorem map_toPolyℝ_eq_toPolyℂ (p : Hex.ZPoly) :
+    (toPolyℝ p).map (algebraMap ℝ ℂ) = toPolyℂ p := by
+  ext n
+  rw [Polynomial.coeff_map, coeff_toPolyℝ, coeff_toPolyℂ, Complex.coe_algebraMap]
+  push_cast; ring
+
+/-- `toPolyℂ p` is separable for square-free `p`, hence has nodup roots. -/
+private theorem nodup_roots_toPolyℂ (hp0 : p ≠ 0) (hp : Hex.ZPoly.SquareFreeRat p) :
+    (toPolyℂ p).roots.Nodup := by
+  have hsepℝ : (toPolyℝ p).Separable := separable_toPolyℝ p ((squareFreeRat_iff p hp0).mp hp)
+  have hsepℂ : (toPolyℂ p).Separable := by
+    rw [← map_toPolyℝ_eq_toPolyℂ]; exact hsepℝ.map
+  exact nodup_roots hsepℂ
+
+/-- **The `V ≥ 2` row is impossible at the depth budget.** Two or more
+transform-roots outside the sector correspond to two distinct roots of `p` inside
+the two-circle region, which are closer than `4·2^{−sepPrec p}`, contradicting
+the Mahler separation bound. -/
+theorem bisect_refute_sector (hdeg : 1 ≤ (p.degree?).getD 0)
+    (hp : Hex.ZPoly.SquareFreeRat p) {lo hi : Dyadic} (hlt : lo < hi)
+    (hw : Dyadic.toReal hi - Dyadic.toReal lo ≤ (2 : ℝ) ^ (-(Hex.sepPrec p : ℤ)))
+    (hV2 : 2 ≤ Hex.descartesVar (Hex.mobiusTransform p ⟨lo, hi, hlt⟩)) :
+    False := by
+  classical
+  have hp0 : p ≠ 0 := by
+    intro hh; rw [hh] at hdeg; simp only [Hex.DensePoly.degree?_zero_getD] at hdeg; omega
+  have hP0 : toPolyℝ p ≠ 0 := fun h => hp0 (toPolyℝ_eq_zero_iff.mp h)
+  have hPℂ0 : toPolyℂ p ≠ 0 := fun h => hp0 (by
+    have : toPolyℝ p = 0 := by
+      rw [← map_toPolyℝ_eq_toPolyℂ] at h
+      exact (Polynomial.map_eq_zero_iff (RingHom.injective (algebraMap ℝ ℂ))).mp h
+    exact toPolyℝ_eq_zero_iff.mp this)
+  set a := Dyadic.toReal lo with ha
+  set b := Dyadic.toReal hi with hb
+  have hab : a < b := toReal_lt_toReal_iff.mpr hlt
+  have habℂ : (a : ℂ) ≠ (b : ℂ) := fun h => (ne_of_lt hab) (Complex.ofReal_inj.mp h)
+  set M := mobiusPoly ((p.degree?).getD 0) a b (toPolyℝ p) with hM
+  have hMne : M ≠ 0 := mobiusPoly_ne_zero_of_ne (ne_of_lt hab) hP0
+  have hV2M : 2 ≤ Polynomial.signVariations M := by
+    have h := descartesVar_mobiusTransform p ⟨lo, hi, hlt⟩ hdeg
+    rw [show (⟨lo, hi, hlt⟩ : Hex.DyadicInterval).lower = lo from rfl,
+      show (⟨lo, hi, hlt⟩ : Hex.DyadicInterval).upper = hi from rfl, ← ha, ← hb] at h
+    rw [hM]; omega
+  -- `≥ 2` transform-roots lie outside the sector.
+  have hcount2 : 2 ≤ (M.map (algebraMap ℝ ℂ)).roots.countP (· ∉ Polynomial.sector) := by
+    by_contra h
+    have hle := Polynomial.signVariations_le_one_of_sector hMne (by omega)
+    omega
+  -- Identify the complex transform with the abstract complex Möbius polynomial.
+  have hMmap : M.map (algebraMap ℝ ℂ)
+      = mobiusPoly (toPolyℂ p).natDegree (a : ℂ) (b : ℂ) (toPolyℂ p) := by
+    rw [natDegree_toPolyℂ, hM, mobiusPoly_map, map_toPolyℝ_eq_toPolyℂ, Complex.coe_algebraMap]
+  rw [hMmap, roots_mobiusPoly habℂ hPℂ0, Multiset.countP_map] at hcount2
+  -- Two distinct region roots.
+  set T := ((toPolyℂ p).roots.filter (· ≠ (b : ℂ))).filter
+      (fun w => (w - (a : ℂ)) / ((b : ℂ) - w) ∉ Polynomial.sector) with hT
+  have hnodupℂ := nodup_roots_toPolyℂ hp0 hp
+  have hnodupT : T.Nodup := (hnodupℂ.filter _).filter _
+  have hcardT : 2 ≤ T.card := hcount2
+  have hfin : 1 < T.toFinset.card := by
+    rw [Multiset.toFinset_card_of_nodup hnodupT]; omega
+  obtain ⟨w₁, hw₁, w₂, hw₂, hne⟩ := Finset.one_lt_card.mp hfin
+  rw [Multiset.mem_toFinset, hT, Multiset.mem_filter, Multiset.mem_filter] at hw₁ hw₂
+  obtain ⟨⟨hw₁roots, hw₁neb⟩, hw₁sec⟩ := hw₁
+  obtain ⟨⟨hw₂roots, hw₂neb⟩, hw₂sec⟩ := hw₂
+  have hIn₁ : TwoCircle.InTwoCircle a b w₁ := by
+    by_contra hcon
+    have hmem := (TwoCircle.not_inTwoCircle_iff_mem_sector a b w₁ hw₁neb).mp hcon
+    exact hw₁sec (Polynomial.mem_sector.mpr (TwoCircle.mem_sector.mp hmem))
+  have hIn₂ : TwoCircle.InTwoCircle a b w₂ := by
+    by_contra hcon
+    have hmem := (TwoCircle.not_inTwoCircle_iff_mem_sector a b w₂ hw₂neb).mp hcon
+    exact hw₂sec (Polynomial.mem_sector.mpr (TwoCircle.mem_sector.mp hmem))
+  have hr₁ : (toPolyℂ p).IsRoot w₁ := (Polynomial.mem_roots'.mp hw₁roots).2
+  have hr₂ : (toPolyℂ p).IsRoot w₂ := (Polynomial.mem_roots'.mp hw₂roots).2
+  -- Distance bound from the ball enclosure.
+  have hd₁ := TwoCircle.dist_le a b w₁ hab.le hIn₁
+  have hd₂ := TwoCircle.dist_le a b w₂ hab.le hIn₂
+  have hdist : dist w₁ w₂ ≤ Real.sqrt 3 * (b - a) := by
+    have htri := dist_triangle w₁ (((a + b) / 2 : ℝ) : ℂ) w₂
+    have hd₂' : dist (((a + b) / 2 : ℝ) : ℂ) w₂ ≤ Real.sqrt 3 * (b - a) / 2 := by
+      rw [dist_comm]; exact hd₂
+    linarith [htri, hd₁, hd₂']
+  have hnorm : ‖w₁ - w₂‖ ≤ Real.sqrt 3 * (b - a) := by rw [← dist_eq_norm]; exact hdist
+  -- Separation contradiction.
+  have hsep := sepPrec_separates' p hp0 hp w₁ w₂ hr₁ hr₂ hne
+  have h3 : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  have h3nn : (0 : ℝ) ≤ Real.sqrt 3 := Real.sqrt_nonneg _
+  have hpow : (0 : ℝ) < 2 ^ (-(Hex.sepPrec p : ℤ)) := by positivity
+  have hchain : 4 * 2 ^ (-(Hex.sepPrec p : ℤ)) < Real.sqrt 3 * (b - a) := by
+    linarith [hsep, hnorm]
+  have hwidth : Real.sqrt 3 * (b - a) ≤ Real.sqrt 3 * 2 ^ (-(Hex.sepPrec p : ℤ)) :=
+    mul_le_mul_of_nonneg_left hw h3nn
+  have hlt4 : 4 * 2 ^ (-(Hex.sepPrec p : ℤ)) < Real.sqrt 3 * 2 ^ (-(Hex.sepPrec p : ℤ)) :=
+    lt_of_lt_of_le hchain hwidth
+  have h4 : (4 : ℝ) < Real.sqrt 3 := lt_of_mul_lt_mul_right hlt4 hpow.le
+  nlinarith [h4, h3, h3nn]
+
+/-- **The `V = 1 ∧ p(hi) = 0` row is impossible at the depth budget.** It puts
+two real roots — an interior root and `hi` — in `(lo, hi]`, a Sturm count of `2`,
+contradicting `sturmCount_le_one`. -/
+theorem bisect_refute_double (hdeg : 1 ≤ (p.degree?).getD 0)
+    (hp : Hex.ZPoly.SquareFreeRat p) {lo hi : Dyadic} (hlt : lo < hi)
+    (hw : Dyadic.toReal hi - Dyadic.toReal lo ≤ (2 : ℝ) ^ (-(Hex.sepPrec p : ℤ)))
+    (hV1 : Hex.descartesVar (Hex.mobiusTransform p ⟨lo, hi, hlt⟩) = 1)
+    (hbz : (Hex.dyadicSign (p.evalDyadic hi) == 0) = true) :
+    False := by
+  have hp0 : p ≠ 0 := by
+    intro hh; rw [hh] at hdeg; simp only [Hex.DensePoly.degree?_zero_getD] at hdeg; omega
+  have hP0 : toPolyℝ p ≠ 0 := fun h => hp0 (toPolyℝ_eq_zero_iff.mp h)
+  have hab : Dyadic.toReal lo < Dyadic.toReal hi := toReal_lt_toReal_iff.mpr hlt
+  set M := mobiusPoly ((p.degree?).getD 0) (Dyadic.toReal lo) (Dyadic.toReal hi) (toPolyℝ p) with hM
+  have hMne : M ≠ 0 := mobiusPoly_ne_zero_of_ne (ne_of_lt hab) hP0
+  have hV : Hex.descartesVar (Hex.mobiusTransform p ⟨lo, hi, hlt⟩) = Polynomial.signVariations M :=
+    descartesVar_mobiusTransform p ⟨lo, hi, hlt⟩ hdeg
+  have hSV1 : Polynomial.signVariations M = 1 := by rw [← hV]; exact hV1
+  have hcp := Polynomial.countP_pos_eq_one_of_signVariations_eq_one hMne hSV1
+  have hroot : (toPolyℝ p).IsRoot (Dyadic.toReal hi) := (bZero_iff hi).mp hbz
+  have hcnt := descartes_node_count hdeg hp hlt
+  rw [← hM] at hcnt
+  have h2 : (Hex.sturmVarAt (Hex.ZPoly.sturmChain p) lo : Int)
+      - Hex.sturmVarAt (Hex.ZPoly.sturmChain p) hi = 2 := by
+    rw [hcnt, hcp, if_pos hroot]; norm_num
+  have hle := sturmCount_le_one hdeg hp ⟨lo, hi, hlt⟩ hw
+  have hle' : (Hex.sturmVarAt (Hex.ZPoly.sturmChain p) lo : Int)
+      - Hex.sturmVarAt (Hex.ZPoly.sturmChain p) hi ≤ 1 := hle
+  omega
+
+/-! ### The Descartes worklist drains -/
+
+/-- **The `descartesVisit` worklist drains, ordered and count-exact.** For a
+positive-degree square-free `p`, on a nonempty interval whose width is within the
+depth budget, `descartesVisit` returns `some arr` where `arr` is an ordered array
+of `arr.size = sturmVarAt chain lo − sturmVarAt chain hi` isolations, each with
+its interval inside `(lo, hi]`.
+
+Structural induction on `depth`. Candidate and discard nodes are exact leaves
+(`node_candidate`, `node_discard`, no budget). The bisecting rows are refuted at
+`depth = 0` (`bisect_refute_double`, `bisect_refute_sector`) and recurse into
+halved children at `depth + 1`; the size telescopes and the emissions stay
+ordered exactly as in `sturmVisit_spec`. -/
+private theorem descartesVisit_spec (hdeg : 1 ≤ (p.degree?).getD 0)
+    (hp : Hex.ZPoly.SquareFreeRat p) :
+    ∀ (depth : Nat) (lo hi : Dyadic),
+      lo < hi →
+      Dyadic.toReal hi - Dyadic.toReal lo ≤ (2 : ℝ) ^ ((depth : ℤ) - (Hex.sepPrec p : ℤ)) →
+      ∃ arr : Array (Hex.RealRootIsolation p),
+        Hex.descartesVisit p (Hex.ZPoly.sturmChain p) rfl depth lo hi = some arr ∧
+        arr.size = Hex.sturmVarAt (Hex.ZPoly.sturmChain p) lo
+          - Hex.sturmVarAt (Hex.ZPoly.sturmChain p) hi ∧
+        (∀ i j : Fin arr.size, i < j → arr[i].interval.upper ≤ arr[j].interval.lower) ∧
+        (∀ I ∈ arr, lo ≤ I.interval.lower) ∧ (∀ I ∈ arr, I.interval.upper ≤ hi) := by
+  intro depth
+  induction depth with
+  | zero =>
+    intro lo hi hlt hw
+    simp only [Nat.cast_zero, zero_sub] at hw
+    have hunf : Hex.descartesVisit p (Hex.ZPoly.sturmChain p) rfl 0 lo hi
+        = (if hlt' : lo < hi then
+            (if dispatchC p lo hi hlt' then
+              (if h : (Hex.sturmVarAt (Hex.ZPoly.sturmChain p) lo : Int)
+                  - Hex.sturmVarAt (Hex.ZPoly.sturmChain p) hi = 1 then
+                some #[⟨⟨lo, hi, hlt'⟩, by exact h⟩]
+              else none)
+            else if Hex.descartesVar (Hex.mobiusTransform p ⟨lo, hi, hlt'⟩) = 0 then
+              some #[]
+            else none)
+          else some #[]) := rfl
+    rw [dif_pos hlt] at hunf
+    by_cases hC : dispatchC p lo hi hlt = true
+    · -- candidate leaf
+      have hcert := node_candidate hdeg hp hlt hC
+      rw [if_pos hC, dif_pos hcert] at hunf
+      refine ⟨#[⟨⟨lo, hi, hlt⟩, by exact hcert⟩], hunf, ?_, ?_, ?_, ?_⟩
+      · simp only [Array.size_singleton]; omega
+      · intro i j hij
+        have hi1 : (i : ℕ) < 1 := i.isLt
+        have hj1 : (j : ℕ) < 1 := j.isLt
+        have hij' : (i : ℕ) < (j : ℕ) := hij
+        omega
+      · intro I hI
+        simp only [List.mem_toArray, List.mem_singleton] at hI
+        subst hI; exact dle_refl lo
+      · intro I hI
+        simp only [List.mem_toArray, List.mem_singleton] at hI
+        subst hI; exact dle_refl hi
+    · -- either discard leaf or a refuted bisect
+      rw [if_neg hC] at hunf
+      have hCfalse : dispatchC p lo hi hlt = false := by
+        cases h : dispatchC p lo hi hlt with
+        | false => rfl
+        | true => exact absurd h hC
+      by_cases hV0 : Hex.descartesVar (Hex.mobiusTransform p ⟨lo, hi, hlt⟩) = 0
+      · -- discard leaf
+        have hcert := node_discard hdeg hp hlt hCfalse hV0
+        rw [if_pos hV0] at hunf
+        refine ⟨#[], hunf, ?_, ?_, ?_, ?_⟩
+        · simp only [Array.size_empty]; omega
+        · intro i j hij; exact absurd i.isLt (by simp)
+        · intro I hI; simp at hI
+        · intro I hI; simp at hI
+      · -- bisect at depth 0: refuted
+        exfalso
+        rw [if_neg hV0] at hunf
+        rcases Nat.lt_or_ge (Hex.descartesVar (Hex.mobiusTransform p ⟨lo, hi, hlt⟩)) 2 with hV2 | hV2
+        · have hV1 : Hex.descartesVar (Hex.mobiusTransform p ⟨lo, hi, hlt⟩) = 1 := by omega
+          have hbz : (Hex.dyadicSign (p.evalDyadic hi) == 0) = true := by
+            unfold dispatchC at hCfalse; rw [hV1] at hCfalse; simpa using hCfalse
+          exact bisect_refute_double hdeg hp hlt hw hV1 hbz
+        · exact bisect_refute_sector hdeg hp hlt hw hV2
+  | succ d ih =>
+    intro lo hi hlt hw
+    have hunf : Hex.descartesVisit p (Hex.ZPoly.sturmChain p) rfl (d + 1) lo hi
+        = (if hlt' : lo < hi then
+            (if dispatchC p lo hi hlt' then
+              (if h : (Hex.sturmVarAt (Hex.ZPoly.sturmChain p) lo : Int)
+                  - Hex.sturmVarAt (Hex.ZPoly.sturmChain p) hi = 1 then
+                some #[⟨⟨lo, hi, hlt'⟩, by exact h⟩]
+              else none)
+            else if Hex.descartesVar (Hex.mobiusTransform p ⟨lo, hi, hlt'⟩) = 0 then
+              some #[]
+            else
+              match Hex.descartesVisit p (Hex.ZPoly.sturmChain p) rfl d lo
+                  ((lo + hi) >>> (1 : Int)) with
+              | none => none
+              | some left =>
+                match Hex.descartesVisit p (Hex.ZPoly.sturmChain p) rfl d
+                    ((lo + hi) >>> (1 : Int)) hi with
+                | none => none
+                | some right => some (left ++ right))
+          else some #[]) := rfl
+    rw [dif_pos hlt] at hunf
+    by_cases hC : dispatchC p lo hi hlt = true
+    · have hcert := node_candidate hdeg hp hlt hC
+      rw [if_pos hC, dif_pos hcert] at hunf
+      refine ⟨#[⟨⟨lo, hi, hlt⟩, by exact hcert⟩], hunf, ?_, ?_, ?_, ?_⟩
+      · simp only [Array.size_singleton]; omega
+      · intro i j hij
+        have hi1 : (i : ℕ) < 1 := i.isLt
+        have hj1 : (j : ℕ) < 1 := j.isLt
+        have hij' : (i : ℕ) < (j : ℕ) := hij
+        omega
+      · intro I hI
+        simp only [List.mem_toArray, List.mem_singleton] at hI
+        subst hI; exact dle_refl lo
+      · intro I hI
+        simp only [List.mem_toArray, List.mem_singleton] at hI
+        subst hI; exact dle_refl hi
+    · rw [if_neg hC] at hunf
+      have hCfalse : dispatchC p lo hi hlt = false := by
+        cases h : dispatchC p lo hi hlt with
+        | false => rfl
+        | true => exact absurd h hC
+      by_cases hV0 : Hex.descartesVar (Hex.mobiusTransform p ⟨lo, hi, hlt⟩) = 0
+      · have hcert := node_discard hdeg hp hlt hCfalse hV0
+        rw [if_pos hV0] at hunf
+        refine ⟨#[], hunf, ?_, ?_, ?_, ?_⟩
+        · simp only [Array.size_empty]; omega
+        · intro i j hij; exact absurd i.isLt (by simp)
+        · intro I hI; simp at hI
+        · intro I hI; simp at hI
+      · -- bisect: recurse into the two halves
+        rw [if_neg hV0] at hunf
+        have hlm : lo < (lo + hi) >>> (1 : Int) := lower_lt_midpoint ⟨lo, hi, hlt⟩
+        have hmh : (lo + hi) >>> (1 : Int) < hi := midpoint_lt_upper ⟨lo, hi, hlt⟩
+        have hmidR : Dyadic.toReal ((lo + hi) >>> (1 : Int))
+            = (Dyadic.toReal lo + Dyadic.toReal hi) / 2 := toReal_midpoint ⟨lo, hi, hlt⟩
+        have hzp : (2 : ℝ) ^ (((d + 1 : ℕ) : ℤ) - (Hex.sepPrec p : ℤ))
+            = 2 * (2 : ℝ) ^ ((d : ℤ) - (Hex.sepPrec p : ℤ)) := by
+          rw [show ((d + 1 : ℕ) : ℤ) - (Hex.sepPrec p : ℤ)
+              = ((d : ℤ) - (Hex.sepPrec p : ℤ)) + 1 by push_cast; ring,
+            zpow_add_one₀ (by norm_num : (2 : ℝ) ≠ 0)]
+          ring
+        rw [hzp] at hw
+        have hwl : Dyadic.toReal ((lo + hi) >>> (1 : Int)) - Dyadic.toReal lo
+            ≤ (2 : ℝ) ^ ((d : ℤ) - (Hex.sepPrec p : ℤ)) := by rw [hmidR]; linarith
+        have hwr : Dyadic.toReal hi - Dyadic.toReal ((lo + hi) >>> (1 : Int))
+            ≤ (2 : ℝ) ^ ((d : ℤ) - (Hex.sepPrec p : ℤ)) := by rw [hmidR]; linarith
+        obtain ⟨left, hLeq, hLsize, hLord, hLlo, hLhi⟩ := ih lo ((lo + hi) >>> (1 : Int)) hlm hwl
+        obtain ⟨right, hReq, hRsize, hRord, hRlo, hRhi⟩ := ih ((lo + hi) >>> (1 : Int)) hi hmh hwr
+        have hle1 : Hex.sturmVarAt (Hex.ZPoly.sturmChain p) ((lo + hi) >>> (1 : Int))
+            ≤ Hex.sturmVarAt (Hex.ZPoly.sturmChain p) lo := sturmVarAt_le hdeg hp hlm
+        have hle2 : Hex.sturmVarAt (Hex.ZPoly.sturmChain p) hi
+            ≤ Hex.sturmVarAt (Hex.ZPoly.sturmChain p) ((lo + hi) >>> (1 : Int)) :=
+          sturmVarAt_le hdeg hp hmh
+        refine ⟨left ++ right, ?_, ?_, ?_, ?_, ?_⟩
+        · rw [hunf, hLeq, hReq]
+        · rw [Array.size_append, hLsize, hRsize]; omega
+        · intro i j hij
+          have hij' : (i : ℕ) < (j : ℕ) := hij
+          have hi' : (i : ℕ) < left.size + right.size := i.isLt.trans_eq Array.size_append
+          have hj' : (j : ℕ) < left.size + right.size := j.isLt.trans_eq Array.size_append
+          by_cases hjL : (j : ℕ) < left.size
+          · have hiL : (i : ℕ) < left.size := lt_trans hij' hjL
+            rw [Fin.getElem_fin, Fin.getElem_fin, Array.getElem_append_left hiL,
+              Array.getElem_append_left hjL]
+            exact hLord ⟨(i : ℕ), hiL⟩ ⟨(j : ℕ), hjL⟩ hij'
+          · have hjR : left.size ≤ (j : ℕ) := le_of_not_gt hjL
+            by_cases hiL : (i : ℕ) < left.size
+            · rw [Fin.getElem_fin, Fin.getElem_fin, Array.getElem_append_left hiL,
+                Array.getElem_append_right hjR]
+              exact dle_trans (hLhi _ (Array.getElem_mem hiL))
+                (hRlo _ (Array.getElem_mem (by omega)))
+            · have hiR : left.size ≤ (i : ℕ) := le_of_not_gt hiL
+              rw [Fin.getElem_fin, Fin.getElem_fin, Array.getElem_append_right hiR,
+                Array.getElem_append_right hjR]
+              exact hRord ⟨(i : ℕ) - left.size, by omega⟩ ⟨(j : ℕ) - left.size, by omega⟩
+                (by simp only [Fin.mk_lt_mk]; omega)
+        · intro I hI
+          rcases Array.mem_append.mp hI with h | h
+          · exact hLlo I h
+          · exact dle_trans (dle_of_lt hlm) (hRlo I h)
+        · intro I hI
+          rcases Array.mem_append.mp hI with h | h
+          · exact dle_trans (hLhi I h) (dle_of_lt hmh)
+          · exact hRhi I h
+
+/-! ### Driver completeness -/
+
+/-- The positive-degree core: the worklist drains (`descartesVisit_spec`) and the
+emitted total matches `rootCount p = sturmVarNegInf − sturmVarPosInf` (the
+`±rootBound` gap counts every root), so `assemble?` certifies. -/
+private theorem isolateDescartes?_isSome_of_degree_pos (hdeg : 1 ≤ (p.degree?).getD 0)
+    (hp : Hex.ZPoly.SquareFreeRat p) : (Hex.isolateDescartes? p).isSome := by
+  obtain ⟨d, hd⟩ : ∃ d, p.degree? = some (d + 1) := by
+    rcases hh : p.degree? with _ | n
+    · rw [hh] at hdeg; simp at hdeg
+    · rcases n with _ | m
+      · rw [hh] at hdeg; simp at hdeg
+      · exact ⟨m, rfl⟩
+  have hlt : -(Hex.rootBound p) < Hex.rootBound p := neg_rootBound_lt_rootBound p
+  obtain ⟨arr, hvisit, hsize, hord, -, -⟩ :=
+    descartesVisit_spec hdeg hp (Hex.isolationDepth p) (-(Hex.rootBound p)) (Hex.rootBound p)
+      hlt (initial_width_le p hdeg)
+  have hInt := sturmVar_neg_pos_sub hdeg hp
+  have hsize' : arr.size = Hex.sturmVarNegInf (Hex.ZPoly.sturmChain p)
+      - Hex.sturmVarPosInf (Hex.ZPoly.sturmChain p) := by
+    have hrc : Hex.rootCount p = Hex.sturmVarNegInf (Hex.ZPoly.sturmChain p)
+        - Hex.sturmVarPosInf (Hex.ZPoly.sturmChain p) := rfl
+    rw [hsize, ← hrc]; omega
+  -- `isolateDescartes?` on positive-degree square-free `p` is the top run + `assemble?`.
+  have heq : Hex.isolateDescartes? p
+      = (match Hex.descartesVisit p (Hex.ZPoly.sturmChain p) rfl (Hex.isolationDepth p)
+            (-(Hex.rootBound p)) (Hex.rootBound p) with
+          | none => none
+          | some arr => Hex.assemble? p (Hex.ZPoly.sturmChain p) rfl arr) := by
+    unfold Hex.isolateDescartes?
+    simp only [hd]
+    rw [if_pos hp]
+    rfl
+  rw [heq, hvisit]
+  exact assemble?_isSome rfl arr hord hsize'
+
+/-- The Descartes engine on a nonzero constant: the driver's `some 0` branch
+hands `assemble?` the empty array through the empty chain. -/
+private theorem isolateDescartes?_isSome_of_degree_zero (hd : p.degree? = some 0) :
+    (Hex.isolateDescartes? p).isSome := by
+  have heq : Hex.isolateDescartes? p = Hex.assemble? p (Hex.ZPoly.sturmChain p) rfl #[] := by
+    unfold Hex.isolateDescartes?; rw [hd]
+  have hchain0 : Hex.ZPoly.sturmChain p = #[] := by
+    unfold Hex.ZPoly.sturmChain; rw [hd]; rfl
+  rw [heq]
+  refine assemble?_isSome rfl #[] ?_ ?_
+  · intro i j hij; exact absurd i.isLt (by simp)
+  · rw [hchain0]; rfl
+
+/-- **The Descartes engine succeeds on nonzero square-free input.** The last
+theorem of `HexRealRootsMathlib`: `isolateDescartes? p ≠ none` for nonzero `p`
+passing the executable `SquareFreeRat` test, so the runtime never falls back to
+the Sturm engine.
+
+Positive degree is the real content (`isolateDescartes?_isSome_of_degree_pos`,
+the two-circle termination argument); a nonzero constant certifies through the
+empty chain. As with `isolateSturm?_isSome`, the `p ≠ 0` hypothesis is added
+because `SquareFreeRat 0` is vacuous while `isolateDescartes? 0 = none`. -/
 theorem isolateDescartes?_isSome (p : Hex.ZPoly) (hp0 : p ≠ 0)
-    (hp : Hex.ZPoly.SquareFreeRat p) : (Hex.isolateDescartes? p).isSome := sorry
+    (hp : Hex.ZPoly.SquareFreeRat p) : (Hex.isolateDescartes? p).isSome := by
+  rcases hd : p.degree? with _ | n
+  · exact absurd hd (degree?_ne_none hp0)
+  · rcases n with _ | n
+    · exact isolateDescartes?_isSome_of_degree_zero hd
+    · exact isolateDescartes?_isSome_of_degree_pos (by simp [hd]) hp
+
+end
 
 end HexRealRootsMathlib

--- a/HexRealRootsMathlib/TwoCircle.lean
+++ b/HexRealRootsMathlib/TwoCircle.lean
@@ -39,8 +39,8 @@ with it the companion is fully `sorry`-free.
 
 The classical statement is **not** a general count bound. It is *λ-graded*
 (Obreschkoff 1963; modern treatments Krandick–Mehlhorn 2006, Eigenwillig 2008):
-if all but `λ` complex roots of a real polynomial lie in the open sector of
-half-angle `π/(λ+2)` about the positive real axis (equivalently, at most `λ`
+if all but `λ` complex roots of a real polynomial lie in the closed sector of
+half-angle `π/(λ+2)` about the negative real axis (equivalently, at most `λ`
 roots lie outside), then the coefficient sequence has at most `λ` sign
 variations. The naive reading "variation count ≤ number of roots in the
 two-circle region" is **false**: `(X²+X+1)·(X²−(3/2)X+1)` has four sign

--- a/HexRealRootsMathlib/TwoCircleRegion.lean
+++ b/HexRealRootsMathlib/TwoCircleRegion.lean
@@ -66,6 +66,11 @@ of the Möbius image. Classically written with `Complex.abs`; here the modulus i
 the norm `‖·‖`. -/
 def sector : Set ℂ := {z : ℂ | z.re ≤ -‖z‖ / 2}
 
+/-- Membership in the closed sector unfolds to the scalar inequality. Exported so
+consumers can bridge this sector to `Polynomial.sector` (the identical set in the
+sign-variation development) without unfolding the opaque `def` across modules. -/
+theorem mem_sector {z : ℂ} : z ∈ sector ↔ z.re ≤ -‖z‖ / 2 := Iff.rfl
+
 /-- Real part of the Möbius seed `s = (w − a)·conj(b − w)`. -/
 theorem seed_re (a b : ℝ) (w : ℂ) :
     ((w - a) * (starRingEnd ℂ) (b - w)).re = (w.re - a) * (b - w.re) - w.im ^ 2 := by

--- a/SPEC/Libraries/hex-real-roots-mathlib.md
+++ b/SPEC/Libraries/hex-real-roots-mathlib.md
@@ -251,7 +251,7 @@ Sturm engine.
 Prerequisite: the **Obreshkoff two-circle theorem**, in its correct
 *λ-graded* form (Obreschkoff 1963; Krandick-Mehlhorn 2006,
 Eigenwillig 2008): if all but `λ` complex roots of a real polynomial
-lie in the open sector of half-angle `π/(λ+2)` about the positive real
+lie in the closed sector of half-angle `π/(λ+2)` about the negative real
 axis (equivalently, at most `λ` roots lie outside), then the
 coefficient sequence has at most `λ` sign variations. The naive count
 bound "variation count ≤ number of roots in the two-circle region" is

--- a/SPEC/Libraries/hex-real-roots-mathlib.md
+++ b/SPEC/Libraries/hex-real-roots-mathlib.md
@@ -236,41 +236,64 @@ theorem sameRoot_iff (hp) (i₁ i₂) :
 `theRoot` is the unique root delivered by
 `RealRootIsolation.exists_unique_root`.
 
-## Deferred: Descartes engine termination
+## Descartes engine termination (the two-circle theorem)
 
 ```lean
 theorem isolateDescartes?_isSome (p : ZPoly) (hp0 : p ≠ 0)
     (hp : SquareFreeRat p) : (Hex.isolateDescartes? p).isSome
 ```
 
-Prerequisite: the **Obreshkoff two-circle theorem**. For an interval
-`(a, b)`, the variation count of the Möbius-transformed polynomial is
-at least the number of roots in the one-circle region (the open disc
-with diameter `(a, b)`) and at most the number of roots in the
-two-circle region (the union of the two discs through `a` and `b`
-whose centres lie at `(a+b)/2 ± i·(b−a)/(2√3)`), counted with
-multiplicity. Consequences: a short interval far from all roots has
-count 0, and a short interval whose two-circle region contains one
-simple real root has count 1, so at `isolationDepth p` the Descartes
-worklist drains and every candidate certifies.
+Proven in `TwoCircle.lean`; with it the companion is fully
+`sorry`-free. The Descartes engine alone returns `some` on every
+nonzero square-free input, so the runtime never falls back to the
+Sturm engine.
+
+Prerequisite: the **Obreshkoff two-circle theorem**, in its correct
+*λ-graded* form (Obreschkoff 1963; Krandick-Mehlhorn 2006,
+Eigenwillig 2008): if all but `λ` complex roots of a real polynomial
+lie in the open sector of half-angle `π/(λ+2)` about the positive real
+axis (equivalently, at most `λ` roots lie outside), then the
+coefficient sequence has at most `λ` sign variations. The naive count
+bound "variation count ≤ number of roots in the two-circle region" is
+**false** — `(X²+X+1)·(X²−(3/2)X+1)` has four sign variations while
+only two of its roots lie outside the sector (the counterexample is
+recorded in `TwoCircleSector.lean`). We use only the two lowest graded
+cases, `λ ∈ {0, 1}`: `Polynomial.signVariations_le_one_of_sector`
+(`TwoCircleSector.lean`, the `λ = 1` bound via Hoggar log-concavity)
+and its `λ = 0` corollary.
+
+Route (`TwoCircle.lean`): at each node the Descartes count `V` equals
+`signVariations` of the Möbius transform; the Descartes parity exports
+(`DescartesParity.lean`) pin the open-interval root count exactly when
+`V ∈ {0, 1}`, and the exact endpoint test settles `p(b) = 0`, so the
+half-open Sturm count is computed exactly and every candidate certifies
+(count `1`) and every discard emits `#[]` (count `0`). At the depth
+budget the bisecting rows are refuted: `V = 1 ∧ p(b) = 0` forces a
+Sturm count of `2` against `sturmCount_le_one`, and `V ≥ 2` triggers
+the sector bound (`≥ 2` transform-roots outside the sector correspond
+via `roots_mobiusPoly`/`not_inTwoCircle_iff_mem_sector` to two distinct
+`p`-roots in the two-circle region, closer than the Mahler separation
+`sepPrec_separates'` allows). The worklist therefore drains at
+`isolationDepth p`.
 
 Status and boundaries:
 
-- The two-circle theorem has no formalisation in any proof assistant
-  that we know of. The classical proof (Obreschkoff 1963; modern
-  treatment in Krandick-Mehlhorn 2006 and Eigenwillig 2008) is an
-  induction on multiplying in linear and conjugate-quadratic factors,
-  with sector inequalities on coefficient sequences. Elementary but
-  long, and the effort is genuinely uncertain.
-- **Nothing else waits for it.** `isolate?_isSome`, all soundness
-  theorems, and hex-rcf's decision procedure are complete without it.
-  Its value is to retire the Sturm fallback path from the trusted
-  runtime story and to delete the conformance assertions described in
-  [hex-real-roots.md](hex-real-roots.md) §"Conformance fixtures"
-  (the PR that proves this theorem must delete those assertions).
-- Like the Sturm slice, it should be developed against
-  `Polynomial ℝ` (and `ℂ` for the regions) with no `HexRealRoots`
-  dependence, as a Mathlib contribution in its own right.
+- The two-circle theorem is now formalised here (the sector core
+  `signVariations_le_one_of_sector`, the region geometry
+  `TwoCircleRegion.lean`, and the Descartes parity). The classical
+  proof (Obreschkoff 1963; Krandick-Mehlhorn 2006, Eigenwillig 2008)
+  runs by induction on multiplying in linear and conjugate-quadratic
+  factors, with sector inequalities on coefficient sequences.
+- **Nothing else waited for it.** `isolate?_isSome`, all soundness
+  theorems, and hex-rcf's decision procedure were complete without it;
+  its value is to retire the Sturm fallback path from the trusted
+  runtime story. The executable conformance stand-ins for this
+  theorem (`isolateDescartes?` succeeds and agrees with `isolate?` per
+  fixture) are retired in the same change now that the theorem carries
+  the claim.
+- Like the Sturm slice, the sector/region/parity development is stated
+  against `Polynomial ℝ`/`ℂ` with no `HexRealRoots` dependence, ready
+  as a Mathlib contribution in its own right.
 
 ## File organisation
 

--- a/SPEC/Libraries/hex-real-roots.md
+++ b/SPEC/Libraries/hex-real-roots.md
@@ -282,15 +282,19 @@ is required. What the depth budget *suffices for* differs:
   Obreshkoff two-circle theorem; Krandick-Mehlhorn 2006) shows that
   once an interval's width is below a constant multiple of `sep(p)`
   (the minimum distance between distinct complex roots), its
-  variation count is `0` or `1`: the two-circle region around a
-  short interval is too small to hold two roots, and it cannot hold a
-  single non-real root because it is symmetric about the real axis
-  and non-real roots arrive in conjugate pairs. So
-  `isolateDescartes? p ≠ none` for squarefree `p` at this depth. The
-  two-circle theorem is formalised nowhere yet, and this statement is
-  the one deferred theorem of the companion
-  (`isolateDescartes?_isSome`): no other theorem depends on it, and
-  the driver's completeness does not wait for it.
+  variation count is `0` or `1`, so `isolateDescartes? p ≠ none` for
+  squarefree `p` at this depth. The mechanism is the *λ-graded* sector
+  bound (not a general count bound — the reading "variation count ≤
+  number of roots in the two-circle region" is false): at most `λ`
+  roots outside the half-angle-`π/(λ+2)` sector force at most `λ` sign
+  variations. A short interval's two-circle region is too small to hold
+  two roots, and a lone non-real root there is excluded because the
+  region is symmetric about the real axis (conjugate pairs), so the
+  outside-sector count stays `≤ 1` and hence the variation count `≤ 1`.
+  This is now a theorem of the companion
+  (`isolateDescartes?_isSome`): it retires the Sturm fallback from the
+  runtime story, though no other theorem depends on it and the driver's
+  completeness never waited for it.
 
 Note the separation quantity is over **complex** roots in both cases.
 A real-gap bound is not enough for the Descartes engine: a conjugate
@@ -462,15 +466,19 @@ Per [SPEC/testing.md](../testing.md), fixtures are tiered into
 External oracles, in role order: SageMath (`real_roots`),
 python-flint (`fmpz_poly` real root API), FLINT/Arb.
 
-**Descartes-engine checks, until the deferred theorem lands.** The
-conformance suite must additionally assert, on every fixture in every
-profile it runs, that `isolateDescartes?` returns `some` and agrees
-with `isolate?`. These assertions stand in for the deferred theorem
-`isolateDescartes?_isSome`: they are how the repository notices if
-the fast engine ever falls back in practice. The change that proves
-`isolateDescartes?_isSome` in the companion **must delete these
-assertions** in the same PR; from that point the theorem carries the
-claim and re-testing it per fixture is noise.
+**Descartes-engine checks (retired).** While
+`isolateDescartes?_isSome` was open, the conformance suite asserted on
+every fixture that `isolateDescartes?` returns `some` and agrees with
+`isolate?`, standing in for the theorem. Now that
+`isolateDescartes?_isSome` is proven in the companion, those stand-ins
+are retired: the theorem carries the claim, and re-testing it per
+fixture is noise. The suite keeps only the ordinary input-contract
+checks — the `isolateDescartes? = none` rejection of the zero and
+non-squarefree inputs (which test the engine's classification of
+inadmissible input, not the termination theorem) — and the executable
+`mobiusTransform`/`descartesVar` transform tests. `EmitFixtures` emits
+from `isolate?` alone; the cross-engine agreement check it once carried
+is removed with the same change.
 
 ## Complexity contract
 

--- a/conformance/HexRealRoots/Conformance.lean
+++ b/conformance/HexRealRoots/Conformance.lean
@@ -44,9 +44,6 @@ Covered properties:
   root exactly at the included upper endpoint), so a real root sits in each
   half-open interval.
 - Emitted isolations are ordered and pairwise disjoint (`upperᵢ ≤ lowerᵢ₊₁`).
-- The Descartes engine returns `some` and agrees with `isolate?` on the exact
-  interval endpoints (the SPEC-mandated stand-in for `isolateDescartes?_isSome`,
-  see the deletion note below).
 - The Sturm engine returns `some` and agrees with `isolate?` on the isolation
   *count* (the intervals themselves need not coincide, and do not for
   `x³ − x − 1`).
@@ -196,14 +193,15 @@ For each fixture: the exact interval endpoints of `isolate?` (a human-readable
 regression pin, cross-checked against `python-flint` in the oracle PR); the
 independent teeth that make the pin more than a determinism check — the emitted
 count equals the mathematically known real-root count `rootCount`, every
-interval brackets a real root, and the intervals are ordered and disjoint; the
-mandated Descartes stand-in assertions; and the Sturm engine's count agreement.
+interval brackets a real root, and the intervals are ordered and disjoint; and
+the Sturm engine's count agreement.
 
-**Descartes stand-in deletion note.** The `isolateDescartes?_isSome` /
-`endpoints (isolateDescartes? p) = endpoints (isolate? p)` assertions below
-stand in for the deferred companion theorem `isolateDescartes?_isSome`. The PR
-that proves that theorem in `HexRealRootsMathlib` MUST delete these Descartes
-assertions in the same change; from then the theorem carries the claim. -/
+The Descartes engine's per-fixture `some`/agreement stand-ins are retired: the
+companion theorem `HexRealRootsMathlib.isolateDescartes?_isSome` now carries the
+claim that `isolateDescartes?` never falls back on nonzero square-free input, so
+re-testing it here is noise. The zero / non-square-free `isolateDescartes? =
+none` rejections below stay: they test the engine's input-contract
+classification, not the termination theorem. -/
 
 /-- Assert the shared per-fixture invariants, given the expected `isolate?`
 endpoints and the known real-root count `n`. Bundled so each fixture is one
@@ -215,8 +213,6 @@ private def isolatesAs (p : ZPoly) (expected : Array (Dyadic × Dyadic)) (n : Na
   (isoCount (isolate? p) == some n) && (rootCount p == n) &&
   -- Each interval brackets a real root; the whole run is ordered and disjoint.
   allBracket (isolate? p) && ((endpoints (isolate? p)).elim false sortedDisjoint) &&
-  -- Descartes stand-in: returns `some` and agrees with `isolate?` exactly.
-  (isolateDescartes? p).isSome && (endpoints (isolateDescartes? p) == endpoints (isolate? p)) &&
   -- Sturm engine: returns `some` and agrees on the isolation count.
   (isolateSturm? p).isSome && (isoCount (isolateSturm? p) == some n)
 
@@ -235,28 +231,28 @@ private def isolatesAs (p : ZPoly) (expected : Array (Dyadic × Dyadic)) (n : Na
   #[(di 0, di 1), (di 1, di 2), (di 2, di 3), (di 3, di 4),
     (di 4, di 5), (di 5, di 6), (di 6, di 7), (di 7, di 8)] 8
 
--- The Sturm engine's intervals need NOT coincide with the Descartes engine's:
--- for `x³ − x − 1` the Sturm search emits the whole initial interval `(−4, 4]`
--- (the count is already `1`, so it never bisects) while the Descartes search
+-- The Sturm engine's intervals need NOT coincide with the driver's: for
+-- `x³ − x − 1` the Sturm search emits the whole initial interval `(−4, 4]` (the
+-- count is already `1`, so it never bisects) while `isolate?` (Descartes-first)
 -- narrows to `(0, 4]`. Only the count is invariant across engines.
 #guard endpoints (isolateSturm? cubicSingle) = some #[(di (-4), di 4)]
-#guard endpoints (isolateDescartes? cubicSingle) = some #[(di 0, di 4)]
+#guard endpoints (isolate? cubicSingle) = some #[(di 0, di 4)]
 
 /-! ### Edge cases: zero, constant, non-square-free. -/
 
--- The zero polynomial is rejected by every engine.
+-- The zero polynomial is rejected by every engine (input-contract classification,
+-- independent of the termination theorem).
 #guard isolate? zeroPoly = none
 #guard isolateSturm? zeroPoly = none
 #guard isolateDescartes? zeroPoly = none
 
 -- A nonzero constant isolates with zero roots (empty chain, `rootCount = 0`),
--- through the full per-fixture invariant bundle including the Descartes
--- stand-in.
+-- through the full per-fixture invariant bundle.
 #guard isolatesAs const7 #[] 0
 
--- Non-square-free rejection: both engines and the driver decline, and the
--- square-free core (`x² − 1`, from `(x − 1)²(x + 1)`) isolates its two roots,
--- again through the full bundle (Descartes stand-in included).
+-- Non-square-free rejection: both engines and the driver decline (input-contract
+-- classification), and the square-free core (`x² − 1`, from `(x − 1)²(x + 1)`)
+-- isolates its two roots through the full bundle.
 #guard isolate? nonSquareFree = none
 #guard isolateSturm? nonSquareFree = none
 #guard isolateDescartes? nonSquareFree = none

--- a/conformance/HexRealRoots/EmitFixtures.lean
+++ b/conformance/HexRealRoots/EmitFixtures.lean
@@ -27,16 +27,15 @@ Operations covered:
   dyadic endpoint is encoded as `[num, exp]` with value `num · 2^(−exp)`
   (`Dyadic.zero` as `[0, 0]`, `Dyadic.ofOdd n k _` as `[n, k]`).
 * `isolate_none` — value `true` for the rejection cases (the zero
-  polynomial and non-square-free inputs), where both engines decline.
+  polynomial and non-square-free inputs), where the driver declines.
 
-**Descartes-engine cross-check (the deferred-theorem stand-in).**  Per
-`SPEC/Libraries/hex-real-roots.md` §"Conformance fixtures", until the
-companion proves `isolateDescartes?_isSome`, every fixture asserts that
-the fast Descartes engine does not fall back and agrees with the Sturm
-engine.  This driver computes *both* engines on every case and
-`throw`s (exiting non-zero) on any disagreement: for a square-free case
-both engines must return `some` with identical isolating intervals; for
-a rejection case both must return `none`.
+Records are emitted from the single top-level driver `Hex.isolate? p`.
+The Descartes/Sturm cross-engine agreement check this driver once
+carried (the executable stand-in for the termination theorem) is
+retired now that `HexRealRootsMathlib.isolateDescartes?_isSome` is
+proven; `isolate?` is Descartes-first, so on a square-free input its
+output is exactly the Descartes engine's, and the emitted stream is
+unchanged.
 
 **ci tier.**  Thirty degree-15 polynomials with coefficients in
 `[−9, 9]` drawn from the POSIX `rand` LCG
@@ -69,55 +68,27 @@ private def isoRows {p : ZPoly} (res : RealRootIsolations p) : List (List Int) :
   res.isolations.toList.map fun iso =>
     dyadicPair iso.interval.lower ++ dyadicPair iso.interval.upper
 
-private def dmax (a b : Dyadic) : Dyadic := if a < b then b else a
-private def dmin (a b : Dyadic) : Dyadic := if a < b then a else b
-
-/-- Two half-open dyadic intervals `(a₁, b₁]` and `(a₂, b₂]` overlap
-iff `max a₁ a₂ < min b₁ b₂`.  Two isolations of the same real root
-always overlap (both half-open intervals contain that root), so this is
-the cross-engine agreement test: the Descartes and Sturm runs isolate
-the same roots in the same order exactly when their `i`-th intervals
-overlap. -/
-private def overlaps (i₁ i₂ : DyadicInterval) : Bool :=
-  decide (dmax i₁.lower i₂.lower < dmin i₁.upper i₂.upper)
-
-/-- The Descartes and Sturm runs agree: same number of isolations (the
-`complete` invariant guarantees both equal `rootCount p`), and the
-`i`-th intervals overlap, so both pin the same root at each position. -/
-private def enginesAgree {p : ZPoly} (dr sr : RealRootIsolations p) : Bool :=
-  let di := dr.isolations.toList.map (·.interval)
-  let si := sr.isolations.toList.map (·.interval)
-  di.length == si.length && (di.zip si).all fun (a, b) => overlaps a b
-
-/-- Emit one case.  When `squarefree`, both engines must return `some`
-with identical intervals; the run is emitted from the Descartes engine's
-output (which, for a square-free input, equals `isolate? p`).  Otherwise
-both engines must return `none` and the case is a rejection.  Any
-deviation `throw`s, exiting non-zero — the Descartes-engine stand-in for
-the deferred termination theorem. -/
+/-- Emit one case from the top-level driver `isolate? p`.  When
+`squarefree`, `isolate?` must return `some` (guaranteed by
+`isolate?_isSome`); the run is emitted from its output.  Otherwise it
+must return `none` and the case is a rejection.  Any deviation `throw`s,
+exiting non-zero. -/
 private def emitCase (id : String) (coeffs : List Int) (squarefree : Bool) : IO Unit := do
   emitPolyFixture lib id coeffs
   let p : ZPoly := DensePoly.ofCoeffs coeffs.toArray
-  let d := isolateDescartes? p
-  let s := isolateSturm? p
   if squarefree then
-    match d, s with
-    | some dr, some sr =>
-      unless enginesAgree dr sr do
-        throw <| IO.userError
-          s!"{lib}/{id}: Descartes and Sturm engines isolate different roots"
+    match isolate? p with
+    | some r =>
       emitResult lib id "root_count" (toString (rootCount p))
-      emitResult lib id "isolations" (intMatrixValue (isoRows dr))
-    | _, _ =>
-      throw <| IO.userError
-        s!"{lib}/{id}: engine fallback (descartes.isSome={d.isSome}, sturm.isSome={s.isSome})"
+      emitResult lib id "isolations" (intMatrixValue (isoRows r))
+    | none =>
+      throw <| IO.userError s!"{lib}/{id}: isolate? fell back to none on a square-free input"
   else
-    match d, s with
-    | none, none =>
+    match isolate? p with
+    | none =>
       emitResult lib id "isolate_none" "true"
-    | _, _ =>
-      throw <| IO.userError
-        s!"{lib}/{id}: expected both engines to reject (descartes.isSome={d.isSome}, sturm.isSome={s.isSome})"
+    | some _ =>
+      throw <| IO.userError s!"{lib}/{id}: expected isolate? to reject a non-square-free input"
 
 /-! ## SPEC core fixtures. -/
 


### PR DESCRIPTION
This PR proves `HexRealRootsMathlib.isolateDescartes?_isSome`, that the Descartes real-root isolation engine returns `some` on every nonzero square-free input, so the runtime never needs the Sturm fallback. With it the `HexRealRootsMathlib` companion is fully sorry-free; the theorem's axiom audit is `[propext, Classical.choice, Quot.sound]` (no `sorry`, no `native_decide`, no added axioms).

The proof mirrors the Sturm engine's `sturmVisit_spec`/`isolateSturm?_isSome`. Each node's Descartes variation count `V` equals `signVariations` of the Möbius transform; the Descartes parity exports pin the open-interval root count exactly when `V` is 0 or 1, and the exact endpoint test settles `p(b) = 0`, so the half-open Sturm count is computed exactly and every candidate certifies (count 1) while every discard emits `#[]` (count 0), needing no width budget. At the depth budget the two bisecting rows are refuted: a `V = 1` node with `p(b) = 0` is a Sturm count of 2 against `sturmCount_le_one`, and a `V ≥ 2` node yields (via `roots_mobiusPoly` on the complex cast and `not_inTwoCircle_iff_mem_sector`) two distinct roots of `p` inside the two-circle region, which is enclosed in a ball of radius `√3·(b−a)/2` and so holds roots closer than the Mahler separation `sepPrec_separates'` permits. Square-freeness supplies distinctness. New supporting lemmas are `mobiusPoly_map` (ring-hom commutation of the transform) and `TwoCircle.mem_sector`; the engine-agnostic Drivers helpers are made public for reuse.

The two-circle theorem is corrected everywhere it was paraphrased as a general count bound. The true statement is λ-graded: at most λ complex roots outside the half-angle-`π/(λ+2)` sector force at most λ sign variations. The naive reading "variation count ≤ number of roots in the two-circle region" is false, with counterexample `(X²+X+1)·(X²−(3/2)X+1)` (four sign variations, two roots outside the sector) already recorded in `TwoCircleSector.lean`. The PR needs only the two lowest graded cases and rewrites the `TwoCircle` module docstring, the umbrella docstring, and the SPEC echoes in `SPEC/Libraries/hex-real-roots.md` (the Termination section) and `SPEC/Libraries/hex-real-roots-mathlib.md` (the formerly-deferred section, now stating what was proven and dropping the "no formalisation in any proof assistant" and "must delete the conformance assertions" obligations, which this change fulfils).

The conformance stand-ins for the theorem are retired in the same change, as the SPEC mandated. The per-fixture `(isolateDescartes? p).isSome` and endpoint-agreement conjuncts are dropped from `Conformance.lean`, and `EmitFixtures.lean` is reduced to the single top-level `isolate?` driver (its cross-engine agreement check, `enginesAgree`/`overlaps`, is removed). Since `isolate?` is Descartes-first and now provably succeeds on square-free input, the emitted JSONL is byte-identical to the committed `realroots.jsonl` (verified by regenerating and diffing). I read the SPEC's deletion mandate ("the conformance suite") to cover this driver's cross-engine check as well.

Judgement call on the rejection guards: the zero and non-square-free `isolateDescartes? = none` guards stay. They test the engine's input-contract classification of inadmissible input, not the termination theorem (which concerns nonzero square-free input returning `some` and says nothing about these cases), so they are ordinary conformance rather than a re-test of the discharged theorem.

CI is the test plan: `HexRealRootsMathlib` and `HexConformance` build green with zero `sorry` warnings, `check_dag.py` and `conformance_targets.py --check` pass, and the emit/diff is byte-identical. python-flint is not installed locally, so the oracle cross-check runs in CI.

🤖 Prepared with Claude Code