### PR TITLE
hex-roots-mathlib: prove the Taylor coefficient bridge

### DIFF
--- a/HexRootsMathlib.lean
+++ b/HexRootsMathlib.lean
@@ -9,6 +9,7 @@ module
 public import HexRootsMathlib.Basic
 public import HexRootsMathlib.Geometry
 public import HexRootsMathlib.MahlerPrec
+public import HexRootsMathlib.Taylor
 
 public section
 

--- a/HexRootsMathlib/Basic.lean
+++ b/HexRootsMathlib/Basic.lean
@@ -186,6 +186,20 @@ integer. -/
     toComplex (Hex.GaussDyadic.mul z w) = toComplex z * toComplex w := by
   apply Complex.ext <;> simp [toComplex, Hex.GaussDyadic.mul]
 
+/-- Casting a natural multiple of a Gaussian dyadic gives scalar
+multiplication in `ℂ`. -/
+@[simp] theorem toComplex_nsmul (n : Nat) (z : Hex.GaussDyadic) :
+    toComplex (Hex.GaussDyadic.nsmul n z) = (n : ℂ) * toComplex z := by
+  simp [Hex.GaussDyadic.nsmul]
+
+/-- Casting an exact Gaussian-dyadic power gives the corresponding complex
+power. -/
+@[simp] theorem toComplex_pow (z : Hex.GaussDyadic) (n : Nat) :
+    toComplex (Hex.GaussDyadic.pow z n) = toComplex z ^ n := by
+  induction n with
+  | zero => simp [Hex.GaussDyadic.pow]
+  | succ n ih => simp [Hex.GaussDyadic.pow, ih, pow_succ]
+
 /-- The real value of the exact squared modulus is the complex squared
 modulus. -/
 @[simp] theorem toReal_normSq (z : Hex.GaussDyadic) :

--- a/HexRootsMathlib/SPEC/hex-roots-mathlib.md
+++ b/HexRootsMathlib/SPEC/hex-roots-mathlib.md
@@ -265,6 +265,14 @@ developments above.
   square, and open/closed circumscribed discs. Simp lemmas
   `DyadicSquare.center_eq`, `DyadicSquare.disc_eq`. The later Pellet
   correspondence in this module proves "witness implies Pellet".
+- `HexRootsMathlib/Taylor.lean`: the shared exact-coefficient bridge
+  ```lean
+  theorem taylor_coeff (p : ZPoly) (z : GaussDyadic) (k : Nat) :
+      toComplex ((taylor p z).getD k (0, 0)) =
+        ((toPolyℂ p).comp (X + C (toComplex z))).coeff k
+  ```
+  including the out-of-bounds case. Its proof consumes the executable
+  `taylor_getD` characterization rather than unfolding the in-place folds.
 - `HexRootsMathlib/HasOnlySimpleRoots.lean`:
   for `p ≠ 0`, `Hex.HasOnlySimpleRoots p` is equivalent to separability of
   `(toPolynomial p).map (Int.castRingHom ℚ)`. Connects
@@ -393,6 +401,7 @@ port of Mehta-Macbeth, see the intro):
 Correspondence theorems (depend on hex-roots data structures):
   HexRootsMathlib/Basic.lean
   HexRootsMathlib/Geometry.lean
+  HexRootsMathlib/Taylor.lean
   HexRootsMathlib/HasOnlySimpleRoots.lean
   HexRootsMathlib/MahlerPrec.lean
   HexRootsMathlib/SimpleRoot.lean

--- a/HexRootsMathlib/Taylor.lean
+++ b/HexRootsMathlib/Taylor.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRootsMathlib.Basic
+public import Mathlib.Algebra.Polynomial.Taylor
+
+public section
+
+/-!
+# Taylor coefficient correspondence
+
+This module identifies the exact Gaussian-dyadic coefficients computed by
+`Hex.taylor` with Mathlib's coefficients of `p.comp (X + C z)`.  The executable
+fold semantics are encapsulated by `Hex.ZPoly.taylor_getD`; this companion only
+casts its closed binomial sum into `ℂ`.
+-/
+
+open Polynomial Finset
+
+namespace HexRootsMathlib
+
+noncomputable section
+
+/-- The Mathlib and Mathlib-free Pascal recursions define the same binomial
+coefficient. -/
+theorem choose_eq_choose (n k : Nat) : Hex.Nat.choose n k = Nat.choose n k := by
+  induction n generalizing k with
+  | zero => cases k <;> simp
+  | succ n ih =>
+      cases k with
+      | zero => simp
+      | succ k => rw [Hex.Nat.choose_succ_succ, Nat.choose_succ_succ, ih, ih]
+
+/-- Casting the executable finite Gaussian-dyadic sum gives a `Finset` sum in
+`ℂ`. -/
+theorem toComplex_gaussSum (n : Nat) (f : Nat → Hex.GaussDyadic) :
+    GaussDyadic.toComplex (Hex.gaussSum n f) =
+      ∑ i ∈ Finset.range n, GaussDyadic.toComplex (f i) := by
+  induction n with
+  | zero =>
+      simp only [Hex.gaussSum, List.range_zero, List.foldl_nil, Finset.range_zero,
+        Finset.sum_empty]
+      apply Complex.ext <;> simp [GaussDyadic.toComplex]
+  | succ n ih =>
+      rw [Hex.gaussSum_succ, GaussDyadic.toComplex_add, ih,
+        Finset.sum_range_succ]
+
+/-- The executable closed-form Taylor coefficient casts to its ordinary
+complex binomial sum. -/
+theorem toComplex_taylorCoeff (p : Hex.ZPoly) (z : Hex.GaussDyadic) (k : Nat) :
+    GaussDyadic.toComplex (Hex.taylorCoeff p z k) =
+      ∑ r ∈ Finset.range (p.size - k),
+        ((k + r).choose k : ℂ) * (p.coeff (k + r) : ℂ) *
+          GaussDyadic.toComplex z ^ r := by
+  unfold Hex.taylorCoeff
+  rw [toComplex_gaussSum]
+  apply Finset.sum_congr rfl
+  intro r _
+  simp [Hex.Nat.binom_eq_choose, choose_eq_choose]
+  ring
+
+/-- A nonempty executable polynomial has complex-cast degree strictly below
+its stored coefficient count. -/
+private theorem natDegree_lt_size (p : Hex.ZPoly) (hp : 0 < p.size) :
+    (toPolyℂ p).natDegree < p.size := by
+  rw [natDegree_toPolyℂ]
+  have hdegree : p.degree? = some (p.size - 1) := by
+    simp [Hex.DensePoly.degree?, Nat.ne_of_gt hp]
+  rw [hdegree, Option.getD_some]
+  omega
+
+/-- Coefficient `k` of the Mathlib Taylor shift is the same finite binomial
+sum used by the executable implementation. -/
+theorem coeff_shift (p : Hex.ZPoly) (z : Hex.GaussDyadic) (k : Nat) :
+    ((toPolyℂ p).comp (X + C (GaussDyadic.toComplex z))).coeff k =
+      ∑ r ∈ Finset.range (p.size - k),
+        ((k + r).choose k : ℂ) * (p.coeff (k + r) : ℂ) *
+          GaussDyadic.toComplex z ^ r := by
+  rw [← Polynomial.taylor_apply, Polynomial.taylor_coeff]
+  by_cases hk : k < p.size
+  · have hp : 0 < p.size := Nat.zero_lt_of_lt hk
+    have hdegree : (Polynomial.hasseDeriv k (toPolyℂ p)).natDegree < p.size - k :=
+      lt_of_le_of_lt (Polynomial.natDegree_hasseDeriv_le (toPolyℂ p) k) (by
+        have := natDegree_lt_size p hp
+        omega)
+    rw [Polynomial.eval_eq_sum_range' hdegree]
+    apply Finset.sum_congr rfl
+    intro r _
+    rw [Polynomial.hasseDeriv_coeff, coeff_toPolyℂ]
+    simp only [Nat.add_comm r k]
+  · have hksize : p.size ≤ k := Nat.le_of_not_gt hk
+    rw [Nat.sub_eq_zero_of_le hksize]
+    simp only [Finset.range_zero, Finset.sum_empty]
+    by_cases hp : p.size = 0
+    · have hp0 : p = 0 := by
+        apply Hex.DensePoly.ext_coeff
+        intro i
+        rw [Hex.DensePoly.coeff_zero]
+        exact Hex.DensePoly.coeff_eq_zero_of_size_le p (by omega)
+      simp [hp0, toPolyℂ]
+    · have hdegree : (toPolyℂ p).natDegree < k :=
+        (natDegree_lt_size p (Nat.pos_of_ne_zero hp)).trans_le hksize
+      rw [Polynomial.hasseDeriv_eq_zero_of_lt_natDegree (toPolyℂ p) k hdegree]
+      exact Polynomial.eval_zero
+
+/-- **Taylor bridge.** Every executable Taylor array entry, including an
+out-of-bounds `getD`, casts to the corresponding coefficient of the exact
+Mathlib shift `p(X + z)`. -/
+theorem taylor_coeff (p : Hex.ZPoly) (z : Hex.GaussDyadic) (k : Nat) :
+    GaussDyadic.toComplex ((Hex.taylor p z).getD k (0, 0)) =
+      ((toPolyℂ p).comp (X + C (GaussDyadic.toComplex z))).coeff k := by
+  rw [Hex.taylor_getD]
+  by_cases hk : k < p.size
+  · rw [if_pos hk, toComplex_taylorCoeff, coeff_shift]
+  · rw [if_neg hk, coeff_shift,
+      Nat.sub_eq_zero_of_le (Nat.le_of_not_gt hk)]
+    simp only [Finset.range_zero, Finset.sum_empty]
+    apply Complex.ext <;> simp [GaussDyadic.toComplex]
+
+end
+
+end HexRootsMathlib

--- a/progress/20260719T112152Z_issue-8755-taylor.md
+++ b/progress/20260719T112152Z_issue-8755-taylor.md
@@ -1,0 +1,29 @@
+# Accomplished
+
+- Proved the exact Taylor bridge from every executable `getD` coefficient to
+  the corresponding coefficient of the complex polynomial shift `p(X + z)`.
+- Consumed the exported `Hex.taylor_getD` closed form from #8730 and covered
+  in-bounds, out-of-bounds, zero-polynomial, and degree edge cases without
+  unfolding the mutable Taylor implementation.
+- Added reusable Gaussian-dyadic natural-multiple and power casts to the basic
+  correspondence layer, plus the finite-sum and binomial bridges needed by the
+  Taylor proof.
+- Updated the umbrella and SPEC, passed focused and full builds, and addressed
+  every actionable Claude Opus review finding.
+- Confirmed predecessor PR #8780 passed exact CI run 29684686025 and
+  auto-merged without conflicts.
+
+# Current frontier
+
+Issue #8781 is implemented and ready to rebase onto the squash merge of #8780,
+commit, and publish.
+
+# Next step
+
+Open the Taylor PR with auto-merge and exact CI monitoring, then begin plan item
+7: elementary Cauchy/root-free/subdivision coverage.
+
+# Blockers
+
+Plan item 2 / #8772 remains paused on the documented false integral
+squarefreeness premise; it does not block the Taylor or coverage slices.


### PR DESCRIPTION
## Summary

- prove that every executable `Hex.taylor` array entry casts to the matching coefficient of the complex shift `p(X + z)`
- derive both sides through the exported `Hex.taylor_getD` closed form and Mathlib Hasse derivatives, without reopening the mutable fold implementation
- cover in-bounds, out-of-bounds, zero-polynomial, and degree edge cases
- add reusable Gaussian-dyadic natural-multiple and power casts to the basic correspondence layer
- expose the module through the umbrella and document the exact API in the SPEC

## Why

This is the shared load-bearing Taylor correspondence required by both Pellet and Newton–Kantorovich witness soundness in #8755.

## Review

Claude Opus independently checked the shift orientation, `j = k + r` reindexing, coefficient and power indices, and all edge cases. It found no blocking concern. Its actionable naming, cast-layer, and SPEC findings were applied.

## Validation

- `lake build HexRootsMathlib.Basic HexRootsMathlib.Taylor`
- full `lake build` (9,382 targets) after rebasing onto #8780
- copyright, line-count, DAG, Phase-4, and diff checks
- no new `sorry`, `axiom`, or `native_decide`

Closes #8781
Part of #8755