### PR TITLE
chore: reconcile the HexLLLMathlib conformance-reviewed token

### DIFF
--- a/status/hex-lll-mathlib.conformance-reviewed
+++ b/status/hex-lll-mathlib.conformance-reviewed
@@ -1,1 +1,10 @@
-HexLLLMathlib Phase 3 conformance module is present and imported by the library umbrella.
+HexLLLMathlib Phase 3 conformance was reviewed and its module landed in
+#2581 (HexLLLMathlib/Conformance.lean, imported from the umbrella). That
+module was later deliberately deleted in #3707 per the ceremonial-bridge
+Conformance ban added to SPEC/testing.md in #3700: bridge libraries
+expose proof-only equivalences with no runtime kernel to conform to, and
+every #guard in the deleted file was audited as either exercising a
+bridge function or duplicating coverage in the computational sibling
+HexLLL conformance module. This token records that history; the Phase 3
+review itself stands, and the absence of a HexLLLMathlib conformance
+module in-tree is intentional, not an omission.


### PR DESCRIPTION
This PR reconciles the stale attestation in status/hex-lll-mathlib.conformance-reviewed with the tree: the token still claimed the HexLLLMathlib conformance module is present and imported by the umbrella, but that module was deliberately deleted in https://github.com/kim-em/hex-dev/pull/3707 (strip ceremonial Hex*Mathlib Conformance files) per the ceremonial-bridge ban added to SPEC/testing.md in https://github.com/kim-em/hex-dev/pull/3700. The token now records that history explicitly so the point-in-time attestation matches reality: the Phase 3 review stands and the module's absence is intentional. Found during the hex-real-roots companion close-out review.

🤖 Prepared with Claude Code
