### PR TITLE
hex-roots-mathlib: prove the parametric isolation-loop kernel

### DIFF
--- a/HexRoots/Bisection.lean
+++ b/HexRoots/Bisection.lean
@@ -85,6 +85,19 @@ namespace Hex
       result := result.push comp
   return result
 
+/-- Connected-component gluing with an executable coverage guard. The normal
+`glue` result is used when every input square occurs in an output component;
+the defensive fallback returns singleton components. This preserves coverage
+and makes every fallback component trivially connected, but does not preserve
+the maximal connected grouping if the imperative DFS is ever changed
+incorrectly. -/
+@[expose] def glueCovered (sqs : Array DyadicSquare) : Array (Array DyadicSquare) :=
+  let cs := glue sqs
+  if ∀ s ∈ sqs.toList, ∃ c ∈ cs.toList, s ∈ c.toList then
+    cs
+  else
+    sqs.map (#[·])
+
 namespace Component
 
 /-- One subdivision round: split every square into four children one bit
@@ -92,10 +105,10 @@ namespace Component
     `T₀` test; a child whose `T₀` test fails to certify is kept, which is
     always sound), and glue the survivors into edge-connected components.
     Total: no certification is required during refinement. -/
-def refine1 (p : ZPoly) (c : Component) : Array Component :=
+@[expose] def refine1 (p : ZPoly) (c : Component) : Array Component :=
   let survivors := (c.squares.flatMap DyadicSquare.subdivide).filter
     (fun s => !rootFree p s)
-  (glue survivors).map fun ss => { squares := ss, candidateK := c.candidateK }
+  (glueCovered survivors).map fun ss => { squares := ss, candidateK := c.candidateK }
 
 /-- Try to certify the component. Per `strategy`, first the
     Newton-Kantorovich atom witness on the doubled enclosing square (with a

--- a/HexRoots/Refine.lean
+++ b/HexRoots/Refine.lean
@@ -96,6 +96,63 @@ end Component
 @[expose] def fuelFor (p : ZPoly) (target : Int) (start : Int) : Nat :=
   (stopDepth p target - start).toNat + (stopDepth p target - target).toNat + 1
 
+namespace IsolationLoop
+
+/-- Attempt certification on every component in a worklist. -/
+@[expose] def attempts (p : ZPoly) (strategy : AtomStrategy)
+    (work : Array Component) : Array (Component × Option (Certified p)) :=
+  work.map fun c => (c, Component.certify? p strategy c)
+
+/-- Every attempted component certified at the requested stored precision. -/
+@[expose] def allReady {p : ZPoly} (target : Int)
+    (tried : Array (Component × Option (Certified p))) : Bool :=
+  tried.all fun t => match t.2 with
+    | some r => target ≤ r.square.prec
+    | none => false
+
+/-- The successful certificates in an attempts array. -/
+@[expose] def outputs {p : ZPoly}
+    (tried : Array (Component × Option (Certified p))) : Array (Certified p) :=
+  tried.filterMap (·.2)
+
+/-- The stored squares of successful attempts are pairwise disjoint. -/
+@[expose] def disjoint {p : ZPoly}
+    (tried : Array (Component × Option (Certified p))) : Bool :=
+  pairwiseDisjoint (outputs tried |>.map (·.square))
+
+/-- Whether a successful result overlaps another successful result in the
+attempts array. -/
+@[expose] def overlaps {p : ZPoly}
+    (tried : Array (Component × Option (Certified p))) (i : Nat)
+    (res : Certified p) : Bool :=
+  let certSquares := tried.map fun t => t.2.map (·.square)
+  (Array.range tried.size).any fun j =>
+    i ≠ j && (match certSquares.getD j none with
+              | some sj => res.square.discsMeet sj
+              | none => false)
+
+/-- The contribution of one attempted component to a non-emitting round. -/
+@[expose] def step (p : ZPoly) (target : Int)
+    (tried : Array (Component × Option (Certified p))) (i : Nat) :
+    Array Component :=
+  match tried.getD i (⟨#[], 0⟩, none) with
+  | (c, some res) =>
+    let ready := target ≤ res.square.prec
+    if ready && !overlaps tried i res then #[c]
+    else
+      let c' := res.toComponent
+      if c.prec < c'.prec then #[c'] else c.refine1 p
+  | (c, none) => c.refine1 p
+
+/-- Worklist for a non-emitting round. Ready certificates disjoint from all
+other successful certificates hold their input component; other successes
+adopt a strictly finer doubled result or refine, and failures refine. -/
+@[expose] def next (p : ZPoly) (target : Int)
+    (tried : Array (Component × Option (Certified p))) : Array Component :=
+  (Array.range tried.size).flatMap (step p target tried)
+
+end IsolationLoop
+
 /-- The shared driver loop over the worklist. Each round certifies every
     component; if all certify at stored prec at least `target` with pairwise
     disjoint circumscribed discs (SPEC "Separation of the output"), the round
@@ -114,18 +171,14 @@ end Component
     suffice. `fuel = 0` returns `none`, the SPEC give-up semantics (up to a
     harmless constant of overshoot). The recursion is structural on the
     fuel `Nat`. -/
-def isolateLoop (p : ZPoly) (target : Int) (strategy : AtomStrategy) :
+@[expose] def isolateLoop (p : ZPoly) (target : Int) (strategy : AtomStrategy) :
     Nat → Array Component → Option (Array (Certified p))
   | 0, _ => none
   | fuel + 1, work =>
     if work.isEmpty then some #[] else
-    let tried := work.map fun c => (c, Component.certify? p strategy c)
-    let allReady := tried.all fun t => match t.2 with
-      | some r => target ≤ r.square.prec
-      | none => false
-    let disjoint := pairwiseDisjoint (tried.filterMap fun t => t.2.map (·.square))
-    if allReady && disjoint then
-      some (tried.filterMap (·.2))
+    let tried := IsolationLoop.attempts p strategy work
+    if IsolationLoop.allReady target tried && IsolationLoop.disjoint tried then
+      some (IsolationLoop.outputs tried)
     else
       -- A component whose certification already meets the target and whose
       -- disc is disjoint from every other certified disc holds its position
@@ -136,21 +189,8 @@ def isolateLoop (p : ZPoly) (target : Int) (strategy : AtomStrategy) :
       -- round and blowing the working bit-length while a slow sibling
       -- (e.g. a tight cluster forced down to its separation depth)
       -- subdivides.
-      let certSquares := tried.map fun t => t.2.map (·.square)
       isolateLoop p target strategy fuel <|
-        (Array.range tried.size).flatMap fun i =>
-          match tried.getD i (⟨#[], 0⟩, none) with
-          | (c, some res) =>
-            let ready := target ≤ res.square.prec
-            let overlaps := (Array.range tried.size).any fun j =>
-              i ≠ j && (match certSquares.getD j none with
-                        | some sj => res.square.discsMeet sj
-                        | none => false)
-            if ready && !overlaps then #[c]
-            else
-              let c' := res.toComponent
-              if c.prec < c'.prec then #[c'] else c.refine1 p
-          | (c, none) => c.refine1 p
+        IsolationLoop.next p target tried
 
 /-- Refine to `target` precision: speculative Newton steps, falling back to
     subdivision of the atom's square as a one-square component. `none` only

--- a/HexRootsMathlib.lean
+++ b/HexRootsMathlib.lean
@@ -13,6 +13,7 @@ public import HexRootsMathlib.Component
 public import HexRootsMathlib.Geometry
 public import HexRootsMathlib.Kantorovich
 public import HexRootsMathlib.KantorovichPoly
+public import HexRootsMathlib.Loop
 public import HexRootsMathlib.MahlerPrec
 public import HexRootsMathlib.NKWitness
 public import HexRootsMathlib.RootFree

--- a/HexRootsMathlib/Geometry.lean
+++ b/HexRootsMathlib/Geometry.lean
@@ -198,6 +198,84 @@ theorem radius_lt_radiusHi (s : Hex.DyadicSquare) :
   rw [halfWidth_eq]
   exact zpow_pos (by norm_num) _
 
+/-- The exact executable squared centre distance casts to the square of the
+Euclidean distance. -/
+@[simp] theorem toReal_distSq (z w : Hex.GaussDyadic) :
+    Dyadic.toReal (Hex.GaussDyadic.distSq z w) =
+      dist (GaussDyadic.toComplex z) (GaussDyadic.toComplex w) ^ 2 := by
+  simp [Hex.GaussDyadic.distSq, Complex.dist_eq, Complex.sq_norm]
+
+/-- A negative executable disc-intersection test certifies disjoint closed
+circumscribed discs. -/
+theorem closedDisc_disjoint_of_discsMeet_eq_false (s t : Hex.DyadicSquare)
+    (h : s.discsMeet t = false) : Disjoint (closedDisc s) (closedDisc t) := by
+  have hnot : ¬ Hex.GaussDyadic.distSq s.center t.center ≤
+      (2 : _root_.Dyadic) * .ofIntWithPrec 1 (2 * s.prec) +
+        2 * .ofIntWithPrec 1 (2 * t.prec) +
+        4 * .ofIntWithPrec 1 (s.prec + t.prec) := by
+    simpa [Hex.DyadicSquare.discsMeet] using h
+  have hrealnot : ¬ Dyadic.toReal (Hex.GaussDyadic.distSq s.center t.center) ≤
+      Dyadic.toReal ((2 : _root_.Dyadic) * .ofIntWithPrec 1 (2 * s.prec) +
+        2 * .ofIntWithPrec 1 (2 * t.prec) +
+        4 * .ofIntWithPrec 1 (s.prec + t.prec)) := by
+    simpa only [Dyadic.toReal_le_toReal_iff] using hnot
+  have hlt := lt_of_not_ge hrealnot
+  have hs : (2 : ℝ) ^ (-(2 * s.prec)) = ((2 : ℝ) ^ (-s.prec)) ^ 2 := by
+    rw [show -(2 * s.prec) = (-s.prec) * 2 by ring, zpow_mul]
+    rfl
+  have ht : (2 : ℝ) ^ (-(2 * t.prec)) = ((2 : ℝ) ^ (-t.prec)) ^ 2 := by
+    rw [show -(2 * t.prec) = (-t.prec) * 2 by ring, zpow_mul]
+    rfl
+  have hst : (2 : ℝ) ^ (-(s.prec + t.prec)) =
+      (2 : ℝ) ^ (-s.prec) * (2 : ℝ) ^ (-t.prec) := by
+    rw [show -(s.prec + t.prec) = -s.prec + -t.prec by ring,
+      zpow_add₀ (by norm_num : (2 : ℝ) ≠ 0)]
+  have htwo : Dyadic.toReal (2 : _root_.Dyadic) = (2 : ℝ) :=
+    Dyadic.toReal_two
+  have hfour : Dyadic.toReal (4 : _root_.Dyadic) = (4 : ℝ) := by
+    change Dyadic.toReal (.ofInt 4) = (4 : ℝ)
+    simp
+  have hradii : (radius s + radius t) ^ 2 <
+      dist (center s) (center t) ^ 2 := by
+    rw [radius_eq, radius_eq]
+    calc
+      ((2 : ℝ) ^ (-s.prec) * √2 + (2 : ℝ) ^ (-t.prec) * √2) ^ 2 =
+          2 * ((2 : ℝ) ^ (-s.prec)) ^ 2 +
+          2 * ((2 : ℝ) ^ (-t.prec)) ^ 2 +
+          4 * ((2 : ℝ) ^ (-s.prec) * (2 : ℝ) ^ (-t.prec)) := by
+        nlinarith [Real.sq_sqrt (by norm_num : (0 : ℝ) ≤ 2)]
+      _ < _ := by
+        simpa only [Dyadic.toReal_add, Dyadic.toReal_mul,
+          Dyadic.toReal_ofIntWithPrec, Dyadic.toReal_ofInt, Int.cast_one,
+          one_mul, Int.cast_ofNat, toReal_distSq, Hex.DyadicSquare.center,
+          center_eq, hs, ht, hst, htwo, hfour] using hlt
+  apply Metric.closedBall_disjoint_closedBall
+  have hrs : 0 ≤ radius s + radius t := by
+    simp only [radius_eq]
+    exact add_nonneg
+      (mul_nonneg (zpow_pos (by norm_num : (0 : ℝ) < 2) _).le
+        (Real.sqrt_nonneg _))
+      (mul_nonneg (zpow_pos (by norm_num : (0 : ℝ) < 2) _).le
+        (Real.sqrt_nonneg _))
+  exact (sq_lt_sq₀ hrs dist_nonneg).mp hradii
+
+/-- The executable array test gives semantic disjointness for every ordered
+pair of stored squares. -/
+theorem closedDisc_disjoint_of_pairwiseDisjoint {ss : Array Hex.DyadicSquare}
+    (h : Hex.pairwiseDisjoint ss = true) {i j : Nat}
+    (hi : i < ss.size) (hj : j < ss.size) (hij : i < j) :
+    Disjoint (closedDisc ss[i]) (closedDisc ss[j]) := by
+  have hiAll := (List.all_eq_true.mp h) i (List.mem_range.mpr hi)
+  have hijAll := (List.all_eq_true.mp hiAll) j (List.mem_range.mpr hj)
+  simp only [hij, ↓reduceIte] at hijAll
+  have hgeti : ss.getD i ⟨0, 0, 0⟩ = ss[i] := by
+    exact (Array.getElem_eq_getD (Hex.DyadicSquare.mk 0 0 0)).symm
+  have hgetj : ss.getD j ⟨0, 0, 0⟩ = ss[j] := by
+    exact (Array.getElem_eq_getD (Hex.DyadicSquare.mk 0 0 0)).symm
+  rw [hgeti, hgetj] at hijAll
+  exact closedDisc_disjoint_of_discsMeet_eq_false _ _
+    (Bool.eq_false_of_not_eq_true' hijAll)
+
 /-- The square is contained in its closed circumscribed Euclidean disc. -/
 theorem closedSquare_subset_closedDisc (s : Hex.DyadicSquare) :
     closedSquare s ⊆ closedDisc s := by

--- a/HexRootsMathlib/Loop.lean
+++ b/HexRootsMathlib/Loop.lean
@@ -1,0 +1,317 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRootsMathlib.Bisection
+public import HexRootsMathlib.Component
+
+public section
+
+/-!
+# Structural soundness of the isolation loop
+
+The results in this module are parametric in the semantic meaning of a
+successful certificate. They prove the coverage and output-geometry facts
+that follow solely from the executable worklist transitions.
+-/
+
+namespace HexRootsMathlib
+
+noncomputable section
+
+/-- Every input square occurs in one of the guarded connected components. -/
+theorem mem_glueCovered {sqs : Array Hex.DyadicSquare} {s : Hex.DyadicSquare}
+    (hs : s ∈ sqs.toList) :
+    ∃ c ∈ (Hex.glueCovered sqs).toList, s ∈ c.toList := by
+  rw [Hex.glueCovered]
+  split
+  · rename_i h
+    exact h s hs
+  · exact ⟨#[s], by simpa using hs, by simp⟩
+
+/-- One guarded subdivision round preserves every polynomial root covered by
+the input component. -/
+theorem isRoot_mem_refine1 {p : Hex.ZPoly} {c : Hex.Component} {z : ℂ}
+    (hzroot : (toPolyℂ p).IsRoot z) (hz : z ∈ Component.region c) :
+    ∃ d ∈ (c.refine1 p).toList, z ∈ Component.region d := by
+  obtain ⟨s, hs, hzs⟩ := hz
+  let survivors := (c.squares.flatMap Hex.DyadicSquare.subdivide).filter
+    (fun u => !Hex.rootFree p u)
+  obtain ⟨t, ht, hzt⟩ := isRoot_mem_survivors hzroot hs hzs
+  change t ∈ survivors.toList at ht
+  obtain ⟨ss, hss, htss⟩ := mem_glueCovered ht
+  let d : Hex.Component := { squares := ss, candidateK := c.candidateK }
+  refine ⟨d, ?_, ⟨t, htss, hzt⟩⟩
+  rw [Hex.Component.refine1]
+  change d ∈ ((Hex.glueCovered survivors).map fun ss =>
+    { squares := ss, candidateK := c.candidateK }).toList
+  simp only [Array.toList_map, List.mem_map]
+  exact ⟨ss, hss, rfl⟩
+
+namespace Worklist
+
+/-- Union of the closed-square regions retained by a worklist. -/
+@[expose] def region (work : Array Hex.Component) : Set ℂ :=
+  {z | ∃ c ∈ work.toList, z ∈ Component.region c}
+
+end Worklist
+
+namespace Results
+
+/-- Union of the semantic regions of an array of certificates. -/
+@[expose] def region {p : Hex.ZPoly} (rs : Array (Hex.Certified p)) : Set ℂ :=
+  {z | ∃ r ∈ rs.toList, z ∈ Certified.region r}
+
+end Results
+
+namespace Certifier
+
+/-- Semantic hypothesis consumed by the structural loop proof: every
+successful certificate covers every polynomial root covered by its input
+component. The `.nk` and general certificate developments instantiate this
+separately. In particular, speculative recentring must use the executable
+containment and same-count guards; it does not follow from geometric
+containment of the input component in the returned region. -/
+@[expose] def Preserves (p : Hex.ZPoly) (strategy : Hex.AtomStrategy) : Prop :=
+  ∀ c r, Hex.Component.certify? p strategy c = some r →
+    ∀ z, (toPolyℂ p).IsRoot z → z ∈ Component.region c →
+      z ∈ Certified.region r
+
+end Certifier
+
+/-- The non-emitting transition preserves every covered polynomial root. -/
+theorem isRoot_mem_next {p : Hex.ZPoly} {target : Int}
+    {strategy : Hex.AtomStrategy} (hcert : Certifier.Preserves p strategy)
+    {work : Array Hex.Component} {z : ℂ} (hzroot : (toPolyℂ p).IsRoot z)
+    (hz : z ∈ Worklist.region work) :
+    z ∈ Worklist.region (Hex.IsolationLoop.next p target
+      (Hex.IsolationLoop.attempts p strategy work)) := by
+  obtain ⟨c, hc, hzc⟩ := hz
+  let tried := Hex.IsolationLoop.attempts p strategy work
+  have ht : (c, Hex.Component.certify? p strategy c) ∈ tried := by
+    apply Array.mem_map_of_mem
+    exact Array.mem_toList_iff.mp hc
+  obtain ⟨i, hi, hget⟩ := Array.getElem_of_mem ht
+  have hiRange : i ∈ Array.range tried.size := by simp [hi]
+  rw [Worklist.region]
+  change ∃ d ∈ (Hex.IsolationLoop.next p target tried).toList,
+    z ∈ Component.region d
+  rw [Hex.IsolationLoop.next]
+  let step := Hex.IsolationLoop.step p target tried
+  change ∃ d ∈ ((Array.range tried.size).flatMap step).toList,
+    z ∈ Component.region d
+  have hgetD : tried.getD i (⟨#[], 0⟩, none) =
+      (c, Hex.Component.certify? p strategy c) := by
+    calc
+      _ = tried[i] :=
+        (Array.getElem_eq_getD (⟨#[], 0⟩, none)).symm
+      _ = _ := hget
+  have hlocal : ∃ d, d ∈ step i ∧ z ∈ Component.region d := by
+    dsimp only [step]
+    rw [Hex.IsolationLoop.step, hgetD]
+    cases htry : Hex.Component.certify? p strategy c with
+    | none =>
+        obtain ⟨d, hd, hzd⟩ := isRoot_mem_refine1 hzroot hzc
+        exact ⟨d, Array.mem_toList_iff.mp hd, hzd⟩
+    | some res =>
+        dsimp only
+        split
+        · exact ⟨c, by simp, hzc⟩
+        · split
+          · have hzres := hcert c res htry z hzroot hzc
+            exact ⟨res.toComponent, by simp,
+              Certified.region_subset_toComponent res hzres⟩
+          · obtain ⟨d, hd, hzd⟩ := isRoot_mem_refine1 hzroot hzc
+            exact ⟨d, Array.mem_toList_iff.mp hd, hzd⟩
+  obtain ⟨d, hd, hzd⟩ := hlocal
+  exact ⟨d, Array.mem_toList_iff.mpr
+    (Array.mem_flatMap_of_mem hiRange hd), hzd⟩
+
+/-- A target-ready successful attempt whose disc meets no other successful
+attempt holds its original component in the next worklist. -/
+theorem mem_next_of_hold {p : Hex.ZPoly} {target : Int}
+    {tried : Array (Hex.Component × Option (Hex.Certified p))}
+    {i : Nat} (hi : i < tried.size) {c : Hex.Component} {r : Hex.Certified p}
+    (hget : tried[i] = (c, some r))
+    (hready : target ≤ r.square.prec)
+    (hdisjoint : Hex.IsolationLoop.overlaps tried i r = false) :
+    c ∈ Hex.IsolationLoop.next p target tried := by
+  rw [Hex.IsolationLoop.next]
+  apply Array.mem_flatMap_of_mem (by simp [hi] : i ∈ Array.range tried.size)
+  rw [Hex.IsolationLoop.step]
+  have hgetD : tried.getD i (⟨#[], 0⟩, none) = (c, some r) := by
+    calc
+      _ = tried[i] := (Array.getElem_eq_getD (⟨#[], 0⟩, none)).symm
+      _ = _ := hget
+  rw [hgetD]
+  simp [hready, hdisjoint]
+
+/-- A non-held successful attempt whose doubled result is strictly finer
+re-enters the next worklist as that doubled covering component. -/
+theorem mem_next_of_adopt {p : Hex.ZPoly} {target : Int}
+    {tried : Array (Hex.Component × Option (Hex.Certified p))}
+    {i : Nat} (hi : i < tried.size) {c : Hex.Component} {r : Hex.Certified p}
+    (hget : tried[i] = (c, some r))
+    (hcontinue : (decide (target ≤ r.square.prec) &&
+      !Hex.IsolationLoop.overlaps tried i r) = false)
+    (hfiner : c.prec < r.toComponent.prec) :
+    r.toComponent ∈ Hex.IsolationLoop.next p target tried := by
+  rw [Hex.IsolationLoop.next]
+  apply Array.mem_flatMap_of_mem (by simp [hi] : i ∈ Array.range tried.size)
+  rw [Hex.IsolationLoop.step]
+  have hgetD : tried.getD i (⟨#[], 0⟩, none) = (c, some r) := by
+    calc
+      _ = tried[i] := (Array.getElem_eq_getD (⟨#[], 0⟩, none)).symm
+      _ = _ := hget
+  rw [hgetD]
+  rw [Certified.toComponent_prec] at hfiner
+  simp [hcontinue, hfiner]
+
+/-- `allReady` means every emitted certificate meets the target precision. -/
+theorem outputs_ready {p : Hex.ZPoly} {target : Int}
+    {tried : Array (Hex.Component × Option (Hex.Certified p))}
+    (hready : Hex.IsolationLoop.allReady target tried) :
+    ∀ r ∈ (Hex.IsolationLoop.outputs tried).toList,
+      target ≤ r.square.prec := by
+  intro r hr
+  have hr' := Array.mem_toList_iff.mp hr
+  obtain ⟨t, ht, htr⟩ := Array.mem_filterMap.mp hr'
+  have htready := (Array.all_eq_true_iff_forall_mem.mp hready) t ht
+  rw [Hex.IsolationLoop.outputs] at hr'
+  cases t with
+  | mk c o =>
+      cases o with
+      | none => simp at htr
+      | some r' =>
+          simp only at htr
+          cases htr
+          simpa using htready
+
+/-- When every attempt succeeds, the emitted certificate regions cover every
+polynomial root covered by the attempted worklist. -/
+theorem isRoot_mem_outputs {p : Hex.ZPoly} {target : Int}
+    {strategy : Hex.AtomStrategy} (hcert : Certifier.Preserves p strategy)
+    {work : Array Hex.Component} {z : ℂ} (hzroot : (toPolyℂ p).IsRoot z)
+    (hz : z ∈ Worklist.region work)
+    (hready : Hex.IsolationLoop.allReady target
+      (Hex.IsolationLoop.attempts p strategy work)) :
+    z ∈ Results.region (Hex.IsolationLoop.outputs
+      (Hex.IsolationLoop.attempts p strategy work)) := by
+  obtain ⟨c, hc, hzc⟩ := hz
+  let tried := Hex.IsolationLoop.attempts p strategy work
+  have ht : (c, Hex.Component.certify? p strategy c) ∈ tried := by
+    apply Array.mem_map_of_mem
+    exact Array.mem_toList_iff.mp hc
+  have htready := (Array.all_eq_true_iff_forall_mem.mp hready) _ ht
+  cases htry : Hex.Component.certify? p strategy c with
+  | none => simp [htry] at htready
+  | some r =>
+      refine ⟨r, ?_, hcert c r htry z hzroot hzc⟩
+      apply Array.mem_toList_iff.mpr
+      rw [Hex.IsolationLoop.outputs, Array.mem_filterMap]
+      exact ⟨(c, some r), by simpa [htry] using ht, rfl⟩
+
+/-- Parametric coverage theorem for the fuel-based isolation loop. No
+certificate analysis enters: the proof consumes only `Certifier.Preserves`
+and follows the executable emitting and non-emitting branches. -/
+theorem isolateLoop_covers {p : Hex.ZPoly} {target : Int}
+    {strategy : Hex.AtomStrategy} (hcert : Certifier.Preserves p strategy)
+    {fuel : Nat} {work : Array Hex.Component} {rs : Array (Hex.Certified p)}
+    (hloop : Hex.isolateLoop p target strategy fuel work = some rs)
+    {z : ℂ} (hzroot : (toPolyℂ p).IsRoot z)
+    (hz : z ∈ Worklist.region work) : z ∈ Results.region rs := by
+  induction fuel generalizing work rs with
+  | zero => simp [Hex.isolateLoop] at hloop
+  | succ fuel ih =>
+      rw [Hex.isolateLoop] at hloop
+      split at hloop
+      · rename_i hempty
+        have hwork : work = #[] := Array.eq_empty_of_size_eq_zero
+          (Array.isEmpty_iff_size_eq_zero.mp hempty)
+        subst work
+        simp [Worklist.region] at hz
+      · rename_i hnonempty
+        let tried := Hex.IsolationLoop.attempts p strategy work
+        change (if Hex.IsolationLoop.allReady target tried &&
+            Hex.IsolationLoop.disjoint tried then
+          some (Hex.IsolationLoop.outputs tried)
+        else Hex.isolateLoop p target strategy fuel
+          (Hex.IsolationLoop.next p target tried)) = some rs at hloop
+        split at hloop
+        · rename_i hemit
+          have hrs : rs = Hex.IsolationLoop.outputs tried := by
+            exact Option.some.inj hloop.symm
+          subst rs
+          have hready : Hex.IsolationLoop.allReady target tried := by
+            simp only [Bool.and_eq_true] at hemit
+            exact hemit.1
+          exact isRoot_mem_outputs hcert hzroot hz hready
+        · exact ih hloop (isRoot_mem_next hcert hzroot hz)
+
+/-- Every successful loop result meets the requested precision and passes the
+executable pairwise-disjoint-disc test. -/
+theorem isolateLoop_ready_disjoint {p : Hex.ZPoly} {target : Int}
+    {strategy : Hex.AtomStrategy} {fuel : Nat} {work : Array Hex.Component}
+    {rs : Array (Hex.Certified p)}
+    (hloop : Hex.isolateLoop p target strategy fuel work = some rs) :
+    (∀ r ∈ rs.toList, target ≤ r.square.prec) ∧
+      Hex.pairwiseDisjoint (rs.map (·.square)) = true := by
+  induction fuel generalizing work rs with
+  | zero => simp [Hex.isolateLoop] at hloop
+  | succ fuel ih =>
+      rw [Hex.isolateLoop] at hloop
+      split at hloop
+      · have hrs : rs = #[] := Option.some.inj hloop.symm
+        subst rs
+        simp [Hex.pairwiseDisjoint]
+      · let tried := Hex.IsolationLoop.attempts p strategy work
+        change (if Hex.IsolationLoop.allReady target tried &&
+            Hex.IsolationLoop.disjoint tried then
+          some (Hex.IsolationLoop.outputs tried)
+        else Hex.isolateLoop p target strategy fuel
+          (Hex.IsolationLoop.next p target tried)) = some rs at hloop
+        split at hloop
+        · rename_i hemit
+          simp only [Bool.and_eq_true] at hemit
+          have hrs : rs = Hex.IsolationLoop.outputs tried :=
+            Option.some.inj hloop.symm
+          subst rs
+          exact ⟨outputs_ready hemit.1, by
+            simpa [Hex.IsolationLoop.disjoint] using hemit.2⟩
+        · exact ih hloop
+
+/-- Distinct loop outputs have disjoint closed circumscribed discs. -/
+theorem isolateLoop_disjoint {p : Hex.ZPoly} {target : Int}
+    {strategy : Hex.AtomStrategy} {fuel : Nat} {work : Array Hex.Component}
+    {rs : Array (Hex.Certified p)}
+    (hloop : Hex.isolateLoop p target strategy fuel work = some rs)
+    {i j : Nat} (hi : i < rs.size) (hj : j < rs.size) (hij : i < j) :
+    Disjoint (DyadicSquare.closedDisc rs[i].square)
+      (DyadicSquare.closedDisc rs[j].square) := by
+  have hpair := (isolateLoop_ready_disjoint hloop).2
+  have hi' : i < (rs.map (·.square)).size := by simpa using hi
+  have hj' : j < (rs.map (·.square)).size := by simpa using hj
+  have hsem := DyadicSquare.closedDisc_disjoint_of_pairwiseDisjoint
+    hpair hi' hj' hij
+  simpa using hsem
+
+/-- Any two differently indexed loop outputs have disjoint closed
+circumscribed discs. -/
+theorem isolateLoop_disjoint_of_ne {p : Hex.ZPoly} {target : Int}
+    {strategy : Hex.AtomStrategy} {fuel : Nat} {work : Array Hex.Component}
+    {rs : Array (Hex.Certified p)}
+    (hloop : Hex.isolateLoop p target strategy fuel work = some rs)
+    {i j : Nat} (hi : i < rs.size) (hj : j < rs.size) (hij : i ≠ j) :
+    Disjoint (DyadicSquare.closedDisc rs[i].square)
+      (DyadicSquare.closedDisc rs[j].square) := by
+  rcases lt_or_gt_of_ne hij with hij | hji
+  · exact isolateLoop_disjoint hloop hi hj hij
+  · exact (isolateLoop_disjoint hloop hj hi hji).symm
+
+end
+
+end HexRootsMathlib

--- a/progress/2026-07-19T14-05-27Z.md
+++ b/progress/2026-07-19T14-05-27Z.md
@@ -1,0 +1,30 @@
+# Accomplished
+
+- Completed execution-plan item 12, the parametric isolation-loop kernel.
+- Refactored the executable loop into named attempt, readiness, output,
+  overlap, step, and next helpers without changing its branch behavior.
+- Added guarded gluing coverage, subdivision/root preservation, held-position
+  and doubled-adoption facts, recursive worklist coverage, target-readiness,
+  and pairwise closed-disc disjointness.
+- Added the exact `discsMeet = false` to semantic closed-disc-disjointness
+  bridge.
+- Obtained an Opus second opinion; it found no soundness blocker. Addressed its
+  API/documentation concerns and recorded the direct `glue` characterization
+  as follow-up work for the umbrella.
+- Verified focused builds, all structural checks, the full 9390-target build,
+  Hex conformance targets, fixture emission, and all 14 HexRoots benchmarks
+  (7 seconds under the 360-second cap).
+
+# Current frontier
+
+- The item-12 implementation is ready to commit, rebase onto merged PR #8793,
+  publish as the PR closing #8794, and hand to CI/auto-merge.
+
+# Next step
+
+- Open and merge the loop-kernel PR, then start plan item 13: instantiate the
+  parametric certificate-preservation hypothesis for the NK atom path.
+
+# Blockers
+
+- None.


### PR DESCRIPTION
Closes #8794.

Part of #8755, execution-plan item 12.

## What changed

- extract the executable isolation-loop branch helpers without changing behavior
- make refinement coverage explicit through guarded component gluing
- prove root preservation across subdivision and every non-emitting transition
- prove held-position and doubled-result adoption membership facts
- prove successful-loop coverage under the explicit `Certifier.Preserves` semantic hypothesis
- prove target readiness and semantic pairwise disjointness of returned closed discs

## Verification

- `lake build HexRootsMathlib.Loop HexRootsMathlib`
- full `lake build` (9390 jobs)
- `lake build HexConformance hexroots_emit_fixtures hexroots_bench`
- all 14 HexRoots benchmarks (7s, 360s cap)
- copyright, line-count, DAG, Phase-4, diff, and forbidden-token checks

## Second opinion

Claude Opus found no soundness blocker and independently traced every loop branch and the exact disc geometry. I addressed its concrete suggestions by adding a standalone doubled-adoption lemma, an unordered semantic disjointness API, and explicit documentation of the speculative-recentring obligation carried by `Certifier.Preserves`. It noted that `glueCovered` adds an unreachable defensive fallback and an extra O(m²) pass; current HexRoots bench verification remains green at 7s. A direct characterization of imperative `glue` is recorded for follow-up on #8755.