### PR TITLE
refactor(HexPolyZMathlib): share rational squarefreeness

### DIFF
--- a/HexPolyZMathlib.lean
+++ b/HexPolyZMathlib.lean
@@ -12,6 +12,7 @@ public import HexPolyZMathlib.Hadamard
 public import HexPolyZMathlib.MahlerSeparation
 public import HexPolyZMathlib.Mignotte
 public import HexPolyZMathlib.RobinsonForm
+public import HexPolyZMathlib.Squarefree
 
 public section
 

--- a/HexPolyZMathlib/SPEC/hex-poly-z-mathlib.md
+++ b/HexPolyZMathlib/SPEC/hex-poly-z-mathlib.md
@@ -116,6 +116,8 @@ discharged here.
 **Shared root-separation foundations.** The generic parts of the Mahler
 root-separation development live here once for both roots companions:
 
+- `HexPolyZMathlib/Squarefree.lean` identifies the executable rational-gcd
+  test with squarefreeness of the rational cast, for nonzero inputs.
 - `HexPolyZMathlib/Discriminant.lean` proves the root-product form of
   `Polynomial.discr`, its nonvanishing for separable polynomials, base-change
   compatibility, and the integer lower bound `1 ≤ |discr f|`.

--- a/HexPolyZMathlib/Squarefree.lean
+++ b/HexPolyZMathlib/Squarefree.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import Mathlib
+public import HexPolyMathlib.Euclid
+public import HexPolyZMathlib.Basic
+
+public section
+
+/-!
+# Rational squarefreeness of executable integer polynomials
+
+This module identifies the executable rational-gcd test with squarefreeness
+after mapping the integer polynomial to `ℚ[X]`. The statement is deliberately
+about the rational cast: integral-polynomial squarefreeness additionally sees
+square factors in the content.
+-/
+
+namespace HexPolyZMathlib
+
+open Polynomial
+
+noncomputable section
+
+/-- The rational cast of an executable integer polynomial. -/
+abbrev toPolyℚ (p : Hex.ZPoly) : Polynomial ℚ :=
+  (toPolynomial p).map (Int.castRingHom ℚ)
+
+/-- A dense polynomial stores at most one coefficient exactly when its
+Mathlib image has natural degree zero. -/
+theorem size_le_one_iff_natDegree_eq_zero {R : Type*} [Semiring R] [DecidableEq R]
+    (g : Hex.DensePoly R) :
+    g.size ≤ 1 ↔ (HexPolyMathlib.toPolynomial g).natDegree = 0 := by
+  rw [HexPolyMathlib.natDegree_toPolynomial]
+  by_cases h : g.size = 0
+  · rw [(Hex.DensePoly.degree?_eq_none_iff g).mpr h]
+    simp [h]
+  · rw [Hex.DensePoly.degree?_eq_some_of_pos_size g (Nat.pos_of_ne_zero h),
+      Option.getD_some]
+    omega
+
+/-- `toRatPoly` corresponds to the rational cast under `toPolynomial`. -/
+theorem toPolynomial_toRatPoly (f : Hex.ZPoly) :
+    HexPolyMathlib.toPolynomial (Hex.ZPoly.toRatPoly f) = toPolyℚ f := by
+  ext n
+  rw [HexPolyMathlib.coeff_toPolynomial, Hex.ZPoly.coeff_toRatPoly, toPolyℚ,
+    Polynomial.coeff_map, coeff_toPolynomial]
+  simp
+
+/-- Coefficients of the rational cast are the rational casts of the integer
+coefficients. -/
+@[simp] theorem coeff_toPolyℚ (p : Hex.ZPoly) (n : Nat) :
+    (toPolyℚ p).coeff n = (p.coeff n : ℚ) := by
+  simp [toPolyℚ]
+
+/-- Evaluation of the rational cast is the degree-indexed coefficient sum. -/
+theorem eval_toPolyℚ (p : Hex.ZPoly) (x : ℚ) :
+    (toPolyℚ p).eval x = ∑ i ∈ Finset.range p.size, (p.coeff i : ℚ) * x ^ i := by
+  rw [toPolyℚ, Polynomial.eval_map, HexPolyMathlib.eval₂_toPolynomial]
+  simp
+
+/-- The rational cast of a nonzero executable polynomial is nonzero. -/
+theorem toPolyℚ_ne_zero {f : Hex.ZPoly} (hf : f ≠ 0) : toPolyℚ f ≠ 0 := by
+  rw [toPolyℚ, Ne,
+    Polynomial.map_eq_zero_iff (RingHom.injective_int (Int.castRingHom ℚ))]
+  intro h
+  exact hf (by have := congrArg ofPolynomial h; simpa using this)
+
+/-- For a nonzero executable integer polynomial, the executable rational-gcd
+test is equivalent to squarefreeness of its rational cast. -/
+theorem squareFreeRat_iff (f : Hex.ZPoly) (hf : f ≠ 0) :
+    Hex.ZPoly.SquareFreeRat f ↔ Squarefree (toPolyℚ f) := by
+  unfold Hex.ZPoly.SquareFreeRat
+  set a := Hex.ZPoly.toRatPoly f with ha
+  set a' := Hex.DensePoly.derivative a with ha'
+  have hPa : HexPolyMathlib.toPolynomial a = toPolyℚ f :=
+    toPolynomial_toRatPoly f
+  have hPa' : HexPolyMathlib.toPolynomial a' = derivative (toPolyℚ f) := by
+    rw [ha', HexPolyMathlib.toPolynomial_derivative, hPa]
+  have hP0 : toPolyℚ f ≠ 0 := toPolyℚ_ne_zero hf
+  rw [size_le_one_iff_natDegree_eq_zero]
+  have hassoc := HexPolyMathlib.toPolynomial_gcd_associated a a'
+  have hdeg : (HexPolyMathlib.toPolynomial (Hex.DensePoly.gcd a a')).natDegree
+      = (EuclideanDomain.gcd (toPolyℚ f) (derivative (toPolyℚ f))).natDegree := by
+    have h := Polynomial.natDegree_eq_of_degree_eq
+      (Polynomial.degree_eq_degree_of_associated hassoc)
+    rw [hPa, hPa'] at h
+    exact h
+  rw [hdeg]
+  set G := EuclideanDomain.gcd (toPolyℚ f) (derivative (toPolyℚ f)) with hG
+  have hG0 : G ≠ 0 := by
+    rw [hG, Ne, EuclideanDomain.gcd_eq_zero_iff]
+    exact fun h => hP0 h.1
+  have key : G.natDegree = 0 ↔ IsUnit G := by
+    rw [Polynomial.isUnit_iff_degree_eq_zero, Polynomial.degree_eq_natDegree hG0]
+    exact_mod_cast Iff.rfl
+  rw [key, hG, EuclideanDomain.gcd_isUnit_iff, ← Polynomial.separable_def,
+    PerfectField.separable_iff_squarefree]
+
+end
+
+end HexPolyZMathlib

--- a/HexRealRootsMathlib/ChainCorrespond.lean
+++ b/HexRealRootsMathlib/ChainCorrespond.lean
@@ -9,6 +9,7 @@ module
 public import Mathlib
 public import HexPolyZ
 public import HexPolyMathlib.Euclid
+public import HexPolyZMathlib.Squarefree
 public import HexRealRootsMathlib.SturmTheorem
 public import HexRealRootsMathlib.Separation
 public import HexRealRoots.Var
@@ -49,89 +50,34 @@ open Polynomial HexPolyZMathlib
 
 noncomputable section
 
-/-- The rational cast of an executable integer polynomial. -/
-abbrev toPolyℚ (p : Hex.ZPoly) : Polynomial ℚ :=
-  (toPolynomial p).map (Int.castRingHom ℚ)
+/-- Compatibility alias for the rational cast, now shared by integer-polynomial
+companions. -/
+abbrev toPolyℚ (p : Hex.ZPoly) := HexPolyZMathlib.toPolyℚ p
 
-/-- A dense polynomial stores at most one coefficient exactly when its Mathlib
-image is a constant. The `DensePoly` normalization invariant makes `size ≤ 1`
-(zero, or a single nonzero coefficient) coincide with `natDegree = 0`. -/
-theorem size_le_one_iff_natDegree_eq_zero {R : Type*} [Semiring R] [DecidableEq R]
-    (g : Hex.DensePoly R) :
-    g.size ≤ 1 ↔ (HexPolyMathlib.toPolynomial g).natDegree = 0 := by
-  rw [HexPolyMathlib.natDegree_toPolynomial]
-  by_cases h : g.size = 0
-  · rw [(Hex.DensePoly.degree?_eq_none_iff g).mpr h]; simp [h]
-  · rw [Hex.DensePoly.degree?_eq_some_of_pos_size g (Nat.pos_of_ne_zero h),
-      Option.getD_some]
-    omega
+theorem size_le_one_iff_natDegree_eq_zero {R : Type*} [Semiring R]
+    [DecidableEq R] (g : Hex.DensePoly R) :
+    g.size ≤ 1 ↔ (HexPolyMathlib.toPolynomial g).natDegree = 0 :=
+  HexPolyZMathlib.size_le_one_iff_natDegree_eq_zero g
 
-/-- `toRatPoly` corresponds to the rational cast under `toPolynomial`. -/
 theorem toPolynomial_toRatPoly (f : Hex.ZPoly) :
-    HexPolyMathlib.toPolynomial (Hex.ZPoly.toRatPoly f) = toPolyℚ f := by
-  ext n
-  rw [HexPolyMathlib.coeff_toPolynomial, Hex.ZPoly.coeff_toRatPoly, toPolyℚ,
-    Polynomial.coeff_map, coeff_toPolynomial]
-  simp
+    HexPolyMathlib.toPolynomial (Hex.ZPoly.toRatPoly f) = toPolyℚ f :=
+  HexPolyZMathlib.toPolynomial_toRatPoly f
 
-/-- Coefficients of the rational cast are the rational casts of the integer
-coefficients (the ℚ analogue of `coeff_toPolyℝ`). -/
-@[simp] theorem coeff_toPolyℚ (p : Hex.ZPoly) (n : Nat) :
-    (toPolyℚ p).coeff n = (p.coeff n : ℚ) := by
-  simp [toPolyℚ]
+theorem coeff_toPolyℚ (p : Hex.ZPoly) (n : Nat) :
+    (toPolyℚ p).coeff n = (p.coeff n : ℚ) :=
+  HexPolyZMathlib.coeff_toPolyℚ p n
 
-/-- Evaluating the rational cast at `x` is the degree-indexed sum of the integer
-coefficients cast to `ℚ` (the ℚ analogue of `eval_toPolyℝ`). -/
 theorem eval_toPolyℚ (p : Hex.ZPoly) (x : ℚ) :
-    (toPolyℚ p).eval x = ∑ i ∈ Finset.range p.size, (p.coeff i : ℚ) * x ^ i := by
-  rw [toPolyℚ, Polynomial.eval_map, HexPolyMathlib.eval₂_toPolynomial]
-  simp
+    (toPolyℚ p).eval x = ∑ i ∈ Finset.range p.size, (p.coeff i : ℚ) * x ^ i :=
+  HexPolyZMathlib.eval_toPolyℚ p x
 
-/-- The rational cast of a nonzero executable polynomial is nonzero. -/
-theorem toPolyℚ_ne_zero {f : Hex.ZPoly} (hf : f ≠ 0) : toPolyℚ f ≠ 0 := by
-  rw [toPolyℚ, Ne, Polynomial.map_eq_zero_iff (RingHom.injective_int (Int.castRingHom ℚ))]
-  intro h
-  exact hf (by have := congrArg ofPolynomial h; simpa using this)
+theorem toPolyℚ_ne_zero {f : Hex.ZPoly} (hf : f ≠ 0) : toPolyℚ f ≠ 0 :=
+  HexPolyZMathlib.toPolyℚ_ne_zero hf
 
-/-- **Square-freeness bridge.** For a nonzero executable integer polynomial `f`,
-the executable rational-gcd test `SquareFreeRat f` holds exactly when the
-rational cast `toPolyℚ f` is square-free.
-
-The executable test is `(gcd (toRatPoly f) (toRatPoly f)').size ≤ 1`. Under
-`toPolynomial` this raw gcd is associated to Mathlib's normalized
-`EuclideanDomain.gcd` of `toPolyℚ f` and its derivative
-(`HexPolyMathlib.toPolynomial_gcd_associated`), so the size test becomes a
-degree-zero test on that gcd. For nonzero `toPolyℚ f` the gcd is nonzero, so
-degree zero means the gcd is a unit, i.e. `toPolyℚ f` is coprime to its
-derivative, i.e. `Separable`, i.e. (over the perfect field `ℚ`) `Squarefree`. -/
+/-- Compatibility alias for the shared rational squarefreeness bridge. -/
 theorem squareFreeRat_iff (f : Hex.ZPoly) (hf : f ≠ 0) :
-    Hex.ZPoly.SquareFreeRat f ↔ Squarefree (toPolyℚ f) := by
-  unfold Hex.ZPoly.SquareFreeRat
-  set a := Hex.ZPoly.toRatPoly f with ha
-  set a' := Hex.DensePoly.derivative a with ha'
-  have hPa : HexPolyMathlib.toPolynomial a = toPolyℚ f := toPolynomial_toRatPoly f
-  have hPa' : HexPolyMathlib.toPolynomial a' = derivative (toPolyℚ f) := by
-    rw [ha', HexPolyMathlib.toPolynomial_derivative, hPa]
-  have hP0 : toPolyℚ f ≠ 0 := toPolyℚ_ne_zero hf
-  rw [size_le_one_iff_natDegree_eq_zero]
-  -- The raw dense gcd's image is degree-associated to Mathlib's normalized gcd.
-  have hassoc := HexPolyMathlib.toPolynomial_gcd_associated a a'
-  have hdeg : (HexPolyMathlib.toPolynomial (Hex.DensePoly.gcd a a')).natDegree
-      = (EuclideanDomain.gcd (toPolyℚ f) (derivative (toPolyℚ f))).natDegree := by
-    have h := Polynomial.natDegree_eq_of_degree_eq
-      (Polynomial.degree_eq_degree_of_associated hassoc)
-    rw [hPa, hPa'] at h
-    exact h
-  rw [hdeg]
-  set G := EuclideanDomain.gcd (toPolyℚ f) (derivative (toPolyℚ f)) with hG
-  have hG0 : G ≠ 0 := by
-    rw [hG, Ne, EuclideanDomain.gcd_eq_zero_iff]
-    exact fun h => hP0 h.1
-  have key : G.natDegree = 0 ↔ IsUnit G := by
-    rw [Polynomial.isUnit_iff_degree_eq_zero, Polynomial.degree_eq_natDegree hG0]
-    exact_mod_cast Iff.rfl
-  rw [key, hG, EuclideanDomain.gcd_isUnit_iff, ← Polynomial.separable_def,
-    PerfectField.separable_iff_squarefree]
+    Hex.ZPoly.SquareFreeRat f ↔ Squarefree (toPolyℚ f) :=
+  HexPolyZMathlib.squareFreeRat_iff f hf
 
 /-! ### Sign-variation correspondence at a dyadic point -/
 

--- a/HexRootsMathlib.lean
+++ b/HexRootsMathlib.lean
@@ -16,6 +16,7 @@ public import HexRootsMathlib.CircleIntegralLemmas
 public import HexRootsMathlib.Component
 public import HexRootsMathlib.Driver
 public import HexRootsMathlib.Geometry
+public import HexRootsMathlib.HasOnlySimpleRoots
 public import HexRootsMathlib.Kantorovich
 public import HexRootsMathlib.KantorovichPoly
 public import HexRootsMathlib.Loop

--- a/HexRootsMathlib/HasOnlySimpleRoots.lean
+++ b/HexRootsMathlib/HasOnlySimpleRoots.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRoots.Basic
+public import HexPolyZMathlib.Squarefree
+
+public section
+
+/-!
+# Semantics of `Hex.HasOnlySimpleRoots`
+
+The executable predicate computes a rational polynomial gcd, so its faithful
+Mathlib interpretation is squarefreeness (or separability) after mapping to
+`ℚ[X]`. It is not integral-polynomial squarefreeness, which additionally sees
+square factors in the integer content.
+-/
+
+open Polynomial
+
+namespace HexRootsMathlib
+
+/-- On nonzero inputs, the executable simple-root predicate is exactly
+squarefreeness of the rational cast. -/
+theorem hasOnlySimpleRoots_iff_squarefree (p : Hex.ZPoly) (hp : p ≠ 0) :
+    Hex.HasOnlySimpleRoots p ↔ Squarefree (HexPolyZMathlib.toPolyℚ p) := by
+  change Hex.ZPoly.SquareFreeRat p ↔ _
+  exact HexPolyZMathlib.squareFreeRat_iff p hp
+
+/-- Equivalent separability form of the executable simple-root predicate. -/
+theorem hasOnlySimpleRoots_iff_separable (p : Hex.ZPoly) (hp : p ≠ 0) :
+    Hex.HasOnlySimpleRoots p ↔ (HexPolyZMathlib.toPolyℚ p).Separable :=
+  (hasOnlySimpleRoots_iff_squarefree p hp).trans
+    PerfectField.separable_iff_squarefree.symm
+
+/-- A nonzero executable polynomial with only simple roots has separable
+rational cast. -/
+theorem HasOnlySimpleRoots.separable {p : Hex.ZPoly} (h : Hex.HasOnlySimpleRoots p)
+    (hp : p ≠ 0) : (HexPolyZMathlib.toPolyℚ p).Separable :=
+  (hasOnlySimpleRoots_iff_separable p hp).mp h
+
+end HexRootsMathlib

--- a/HexRootsMathlib/SPEC/hex-roots-mathlib.md
+++ b/HexRootsMathlib/SPEC/hex-roots-mathlib.md
@@ -394,6 +394,7 @@ scope is honest; nothing else in the plan silently depends on them.
 
 ```
 Shared discriminant / separation development (candidate Mathlib contribution):
+  HexPolyZMathlib/Squarefree.lean
   HexPolyZMathlib/Discriminant.lean
   HexPolyZMathlib/Hadamard.lean
   HexPolyZMathlib/MahlerSeparation.lean

--- a/SPEC/Libraries/hex-real-roots-mathlib.md
+++ b/SPEC/Libraries/hex-real-roots-mathlib.md
@@ -316,7 +316,8 @@ HexRealRootsMathlib/
   SturmChainDefs.lean  -- IsSturmChain, sturmVar over Polynomial ℝ
   SturmTheorem.lean    -- the counting theorem and the line form
   ChainCorrespond.lean -- sturmChain_isSturmChain, sturmVarAt_eq,
-                          squareFreeRat_iff, sturmCount_eq_card_roots
+                          sturmCount_eq_card_roots; compatibility aliases for
+                          HexPolyZMathlib.Squarefree
   Discr.lean            -- compatibility import of the shared discriminant API
   Hadamard.lean         -- compatibility import of the shared determinant bound
   Separation.lean      -- sepPrec_separates, rootBound_bounds_roots;

--- a/progress/2026-07-19T17-20-24Z.md
+++ b/progress/2026-07-19T17-20-24Z.md
@@ -1,0 +1,19 @@
+# Accomplished
+
+- Corrected the stopped squarefreeness directive to target the rational cast rather than integral-polynomial squarefreeness.
+- Extracted the executable rational-gcd correspondence into `HexPolyZMathlib.Squarefree`, free of roots-library imports.
+- Preserved `HexRealRootsMathlib` source compatibility through narrow aliases.
+- Added the nonzero `Hex.HasOnlySimpleRoots` equivalences with rational squarefreeness and separability in `HexRootsMathlib`.
+- Updated the three affected module maps; focused/full builds and structural checks pass.
+
+# Current frontier
+
+Corrected plan item 2 is implementation-complete and ready for independent review and PR publication.
+
+# Next step
+
+Obtain the required Opus review, address findings, then open and merge the PR before resuming SimpleRoot semantics.
+
+# Blockers
+
+None.


### PR DESCRIPTION
Closes #8772.\n\nCompletes the corrected plan-item-2 premise from #8755:\n\n- extracts the executable rational-gcd correspondence into HexPolyZMathlib\n- preserves HexRealRootsMathlib compatibility aliases\n- proves nonzero HasOnlySimpleRoots iff rational Squarefree/Separable\n- deliberately does not claim false integral-polynomial Squarefree (counterexample 4X+4)\n\nValidation: focused/full builds of all affected libraries, import/structural checks, and independent Claude Opus review (no blockers).