### PR TITLE
Prove elementary root coverage primitives

### DIFF
--- a/HexRootsMathlib.lean
+++ b/HexRootsMathlib.lean
@@ -7,8 +7,11 @@ Authors: Kim Morrison
 module
 
 public import HexRootsMathlib.Basic
+public import HexRootsMathlib.Bisection
+public import HexRootsMathlib.Cauchy
 public import HexRootsMathlib.Geometry
 public import HexRootsMathlib.MahlerPrec
+public import HexRootsMathlib.RootFree
 public import HexRootsMathlib.Taylor
 
 public section

--- a/HexRootsMathlib/Bisection.lean
+++ b/HexRootsMathlib/Bisection.lean
@@ -1,0 +1,144 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRootsMathlib.RootFree
+
+public section
+
+/-!
+# Four-way square subdivision
+
+The executable subdivision produces four closed children.  They cover their
+parent exactly; children may overlap on shared boundary segments, which is the
+closed-set behavior needed by root-preservation proofs.
+-/
+
+namespace HexRootsMathlib
+
+noncomputable section
+
+namespace DyadicSquare
+
+/-- The four closed children returned by executable subdivision cover their
+parent square. -/
+theorem exists_mem_subdivide {s : Hex.DyadicSquare} {z : ℂ}
+    (hz : z ∈ closedSquare s) :
+    ∃ t ∈ (Hex.DyadicSquare.subdivide s).toList, z ∈ closedSquare t := by
+  let h : _root_.Dyadic := .ofIntWithPrec 1 (s.prec + 1)
+  let hr : ℝ := Dyadic.toReal h
+  have hhr : 0 < hr := by
+    simp only [hr, h, Dyadic.toReal_ofIntWithPrec, Int.cast_one, one_mul]
+    exact zpow_pos (by norm_num) _
+  have hparent : halfWidth s = 2 * hr := by
+    rw [halfWidth_eq]
+    simp only [hr, h, Dyadic.toReal_ofIntWithPrec, Int.cast_one, one_mul]
+    rw [show -s.prec = -(s.prec + 1) + 1 by ring,
+      zpow_add₀ (by norm_num : (2 : ℝ) ≠ 0)]
+    norm_num
+    ring
+  change supNorm (z - center s) ≤ halfWidth s at hz
+  have hx : |(z - center s).re| ≤ 2 * hr := by
+    rw [← hparent]
+    exact (le_max_left _ _).trans hz
+  have hy : |(z - center s).im| ≤ 2 * hr := by
+    rw [← hparent]
+    exact (le_max_right _ _).trans hz
+  have hchild : (2 : ℝ) ^ (-(s.prec + 1)) = hr := by
+    simp [hr, h, Dyadic.toReal_ofIntWithPrec]
+  have hwest (x : ℝ) (hx : |x| ≤ 2 * hr) (hx0 : x ≤ 0) :
+      |x + hr| ≤ hr := by
+    have habs := (abs_le.mp hx)
+    rw [abs_le]
+    constructor <;> linarith
+  have heast (x : ℝ) (hx : |x| ≤ 2 * hr) (hx0 : ¬x ≤ 0) :
+      |x - hr| ≤ hr := by
+    have habs := (abs_le.mp hx)
+    rw [abs_le]
+    constructor <;> linarith
+  by_cases hx0 : (z - center s).re ≤ 0 <;>
+    by_cases hy0 : (z - center s).im ≤ 0
+  · refine ⟨⟨s.re - h, s.im - h, s.prec + 1⟩, ?_, ?_⟩
+    · simp [Hex.DyadicSquare.subdivide, h]
+    · change supNorm (z - center ⟨s.re - h, s.im - h, s.prec + 1⟩) ≤
+        halfWidth ⟨s.re - h, s.im - h, s.prec + 1⟩
+      rw [halfWidth_eq, hchild]
+      apply max_le
+      · have hxb := hwest (z - center s).re hx hx0
+        simpa [center, Hex.DyadicSquare.center, GaussDyadic.toComplex,
+          Dyadic.toReal_sub, hr, h, sub_eq_add_neg, add_assoc, add_comm, add_left_comm] using hxb
+      · have hyb := hwest (z - center s).im hy hy0
+        simpa [center, Hex.DyadicSquare.center, GaussDyadic.toComplex,
+          Dyadic.toReal_sub, hr, h, sub_eq_add_neg, add_assoc, add_comm, add_left_comm] using hyb
+  · refine ⟨⟨s.re - h, s.im + h, s.prec + 1⟩, ?_, ?_⟩
+    · simp [Hex.DyadicSquare.subdivide, h]
+    · change supNorm (z - center ⟨s.re - h, s.im + h, s.prec + 1⟩) ≤
+        halfWidth ⟨s.re - h, s.im + h, s.prec + 1⟩
+      rw [halfWidth_eq, hchild]
+      apply max_le
+      · have hxb := hwest (z - center s).re hx hx0
+        simpa [center, Hex.DyadicSquare.center, GaussDyadic.toComplex,
+          Dyadic.toReal_sub, hr, h, sub_eq_add_neg, add_assoc, add_comm, add_left_comm] using hxb
+      · have hyb := heast (z - center s).im hy hy0
+        simpa [center, Hex.DyadicSquare.center, GaussDyadic.toComplex,
+          Dyadic.toReal_add, hr, h, sub_eq_add_neg, add_assoc, add_comm, add_left_comm] using hyb
+  · refine ⟨⟨s.re + h, s.im - h, s.prec + 1⟩, ?_, ?_⟩
+    · simp [Hex.DyadicSquare.subdivide, h]
+    · change supNorm (z - center ⟨s.re + h, s.im - h, s.prec + 1⟩) ≤
+        halfWidth ⟨s.re + h, s.im - h, s.prec + 1⟩
+      rw [halfWidth_eq, hchild]
+      apply max_le
+      · have hxb := heast (z - center s).re hx hx0
+        simpa [center, Hex.DyadicSquare.center, GaussDyadic.toComplex,
+          Dyadic.toReal_add, hr, h, sub_eq_add_neg, add_assoc, add_comm, add_left_comm] using hxb
+      · have hyb := hwest (z - center s).im hy hy0
+        simpa [center, Hex.DyadicSquare.center, GaussDyadic.toComplex,
+          Dyadic.toReal_sub, hr, h, sub_eq_add_neg, add_assoc, add_comm, add_left_comm] using hyb
+  · refine ⟨⟨s.re + h, s.im + h, s.prec + 1⟩, ?_, ?_⟩
+    · simp [Hex.DyadicSquare.subdivide, h]
+    · change supNorm (z - center ⟨s.re + h, s.im + h, s.prec + 1⟩) ≤
+        halfWidth ⟨s.re + h, s.im + h, s.prec + 1⟩
+      rw [halfWidth_eq, hchild]
+      apply max_le
+      · have hxb := heast (z - center s).re hx hx0
+        simpa [center, Hex.DyadicSquare.center, GaussDyadic.toComplex,
+          Dyadic.toReal_add, hr, h, sub_eq_add_neg, add_assoc, add_comm, add_left_comm] using hxb
+      · have hyb := heast (z - center s).im hy hy0
+        simpa [center, Hex.DyadicSquare.center, GaussDyadic.toComplex,
+          Dyadic.toReal_add, hr, h, sub_eq_add_neg, add_assoc, add_comm, add_left_comm] using hyb
+
+end DyadicSquare
+
+/-- Subdividing every square in an array preserves coverage of their union. -/
+theorem exists_mem_subdivideAll {squares : Array Hex.DyadicSquare} {z : ℂ}
+    {s : Hex.DyadicSquare} (hs : s ∈ squares.toList)
+    (hz : z ∈ DyadicSquare.closedSquare s) :
+    ∃ t ∈ (squares.flatMap Hex.DyadicSquare.subdivide).toList,
+      z ∈ DyadicSquare.closedSquare t := by
+  obtain ⟨t, ht, hzt⟩ := DyadicSquare.exists_mem_subdivide hz
+  refine ⟨t, ?_, hzt⟩
+  simp only [Array.toList_flatMap, List.mem_flatMap]
+  exact ⟨s, hs, ht⟩
+
+/-- A child containing a root survives the elementary `T₀` filter. -/
+theorem isRoot_mem_survivors {p : Hex.ZPoly} {squares : Array Hex.DyadicSquare}
+    {z : ℂ} (hzroot : (toPolyℂ p).IsRoot z) {s : Hex.DyadicSquare}
+    (hs : s ∈ squares.toList) (hz : z ∈ DyadicSquare.closedSquare s) :
+    ∃ t ∈ ((squares.flatMap Hex.DyadicSquare.subdivide).filter
+        (fun u => !Hex.rootFree p u)).toList,
+      z ∈ DyadicSquare.closedSquare t := by
+  obtain ⟨t, ht, hzt⟩ := exists_mem_subdivideAll hs hz
+  have hnot : Hex.rootFree p t ≠ true := by
+    intro hfree
+    exact rootFree_closedSquare hfree hzt hzroot
+  have hfalse : Hex.rootFree p t = false := Bool.eq_false_of_not_eq_true hnot
+  refine ⟨t, ?_, hzt⟩
+  simpa [hfalse] using ht
+
+end
+
+end HexRootsMathlib

--- a/HexRootsMathlib/Cauchy.lean
+++ b/HexRootsMathlib/Cauchy.lean
@@ -1,0 +1,170 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRootsMathlib.Geometry
+public import HexRootsMathlib.MahlerPrec
+public import Mathlib.Analysis.Polynomial.CauchyBound
+
+public section
+
+/-!
+# Coverage by the initial Cauchy square
+
+The executable integer ceiling and base-two ceiling are related to Mathlib's
+Cauchy root bound.  Consequently the singleton component used to start the
+driver contains every complex root.
+-/
+
+open Polynomial Finset
+
+namespace HexRootsMathlib
+
+noncomputable section
+
+private theorem le_foldl_max_init (l : List Int) (init : Nat) :
+    init ≤ l.foldl (fun acc a => max acc a.natAbs) init := by
+  induction l generalizing init with
+  | nil => simp
+  | cons a l ih =>
+      simp only [List.foldl_cons]
+      exact (Nat.le_max_left _ _).trans (ih _)
+
+private theorem le_foldl_max_of_mem (l : List Int) (init : Nat) {a : Int}
+    (ha : a ∈ l) :
+    a.natAbs ≤ l.foldl (fun acc b => max acc b.natAbs) init := by
+  induction l generalizing init with
+  | nil => simp at ha
+  | cons b l ih =>
+      simp only [List.foldl_cons]
+      rw [List.mem_cons] at ha
+      rcases ha with rfl | ha
+      · exact (Nat.le_max_right _ _).trans (le_foldl_max_init l _)
+      · exact ih _ ha
+
+/-- Every non-leading coefficient is bounded by the exact maximum used in
+`cauchyExp`. -/
+private theorem coeff_le_cauchyMax (p : Hex.ZPoly) {i : Nat} (hi : i < p.size - 1) :
+    (p.coeff i).natAbs ≤
+      (p.toArray.extract 0 (p.size - 1)).foldl
+        (init := 0) fun acc a => max acc a.natAbs := by
+  let a := p.toArray.extract 0 (p.size - 1)
+  have hia : i < a.size := by
+    simp only [a, Array.size_extract, Hex.DensePoly.toArray_size]
+    omega
+  have hget : a[i] = p.coeff i := by
+    simp only [a, Array.getElem_extract]
+    simp only [zero_add]
+    rw [Array.getElem_eq_getD (0 : Int)]
+    exact Hex.DensePoly.toArray_getD p i
+  have hmem : p.coeff i ∈ a.toList := by
+    rw [← hget]
+    exact Array.getElem_mem_toList hia
+  change (p.coeff i).natAbs ≤ a.foldl (fun acc b => max acc b.natAbs) 0
+  rw [← Array.foldl_toList]
+  exact le_foldl_max_of_mem a.toList 0 hmem
+
+/-- The Mathlib Cauchy bound is no larger than the power of two selected by
+the executable integer calculation. -/
+theorem cauchyBound_le_two_pow (p : Hex.ZPoly) (h : 0 < p.degree?.getD 0) :
+    (Polynomial.cauchyBound (toPolyℂ p) : ℝ) ≤ (2 : ℝ) ^ Hex.cauchyExp p := by
+  have hsize : 0 < p.size := by
+    by_contra hp
+    have hp0 : p.size = 0 := Nat.eq_zero_of_not_pos hp
+    simp [Hex.DensePoly.degree?, hp0] at h
+  have hdegree : p.degree?.getD 0 = p.size - 1 := by
+    rw [Hex.DensePoly.degree?_eq_some_of_pos_size p hsize]
+    rfl
+  let L := p.leadingCoeff.natAbs
+  let M := (p.toArray.extract 0 (p.size - 1)).foldl
+    (init := 0) fun acc a => max acc a.natAbs
+  let Q := (L + M + L - 1) / L
+  have hlead : p.leadingCoeff ≠ 0 := by
+    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last p hsize]
+    exact Hex.DensePoly.coeff_last_ne_zero_of_pos_size p hsize
+  have hL : 0 < L := Int.natAbs_pos.mpr hlead
+  have hsup : (Finset.range (toPolyℂ p).natDegree).sup
+      (fun i => ‖(toPolyℂ p).coeff i‖₊) ≤ (M : NNReal) := by
+    apply Finset.sup_le
+    intro i hi
+    rw [Finset.mem_range, natDegree_toPolyℂ, hdegree] at hi
+    rw [coeff_toPolyℂ, Complex.nnnorm_intCast]
+    rw [← NNReal.natCast_natAbs]
+    exact_mod_cast coeff_le_cauchyMax p hi
+  have hceil : L + M ≤ L * Q := by
+    change L + M ≤ L * ((L + M) ⌈/⌉ L)
+    exact le_smul_ceilDiv hL
+  have hratio : (M : ℝ) / L + 1 ≤ (Q : ℝ) := by
+    have hLreal : (0 : ℝ) < L := by exact_mod_cast hL
+    rw [div_add_one hLreal.ne']
+    apply (div_le_iff₀ hLreal).mpr
+    exact_mod_cast (show M + L ≤ Q * L by simpa [Nat.add_comm, Nat.mul_comm] using hceil)
+  have hQ : (Q : ℝ) ≤ (2 : ℝ) ^ Hex.ceilLog2 Q := by
+    exact_mod_cast le_two_pow_ceilLog2 Q
+  calc
+    (Polynomial.cauchyBound (toPolyℂ p) : ℝ) =
+        (((Finset.range (toPolyℂ p).natDegree).sup
+          (fun i => ‖(toPolyℂ p).coeff i‖₊) : NNReal) : ℝ) /
+            ‖(toPolyℂ p).leadingCoeff‖₊ + 1 := by
+      rfl
+    _ ≤ (M : ℝ) / L + 1 := by
+      have hleadnorm : (‖(toPolyℂ p).leadingCoeff‖₊ : ℝ) = L := by
+        have hleadnormNN : ‖(toPolyℂ p).leadingCoeff‖₊ = (L : NNReal) := by
+          rw [Polynomial.leadingCoeff, natDegree_toPolyℂ, hdegree, coeff_toPolyℂ,
+            Complex.nnnorm_intCast, ← NNReal.natCast_natAbs,
+            ← Hex.DensePoly.leadingCoeff_eq_coeff_last p hsize]
+        exact congrArg ((↑) : NNReal → ℝ) hleadnormNN
+      rw [hleadnorm]
+      gcongr
+      exact_mod_cast hsup
+    _ ≤ (Q : ℝ) := hratio
+    _ ≤ (2 : ℝ) ^ Hex.ceilLog2 Q := hQ
+    _ = (2 : ℝ) ^ Hex.cauchyExp p := by
+      simp only [Hex.cauchyExp, L, M, Q, if_neg (Nat.ne_of_gt hL)]
+
+/-- Every root of the complex cast lies in the closed square stored in the
+executable initial component. -/
+theorem isRoot_mem_cauchySquare (p : Hex.ZPoly) (h : 0 < p.degree?.getD 0)
+    {z : ℂ} (hz : (toPolyℂ p).IsRoot z) :
+    z ∈ DyadicSquare.closedSquare
+      ⟨0, 0, -(Hex.cauchyExp p : Int)⟩ := by
+  have hp : toPolyℂ p ≠ 0 := by
+    intro hp0
+    have hnat : (toPolyℂ p).natDegree = p.degree?.getD 0 := natDegree_toPolyℂ p
+    rw [hp0, Polynomial.natDegree_zero] at hnat
+    omega
+  have hroot : ‖z‖ < (Polynomial.cauchyBound (toPolyℂ p) : ℝ) := by
+    exact_mod_cast hz.norm_lt_cauchyBound hp
+  have hnorm : ‖z‖ < (2 : ℝ) ^ Hex.cauchyExp p :=
+    hroot.trans_le (cauchyBound_le_two_pow p h)
+  change supNorm
+      (z - DyadicSquare.center ⟨0, 0, -(Hex.cauchyExp p : Int)⟩) ≤
+    DyadicSquare.halfWidth ⟨0, 0, -(Hex.cauchyExp p : Int)⟩
+  have hcenter : DyadicSquare.center
+      ⟨0, 0, -(Hex.cauchyExp p : Int)⟩ = 0 := by
+    apply Complex.ext <;>
+      simp [DyadicSquare.center, Hex.DyadicSquare.center, GaussDyadic.toComplex]
+  rw [hcenter, sub_zero]
+  calc
+    supNorm z ≤ ‖z‖ := max_le (Complex.abs_re_le_norm z) (Complex.abs_im_le_norm z)
+    _ ≤ (2 : ℝ) ^ Hex.cauchyExp p := hnorm.le
+    _ = DyadicSquare.halfWidth ⟨0, 0, -(Hex.cauchyExp p : Int)⟩ := by
+      rw [DyadicSquare.halfWidth_eq]
+      simp
+
+/-- Component-level form of Cauchy coverage: every root occurs in the union
+of the squares returned by `Component.cauchy`. -/
+theorem exists_mem_component_cauchy (p : Hex.ZPoly) (h : 0 < p.degree?.getD 0)
+    {z : ℂ} (hz : (toPolyℂ p).IsRoot z) :
+    ∃ s ∈ (Hex.Component.cauchy p h).squares.toList,
+      z ∈ DyadicSquare.closedSquare s := by
+  refine ⟨⟨0, 0, -(Hex.cauchyExp p : Int)⟩, ?_, isRoot_mem_cauchySquare p h hz⟩
+  simp [Hex.Component.cauchy]
+
+end
+
+end HexRootsMathlib

--- a/HexRootsMathlib/RootFree.lean
+++ b/HexRootsMathlib/RootFree.lean
@@ -1,0 +1,240 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRootsMathlib.Taylor
+public import HexRootsMathlib.Geometry
+
+public section
+
+/-!
+# Soundness of the elementary root-exclusion test
+
+`Hex.rootFree` is the `k = 0` Taylor dominance inequality.  Its soundness is
+only the triangle inequality: no Rouché theorem or complex integration is
+needed.
+-/
+
+open Polynomial Finset
+
+namespace HexRootsMathlib
+
+noncomputable section
+
+namespace Dyadic
+
+/-- The real-value map preserves natural powers. -/
+@[simp] theorem toReal_pow (x : _root_.Dyadic) (n : Nat) :
+    toReal (x ^ n) = toReal x ^ n := by
+  unfold toReal
+  rw [_root_.Dyadic.toRat_pow]
+  norm_cast
+
+end Dyadic
+
+/-- Closed form of the accumulator used by `pelletAt`: its first component is
+the sum with coefficient `k` omitted, and its second component is the next
+power of the radius. -/
+private theorem pelletFold (cs : Array Hex.GaussDyadic) (k : Nat)
+    (r : _root_.Dyadic) (n : Nat) :
+    let result := (List.range n).foldl
+        (fun acc i =>
+          let acc' := if i = k then acc.1
+            else acc.1 + Hex.GaussDyadic.hi (cs.getD i (0, 0)) * acc.2
+          (acc', acc.2 * r))
+        ((0 : _root_.Dyadic), (1 : _root_.Dyadic))
+    Dyadic.toReal result.1 =
+        (∑ i ∈ Finset.range n,
+          if i = k then 0 else
+            Dyadic.toReal (Hex.GaussDyadic.hi (cs.getD i (0, 0))) *
+              Dyadic.toReal r ^ i) ∧
+      Dyadic.toReal result.2 = Dyadic.toReal r ^ n := by
+  induction n with
+  | zero =>
+      constructor
+      · simp
+      · change Dyadic.toReal (_root_.Dyadic.ofInt 1) = 1
+        simp
+  | succ n ih =>
+      dsimp at ih
+      simp only [List.range_succ, List.foldl_append, List.foldl_cons, List.foldl_nil]
+      constructor
+      · by_cases hnk : n = k
+        · rw [if_pos hnk, ih.1, Finset.sum_range_succ]
+          simp only [hnk, if_pos, add_zero]
+        · rw [if_neg hnk, Dyadic.toReal_add, Dyadic.toReal_mul, ih.1, ih.2,
+            Finset.sum_range_succ]
+          simp only [hnk, if_false]
+      · rw [Dyadic.toReal_mul, ih.2, pow_succ]
+
+/-- A polynomial cannot vanish where its constant coefficient strictly
+dominates the norms of all remaining evaluated terms. -/
+private theorem eval_ne_zero_of_dominates {q : Polynomial ℂ} {z : ℂ} {n : Nat}
+    (hn : q.natDegree < n)
+    (hdom :
+      (∑ i ∈ Finset.range n,
+        if i = 0 then 0 else ‖q.coeff i‖ * ‖z‖ ^ i) < ‖q.coeff 0‖) :
+    q.eval z ≠ 0 := by
+  intro hz
+  have hnpos : 0 < n := Nat.zero_lt_of_lt hn
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (Nat.ne_of_gt hnpos)
+  rw [Polynomial.eval_eq_sum_range' hn, Finset.sum_range_succ'] at hz
+  simp only [pow_zero, mul_one] at hz
+  rw [Finset.sum_range_succ'] at hdom
+  simp only [if_pos, pow_zero, mul_one, Nat.succ_ne_zero, if_false, add_zero] at hdom
+  have hcoeff : ‖q.coeff 0‖ ≤
+      ∑ i ∈ Finset.range m, ‖q.coeff (i + 1)‖ * ‖z‖ ^ (i + 1) := by
+    calc
+      ‖q.coeff 0‖ = ‖-(∑ i ∈ Finset.range m, q.coeff (i + 1) * z ^ (i + 1))‖ := by
+        rw [eq_neg_of_add_eq_zero_right hz]
+      _ = ‖∑ i ∈ Finset.range m, q.coeff (i + 1) * z ^ (i + 1)‖ := norm_neg _
+      _ ≤ ∑ i ∈ Finset.range m, ‖q.coeff (i + 1) * z ^ (i + 1)‖ :=
+        norm_sum_le _ _
+      _ = ∑ i ∈ Finset.range m, ‖q.coeff (i + 1)‖ * ‖z‖ ^ (i + 1) := by
+        apply Finset.sum_congr rfl
+        intro i _
+        rw [norm_mul, norm_pow]
+  exact (hcoeff.trans_lt hdom).false
+
+/-- A successful root-exclusion test can only occur for a nonempty stored
+polynomial. -/
+theorem rootFree_size_pos {p : Hex.ZPoly} {s : Hex.DyadicSquare}
+    (h : Hex.rootFree p s = true) : 0 < p.size := by
+  unfold Hex.rootFree Hex.pelletAt at h
+  rw [Hex.taylor_size] at h
+  by_contra hp
+  rw [if_neg (by omega)] at h
+  contradiction
+
+/-- A nonempty polynomial's shift has degree strictly below its executable
+coefficient count. -/
+private theorem shift_natDegree_lt_size (p : Hex.ZPoly) (hp : 0 < p.size) (c : ℂ) :
+    ((toPolyℂ p).comp (X + C c)).natDegree < p.size := by
+  have hpoly : (toPolyℂ p).natDegree < p.size := by
+    rw [natDegree_toPolyℂ]
+    have hdegree : p.degree? = some (p.size - 1) := by
+      simp [Hex.DensePoly.degree?, Nat.ne_of_gt hp]
+    rw [hdegree, Option.getD_some]
+    omega
+  exact (Polynomial.natDegree_comp_le.trans_lt (by simpa using hpoly))
+
+/-- The Boolean `rootFree` result exposes the strict real Taylor-dominance
+inequality used by its soundness proof. -/
+theorem rootFree_bound {p : Hex.ZPoly} {s : Hex.DyadicSquare}
+    (h : Hex.rootFree p s = true) :
+    (∑ i ∈ Finset.range p.size,
+        if i = 0 then 0 else
+          Dyadic.toReal (Hex.GaussDyadic.hi ((Hex.taylor p s.center).getD i (0, 0))) *
+            Dyadic.toReal s.radiusHi ^ i) <
+      Dyadic.toReal (Hex.GaussDyadic.lo ((Hex.taylor p s.center).getD 0 (0, 0))) := by
+  have hsize : 0 < p.size := rootFree_size_pos h
+  unfold Hex.rootFree Hex.pelletAt at h
+  rw [Hex.taylor_size] at h
+  rw [if_pos hsize] at h
+  simp only [_root_.Dyadic.pow_zero, _root_.Dyadic.mul_one] at h
+  let result := (List.range p.size).foldl
+      (fun acc i =>
+        let acc' := if i = 0 then acc.1 else
+          acc.1 + Hex.GaussDyadic.hi ((Hex.taylor p s.center).getD i (0, 0)) * acc.2
+        (acc', acc.2 * s.radiusHi))
+      ((0 : _root_.Dyadic), (1 : _root_.Dyadic))
+  have hdyadic : result.1 <
+      Hex.GaussDyadic.lo ((Hex.taylor p s.center).getD 0 (0, 0)) := by
+    simpa [result] using of_decide_eq_true h
+  have hreal := Dyadic.toReal_lt_toReal_iff.mpr hdyadic
+  have hfold := (pelletFold (Hex.taylor p s.center) 0 s.radiusHi p.size).1
+  rw [show Dyadic.toReal result.1 =
+      (∑ i ∈ Finset.range p.size,
+        if i = 0 then 0 else
+          Dyadic.toReal (Hex.GaussDyadic.hi ((Hex.taylor p s.center).getD i (0, 0))) *
+            Dyadic.toReal s.radiusHi ^ i) from hfold] at hreal
+  exact hreal
+
+/-- **Elementary `T₀` soundness.** If `rootFree` succeeds, the polynomial has
+no zero anywhere in the open disc using the executable upper-radius bound.
+This is stronger than exclusion on the square's circumscribed disc. -/
+theorem rootFree_ne_zero {p : Hex.ZPoly} {s : Hex.DyadicSquare}
+    (h : Hex.rootFree p s = true) {z : ℂ}
+    (hz : z ∈ Metric.ball (DyadicSquare.center s) (Dyadic.toReal s.radiusHi)) :
+    (toPolyℂ p).eval z ≠ 0 := by
+  let c := DyadicSquare.center s
+  let d := z - c
+  let q := (toPolyℂ p).comp (X + C c)
+  have hsize : 0 < p.size := rootFree_size_pos h
+  have hdegree : q.natDegree < p.size := shift_natDegree_lt_size p hsize c
+  have hdist : ‖d‖ < Dyadic.toReal s.radiusHi := by
+    rw [Metric.mem_ball, Complex.dist_eq] at hz
+    simpa only [d] using hz
+  have hdom :
+      (∑ i ∈ Finset.range p.size,
+        if i = 0 then 0 else ‖q.coeff i‖ * ‖d‖ ^ i) < ‖q.coeff 0‖ := by
+    calc
+      (∑ i ∈ Finset.range p.size,
+          if i = 0 then 0 else ‖q.coeff i‖ * ‖d‖ ^ i) ≤
+          ∑ i ∈ Finset.range p.size,
+            if i = 0 then 0 else
+              Dyadic.toReal
+                  (Hex.GaussDyadic.hi ((Hex.taylor p s.center).getD i (0, 0))) *
+                Dyadic.toReal s.radiusHi ^ i := by
+        apply Finset.sum_le_sum
+        intro i hi
+        by_cases hi0 : i = 0
+        · simp [hi0]
+        · simp only [hi0, if_false]
+          have hcoeff : ‖q.coeff i‖ ≤ Dyadic.toReal
+              (Hex.GaussDyadic.hi ((Hex.taylor p s.center).getD i (0, 0))) := by
+            rw [show q.coeff i =
+                GaussDyadic.toComplex ((Hex.taylor p s.center).getD i (0, 0)) by
+              change ((toPolyℂ p).comp
+                (X + C (GaussDyadic.toComplex s.center))).coeff i = _
+              exact (taylor_coeff p s.center i).symm]
+            exact GaussDyadic.norm_le_hi _
+          have hpow : ‖d‖ ^ i ≤ Dyadic.toReal s.radiusHi ^ i := by
+            gcongr
+          have hhi : 0 ≤ Dyadic.toReal
+              (Hex.GaussDyadic.hi ((Hex.taylor p s.center).getD i (0, 0))) :=
+            (norm_nonneg _).trans hcoeff
+          exact mul_le_mul hcoeff hpow (pow_nonneg (norm_nonneg _) _)
+            hhi
+      _ < Dyadic.toReal
+          (Hex.GaussDyadic.lo ((Hex.taylor p s.center).getD 0 (0, 0))) :=
+        rootFree_bound h
+      _ ≤ ‖q.coeff 0‖ := by
+        rw [show q.coeff 0 =
+            GaussDyadic.toComplex ((Hex.taylor p s.center).getD 0 (0, 0)) by
+          change ((toPolyℂ p).comp
+            (X + C (GaussDyadic.toComplex s.center))).coeff 0 = _
+          exact (taylor_coeff p s.center 0).symm]
+        exact GaussDyadic.lo_le_norm _
+  have hq : q.eval d ≠ 0 := eval_ne_zero_of_dominates hdegree hdom
+  intro hpz
+  apply hq
+  change ((toPolyℂ p).comp (X + C c)).eval d = 0
+  rw [Polynomial.eval_comp, Polynomial.eval_add, Polynomial.eval_X,
+    Polynomial.eval_C]
+  simpa only [d, c, sub_add_cancel] using hpz
+
+/-- A successful `rootFree` test excludes roots from the represented closed
+square. -/
+theorem rootFree_closedSquare {p : Hex.ZPoly} {s : Hex.DyadicSquare}
+    (h : Hex.rootFree p s = true) {z : ℂ} (hz : z ∈ DyadicSquare.closedSquare s) :
+    (toPolyℂ p).eval z ≠ 0 :=
+  rootFree_ne_zero h (DyadicSquare.closedSquare_subset_ball_radiusHi s hz)
+
+/-- The stated circumscribed closed disc is root-free as well; its radius is
+strictly below the executable upper-radius bound used by `rootFree`. -/
+theorem rootFree_closedDisc {p : Hex.ZPoly} {s : Hex.DyadicSquare}
+    (h : Hex.rootFree p s = true) {z : ℂ} (hz : z ∈ DyadicSquare.closedDisc s) :
+    (toPolyℂ p).eval z ≠ 0 := by
+  apply rootFree_ne_zero h
+  rw [DyadicSquare.closedDisc, Metric.mem_closedBall] at hz
+  rw [Metric.mem_ball]
+  exact hz.trans_lt (DyadicSquare.radius_lt_radiusHi s)
+
+end
+
+end HexRootsMathlib

--- a/HexRootsMathlib/SPEC/hex-roots-mathlib.md
+++ b/HexRootsMathlib/SPEC/hex-roots-mathlib.md
@@ -300,8 +300,11 @@ developments above.
   sep/4` radius bound from item 4 is what makes
   `intersects_iff_root_eq` true.
 - `HexRootsMathlib/Cauchy.lean`: `Component.cauchy`
-  correctness. The starting disc contains all of `Polynomial.roots p`
-  by `Polynomial.IsRoot.norm_lt_cauchyBound`, and the degree-`n`
+  correctness. The starting closed square contains all of `Polynomial.roots p`
+  by `Polynomial.IsRoot.norm_lt_cauchyBound`: the executable maximum bounds
+  every non-leading coefficient, its ceiling division bounds Mathlib's
+  Cauchy bound, and `ceilLog2` rounds that integer bound up to the square's
+  power-of-two half-width. The degree-`n`
   witness holds at the base, doubled, and quadrupled radii because the
   leading-term inequality `|aₙ|·Rⁿ > Σ_{i<n}|aᵢ|·Rⁱ` only improves as
   `R` grows past the Cauchy bound.
@@ -312,8 +315,20 @@ developments above.
   hex-roots.md relies on). Uses `Polynomial.newtonMap`,
   `aeval_pow_two_pow_dvd_aeval_iterate_newtonMap`, and the
   `Dyadic.invAtPrec` error bounds.
-- `HexRootsMathlib/Bisection.lean`: `Component.refine1` and
-  `Component.certify?` soundness. A `T_0`-discarded child's disc
+- `HexRootsMathlib/RootFree.lean`: elementary `T₀` soundness. The exact
+  accumulator inequality and the Taylor coefficient bridge imply, by the
+  finite triangle inequality, that a successful `rootFree` test excludes
+  roots from the open disc of radius `radiusHi`. This contains both the
+  represented closed square and its true closed circumscribed disc because
+  `√2 < 1449/1024`.
+- `HexRootsMathlib/Bisection.lean`: elementary subdivision coverage. The four
+  closed children cover the parent, and every child containing a root survives
+  the `rootFree` filter. They are not pairwise disjoint, since adjacent
+  children share boundary segments. Completing `Component.refine1`
+  preservation additionally requires
+  a characterization that `glue` preserves membership (equivalently, that
+  flattening its output permutes its input). Once that bridge is available, a
+  `T_0`-discarded child's disc
   contains no root, so every root covered by the parent lies in some
   retained child; when `certify?` returns a cluster, its disc
   contains exactly `k` roots with multiplicity (Pellet, item 8); when

--- a/progress/20260719T115209Z_issue-8755-coverage.md
+++ b/progress/20260719T115209Z_issue-8755-coverage.md
@@ -1,0 +1,20 @@
+# Accomplished
+
+- Proved the exact real inequality exposed by the executable `rootFree` fold and its soundness on the open `radiusHi` disc using only the Taylor bridge and the finite triangle inequality.
+- Derived root exclusion on the represented closed square and true closed circumscribed disc.
+- Proved that Mathlib's Cauchy bound is below the executable power-of-two bound and that `Component.cauchy` covers every root of the complex cast.
+- Proved closed-child subdivision coverage, array-wide coverage, and root preservation through the `rootFree` survivor filter.
+- Corrected the SPEC's closed-boundary language and recorded the precise remaining `glue` characterization.
+- Obtained an Opus second opinion; its SPEC-accuracy concern was addressed and its review found no soundness defect.
+
+# Current frontier
+
+The elementary coverage primitives are complete and build locally. Full `Component.refine1` preservation stops at the imperative `glue` boundary.
+
+# Next step
+
+Publish this primitive-coverage PR, then prove the Mathlib-free `glue` membership/permutation characterization in #8784 and consume it here to finish `refine1` preservation.
+
+# Blockers
+
+None for this PR. The remaining theorem in #8783 depends on #8784.


### PR DESCRIPTION
## Summary

- prove exact `rootFree` / T₀ soundness from the Taylor bridge and finite triangle inequality, including closed-square and closed-disc corollaries
- prove the executable Cauchy square covers every complex root
- prove four-child closed-square coverage and preservation through the `rootFree` survivor filter
- correct the SPEC boundary semantics and record the missing `glue` characterization prerequisite

Part of #8755 and #8783. Follow-up prerequisite: #8784.

## Premise audit

Closed subdivision children cover their parent but are not pairwise disjoint because their boundaries overlap. Full `Component.refine1` preservation additionally needs the Mathlib-free theorem that `glue` preserves membership / flattens to a permutation; this PR deliberately stops at the survivor filter instead of weakening the requested theorem.

## Verification

- `lake build HexRootsMathlib.RootFree HexRootsMathlib.Bisection`
- `lake build HexRootsMathlib.Cauchy`
- `lake build HexRootsMathlib`
- `lake build` (9385 jobs)
- copyright, DAG, phase-4, and diff checks
- no `sorry`, `axiom`, or `native_decide`
- Claude Opus high-effort second-opinion review; SPEC accuracy concern addressed, no soundness defect found