### PR TITLE
Establish root-isolator component invariants

### DIFF
--- a/HexRoots/Refine.lean
+++ b/HexRoots/Refine.lean
@@ -74,7 +74,7 @@ end Component
     the cost of one precision level, which the strictly-finer adoption
     guard in `isolateLoop` still absorbs (a Newton jump gains at least
     two levels). -/
-def Certified.toComponent {p : ZPoly} : Certified p → Component
+@[expose] def Certified.toComponent {p : ZPoly} : Certified p → Component
   | .atom iso => ⟨#[iso.square.doubled], 1⟩
   | .cluster cl => ⟨#[(encSquare cl.squares).doubled], cl.k⟩
 

--- a/HexRootsMathlib.lean
+++ b/HexRootsMathlib.lean
@@ -9,6 +9,7 @@ module
 public import HexRootsMathlib.Basic
 public import HexRootsMathlib.Bisection
 public import HexRootsMathlib.Cauchy
+public import HexRootsMathlib.Component
 public import HexRootsMathlib.Geometry
 public import HexRootsMathlib.Kantorovich
 public import HexRootsMathlib.KantorovichPoly

--- a/HexRootsMathlib/Component.lean
+++ b/HexRootsMathlib/Component.lean
@@ -1,0 +1,201 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRoots.Refine
+public import HexRootsMathlib.Cauchy
+
+public section
+
+/-!
+# Semantic regions and component invariants
+
+This module records the companion-side invariants of certified results as
+they re-enter the executable worklist. In particular, the doubled retained
+square contains both possible atom regions and a cluster's circumscribed disc.
+-/
+
+namespace HexRootsMathlib
+
+noncomputable section
+
+namespace DyadicSquare
+
+@[simp] theorem doubled_center (s : Hex.DyadicSquare) :
+    center s.doubled = center s := rfl
+
+@[simp] theorem doubled_prec (s : Hex.DyadicSquare) :
+    s.doubled.prec = s.prec - 1 := rfl
+
+@[simp] theorem doubled_halfWidth (s : Hex.DyadicSquare) :
+    halfWidth s.doubled = 2 * halfWidth s := by
+  rw [halfWidth_eq, halfWidth_eq, doubled_prec]
+  rw [show -(s.prec - 1) = 1 + -s.prec by ring,
+    zpow_add₀ (by norm_num : (2 : ℝ) ≠ 0)]
+  norm_num
+
+/-- A square is contained in its concentric doubled square. -/
+theorem closedSquare_subset_doubled (s : Hex.DyadicSquare) :
+    closedSquare s ⊆ closedSquare s.doubled := by
+  intro z hz
+  change supDist z (center s) ≤ halfWidth s at hz
+  change supDist z (center s.doubled) ≤ halfWidth s.doubled
+  rw [doubled_center, doubled_halfWidth]
+  exact hz.trans (by
+    have hwidth : 0 ≤ halfWidth s := by
+      rw [halfWidth_eq]
+      positivity
+    linarith)
+
+/-- The circumscribed closed disc is contained in the concentric doubled
+square; this is the geometric reason certified re-entry must double. -/
+theorem closedDisc_subset_doubled (s : Hex.DyadicSquare) :
+    closedDisc s ⊆ closedSquare s.doubled := by
+  intro z hz
+  rw [closedDisc, Metric.mem_closedBall, Complex.dist_eq] at hz
+  change supNorm (z - center s.doubled) ≤ halfWidth s.doubled
+  rw [doubled_center, doubled_halfWidth]
+  have hsqrt : √2 < (2 : ℝ) := by
+    nlinarith [Real.sq_sqrt (show (0 : ℝ) ≤ 2 by norm_num),
+      Real.sqrt_nonneg 2]
+  have hwidth : 0 < halfWidth s := by
+    rw [halfWidth_eq]
+    positivity
+  apply le_of_lt
+  calc
+    supNorm (z - center s) ≤ ‖z - center s‖ :=
+      max_le (Complex.abs_re_le_norm _) (Complex.abs_im_le_norm _)
+    _ ≤ radius s := hz
+    _ = halfWidth s * √2 := rfl
+    _ < halfWidth s * 2 := mul_lt_mul_of_pos_left hsqrt hwidth
+    _ = 2 * halfWidth s := by ring
+
+end DyadicSquare
+
+namespace Component
+
+/-- The structural invariant actually required of a worklist component:
+there is a first square and every square has its precision. Connectivity is
+an algorithmic optimization and is not needed by soundness. -/
+@[expose] def WellFormed (c : Hex.Component) : Prop :=
+  0 < c.squares.size ∧
+    ∀ s ∈ c.squares.toList, s.prec = c.prec
+
+/-- The union of the closed squares retained by a component. -/
+@[expose] def region (c : Hex.Component) : Set ℂ :=
+  {z | ∃ s ∈ c.squares.toList, z ∈ DyadicSquare.closedSquare s}
+
+/-- The initial Cauchy component is a nonempty singleton component. -/
+theorem cauchy_wellFormed (p : Hex.ZPoly) (h : 0 < p.degree?.getD 0) :
+    WellFormed (Hex.Component.cauchy p h) := by
+  simp [WellFormed, Hex.Component.cauchy, Hex.Component.prec]
+
+/-- Component-level restatement of executable Cauchy coverage. -/
+theorem isRoot_mem_cauchy (p : Hex.ZPoly) (h : 0 < p.degree?.getD 0)
+    {z : ℂ} (hz : (toPolyℂ p).IsRoot z) :
+    z ∈ region (Hex.Component.cauchy p h) :=
+  exists_mem_component_cauchy p h hz
+
+end Component
+
+namespace DyadicRootIsolation
+
+/-- The certified region selected by an atom witness. If both disjuncts hold,
+the Newton square is chosen; either choice contains the same unique root once
+both semantic developments are available. -/
+@[expose] def region {p : Hex.ZPoly} (iso : Hex.DyadicRootIsolation p) : Set ℂ :=
+  if Hex.nkWitness p iso.square then
+    DyadicSquare.closedSquare iso.square
+  else
+    DyadicSquare.closedDisc iso.square
+
+end DyadicRootIsolation
+
+namespace Certified
+
+/-- The region whose root count is asserted by a certified result. -/
+@[expose] def region {p : Hex.ZPoly} : Hex.Certified p → Set ℂ
+  | .atom iso => DyadicRootIsolation.region iso
+  | .cluster cl => DyadicSquare.closedDisc (Hex.encSquare cl.squares)
+
+/-- The root count carried by a certified result. -/
+@[expose] def count {p : Hex.ZPoly} : Hex.Certified p → Nat
+  | .atom _ => 1
+  | .cluster cl => cl.k
+
+theorem count_pos {p : Hex.ZPoly} (r : Hex.Certified p) : 0 < count r := by
+  cases r with
+  | atom => simp [count]
+  | cluster cl => exact cl.k_pos
+
+@[simp] theorem toComponent_squares {p : Hex.ZPoly} (r : Hex.Certified p) :
+    r.toComponent.squares = #[r.square.doubled] := by
+  cases r <;> rfl
+
+@[simp] theorem toComponent_count {p : Hex.ZPoly} (r : Hex.Certified p) :
+    r.toComponent.candidateK = count r := by
+  cases r <;> rfl
+
+@[simp] theorem toComponent_prec {p : Hex.ZPoly} (r : Hex.Certified p) :
+    r.toComponent.prec = r.square.prec - 1 := by
+  cases r <;> simp [Hex.Certified.toComponent, Hex.Certified.square,
+    Hex.Component.prec]
+
+@[simp] theorem toComponent_region {p : Hex.ZPoly} (r : Hex.Certified p) :
+    Component.region r.toComponent =
+      DyadicSquare.closedSquare r.square.doubled := by
+  ext z
+  simp [Component.region]
+
+/-- Re-entry always constructs a nonempty common-precision component. -/
+theorem toComponent_wellFormed {p : Hex.ZPoly} (r : Hex.Certified p) :
+    Component.WellFormed r.toComponent := by
+  simp [Component.WellFormed, Hex.Component.prec]
+
+theorem toComponent_count_pos {p : Hex.ZPoly} (r : Hex.Certified p) :
+    0 < r.toComponent.candidateK := by
+  rw [toComponent_count]
+  exact count_pos r
+
+/-- The doubled square retained on re-entry contains the certified region,
+for both atom certificate forms and for clusters. -/
+theorem region_subset_doubled {p : Hex.ZPoly} (r : Hex.Certified p) :
+    region r ⊆ DyadicSquare.closedSquare r.square.doubled := by
+  cases r with
+  | atom iso =>
+      simp only [region, DyadicRootIsolation.region, Hex.Certified.square]
+      split
+      · exact DyadicSquare.closedSquare_subset_doubled iso.square
+      · exact DyadicSquare.closedDisc_subset_doubled iso.square
+  | cluster cl =>
+      exact DyadicSquare.closedDisc_subset_doubled (Hex.encSquare cl.squares)
+
+/-- Re-entry contains the stored square, independently of certificate form. -/
+theorem square_subset_toComponent {p : Hex.ZPoly} (r : Hex.Certified p) :
+    DyadicSquare.closedSquare r.square ⊆ Component.region r.toComponent := by
+  rw [toComponent_region]
+  exact DyadicSquare.closedSquare_subset_doubled r.square
+
+/-- Re-entry contains the stored circumscribed disc, independently of
+certificate form. This stronger conservative fact is useful to the loop
+kernel, which need not inspect the atom-witness disjunction. -/
+theorem disc_subset_toComponent {p : Hex.ZPoly} (r : Hex.Certified p) :
+    DyadicSquare.closedDisc r.square ⊆ Component.region r.toComponent := by
+  rw [toComponent_region]
+  exact DyadicSquare.closedDisc_subset_doubled r.square
+
+/-- The worklist region of `toComponent` contains the certified region. -/
+theorem region_subset_toComponent {p : Hex.ZPoly} (r : Hex.Certified p) :
+    region r ⊆ Component.region r.toComponent := by
+  rw [toComponent_region]
+  exact region_subset_doubled r
+
+end Certified
+
+end
+
+end HexRootsMathlib

--- a/progress/2026-07-19T13-34-26Z.md
+++ b/progress/2026-07-19T13-34-26Z.md
@@ -1,0 +1,34 @@
+# Accomplished
+
+- Defined component worklist regions and the nonempty/common-precision
+  `Component.WellFormed` predicate without assuming unencoded connectivity.
+- Defined the certificate-selected atom region, general certified regions,
+  and their positive root counts.
+- Proved exact doubled-square centre, precision, and half-width formulas.
+- Proved both the original closed square and its full circumscribed closed
+  disc lie in the doubled retained square.
+- Exposed the simple executable `Certified.toComponent` definition and proved
+  its singleton squares, count, precision, positivity, region equality, and
+  well-formedness contracts.
+- Restated initial Cauchy coverage as membership in the component region and
+  proved the Cauchy component well formed.
+- Added `HexRootsMathlib.Component` to the umbrella and kept the slice free of
+  certificate semantic assumptions intended for the loop kernel.
+- Ran focused and full repository builds and source policy checks.
+- Addressed Opus review by removing an unused import, adding the exact
+  `toComponent_region` rewrite lemma, and clarifying the module documentation.
+
+# Current frontier
+
+Execution-plan item 11 (#8791) is implemented and review-clean. Its parent
+item, #8790 / PR #8792, passed exact CI and has merged.
+
+# Next step
+
+Commit and rebase item 11 onto merged `main`, publish and merge its PR, then
+open item 12 and build the parametric loop kernel over these structural region,
+count, precision, and well-formedness contracts.
+
+# Blockers
+
+None.


### PR DESCRIPTION
Closes #8791. Part of #8755 (execution-plan item 11).

## What changed

- define worklist component well-formedness and semantic square-union regions
- define certificate-selected atom regions and certified root counts
- prove exact doubled-square centre, precision, and half-width formulas
- prove the doubled re-entry square contains both the stored square and its full circumscribed disc
- expose and characterize `Certified.toComponent`: singleton region, count, positive count, precision cost, and well-formedness
- restate initial Cauchy coverage through the component-region API

## Why

The parametric loop soundness proof needs explicit structural contracts for re-entry. In particular, a retained square must cover a Pellet disc as well as an NK square; the `sqrt 2 < 2` argument proves the implementation’s doubled-square rule does so.

## Validation

- `lake build HexRootsMathlib.Component HexRootsMathlib`
- full `lake build` (9389 jobs)
- copyright, line-count, DAG, forbidden-token, and diff checks
- Claude Opus high-effort review: no soundness issue; review suggestions for import hygiene and the exact `toComponent_region` rewrite lemma were addressed

No `sorry`, `axiom`, or `native_decide` was introduced.