### PR TITLE
feat(hex-roots-mathlib): activate exact cast bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
       # fresh against the restored libs, which is cheap.
       - name: Define the hex-dev cache + build target sets
         run: |
-          echo "HEX_LIB_TARGETS=HexBasic HexArith HexPoly HexModArith HexGF2 HexPolyZ HexRoots HexPolyFp HexGFqRing HexGFqField HexBerlekamp HexHensel HexConway HexGFq HexBerlekampZassenhaus HexRealRoots HexMatrix HexRowReduce HexDeterminant HexBareiss HexGramSchmidt HexLLL HexMatrixMathlib HexGramSchmidtMathlib HexLLLMathlib HexBerlekampZassenhausMathlib HexRealRootsMathlib" >> "$GITHUB_ENV"
+          echo "HEX_LIB_TARGETS=HexBasic HexArith HexPoly HexModArith HexGF2 HexPolyZ HexRoots HexPolyFp HexGFqRing HexGFqField HexBerlekamp HexHensel HexConway HexGFq HexBerlekampZassenhaus HexRealRoots HexMatrix HexRowReduce HexDeterminant HexBareiss HexGramSchmidt HexLLL HexMatrixMathlib HexGramSchmidtMathlib HexLLLMathlib HexBerlekampZassenhausMathlib HexRealRootsMathlib HexRootsMathlib" >> "$GITHUB_ENV"
           echo "HEX_EXE_TARGETS=hexarith_bench hexpoly_bench hexpolyz_bench hexpolyfp_bench hexmodarith_bench hexgf2_bench hexgfqring_bench hexgfqfield_bench hexgfq_bench hexhensel_bench hexberlekamp_bench hexbz_bench hexconway_bench hexmatrix_bench hexdeterminant_bench hexbareiss_bench hexgramschmidt_bench hexrealroots_bench hexroots_bench hexlll_bench hexlll_provider_probe" >> "$GITHUB_ENV"
       # Shared build. The libraries, bench exes, conformance #guard drivers, and
       # emit-fixture exes are all elaborated here so the two verification tails

--- a/HexRoots/SPEC/hex-roots.md
+++ b/HexRoots/SPEC/hex-roots.md
@@ -445,7 +445,7 @@ certifies the pinned value (or shows a smaller one suffices). A
 `none` from the drivers has one precise meaning: *no certificate the
 selected strategy attempts appeared by separation depth*. The
 Mathlib companion's completeness development
-([hex-roots-mathlib.md](../../SPEC/Libraries/hex-roots-mathlib.md)) is expected to prove
+([hex-roots-mathlib.md](../../HexRootsMathlib/SPEC/hex-roots-mathlib.md)) is expected to prove
 this impossible for squarefree inputs, for each strategy it covers
 (the Pellet converse for strategies that attempt Pellet, the
 Newton-Kantorovich converse for `.nk`). Until it does, the soundness
@@ -527,7 +527,7 @@ Mahler bound concerns *distinct* roots, so `mahlerPrec` is meaningful
 even for non-squarefree `p`: if `p_sf` is the squarefree part then
 `M(p_sf) ≤ M(p)` and `|disc p_sf| ≥ 1`, so the same closed form
 applies. The Mathlib companion proves correctness; see
-[hex-roots-mathlib.md](../../SPEC/Libraries/hex-roots-mathlib.md).
+[hex-roots-mathlib.md](../../HexRootsMathlib/SPEC/hex-roots-mathlib.md).
 
 ```lean
 def separationDepth (p : ZPoly) : Nat :=

--- a/HexRootsMathlib.lean
+++ b/HexRootsMathlib.lean
@@ -1,0 +1,20 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRootsMathlib.Basic
+
+public section
+
+/-!
+The `HexRootsMathlib` library is the Mathlib companion for the executable
+complex-root isolation library `HexRoots`.
+
+It connects exact dyadic witnesses to Mathlib's real and complex geometry and
+will prove soundness of the atom-path isolation driver. The first module
+supplies the exact casts used by every later correspondence proof.
+-/

--- a/HexRootsMathlib/Basic.lean
+++ b/HexRootsMathlib/Basic.lean
@@ -1,0 +1,160 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRoots
+public import Mathlib.Analysis.Complex.Basic
+
+public section
+
+/-!
+# Exact casts for complex root isolation
+
+This module embeds the executable dyadic and Gaussian-dyadic arithmetic from
+`HexRoots` into `ℝ` and `ℂ`. The named maps, rather than global coercion
+instances, keep the executable representation explicit at correspondence
+boundaries. The algebra and order lemmas below are the shared cast layer for
+the geometry, Taylor, and Newton--Kantorovich soundness developments.
+-/
+
+namespace HexRootsMathlib
+
+noncomputable section
+
+namespace Dyadic
+
+/-- The real value of an exact dyadic number, through its rational value. -/
+@[expose] def toReal (x : _root_.Dyadic) : ℝ := (x.toRat : ℝ)
+
+/-- The real value of zero is zero. -/
+@[simp] theorem toReal_zero : toReal 0 = 0 := by
+  unfold toReal
+  rw [_root_.Dyadic.toRat_zero]
+  norm_num
+
+/-- The real value of an integer dyadic is the corresponding integer. -/
+@[simp] theorem toReal_ofInt (n : Int) : toReal (.ofInt n) = (n : ℝ) := by
+  unfold toReal
+  rw [show _root_.Dyadic.ofInt n = ((n : Int) : _root_.Dyadic) from rfl,
+    _root_.Dyadic.toRat_intCast]
+  norm_num
+
+/-- The real-value map preserves addition. -/
+@[simp] theorem toReal_add (x y : _root_.Dyadic) :
+    toReal (x + y) = toReal x + toReal y := by
+  unfold toReal
+  rw [_root_.Dyadic.toRat_add]
+  push_cast
+  rfl
+
+/-- The real-value map preserves negation. -/
+@[simp] theorem toReal_neg (x : _root_.Dyadic) :
+    toReal (-x) = -toReal x := by
+  unfold toReal
+  rw [_root_.Dyadic.toRat_neg]
+  push_cast
+  rfl
+
+/-- The real-value map preserves subtraction. -/
+@[simp] theorem toReal_sub (x y : _root_.Dyadic) :
+    toReal (x - y) = toReal x - toReal y := by
+  unfold toReal
+  rw [_root_.Dyadic.toRat_sub]
+  push_cast
+  rfl
+
+/-- The real-value map preserves multiplication. -/
+@[simp] theorem toReal_mul (x y : _root_.Dyadic) :
+    toReal (x * y) = toReal x * toReal y := by
+  unfold toReal
+  rw [_root_.Dyadic.toRat_mul]
+  push_cast
+  rfl
+
+/-- Real-value comparison reflects and preserves dyadic non-strict order. -/
+@[simp] theorem toReal_le_toReal_iff {x y : _root_.Dyadic} :
+    toReal x ≤ toReal y ↔ x ≤ y := by
+  unfold toReal
+  rw [Rat.cast_le, _root_.Dyadic.toRat_le_toRat_iff]
+
+/-- Real-value comparison reflects and preserves dyadic strict order. -/
+@[simp] theorem toReal_lt_toReal_iff {x y : _root_.Dyadic} :
+    toReal x < toReal y ↔ x < y := by
+  unfold toReal
+  rw [Rat.cast_lt, _root_.Dyadic.toRat_lt_toRat_iff]
+
+/-- The real-value map is injective. -/
+theorem toReal_injective : Function.Injective toReal := by
+  intro x y h
+  apply _root_.Dyadic.toRat_inj.mp
+  unfold toReal at h
+  exact_mod_cast h
+
+end Dyadic
+
+namespace GaussDyadic
+
+/-- The complex value of an exact Gaussian dyadic. -/
+@[expose] def toComplex (z : Hex.GaussDyadic) : ℂ :=
+  ⟨Dyadic.toReal z.1, Dyadic.toReal z.2⟩
+
+/-- The real part of the complex value is the real value of the first
+coordinate. -/
+@[simp] theorem toComplex_re (z : Hex.GaussDyadic) :
+    (toComplex z).re = Dyadic.toReal z.1 := rfl
+
+/-- The imaginary part of the complex value is the real value of the second
+coordinate. -/
+@[simp] theorem toComplex_im (z : Hex.GaussDyadic) :
+    (toComplex z).im = Dyadic.toReal z.2 := rfl
+
+/-- Casting an integer Gaussian dyadic gives the corresponding complex
+integer. -/
+@[simp] theorem toComplex_ofInt (n : Int) :
+    toComplex (Hex.GaussDyadic.ofInt n) = (n : ℂ) := by
+  apply Complex.ext <;> simp [toComplex, Hex.GaussDyadic.ofInt]
+
+/-- The complex-value map preserves Gaussian-dyadic addition. -/
+@[simp] theorem toComplex_add (z w : Hex.GaussDyadic) :
+    toComplex (Hex.GaussDyadic.add z w) = toComplex z + toComplex w := by
+  apply Complex.ext <;> simp [toComplex, Hex.GaussDyadic.add]
+
+/-- The complex-value map preserves Gaussian-dyadic subtraction. -/
+@[simp] theorem toComplex_sub (z w : Hex.GaussDyadic) :
+    toComplex (Hex.GaussDyadic.sub z w) = toComplex z - toComplex w := by
+  apply Complex.ext <;> simp [toComplex, Hex.GaussDyadic.sub]
+
+/-- The complex-value map preserves Gaussian-dyadic conjugation. -/
+@[simp] theorem toComplex_conj (z : Hex.GaussDyadic) :
+    toComplex (Hex.GaussDyadic.conj z) = star (toComplex z) := by
+  apply Complex.ext <;> simp [toComplex, Hex.GaussDyadic.conj]
+
+/-- The complex-value map preserves Gaussian-dyadic multiplication. -/
+@[simp] theorem toComplex_mul (z w : Hex.GaussDyadic) :
+    toComplex (Hex.GaussDyadic.mul z w) = toComplex z * toComplex w := by
+  apply Complex.ext <;> simp [toComplex, Hex.GaussDyadic.mul]
+
+/-- The real value of the exact squared modulus is the complex squared
+modulus. -/
+@[simp] theorem toReal_normSq (z : Hex.GaussDyadic) :
+    Dyadic.toReal (Hex.GaussDyadic.normSq z) = Complex.normSq (toComplex z) := by
+  simp [Hex.GaussDyadic.normSq, Complex.normSq_apply]
+
+/-- The complex-value map is injective. -/
+theorem toComplex_injective : Function.Injective toComplex := by
+  intro z w h
+  apply Prod.ext
+  · apply Dyadic.toReal_injective
+    exact congrArg Complex.re h
+  · apply Dyadic.toReal_injective
+    exact congrArg Complex.im h
+
+end GaussDyadic
+
+end
+
+end HexRootsMathlib

--- a/HexRootsMathlib/SPEC/hex-roots-mathlib.md
+++ b/HexRootsMathlib/SPEC/hex-roots-mathlib.md
@@ -1,6 +1,6 @@
 # hex-roots-mathlib (depends on hex-roots + hex-poly-z-mathlib + Mathlib)
 
-Mathlib companion for [hex-roots](hex-roots.md). Proves **soundness**
+Mathlib companion for [hex-roots](../../HexRoots/SPEC/hex-roots.md). Proves **soundness**
 of the certified root isolation: every `DyadicRootIsolation` witness
 implies a unique simple complex root in its certified region (the
 stored square for the Newton-Kantorovich disjunct, the circumscribed
@@ -233,7 +233,7 @@ Pellet witnesses.
 
 The computational library never states this inequality directly: its
 witness compares dyadic bounds (`lo`, `hi`, and the rational `√2`
-bounds; see [hex-roots.md](hex-roots.md)). The one-directional lemma
+bounds; see [hex-roots.md](../../HexRoots/SPEC/hex-roots.md)). The one-directional lemma
 "the dyadic-bound witness implies the exact Pellet inequality" lives
 in `HexRootsMathlib/Geometry.lean`, so the analytic development above
 stays in the standard form (the form worth contributing to Mathlib)
@@ -397,7 +397,7 @@ by building it. Conformance fixtures live with `hex-roots`.
 
 ## References
 
-See [hex-roots.md](hex-roots.md) for the BSSY, Pellet, Mahler, and
+See [hex-roots.md](../../HexRoots/SPEC/hex-roots.md) for the BSSY, Pellet, Mahler, and
 Mignotte references. In addition:
 
 - Becker, Sagraloff, Sharma, Yap, JSC 2018, §2: the exact form of the

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -172,7 +172,7 @@ this directory belong to planned libraries not yet started.
 - [hex-poly-z](../../HexPolyZ/SPEC/hex-poly-z.md): polynomials over `Z`, content/primitive part, Mignotte bound
 - [hex-poly-z-mathlib](../../HexPolyZMathlib/SPEC/hex-poly-z-mathlib.md): Mignotte bound proof via Mathlib's Mahler measure
 - [hex-roots.md](hex-roots.md): certified complex root isolation for `Z[x]`
-- [hex-roots-mathlib.md](hex-roots-mathlib.md): Pellet's test on circles, the Mahler separation bound, soundness of refinement and `isolate`
+- [hex-roots-mathlib](../../HexRootsMathlib/SPEC/hex-roots-mathlib.md): Pellet's test on circles, the Mahler separation bound, soundness of refinement and `isolate`
 - [hex-real-roots.md](hex-real-roots.md): certified real root isolation for `Z[x]`, Sturm-count witnesses, Descartes search with Sturm fallback
 - [hex-real-roots-mathlib.md](hex-real-roots-mathlib.md): Sturm's theorem, chain correspondence, soundness and completeness of `isolate?`
 - [hex-rcf.md](hex-rcf.md): the `rcf` tactic for univariate real-closed-field sentences

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -123,6 +123,9 @@ lean_lib HexModArithMathlib where
 lean_lib HexPolyZMathlib where
 
 @[default_target]
+lean_lib HexRootsMathlib where
+
+@[default_target]
 lean_lib HexBerlekampMathlib where
 
 @[default_target]

--- a/libraries.yml
+++ b/libraries.yml
@@ -473,7 +473,7 @@ libraries:
     deps: [HexRoots, HexPolyZMathlib]
     mathlib: true
     done_through: 0
-    status: planned
+    status: active
   HexResultant:
     deps: [HexPoly]
     mathlib: false

--- a/progress/20260718T212736Z_issue-8755.md
+++ b/progress/20260718T212736Z_issue-8755.md
@@ -1,0 +1,20 @@
+# Accomplished
+
+- Claimed directive #8755 and rebased `issue-8755` onto `origin/main`.
+- Activated `HexRootsMathlib`, moved its SPEC into the per-library layout, and repaired the relocation links.
+- Added the `HexRootsMathlib` umbrella and an initial `Basic` module embedding exact dyadics into `ℝ` and Gaussian dyadics into `ℂ`, with proved algebra, order, norm-square, and injectivity correspondence lemmas.
+- Added the default Lake target and the existing single-job CI library target.
+- Passed the focused 1,934-job build, Mathlib linter, DAG/header/line-count/Phase-4 checks, and the full 9,376-job default build.
+- Ran the requested Claude Opus second opinion; removed the unused polynomial-bridge import and fixed the library-index link it identified. Kept the companion-local dyadic cast because the analogous real-roots definition is also companion-local and moving shared API into the polynomial bridge is outside this activation slice.
+
+# Current frontier
+
+The bounded activation and exact cast starter are ready to publish as the first partial PR for #8755. The analytic and driver-soundness theorem slices remain intentionally outside this activation PR.
+
+# Next step
+
+Open narrow child issues from the directive's remaining slices, beginning with C1 geometry (`lo`/`hi`, rational square-root bounds, and dyadic-square regions), then the independent discriminant/separation and Newton--Kantorovich developments.
+
+# Blockers
+
+None.


### PR DESCRIPTION
Part of #8755.

## What changed

- activate `HexRootsMathlib` and move its SPEC into the per-library layout
- add the default Lake target and append it to the existing single-job CI library target set
- add the umbrella plus an exact `Dyadic → ℝ` / `GaussDyadic → ℂ` cast bridge with proved algebra, order, norm-square, and injectivity lemmas
- repair inbound and index links affected by the SPEC relocation

This is the directive’s explicitly listed small activation PR. The discriminant, Newton–Kantorovich, geometry, Taylor, refinement, driver, and deferred completeness/Rouché slices remain on #8755 for narrow follow-up issues; this PR intentionally does not close the umbrella.

## Validation

- `lake build HexRootsMathlib` — 1,934 jobs, success
- `lake build` — 9,376 jobs, success
- `lake exe runLinter HexRootsMathlib.Basic`
- `python3 scripts/check_copyright_headers.py`
- `python3 scripts/check_file_line_counts.py`
- `python3 scripts/check_dag.py`
- `python3 scripts/check_phase4.py`
- Claude Opus second-opinion review; actionable import/link findings addressed