### PR TITLE
HexRootsMathlib: prove classical and symmetric Rouche forms

### DIFF
--- a/HexRootsMathlib.lean
+++ b/HexRootsMathlib.lean
@@ -22,6 +22,7 @@ public import HexRootsMathlib.NKCertify
 public import HexRootsMathlib.NKDriver
 public import HexRootsMathlib.NKWitness
 public import HexRootsMathlib.RootFree
+public import HexRootsMathlib.Rouche
 public import HexRootsMathlib.RoucheHomotopy
 public import HexRootsMathlib.Taylor
 

--- a/HexRootsMathlib/Rouche.lean
+++ b/HexRootsMathlib/Rouche.lean
@@ -1,0 +1,77 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRootsMathlib.RoucheHomotopy
+
+public section
+
+/-!
+# Rouché's theorem for complex polynomials on circles
+
+The classical and symmetric norm inequalities exclude zeros of the affine
+path on the boundary circle.  Root-count equality then follows from the
+homotopy theorem.
+-/
+
+open Complex Metric Polynomial Set
+
+namespace HexRootsMathlib
+
+noncomputable section
+
+/-- Classical Rouché theorem for complex polynomials on a circle, with roots
+counted with multiplicity in the enclosed open disc. -/
+theorem rouche {f g : ℂ[X]} {c : ℂ} {R : ℝ} (hR : 0 ≤ R)
+    (h : ∀ z ∈ sphere c R, ‖f.eval z - g.eval z‖ < ‖g.eval z‖) :
+    rootsInDisc f c R = rootsInDisc g c R := by
+  apply (affineHomotopy.rootsInDisc_eq hR ?_).symm
+  intro t ht z hz hzero
+  rw [affineHomotopy.eval] at hzero
+  let d := f.eval z - g.eval z
+  change g.eval z + (t : ℂ) * d = 0 at hzero
+  have hg : g.eval z = -(t : ℂ) * d := by
+    linear_combination hzero
+  have hnorm : ‖g.eval z‖ = t * ‖d‖ := by
+    rw [hg, norm_mul, norm_neg, norm_real, Real.norm_eq_abs, abs_of_nonneg ht.1]
+  have hle : ‖g.eval z‖ ≤ ‖d‖ := by
+    rw [hnorm]
+    exact mul_le_of_le_one_left (norm_nonneg _) ht.2
+  exact (not_le_of_gt (by simpa only [d] using h z hz)) hle
+
+/-- Symmetric Rouché theorem: strictness in the triangle inequality on the
+boundary circle is enough to give equal root counts in the disc. -/
+theorem rouche_symmetric {f g : ℂ[X]} {c : ℂ} {R : ℝ} (hR : 0 ≤ R)
+    (h : ∀ z ∈ sphere c R,
+      ‖f.eval z - g.eval z‖ < ‖f.eval z‖ + ‖g.eval z‖) :
+    rootsInDisc f c R = rootsInDisc g c R := by
+  apply (affineHomotopy.rootsInDisc_eq hR ?_).symm
+  intro t ht z hz hzero
+  rw [affineHomotopy.eval] at hzero
+  let d := f.eval z - g.eval z
+  change g.eval z + (t : ℂ) * d = 0 at hzero
+  have hg : g.eval z = -(t : ℂ) * d := by
+    linear_combination hzero
+  have hf : f.eval z = ((1 - t : ℝ) : ℂ) * d := by
+    push_cast
+    linear_combination hzero
+  have hnormg : ‖g.eval z‖ = t * ‖d‖ := by
+    rw [hg, norm_mul, norm_neg, norm_real, Real.norm_eq_abs, abs_of_nonneg ht.1]
+  have hnormf : ‖f.eval z‖ = (1 - t) * ‖d‖ := by
+    rw [hf, norm_mul, norm_real, Real.norm_eq_abs, abs_of_nonneg (sub_nonneg.mpr ht.2)]
+  have hsum : ‖d‖ = ‖f.eval z‖ + ‖g.eval z‖ := by
+    rw [hnormf, hnormg]
+    ring
+  have hlt : ‖d‖ < ‖f.eval z‖ + ‖g.eval z‖ := by
+    simpa only [d] using h z hz
+  rw [← hsum] at hlt
+  exact (lt_irrefl _ hlt)
+
+end
+
+
+end HexRootsMathlib

--- a/progress/2026-07-19T16-00-44Z.md
+++ b/progress/2026-07-19T16-00-44Z.md
@@ -1,0 +1,20 @@
+## Accomplished
+
+- Proved the classical and symmetric Rouché inequalities imply boundary nonvanishing of the affine polynomial homotopy.
+- Derived equality of multiplicity-counted roots in the open disc from the homotopy invariance theorem.
+- Added the Rouché module to the HexRootsMathlib umbrella.
+- Passed the focused build, structural checks, and the complete 9,397-job `lake build`.
+- Obtained an independent Claude Opus review; it found no mathematical or soundness blocker. Its only concrete check was the let-bound `linear_combination` step, which the focused and full builds confirm.
+
+## Current frontier
+
+- Plan item 19 is ready to rebase onto the merged homotopy foundation and publish as the PR closing #8807.
+- Plan item 20 is tracked by #8809 with its executable and generic theorem shapes premise-checked.
+
+## Next step
+
+- Rebase this single commit onto current `main`, open the Rouché forms PR, enable auto-merge, and begin the Pellet soundness implementation while CI runs.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
Closes #8807.

Part of #8755 (plan item 19).

## Summary

- derive the classical Rouché theorem from affine-homotopy root-count invariance
- derive the symmetric Rouché form from the exact norm identity forced by a hypothetical homotopy zero
- preserve multiplicity through `rootsInDisc`
- cover nonnegative radii, including the degenerate zero-radius case

## Verification

- `lake build HexRootsMathlib.Rouche HexRootsMathlib`
- complete `lake build` (9,397 jobs)
- copyright, DAG, Phase-4, diff, and forbidden-token checks
- independent Claude Opus review: no mathematical or soundness blockers; its requested check of the let-bound `linear_combination` step is confirmed by both builds

No `sorry`, `axiom`, or `native_decide` introduced.