### PR TITLE
refactor(hex-poly-z-mathlib): share Mahler separation core

### DIFF
--- a/HexPolyZMathlib.lean
+++ b/HexPolyZMathlib.lean
@@ -9,6 +9,7 @@ module
 public import HexPolyZMathlib.Basic
 public import HexPolyZMathlib.Discriminant
 public import HexPolyZMathlib.Hadamard
+public import HexPolyZMathlib.MahlerSeparation
 public import HexPolyZMathlib.Mignotte
 public import HexPolyZMathlib.RobinsonForm
 
@@ -22,6 +23,7 @@ This library specializes the generic dense-polynomial equivalence to
 `Hex.ZPoly`, exposing the concrete conversion functions, the ring equivalence
 used by downstream integer-polynomial proof libraries, and the
 Mahler-measure/Mignotte-bound theorem surface over `Polynomial ℤ`.
-It also hosts the generic discriminant root-product and sharp column-Hadamard
-inequalities shared by the real- and complex-root companions.
+It also hosts the generic discriminant root-product, sharp column-Hadamard,
+and Mahler/Vandermonde inequalities shared by the real- and complex-root
+companions.
 -/

--- a/HexPolyZMathlib/MahlerSeparation.lean
+++ b/HexPolyZMathlib/MahlerSeparation.lean
@@ -1,0 +1,265 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import Mathlib
+public import HexPolyZMathlib.Discriminant
+public import HexPolyZMathlib.Hadamard
+
+public section
+
+/-!
+# Generic Mahler separation analysis
+
+This module develops the Hex-independent analytic core of Mahler's
+root-separation argument over complex roots. It bounds ordinary and differenced
+Vandermonde columns, applies the sharp column form of Hadamard's determinant inequality,
+and identifies the discriminant root product with the squared Vandermonde
+norm.
+
+Executable precision arithmetic and root-isolation specializations remain in
+the corresponding roots companions.
+-/
+
+open Polynomial Finset Matrix
+
+namespace HexPolyZMathlib
+
+noncomputable section
+
+/-- The divided-difference entry bound: `‖yⁱ − xⁱ‖ ≤ i · Cⁱ⁻¹ · ‖y − x‖` when
+`‖x‖, ‖y‖ ≤ C` and `1 ≤ C`. Follows from the geometric factorisation
+`yⁱ − xⁱ = (∑_{l<i} yˡ xⁱ⁻¹⁻ˡ)(y − x)`. -/
+theorem norm_pow_sub_pow_le {x y : ℂ} {C : ℝ} (hx : ‖x‖ ≤ C) (hy : ‖y‖ ≤ C)
+    (hC : 1 ≤ C) (i : ℕ) : ‖y ^ i - x ^ i‖ ≤ (i : ℝ) * C ^ (i - 1) * ‖y - x‖ := by
+  rw [← geom_sum₂_mul y x i, norm_mul]
+  refine mul_le_mul_of_nonneg_right ?_ (norm_nonneg _)
+  calc ‖∑ l ∈ Finset.range i, y ^ l * x ^ (i - 1 - l)‖
+      ≤ ∑ l ∈ Finset.range i, ‖y ^ l * x ^ (i - 1 - l)‖ := norm_sum_le _ _
+    _ ≤ ∑ _l ∈ Finset.range i, C ^ (i - 1) := by
+        apply Finset.sum_le_sum
+        intro l hl
+        have hl' : l ≤ i - 1 := by have := Finset.mem_range.mp hl; omega
+        rw [norm_mul, norm_pow, norm_pow]
+        calc ‖y‖ ^ l * ‖x‖ ^ (i - 1 - l) ≤ C ^ l * C ^ (i - 1 - l) := by
+              gcongr
+          _ = C ^ (l + (i - 1 - l)) := by rw [← pow_add]
+          _ = C ^ (i - 1) := by rw [Nat.add_sub_cancel' hl']
+    _ = (i : ℝ) * C ^ (i - 1) := by
+        rw [Finset.sum_const, Finset.card_range, nsmul_eq_mul]
+
+/-- The L² norm of an ordinary Vandermonde column: `√(∑ᵢ ‖aⁱ‖²) ≤ √N · max(1,‖a‖)^{N-1}`. -/
+theorem sqrt_sum_pow_sq_le (a : ℂ) (N : ℕ) :
+    Real.sqrt (∑ i : Fin N, ‖a ^ (i : ℕ)‖ ^ 2) ≤ Real.sqrt N * (max 1 ‖a‖) ^ (N - 1) := by
+  have hBnn : (0 : ℝ) ≤ max 1 ‖a‖ := le_trans zero_le_one (le_max_left _ _)
+  have hbound : ∑ i : Fin N, ‖a ^ (i : ℕ)‖ ^ 2 ≤ (N : ℝ) * (max 1 ‖a‖) ^ (2 * (N - 1)) := by
+    have : ∀ i : Fin N, ‖a ^ (i : ℕ)‖ ^ 2 ≤ (max 1 ‖a‖) ^ (2 * (N - 1)) := by
+      intro i
+      rw [norm_pow, ← pow_mul]
+      calc ‖a‖ ^ ((i : ℕ) * 2) ≤ (max 1 ‖a‖) ^ ((i : ℕ) * 2) := by
+            gcongr
+            exact le_max_right _ _
+        _ ≤ (max 1 ‖a‖) ^ (2 * (N - 1)) := by
+            apply pow_le_pow_right₀ (le_max_left _ _)
+            have := i.isLt; omega
+    calc ∑ i : Fin N, ‖a ^ (i : ℕ)‖ ^ 2
+        ≤ ∑ _i : Fin N, (max 1 ‖a‖) ^ (2 * (N - 1)) := Finset.sum_le_sum (fun i _ => this i)
+      _ = (N : ℝ) * (max 1 ‖a‖) ^ (2 * (N - 1)) := by
+          rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+  calc Real.sqrt (∑ i : Fin N, ‖a ^ (i : ℕ)‖ ^ 2)
+      ≤ Real.sqrt ((N : ℝ) * (max 1 ‖a‖) ^ (2 * (N - 1))) := Real.sqrt_le_sqrt hbound
+    _ = Real.sqrt N * (max 1 ‖a‖) ^ (N - 1) := by
+        rw [Real.sqrt_mul (Nat.cast_nonneg N), show 2 * (N - 1) = (N - 1) * 2 by ring,
+          pow_mul, Real.sqrt_sq (by positivity)]
+
+/-- The L² norm of the isolating (differenced) Vandermonde column:
+`√(∑ᵢ ‖yⁱ − xⁱ‖²) ≤ C^{N-2} · ‖y − x‖ · √(∑ᵢ i²)`. -/
+theorem sqrt_sum_sub_pow_sq_le {x y : ℂ} {C : ℝ} (hx : ‖x‖ ≤ C) (hy : ‖y‖ ≤ C)
+    (hC : 1 ≤ C) (N : ℕ) :
+    Real.sqrt (∑ i : Fin N, ‖y ^ (i : ℕ) - x ^ (i : ℕ)‖ ^ 2)
+      ≤ C ^ (N - 2) * ‖y - x‖ * Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2) := by
+  have hCnn : (0 : ℝ) ≤ C := le_trans zero_le_one hC
+  have hbound : ∑ i : Fin N, ‖y ^ (i : ℕ) - x ^ (i : ℕ)‖ ^ 2
+      ≤ (C ^ (N - 2) * ‖y - x‖) ^ 2 * ∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2 := by
+    rw [Finset.mul_sum]
+    apply Finset.sum_le_sum
+    intro i _
+    have hentry : ‖y ^ (i : ℕ) - x ^ (i : ℕ)‖ ≤ ((i : ℕ) : ℝ) * C ^ (N - 2) * ‖y - x‖ := by
+      refine (norm_pow_sub_pow_le hx hy hC (i : ℕ)).trans ?_
+      have hstep : C ^ ((i : ℕ) - 1) ≤ C ^ (N - 2) := by
+        apply pow_le_pow_right₀ hC; have := i.isLt; omega
+      exact mul_le_mul_of_nonneg_right
+        (mul_le_mul_of_nonneg_left hstep (Nat.cast_nonneg _)) (norm_nonneg _)
+    calc ‖y ^ (i : ℕ) - x ^ (i : ℕ)‖ ^ 2
+        ≤ (((i : ℕ) : ℝ) * C ^ (N - 2) * ‖y - x‖) ^ 2 :=
+          pow_le_pow_left₀ (norm_nonneg _) hentry 2
+      _ = (C ^ (N - 2) * ‖y - x‖) ^ 2 * ((i : ℕ) : ℝ) ^ 2 := by ring
+  calc Real.sqrt (∑ i : Fin N, ‖y ^ (i : ℕ) - x ^ (i : ℕ)‖ ^ 2)
+      ≤ Real.sqrt ((C ^ (N - 2) * ‖y - x‖) ^ 2 * ∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2) :=
+        Real.sqrt_le_sqrt hbound
+    _ = C ^ (N - 2) * ‖y - x‖ * Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2) := by
+        rw [Real.sqrt_mul (sq_nonneg _), Real.sqrt_sq (by positivity)]
+
+/-- `√(∑_{i<N} i²) ≤ (√N)³`. -/
+theorem sqrt_sum_sq_le (N : ℕ) :
+    Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2) ≤ Real.sqrt N ^ 3 := by
+  have hb : ∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2 ≤ (N : ℝ) ^ 3 := by
+    calc ∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2
+        ≤ ∑ _i : Fin N, (N : ℝ) ^ 2 := by
+          apply Finset.sum_le_sum
+          intro i _
+          have hi : ((i : ℕ) : ℝ) ≤ (N : ℝ) := by exact_mod_cast Nat.le_of_lt i.isLt
+          exact pow_le_pow_left₀ (Nat.cast_nonneg _) hi 2
+      _ = (N : ℝ) ^ 3 := by
+          rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]; ring
+  have hsq : (Real.sqrt N ^ 3) ^ 2 = (N : ℝ) ^ 3 := by
+    rw [← pow_mul, show 3 * 2 = 2 * 3 from rfl, pow_mul, Real.sq_sqrt (Nat.cast_nonneg N)]
+  refine (Real.sqrt_le_sqrt hb).trans (le_of_eq ?_)
+  rw [← hsq, Real.sqrt_sq (by positivity)]
+
+/-- **Mahler's isolating-column bound.** For a leading coefficient `c` and points
+`α : Fin N → ℂ` with `‖α i₀‖ ≤ ‖α i₁‖`, the scaled Vandermonde determinant is
+bounded by `√N^{N-1} · √(∑ i²) · (‖c‖ · ∏ max(1,‖α j‖))^{N-1} · ‖α i₁ − α i₀‖`. -/
+theorem norm_det_vandermonde_le {N : ℕ} (hN : 2 ≤ N) (c : ℂ) (α : Fin N → ℂ)
+    {i₀ i₁ : Fin N} (hne : i₀ ≠ i₁) (hle : ‖α i₀‖ ≤ ‖α i₁‖) :
+    ‖c‖ ^ (N - 1) * ‖(Matrix.vandermonde α).det‖ ≤
+      Real.sqrt N ^ (N - 1) * Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2)
+        * (‖c‖ * ∏ j, max 1 ‖α j‖) ^ (N - 1) * ‖α i₁ - α i₀‖ := by
+  classical
+  set B : Fin N → ℝ := fun j => max 1 ‖α j‖ with hBdef
+  have hB1 : ∀ j, (1 : ℝ) ≤ B j := fun j => le_max_left _ _
+  have hBnorm : ∀ j, ‖α j‖ ≤ B j := fun j => le_max_right _ _
+  have hB0 : ∀ j, (0 : ℝ) ≤ B j := fun j => le_trans zero_le_one (hB1 j)
+  -- The row-reduced matrix `W`: subtract row `i₀` from row `i₁`.
+  set W : Matrix (Fin N) (Fin N) ℂ :=
+    (Matrix.vandermonde α).updateRow i₁
+      ((Matrix.vandermonde α) i₁ + (-1 : ℂ) • (Matrix.vandermonde α) i₀) with hWdef
+  have hWdet : W.det = (Matrix.vandermonde α).det :=
+    Matrix.det_updateRow_add_smul_self _ (Ne.symm hne) _
+  have hWne : ∀ j, j ≠ i₁ → ∀ i : Fin N, W j i = α j ^ (i : ℕ) := by
+    intro j hj i
+    rw [hWdef, Matrix.updateRow_ne hj, Matrix.vandermonde_apply]
+  have hWeq : ∀ i : Fin N, W i₁ i = α i₁ ^ (i : ℕ) - α i₀ ^ (i : ℕ) := by
+    intro i
+    rw [hWdef, Matrix.updateRow_self]
+    simp only [Pi.add_apply, Pi.smul_apply, Matrix.vandermonde_apply, smul_eq_mul, neg_one_mul]
+    ring
+  -- Hadamard's inequality applied to the transpose.
+  have hHad : ‖(Matrix.vandermonde α).det‖ ≤ ∏ j, Real.sqrt (∑ i, ‖W j i‖ ^ 2) := by
+    rw [← hWdet, ← Matrix.det_transpose W]
+    exact Matrix.norm_det_le_prod_norm_column Wᵀ
+  -- Column bounds.
+  have hRi1 : Real.sqrt (∑ i, ‖W i₁ i‖ ^ 2)
+      ≤ B i₁ ^ (N - 2) * ‖α i₁ - α i₀‖ * Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2) := by
+    rw [show (∑ i, ‖W i₁ i‖ ^ 2) = ∑ i : Fin N, ‖α i₁ ^ (i : ℕ) - α i₀ ^ (i : ℕ)‖ ^ 2 from
+      Finset.sum_congr rfl (fun i _ => by rw [hWeq i])]
+    exact sqrt_sum_sub_pow_sq_le (le_trans hle (hBnorm i₁)) (hBnorm i₁) (hB1 i₁) N
+  have hRj : ∀ j, j ≠ i₁ →
+      Real.sqrt (∑ i, ‖W j i‖ ^ 2) ≤ Real.sqrt N * B j ^ (N - 1) := by
+    intro j hj
+    rw [show (∑ i, ‖W j i‖ ^ 2) = ∑ i : Fin N, ‖α j ^ (i : ℕ)‖ ^ 2 from
+      Finset.sum_congr rfl (fun i _ => by rw [hWne j hj i])]
+    exact sqrt_sum_pow_sq_le (α j) N
+  -- Product of column bounds.
+  have herasecard : (univ.erase i₁).card = N - 1 := by
+    rw [Finset.card_erase_of_mem (Finset.mem_univ i₁), Finset.card_univ, Fintype.card_fin]
+  have hprodEnn : (0 : ℝ) ≤ ∏ j ∈ univ.erase i₁, B j := Finset.prod_nonneg (fun j _ => hB0 j)
+  have hprodbound : ∏ j, Real.sqrt (∑ i, ‖W j i‖ ^ 2)
+      ≤ (B i₁ ^ (N - 2) * ‖α i₁ - α i₀‖ * Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2))
+        * ∏ j ∈ univ.erase i₁, (Real.sqrt N * B j ^ (N - 1)) := by
+    rw [← Finset.mul_prod_erase univ _ (Finset.mem_univ i₁)]
+    refine mul_le_mul hRi1 ?_ (Finset.prod_nonneg (fun j _ => Real.sqrt_nonneg _))
+      (mul_nonneg (mul_nonneg (pow_nonneg (hB0 i₁) _) (norm_nonneg _)) (Real.sqrt_nonneg _))
+    exact Finset.prod_le_prod (fun j _ => Real.sqrt_nonneg _)
+      (fun j hj => hRj j (Finset.mem_erase.mp hj).1)
+  have hprodrw : ∏ j ∈ univ.erase i₁, (Real.sqrt N * B j ^ (N - 1))
+      = Real.sqrt N ^ (N - 1) * (∏ j ∈ univ.erase i₁, B j) ^ (N - 1) := by
+    rw [Finset.prod_mul_distrib, Finset.prod_const, herasecard, Finset.prod_pow]
+  -- Combine.
+  have hcombine : ‖c‖ ^ (N - 1) * ‖(Matrix.vandermonde α).det‖
+      ≤ ‖c‖ ^ (N - 1) * (B i₁ ^ (N - 2) * ‖α i₁ - α i₀‖
+          * Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2)
+          * (Real.sqrt N ^ (N - 1) * (∏ j ∈ univ.erase i₁, B j) ^ (N - 1))) := by
+    refine mul_le_mul_of_nonneg_left ?_ (pow_nonneg (norm_nonneg c) _)
+    calc ‖(Matrix.vandermonde α).det‖ ≤ ∏ j, Real.sqrt (∑ i, ‖W j i‖ ^ 2) := hHad
+      _ ≤ (B i₁ ^ (N - 2) * ‖α i₁ - α i₀‖ * Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2))
+            * ∏ j ∈ univ.erase i₁, (Real.sqrt N * B j ^ (N - 1)) := hprodbound
+      _ = _ := by rw [hprodrw]
+  refine hcombine.trans ?_
+  -- The final algebra: `(B i₁)^{N-2} ≤ (B i₁)^{N-1}` absorbs the leftover factor.
+  set K := Real.sqrt N ^ (N - 1) * Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2) * ‖c‖ ^ (N - 1)
+      * (∏ j ∈ univ.erase i₁, B j) ^ (N - 1) * ‖α i₁ - α i₀‖ with hKdef
+  have hKnn : (0 : ℝ) ≤ K := by
+    rw [hKdef]
+    exact mul_nonneg (mul_nonneg (mul_nonneg (mul_nonneg
+      (pow_nonneg (Real.sqrt_nonneg _) _) (Real.sqrt_nonneg _))
+      (pow_nonneg (norm_nonneg _) _)) (pow_nonneg hprodEnn _)) (norm_nonneg _)
+  have hBig : ‖c‖ ^ (N - 1) * (B i₁ ^ (N - 2) * ‖α i₁ - α i₀‖
+        * Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2)
+        * (Real.sqrt N ^ (N - 1) * (∏ j ∈ univ.erase i₁, B j) ^ (N - 1)))
+      = K * B i₁ ^ (N - 2) := by rw [hKdef]; ring
+  have hTar : Real.sqrt N ^ (N - 1) * Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2)
+        * (‖c‖ * ∏ j, B j) ^ (N - 1) * ‖α i₁ - α i₀‖ = K * B i₁ ^ (N - 1) := by
+    rw [show (∏ j, B j) = B i₁ * ∏ j ∈ univ.erase i₁, B j from
+      (Finset.mul_prod_erase univ B (Finset.mem_univ i₁)).symm, mul_pow, mul_pow, hKdef]
+    ring
+  rw [hBig, hTar]
+  exact mul_le_mul_of_nonneg_left (pow_le_pow_right₀ (hB1 i₁) (by omega)) hKnn
+
+/-- The off-diagonal root-difference product equals `‖det V‖²` in norm. -/
+theorem norm_prod_roots_eq_sq {N : ℕ} (α : Fin N → ℂ) (hα : Function.Injective α) :
+    ‖((Multiset.map α univ.val).map
+        (fun x => (((Multiset.map α univ.val).erase x).map (fun y => x - y)).prod)).prod‖
+      = ‖(Matrix.vandermonde α).det‖ ^ 2 := by
+  classical
+  -- Reduce the multiset double product to a `Finset` double product.
+  have hD : ((Multiset.map α univ.val).map
+      (fun x => (((Multiset.map α univ.val).erase x).map (fun y => x - y)).prod)).prod
+        = ∏ i, ∏ j ∈ univ.erase i, (α i - α j) := by
+    rw [Multiset.map_map, ← Finset.prod_eq_multiset_prod]
+    refine Finset.prod_congr rfl (fun i _ => ?_)
+    simp only [Function.comp_apply]
+    rw [← Multiset.map_erase α hα, ← Finset.erase_val, Multiset.map_map,
+      ← Finset.prod_eq_multiset_prod]
+    rfl
+  rw [hD, det_vandermonde]
+  simp only [norm_prod]
+  -- Symmetry of the norm of a difference.
+  have hsym : ∀ a b : ℂ, ‖a - b‖ = ‖b - a‖ := fun a b => norm_sub_rev a b
+  -- Rewrite the Vandermonde side to `∏ i, ∏ j ∈ Ioi i, ‖α i - α j‖`.
+  have hQ : ∏ i, ∏ j ∈ Ioi i, ‖α j - α i‖ = ∏ i, ∏ j ∈ Ioi i, ‖α i - α j‖ :=
+    Finset.prod_congr rfl (fun i _ => Finset.prod_congr rfl (fun j _ => hsym _ _))
+  rw [hQ]
+  -- The lower-triangular product equals the upper-triangular product by symmetry.
+  have hPIio : ∏ i, ∏ j ∈ Iio i, ‖α i - α j‖ = ∏ i, ∏ j ∈ Ioi i, ‖α i - α j‖ := by
+    rw [Finset.prod_comm' (s := univ) (t := fun i => Iio i) (t' := univ) (s' := fun j => Ioi j)
+      (by intro x y; simp only [Finset.mem_univ, true_and, and_true,
+        Finset.mem_Iio, Finset.mem_Ioi])]
+    exact Finset.prod_congr rfl (fun i _ => Finset.prod_congr rfl (fun j _ => hsym _ _))
+  -- Split `univ.erase i = Ioi i ⊔ Iio i` and recombine.
+  have hsplit2 : ∀ i : Fin N,
+      univ.erase i = (Ioi i).disjUnion (Iio i) (Finset.disjoint_Ioi_Iio i) := by
+    intro i; rw [Finset.Ioi_disjUnion_Iio, Finset.compl_singleton]
+  calc ∏ i, ∏ j ∈ univ.erase i, ‖α i - α j‖
+      = ∏ i, ((∏ j ∈ Ioi i, ‖α i - α j‖) * ∏ j ∈ Iio i, ‖α i - α j‖) :=
+        Finset.prod_congr rfl (fun i _ => by rw [hsplit2 i, Finset.prod_disjUnion])
+    _ = (∏ i, ∏ j ∈ Ioi i, ‖α i - α j‖) * ∏ i, ∏ j ∈ Iio i, ‖α i - α j‖ :=
+        Finset.prod_mul_distrib
+    _ = (∏ i, ∏ j ∈ Ioi i, ‖α i - α j‖) ^ 2 := by rw [hPIio, sq]
+
+/-- The discriminant in root-enumeration form: `‖disc f‖ = ‖lc‖^{2n-2} · ‖det V‖²`. -/
+theorem norm_discr_eq {N : ℕ} (α : Fin N → ℂ) (hα : Function.Injective α) {f : ℂ[X]}
+    (hf : 0 < f.degree) (hsplit : f.Splits) (hroots : f.roots = Multiset.map α univ.val) :
+    ‖f.discr‖ = ‖f.leadingCoeff‖ ^ (2 * f.natDegree - 2) * ‖(Matrix.vandermonde α).det‖ ^ 2 := by
+  classical
+  rw [discr_eq_prod_roots hf hsplit]
+  simp only [norm_mul, norm_pow, norm_neg, norm_one, one_pow, one_mul]
+  rw [hroots, norm_prod_roots_eq_sq α hα]
+
+end
+
+end HexPolyZMathlib

--- a/HexPolyZMathlib/SPEC/hex-poly-z-mathlib.md
+++ b/HexPolyZMathlib/SPEC/hex-poly-z-mathlib.md
@@ -121,6 +121,9 @@ root-separation development live here once for both roots companions:
   compatibility, and the integer lower bound `1 ≤ |discr f|`.
 - `HexPolyZMathlib/Hadamard.lean` proves the sharp column-norm determinant
   inequality `Matrix.norm_det_le_prod_norm_column` over an `RCLike` field.
+- `HexPolyZMathlib/MahlerSeparation.lean` proves the generic complex
+  Vandermonde column bounds and identifies the discriminant root product with
+  the squared Vandermonde norm.
 
 Both modules are stated at ordinary Mathlib generality and import no executable
 root-isolation library. Companion-specific precision arithmetic remains in the

--- a/HexRealRootsMathlib.lean
+++ b/HexRealRootsMathlib.lean
@@ -36,8 +36,9 @@ free of any `HexRealRoots` dependence, so it can be contributed to Mathlib
 The executable-correspondence and consequence files build on it:
 `ChainCorrespond` connects `Hex.sturmChain`, `Hex.sturmCount`, and `Hex.rootCount`
 to the abstract development; `Separation` supplies the Mahler separation bound,
-using the shared analysis re-exported by the `Discr`/`Hadamard` compatibility
-modules; `Isolations` and `Drivers` prove isolation soundness, run
+using `HexPolyZMathlib.MahlerSeparation` and the analysis re-exported by the
+`Discr`/`Hadamard` compatibility modules; `Isolations` and `Drivers` prove
+isolation soundness, run
 completeness, driver completeness, and refinement; `SimpleRealRoot` proves the
 root-identity theorems (overlap classes are the real roots); and `TwoCircle`
 proves Descartes-engine termination (`isolateDescartes?_isSome`) behind its

--- a/HexRealRootsMathlib/Separation.lean
+++ b/HexRealRootsMathlib/Separation.lean
@@ -9,9 +9,9 @@ module
 public import Mathlib
 public import HexRealRoots.Prec
 public import HexPolyZMathlib.Basic
-public import HexPolyZMathlib.Mignotte
-public import HexPolyZMathlib.Hadamard
 public import HexPolyZMathlib.Discriminant
+public import HexPolyZMathlib.Mignotte
+public import HexPolyZMathlib.MahlerSeparation
 
 public section
 
@@ -30,13 +30,10 @@ real-root isolation in `HexRealRoots.Prec`, against the Mathlib casts
   `toReal_twoPow` evaluates the dyadic power of two.
 
 The Mahler separation bound `sepPrec_separates` — distinct complex roots of a
-squarefree `p` are more than `4 · 2^{-sepPrec p}` apart — is the project's
-hardest remaining assembly (Mahler 1964: `|disc p| ≥ 1`, the discriminant
-root-product formula in `HexPolyZMathlib.Discriminant`, Hadamard's inequality on
-the Vandermonde matrix in `HexPolyZMathlib.Hadamard`, and Landau's
-inequality `HexPolyZMathlib.mahlerMeasure_le_l2norm`). It is not yet
-formalised here; the numeric groundwork (`le_two_pow_ceilLog2Nat`,
-`toReal_twoPow`, the `toPolyℂ` cast) lives in this file for the follow-up.
+squarefree `p` are more than `4 · 2^{-sepPrec p}` apart — combines the generic
+discriminant/Vandermonde analysis in `HexPolyZMathlib.MahlerSeparation` with
+Landau's inequality and the executable `sepPrec` exponent arithmetic retained
+in this companion.
 -/
 
 namespace HexRealRootsMathlib
@@ -282,245 +279,60 @@ the roots two ways: the discriminant root-product gives `|disc| = |lc|^{2n-2} ·
 `|lc|^{n-1} · |det V|` by `n^{(n+2)/2} · M(p)^{n-1} · ‖z₁ − z₂‖`. Combined with
 `|disc| ≥ 1` and Landau's inequality `M(p) ≤ L`, this yields the separation.
 
-The building blocks (`Matrix.norm_det_le_prod_norm_column`,
-`Polynomial.discr_eq_prod_roots`, `Polynomial.mahlerMeasure_le_l2norm`) are stated
-in ordinary Mathlib generality; the pieces below are Hex-free until the final
-assembly. -/
+The generic building blocks and Vandermonde assembly now live in
+`HexPolyZMathlib.MahlerSeparation`; the closed-form exponent and executable
+specialization remain below. -/
 
-section MahlerSep
+/-! The following forwarding theorems intentionally preserve the qualified
+`HexRealRootsMathlib` API from before the shared-module extraction. New proofs
+should use the `HexPolyZMathlib` declarations directly. -/
 
-open Finset Matrix
-
-/-- The divided-difference entry bound: `‖yⁱ − xⁱ‖ ≤ i · Cⁱ⁻¹ · ‖y − x‖` when
-`‖x‖, ‖y‖ ≤ C` and `1 ≤ C`. Follows from the geometric factorisation
-`yⁱ − xⁱ = (∑_{l<i} yˡ xⁱ⁻¹⁻ˡ)(y − x)`. -/
+/-- Compatibility forwarding theorem for the generic divided-difference bound. -/
 theorem norm_pow_sub_pow_le {x y : ℂ} {C : ℝ} (hx : ‖x‖ ≤ C) (hy : ‖y‖ ≤ C)
-    (hC : 1 ≤ C) (i : ℕ) : ‖y ^ i - x ^ i‖ ≤ (i : ℝ) * C ^ (i - 1) * ‖y - x‖ := by
-  rw [← geom_sum₂_mul y x i, norm_mul]
-  refine mul_le_mul_of_nonneg_right ?_ (norm_nonneg _)
-  calc ‖∑ l ∈ Finset.range i, y ^ l * x ^ (i - 1 - l)‖
-      ≤ ∑ l ∈ Finset.range i, ‖y ^ l * x ^ (i - 1 - l)‖ := norm_sum_le _ _
-    _ ≤ ∑ _l ∈ Finset.range i, C ^ (i - 1) := by
-        apply Finset.sum_le_sum
-        intro l hl
-        have hl' : l ≤ i - 1 := by have := Finset.mem_range.mp hl; omega
-        rw [norm_mul, norm_pow, norm_pow]
-        calc ‖y‖ ^ l * ‖x‖ ^ (i - 1 - l) ≤ C ^ l * C ^ (i - 1 - l) := by
-              gcongr
-          _ = C ^ (l + (i - 1 - l)) := by rw [← pow_add]
-          _ = C ^ (i - 1) := by rw [Nat.add_sub_cancel' hl']
-    _ = (i : ℝ) * C ^ (i - 1) := by
-        rw [Finset.sum_const, Finset.card_range, nsmul_eq_mul]
+    (hC : 1 ≤ C) (i : ℕ) : ‖y ^ i - x ^ i‖ ≤ (i : ℝ) * C ^ (i - 1) * ‖y - x‖ :=
+  HexPolyZMathlib.norm_pow_sub_pow_le hx hy hC i
 
-/-- The L² norm of an ordinary Vandermonde column: `√(∑ᵢ ‖aⁱ‖²) ≤ √N · max(1,‖a‖)^{N-1}`. -/
+/-- Compatibility forwarding theorem for the ordinary Vandermonde-column bound. -/
 theorem sqrt_sum_pow_sq_le (a : ℂ) (N : ℕ) :
-    Real.sqrt (∑ i : Fin N, ‖a ^ (i : ℕ)‖ ^ 2) ≤ Real.sqrt N * (max 1 ‖a‖) ^ (N - 1) := by
-  have hBnn : (0 : ℝ) ≤ max 1 ‖a‖ := le_trans zero_le_one (le_max_left _ _)
-  have hbound : ∑ i : Fin N, ‖a ^ (i : ℕ)‖ ^ 2 ≤ (N : ℝ) * (max 1 ‖a‖) ^ (2 * (N - 1)) := by
-    have : ∀ i : Fin N, ‖a ^ (i : ℕ)‖ ^ 2 ≤ (max 1 ‖a‖) ^ (2 * (N - 1)) := by
-      intro i
-      rw [norm_pow, ← pow_mul]
-      calc ‖a‖ ^ ((i : ℕ) * 2) ≤ (max 1 ‖a‖) ^ ((i : ℕ) * 2) := by
-            gcongr
-            exact le_max_right _ _
-        _ ≤ (max 1 ‖a‖) ^ (2 * (N - 1)) := by
-            apply pow_le_pow_right₀ (le_max_left _ _)
-            have := i.isLt; omega
-    calc ∑ i : Fin N, ‖a ^ (i : ℕ)‖ ^ 2
-        ≤ ∑ _i : Fin N, (max 1 ‖a‖) ^ (2 * (N - 1)) := Finset.sum_le_sum (fun i _ => this i)
-      _ = (N : ℝ) * (max 1 ‖a‖) ^ (2 * (N - 1)) := by
-          rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
-  calc Real.sqrt (∑ i : Fin N, ‖a ^ (i : ℕ)‖ ^ 2)
-      ≤ Real.sqrt ((N : ℝ) * (max 1 ‖a‖) ^ (2 * (N - 1))) := Real.sqrt_le_sqrt hbound
-    _ = Real.sqrt N * (max 1 ‖a‖) ^ (N - 1) := by
-        rw [Real.sqrt_mul (Nat.cast_nonneg N), show 2 * (N - 1) = (N - 1) * 2 by ring,
-          pow_mul, Real.sqrt_sq (by positivity)]
+    Real.sqrt (∑ i : Fin N, ‖a ^ (i : ℕ)‖ ^ 2) ≤
+      Real.sqrt N * (max 1 ‖a‖) ^ (N - 1) :=
+  HexPolyZMathlib.sqrt_sum_pow_sq_le a N
 
-/-- The L² norm of the isolating (differenced) Vandermonde column:
-`√(∑ᵢ ‖yⁱ − xⁱ‖²) ≤ C^{N-2} · ‖y − x‖ · √(∑ᵢ i²)`. -/
+/-- Compatibility forwarding theorem for the differenced Vandermonde-column bound. -/
 theorem sqrt_sum_sub_pow_sq_le {x y : ℂ} {C : ℝ} (hx : ‖x‖ ≤ C) (hy : ‖y‖ ≤ C)
     (hC : 1 ≤ C) (N : ℕ) :
-    Real.sqrt (∑ i : Fin N, ‖y ^ (i : ℕ) - x ^ (i : ℕ)‖ ^ 2)
-      ≤ C ^ (N - 2) * ‖y - x‖ * Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2) := by
-  have hCnn : (0 : ℝ) ≤ C := le_trans zero_le_one hC
-  have hbound : ∑ i : Fin N, ‖y ^ (i : ℕ) - x ^ (i : ℕ)‖ ^ 2
-      ≤ (C ^ (N - 2) * ‖y - x‖) ^ 2 * ∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2 := by
-    rw [Finset.mul_sum]
-    apply Finset.sum_le_sum
-    intro i _
-    have hentry : ‖y ^ (i : ℕ) - x ^ (i : ℕ)‖ ≤ ((i : ℕ) : ℝ) * C ^ (N - 2) * ‖y - x‖ := by
-      refine (norm_pow_sub_pow_le hx hy hC (i : ℕ)).trans ?_
-      have hstep : C ^ ((i : ℕ) - 1) ≤ C ^ (N - 2) := by
-        apply pow_le_pow_right₀ hC; have := i.isLt; omega
-      exact mul_le_mul_of_nonneg_right
-        (mul_le_mul_of_nonneg_left hstep (Nat.cast_nonneg _)) (norm_nonneg _)
-    calc ‖y ^ (i : ℕ) - x ^ (i : ℕ)‖ ^ 2
-        ≤ (((i : ℕ) : ℝ) * C ^ (N - 2) * ‖y - x‖) ^ 2 :=
-          pow_le_pow_left₀ (norm_nonneg _) hentry 2
-      _ = (C ^ (N - 2) * ‖y - x‖) ^ 2 * ((i : ℕ) : ℝ) ^ 2 := by ring
-  calc Real.sqrt (∑ i : Fin N, ‖y ^ (i : ℕ) - x ^ (i : ℕ)‖ ^ 2)
-      ≤ Real.sqrt ((C ^ (N - 2) * ‖y - x‖) ^ 2 * ∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2) :=
-        Real.sqrt_le_sqrt hbound
-    _ = C ^ (N - 2) * ‖y - x‖ * Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2) := by
-        rw [Real.sqrt_mul (sq_nonneg _), Real.sqrt_sq (by positivity)]
+    Real.sqrt (∑ i : Fin N, ‖y ^ (i : ℕ) - x ^ (i : ℕ)‖ ^ 2) ≤
+      C ^ (N - 2) * ‖y - x‖ * Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2) :=
+  HexPolyZMathlib.sqrt_sum_sub_pow_sq_le hx hy hC N
 
-/-- `√(∑_{i<N} i²) ≤ (√N)³`. -/
+/-- Compatibility forwarding theorem for the sum-of-squares estimate. -/
 theorem sqrt_sum_sq_le (N : ℕ) :
-    Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2) ≤ Real.sqrt N ^ 3 := by
-  have hb : ∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2 ≤ (N : ℝ) ^ 3 := by
-    calc ∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2
-        ≤ ∑ _i : Fin N, (N : ℝ) ^ 2 := by
-          apply Finset.sum_le_sum
-          intro i _
-          have hi : ((i : ℕ) : ℝ) ≤ (N : ℝ) := by exact_mod_cast Nat.le_of_lt i.isLt
-          exact pow_le_pow_left₀ (Nat.cast_nonneg _) hi 2
-      _ = (N : ℝ) ^ 3 := by
-          rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]; ring
-  have hsq : (Real.sqrt N ^ 3) ^ 2 = (N : ℝ) ^ 3 := by
-    rw [← pow_mul, show 3 * 2 = 2 * 3 from rfl, pow_mul, Real.sq_sqrt (Nat.cast_nonneg N)]
-  refine (Real.sqrt_le_sqrt hb).trans (le_of_eq ?_)
-  rw [← hsq, Real.sqrt_sq (by positivity)]
+    Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2) ≤ Real.sqrt N ^ 3 :=
+  HexPolyZMathlib.sqrt_sum_sq_le N
 
-/-- **Mahler's isolating-column bound.** For a leading coefficient `c` and points
-`α : Fin N → ℂ` with `‖α i₀‖ ≤ ‖α i₁‖`, the scaled Vandermonde determinant is
-bounded by `√N^{N-1} · √(∑ i²) · (‖c‖ · ∏ max(1,‖α j‖))^{N-1} · ‖α i₁ − α i₀‖`. -/
+/-- Compatibility forwarding theorem for the isolating-column determinant bound. -/
 theorem norm_det_vandermonde_le {N : ℕ} (hN : 2 ≤ N) (c : ℂ) (α : Fin N → ℂ)
     {i₀ i₁ : Fin N} (hne : i₀ ≠ i₁) (hle : ‖α i₀‖ ≤ ‖α i₁‖) :
     ‖c‖ ^ (N - 1) * ‖(Matrix.vandermonde α).det‖ ≤
       Real.sqrt N ^ (N - 1) * Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2)
-        * (‖c‖ * ∏ j, max 1 ‖α j‖) ^ (N - 1) * ‖α i₁ - α i₀‖ := by
-  classical
-  set B : Fin N → ℝ := fun j => max 1 ‖α j‖ with hBdef
-  have hB1 : ∀ j, (1 : ℝ) ≤ B j := fun j => le_max_left _ _
-  have hBnorm : ∀ j, ‖α j‖ ≤ B j := fun j => le_max_right _ _
-  have hB0 : ∀ j, (0 : ℝ) ≤ B j := fun j => le_trans zero_le_one (hB1 j)
-  -- The row-reduced matrix `W`: subtract row `i₀` from row `i₁`.
-  set W : Matrix (Fin N) (Fin N) ℂ :=
-    (Matrix.vandermonde α).updateRow i₁
-      ((Matrix.vandermonde α) i₁ + (-1 : ℂ) • (Matrix.vandermonde α) i₀) with hWdef
-  have hWdet : W.det = (Matrix.vandermonde α).det :=
-    Matrix.det_updateRow_add_smul_self _ (Ne.symm hne) _
-  have hWne : ∀ j, j ≠ i₁ → ∀ i : Fin N, W j i = α j ^ (i : ℕ) := by
-    intro j hj i
-    rw [hWdef, Matrix.updateRow_ne hj, Matrix.vandermonde_apply]
-  have hWeq : ∀ i : Fin N, W i₁ i = α i₁ ^ (i : ℕ) - α i₀ ^ (i : ℕ) := by
-    intro i
-    rw [hWdef, Matrix.updateRow_self]
-    simp only [Pi.add_apply, Pi.smul_apply, Matrix.vandermonde_apply, smul_eq_mul, neg_one_mul]
-    ring
-  -- Hadamard's inequality applied to the transpose.
-  have hHad : ‖(Matrix.vandermonde α).det‖ ≤ ∏ j, Real.sqrt (∑ i, ‖W j i‖ ^ 2) := by
-    rw [← hWdet, ← Matrix.det_transpose W]
-    exact Matrix.norm_det_le_prod_norm_column Wᵀ
-  -- Column bounds.
-  have hRi1 : Real.sqrt (∑ i, ‖W i₁ i‖ ^ 2)
-      ≤ B i₁ ^ (N - 2) * ‖α i₁ - α i₀‖ * Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2) := by
-    rw [show (∑ i, ‖W i₁ i‖ ^ 2) = ∑ i : Fin N, ‖α i₁ ^ (i : ℕ) - α i₀ ^ (i : ℕ)‖ ^ 2 from
-      Finset.sum_congr rfl (fun i _ => by rw [hWeq i])]
-    exact sqrt_sum_sub_pow_sq_le (le_trans hle (hBnorm i₁)) (hBnorm i₁) (hB1 i₁) N
-  have hRj : ∀ j, j ≠ i₁ →
-      Real.sqrt (∑ i, ‖W j i‖ ^ 2) ≤ Real.sqrt N * B j ^ (N - 1) := by
-    intro j hj
-    rw [show (∑ i, ‖W j i‖ ^ 2) = ∑ i : Fin N, ‖α j ^ (i : ℕ)‖ ^ 2 from
-      Finset.sum_congr rfl (fun i _ => by rw [hWne j hj i])]
-    exact sqrt_sum_pow_sq_le (α j) N
-  -- Product of column bounds.
-  have herasecard : (univ.erase i₁).card = N - 1 := by
-    rw [Finset.card_erase_of_mem (Finset.mem_univ i₁), Finset.card_univ, Fintype.card_fin]
-  have hprodEnn : (0 : ℝ) ≤ ∏ j ∈ univ.erase i₁, B j := Finset.prod_nonneg (fun j _ => hB0 j)
-  have hprodbound : ∏ j, Real.sqrt (∑ i, ‖W j i‖ ^ 2)
-      ≤ (B i₁ ^ (N - 2) * ‖α i₁ - α i₀‖ * Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2))
-        * ∏ j ∈ univ.erase i₁, (Real.sqrt N * B j ^ (N - 1)) := by
-    rw [← Finset.mul_prod_erase univ _ (Finset.mem_univ i₁)]
-    refine mul_le_mul hRi1 ?_ (Finset.prod_nonneg (fun j _ => Real.sqrt_nonneg _))
-      (mul_nonneg (mul_nonneg (pow_nonneg (hB0 i₁) _) (norm_nonneg _)) (Real.sqrt_nonneg _))
-    exact Finset.prod_le_prod (fun j _ => Real.sqrt_nonneg _)
-      (fun j hj => hRj j (Finset.mem_erase.mp hj).1)
-  have hprodrw : ∏ j ∈ univ.erase i₁, (Real.sqrt N * B j ^ (N - 1))
-      = Real.sqrt N ^ (N - 1) * (∏ j ∈ univ.erase i₁, B j) ^ (N - 1) := by
-    rw [Finset.prod_mul_distrib, Finset.prod_const, herasecard, Finset.prod_pow]
-  -- Combine.
-  have hcombine : ‖c‖ ^ (N - 1) * ‖(Matrix.vandermonde α).det‖
-      ≤ ‖c‖ ^ (N - 1) * (B i₁ ^ (N - 2) * ‖α i₁ - α i₀‖
-          * Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2)
-          * (Real.sqrt N ^ (N - 1) * (∏ j ∈ univ.erase i₁, B j) ^ (N - 1))) := by
-    refine mul_le_mul_of_nonneg_left ?_ (pow_nonneg (norm_nonneg c) _)
-    calc ‖(Matrix.vandermonde α).det‖ ≤ ∏ j, Real.sqrt (∑ i, ‖W j i‖ ^ 2) := hHad
-      _ ≤ (B i₁ ^ (N - 2) * ‖α i₁ - α i₀‖ * Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2))
-            * ∏ j ∈ univ.erase i₁, (Real.sqrt N * B j ^ (N - 1)) := hprodbound
-      _ = _ := by rw [hprodrw]
-  refine hcombine.trans ?_
-  -- The final algebra: `(B i₁)^{N-2} ≤ (B i₁)^{N-1}` absorbs the leftover factor.
-  set K := Real.sqrt N ^ (N - 1) * Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2) * ‖c‖ ^ (N - 1)
-      * (∏ j ∈ univ.erase i₁, B j) ^ (N - 1) * ‖α i₁ - α i₀‖ with hKdef
-  have hKnn : (0 : ℝ) ≤ K := by
-    rw [hKdef]
-    exact mul_nonneg (mul_nonneg (mul_nonneg (mul_nonneg
-      (pow_nonneg (Real.sqrt_nonneg _) _) (Real.sqrt_nonneg _))
-      (pow_nonneg (norm_nonneg _) _)) (pow_nonneg hprodEnn _)) (norm_nonneg _)
-  have hBig : ‖c‖ ^ (N - 1) * (B i₁ ^ (N - 2) * ‖α i₁ - α i₀‖
-        * Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2)
-        * (Real.sqrt N ^ (N - 1) * (∏ j ∈ univ.erase i₁, B j) ^ (N - 1)))
-      = K * B i₁ ^ (N - 2) := by rw [hKdef]; ring
-  have hTar : Real.sqrt N ^ (N - 1) * Real.sqrt (∑ i : Fin N, ((i : ℕ) : ℝ) ^ 2)
-        * (‖c‖ * ∏ j, B j) ^ (N - 1) * ‖α i₁ - α i₀‖ = K * B i₁ ^ (N - 1) := by
-    rw [show (∏ j, B j) = B i₁ * ∏ j ∈ univ.erase i₁, B j from
-      (Finset.mul_prod_erase univ B (Finset.mem_univ i₁)).symm, mul_pow, mul_pow, hKdef]
-    ring
-  rw [hBig, hTar]
-  exact mul_le_mul_of_nonneg_left (pow_le_pow_right₀ (hB1 i₁) (by omega)) hKnn
+        * (‖c‖ * ∏ j, max 1 ‖α j‖) ^ (N - 1) * ‖α i₁ - α i₀‖ :=
+  HexPolyZMathlib.norm_det_vandermonde_le hN c α hne hle
 
-/-- The off-diagonal root-difference product equals `‖det V‖²` in norm. -/
+/-- Compatibility forwarding theorem for the off-diagonal root-product identity. -/
 theorem norm_prod_roots_eq_sq {N : ℕ} (α : Fin N → ℂ) (hα : Function.Injective α) :
-    ‖((Multiset.map α univ.val).map
-        (fun x => (((Multiset.map α univ.val).erase x).map (fun y => x - y)).prod)).prod‖
-      = ‖(Matrix.vandermonde α).det‖ ^ 2 := by
-  classical
-  -- Reduce the multiset double product to a `Finset` double product.
-  have hD : ((Multiset.map α univ.val).map
-      (fun x => (((Multiset.map α univ.val).erase x).map (fun y => x - y)).prod)).prod
-        = ∏ i, ∏ j ∈ univ.erase i, (α i - α j) := by
-    rw [Multiset.map_map, ← Finset.prod_eq_multiset_prod]
-    refine Finset.prod_congr rfl (fun i _ => ?_)
-    simp only [Function.comp_apply]
-    rw [← Multiset.map_erase α hα, ← Finset.erase_val, Multiset.map_map,
-      ← Finset.prod_eq_multiset_prod]
-    rfl
-  rw [hD, det_vandermonde]
-  simp only [norm_prod]
-  -- Symmetry of the norm of a difference.
-  have hsym : ∀ a b : ℂ, ‖a - b‖ = ‖b - a‖ := fun a b => norm_sub_rev a b
-  -- Rewrite the Vandermonde side to `∏ i, ∏ j ∈ Ioi i, ‖α i - α j‖`.
-  have hQ : ∏ i, ∏ j ∈ Ioi i, ‖α j - α i‖ = ∏ i, ∏ j ∈ Ioi i, ‖α i - α j‖ :=
-    Finset.prod_congr rfl (fun i _ => Finset.prod_congr rfl (fun j _ => hsym _ _))
-  rw [hQ]
-  -- The lower-triangular product equals the upper-triangular product by symmetry.
-  have hPIio : ∏ i, ∏ j ∈ Iio i, ‖α i - α j‖ = ∏ i, ∏ j ∈ Ioi i, ‖α i - α j‖ := by
-    rw [Finset.prod_comm' (s := univ) (t := fun i => Iio i) (t' := univ) (s' := fun j => Ioi j)
-      (by intro x y; simp only [Finset.mem_univ, true_and, and_true,
-        Finset.mem_Iio, Finset.mem_Ioi])]
-    exact Finset.prod_congr rfl (fun i _ => Finset.prod_congr rfl (fun j _ => hsym _ _))
-  -- Split `univ.erase i = Ioi i ⊔ Iio i` and recombine.
-  have hsplit2 : ∀ i : Fin N,
-      univ.erase i = (Ioi i).disjUnion (Iio i) (Finset.disjoint_Ioi_Iio i) := by
-    intro i; rw [Finset.Ioi_disjUnion_Iio, Finset.compl_singleton]
-  calc ∏ i, ∏ j ∈ univ.erase i, ‖α i - α j‖
-      = ∏ i, ((∏ j ∈ Ioi i, ‖α i - α j‖) * ∏ j ∈ Iio i, ‖α i - α j‖) :=
-        Finset.prod_congr rfl (fun i _ => by rw [hsplit2 i, Finset.prod_disjUnion])
-    _ = (∏ i, ∏ j ∈ Ioi i, ‖α i - α j‖) * ∏ i, ∏ j ∈ Iio i, ‖α i - α j‖ :=
-        Finset.prod_mul_distrib
-    _ = (∏ i, ∏ j ∈ Ioi i, ‖α i - α j‖) ^ 2 := by rw [hPIio, sq]
+    ‖((Multiset.map α Finset.univ.val).map
+        (fun x => (((Multiset.map α Finset.univ.val).erase x).map
+          (fun y => x - y)).prod)).prod‖ = ‖(Matrix.vandermonde α).det‖ ^ 2 :=
+  HexPolyZMathlib.norm_prod_roots_eq_sq α hα
 
-/-- The discriminant in root-enumeration form: `‖disc f‖ = ‖lc‖^{2n-2} · ‖det V‖²`. -/
+/-- Compatibility forwarding theorem for the discriminant/Vandermonde identity. -/
 theorem norm_discr_eq {N : ℕ} (α : Fin N → ℂ) (hα : Function.Injective α) {f : ℂ[X]}
-    (hf : 0 < f.degree) (hsplit : f.Splits) (hroots : f.roots = Multiset.map α univ.val) :
-    ‖f.discr‖ = ‖f.leadingCoeff‖ ^ (2 * f.natDegree - 2) * ‖(Matrix.vandermonde α).det‖ ^ 2 := by
-  classical
-  rw [discr_eq_prod_roots hf hsplit]
-  simp only [norm_mul, norm_pow, norm_neg, norm_one, one_pow, one_mul]
-  rw [hroots, norm_prod_roots_eq_sq α hα]
+    (hf : 0 < f.degree) (hsplit : f.Splits)
+    (hroots : f.roots = Multiset.map α Finset.univ.val) :
+    ‖f.discr‖ = ‖f.leadingCoeff‖ ^ (2 * f.natDegree - 2) *
+      ‖(Matrix.vandermonde α).det‖ ^ 2 :=
+  HexPolyZMathlib.norm_discr_eq α hα hf hsplit hroots
 
-end MahlerSep
 
 /-- The closed-form separation exponent dominates the analytic bound:
 `√n^{n+2} · L^{n-1} ≤ 2^E` where `E = ((n+2)·⌈log₂ n⌉ + 1)/2 + (n-1)·⌈log₂ L⌉`. -/
@@ -637,7 +449,7 @@ theorem sepPrec_separates (p : Hex.ZPoly)
       rw [hfmap, Polynomial.discr_map_of_injective (Int.castRingHom ℂ)
         (RingHom.injective_int _) hdeg']; simp
     rw [hmap, Complex.norm_intCast]; exact_mod_cast hdiscZ
-  have hdisceq := norm_discr_eq α hαinj hdegf hsplit hroots.symm
+  have hdisceq := HexPolyZMathlib.norm_discr_eq α hαinj hdegf hsplit hroots.symm
   rw [hnatf] at hdisceq
   -- `A := ‖lc‖^{m-1}·‖det V‖ ≥ 1`.
   set V := (Matrix.vandermonde α).det with hV
@@ -651,7 +463,7 @@ theorem sepPrec_separates (p : Hex.ZPoly)
     nlinarith [hsq1, hAnn]
   -- The Mahler/Hadamard bound.
   have hnormα : ‖α i₀‖ ≤ ‖α i₁‖ := by rw [hαi0, hαi1]; exact hnorm
-  have hcrux := norm_det_vandermonde_le hN2 f.leadingCoeff α hii hnormα
+  have hcrux := HexPolyZMathlib.norm_det_vandermonde_le hN2 f.leadingCoeff α hii hnormα
   -- `√m^{m-1}·√(∑ i²) ≤ √m^{m+2}`.
   have hsqrtstep :
       Real.sqrt ℓ.length ^ (ℓ.length - 1) * Real.sqrt (∑ i : Fin ℓ.length, ((i : ℕ) : ℝ) ^ 2)
@@ -659,7 +471,7 @@ theorem sepPrec_separates (p : Hex.ZPoly)
     calc Real.sqrt ℓ.length ^ (ℓ.length - 1)
           * Real.sqrt (∑ i : Fin ℓ.length, ((i : ℕ) : ℝ) ^ 2)
         ≤ Real.sqrt ℓ.length ^ (ℓ.length - 1) * Real.sqrt ℓ.length ^ 3 :=
-          mul_le_mul_of_nonneg_left (sqrt_sum_sq_le ℓ.length) (by positivity)
+          mul_le_mul_of_nonneg_left (HexPolyZMathlib.sqrt_sum_sq_le ℓ.length) (by positivity)
       _ = Real.sqrt ℓ.length ^ (ℓ.length + 2) := by rw [← pow_add]; congr 1; omega
   -- The Mahler measure identity `M = ‖lc‖ · ∏ max(1,‖α j‖)` and Landau bound `M ≤ L`.
   have hMprod : (f.roots.map (fun a => max 1 ‖a‖)).prod = ∏ j, max 1 ‖α j‖ := by

--- a/HexRootsMathlib/SPEC/hex-roots-mathlib.md
+++ b/HexRootsMathlib/SPEC/hex-roots-mathlib.md
@@ -141,18 +141,18 @@ The smaller of the two new developments, and the one needed first:
 
 ### Theorem chain
 
-1. **`Polynomial.discr ≠ 0 ↔ Squarefree`** for `ℤ[x]` (and
-   characteristic zero generally). Assembled from the existing chain
-   `separable_iff_squarefree` ↔ `IsCoprime f f'` ↔ `resultant ≠ 0` ↔
-   `discr ≠ 0`. Lives in
-   `HexRootsMathlib/DiscriminantSquarefree.lean`.
+1. **Discriminant nonvanishing.** A positive-degree separable polynomial
+   has nonzero discriminant, and an integer polynomial whose rational cast is
+   separable satisfies `1 ≤ |discr f|`. The rational-cast condition is the
+   roots-facing squarefreeness notion; squarefreeness in `ℤ[x]` would also
+   constrain the content. Lives in `HexPolyZMathlib/Discriminant.lean`.
 
 2. **Discriminant root-product formula:**
    `discr f = lc(f)^{2n−2} · ∏_{i<j}(αᵢ − αⱼ)²` over the splitting
    field. Mathlib has the resultant version
    (`resultant_eq_prod_roots_sub`); we derive the discriminant version
    through `resultant_deriv`. Lives in
-   `HexRootsMathlib/DiscriminantRootProduct.lean`.
+   `HexPolyZMathlib/Discriminant.lean`.
 
 3. **Mahler separation bound:**
    ```
@@ -166,8 +166,10 @@ The smaller of the two new developments, and the one needed first:
    Mignotte and Ştefănescu, ch. 4, give a self-contained version
    suitable for direct formalisation. (A naive bound on the individual
    factors `|αᵢ − αⱼ| ≤ 2·M(p)` does *not* reach the stated constant;
-   Hadamard is essential.) Lives in
-   `HexRootsMathlib/MahlerSeparation.lean`.
+   Hadamard is essential.) The Hex-independent column estimates and
+   discriminant/Vandermonde identity live in
+   `HexPolyZMathlib/MahlerSeparation.lean`; companion-specific executable
+   exponent arithmetic stays with the relevant roots library.
 
 4. **`mahlerPrec` correctness:** the computational
    `Hex.mahlerPrec p : Nat` (defined in `HexRoots/MahlerPrec.lean`)
@@ -359,10 +361,13 @@ scope is honest; nothing else in the plan silently depends on them.
 ## File organisation
 
 ```
-Discriminant / separation development (candidate Mathlib contribution):
-  HexRootsMathlib/DiscriminantSquarefree.lean
-  HexRootsMathlib/DiscriminantRootProduct.lean
-  HexRootsMathlib/MahlerSeparation.lean
+Shared discriminant / separation development (candidate Mathlib contribution):
+  HexPolyZMathlib/Discriminant.lean
+  HexPolyZMathlib/Hadamard.lean
+  HexPolyZMathlib/MahlerSeparation.lean
+
+Executable complex-root specialization:
+  HexRootsMathlib/MahlerPrec.lean
 
 Rouché-on-circles development (candidate Mathlib contribution;
 the hardest slice):

--- a/SPEC/Libraries/hex-real-roots-mathlib.md
+++ b/SPEC/Libraries/hex-real-roots-mathlib.md
@@ -320,7 +320,7 @@ HexRealRootsMathlib/
   Discr.lean            -- compatibility import of the shared discriminant API
   Hadamard.lean         -- compatibility import of the shared determinant bound
   Separation.lean      -- sepPrec_separates, rootBound_bounds_roots;
-                          consumes shared analysis from hex-poly-z-mathlib
+                          specializes shared Mahler/Vandermonde analysis
   Isolations.lean      -- exists_unique_root, isolates
   Drivers.lean         -- isolateSturm?_isSome, isolate?_isSome,
                           refine1_isolates_same

--- a/progress/20260719T104836Z_issue-8755-mahler-core.md
+++ b/progress/20260719T104836Z_issue-8755-mahler-core.md
@@ -1,0 +1,37 @@
+# Accomplished
+
+- Extracted the exact seven-theorem Mahler/Vandermonde analytic block from
+  `HexRealRootsMathlib/Separation.lean` into the Hex-independent
+  `HexPolyZMathlib/MahlerSeparation.lean` module.
+- Moved the declarations to the `HexPolyZMathlib` namespace while retaining
+  forwarding theorems under their old `HexRealRootsMathlib` qualified names;
+  the real-roots specialization now calls the shared declarations directly.
+- Kept `pow_le_two_pow_sepExp` and `sepPrec_separates` in the executable
+  companion, and made the discriminant import explicit at its direct use site.
+- Updated both library descriptions and three affected SPEC/module maps,
+  including removal of stale private-module paths and the false implication
+  that roots-facing squarefreeness is squarefreeness in `ℤ[X]`.
+- Received a Claude Opus review confirming the extraction boundary,
+  signatures, call sites, imports, and acyclic layering. Addressed its import
+  and documentation findings; retained the compatibility wrappers because
+  source compatibility is an explicit #8775 deliverable.
+- Passed focused shared/downstream builds, the new-module Mathlib linter,
+  DAG/copyright/line-count/diff checks, and a full 9,380-job `lake build`.
+- Confirmed PR #8776 passed its exact CI job and auto-merged, and opened #8777
+  for the following executable `mahlerPrec` contract.
+
+# Current frontier
+
+Issue #8775 is implementation-complete in the stacked worktree and ready to
+commit and rebase onto PR #8776's squash merge on current `origin/main`.
+
+# Next step
+
+Commit, rebase, rerun the full build on the rebased tree, publish the reviewed
+PR with auto-merge, then begin #8777 in a separate worktree while CI runs.
+
+# Blockers
+
+Plan item 2 / #8772 remains paused on the documented nonprimitive-polynomial
+counterexample to squarefreeness in `ℤ[X]`. The shared analytic chain and the
+correct rational-cast separation hypothesis are not blocked.


### PR DESCRIPTION
## Summary

- extract the exact Hex-independent Mahler/Vandermonde theorem block into `HexPolyZMathlib.MahlerSeparation`
- keep executable exponent arithmetic and `sepPrec_separates` in `HexRealRootsMathlib`
- preserve the previous qualified real-roots theorem names through forwarding declarations while making new calls use the shared namespace
- update umbrellas and SPECs, including stale private-module paths and the corrected rational-cast squarefreeness premise

Closes #8775. Part of #8755.

## Verification

- exact theorem-body comparison against the pre-extraction source
- focused builds for the shared module, `HexRealRootsMathlib.Separation`, and the real-roots umbrella
- `lake exe runLinter HexPolyZMathlib.MahlerSeparation` passes
- DAG, copyright, line-count, Phase-4, `git diff --check`, and `sorry`/`axiom` audits pass
- full `lake build` passes before and after rebasing onto PR #8776 (9,380 jobs)

## Second opinion

Claude Opus confirmed the signature preservation, call sites, extraction boundary, and acyclic imports. I addressed its explicit discriminant-import and documentation findings. I retained the forwarding declarations despite its low-severity removal suggestion because preserving the old qualified API is an explicit child-issue deliverable; they are isolated as compatibility names and all implementation calls use `HexPolyZMathlib` directly.
