### PR TITLE
feat: ergonomic API for isolating real roots of a concrete polynomial

### DIFF
--- a/HexPolyMathlib/Basic.lean
+++ b/HexPolyMathlib/Basic.lean
@@ -267,6 +267,17 @@ theorem coeff_toPolynomial [Semiring R] [DecidableEq R] (p : Hex.DensePoly R) (n
       have hne : i ≠ n := by omega
       simp [Polynomial.coeff_monomial, hne]
 
+/-- Horner-style evaluation bridge: evaluating `toPolynomial p` through a ring
+hom `f` at `x` is the degree-indexed sum `∑ f (p.coeff i) * x ^ i`. For a
+literal `ofCoeffs` array this unfolds via `Finset.sum_range_succ` into an
+explicit polynomial in `x`, which `ring`/`norm_num` can then discharge. -/
+theorem eval₂_toPolynomial {S : Type*} [CommSemiring R] [DecidableEq R] [CommSemiring S]
+    (f : R →+* S) (p : Hex.DensePoly R) (x : S) :
+    (toPolynomial p).eval₂ f x = ∑ i ∈ Finset.range p.size, f (p.coeff i) * x ^ i := by
+  unfold toPolynomial
+  rw [Polynomial.eval₂_finsetSum]
+  exact Finset.sum_congr rfl fun i _ => Polynomial.eval₂_monomial f x
+
 /-- `ofPolynomial` sends Mathlib's zero polynomial to the executable zero. -/
 @[simp, grind =]
 theorem ofPolynomial_zero [Semiring R] [DecidableEq R] :

--- a/HexPolyMathlib/Basic.lean
+++ b/HexPolyMathlib/Basic.lean
@@ -267,11 +267,11 @@ theorem coeff_toPolynomial [Semiring R] [DecidableEq R] (p : Hex.DensePoly R) (n
       have hne : i ≠ n := by omega
       simp [Polynomial.coeff_monomial, hne]
 
-/-- Horner-style evaluation bridge: evaluating `toPolynomial p` through a ring
-hom `f` at `x` is the degree-indexed sum `∑ f (p.coeff i) * x ^ i`. For a
-literal `ofCoeffs` array this unfolds via `Finset.sum_range_succ` into an
-explicit polynomial in `x`, which `ring`/`norm_num` can then discharge. -/
-theorem eval₂_toPolynomial {S : Type*} [CommSemiring R] [DecidableEq R] [CommSemiring S]
+/-- Coefficient-sum evaluation bridge: evaluating `toPolynomial p` through a ring
+hom `f` at `x` is the degree-indexed sum `∑ f (p.coeff i) * x ^ i`. For a literal
+`ofCoeffs` array this unfolds via `Finset.sum_range_succ` into an explicit
+polynomial in `x`, which `ring`/`norm_num` can then discharge. -/
+theorem eval₂_toPolynomial {S : Type*} [Semiring R] [DecidableEq R] [Semiring S]
     (f : R →+* S) (p : Hex.DensePoly R) (x : S) :
     (toPolynomial p).eval₂ f x = ∑ i ∈ Finset.range p.size, f (p.coeff i) * x ^ i := by
   unfold toPolynomial

--- a/HexRealRoots/Chain.lean
+++ b/HexRealRoots/Chain.lean
@@ -127,6 +127,21 @@ def sturmChain (p : ZPoly) : Array ZPoly :=
       let s₁ := primitivePart (DensePoly.derivative p)
       sturmChainAux p.size s₀ s₁ #[s₀, s₁]
 
+/-- A `decide`-checkable squarefreeness certificate: `p` has positive degree and
+the last entry of its Sturm chain is a nonzero constant (`size == 1`). When this
+is `true`, `p` is squarefree over `ℚ` — proved as
+`squareFreeRat_of_hasSquarefreeSturmChain` in the Mathlib companion, whence a
+concrete `SquareFreeRat p` is dischargeable by `by decide` on this test.
+
+This is a one-way certificate, not a decision procedure: it returns `false` on
+the zero polynomial and on nonzero constants (empty chain), even though
+`SquareFreeRat` is vacuously/trivially true there. -/
+@[expose]
+def hasSquarefreeSturmChain (p : ZPoly) : Bool :=
+  match (sturmChain p).toList.getLast? with
+  | some z => z.size == 1
+  | none   => false
+
 end ZPoly
 
 /-! Sanity checks (kept light; conformance lives in the shared
@@ -159,5 +174,12 @@ example : ZPoly.sturmChain (DensePoly.ofCoeffs #[(0 : Int), -1, 0, 1])
         DensePoly.ofCoeffs #[(-1 : Int), 0, 3],
         DensePoly.ofCoeffs #[(0 : Int), 1],
         DensePoly.ofCoeffs #[(1 : Int)]] := by decide
+
+-- The squarefree certificate: `x⁴ − 2` and `x³ − x` pass; a nonzero constant,
+-- the zero polynomial, and the non-squarefree `(x − 1)²` all fail.
+example : ZPoly.hasSquarefreeSturmChain (DensePoly.ofCoeffs #[(-2 : Int), 0, 0, 0, 1]) := by decide
+example : ZPoly.hasSquarefreeSturmChain (DensePoly.ofCoeffs #[(0 : Int), -1, 0, 1]) := by decide
+example : ZPoly.hasSquarefreeSturmChain (DensePoly.ofCoeffs #[(7 : Int)]) = false := by decide
+example : ZPoly.hasSquarefreeSturmChain (DensePoly.ofCoeffs #[(1 : Int), -2, 1]) = false := by decide
 
 end Hex

--- a/HexRealRootsMathlib/ChainCorrespond.lean
+++ b/HexRealRootsMathlib/ChainCorrespond.lean
@@ -74,6 +74,19 @@ theorem toPolynomial_toRatPoly (f : Hex.ZPoly) :
     Polynomial.coeff_map, coeff_toPolynomial]
   simp
 
+/-- Coefficients of the rational cast are the rational casts of the integer
+coefficients (the ℚ analogue of `coeff_toPolyℝ`). -/
+@[simp] theorem coeff_toPolyℚ (p : Hex.ZPoly) (n : Nat) :
+    (toPolyℚ p).coeff n = (p.coeff n : ℚ) := by
+  simp [toPolyℚ]
+
+/-- Evaluating the rational cast at `x` is the degree-indexed sum of the integer
+coefficients cast to `ℚ` (the ℚ analogue of `eval_toPolyℝ`). -/
+theorem eval_toPolyℚ (p : Hex.ZPoly) (x : ℚ) :
+    (toPolyℚ p).eval x = ∑ i ∈ Finset.range p.size, (p.coeff i : ℚ) * x ^ i := by
+  rw [toPolyℚ, Polynomial.eval_map, HexPolyMathlib.eval₂_toPolynomial]
+  simp
+
 /-- The rational cast of a nonzero executable polynomial is nonzero. -/
 theorem toPolyℚ_ne_zero {f : Hex.ZPoly} (hf : f ≠ 0) : toPolyℚ f ≠ 0 := by
   rw [toPolyℚ, Ne, Polynomial.map_eq_zero_iff (RingHom.injective_int (Int.castRingHom ℚ))]
@@ -989,6 +1002,86 @@ private theorem chainList_last_unit :
         exact ih cur (-(Hex.ZPoly.primitivePart (Hex.ZPoly.spem prev cur)))
           (neg_primitivePart_ne_zero hr) (by omega) hco' z hz
 
+/-! ### Converse: a terminal-constant chain forces coprime seeds -/
+
+/-- **Reverse of `coprime_step`.** The three-term relation
+`C c₀ · a = Q · b − C k · c'` (with `k ≠ 0`) transports `IsCoprime b c'` *back* to
+`IsCoprime a b`: solving the relation for `c'` and substituting into a Bezout
+combination for `(b, c')` yields one for `(a, b)`. -/
+private theorem coprime_step_rev {a b c' : Polynomial ℝ} {c₀ k : ℝ} {Q : Polynomial ℝ}
+    (hk : k ≠ 0)
+    (hrel : Polynomial.C c₀ * a = Q * b - Polynomial.C k * c')
+    (h : IsCoprime b c') : IsCoprime a b := by
+  obtain ⟨u, v, huv⟩ := h
+  have hCk : Polynomial.C k⁻¹ * Polynomial.C k = 1 := by
+    rw [← Polynomial.C_mul, inv_mul_cancel₀ hk, Polynomial.C_1]
+  have hc' : c' = Polynomial.C k⁻¹ * (Q * b - Polynomial.C c₀ * a) := by
+    have hkc' : Polynomial.C k * c' = Q * b - Polynomial.C c₀ * a := by rw [hrel]; ring
+    calc c' = Polynomial.C k⁻¹ * (Polynomial.C k * c') := by rw [← mul_assoc, hCk, one_mul]
+      _ = Polynomial.C k⁻¹ * (Q * b - Polynomial.C c₀ * a) := by rw [hkc']
+  refine ⟨-(v * Polynomial.C k⁻¹ * Polynomial.C c₀), u + v * Polynomial.C k⁻¹ * Q, ?_⟩
+  calc -(v * Polynomial.C k⁻¹ * Polynomial.C c₀) * a
+        + (u + v * Polynomial.C k⁻¹ * Q) * b
+      = u * b + v * (Polynomial.C k⁻¹ * (Q * b - Polynomial.C c₀ * a)) := by ring
+    _ = u * b + v * c' := by rw [← hc']
+    _ = 1 := huv
+
+/-- **A terminal-constant chain has coprime seeds.** If the last element of
+`prev :: cur :: chainList fuel prev cur` is a unit of `ℝ[X]` (its real cast), then
+the seed pair `(prev, cur)` is coprime: a unit is coprime to its predecessor, and
+`coprime_step_rev` walks that coprimality back to the front. The converse of
+`chainList_last_unit`. -/
+private theorem chainList_seeds_coprime :
+    ∀ (fuel : ℕ) (prev cur : Hex.ZPoly), cur ≠ 0 →
+      (cur.degree?).getD 0 < fuel →
+      (∀ z, (prev :: cur :: chainList fuel prev cur).getLast? = some z →
+        IsUnit (toPolyℝ z)) →
+      IsCoprime (toPolyℝ prev) (toPolyℝ cur) := by
+  intro fuel
+  induction fuel with
+  | zero => intro prev cur _ hfuel _; omega
+  | succ fuel ih =>
+      intro prev cur hcur hfuel hunit
+      by_cases h : (Hex.ZPoly.spem prev cur).isZero
+      · -- The loop stops: the chain is `[prev, cur]`, so `cur` is the terminal unit.
+        have hz : (prev :: cur :: chainList (fuel + 1) prev cur).getLast? = some cur := by
+          rw [chainList, if_pos h]; rfl
+        obtain ⟨w, hw⟩ := hunit cur hz
+        exact ⟨0, ↑w⁻¹, by rw [← hw]; simp⟩
+      · have hr : Hex.ZPoly.spem prev cur ≠ 0 := fun hh => h (isZero_iff_eq_zero.mpr hh)
+        obtain ⟨c₀, k, Q, hc₀, hk, hrel⟩ := chain_step hcur hr
+        have hnext_ne : -(Hex.ZPoly.primitivePart (Hex.ZPoly.spem prev cur)) ≠ 0 :=
+          neg_primitivePart_ne_zero hr
+        have hdeg1 : 1 ≤ (cur.degree?).getD 0 := one_le_degree_of_spem_ne_zero hcur hr
+        have hppdeg : ((Hex.ZPoly.primitivePart (Hex.ZPoly.spem prev cur)).degree?).getD 0
+            = ((Hex.ZPoly.spem prev cur).degree?).getD 0 := by
+          have h2 := congrArg Polynomial.natDegree
+            (toPolyℝ_eq_C_content_mul_primitivePart (Hex.ZPoly.spem prev cur))
+          rw [Polynomial.natDegree_C_mul (ne_of_gt (content_real_pos hr)),
+            natDegree_toPolyℝ, natDegree_toPolyℝ] at h2
+          omega
+        have hnextdeg :
+            (((-(Hex.ZPoly.primitivePart (Hex.ZPoly.spem prev cur))).degree?).getD 0)
+              = ((Hex.ZPoly.spem prev cur).degree?).getD 0 := by
+          rw [← natDegree_toPolyℝ, toPolyℝ_neg, Polynomial.natDegree_neg,
+            natDegree_toPolyℝ, hppdeg]
+        have hdr : ((Hex.ZPoly.spem prev cur).degree?).getD 0 < (cur.degree?).getD 0 := by
+          rcases spem_degree hcur hdeg1 with h0 | hlt
+          · exact absurd h0 hr
+          · exact hlt
+        have hunit' : ∀ z, (cur :: -(Hex.ZPoly.primitivePart (Hex.ZPoly.spem prev cur))
+              :: chainList fuel cur (-(Hex.ZPoly.primitivePart (Hex.ZPoly.spem prev cur)))).getLast?
+              = some z → IsUnit (toPolyℝ z) := by
+          intro z hz
+          apply hunit z
+          rw [chainList, if_neg h, List.getLast?_cons_cons]
+          exact hz
+        have hco_tail : IsCoprime (toPolyℝ cur)
+            (toPolyℝ (-(Hex.ZPoly.primitivePart (Hex.ZPoly.spem prev cur)))) :=
+          ih cur (-(Hex.ZPoly.primitivePart (Hex.ZPoly.spem prev cur)))
+            hnext_ne (by omega) hunit'
+        exact coprime_step_rev (ne_of_gt hk) hrel hco_tail
+
 /-! ### Sign flanks at a simple zero -/
 
 /-- A real polynomial vanishing at `r` with positive derivative there is
@@ -1221,6 +1314,97 @@ theorem sturmChain_isSturmChain (p : Hex.ZPoly) (hp : 1 ≤ (p.degree?).getD 0)
     omega
   rw [sturmChain_toList p hp]
   exact isSturmChain_of_seeds _ _ _ hs₀0 hs₁0 hfuel hcop _ hγ hkey
+
+/-- **The Sturm squarefree certificate is sound.** If the executable
+`Hex.ZPoly.hasSquarefreeSturmChain p` is `true` — `p` has positive degree and the
+terminal element of its Sturm chain is a nonzero constant — then `p` is squarefree
+over `ℚ`. This is the converse packaging of `sturmChain_isSturmChain`: it lets a
+concrete `SquareFreeRat p` be discharged by `by decide` on the executable chain,
+sidestepping the non-kernel-reducible rational gcd inside `SquareFreeRat` itself. -/
+theorem squareFreeRat_of_hasSquarefreeSturmChain (p : Hex.ZPoly)
+    (h : Hex.ZPoly.hasSquarefreeSturmChain p = true) : Hex.ZPoly.SquareFreeRat p := by
+  unfold Hex.ZPoly.hasSquarefreeSturmChain at h
+  cases hlast : (Hex.ZPoly.sturmChain p).toList.getLast? with
+  | none => rw [hlast] at h; simp at h
+  | some z =>
+    rw [hlast] at h
+    have hzsize : z.size = 1 := by simpa using h
+    -- The chain is nonempty, so `p` has positive degree.
+    have hne : Hex.ZPoly.sturmChain p ≠ #[] := by
+      intro he; rw [he] at hlast; simp at hlast
+    have hp : 1 ≤ (p.degree?).getD 0 := by
+      rcases hd : p.degree? with _ | m
+      · exact absurd (by simp only [Hex.ZPoly.sturmChain, hd]) hne
+      · rcases m with _ | m'
+        · exact absurd (by simp only [Hex.ZPoly.sturmChain, hd]) hne
+        · simp
+    have hp0 : p ≠ 0 := by
+      intro hh; rw [hh] at hp; simp only [Hex.DensePoly.degree?_zero_getD] at hp; omega
+    have hnd : (toPolyℝ p).natDegree = (p.degree?).getD 0 := natDegree_toPolyℝ p
+    have hd0 : Hex.DensePoly.derivative p ≠ 0 := by
+      intro hh
+      have h2 : Polynomial.derivative (toPolyℝ p) = 0 := by
+        rw [← toPolyℝ_derivative, hh, toPolyℝ_zero]
+      have h3 := Polynomial.derivative_eq_zero.mp h2
+      omega
+    have hs₁0 : Hex.ZPoly.primitivePart (Hex.DensePoly.derivative p) ≠ 0 :=
+      primitivePart_ne_zero hd0
+    -- The terminal element is a nonzero constant, hence a unit of `ℝ[X]`.
+    have hzne : z ≠ 0 := by rintro rfl; simp at hzsize
+    have hzdeg : (z.degree?).getD 0 = 0 := by
+      rw [degree?_of_ne_zero hzne]; simp [hzsize]
+    have hzunit : IsUnit (toPolyℝ z) := by
+      have hne' : toPolyℝ z ≠ 0 := fun hh => hzne (toPolyℝ_eq_zero_iff.mp hh)
+      rw [Polynomial.isUnit_iff_degree_eq_zero, Polynomial.degree_eq_natDegree hne',
+        natDegree_toPolyℝ, hzdeg]; rfl
+    -- Seed coprimality by walking the terminal unit back to the front.
+    rw [sturmChain_toList p hp] at hlast
+    have hfuel : ((Hex.ZPoly.primitivePart (Hex.DensePoly.derivative p)).degree?).getD 0
+        < p.size := by
+      have hc₁ : (0:ℝ) < ((Hex.ZPoly.content (Hex.DensePoly.derivative p) : Int) : ℝ) :=
+        content_real_pos hd0
+      have hdecomp₁ := toPolyℝ_eq_C_content_mul_primitivePart (Hex.DensePoly.derivative p)
+      have hdp : ((Hex.DensePoly.derivative p).degree?).getD 0 < (p.degree?).getD 0 := by
+        rw [← natDegree_toPolyℝ, ← natDegree_toPolyℝ, toPolyℝ_derivative]
+        exact Polynomial.natDegree_derivative_lt (by omega)
+      have hpp : ((Hex.ZPoly.primitivePart (Hex.DensePoly.derivative p)).degree?).getD 0
+          = ((Hex.DensePoly.derivative p).degree?).getD 0 := by
+        have h3 := congrArg Polynomial.natDegree hdecomp₁
+        rw [Polynomial.natDegree_C_mul (ne_of_gt hc₁), natDegree_toPolyℝ,
+          natDegree_toPolyℝ] at h3
+        omega
+      have h4 : p.degree? = some (p.size - 1) := degree?_of_ne_zero hp0
+      rw [h4] at hdp
+      simp only [Option.getD_some] at hdp
+      omega
+    have hcop_seeds : IsCoprime (toPolyℝ (Hex.ZPoly.primitivePart p))
+        (toPolyℝ (Hex.ZPoly.primitivePart (Hex.DensePoly.derivative p))) :=
+      chainList_seeds_coprime p.size _ _ hs₁0 hfuel (by
+        intro z' hz'
+        rw [hlast] at hz'
+        obtain rfl := Option.some.inj hz'
+        exact hzunit)
+    -- Lift seed coprimality to `p` and its derivative by unit (content) scaling.
+    have hcop_p : IsCoprime (toPolyℝ p) (Polynomial.derivative (toPolyℝ p)) := by
+      have hd₀ := toPolyℝ_eq_C_content_mul_primitivePart p
+      have hd₁ : Polynomial.derivative (toPolyℝ p)
+          = Polynomial.C ((Hex.ZPoly.content (Hex.DensePoly.derivative p) : Int) : ℝ)
+              * toPolyℝ (Hex.ZPoly.primitivePart (Hex.DensePoly.derivative p)) := by
+        rw [← toPolyℝ_derivative]
+        exact toPolyℝ_eq_C_content_mul_primitivePart (Hex.DensePoly.derivative p)
+      have hu0 : IsUnit (Polynomial.C ((Hex.ZPoly.content p : Int) : ℝ)) :=
+        isUnit_C.mpr (isUnit_iff_ne_zero.mpr (ne_of_gt (content_real_pos hp0)))
+      have hu1 : IsUnit (Polynomial.C ((Hex.ZPoly.content (Hex.DensePoly.derivative p) : Int) : ℝ)) :=
+        isUnit_C.mpr (isUnit_iff_ne_zero.mpr (ne_of_gt (content_real_pos hd0)))
+      rw [hd₁, hd₀]
+      exact (isCoprime_mul_unit_left_left hu0 _ _).mpr
+        ((isCoprime_mul_unit_left_right hu1 _ _).mpr hcop_seeds)
+    -- Separability over `ℝ`, reflected to `ℚ`, gives squarefreeness.
+    have hsep_ℝ : (toPolyℝ p).Separable := (Polynomial.separable_def (toPolyℝ p)).mpr hcop_p
+    have hmap : toPolyℝ p = (toPolyℚ p).map (algebraMap ℚ ℝ) := by
+      rw [toPolyℝ, toPolyℚ, Polynomial.map_map]; congr 1
+    have hsep_ℚ : (toPolyℚ p).Separable := (separable_map (algebraMap ℚ ℝ)).mp (hmap ▸ hsep_ℝ)
+    exact (squareFreeRat_iff p hp0).mpr hsep_ℚ.squarefree
 
 /-! ### Consequences: the executable counts equal Mathlib root counts -/
 

--- a/HexRealRootsMathlib/Isolations.lean
+++ b/HexRealRootsMathlib/Isolations.lean
@@ -230,6 +230,25 @@ theorem RealRootIsolations.isolates (hp0 : p ≠ 0)
       exact hP0 (by rw [hC, hc0, Polynomial.C_0])
     · exact isolates_of_degree_pos (by simp [hd]) hp out
 
+/-- Dot-notation alias in the `Hex` namespace for
+`HexRealRootsMathlib.RealRootIsolation.exists_unique_root`, so
+`iso.exists_unique_root` resolves directly on a `Hex.RealRootIsolation`. -/
+theorem _root_.Hex.RealRootIsolation.exists_unique_root
+    (hp : Hex.ZPoly.SquareFreeRat p) (iso : Hex.RealRootIsolation p) :
+    ∃! r : ℝ, (toPolyℝ p).IsRoot r ∧
+      Dyadic.toReal iso.interval.lower < r ∧ r ≤ Dyadic.toReal iso.interval.upper :=
+  HexRealRootsMathlib.RealRootIsolation.exists_unique_root hp iso
+
+/-- Dot-notation alias in the `Hex` namespace for
+`HexRealRootsMathlib.RealRootIsolations.isolates`, so `out.isolates` resolves
+directly on a `Hex.RealRootIsolations`. -/
+theorem _root_.Hex.RealRootIsolations.isolates (hp0 : p ≠ 0)
+    (hp : Hex.ZPoly.SquareFreeRat p) (out : Hex.RealRootIsolations p) :
+    ∀ r : ℝ, (toPolyℝ p).IsRoot r →
+      ∃! iso ∈ out.isolations.toList,
+        Dyadic.toReal iso.interval.lower < r ∧ r ≤ Dyadic.toReal iso.interval.upper :=
+  HexRealRootsMathlib.RealRootIsolations.isolates hp0 hp out
+
 end
 
 end HexRealRootsMathlib

--- a/HexRealRootsMathlib/Separation.lean
+++ b/HexRealRootsMathlib/Separation.lean
@@ -69,6 +69,17 @@ theorem toRat_shiftLeft (x : Dyadic) (i : Int) :
       show -(k - i) = -k + i by ring, zpow_add₀ (by norm_num)]
     ring
 
+/-- `toRat` turns a right shift into multiplication by a negative power of two. -/
+theorem toRat_shiftRight (x : Dyadic) (i : Int) :
+    (x >>> i).toRat = x.toRat * (2 : ℚ) ^ (-i) := by
+  cases x with
+  | zero => simp [HShiftRight.hShiftRight, Dyadic.shiftRight]
+  | ofOdd n k hn =>
+    show (Dyadic.ofOdd n (k + i) hn).toRat = _
+    rw [Dyadic.toRat_ofOdd_eq_mul_two_pow, Dyadic.toRat_ofOdd_eq_mul_two_pow,
+      show -(k + i) = -k + -i by ring, zpow_add₀ (by norm_num)]
+    ring
+
 /-- The real value of an integer dyadic is the integer cast. -/
 @[simp] theorem toReal_ofInt (n : Int) : Dyadic.toReal (Dyadic.ofInt n) = (n : ℝ) := by
   unfold Dyadic.toReal
@@ -83,6 +94,23 @@ theorem toRat_shiftLeft (x : Dyadic) (i : Int) :
   rw [toRat_shiftLeft, h1, one_mul]
   push_cast
   norm_cast
+
+/-- The real value of a left shift is multiplication by a power of two. -/
+theorem toReal_shiftLeft (x : Dyadic) (i : Int) :
+    Dyadic.toReal (x <<< i) = Dyadic.toReal x * (2 : ℝ) ^ i := by
+  unfold Dyadic.toReal
+  rw [toRat_shiftLeft]; push_cast; ring
+
+/-- The real value of a right shift is multiplication by a negative power of two. -/
+theorem toReal_shiftRight (x : Dyadic) (i : Int) :
+    Dyadic.toReal (x >>> i) = Dyadic.toReal x * (2 : ℝ) ^ (-i) := by
+  unfold Dyadic.toReal
+  rw [toRat_shiftRight]; push_cast; ring
+
+/-- The real value of the dyadic `n / 2ⁱ` (an integer shifted right by `i` bits). -/
+@[simp] theorem toReal_ofInt_shiftRight (n i : Int) :
+    Dyadic.toReal (Dyadic.ofInt n >>> i) = (n : ℝ) * (2 : ℝ) ^ (-i) := by
+  rw [toReal_shiftRight, toReal_ofInt]
 
 /-- `ceilLog2Nat m` is a base-two ceiling: `m ≤ 2 ^ (ceilLog2Nat m)`. -/
 theorem le_two_pow_ceilLog2Nat (m : Nat) : m ≤ 2 ^ Hex.ceilLog2Nat m := by
@@ -112,6 +140,16 @@ theorem range_foldl_max_eq_finset_sup (g : Nat → Nat) (m : Nat) :
 @[simp] theorem coeff_toPolyℝ (p : Hex.ZPoly) (n : Nat) :
     (toPolyℝ p).coeff n = (p.coeff n : ℝ) := by
   simp [toPolyℝ]
+
+/-- Evaluating the real cast at `x` is the degree-indexed sum of the integer
+coefficients cast to `ℝ`. For a literal `ofCoeffs` this unfolds via
+`Finset.sum_range_succ` into an explicit polynomial in `x`; combined with
+`Polynomial.IsRoot`, it turns a root goal into a plain equation
+`ring`/`norm_num` can discharge. -/
+theorem eval_toPolyℝ (p : Hex.ZPoly) (x : ℝ) :
+    (toPolyℝ p).eval x = ∑ i ∈ Finset.range p.size, (p.coeff i : ℝ) * x ^ i := by
+  rw [toPolyℝ, Polynomial.eval_map, HexPolyMathlib.eval₂_toPolynomial]
+  simp
 
 theorem natDegree_toPolyℝ (p : Hex.ZPoly) :
     (toPolyℝ p).natDegree = p.degree?.getD 0 := by

--- a/conformance/HexRealRootsMathlib/Conformance.lean
+++ b/conformance/HexRealRootsMathlib/Conformance.lean
@@ -212,5 +212,43 @@ private theorem squareFreeRat_linear : Hex.ZPoly.SquareFreeRat linear := by
 private theorem rootCount_x_sub_5 : Hex.rootCount linear = 1 := by
   rw [rootCount_eq_card_roots linear (by decide) squareFreeRat_linear, card_linear]
 
+/-! ### End-to-end ergonomics regression on `x⁴ − 2`.
+
+This exercises the caller-facing API added for isolating the real roots of a
+concrete polynomial, so the "one certified interval, `simp`" path stays green:
+
+* the Sturm squarefree certificate `squareFreeRat_of_hasSquarefreeSturmChain`,
+  discharged by `by decide` on the executable chain (no rational gcd);
+* the Horner `eval_toPolyℝ` bridge, turning `IsRoot` into `x⁴ − 2 = 0`;
+* the `toReal_ofInt_shiftRight` simp lemma for the `k / 2²⁰` dyadic endpoints;
+* the `Hex`-namespace dot-notation alias `RealRootIsolation.exists_unique_root`.
+
+The tight interval `(1246974/2²⁰, 1246975/2²⁰]` isolates `+2^{1/4}`. -/
+
+/-- `x⁴ − 2`; two real roots `±2^{1/4}`. -/
+private def quartic : Hex.ZPoly := Hex.DensePoly.ofCoeffs #[(-2 : Int), 0, 0, 0, 1]
+
+private theorem quartic_squarefree : Hex.ZPoly.SquareFreeRat quartic :=
+  squareFreeRat_of_hasSquarefreeSturmChain _ (by decide)
+
+/-- The refined, width-`2⁻²⁰` isolating interval for the positive root. -/
+private def quarticIsoTight : Hex.RealRootIsolation quartic :=
+  ⟨⟨Dyadic.ofInt 1246974 >>> (20 : Int), Dyadic.ofInt 1246975 >>> (20 : Int), by decide⟩,
+    by decide⟩
+
+private theorem quartic_isRoot_iff (x : ℝ) : (toPolyℝ quartic).IsRoot x ↔ x ^ 4 - 2 = 0 := by
+  rw [Polynomial.IsRoot, eval_toPolyℝ, show quartic.size = 5 from by decide]
+  simp only [Finset.sum_range_succ, Finset.sum_range_zero, quartic,
+    Hex.DensePoly.coeff_ofCoeffs]
+  norm_num
+  constructor <;> intro h <;> linarith
+
+private theorem quartic_root_pos_tight :
+    ∃! x : ℝ, x ^ 4 - 2 = 0 ∧ (1246974 : ℝ) / 2 ^ 20 < x ∧ x ≤ 1246975 / 2 ^ 20 := by
+  have h := quarticIsoTight.exists_unique_root quartic_squarefree
+  simp only [quarticIsoTight, toReal_ofInt_shiftRight, quartic_isRoot_iff] at h
+  convert h using 3
+  all_goals norm_num
+
 end Conformance
 end HexRealRootsMathlib

--- a/conformance/HexRealRootsMathlib/Conformance.lean
+++ b/conformance/HexRealRootsMathlib/Conformance.lean
@@ -219,7 +219,7 @@ concrete polynomial, so the "one certified interval, `simp`" path stays green:
 
 * the Sturm squarefree certificate `squareFreeRat_of_hasSquarefreeSturmChain`,
   discharged by `by decide` on the executable chain (no rational gcd);
-* the Horner `eval_toPolyℝ` bridge, turning `IsRoot` into `x⁴ − 2 = 0`;
+* the coefficient-sum `eval_toPolyℝ` bridge, turning `IsRoot` into `x⁴ − 2 = 0`;
 * the `toReal_ofInt_shiftRight` simp lemma for the `k / 2²⁰` dyadic endpoints;
 * the `Hex`-namespace dot-notation alias `RealRootIsolation.exists_unique_root`.
 


### PR DESCRIPTION
This PR adds the caller-facing bridges needed to go from a concrete `ZPoly` literal to an `∃!`-over-`ℝ` statement about its real roots without hand-rolled scaffolding.

It introduces `ZPoly.hasSquarefreeSturmChain`, a `decide`-checkable squarefreeness certificate (positive degree, terminal Sturm-chain entry a nonzero constant), with the soundness bridge `squareFreeRat_of_hasSquarefreeSturmChain` proved by walking the terminal unit back to coprime seeds via a reverse `coprime_step`, then content-unit scaling and separability reflected from `ℝ` to `ℚ`. This lets `SquareFreeRat p` be discharged by `by decide`, sidestepping the non-kernel-reducible rational gcd inside `SquareFreeRat`.

It adds a Horner evaluation bridge `eval₂_toPolynomial` with the `eval_toPolyℝ` / `eval_toPolyℚ` specializations and the missing `coeff_toPolyℚ`, so `IsRoot` on a literal rewrites into an explicit polynomial equation; the dyadic `toReal_shiftLeft` / `toReal_shiftRight` / `toReal_ofInt_shiftRight` simp lemmas for `k / 2ᵏ` endpoints; and `Hex`-namespace dot-notation aliases for `RealRootIsolation.exists_unique_root` and `RealRootIsolations.isolates`. An end-to-end `x⁴ − 2` conformance example covers the whole path.

🤖 Prepared with Claude Code