### PR TITLE
spec(real-roots): the isolate_roots term elaborator

### DIFF
--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -135,7 +135,9 @@ a proof that `Sentence.toProp` of it is definitionally the goal.
    roots are exactly the union of the atoms' real roots. Run
    `Hex.isolate? P` and eliminate the `Option` with
    `isolate?_isSome` (squarefreeness of `squareFreeCore` is a lemma
-   here, through hex-poly-z-mathlib's gcd correspondence). If there
+   here, through hex-poly-z-mathlib's gcd correspondence; the
+   root-set equality is `aevalIff_squareFreeCore` from the
+   hex-real-roots companion's `isolate_roots` development). If there
    are no nonconstant atoms, the decomposition is the single cell
    `ℝ` and steps 4-6 degenerate to one test-point evaluation.
 

--- a/SPEC/Libraries/hex-real-roots-mathlib.md
+++ b/SPEC/Libraries/hex-real-roots-mathlib.md
@@ -194,7 +194,8 @@ expression over `X`, `C`, numerals, `+`, `-`, `*`, `^` whose
 coefficients are integers (non-integer coefficients are rejected with
 a clear message). The width `x` is any closed positive rational
 literal expression (`1/1000`, `2^(-20)`, `10^(-2)`); it converts to
-the bit target `k = ⌈log₂ x⁻¹⌉` in exact integer arithmetic and is an
+the bit target `k = max 0 ⌈log₂ x⁻¹⌉` in exact integer arithmetic
+(widths above `1` never coarsen the natural intervals) and is an
 operational promise about the emitted intervals, not a field of the
 result. The syntax uses an `atomic` lookahead on `"(" "width" ":="`
 so a parenthesised polynomial argument parses as the polynomial.
@@ -209,10 +210,15 @@ structure Hex.IsolatedRealRoots {R : Type*} [CommRing R] [Algebra R ℝ]
       Polynomial.aeval x P = 0 ∧ (intervals[i].1 : ℝ) < x ∧ x ≤ intervals[i].2
   covers      : ∀ x : ℝ, Polynomial.aeval x P = 0 →
       ∃ i : Fin n, (intervals[i].1 : ℝ) < x ∧ x ≤ intervals[i].2
+  ordered     : ∀ i j : Fin n, i < j → intervals[i].2 ≤ intervals[j].1
 ```
 
-Intervals are half-open `(lo, hi]` with exact rational endpoints (the
-isolator's dyadics). A `ZPoly` input is stated over `toPolynomial p :
+`ordered` makes the enumeration honest: without it, duplicate
+intervals could satisfy the other two fields and `n` would not
+determine the root count; with it the intervals are pairwise
+disjoint and sorted, so `n` is exactly the number of distinct real
+roots (a derived lemma, not a field). Intervals are half-open
+`(lo, hi]` with exact rational endpoints (the isolator's dyadics). A `ZPoly` input is stated over `toPolynomial p :
 Polynomial ℤ`. The elaborator is fat-API/thin-meta: all proof content
 lives in library constructors, and the emitted term only instantiates
 them with literals and `decide`-style certificates.
@@ -258,24 +264,34 @@ rebuilding the Sturm chain) grows superlinearly — heartbeats
 33k/103k/326k at Wilkinson degrees 6/8/10 — while the replay shape
 (reify the Sturm chain once as an `Array ZPoly` literal, then check
 per-endpoint sign variations against it) amortises to 29k/66k/138k,
-2.4× cheaper at degree 10 and scaling. The elaborator therefore
-emits the replay shape. Two constraints shape its soundness lemma:
+2.4× cheaper at degree 10 and scaling. The prototype's replay
+numbers are surrogate measurements: its chain-identification lemmas
+were assumed, so the cost of the `SturmChainCert` validity check
+itself is not yet measured and is re-measured when the production
+constructor lands. The elaborator emits the replay shape. Two constraints shape its soundness lemma:
 
-- chain validity is verified by a structural `IsSturmChain`
-  predicate over coefficient-level checks, NOT by deciding
-  `chain = sturmChain p` (a nonempty `Array ZPoly` equality, which
-  does not kernel-reduce under the module system: the core
-  `Array.instDecidableEqImpl` issue);
+- chain validity is verified by a decidable executable certificate
+  predicate `SturmChainCert p chain` over coefficient-level checks
+  (distinct from the companion's existing semantic `IsSturmChain`
+  over `Polynomial ℝ`, which is stated through `primitivePart p` and
+  is not decidable), NOT by deciding `chain = sturmChain p` (a
+  nonempty `Array ZPoly` equality, which does not kernel-reduce
+  under the module system: the core `Array.instDecidableEqImpl`
+  issue). Its soundness bridge to the certified counts goes through
+  the executable chain's `primitivePart` head, exactly as the
+  existing chain correspondence does;
 - nonzeroness is stated as a size check (`p.size ≠ 0` via a Bool
-  test plus `of_size_ne_zero`), avoiding structural `DensePoly`
-  equality for the same reason.
+  test plus `ne_zero_of_size_ne_zero`), avoiding structural
+  `DensePoly` equality for the same reason.
 
-The executable closure the kernel replays (`sturmChain`, `spem*`,
-`signVar`, `sturmVarAt/±Inf`, `sturmCount`, `rootCount`,
-`evalDyadic`, `dyadicSign`) is `@[expose]`d in hex-real-roots for
-this purpose, with the `spem` helpers de-privatized (an exposed
-public definition may not reference a `private` one); see the
-hex-real-roots SPEC. `Dyadic.toReal`'s unfolding is provided by a
+The executable closure the kernel replays — thirteen definitions:
+`sturmChain`, `sturmChainAux`, `spem`, `spemAux`, `spemStep`,
+`signVar`, `sturmVarAt`, `sturmVarNegInf`, `sturmVarPosInf`,
+`sturmCount`, `rootCount`, `ZPoly.evalDyadic`, `dyadicSign` — is
+`@[expose]`d in hex-real-roots for this purpose, with the three
+private helpers (`spemStep`, `spemAux`, `sturmChainAux`)
+de-privatized (an exposed public definition may not reference a
+`private` one); see the hex-real-roots SPEC. `Dyadic.toReal`'s unfolding is provided by a
 cast lemma rather than cross-module defeq.
 
 **Errors** are user-grade and distinguish: the zero polynomial
@@ -286,8 +302,10 @@ non-closed width, backend failure, and internal certificate mismatch
 (a bug, reported as such).
 
 **Practical limits** (Stage-1 measurements, single-threaded
-elaboration): degree ≤ 10 with widths to `2^(-20)` costs seconds;
-per-field certificates remain acceptable only below degree ~6. The
+elaboration): degree ≤ 10 at natural widths, and degree ≤ 6 refined
+to `2^(-20)`, cost seconds (deeper refined-width combinations are
+unmeasured); per-field certificates remain acceptable only below
+degree ~6. The
 elaborator caps refinement with a diagnostic for pathological widths.
 
 A Mathlib-free variant (same meta core, emitting a

--- a/SPEC/Libraries/hex-real-roots-mathlib.md
+++ b/SPEC/Libraries/hex-real-roots-mathlib.md
@@ -175,6 +175,126 @@ roots among them, and that is all the roots there are. Both are also
 exported in the `Hex` namespace, so dot notation resolves on the
 executable structures (`iso.exists_unique_root`).
 
+## The `isolate_roots` term elaborator
+
+A user-facing front-end that automates the pattern of the worked
+`x⁴ − 2` example: run the executable isolator at elaboration time and
+package the certified result as one term the caller can `obtain`,
+`have`, or pass to `grind`.
+
+```lean
+-- natural intervals (whatever the isolator's separation produced)
+isolate_roots p
+-- every interval refined to width at most x
+isolate_roots (width := x) p
+```
+
+`p` is either a closed `Hex.ZPoly` term or a closed `Polynomial ℤ/ℚ/ℝ`
+expression over `X`, `C`, numerals, `+`, `-`, `*`, `^` whose
+coefficients are integers (non-integer coefficients are rejected with
+a clear message). The width `x` is any closed positive rational
+literal expression (`1/1000`, `2^(-20)`, `10^(-2)`); it converts to
+the bit target `k = ⌈log₂ x⁻¹⌉` in exact integer arithmetic and is an
+operational promise about the emitted intervals, not a field of the
+result. The syntax uses an `atomic` lookahead on `"(" "width" ":="`
+so a parenthesised polynomial argument parses as the polynomial.
+
+The result type, uniform over the input rings through `aeval`:
+
+```lean
+structure Hex.IsolatedRealRoots {R : Type*} [CommRing R] [Algebra R ℝ]
+    (P : Polynomial R) (n : ℕ) where
+  intervals   : Vector (ℚ × ℚ) n
+  unique_root : ∀ i : Fin n, ∃! x : ℝ,
+      Polynomial.aeval x P = 0 ∧ (intervals[i].1 : ℝ) < x ∧ x ≤ intervals[i].2
+  covers      : ∀ x : ℝ, Polynomial.aeval x P = 0 →
+      ∃ i : Fin n, (intervals[i].1 : ℝ) < x ∧ x ≤ intervals[i].2
+```
+
+Intervals are half-open `(lo, hi]` with exact rational endpoints (the
+isolator's dyadics). A `ZPoly` input is stated over `toPolynomial p :
+Polynomial ℤ`. The elaborator is fat-API/thin-meta: all proof content
+lives in library constructors, and the emitted term only instantiates
+them with literals and `decide`-style certificates.
+
+- `IsolatedRealRoots.of` : from `p ≠ 0` (stated as a size check, see
+  below), `SquareFreeRat p`, and a `RealRootIsolations p` value, via
+  `exists_unique_root` + `isolates` and the cast lemmas.
+- `IsolatedRealRoots.congrRoots` : transport along
+  `∀ x : ℝ, aeval x P = 0 ↔ aeval x Q = 0`, heterogeneous in the
+  coefficient rings (`P : Polynomial R`, `Q : Polynomial S`) since it
+  is used twice with different rings: once for the squarefree-core
+  step and once to restate over the user's polynomial (the latter
+  hypothesis closed by a bridge tactic over
+  `aeval`-of-`toPolynomial` unfolding, coefficient lookups, and
+  `norm_num` — a pointwise evaluation bridge, not a `Polynomial`
+  identity).
+- `IsolatedRealRoots.constant` : the `n = 0` result for nonzero
+  constants, which never enter the isolator (the squarefree Sturm
+  certificate is `false` on constants by design).
+- The **replay constructor**: the production certificate shape (see
+  below).
+
+**Squarefreeness is invisible to the user.** If
+`hasSquarefreeSturmChain p` fails, the elaborator runs on
+`squareFreeCore p` and transports along
+
+```lean
+theorem aevalIff_squareFreeCore (hp0 : p ≠ 0) (x : ℝ) :
+    Polynomial.aeval x (toPolynomial (ZPoly.squareFreeCore p)) = 0 ↔
+    Polynomial.aeval x (toPolynomial p) = 0
+```
+
+(the roots of a nonzero polynomial and of its squarefree core agree
+as sets; proven through the `primitiveSquareFreeDecomposition`
+bridge and a root-multiplicity argument, and shared with the `rcf`
+tactic's step 3).
+
+**Kernel replay.** Following the `irreducible_cert` pattern (and
+hex-rcf §Kernel replay), the elaborator never asks the kernel to
+re-run the search. Measured on the Stage-1 prototype, the naive
+per-field `decide` shape (each `count_one`/`complete` certificate
+rebuilding the Sturm chain) grows superlinearly — heartbeats
+33k/103k/326k at Wilkinson degrees 6/8/10 — while the replay shape
+(reify the Sturm chain once as an `Array ZPoly` literal, then check
+per-endpoint sign variations against it) amortises to 29k/66k/138k,
+2.4× cheaper at degree 10 and scaling. The elaborator therefore
+emits the replay shape. Two constraints shape its soundness lemma:
+
+- chain validity is verified by a structural `IsSturmChain`
+  predicate over coefficient-level checks, NOT by deciding
+  `chain = sturmChain p` (a nonempty `Array ZPoly` equality, which
+  does not kernel-reduce under the module system: the core
+  `Array.instDecidableEqImpl` issue);
+- nonzeroness is stated as a size check (`p.size ≠ 0` via a Bool
+  test plus `of_size_ne_zero`), avoiding structural `DensePoly`
+  equality for the same reason.
+
+The executable closure the kernel replays (`sturmChain`, `spem*`,
+`signVar`, `sturmVarAt/±Inf`, `sturmCount`, `rootCount`,
+`evalDyadic`, `dyadicSign`) is `@[expose]`d in hex-real-roots for
+this purpose, with the `spem` helpers de-privatized (an exposed
+public definition may not reference a `private` one); see the
+hex-real-roots SPEC. `Dyadic.toReal`'s unfolding is provided by a
+cast lemma rather than cross-module defeq.
+
+**Errors** are user-grade and distinguish: the zero polynomial
+("every real number is a root"), non-integer coefficients,
+unsupported polynomial syntax, non-closed input (free variables or
+metavariables, in the polynomial or the width), non-positive or
+non-closed width, backend failure, and internal certificate mismatch
+(a bug, reported as such).
+
+**Practical limits** (Stage-1 measurements, single-threaded
+elaboration): degree ≤ 10 with widths to `2^(-20)` costs seconds;
+per-field certificates remain acceptable only below degree ~6. The
+elaborator caps refinement with a diagnostic for pathological widths.
+
+A Mathlib-free variant (same meta core, emitting a
+`RealRootIsolations` value whose conclusions are the executable
+Sturm certificates) is a possible follow-up for consumers who cannot
+import Mathlib; the ℝ-valued statements above necessarily live here.
+
 ## Bounds and depths
 
 ```lean
@@ -323,6 +443,9 @@ HexRealRootsMathlib/
   Separation.lean      -- sepPrec_separates, rootBound_bounds_roots;
                           specializes shared Mahler/Vandermonde analysis
   Isolations.lean      -- exists_unique_root, isolates
+  IsolateRoots.lean    -- IsolatedRealRoots, its constructors, the
+                          bridge tactic, and the isolate_roots
+                          term elaborator
   Drivers.lean         -- isolateSturm?_isSome, isolate?_isSome,
                           refine1_isolates_same
   SimpleRealRoot.lean  -- overlaps_iff_same_root, toReal, sameRoot_iff

--- a/SPEC/Libraries/hex-real-roots.md
+++ b/SPEC/Libraries/hex-real-roots.md
@@ -348,13 +348,14 @@ same semantics, one chain construction total.
 ## Kernel-replay exposure
 
 The `isolate_roots` term elaborator (companion SPEC) replays Sturm
-certificates in the kernel. The replayed closure — `sturmChain`, the
-`spem` helpers, `signVar`, `sturmVarAt`, `sturmVarNegInf`,
+certificates in the kernel. The replayed closure — thirteen
+definitions: `sturmChain`, `sturmChainAux`, `spem`, `spemAux`,
+`spemStep`, `signVar`, `sturmVarAt`, `sturmVarNegInf`,
 `sturmVarPosInf`, `sturmCount`, `rootCount`, `ZPoly.evalDyadic`,
 `dyadicSign` — carries `@[expose]` so downstream `module` consumers
-can `decide` against it without `import all`, and the `spem` helpers
-are public (an exposed definition may not reference a `private`
-one). The whole closure is structural-fuel recursion; nothing in it
+can `decide` against it without `import all`, and the three private
+helpers (`spemStep`, `spemAux`, `sturmChainAux`) become public (an
+exposed definition may not reference a `private` one). The whole closure is structural-fuel recursion; nothing in it
 is well-founded, so exposure suffices for kernel reduction.
 
 ## `SimpleRealRoot`: identity of a root, up to isolation

--- a/SPEC/Libraries/hex-real-roots.md
+++ b/SPEC/Libraries/hex-real-roots.md
@@ -339,6 +339,24 @@ violates the isolation semantics the fallback branch returns the
 input unchanged and `refineTo` stops when its fuel runs out; neither
 function can loop.
 
+`refine1` recomputes the Sturm chain on every bisection. For callers
+that refine many levels in one go (the `isolate_roots` term
+elaborator refining every root to a requested width), a cached-chain
+variant threads one precomputed chain through the bisection loop;
+same semantics, one chain construction total.
+
+## Kernel-replay exposure
+
+The `isolate_roots` term elaborator (companion SPEC) replays Sturm
+certificates in the kernel. The replayed closure — `sturmChain`, the
+`spem` helpers, `signVar`, `sturmVarAt`, `sturmVarNegInf`,
+`sturmVarPosInf`, `sturmCount`, `rootCount`, `ZPoly.evalDyadic`,
+`dyadicSign` — carries `@[expose]` so downstream `module` consumers
+can `decide` against it without `import all`, and the `spem` helpers
+are public (an exposed definition may not reference a `private`
+one). The whole closure is structural-fuel recursion; nothing in it
+is well-founded, so exposure suffices for kernel reduction.
+
 ## `SimpleRealRoot`: identity of a root, up to isolation
 
 ```lean

--- a/progress/2026-07-17T19-38-22Z-inv-floor-proof-review.md
+++ b/progress/2026-07-17T19-38-22Z-inv-floor-proof-review.md
@@ -1,0 +1,21 @@
+# `invFloor` agreement proof review
+
+## Accomplished
+
+- Reviewed commit `49841613` and the actual core declarations used by
+  `Dyadic.invFloor_eq_invAtPrec_of_pos`.
+- Confirmed the `Dyadic.eq_invAtPrec` obligations, strict negative-exponent
+  branch, and signed Euclidean-division lemma hypotheses all match the proof.
+- Confirmed the added diff contains no `sorry`, `axiom`, or Mathlib import.
+
+## Current frontier
+
+The proof has no concrete correctness findings.
+
+## Next step
+
+No proof change is required.
+
+## Blockers
+
+None.

--- a/progress/2026-07-18T05-27-17Z.md
+++ b/progress/2026-07-18T05-27-17Z.md
@@ -1,0 +1,23 @@
+# SPEC time-budget review
+
+## Accomplished
+
+- Reviewed the HexRoots time-budget SPEC-only change against
+  `reports/hexroots-performance.md` and the implementation formulas.
+- Confirmed the degree-10, degree-50, and degree-100 measurements.
+- Computed the degree-50 height-10 separation floor: `T = 998`,
+  `mahlerPrec = 502`, and `separationDepth = 516`.
+- Found that the new degree-20 claim of about 15 seconds conflicts with the
+  report's 4.018-second `isolateAll?@32` measurement.
+
+## Current frontier
+
+- Review complete; no source changes were made.
+
+## Next step
+
+- Correct or source the degree-20 measured value before merging.
+
+## Blockers
+
+- The independent second-opinion API was unavailable (`FailedToOpenSocket`).

--- a/progress/20260711T173858Z.md
+++ b/progress/20260711T173858Z.md
@@ -1,0 +1,22 @@
+# HexRoots Phase 3 metadata bump review
+
+## Accomplished
+
+- Checked the requested Phase 3 exit artifacts on `origin/main` for the `HexRoots` `done_through: 3` metadata bump.
+- Verified `conformance/HexRoots/Conformance.lean` exists and carries the mandated conformance-contract docstring.
+- Verified `lakefile.lean` includes `HexRoots.Conformance` in the `HexConformance` globs.
+- Verified `scripts/oracle/roots_flint.py` is present and wired in `scripts/ci/run_oracles.sh`.
+- Verified `conformance-fixtures/HexRoots/roots.jsonl` is committed.
+- Confirmed the landing PRs `#8737` and `#8740` are merged; the PR descriptions record green local/CI-relevant verification, though the GitHub status API returned no commit statuses for the merge SHAs.
+
+## Current frontier
+
+- No missing Phase 3 artifact found for the metadata bump.
+
+## Next step
+
+- Proceed with the one-line `libraries.yml` bump if no separate CI-status source is required.
+
+## Blockers
+
+- None for the artifact spot-check.

--- a/progress/20260711T180306Z.md
+++ b/progress/20260711T180306Z.md
@@ -1,0 +1,19 @@
+**Accomplished**
+
+Reviewed the pasted Phase-4 HexRoots benchmark PR against `SPEC/benchmarking.md`,
+the current HexRoots isolation/refinement APIs, `lean-bench` verify semantics,
+and the CI/Lake wiring shape.
+
+**Current frontier**
+
+No source edits were made. The checked-out worktree does not contain the pasted
+`bench/HexRoots/Bench.lean`, so the review was performed from the supplied diff
+and the current API definitions.
+
+**Next step**
+
+Report concrete review findings only.
+
+**Blockers**
+
+None.

--- a/progress/20260711T191248Z.md
+++ b/progress/20260711T191248Z.md
@@ -1,0 +1,19 @@
+**Accomplished**
+
+- Reviewed the supplied Phase-4 HexRoots measurement PR diff as a concrete-bugs-only code review.
+- Traced the proposed `scripts/check_phase4.py` diff parser state machine against deleted Lean `--` comments rendered as `--- ...` and genuine `--- a/<file>` headers.
+- Checked the proposed `libraries.yml` Phase-4 block shape against the documented parser/schema.
+- Inspected the python-flint comparator script and the benchmark model derivations in the supplied diff.
+
+**Current frontier**
+
+- The parser fix and metadata shape appear sound.
+- Two review findings remain: the `linProdPoly` compare-group `n^5` wall models drop non-constant bit-growth, and the python-flint comparator script does not actually byte-verify its generated coefficients against Lean output.
+
+**Next step**
+
+- Patch the PR to either model the compare-group registrations with the missing logarithmic/height factor or add a defensible explicit policy for suppressing that factor, and add a real coefficient verification path to `scripts/bench/hexroots_flint_compare.py`.
+
+**Blockers**
+
+- None for the review.

--- a/progress/20260718T195047Z-root-ergonomics-plan-review.md
+++ b/progress/20260718T195047Z-root-ergonomics-plan-review.md
@@ -1,0 +1,39 @@
+# Concrete real-root ergonomics plan review
+
+## Accomplished
+
+- Reviewed the five-item ergonomics plan against the current Sturm-chain,
+  squarefree correspondence, isolation semantics, driver, dyadic conversion,
+  and dense-polynomial bridge implementations.
+- Traced the concrete `x^4 - 2` scratch proof to identify which proposed APIs
+  actually remove its scaffolding.
+- Identified a simpler Item 1 proof: propagate coprimality backward from the
+  terminal constant using the existing three-term `chain_step` relation,
+  avoiding a full terminal-gcd association theorem.
+- Confirmed that `primitivePart`, positive pseudo-remainder scaling, and the
+  explicit negation only introduce units/nonzero constants over `R[X]` and do
+  not obstruct the backward argument.
+- Found that Item 4's stated theorem is honest but largely redundant, omits the
+  promised per-interval soundness conjunct, and does not help prove concrete
+  interval bounds for the opaque existential output.
+- Determined that a Horner/fold evaluation normal form is substantially more
+  useful for concrete coefficient literals than a public finite-sum normal
+  form.
+
+## Current frontier
+
+- Review is complete; no library source files were changed.
+- The plan should be revised before implementation, chiefly for Item 1's proof
+  strategy, Item 4's scope, and committed end-to-end conformance coverage.
+
+## Next step
+
+- Rewrite Item 1 around a backward `IsCoprime` induction and decide whether the
+  Boolean API is a one-way certificate or a fully characterized replacement
+  for `SquareFreeRat` on all degree cases.
+- Replace or demote Item 4, and add a committed concise `x^4 - 2` conformance
+  example that exercises Items 1--3 and the namespace alias.
+
+## Blockers
+
+- None.

--- a/progress/20260718T204252Z-pr8768-pr8769-correctness-review.md
+++ b/progress/20260718T204252Z-pr8768-pr8769-correctness-review.md
@@ -1,0 +1,32 @@
+# PR #8768 / #8769 correctness review
+
+## Accomplished
+
+- Reviewed the reverse coprimality algebra, backward chain induction, degree/fuel
+  bookkeeping, content-unit lifting, and separability reflection in PR #8768.
+- Checked the executable terminal-size certificate against the normalized
+  `DensePoly` representation and exhaustively compared it with `SquareFreeRat`
+  for coefficient lists of lengths 0 through 6 over `{-2, -1, 0, 1, 2}`.
+- Checked the evaluation and dyadic-shift bridges and compiled focused external
+  API examples for the namespace aliases.
+- Reviewed PR #8769 against the actual theorem signatures.
+
+## Current frontier
+
+- The code proof is sound; no code-level merge blocker was found.
+- The docs PR still displays `RealRootIsolations.isolates` without its required
+  `p ≠ 0` hypothesis, so the SPEC remains false at `p = 0`.
+- The namespace alias is semantically harmless and dot notation works, but
+  opening both `Hex` and `HexRealRootsMathlib` makes the qualified shorthand
+  `RealRootIsolation.exists_unique_root` ambiguous.
+
+## Next step
+
+- Fix the `RealRootIsolations.isolates` SPEC signature before merging #8769;
+  optionally tighten the new certificate signature/wording and the dyadic
+  endpoint notation.
+
+## Blockers
+
+- PR #8769 documentation accuracy: missing `hp0 : p ≠ 0` on
+  `RealRootIsolations.isolates`.

--- a/progress/20260719T095057Z-isolate-roots-plan-review.md
+++ b/progress/20260719T095057Z-isolate-roots-plan-review.md
@@ -1,0 +1,41 @@
+# `isolate_roots` implementation-plan review
+
+## Accomplished
+
+- Reviewed the proposed term elaborator against the current real-root certificate,
+  Mathlib companion, dense-polynomial, decomposition, and certificate-reification
+  implementations.
+- Confirmed that root-predicate transport is sound and that `aeval` supports the
+  intended `Int`/`Rat`/`Real` coefficient rings with their canonical algebra maps.
+- Traced the downstream kernel-reduction obligations and identified missing closure
+  around private Sturm helpers, decidable-instance bodies, dense-polynomial equality,
+  and the Core nonempty-array equality bug.
+- Checked pinned Mathlib's polynomial radical, gcd/derivative, and root-multiplicity
+  APIs. There is no direct `p / gcd(p,p') = radical p` shortcut; a focused
+  root-multiplicity proof is the most promising bridge.
+- Identified additional design risks in constant-polynomial handling, coefficient
+  reflection, exact width elaboration, dependent evaluation, refinement/replay
+  recomputation, structure ergonomics, and verification scope.
+
+## Current frontier
+
+- The plan is architecturally viable but should be revised before implementation.
+- The largest proof item remains the executable square-free-core/root-set bridge;
+  the exposure pass and the polynomial-expression interpreter are also larger than
+  currently estimated.
+- No library source files were changed.
+
+## Next step
+
+- Revise the PR decomposition around a minimal replay constructor/call graph, a
+  proof-producing polynomial reifier, a special or uniform square-free-core path
+  that handles nonzero constants, and a generic Mathlib lemma for roots of
+  `p / gcd p p.derivative`.
+- Prototype cached-chain refinement and replay before committing to the literal
+  per-field `by decide` certificate shape.
+
+## Blockers
+
+- None for the review. The Core `Array.instDecidableEqImpl` module-system bug must
+  either be avoided in emitted proofs or fixed upstream before relying on structural
+  `DensePoly` equality decisions downstream.


### PR DESCRIPTION
This PR adds the `isolate_roots` term elaborator to the hex-real-roots companion SPEC, following the approved plan and the Stage-1 prototype (branch `isolate-roots/prototype`): syntax with the optional `(width := x)` group, accepted inputs (closed `ZPoly` terms; `Polynomial ℤ/ℚ/ℝ` with integer coefficients), the `IsolatedRealRoots` structure in aeval form over `Vector (ℚ × ℚ) n`, the constructor set (`of`, ring-heterogeneous `congrRoots`, `constant`, replay), squarefree transparency via `squareFreeCore` + `aevalIff_squareFreeCore`, and the kernel-replay strategy with the prototype's measured heartbeat table (per-field `decide` 33k/103k/326k vs replay 29k/66k/138k at Wilkinson degrees 6/8/10) plus the two module-system constraints the prototype surfaced (structural `IsSturmChain` verification instead of Array equality; size-based nonzeroness). The backend SPEC records the thirteen-definition `@[expose]` obligation (spem helpers de-privatized, whole closure structural) and the cached-chain `refineTo` variant; hex-rcf step 3 now cross-references `aevalIff_squareFreeCore`. The `isolates` `p ≠ 0` SPEC omission flagged in the pod's correctness review turned out to be already fixed on main. Also collects pending review progress notes.

🤖 Prepared with Claude Code

https://claude.ai/code/session_01SpYSH4swVcLJbN2Bn6NfSP