### PR TITLE
chore: real-roots deprecation and oracle-wording cleanups

### DIFF
--- a/HexRealRootsMathlib/Separation.lean
+++ b/HexRealRootsMathlib/Separation.lean
@@ -551,7 +551,7 @@ theorem sepPrec_separates (p : Hex.ZPoly)
   have hf0 : f ≠ 0 := by
     rw [hfmap, ne_eq, Polynomial.map_eq_zero_iff (RingHom.injective_int _)]; exact hp'0
   -- Splitting and separability over `ℂ`.
-  have hsplit : f.Splits := by rw [hfmap]; exact IsAlgClosed.splits_codomain p'
+  have hsplit : f.Splits := IsAlgClosed.splits f
   have hcomp : (algebraMap ℚ ℂ).comp (Int.castRingHom ℚ) = Int.castRingHom ℂ :=
     RingHom.ext_int _ _
   have hsepℂ : f.Separable := by

--- a/conformance/HexRealRootsMathlib/Conformance.lean
+++ b/conformance/HexRealRootsMathlib/Conformance.lean
@@ -10,8 +10,8 @@ import HexRealRootsMathlib.Isolations
 /-!
 Companion conformance checks for `HexRealRootsMathlib`.
 
-Oracle: core uses the **proven correspondence theorems** as the algebraic
-oracle. `rootCount_eq_card_roots` (and `squareFreeRat_iff` feeding its
+Oracle: none; checked against Mathlib root counts via the proven
+correspondence theorems. `rootCount_eq_card_roots` (and `squareFreeRat_iff` feeding its
 square-free hypothesis) is the bridge that ties the executable, computable
 `Hex.rootCount` to the noncomputable Mathlib `(toPolyℝ p).roots.card`. There is
 no external oracle profile: the two sides are pinned independently — the


### PR DESCRIPTION
This PR retires the deprecated IsAlgClosed.splits_codomain use in HexRealRootsMathlib/Separation.lean (the direct IsAlgClosed.splits form also drops a rewrite) and reword the companion conformance module's oracle docstring line to SPEC/testing.md's convention: Oracle none, checked against Mathlib root counts via the proven correspondence theorems. Both were recorded as post-campaign cleanups in the progress notes; the build is warning-free in the touched files.

🤖 Prepared with Claude Code
