### PR TITLE
feat(hex-roots-mathlib): prove dyadic square geometry

### DIFF
--- a/HexRootsMathlib.lean
+++ b/HexRootsMathlib.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexRootsMathlib.Basic
+public import HexRootsMathlib.Geometry
 
 public section
 
@@ -15,6 +16,7 @@ The `HexRootsMathlib` library is the Mathlib companion for the executable
 complex-root isolation library `HexRoots`.
 
 It connects exact dyadic witnesses to Mathlib's real and complex geometry and
-will prove soundness of the atom-path isolation driver. The first module
-supplies the exact casts used by every later correspondence proof.
+will prove soundness of the atom-path isolation driver. The initial modules
+supply the exact casts and geometric bounds used by every later correspondence
+proof.
 -/

--- a/HexRootsMathlib/Basic.lean
+++ b/HexRootsMathlib/Basic.lean
@@ -94,6 +94,36 @@ theorem toReal_injective : Function.Injective toReal := by
   unfold toReal at h
   exact_mod_cast h
 
+/-- The real-value map preserves the executable dyadic absolute value. -/
+@[simp] theorem toReal_abs (x : _root_.Dyadic) :
+    toReal (Hex.Dyadic.abs x) = |toReal x| := by
+  unfold Hex.Dyadic.abs
+  split <;> rename_i h
+  · rw [toReal_neg, abs_of_neg]
+    exact (toReal_lt_toReal_iff.mpr h).trans_eq toReal_zero
+  · have hx : 0 ≤ toReal x := by
+      apply le_of_not_gt
+      intro h'
+      apply h
+      exact toReal_lt_toReal_iff.mp (by simpa using h')
+    rw [abs_of_nonneg hx]
+
+/-- The real-value map preserves the executable dyadic maximum. -/
+@[simp] theorem toReal_max (x y : _root_.Dyadic) :
+    toReal (Hex.Dyadic.max x y) = max (toReal x) (toReal y) := by
+  unfold Hex.Dyadic.max
+  split <;> rename_i h
+  · rw [max_eq_right (toReal_le_toReal_iff.mpr h)]
+  · rw [max_eq_left (le_of_not_ge fun h' => h (toReal_le_toReal_iff.mp h'))]
+
+/-- The real value of `n * 2 ^ (-prec)` represented as a dyadic. -/
+@[simp] theorem toReal_ofIntWithPrec (n prec : Int) :
+    toReal (.ofIntWithPrec n prec) = (n : ℝ) * (2 : ℝ) ^ (-prec) := by
+  unfold toReal
+  rw [_root_.Dyadic.toRat_ofIntWithPrec_eq_mul_two_pow]
+  push_cast
+  rfl
+
 end Dyadic
 
 namespace GaussDyadic

--- a/HexRootsMathlib/Geometry.lean
+++ b/HexRootsMathlib/Geometry.lean
@@ -1,0 +1,219 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRootsMathlib.Basic
+public import Mathlib.Analysis.Complex.Norm
+
+public section
+
+/-!
+# Geometry for complex root isolation
+
+This module relates the executable modulus bounds and dyadic squares from
+`HexRoots` to the Euclidean and sup-norm geometry of `ℂ`.
+-/
+
+namespace HexRootsMathlib
+
+noncomputable section
+
+namespace GaussDyadic
+
+/-- The real value of the executable lower modulus bound. -/
+@[simp] theorem toReal_lo (z : Hex.GaussDyadic) :
+    Dyadic.toReal (Hex.GaussDyadic.lo z) =
+      max |(toComplex z).re| |(toComplex z).im| := by
+  simp [Hex.GaussDyadic.lo]
+
+/-- The real value of the executable upper modulus bound. -/
+@[simp] theorem toReal_hi (z : Hex.GaussDyadic) :
+    Dyadic.toReal (Hex.GaussDyadic.hi z) =
+      |(toComplex z).re| + |(toComplex z).im| := by
+  simp [Hex.GaussDyadic.hi]
+
+/-- The executable `lo` bound is below the complex modulus. -/
+theorem lo_le_norm (z : Hex.GaussDyadic) :
+    Dyadic.toReal (Hex.GaussDyadic.lo z) ≤ ‖toComplex z‖ := by
+  rw [toReal_lo]
+  exact max_le (Complex.abs_re_le_norm _) (Complex.abs_im_le_norm _)
+
+/-- The complex modulus is at most `√2` times the executable `lo` bound. -/
+theorem norm_le_sqrt_two_mul_lo (z : Hex.GaussDyadic) :
+    ‖toComplex z‖ ≤ √2 * Dyadic.toReal (Hex.GaussDyadic.lo z) := by
+  simpa only [toReal_lo] using Complex.norm_le_sqrt_two_mul_max (toComplex z)
+
+/-- The complex modulus is below the executable `hi` bound. -/
+theorem norm_le_hi (z : Hex.GaussDyadic) :
+    ‖toComplex z‖ ≤ Dyadic.toReal (Hex.GaussDyadic.hi z) := by
+  rw [toReal_hi]
+  exact Complex.norm_le_abs_re_add_abs_im _
+
+/-- The executable `hi` bound is at most `√2` times the complex modulus. -/
+theorem hi_le_sqrt_two_mul_norm (z : Hex.GaussDyadic) :
+    Dyadic.toReal (Hex.GaussDyadic.hi z) ≤ √2 * ‖toComplex z‖ := by
+  rw [toReal_hi]
+  refine (sq_le_sq₀ (by positivity) (by positivity)).mp ?_
+  rw [mul_pow, Real.sq_sqrt (by norm_num), Complex.sq_norm, Complex.normSq_apply]
+  have hre : |(toComplex z).re| ^ 2 = (toComplex z).re ^ 2 := sq_abs _
+  have him : |(toComplex z).im| ^ 2 = (toComplex z).im ^ 2 := sq_abs _
+  nlinarith [sq_nonneg (|(toComplex z).re| - |(toComplex z).im|)]
+
+end GaussDyadic
+
+/-! ### Rational bounds for `√2` -/
+
+/-- The executable lower approximation `181/128` is strictly below `√2`. -/
+theorem sqrt2Lo_lt_sqrt_two : Dyadic.toReal Hex.sqrt2Lo < √2 := by
+  rw [← sq_lt_sq₀ (by
+    simp [Hex.sqrt2Lo, Dyadic.toReal_ofIntWithPrec]
+    positivity) (Real.sqrt_nonneg _), Real.sq_sqrt (by norm_num)]
+  have h := Dyadic.toReal_lt_toReal_iff.mpr Hex.sqrt2Lo_sq_lt_two
+  have htwo : Dyadic.toReal (2 : _root_.Dyadic) = (2 : ℝ) := by
+    change Dyadic.toReal (.ofInt 2) = (2 : ℝ)
+    simp
+  rw [htwo] at h
+  simpa only [Dyadic.toReal_mul, pow_two] using h
+
+/-- The executable upper approximation `1449/1024` is strictly above `√2`. -/
+theorem sqrt_two_lt_sqrt2Hi : √2 < Dyadic.toReal Hex.sqrt2Hi := by
+  rw [← sq_lt_sq₀ (Real.sqrt_nonneg _) (by
+    simp [Hex.sqrt2Hi, Dyadic.toReal_ofIntWithPrec]
+    positivity), Real.sq_sqrt (by norm_num)]
+  have h := Dyadic.toReal_lt_toReal_iff.mpr Hex.two_lt_sqrt2Hi_sq
+  have htwo : Dyadic.toReal (2 : _root_.Dyadic) = (2 : ℝ) := by
+    change Dyadic.toReal (.ofInt 2) = (2 : ℝ)
+    simp
+  rw [htwo] at h
+  simpa only [Dyadic.toReal_mul, pow_two] using h
+
+/-! ### Sup-norm squares and circumscribed discs -/
+
+/-- The sup norm on `ℂ`, used to view an axis-aligned square as a ball. -/
+@[expose] def supNorm (z : ℂ) : ℝ := max |z.re| |z.im|
+
+/-- The distance associated to `supNorm`. -/
+@[expose] def supDist (z w : ℂ) : ℝ := supNorm (z - w)
+
+/-- A closed sup-norm ball in `ℂ`. -/
+@[expose] def supClosedBall (c : ℂ) (r : ℝ) : Set ℂ :=
+  {z | supDist z c ≤ r}
+
+namespace DyadicSquare
+
+/-
+These names deliberately mirror `Hex.DyadicSquare.center` and `halfWidth`.
+Dot notation on `s : Hex.DyadicSquare` selects the executable definitions;
+the Mathlib interpretations use the explicit `DyadicSquare.*` prefix.
+-/
+
+/-- The complex centre of a dyadic square. -/
+@[expose] def center (s : Hex.DyadicSquare) : ℂ :=
+  GaussDyadic.toComplex s.center
+
+/-- The real half-width of a dyadic square. -/
+@[expose] def halfWidth (s : Hex.DyadicSquare) : ℝ :=
+  Dyadic.toReal s.halfWidth
+
+/-- The Euclidean radius of the square's circumscribed disc. -/
+@[expose] def radius (s : Hex.DyadicSquare) : ℝ :=
+  halfWidth s * √2
+
+/-- The closed axis-aligned square represented by `s`. -/
+@[expose] def closedSquare (s : Hex.DyadicSquare) : Set ℂ :=
+  supClosedBall (center s) (halfWidth s)
+
+/-- The open circumscribed disc of `s`. -/
+@[expose] def disc (s : Hex.DyadicSquare) : Set ℂ :=
+  Metric.ball (center s) (radius s)
+
+/-- The closed circumscribed disc of `s`. -/
+@[expose] def closedDisc (s : Hex.DyadicSquare) : Set ℂ :=
+  Metric.closedBall (center s) (radius s)
+
+@[simp] theorem center_eq (s : Hex.DyadicSquare) :
+    center s = GaussDyadic.toComplex s.center := rfl
+
+@[simp] theorem halfWidth_eq (s : Hex.DyadicSquare) :
+    halfWidth s = (2 : ℝ) ^ (-s.prec) := by
+  simp [halfWidth, Hex.DyadicSquare.halfWidth]
+
+@[simp] theorem radius_eq (s : Hex.DyadicSquare) :
+    radius s = (2 : ℝ) ^ (-s.prec) * √2 := by
+  simp [radius]
+
+@[simp] theorem disc_eq (s : Hex.DyadicSquare) :
+    disc s = Metric.ball (center s) ((2 : ℝ) ^ (-s.prec) * √2) := by
+  simp [disc]
+
+theorem closedSquare_eq_supClosedBall (s : Hex.DyadicSquare) :
+    closedSquare s = supClosedBall (center s) (halfWidth s) := rfl
+
+/-- The centre belongs to its closed square. -/
+theorem center_mem_closedSquare (s : Hex.DyadicSquare) : center s ∈ closedSquare s := by
+  rw [closedSquare, supClosedBall, Set.mem_setOf_eq, supDist, sub_self, supNorm]
+  simp only [Complex.zero_re, abs_zero, Complex.zero_im, max_self]
+  rw [halfWidth_eq]
+  exact (zpow_pos (by norm_num) _).le
+
+theorem radiusLo_eq (s : Hex.DyadicSquare) :
+    Dyadic.toReal s.radiusLo = halfWidth s * Dyadic.toReal Hex.sqrt2Lo := by
+  simp only [Hex.DyadicSquare.radiusLo, Hex.sqrt2Lo, Dyadic.toReal_ofIntWithPrec,
+    halfWidth_eq]
+  rw [show -(s.prec + 7) = -s.prec + (-7) by ring,
+    zpow_add₀ (by norm_num : (2 : ℝ) ≠ 0)]
+  ring
+
+theorem radiusHi_eq (s : Hex.DyadicSquare) :
+    Dyadic.toReal s.radiusHi = halfWidth s * Dyadic.toReal Hex.sqrt2Hi := by
+  simp only [Hex.DyadicSquare.radiusHi, Hex.sqrt2Hi, Dyadic.toReal_ofIntWithPrec,
+    halfWidth_eq]
+  rw [show -(s.prec + 10) = -s.prec + (-10) by ring,
+    zpow_add₀ (by norm_num : (2 : ℝ) ≠ 0)]
+  ring
+
+theorem radiusLo_lt_radius (s : Hex.DyadicSquare) :
+    Dyadic.toReal s.radiusLo < radius s := by
+  rw [radiusLo_eq, radius]
+  apply mul_lt_mul_of_pos_left sqrt2Lo_lt_sqrt_two
+  rw [halfWidth_eq]
+  exact zpow_pos (by norm_num) _
+
+theorem radius_lt_radiusHi (s : Hex.DyadicSquare) :
+    radius s < Dyadic.toReal s.radiusHi := by
+  rw [radiusHi_eq, radius]
+  apply mul_lt_mul_of_pos_left sqrt_two_lt_sqrt2Hi
+  rw [halfWidth_eq]
+  exact zpow_pos (by norm_num) _
+
+/-- The square is contained in its closed circumscribed Euclidean disc. -/
+theorem closedSquare_subset_closedDisc (s : Hex.DyadicSquare) :
+    closedSquare s ⊆ closedDisc s := by
+  intro z hz
+  rw [closedSquare, supClosedBall, Set.mem_setOf_eq] at hz
+  rw [closedDisc, Metric.mem_closedBall, Complex.dist_eq]
+  calc
+    ‖z - center s‖ ≤ √2 * supNorm (z - center s) :=
+      Complex.norm_le_sqrt_two_mul_max (z - center s)
+    _ ≤ √2 * halfWidth s := mul_le_mul_of_nonneg_left hz (Real.sqrt_nonneg _)
+    _ = radius s := by rw [radius, mul_comm]
+
+/-- The closed square lies in the open disc obtained from the executable
+strict upper radius bound. -/
+theorem closedSquare_subset_ball_radiusHi (s : Hex.DyadicSquare) :
+    closedSquare s ⊆ Metric.ball (center s) (Dyadic.toReal s.radiusHi) := by
+  intro z hz
+  have hclosed := closedSquare_subset_closedDisc s hz
+  rw [closedDisc, Metric.mem_closedBall] at hclosed
+  rw [Metric.mem_ball]
+  exact hclosed.trans_lt (radius_lt_radiusHi s)
+
+end DyadicSquare
+
+end
+
+end HexRootsMathlib

--- a/HexRootsMathlib/SPEC/hex-roots-mathlib.md
+++ b/HexRootsMathlib/SPEC/hex-roots-mathlib.md
@@ -247,14 +247,14 @@ below.
 These files connect the `HexRoots` data structures to the two
 developments above.
 
-- `HexRootsMathlib/Basic.lean`: a `DyadicSquare` determines a centre
-  `c : ℂ` and a radius `r : ℝ`, and a circumscribed disc
-  `Metric.ball c (r·√2)`; all witness counts are counts in the open
-  disc, which equal counts in the closed disc because the strict
-  witness inequality excludes roots from the boundary circle. Simp
-  lemmas `DyadicSquare.center_eq`, `DyadicSquare.disc_eq`.
+- `HexRootsMathlib/Basic.lean`: exact `Dyadic → ℝ` and
+  `GaussDyadic → ℂ` casts and their algebra/order correspondence.
 - `HexRootsMathlib/Geometry.lean`: `lo(c) ≤ |c| ≤ hi(c)`, the
-  `181/128 < √2 < 1449/1024` bounds, and "witness implies Pellet".
+  `181/128 < √2 < 1449/1024` bounds, and the Mathlib geometry of a
+  `DyadicSquare`: its complex centre, real half-width, closed sup-norm
+  square, and open/closed circumscribed discs. Simp lemmas
+  `DyadicSquare.center_eq`, `DyadicSquare.disc_eq`. The later Pellet
+  correspondence in this module proves "witness implies Pellet".
 - `HexRootsMathlib/HasOnlySimpleRoots.lean`:
   `Hex.HasOnlySimpleRoots p ↔ Squarefree (toPolynomial p)`. Connects
   the executable test (the `ℚ[x]` gcd of `p` and `p'` is constant)

--- a/progress/20260719T100905Z_issue-8755-geometry.md
+++ b/progress/20260719T100905Z_issue-8755-geometry.md
@@ -1,0 +1,21 @@
+# Accomplished
+
+- Posted the reviewed 33-PR execution plan on #8755 and claimed geometry child #8771.
+- Added the exact dyadic cast lemmas for executable absolute value, maximum, and `ofIntWithPrec`.
+- Implemented `HexRootsMathlib.Geometry`: the `lo`/`hi` modulus sandwiches, strict rational bounds around `√2`, exact radius-bound casts, complex centre/half-width/disc interpretations, the closed sup-norm square, and its closed/open disc containments.
+- Ran the requested Claude Opus review and addressed its material API findings by hoisting the general sup-norm notions, adding direct imports and downstream containment lemmas, and reconciling the SPEC placement.
+- Passed the focused builds, Mathlib linters, repository structural checks, and the full 9,377-job build.
+- While preparing the next child, found that `HasOnlySimpleRoots p ↔ Squarefree (toPolynomial p : ℤ[X])` is false for `p = 4X + 4`; documented the counterexample on #8772 and #8755 and unassigned the blocked child as required.
+- Opened independent extraction child #8773 and began its mechanical move in a separate worktree.
+
+# Current frontier
+
+The C1 geometry change is ready to commit, push, and open as the PR closing #8771. The independent #8773 extraction is being built in a separate worktree while this PR passes review and CI.
+
+# Next step
+
+Publish and merge the #8771 PR, then finish and review #8773. Resume the squarefree correspondence only after #8772 is corrected to target the rational/complex cast rather than squarefreeness in `ℤ[X]`.
+
+# Blockers
+
+- #8772 has an unsound integer-squarefreeness endpoint; the valid replacement is squarefreeness of `(toPolynomial p).map (Int.castRingHom ℚ)` (or the equivalent separability statement), still with `p ≠ 0`.


### PR DESCRIPTION
## Summary

- extend the exact cast layer with dyadic `abs`, `max`, and `ofIntWithPrec` correspondence
- prove the complete `lo`/`hi` modulus sandwiches and strict `181/128 < √2 < 1449/1024` bounds
- interpret `DyadicSquare` as a closed sup-norm square with true/open/closed circumscribed discs and exact executable radius bounds
- reconcile the companion SPEC and import the new geometry module from the umbrella

## Why

This closes correspondence slice C1 and supplies the geometric vocabulary used by the later Taylor, Newton–Kantorovich, Pellet, and driver-soundness developments.

Closes #8771
Part of #8755

## Validation

- `lake build HexRootsMathlib.Geometry`
- `lake build HexRootsMathlib`
- `lake exe runLinter HexRootsMathlib.Basic HexRootsMathlib.Geometry`
- `python3 scripts/check_dag.py`
- `python3 scripts/check_copyright_headers.py`
- `python3 scripts/check_file_line_counts.py`
- `git diff --check`
- full `lake build` (9,377 jobs)
- Claude Opus second-opinion review; addressed placement, namespace, direct-import, and downstream-containment findings
