### PR TITLE
feat(HexRootsMathlib): define SimpleRoot semantics

### DIFF
--- a/HexRootsMathlib.lean
+++ b/HexRootsMathlib.lean
@@ -28,6 +28,7 @@ public import HexRootsMathlib.Pellet
 public import HexRootsMathlib.RootFree
 public import HexRootsMathlib.Rouche
 public import HexRootsMathlib.RoucheHomotopy
+public import HexRootsMathlib.SimpleRoot
 public import HexRootsMathlib.Taylor
 
 public section

--- a/HexRootsMathlib/Geometry.lean
+++ b/HexRootsMathlib/Geometry.lean
@@ -339,6 +339,57 @@ theorem closedDisc_disjoint_of_discsMeet_eq_false (s t : Hex.DyadicSquare)
         (Real.sqrt_nonneg _))
   exact (sq_lt_sq₀ hrs dist_nonneg).mp hradii
 
+/-- A positive executable disc-intersection test is the corresponding centre
+distance bound. -/
+theorem dist_center_le_of_discsMeet {s t : Hex.DyadicSquare}
+    (h : s.discsMeet t = true) :
+    dist (center s) (center t) ≤ radius s + radius t := by
+  have hdy : Hex.GaussDyadic.distSq s.center t.center ≤
+      (2 : _root_.Dyadic) * .ofIntWithPrec 1 (2 * s.prec) +
+        2 * .ofIntWithPrec 1 (2 * t.prec) +
+        4 * .ofIntWithPrec 1 (s.prec + t.prec) := by
+    simpa [Hex.DyadicSquare.discsMeet] using of_decide_eq_true h
+  have hreal := Dyadic.toReal_le_toReal_iff.mpr hdy
+  have hs : (2 : ℝ) ^ (-(2 * s.prec)) = ((2 : ℝ) ^ (-s.prec)) ^ 2 := by
+    rw [show -(2 * s.prec) = (-s.prec) * 2 by ring, zpow_mul]
+    rfl
+  have ht : (2 : ℝ) ^ (-(2 * t.prec)) = ((2 : ℝ) ^ (-t.prec)) ^ 2 := by
+    rw [show -(2 * t.prec) = (-t.prec) * 2 by ring, zpow_mul]
+    rfl
+  have hst : (2 : ℝ) ^ (-(s.prec + t.prec)) =
+      (2 : ℝ) ^ (-s.prec) * (2 : ℝ) ^ (-t.prec) := by
+    rw [show -(s.prec + t.prec) = -s.prec + -t.prec by ring,
+      zpow_add₀ (by norm_num : (2 : ℝ) ≠ 0)]
+  have htwo : Dyadic.toReal (2 : _root_.Dyadic) = (2 : ℝ) :=
+    Dyadic.toReal_two
+  have hfour : Dyadic.toReal (4 : _root_.Dyadic) = (4 : ℝ) := by
+    change Dyadic.toReal (.ofInt 4) = (4 : ℝ)
+    simp
+  have hsquare : dist (center s) (center t) ^ 2 ≤
+      (radius s + radius t) ^ 2 := by
+    rw [radius_eq, radius_eq]
+    calc
+      dist (center s) (center t) ^ 2 ≤
+          2 * ((2 : ℝ) ^ (-s.prec)) ^ 2 +
+          2 * ((2 : ℝ) ^ (-t.prec)) ^ 2 +
+          4 * ((2 : ℝ) ^ (-s.prec) * (2 : ℝ) ^ (-t.prec)) := by
+        simpa only [Dyadic.toReal_add, Dyadic.toReal_mul,
+          Dyadic.toReal_ofIntWithPrec, Dyadic.toReal_ofInt, Int.cast_one,
+          one_mul, Int.cast_ofNat, toReal_distSq, Hex.DyadicSquare.center,
+          center_eq, hs, ht, hst, htwo, hfour] using hreal
+      _ = ((2 : ℝ) ^ (-s.prec) * √2 +
+          (2 : ℝ) ^ (-t.prec) * √2) ^ 2 := by
+        nlinarith [Real.sq_sqrt (by norm_num : (0 : ℝ) ≤ 2)]
+  have hrs : 0 ≤ radius s + radius t := by
+    simp only [radius_eq]
+    exact add_nonneg
+      (mul_nonneg (zpow_pos (by norm_num : (0 : ℝ) < 2) _).le
+        (Real.sqrt_nonneg _))
+      (mul_nonneg (zpow_pos (by norm_num : (0 : ℝ) < 2) _).le
+        (Real.sqrt_nonneg _))
+  apply (sq_le_sq₀ dist_nonneg hrs).mp
+  exact hsquare
+
 /-- The executable array test gives semantic disjointness for every ordered
 pair of stored squares. -/
 theorem closedDisc_disjoint_of_pairwiseDisjoint {ss : Array Hex.DyadicSquare}

--- a/HexRootsMathlib/SPEC/hex-roots-mathlib.md
+++ b/HexRootsMathlib/SPEC/hex-roots-mathlib.md
@@ -289,16 +289,21 @@ developments above.
       isolation's disc, which both disjuncts give. -/
   def RefinedIsolation.root (i : RefinedIsolation p) : ℂ
 
-  theorem intersects_iff_root_eq (i₁ i₂ : RefinedIsolation p) :
+  theorem intersects_iff_root_eq
+      (hsep : (HexPolyZMathlib.toPolyℚ p).Separable)
+      (i₁ i₂ : RefinedIsolation p) :
       Intersects i₁ i₂ ↔ i₁.root = i₂.root
   ```
-  Consequences: `Intersects` restricted to `RefinedIsolation p` is an
-  equivalence relation; `Hex.rootOf : SimpleRoot p → ℂ` is
-  well-defined by `Quot.lift`; `sameRoot i₁ i₂ = true ↔
-  SimpleRoot.mk i₁ = SimpleRoot.mk i₂`, so the Boolean test used by
-  the Mathlib-free layer decides equality in the quotient. The `<
-  sep/4` radius bound from item 4 is what makes
-  `intersects_iff_root_eq` true.
+  A local atom witness makes its selected root simple but does not imply
+  global separability, so the separation premise is necessary. Successful
+  nonzero `isolate` input obtains it from `HasOnlySimpleRoots`; the companion
+  also exposes `intersects_iff_root_eq_of_simple` with those hypotheses.
+  Under the same premise, `Intersects` restricted to `RefinedIsolation p` is
+  an equivalence relation; `Hex.rootOf` is well-defined by `Quot.lift`; and
+  `sameRoot i₁ i₂ = true ↔ SimpleRoot.mk i₁ = SimpleRoot.mk i₂`, so the
+  Boolean test used by the Mathlib-free layer decides equality in the
+  quotient. The `< sep/4` radius bound from item 4 makes the conditional
+  `intersects_iff_root_eq` theorem true.
 - `HexRootsMathlib/Cauchy.lean`: `Component.cauchy`
   correctness. The starting closed square contains all of `Polynomial.roots p`
   by `Polynomial.IsRoot.norm_lt_cauchyBound`: the executable maximum bounds

--- a/HexRootsMathlib/SimpleRoot.lean
+++ b/HexRootsMathlib/SimpleRoot.lean
@@ -1,0 +1,235 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRoots.SimpleRoot
+public import HexRootsMathlib.Certificate
+public import HexRootsMathlib.Driver
+public import HexRootsMathlib.HasOnlySimpleRoots
+public import HexRootsMathlib.MahlerPrec
+
+public section
+
+/-!
+# Semantic identity of isolated simple roots
+
+Every refined atom has a canonical complex root. Under the rational-cast
+separability hypothesis used by the Mahler bound, the executable disc
+intersection relation is exactly equality of these roots.
+-/
+
+open Complex Metric Polynomial Set
+
+namespace HexRootsMathlib
+
+noncomputable section
+
+namespace RefinedIsolation
+
+/-- The unique root in a refined isolation's selected certified region. -/
+@[expose] noncomputable def root {p : Hex.ZPoly} (i : Hex.RefinedIsolation p) : ℂ :=
+  (DyadicRootIsolation.sound i.1).choose
+
+/-- The selected root is a simple polynomial root, interior to the selected
+region and unique in its closed counterpart. -/
+theorem root_spec {p : Hex.ZPoly} (i : Hex.RefinedIsolation p) :
+    (toPolyℂ p).eval (root i) = 0 ∧
+      root i ∈ DyadicRootIsolation.openRegion i.1 ∧
+      (toPolyℂ p).derivative.eval (root i) ≠ 0 ∧
+      ∀ w, (toPolyℂ p).eval w = 0 →
+        w ∈ DyadicRootIsolation.region i.1 → w = root i :=
+  (DyadicRootIsolation.sound i.1).choose_spec
+
+theorem isRoot {p : Hex.ZPoly} (i : Hex.RefinedIsolation p) :
+    (toPolyℂ p).IsRoot (root i) :=
+  (root_spec i).1
+
+/-- The semantic root lies in its atom's selected closed region. -/
+theorem root_mem_region {p : Hex.ZPoly} (i : Hex.RefinedIsolation p) :
+    root i ∈ DyadicRootIsolation.region i.1 :=
+  DyadicRootIsolation.openRegion_subset_region i.1 (root_spec i).2.1
+
+/-- Both atom witness forms place the semantic root in the stored square's
+circumscribed disc. -/
+theorem root_mem_closedDisc {p : Hex.ZPoly} (i : Hex.RefinedIsolation p) :
+    root i ∈ DyadicSquare.closedDisc i.1.square := by
+  apply Certified.region_subset_closedDisc (.atom i.1)
+  exact root_mem_region i
+
+private theorem radius_lt_quarter {p : Hex.ZPoly}
+    (hsep : (HexPolyZMathlib.toPolyℚ p).Separable)
+    (i : Hex.RefinedIsolation p) {z : ℂ}
+    (hz : (toPolyℂ p).IsRoot z) (hne : root i ≠ z) :
+    DyadicSquare.radius i.1.square < ‖root i - z‖ / 4 := by
+  have hpow : (2 : ℝ) ^ (-i.1.square.prec) ≤
+      (2 : ℝ) ^ (-(Hex.mahlerPrec p : ℤ)) := by
+    have hi := i.property
+    apply zpow_le_zpow_right₀ (by norm_num : (1 : ℝ) ≤ 2)
+    omega
+  have hsqrt : √2 < (1449 / 1024 : ℝ) := by
+    convert sqrt_two_lt_sqrt2Hi using 1
+    norm_num [Hex.sqrt2Hi, Dyadic.toReal_ofIntWithPrec]
+  calc
+    DyadicSquare.radius i.1.square =
+        (2 : ℝ) ^ (-i.1.square.prec) * √2 := DyadicSquare.radius_eq _
+    _ < (2 : ℝ) ^ (-i.1.square.prec) * (1449 / 1024 : ℝ) :=
+      mul_lt_mul_of_pos_left hsqrt (zpow_pos (by norm_num) _)
+    _ ≤ (2 : ℝ) ^ (-(Hex.mahlerPrec p : ℤ)) * (1449 / 1024 : ℝ) :=
+      mul_le_mul_of_nonneg_right hpow (by norm_num)
+    _ < ‖root i - z‖ / 4 :=
+      mahlerPrec_separates p hsep (root i) z (isRoot i) hz hne
+
+/-- At separation precision, executable disc intersection is exactly semantic
+root equality. Global separability is explicit because a local atom witness
+does not imply that every root of the polynomial is simple. -/
+theorem intersects_iff_root_eq {p : Hex.ZPoly}
+    (hsep : (HexPolyZMathlib.toPolyℚ p).Separable)
+    (i₁ i₂ : Hex.RefinedIsolation p) :
+    Hex.Intersects i₁ i₂ ↔ root i₁ = root i₂ := by
+  constructor
+  · intro hmeet
+    by_contra hne
+    have hr₁ := radius_lt_quarter hsep i₁ (isRoot i₂) hne
+    have hr₂ := radius_lt_quarter hsep i₂ (isRoot i₁) (Ne.symm hne)
+    rw [norm_sub_rev] at hr₂
+    have hc : dist (DyadicSquare.center i₁.1.square)
+        (DyadicSquare.center i₂.1.square) ≤
+        DyadicSquare.radius i₁.1.square + DyadicSquare.radius i₂.1.square :=
+      DyadicSquare.dist_center_le_of_discsMeet hmeet
+    have hm₁ : dist (root i₁) (DyadicSquare.center i₁.1.square) ≤
+        DyadicSquare.radius i₁.1.square := by
+      simpa only [DyadicSquare.closedDisc, Metric.mem_closedBall] using
+        root_mem_closedDisc i₁
+    have hm₂ : dist (DyadicSquare.center i₂.1.square) (root i₂) ≤
+        DyadicSquare.radius i₂.1.square := by
+      rw [dist_comm]
+      simpa only [DyadicSquare.closedDisc, Metric.mem_closedBall] using
+        root_mem_closedDisc i₂
+    have hdist : dist (root i₁) (root i₂) ≤
+        2 * (DyadicSquare.radius i₁.1.square +
+          DyadicSquare.radius i₂.1.square) := by
+      calc
+        dist (root i₁) (root i₂) ≤
+            dist (root i₁) (DyadicSquare.center i₁.1.square) +
+              dist (DyadicSquare.center i₁.1.square) (root i₂) :=
+          dist_triangle _ _ _
+        _ ≤ dist (root i₁) (DyadicSquare.center i₁.1.square) +
+            (dist (DyadicSquare.center i₁.1.square)
+              (DyadicSquare.center i₂.1.square) +
+              dist (DyadicSquare.center i₂.1.square) (root i₂)) :=
+          by
+            simpa only [add_assoc] using
+              add_le_add_right (dist_triangle (DyadicSquare.center i₁.1.square)
+                (DyadicSquare.center i₂.1.square) (root i₂))
+                (dist (root i₁) (DyadicSquare.center i₁.1.square))
+        _ ≤ DyadicSquare.radius i₁.1.square +
+            ((DyadicSquare.radius i₁.1.square +
+              DyadicSquare.radius i₂.1.square) +
+              DyadicSquare.radius i₂.1.square) :=
+          add_le_add hm₁ (add_le_add hc hm₂)
+        _ = 2 * (DyadicSquare.radius i₁.1.square +
+            DyadicSquare.radius i₂.1.square) := by ring
+    have hnorm : dist (root i₁) (root i₂) = ‖root i₁ - root i₂‖ :=
+      Complex.dist_eq _ _
+    rw [hnorm] at hdist
+    have : ‖root i₁ - root i₂‖ < ‖root i₁ - root i₂‖ := by
+      nlinarith [hr₁, hr₂]
+    exact (lt_irrefl _ this)
+  · intro hroot
+    by_contra hnot
+    change ¬i₁.1.square.discsMeet i₂.1.square = true at hnot
+    have hfalse : i₁.1.square.discsMeet i₂.1.square = false :=
+      Bool.eq_false_of_not_eq_true hnot
+    have hdisj := DyadicSquare.closedDisc_disjoint_of_discsMeet_eq_false
+      i₁.1.square i₂.1.square hfalse
+    exact (Set.disjoint_left.mp hdisj) (root_mem_closedDisc i₁)
+      (hroot ▸ root_mem_closedDisc i₂)
+
+/-- Under separability, `Intersects` is an equivalence relation on refined
+isolations. -/
+theorem intersects_equivalence {p : Hex.ZPoly}
+    (hsep : (HexPolyZMathlib.toPolyℚ p).Separable) :
+    Equivalence (@Hex.Intersects p) := by
+  refine ⟨?_, ?_, ?_⟩
+  · intro i
+    exact (intersects_iff_root_eq hsep i i).mpr rfl
+  · intro i j hij
+    have hroot := (intersects_iff_root_eq hsep i j).mp hij
+    exact (intersects_iff_root_eq hsep j i).mpr hroot.symm
+  · intro i j k hij hjk
+    exact (intersects_iff_root_eq hsep i k).mpr <|
+      (intersects_iff_root_eq hsep i j).mp hij |>.trans
+        ((intersects_iff_root_eq hsep j k).mp hjk)
+
+/-- Executable simple-root input supplies the separation hypothesis needed by
+the intersection semantics. -/
+theorem intersects_iff_root_eq_of_simple {p : Hex.ZPoly}
+    (h : Hex.HasOnlySimpleRoots p) (hp : p ≠ 0)
+    (i₁ i₂ : Hex.RefinedIsolation p) :
+    Hex.Intersects i₁ i₂ ↔ root i₁ = root i₂ :=
+  intersects_iff_root_eq (HasOnlySimpleRoots.separable h hp) i₁ i₂
+
+end RefinedIsolation
+
+namespace SimpleRoot
+
+/-- Interpret a quotient root as its complex value. Separability makes the
+stored intersection relation respect semantic root equality. -/
+@[expose] noncomputable def rootOf {p : Hex.ZPoly}
+    (hsep : (HexPolyZMathlib.toPolyℚ p).Separable) : Hex.SimpleRoot p → ℂ :=
+  Quot.lift RefinedIsolation.root fun i j hij =>
+    (RefinedIsolation.intersects_iff_root_eq hsep i j).mp hij
+
+@[simp] theorem rootOf_mk {p : Hex.ZPoly}
+    (hsep : (HexPolyZMathlib.toPolyℚ p).Separable)
+    (i : Hex.RefinedIsolation p) :
+    rootOf hsep (Hex.SimpleRoot.mk i) = RefinedIsolation.root i := rfl
+
+end SimpleRoot
+
+namespace RefinedIsolation
+
+/-- The executable Boolean test is the proposition `Intersects`. -/
+theorem sameRoot_eq_true_iff {p : Hex.ZPoly} (i₁ i₂ : Hex.RefinedIsolation p) :
+    i₁.sameRoot i₂ = true ↔ Hex.Intersects i₁ i₂ := Iff.rfl
+
+/-- Under separability, the executable test decides equality in the quotient
+of refined isolations. -/
+theorem sameRoot_iff_mk_eq {p : Hex.ZPoly}
+    (hsep : (HexPolyZMathlib.toPolyℚ p).Separable)
+    (i₁ i₂ : Hex.RefinedIsolation p) :
+    i₁.sameRoot i₂ = true ↔ Hex.SimpleRoot.mk i₁ = Hex.SimpleRoot.mk i₂ := by
+  rw [sameRoot_eq_true_iff]
+  constructor
+  · exact Quot.sound
+  · intro heq
+    apply (intersects_iff_root_eq hsep i₁ i₂).mpr
+    simpa only [SimpleRoot.rootOf_mk] using
+      congrArg (SimpleRoot.rootOf hsep) heq
+
+end RefinedIsolation
+
+end
+
+end HexRootsMathlib
+
+namespace Hex.RefinedIsolation
+
+/-- Field-notation alias for the companion's semantic root. -/
+noncomputable abbrev root {p : Hex.ZPoly} (i : Hex.RefinedIsolation p) : ℂ :=
+  HexRootsMathlib.RefinedIsolation.root i
+
+end Hex.RefinedIsolation
+
+namespace Hex
+
+/-- Mathlib interpretation of a quotient simple root. -/
+noncomputable abbrev rootOf {p : Hex.ZPoly}
+    (hsep : (HexPolyZMathlib.toPolyℚ p).Separable) : Hex.SimpleRoot p → ℂ :=
+  HexRootsMathlib.SimpleRoot.rootOf hsep
+
+end Hex

--- a/progress/2026-07-19T17-38-06Z.md
+++ b/progress/2026-07-19T17-38-06Z.md
@@ -1,0 +1,26 @@
+# Accomplished
+
+- Added the canonical complex root of a `RefinedIsolation`, with root, region,
+  and circumscribed-disc specifications.
+- Proved that `Intersects` is semantic root equality at Mahler precision under
+  the necessary rational-cast separability hypothesis, and hence is an
+  equivalence relation.
+- Defined the complex interpretation of `SimpleRoot`, proved that `sameRoot`
+  decides quotient equality, and exposed field-notation aliases.
+- Proved the missing forward geometry lemma for a positive `discsMeet` test.
+- Ran focused builds, the full `lake build`, and repository structural checks.
+
+# Current frontier
+
+The implementation for plan item 23 is complete locally and awaiting its
+required independent Opus review before publication.
+
+# Next step
+
+Address the review, rebase from the now-merged rational squarefreeness bridge,
+publish the PR, and proceed to exact atom enumeration and refinement
+preservation.
+
+# Blockers
+
+None.


### PR DESCRIPTION
Closes #8815.

## Summary

- define the canonical complex root of every refined atom, with root, region, and circumscribed-disc specifications
- prove a positive executable `discsMeet` test implies the corresponding centre-distance bound
- prove `Intersects` is semantic root equality at Mahler precision under the necessary rational-cast separability premise, and derive its equivalence laws
- interpret `SimpleRoot` in `ℂ` by `Quot.lift` and prove `sameRoot` decides quotient equality
- expose `Hex.RefinedIsolation.root` and `Hex.rootOf` aliases and reconcile the SPEC with the corrected premise

The issue's requested unconditional theorem is false in general: a `RefinedIsolation` stores only a local simple-root witness and does not imply that all roots of the polynomial are simple. The theorem therefore carries exactly the separability premise consumed by the Mahler separation bound; `intersects_iff_root_eq_of_simple` supplies the executable-input form.

## Validation

- `lake build HexRootsMathlib.SimpleRoot HexRootsMathlib`
- `lake build`
- copyright, DAG, Phase-4, whitespace, and forbidden-declaration checks
- independent Claude Opus review: no mathematical or Lean blockers; its required SPEC correction is included
