### PR TITLE
doc: record the Sturm squarefree certificate and cast bridges in the real-roots SPECs

### DIFF
--- a/SPEC/Libraries/hex-real-roots-mathlib.md
+++ b/SPEC/Libraries/hex-real-roots-mathlib.md
@@ -119,20 +119,20 @@ theorem sturmVarAt_eq (p : ZPoly) (x : Dyadic) : …
     `ℝ`. -/
 theorem squareFreeRat_iff : …
 
-/-- Converse of `sturmChain_isSturmChain`: a terminal-constant chain
-    forces `SquareFreeRat`, by walking the terminal unit back to coprime
-    seeds. Lets a concrete `SquareFreeRat p` be discharged by `by decide`
-    on the chain. -/
+/-- A terminal-constant Sturm chain forces `SquareFreeRat` — the reverse
+    of the terminal-unit step in `sturmChain_isSturmChain`, walked back to
+    coprime seeds. Lets a concrete `SquareFreeRat p` be discharged by
+    `by decide` on the chain. -/
 theorem squareFreeRat_of_hasSquarefreeSturmChain
-    (h : Hex.ZPoly.hasSquarefreeSturmChain p) : SquareFreeRat p
+    (p : ZPoly) (h : hasSquarefreeSturmChain p = true) : SquareFreeRat p
 ```
 
 `toPolyℝ` abbreviates the `hex-poly-z-mathlib` cast composed with
-`Polynomial.map (Int.castRingHom ℝ)`. Its coefficient/Horner bridges
-(`coeff_toPolyℝ` / `coeff_toPolyℚ`, `eval_toPolyℝ` / `eval_toPolyℚ`)
-rewrite a root goal on a literal `ofCoeffs` to an explicit polynomial
-equation, and `toReal_ofInt_shiftRight` normalizes `k / 2ᵏ` dyadic
-endpoints.
+`Polynomial.map (Int.castRingHom ℝ)`. Its coefficient/coefficient-sum
+bridges (`coeff_toPolyℝ` / `coeff_toPolyℚ`, `eval_toPolyℝ` /
+`eval_toPolyℚ`) rewrite a root goal on a literal `ofCoeffs` to an explicit
+polynomial equation, and `toReal_ofInt_shiftRight` normalizes `n / 2ⁱ`
+dyadic endpoints.
 
 ### Consequences for the executable counts
 
@@ -149,8 +149,9 @@ theorem rootCount_eq_card_roots (p : ZPoly) (hp : SquareFreeRat p) :
 ## Isolation semantics
 
 Everything below consumes only the decidable fields of the output
-structures plus the `SquareFreeRat p` hypothesis, so it holds for any
-`RealRootIsolations p` value, no matter which engine produced it.
+structures plus `SquareFreeRat p` (and, for `isolates`, `p ≠ 0`, since
+`SquareFreeRat 0` is vacuous), so it holds for any `RealRootIsolations p`
+value, no matter which engine produced it.
 
 ```lean
 /-- The witness means what it says: exactly one real root in the
@@ -162,7 +163,7 @@ theorem RealRootIsolation.exists_unique_root
 
 /-- A complete run captures every real root exactly once. -/
 theorem RealRootIsolations.isolates
-    (hp : SquareFreeRat p) (out : RealRootIsolations p) :
+    (hp0 : p ≠ 0) (hp : SquareFreeRat p) (out : RealRootIsolations p) :
     ∀ r : ℝ, (toPolyℝ p).IsRoot r →
       ∃! iso ∈ out.isolations.toList,
         (iso.interval.lower : ℝ) < r ∧ r ≤ (iso.interval.upper : ℝ)

--- a/SPEC/Libraries/hex-real-roots-mathlib.md
+++ b/SPEC/Libraries/hex-real-roots-mathlib.md
@@ -118,10 +118,21 @@ theorem sturmVarAt_eq (p : ZPoly) (x : Dyadic) : …
     executable gcd correspondence), and squarefreeness transfers to
     `ℝ`. -/
 theorem squareFreeRat_iff : …
+
+/-- Converse of `sturmChain_isSturmChain`: a terminal-constant chain
+    forces `SquareFreeRat`, by walking the terminal unit back to coprime
+    seeds. Lets a concrete `SquareFreeRat p` be discharged by `by decide`
+    on the chain. -/
+theorem squareFreeRat_of_hasSquarefreeSturmChain
+    (h : Hex.ZPoly.hasSquarefreeSturmChain p) : SquareFreeRat p
 ```
 
 `toPolyℝ` abbreviates the `hex-poly-z-mathlib` cast composed with
-`Polynomial.map (Int.castRingHom ℝ)`.
+`Polynomial.map (Int.castRingHom ℝ)`. Its coefficient/Horner bridges
+(`coeff_toPolyℝ` / `coeff_toPolyℚ`, `eval_toPolyℝ` / `eval_toPolyℚ`)
+rewrite a root goal on a literal `ofCoeffs` to an explicit polynomial
+equation, and `toReal_ofInt_shiftRight` normalizes `k / 2ᵏ` dyadic
+endpoints.
 
 ### Consequences for the executable counts
 
@@ -159,7 +170,9 @@ theorem RealRootIsolations.isolates
 
 The second follows from the first plus `ordered` (disjointness) and
 `complete` (counting): the isolations hold `rootCount p` distinct
-roots among them, and that is all the roots there are.
+roots among them, and that is all the roots there are. Both are also
+exported in the `Hex` namespace, so dot notation resolves on the
+executable structures (`iso.exists_unique_root`).
 
 ## Bounds and depths
 

--- a/SPEC/Libraries/hex-real-roots.md
+++ b/SPEC/Libraries/hex-real-roots.md
@@ -71,11 +71,12 @@ The last chain element is a nonzero constant exactly when `p` is
 squarefree (of positive degree).
 
 `hasSquarefreeSturmChain p` reads off exactly this: `true` when `p` has
-positive degree and the last chain element is a nonzero constant. It is
-`Decidable`, so a caller discharges the drivers' `SquareFreeRat p`
-obligation by `by decide` on the chain rather than the rational gcd
-(soundness bridge `squareFreeRat_of_hasSquarefreeSturmChain` in the
-companion). One-way: `false` on the zero polynomial and nonzero constants.
+positive degree and the last chain element is a nonzero constant. It is a
+reducible executable `Bool`, so a caller discharges the drivers'
+`SquareFreeRat p` obligation by `by decide` on the chain rather than the
+rational gcd (soundness bridge `squareFreeRat_of_hasSquarefreeSturmChain`
+in the companion). One-way: `false` on the zero polynomial and nonzero
+constants.
 
 **Input contract.** The drivers do not take hypotheses; they classify
 every input explicitly:

--- a/SPEC/Libraries/hex-real-roots.md
+++ b/SPEC/Libraries/hex-real-roots.md
@@ -70,6 +70,13 @@ pseudo-remainder scheme allows.
 The last chain element is a nonzero constant exactly when `p` is
 squarefree (of positive degree).
 
+`hasSquarefreeSturmChain p` reads off exactly this: `true` when `p` has
+positive degree and the last chain element is a nonzero constant. It is
+`Decidable`, so a caller discharges the drivers' `SquareFreeRat p`
+obligation by `by decide` on the chain rather than the rational gcd
+(soundness bridge `squareFreeRat_of_hasSquarefreeSturmChain` in the
+companion). One-way: `false` on the zero polynomial and nonzero constants.
+
 **Input contract.** The drivers do not take hypotheses; they classify
 every input explicitly:
 


### PR DESCRIPTION
This PR documents the ergonomic API added in kim-em/hex-dev#8768 in the real-root isolation SPECs, so the design docs match the API surface.

It records `hasSquarefreeSturmChain` (the `decide`-checkable squarefreeness certificate) in the hex-real-roots SPEC, and its soundness bridge `squareFreeRat_of_hasSquarefreeSturmChain`, the coefficient/Horner cast bridges (`eval_toPolyℝ` / `eval_toPolyℚ`, `coeff_toPolyℚ`), the `toReal_ofInt_shiftRight` dyadic endpoint simp lemma, and the `Hex`-namespace dot-notation aliases in the companion SPEC.

🤖 Prepared with Claude Code