### PR TITLE
hex-roots-mathlib: prove .nk certifier soundness

### DIFF
--- a/HexRoots/Basic.lean
+++ b/HexRoots/Basic.lean
@@ -177,6 +177,39 @@ structure Component where
       an untrusted hint for step ordering. -/
   candidateK : Nat
 
+/-- Exact axis-aligned bounds used to enclose an array of dyadic squares. -/
+structure SquareBounds where
+  /-- Lower real-coordinate bound. -/
+  xmin : Dyadic
+  /-- Upper real-coordinate bound. -/
+  xmax : Dyadic
+  /-- Lower imaginary-coordinate bound. -/
+  ymin : Dyadic
+  /-- Upper imaginary-coordinate bound. -/
+  ymax : Dyadic
+
+/-- The exact coordinate bounds contributed by one dyadic square. -/
+@[expose] def DyadicSquare.bounds (s : DyadicSquare) : SquareBounds :=
+  let hw := s.halfWidth
+  ⟨s.re - hw, s.re + hw, s.im - hw, s.im + hw⟩
+
+/-- Extend exact coordinate bounds by one dyadic square. -/
+@[expose] def SquareBounds.merge (b : SquareBounds) (s : DyadicSquare) : SquareBounds :=
+  let sb := s.bounds
+  ⟨Hex.Dyadic.min b.xmin sb.xmin, Hex.Dyadic.max b.xmax sb.xmax,
+    Hex.Dyadic.min b.ymin sb.ymin, Hex.Dyadic.max b.ymax sb.ymax⟩
+
+/-- Add one square to an optional bounding box. -/
+@[expose] def SquareBounds.extend (b : Option SquareBounds)
+    (s : DyadicSquare) : Option SquareBounds :=
+  match b with
+  | none => some s.bounds
+  | some b => some (b.merge s)
+
+/-- Exact bounding box of an array of dyadic squares. -/
+@[expose] def boundingBox (squares : Array DyadicSquare) : Option SquareBounds :=
+  squares.foldl (init := none) SquareBounds.extend
+
 /-- The smallest square with power-of-two half-width, centred at the
     bounding-box centre, containing every square. Junk `⟨0,0,0⟩` on the
     empty array (callers keep components nonempty).
@@ -188,22 +221,13 @@ structure Component where
     the box half-width. On a single square input this returns that
     square exactly. -/
 @[expose] def encSquare (squares : Array DyadicSquare) : DyadicSquare :=
-  let box : Option (Dyadic × Dyadic × Dyadic × Dyadic) :=
-    squares.foldl (init := none) fun acc s =>
-      let hw := s.halfWidth
-      let xlo := s.re - hw; let xhi := s.re + hw
-      let ylo := s.im - hw; let yhi := s.im + hw
-      match acc with
-      | none => some (xlo, xhi, ylo, yhi)
-      | some (xmin, xmax, ymin, ymax) =>
-          some (Hex.Dyadic.min xmin xlo, Hex.Dyadic.max xmax xhi,
-                Hex.Dyadic.min ymin ylo, Hex.Dyadic.max ymax yhi)
-  match box with
+  match boundingBox squares with
   | none => ⟨0, 0, 0⟩
-  | some (xmin, xmax, ymin, ymax) =>
-      let cx := (xmin + xmax) >>> (1 : Int)
-      let cy := (ymin + ymax) >>> (1 : Int)
-      let w := Hex.Dyadic.max ((xmax - xmin) >>> (1 : Int)) ((ymax - ymin) >>> (1 : Int))
+  | some b =>
+      let cx := (b.xmin + b.xmax) >>> (1 : Int)
+      let cy := (b.ymin + b.ymax) >>> (1 : Int)
+      let w := Hex.Dyadic.max ((b.xmax - b.xmin) >>> (1 : Int))
+        ((b.ymax - b.ymin) >>> (1 : Int))
       let q := -(Hex.Dyadic.ceilLog2 w)
       ⟨cx, cy, q⟩
 

--- a/HexRoots/Bisection.lean
+++ b/HexRoots/Bisection.lean
@@ -119,7 +119,7 @@ namespace Component
     coverage guard: the base region must certify the same count in the same
     certificate form, and the recentred certified region must be contained
     in the base one. -/
-def certify? (p : ZPoly) (strategy : AtomStrategy := .nkThenPellet)
+@[expose] def certify? (p : ZPoly) (strategy : AtomStrategy := .nkThenPellet)
     (c : Component) : Option (Certified p) := Id.run do
   let enc := encSquare c.squares
   -- Newton-Kantorovich attempt, on the doubled enclosing square.

--- a/HexRootsMathlib.lean
+++ b/HexRootsMathlib.lean
@@ -15,6 +15,7 @@ public import HexRootsMathlib.Kantorovich
 public import HexRootsMathlib.KantorovichPoly
 public import HexRootsMathlib.Loop
 public import HexRootsMathlib.MahlerPrec
+public import HexRootsMathlib.NKCertify
 public import HexRootsMathlib.NKWitness
 public import HexRootsMathlib.RootFree
 public import HexRootsMathlib.Taylor

--- a/HexRootsMathlib/Basic.lean
+++ b/HexRootsMathlib/Basic.lean
@@ -43,6 +43,18 @@ theorem natDegree_toPolyℂ (p : Hex.ZPoly) :
     (RingHom.injective_int (Int.castRingHom ℂ)),
     HexPolyMathlib.natDegree_toPolynomial]
 
+/-- The executable natural ceiling logarithm is an upper base-two logarithm. -/
+theorem le_two_pow_ceilLog2 (m : Nat) : m ≤ 2 ^ Hex.ceilLog2 m := by
+  unfold Hex.ceilLog2
+  by_cases hm : m ≤ 1
+  · rw [if_pos hm]
+    simpa using hm
+  · rw [if_neg hm]
+    have hm2 : 2 ≤ m := by omega
+    have hne : m - 1 ≠ 0 := by omega
+    have hlog := (Nat.log2_lt hne).1 (Nat.lt_succ_self (m - 1).log2)
+    omega
+
 namespace Dyadic
 
 /-- The real value of an exact dyadic number, through its rational value. -/
@@ -110,6 +122,28 @@ namespace Dyadic
   rw [_root_.Dyadic.toRat_pow]
   norm_cast
 
+/-- `toRat` turns a right shift into multiplication by a negative power of
+two. -/
+theorem toRat_shiftRight (x : _root_.Dyadic) (i : Int) :
+    (x >>> i).toRat = x.toRat * (2 : ℚ) ^ (-i) := by
+  cases x with
+  | zero => simp [HShiftRight.hShiftRight, _root_.Dyadic.shiftRight]
+  | ofOdd n k hn =>
+      show (_root_.Dyadic.ofOdd n (k + i) hn).toRat = _
+      rw [_root_.Dyadic.toRat_ofOdd_eq_mul_two_pow,
+        _root_.Dyadic.toRat_ofOdd_eq_mul_two_pow,
+        show -(k + i) = -k + -i by ring, zpow_add₀ (by norm_num)]
+      ring
+
+/-- The real value of a right shift is multiplication by a negative power of
+two. -/
+theorem toReal_shiftRight (x : _root_.Dyadic) (i : Int) :
+    toReal (x >>> i) = toReal x * (2 : ℝ) ^ (-i) := by
+  unfold toReal
+  rw [toRat_shiftRight]
+  push_cast
+  ring
+
 /-- Real-value comparison reflects and preserves dyadic non-strict order. -/
 @[simp] theorem toReal_le_toReal_iff {x y : _root_.Dyadic} :
     toReal x ≤ toReal y ↔ x ≤ y := by
@@ -150,6 +184,51 @@ theorem toReal_injective : Function.Injective toReal := by
   split <;> rename_i h
   · rw [max_eq_right (toReal_le_toReal_iff.mpr h)]
   · rw [max_eq_left (le_of_not_ge fun h' => h (toReal_le_toReal_iff.mp h'))]
+
+/-- The real-value map preserves the executable dyadic minimum. -/
+@[simp] theorem toReal_min (x y : _root_.Dyadic) :
+    toReal (Hex.Dyadic.min x y) = min (toReal x) (toReal y) := by
+  unfold Hex.Dyadic.min
+  split <;> rename_i h
+  · rw [min_eq_left (toReal_le_toReal_iff.mpr h)]
+  · rw [min_eq_right (le_of_not_ge fun h' => h (toReal_le_toReal_iff.mp h'))]
+
+/-- The executable dyadic ceiling logarithm bounds every positive dyadic by
+the corresponding power of two. -/
+theorem toReal_le_two_pow_ceilLog2 (x : _root_.Dyadic) (hx : 0 < toReal x) :
+    toReal x ≤ (2 : ℝ) ^ Hex.Dyadic.ceilLog2 x := by
+  cases x with
+  | zero => simp at hx
+  | ofOdd n k hn =>
+      have htr : toReal (_root_.Dyadic.ofOdd n k hn) =
+          (n : ℝ) * 2 ^ (-k : Int) := by
+        unfold toReal
+        rw [_root_.Dyadic.toRat_ofOdd_eq_mul_two_pow]
+        push_cast
+        ring
+      have h2k : (0 : ℝ) < 2 ^ (-k : Int) :=
+        zpow_pos (by norm_num) _
+      have hn0 : 0 < n := by
+        by_contra h
+        rw [htr] at hx
+        have hnle : (n : ℝ) ≤ 0 := by exact_mod_cast (not_lt.mp h)
+        nlinarith
+      have hcl : Hex.Dyadic.ceilLog2 (_root_.Dyadic.ofOdd n k hn) =
+          (Hex.ceilLog2 n.toNat : Int) - k := by
+        show (if n < 0 then (0 : Int) else (Hex.ceilLog2 n.toNat : Int) - k) = _
+        rw [if_neg (by omega)]
+      have hnle : (n : ℝ) ≤ (2 : ℝ) ^ Hex.ceilLog2 n.toNat := by
+        have hnat := le_two_pow_ceilLog2 n.toNat
+        have hcast : (n.toNat : ℝ) ≤ (2 : ℝ) ^ Hex.ceilLog2 n.toNat := by
+          exact_mod_cast hnat
+        calc
+          (n : ℝ) = (n.toNat : ℝ) := by
+            exact_mod_cast (Int.toNat_of_nonneg (le_of_lt hn0)).symm
+          _ ≤ _ := hcast
+      rw [htr, hcl, show (Hex.ceilLog2 n.toNat : Int) - k =
+          (Hex.ceilLog2 n.toNat : Int) + (-k) by ring,
+        zpow_add₀ (by norm_num : (2 : ℝ) ≠ 0), zpow_natCast]
+      exact mul_le_mul_of_nonneg_right hnle h2k.le
 
 /-- The real value of `n * 2 ^ (-prec)` represented as a dyadic. -/
 @[simp] theorem toReal_ofIntWithPrec (n prec : Int) :

--- a/HexRootsMathlib/Component.lean
+++ b/HexRootsMathlib/Component.lean
@@ -100,6 +100,20 @@ theorem isRoot_mem_cauchy (p : Hex.ZPoly) (h : 0 < p.degree?.getD 0)
     z ∈ region (Hex.Component.cauchy p h) :=
   exists_mem_component_cauchy p h hz
 
+/-- The executable enclosing square contains the union of all input squares,
+without a common-precision or connectivity hypothesis. -/
+theorem region_subset_encSquare (c : Hex.Component) :
+    region c ⊆ DyadicSquare.closedSquare (Hex.encSquare c.squares) := by
+  rintro z ⟨s, hs, hz⟩
+  exact DyadicSquare.closedSquare_subset_encSquare hs hz
+
+/-- The doubled enclosing square used by NK certification contains the whole
+input component region. -/
+theorem region_subset_doubledEnc (c : Hex.Component) :
+    region c ⊆ DyadicSquare.closedSquare (Hex.encSquare c.squares).doubled :=
+  (region_subset_encSquare c).trans
+    (DyadicSquare.closedSquare_subset_doubled (Hex.encSquare c.squares))
+
 end Component
 
 namespace DyadicRootIsolation

--- a/HexRootsMathlib/Geometry.lean
+++ b/HexRootsMathlib/Geometry.lean
@@ -93,8 +93,88 @@ theorem sqrt_two_lt_sqrt2Hi : √2 < Dyadic.toReal Hex.sqrt2Hi := by
 
 /-! ### Sup-norm squares and circumscribed discs -/
 
+namespace SquareBounds
+
+/-- A computed bounding box contains the full coordinate extent of a square. -/
+def Contains (b : Hex.SquareBounds) (s : Hex.DyadicSquare) : Prop :=
+  Dyadic.toReal b.xmin ≤ Dyadic.toReal (s.re - s.halfWidth) ∧
+  Dyadic.toReal (s.re + s.halfWidth) ≤ Dyadic.toReal b.xmax ∧
+  Dyadic.toReal b.ymin ≤ Dyadic.toReal (s.im - s.halfWidth) ∧
+  Dyadic.toReal (s.im + s.halfWidth) ≤ Dyadic.toReal b.ymax
+
+theorem bounds_contains (s : Hex.DyadicSquare) : Contains s.bounds s := by
+  simp [Contains, Hex.DyadicSquare.bounds]
+
+theorem contains_merge_left {b : Hex.SquareBounds} {s t : Hex.DyadicSquare}
+    (h : Contains b s) : Contains (b.merge t) s := by
+  rcases h with ⟨hxlo, hxhi, hylo, hyhi⟩
+  simp only [Contains, Hex.SquareBounds.merge, Hex.DyadicSquare.bounds,
+    Dyadic.toReal_min, Dyadic.toReal_max]
+  exact ⟨min_le_left _ _ |>.trans hxlo, hxhi.trans (le_max_left _ _),
+    min_le_left _ _ |>.trans hylo, hyhi.trans (le_max_left _ _)⟩
+
+theorem contains_merge_right (b : Hex.SquareBounds) (s : Hex.DyadicSquare) :
+    Contains (b.merge s) s := by
+  simp only [Contains, Hex.SquareBounds.merge, Hex.DyadicSquare.bounds,
+    Dyadic.toReal_min, Dyadic.toReal_max]
+  exact ⟨min_le_right _ _, le_max_right _ _, min_le_right _ _, le_max_right _ _⟩
+
+theorem contains_extend_old {b : Option Hex.SquareBounds} {s t : Hex.DyadicSquare}
+    (h : ∃ box, b = some box ∧ Contains box s) :
+    ∃ box, Hex.SquareBounds.extend b t = some box ∧ Contains box s := by
+  obtain ⟨box, rfl, hs⟩ := h
+  exact ⟨box.merge t, rfl, contains_merge_left hs⟩
+
+theorem contains_extend_new (b : Option Hex.SquareBounds) (s : Hex.DyadicSquare) :
+    ∃ box, Hex.SquareBounds.extend b s = some box ∧ Contains box s := by
+  cases b with
+  | none => exact ⟨s.bounds, rfl, bounds_contains s⟩
+  | some box => exact ⟨box.merge s, rfl, contains_merge_right box s⟩
+
+private theorem contains_foldl (l : List Hex.DyadicSquare)
+    (b : Option Hex.SquareBounds) {s : Hex.DyadicSquare}
+    (h : (∃ box, b = some box ∧ Contains box s) ∨ s ∈ l) :
+    ∃ box, l.foldl Hex.SquareBounds.extend b = some box ∧ Contains box s := by
+  induction l generalizing b with
+  | nil =>
+      rcases h with h | h
+      · simpa using h
+      · simp at h
+  | cons t l ih =>
+      simp only [List.foldl_cons]
+      apply ih
+      rcases h with h | h
+      · exact Or.inl (contains_extend_old h)
+      · rw [List.mem_cons] at h
+        rcases h with rfl | h
+        · exact Or.inl (contains_extend_new b _)
+        · exact Or.inr h
+
+/-- Every input square is contained in the exact bounding box returned by the
+executable fold. -/
+theorem mem_boundingBox {squares : Array Hex.DyadicSquare}
+    {s : Hex.DyadicSquare} (hs : s ∈ squares.toList) :
+    ∃ box, Hex.boundingBox squares = some box ∧ Contains box s := by
+  rw [Hex.boundingBox, ← Array.foldl_toList]
+  exact contains_foldl squares.toList none (Or.inr hs)
+
+end SquareBounds
+
 /-- The sup norm on `ℂ`, used to view an axis-aligned square as a ball. -/
 @[expose] def supNorm (z : ℂ) : ℝ := max |z.re| |z.im|
+
+/-- The complex sup norm satisfies the triangle inequality. -/
+theorem supNorm_add_le (z w : ℂ) :
+    supNorm (z + w) ≤ supNorm z + supNorm w := by
+  apply max_le
+  · calc
+      |(z + w).re| ≤ |z.re| + |w.re| := abs_add_le _ _
+      _ ≤ max |z.re| |z.im| + max |w.re| |w.im| :=
+        add_le_add (le_max_left _ _) (le_max_left _ _)
+  · calc
+      |(z + w).im| ≤ |z.im| + |w.im| := abs_add_le _ _
+      _ ≤ max |z.re| |z.im| + max |w.re| |w.im| :=
+        add_le_add (le_max_right _ _) (le_max_right _ _)
 
 /-- The distance associated to `supNorm`. -/
 @[expose] def supDist (z w : ℂ) : ℝ := supNorm (z - w)
@@ -275,6 +355,154 @@ theorem closedDisc_disjoint_of_pairwiseDisjoint {ss : Array Hex.DyadicSquare}
   rw [hgeti, hgetj] at hijAll
   exact closedDisc_disjoint_of_discsMeet_eq_false _ _
     (Bool.eq_false_of_not_eq_true' hijAll)
+
+/-- The exact executable square-containment check implies containment of the
+represented closed sup-norm squares. -/
+theorem closedSquare_subset_of_squareInside {inner outer : Hex.DyadicSquare}
+    (h : inner.squareInside outer = true) :
+    closedSquare inner ⊆ closedSquare outer := by
+  have hdy : Hex.Dyadic.max
+        (Hex.Dyadic.abs (inner.re - outer.re))
+        (Hex.Dyadic.abs (inner.im - outer.im)) + inner.halfWidth ≤
+      outer.halfWidth := by
+    simpa [Hex.DyadicSquare.squareInside] using h
+  have hreal := Dyadic.toReal_le_toReal_iff.mpr hdy
+  have hwidth (s : Hex.DyadicSquare) :
+      Dyadic.toReal s.halfWidth = halfWidth s := by
+    simp [Hex.DyadicSquare.halfWidth, halfWidth_eq]
+  intro z hz
+  change supNorm (z - center inner) ≤ halfWidth inner at hz
+  change supNorm (z - center outer) ≤ halfWidth outer
+  calc
+    supNorm (z - center outer) =
+        supNorm ((z - center inner) + (center inner - center outer)) := by
+      congr 1
+      ring
+    _ ≤ supNorm (z - center inner) + supNorm (center inner - center outer) :=
+      supNorm_add_le _ _
+    _ ≤ halfWidth inner + supNorm (center inner - center outer) :=
+      add_le_add hz le_rfl
+    _ = supNorm (center inner - center outer) + halfWidth inner := add_comm _ _
+    _ ≤ halfWidth outer := by
+      simpa only [Dyadic.toReal_add, Dyadic.toReal_max, Dyadic.toReal_abs,
+        Dyadic.toReal_sub, hwidth, center, GaussDyadic.toComplex_re,
+        GaussDyadic.toComplex_im, Hex.DyadicSquare.center, Complex.sub_re,
+        Complex.sub_im, supNorm] using hreal
+
+/-- Every input square is contained in the power-of-two square constructed
+from its array's exact bounding box. -/
+theorem closedSquare_subset_encSquare {squares : Array Hex.DyadicSquare}
+    {s : Hex.DyadicSquare} (hs : s ∈ squares.toList) :
+    closedSquare s ⊆ closedSquare (Hex.encSquare squares) := by
+  obtain ⟨b, hbox, hb⟩ := SquareBounds.mem_boundingBox hs
+  rcases hb with ⟨hxlo, hxhi, hylo, hyhi⟩
+  let xhalf := (b.xmax - b.xmin) >>> (1 : Int)
+  let yhalf := (b.ymax - b.ymin) >>> (1 : Int)
+  let w := Hex.Dyadic.max xhalf yhalf
+  have hwidth (u : Hex.DyadicSquare) :
+      Dyadic.toReal u.halfWidth = halfWidth u := by
+    simp [Hex.DyadicSquare.halfWidth, halfWidth_eq]
+  have hswidth : 0 < halfWidth s := by
+    rw [halfWidth_eq]
+    exact zpow_pos (by norm_num) _
+  have hxspan : 2 * halfWidth s ≤
+      Dyadic.toReal b.xmax - Dyadic.toReal b.xmin := by
+    simp only [Dyadic.toReal_sub, Dyadic.toReal_add, hwidth] at hxlo hxhi
+    linarith
+  have hyspan : 2 * halfWidth s ≤
+      Dyadic.toReal b.ymax - Dyadic.toReal b.ymin := by
+    simp only [Dyadic.toReal_sub, Dyadic.toReal_add, hwidth] at hylo hyhi
+    linarith
+  have hxhalf : Dyadic.toReal xhalf =
+      (Dyadic.toReal b.xmax - Dyadic.toReal b.xmin) / 2 := by
+    simp [xhalf, Dyadic.toReal_shiftRight]
+    ring
+  have hyhalf : Dyadic.toReal yhalf =
+      (Dyadic.toReal b.ymax - Dyadic.toReal b.ymin) / 2 := by
+    simp [yhalf, Dyadic.toReal_shiftRight]
+    ring
+  have hwpos : 0 < Dyadic.toReal w := by
+    have hxpos : 0 < Dyadic.toReal xhalf := by
+      rw [hxhalf]
+      linarith
+    dsimp only [w]
+    rw [Dyadic.toReal_max]
+    exact hxpos.trans_le (le_max_left _ _)
+  have hwceil : Dyadic.toReal w ≤
+      (2 : ℝ) ^ Hex.Dyadic.ceilLog2 w :=
+    Dyadic.toReal_le_two_pow_ceilLog2 w hwpos
+  have hencWidth : halfWidth (Hex.encSquare squares) =
+      (2 : ℝ) ^ Hex.Dyadic.ceilLog2 w := by
+    rw [halfWidth_eq, Hex.encSquare, hbox]
+    change (2 : ℝ) ^ (- -Hex.Dyadic.ceilLog2
+      (Hex.Dyadic.max ((b.xmax - b.xmin) >>> (1 : Int))
+        ((b.ymax - b.ymin) >>> (1 : Int)))) = _
+    simp only [neg_neg]
+    rfl
+  have hencRe : (center (Hex.encSquare squares)).re =
+      (Dyadic.toReal b.xmin + Dyadic.toReal b.xmax) / 2 := by
+    simp only [center, Hex.encSquare, hbox, Hex.DyadicSquare.center,
+      GaussDyadic.toComplex_re]
+    rw [Dyadic.toReal_shiftRight, Dyadic.toReal_add]
+    norm_num
+    ring
+  have hencIm : (center (Hex.encSquare squares)).im =
+      (Dyadic.toReal b.ymin + Dyadic.toReal b.ymax) / 2 := by
+    simp only [center, Hex.encSquare, hbox, Hex.DyadicSquare.center,
+      GaussDyadic.toComplex_im]
+    rw [Dyadic.toReal_shiftRight, Dyadic.toReal_add]
+    norm_num
+    ring
+  intro z hz
+  change supNorm (z - center s) ≤ halfWidth s at hz
+  change supNorm (z - center (Hex.encSquare squares)) ≤
+    halfWidth (Hex.encSquare squares)
+  have hzre : |z.re - Dyadic.toReal s.re| ≤ halfWidth s := by
+    exact (le_max_left _ _).trans hz
+  have hzim : |z.im - Dyadic.toReal s.im| ≤ halfWidth s := by
+    exact (le_max_right _ _).trans hz
+  have hxlo' : Dyadic.toReal b.xmin ≤ Dyadic.toReal s.re - halfWidth s := by
+    simpa only [Dyadic.toReal_sub, hwidth] using hxlo
+  have hxhi' : Dyadic.toReal s.re + halfWidth s ≤ Dyadic.toReal b.xmax := by
+    simpa only [Dyadic.toReal_add, hwidth] using hxhi
+  have hylo' : Dyadic.toReal b.ymin ≤ Dyadic.toReal s.im - halfWidth s := by
+    simpa only [Dyadic.toReal_sub, hwidth] using hylo
+  have hyhi' : Dyadic.toReal s.im + halfWidth s ≤ Dyadic.toReal b.ymax := by
+    simpa only [Dyadic.toReal_add, hwidth] using hyhi
+  have hzboxRe : Dyadic.toReal b.xmin ≤ z.re ∧ z.re ≤ Dyadic.toReal b.xmax := by
+    rw [abs_le] at hzre
+    constructor <;> linarith [hxlo', hxhi']
+  have hzboxIm : Dyadic.toReal b.ymin ≤ z.im ∧ z.im ≤ Dyadic.toReal b.ymax := by
+    rw [abs_le] at hzim
+    constructor <;> linarith [hylo', hyhi']
+  rw [supNorm, Complex.sub_re, Complex.sub_im, hencRe, hencIm, max_le_iff]
+  constructor
+  · rw [hencWidth]
+    have hmid : |z.re - (Dyadic.toReal b.xmin + Dyadic.toReal b.xmax) / 2| ≤
+        (Dyadic.toReal b.xmax - Dyadic.toReal b.xmin) / 2 := by
+      rw [abs_le]
+      constructor <;> linarith [hzboxRe.1, hzboxRe.2]
+    apply hmid.trans
+    calc
+      _ = Dyadic.toReal xhalf := hxhalf.symm
+      _ ≤ Dyadic.toReal w := by
+        dsimp only [w]
+        rw [Dyadic.toReal_max]
+        exact le_max_left _ _
+      _ ≤ _ := hwceil
+  · rw [hencWidth]
+    have hmid : |z.im - (Dyadic.toReal b.ymin + Dyadic.toReal b.ymax) / 2| ≤
+        (Dyadic.toReal b.ymax - Dyadic.toReal b.ymin) / 2 := by
+      rw [abs_le]
+      constructor <;> linarith [hzboxIm.1, hzboxIm.2]
+    apply hmid.trans
+    calc
+      _ = Dyadic.toReal yhalf := hyhalf.symm
+      _ ≤ Dyadic.toReal w := by
+        dsimp only [w]
+        rw [Dyadic.toReal_max]
+        exact le_max_right _ _
+      _ ≤ _ := hwceil
 
 /-- The square is contained in its closed circumscribed Euclidean disc. -/
 theorem closedSquare_subset_closedDisc (s : Hex.DyadicSquare) :

--- a/HexRootsMathlib/MahlerPrec.lean
+++ b/HexRootsMathlib/MahlerPrec.lean
@@ -64,18 +64,6 @@ theorem supNorm_toPolyℂ_le (p : Hex.ZPoly) :
     (show ((p.coeff i).natAbs : ℝ) ≤ (p.coeffAbsMax : ℝ) by
       exact_mod_cast coeff_natAbs_le_coeffAbsMax p i)
 
-/-- `ceilLog2Nat m` is an upper base-two logarithm. -/
-theorem le_two_pow_ceilLog2 (m : Nat) : m ≤ 2 ^ Hex.ceilLog2 m := by
-  unfold Hex.ceilLog2
-  by_cases hm : m ≤ 1
-  · rw [if_pos hm]
-    simpa using hm
-  · rw [if_neg hm]
-    have hm2 : 2 ≤ m := by omega
-    have hne : m - 1 ≠ 0 := by omega
-    have := (Nat.log2_lt hne).1 (Nat.lt_succ_self (m - 1).log2)
-    omega
-
 /-- The exact exponent used by `mahlerPrec` dominates the analytic coefficient
 factor in the Mahler separation estimate. -/
 theorem mahlerFactor_le_twoPow (n A : Nat) :

--- a/HexRootsMathlib/NKCertify.lean
+++ b/HexRootsMathlib/NKCertify.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRootsMathlib.Loop
+public import HexRootsMathlib.NKWitness
+
+public section
+
+/-!
+# Soundness of NK-only component certification
+
+This module follows both executable `.nk` certification paths: the doubled
+enclosing square and the coverage-guarded speculative Newton square.
+-/
+
+namespace HexRootsMathlib
+
+noncomputable section
+
+/-- An NK-only certification result is either the coverage-guarded speculative
+candidate or the doubled enclosing base square. -/
+theorem certify_nk_cases {p : Hex.ZPoly} {c : Hex.Component}
+    {r : Hex.Certified p} (hcert : Hex.Component.certify? p .nk c = some r) :
+    let base := (Hex.encSquare c.squares).doubled
+    let cand := (Hex.newtonSquare p base 1).doubled
+    (∃ (_hbase : Hex.nkWitness p base) (_hinside : cand.squareInside base = true)
+        (hcand : Hex.nkWitness p cand),
+        r = .atom ⟨cand, Or.inl hcand⟩) ∨
+      ∃ hbase : Hex.nkWitness p base,
+        r = .atom ⟨base, Or.inl hbase⟩ := by
+  simp only [Hex.Component.certify?, Hex.nkWitness] at hcert ⊢
+  split at hcert <;> rename_i hbase
+  · split at hcert <;> rename_i hinside
+    · split at hcert <;> rename_i hcand
+      · left
+        exact ⟨hbase, hinside, hcand, Option.some.inj hcert.symm⟩
+      · right
+        exact ⟨hbase, Option.some.inj hcert.symm⟩
+    · right
+      exact ⟨hbase, Option.some.inj hcert.symm⟩
+  · simp at hcert
+
+/-- The semantic region of an explicitly NK-certified atom is its closed
+square. -/
+@[simp] theorem nkAtom_region {p : Hex.ZPoly} {s : Hex.DyadicSquare}
+    (h : Hex.nkWitness p s) :
+    Certified.region (.atom ⟨s, Or.inl h⟩) = DyadicSquare.closedSquare s := by
+  simp [Certified.region, DyadicRootIsolation.region, h]
+
+/-- A root in an outer unique-root square belongs to a nested inner square
+that also has a unique root. -/
+private theorem root_mem_nested {p : Hex.ZPoly} {inner outer : Hex.DyadicSquare}
+    (hinner : Hex.nkWitness p inner) (houter : Hex.nkWitness p outer)
+    (hsubset : DyadicSquare.closedSquare inner ⊆
+      DyadicSquare.closedSquare outer) {z : ℂ}
+    (hzroot : (toPolyℂ p).eval z = 0)
+    (hzouter : z ∈ DyadicSquare.closedSquare outer) :
+    z ∈ DyadicSquare.closedSquare inner := by
+  obtain ⟨zi, hzi, -⟩ := NKData.existsUnique_root hinner
+  obtain ⟨zo, hzo, hunique⟩ := NKData.existsUnique_root houter
+  have hz_eq : z = zo := hunique z ⟨hzroot, hzouter⟩
+  have hzi_eq : zi = zo := hunique zi ⟨hzi.1, hsubset hzi.2⟩
+  rw [hz_eq, ← hzi_eq]
+  exact hzi.2
+
+/-- Every NK-only certification result is an atom carrying an executable NK
+witness and hence exactly one root in its stored closed square. -/
+theorem certify_nk_unique {p : Hex.ZPoly} {c : Hex.Component}
+    {r : Hex.Certified p} (hcert : Hex.Component.certify? p .nk c = some r) :
+    ∃ (iso : Hex.DyadicRootIsolation p), r = .atom iso ∧
+      Hex.nkWitness p iso.square ∧
+      ∃! z, (toPolyℂ p).eval z = 0 ∧
+        z ∈ DyadicSquare.closedSquare iso.square := by
+  rcases certify_nk_cases hcert with h | h
+  · obtain ⟨hbase, hinside, hcand, rfl⟩ := h
+    exact ⟨_, rfl, hcand, NKData.existsUnique_root hcand⟩
+  · obtain ⟨hbase, rfl⟩ := h
+    exact ⟨_, rfl, hbase, NKData.existsUnique_root hbase⟩
+
+/-- Every NK-only certification result contains a unique interior simple root
+in its stored square. -/
+theorem certify_nk_sound {p : Hex.ZPoly} {c : Hex.Component}
+    {r : Hex.Certified p} (hcert : Hex.Component.certify? p .nk c = some r) :
+    ∃ (iso : Hex.DyadicRootIsolation p), r = .atom iso ∧
+      ∃ z, (toPolyℂ p).eval z = 0 ∧
+        z ∈ DyadicSquare.openSquare iso.square ∧
+        (toPolyℂ p).derivative.eval z ≠ 0 ∧
+        ∀ w, (toPolyℂ p).eval w = 0 →
+          w ∈ DyadicSquare.closedSquare iso.square → w = z := by
+  rcases certify_nk_cases hcert with h | h
+  · obtain ⟨hbase, hinside, hcand, rfl⟩ := h
+    exact ⟨_, rfl, NKData.sound hcand⟩
+  · obtain ⟨hbase, rfl⟩ := h
+    exact ⟨_, rfl, NKData.sound hbase⟩
+
+/-- NK-only component certification preserves every input-component root,
+including through the speculative recentring branch. -/
+theorem certifier_preserves_nk (p : Hex.ZPoly) : Certifier.Preserves p .nk := by
+  intro c r hcert z hzroot hz
+  rcases certify_nk_cases hcert with h | h
+  · obtain ⟨hbase, hinside, hcand, rfl⟩ := h
+    rw [nkAtom_region hcand]
+    apply root_mem_nested hcand hbase
+      (DyadicSquare.closedSquare_subset_of_squareInside hinside) hzroot
+    exact Component.region_subset_doubledEnc c hz
+  · obtain ⟨hbase, rfl⟩ := h
+    rw [nkAtom_region hbase]
+    exact Component.region_subset_doubledEnc c hz
+
+/-- Successful NK-only loop execution preserves all polynomial roots covered
+by its starting worklist. -/
+theorem isolateLoop_nk_covers {p : Hex.ZPoly} {target : Int} {fuel : Nat}
+    {work : Array Hex.Component} {rs : Array (Hex.Certified p)}
+    (hloop : Hex.isolateLoop p target .nk fuel work = some rs)
+    {z : ℂ} (hzroot : (toPolyℂ p).IsRoot z)
+    (hz : z ∈ Worklist.region work) : z ∈ Results.region rs :=
+  isolateLoop_covers (certifier_preserves_nk p) hloop hzroot hz
+
+end
+
+end HexRootsMathlib

--- a/progress/2026-07-19T14-32-27Z.md
+++ b/progress/2026-07-19T14-32-27Z.md
@@ -1,0 +1,20 @@
+# Accomplished
+
+- Refactored the executable enclosing-square fold into named, behavior-equivalent bounding-box helpers.
+- Proved exact dyadic bounding-box, square-containment, and component-region enclosure lemmas.
+- Proved the exact `.nk` certification control-flow cases, unique/simple-root semantics, and preservation of every covered component root, including the speculative recentering branch.
+- Lifted `.nk` preservation through the parametric isolation-loop coverage theorem.
+- Ran focused and full builds, conformance fixture generation, and all HexRoots benchmarks successfully.
+- Obtained an independent Opus review with no blocking correctness or soundness concerns and applied its API-cleanliness suggestions.
+
+# Current frontier
+
+The `.nk` component certifier now has the semantic preservation contract needed by the loop kernel. The next slice is the end-to-end `.nk` driver theorem from the Cauchy component through successful all-atom output.
+
+# Next step
+
+Land this slice, then prove successful `.nk` isolation covers every polynomial root exactly once using Cauchy coverage, loop coverage, NK uniqueness, and pairwise-disjoint output regions.
+
+# Blockers
+
+None.


### PR DESCRIPTION
Closes #8796.
Part of #8755 (execution-plan item 13).

## Summary

- refactor `encSquare`'s executable fold into behavior-equivalent named bounding-box helpers and prove every input square lies in the result
- prove exact `.nk` certification control flow for both the doubled base square and speculative Newton candidate
- prove successful `.nk` certificates contain a unique interior simple root
- prove the speculative branch preserves covered roots by uniqueness transfer through the guarded nested squares
- instantiate `Certifier.Preserves p .nk` and lift it through the isolation-loop coverage kernel

## Premise check

The implemented candidate path requires both a successful NK witness on the doubled base and `cand.squareInside base = true` before checking the candidate witness. Thus base uniqueness, candidate uniqueness, and candidate containment are sufficient to transfer every root covered by the component; no geometric claim that the candidate directly contains the whole component is needed.

## Verification

- `lake build HexRootsMathlib.NKCertify HexRootsMathlib`
- full `lake build` (9391 jobs before rebase; focused umbrella rebuild after rebase)
- `lake build HexConformance hexroots_emit_fixtures hexroots_bench`
- all 14 HexRoots benchmarks (7s / 360s cap)
- copyright, source-DAG, Phase-4, line-count, diff, and forbidden-token checks
- independent Claude Opus review: no blocking correctness or soundness concerns; it specifically validated the behavior-preserving `encSquare` refactor, exact certifier path split, and uniqueness-based speculative-root transfer. Its field-documentation and proof-helper exposure suggestions were applied; `certify?` remains deliberately `@[expose]` because the theorem unfolds its executable control flow.

A pre-existing duplication between two ceiling-log APIs was noted for later consolidation; it does not affect this proof or alter executable behavior.
