### PR TITLE
feat(real-roots-mathlib): prove aevalIff_squareFreeCore

### DIFF
--- a/HexPolyZ/Core.lean
+++ b/HexPolyZ/Core.lean
@@ -632,6 +632,7 @@ def primitiveSquareFreeDecomposition (f : ZPoly) : PrimitiveSquareFreeDecomposit
         repeatedPart := ratPolyPrimitivePart repeatedRat }
 
 /-- The square-free core projection of `primitiveSquareFreeDecomposition`. -/
+@[expose]
 def squareFreeCore (f : ZPoly) : ZPoly :=
   (primitiveSquareFreeDecomposition f).squareFreeCore
 

--- a/HexPolyZ/Decomposition.lean
+++ b/HexPolyZ/Decomposition.lean
@@ -674,6 +674,79 @@ theorem primitiveSquareFreeDecomposition_reassembly_signed
     rw [← hdprimitive]
     exact htarget.symm
 
+/-- The square-free core of a nonzero polynomial is nonzero: in the signed
+reassembly it is a factor of the (nonzero) primitive part. -/
+theorem squareFreeCore_ne_zero (f : ZPoly) (hf : f ≠ 0) :
+    squareFreeCore f ≠ 0 := by
+  intro hcore
+  rcases primitiveSquareFreeDecomposition_reassembly_signed f hf with ⟨ε, _, hre⟩
+  have hpne : primitivePart f ≠ 0 :=
+    ne_zero_of_primitive (primitivePart f)
+      (primitivePart_primitive f (content_ne_zero_of_ne_zero f hf))
+  apply hpne
+  rw [← hre,
+    show (primitiveSquareFreeDecomposition f).squareFreeCore = 0 from hcore,
+    DensePoly.zero_mul, DensePoly.scale_zero_right]
+
+/-- The square-free core of a nonzero polynomial is square-free over `Rat[x]`:
+combine the executable core square-freeness with core nonzeroness. -/
+theorem squareFreeRat_squareFreeCore (f : ZPoly) (hf : f ≠ 0) :
+    SquareFreeRat (squareFreeCore f) :=
+  primitiveSquareFreeDecomposition_squareFreeCore f (squareFreeCore_ne_zero f hf)
+
+/-- The rational cast of the primitive part's square-free `gcd` associate
+divides its derivative: `gcd(r, r')` divides `r'`, and its primitive integer
+representative is a rational associate of the `gcd`. -/
+private theorem ratPolyPrimitivePart_gcd_dvd_derivative (rp : DensePoly Rat) :
+    toRatPoly (ratPolyPrimitivePart (DensePoly.gcd rp (DensePoly.derivative rp))) ∣
+      DensePoly.derivative rp := by
+  have h1 : DensePoly.gcd rp (DensePoly.derivative rp) ∣ DensePoly.derivative rp :=
+    DensePoly.gcd_dvd_right rp (DensePoly.derivative rp)
+  rcases ratPolyPrimitivePart_rational_associate
+    (DensePoly.gcd rp (DensePoly.derivative rp)) with ⟨u, hu⟩
+  rcases h1 with ⟨b, hb⟩
+  generalize hX :
+      toRatPoly (ratPolyPrimitivePart (DensePoly.gcd rp (DensePoly.derivative rp))) = X
+      at hu ⊢
+  refine ⟨DensePoly.scale u b, ?_⟩
+  have e1 : DensePoly.scale u X * b = DensePoly.scale u (X * b) := by
+    have h := rat_scale_mul_scale u 1 X b
+    rw [rat_scale_one, Rat.mul_one] at h
+    exact h
+  have e2 : X * DensePoly.scale u b = DensePoly.scale u (X * b) := by
+    have h := rat_scale_mul_scale 1 u X b
+    rw [rat_scale_one, Rat.one_mul] at h
+    exact h
+  calc DensePoly.derivative rp
+      = DensePoly.gcd rp (DensePoly.derivative rp) * b := hb
+    _ = DensePoly.scale u X * b := by rw [hu]
+    _ = DensePoly.scale u (X * b) := e1
+    _ = X * DensePoly.scale u b := e2.symm
+
+/-- The rational cast of the repeated part divides the derivative of the
+rational cast of the primitive part. The repeated part is a rational associate
+of `gcd(primitive, primitive')`, which divides `primitive'`; this is the
+divisibility the square-free-core root transfer consumes. -/
+theorem toRatPoly_repeatedPart_dvd_derivative (f : ZPoly) :
+    toRatPoly (primitiveSquareFreeDecomposition f).repeatedPart ∣
+      DensePoly.derivative (toRatPoly (primitivePart f)) := by
+  unfold primitiveSquareFreeDecomposition
+  by_cases hzero : (primitivePart f).isZero
+  · have hpz : primitivePart f = 0 :=
+      densePoly_eq_zero_of_isZero_true (primitivePart f) hzero
+    simp only [hzero, if_true]
+    rw [hpz]
+    simp only [toRatPoly_zero, DensePoly.derivative_zero]
+    exact ⟨0, (DensePoly.zero_mul 0).symm⟩
+  · simp only [hzero, Bool.false_eq_true, if_false]
+    by_cases hderiv : (DensePoly.derivative (toRatPoly (primitivePart f))).isZero
+    · simp only [hderiv, if_true]
+      rw [toRatPoly_one]
+      exact ⟨DensePoly.derivative (toRatPoly (primitivePart f)),
+        by rw [DensePoly.mul_comm_poly, DensePoly.mul_one_right_poly]⟩
+    · simp only [hderiv, Bool.false_eq_true, if_false]
+      exact ratPolyPrimitivePart_gcd_dvd_derivative (toRatPoly (primitivePart f))
+
 /-- A Bezout congruence witness proves that two integer polynomials are coprime
 modulo `p`. -/
 theorem coprimeModP_of_bezout

--- a/HexPolyZ/Decomposition.lean
+++ b/HexPolyZ/Decomposition.lean
@@ -674,6 +674,11 @@ theorem primitiveSquareFreeDecomposition_reassembly_signed
     rw [← hdprimitive]
     exact htarget.symm
 
+/-- The `squareFreeCore` projection is the decomposition's square-free core.
+A definitional bridge for consumers that cannot unfold the unexposed `def`. -/
+theorem squareFreeCore_eq (f : ZPoly) :
+    squareFreeCore f = (primitiveSquareFreeDecomposition f).squareFreeCore := rfl
+
 /-- The square-free core of a nonzero polynomial is nonzero: in the signed
 reassembly it is a factor of the (nonzero) primitive part. -/
 theorem squareFreeCore_ne_zero (f : ZPoly) (hf : f ≠ 0) :

--- a/HexRealRootsMathlib.lean
+++ b/HexRealRootsMathlib.lean
@@ -12,6 +12,7 @@ public import HexRealRootsMathlib.Hadamard
 public import HexRealRootsMathlib.Discr
 public import HexRealRootsMathlib.Separation
 public import HexRealRootsMathlib.ChainCorrespond
+public import HexRealRootsMathlib.SquareFreeCore
 public import HexRealRootsMathlib.Isolations
 public import HexRealRootsMathlib.Drivers
 public import HexRealRootsMathlib.SimpleRealRoot

--- a/HexRealRootsMathlib/SquareFreeCore.lean
+++ b/HexRealRootsMathlib/SquareFreeCore.lean
@@ -1,0 +1,210 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import Mathlib
+public import HexPolyZ
+public import HexPolyZMathlib.Basic
+public import HexPolyZMathlib.Squarefree
+public import HexRealRootsMathlib.Separation
+public import HexRealRootsMathlib.ChainCorrespond
+
+public section
+
+/-!
+# Real roots of the square-free core
+
+The certified isolator only handles square-free input, so the `isolate_roots`
+elaborator (and `rcf` step 3) run the executable square-free reduction
+`Hex.ZPoly.squareFreeCore` first and transport the certified conclusions back
+along `aevalIff_squareFreeCore`: a nonzero integer polynomial and its square-free
+core have exactly the same real roots.
+
+The proof factors through a **field-generic** lemma
+(`isRoot_left_iff_of_mul_of_dvd_derivative`, Hex-free and upstreamable): over a
+characteristic-zero field, if `q = c * r` and `r ∣ q'`, then `c` and `q` have
+the same roots. It is instantiated at `q = primitivePart p` over `ℝ`, with `c`
+the (signed) square-free core and `r` the repeated part, using that the repeated
+part is a rational associate of `gcd(primitive, primitive')` — hence divides the
+derivative (the executable bridge
+`Hex.ZPoly.toRatPoly_repeatedPart_dvd_derivative`).
+-/
+
+namespace HexRealRootsMathlib
+
+open Polynomial HexPolyZMathlib
+
+noncomputable section
+
+/-! ### The field-generic quotient-roots lemma -/
+
+/-- **Field-generic square-free-core root transfer.** Over a characteristic-zero
+field, if `q = c * r` (with `q ≠ 0`) and `r` divides the derivative `q'`, then a
+point is a root of `c` iff it is a root of `q`. The root-multiplicity argument:
+at a root `a` of multiplicity `m ≥ 1`, `q'` has multiplicity `m − 1`
+(characteristic zero), so `r ∣ q'` forces the `r`-multiplicity of `a` below `m`,
+leaving `c` with multiplicity at least one; conversely any root of `c` is a root
+of the product `q`. Hex-free; a candidate Mathlib contribution. -/
+theorem isRoot_left_iff_of_mul_of_dvd_derivative {K : Type*} [Field K] [CharZero K]
+    {q c r : K[X]} (hq : q ≠ 0) (hqcr : q = c * r) (hrd : r ∣ derivative q) (a : K) :
+    c.IsRoot a ↔ q.IsRoot a := by
+  have hcr0 : c * r ≠ 0 := hqcr ▸ hq
+  have hc0 : c ≠ 0 := left_ne_zero_of_mul hcr0
+  have hmul : rootMultiplicity a q = rootMultiplicity a c + rootMultiplicity a r := by
+    rw [hqcr]; exact rootMultiplicity_mul (hqcr ▸ hq)
+  constructor
+  · intro hca
+    have hcpos : 0 < rootMultiplicity a c := (rootMultiplicity_pos hc0).mpr hca
+    rw [← rootMultiplicity_pos hq, hmul]
+    omega
+  · intro hqa
+    rw [← rootMultiplicity_pos hc0]
+    have hqpos : 0 < rootMultiplicity a q := (rootMultiplicity_pos hq).mpr hqa
+    have hderiv : rootMultiplicity a (derivative q) = rootMultiplicity a q - 1 :=
+      derivative_rootMultiplicity_of_root hqa
+    have hq'0 : derivative q ≠ 0 := by
+      intro h
+      have hqC : q = C (q.coeff 0) := eq_C_of_derivative_eq_zero h
+      have hcoeff0 : q.coeff 0 = 0 := by
+        have he : q.eval a = 0 := hqa
+        rw [hqC, eval_C] at he
+        exact he
+      exact hq (by rw [hqC, hcoeff0, C_0])
+    have hle : rootMultiplicity a r ≤ rootMultiplicity a (derivative q) :=
+      rootMultiplicity_le_rootMultiplicity_of_dvd hq'0 hrd a
+    rw [hderiv] at hle
+    omega
+
+/-! ### Cast helpers -/
+
+/-- `aeval` at a real point of an embedded integer polynomial is the evaluation
+of its real cast. -/
+theorem aeval_eq_eval_toPolyℝ (q : Hex.ZPoly) (x : ℝ) :
+    aeval x (toPolynomial q) = (toPolyℝ q).eval x := by
+  rw [aeval_def, eval₂_eq_eval_map, algebraMap_int_eq]
+
+/-- The real cast is multiplicative. -/
+theorem toPolyℝ_mul (p q : Hex.ZPoly) :
+    toPolyℝ (p * q) = toPolyℝ p * toPolyℝ q := by
+  show (HexPolyZMathlib.toPolynomial (p * q)).map (Int.castRingHom ℝ) = _
+  rw [HexPolyZMathlib.toPolynomial_mul, Polynomial.map_mul]
+
+/-- The real cast is the composition of the rational cast with `ℚ → ℝ`. -/
+theorem toPolyℝ_eq_map_toPolyℚ (q : Hex.ZPoly) :
+    toPolyℝ q = (toPolyℚ q).map (algebraMap ℚ ℝ) := by
+  have hcomp : (algebraMap ℚ ℝ).comp (Int.castRingHom ℚ) = Int.castRingHom ℝ :=
+    RingHom.ext_int _ _
+  show (toPolynomial q).map (Int.castRingHom ℝ)
+    = ((toPolynomial q).map (Int.castRingHom ℚ)).map (algebraMap ℚ ℝ)
+  rw [Polynomial.map_map, hcomp]
+
+/-- **Executable-to-real divisibility.** The real cast of the repeated part
+divides the derivative of the real cast of the primitive part: the executable
+rational divisibility, transported through `ℚ` and then `ℚ → ℝ`. -/
+theorem toPolyℝ_repeatedPart_dvd_derivative (p : Hex.ZPoly) :
+    toPolyℝ (Hex.ZPoly.primitiveSquareFreeDecomposition p).repeatedPart ∣
+      derivative (toPolyℝ (Hex.ZPoly.primitivePart p)) := by
+  have hexec := Hex.ZPoly.toRatPoly_repeatedPart_dvd_derivative p
+  -- Transport to `Polynomial ℚ` by destructuring the executable divisibility.
+  obtain ⟨s, hs⟩ := hexec
+  have hq : toPolyℚ (Hex.ZPoly.primitiveSquareFreeDecomposition p).repeatedPart ∣
+      derivative (toPolyℚ (Hex.ZPoly.primitivePart p)) := by
+    refine ⟨HexPolyMathlib.toPolynomial s, ?_⟩
+    have hcong := congrArg HexPolyMathlib.toPolynomial hs
+    rw [HexPolyMathlib.toPolynomial_derivative, HexPolyMathlib.toPolynomial_mul,
+      toPolynomial_toRatPoly, toPolynomial_toRatPoly] at hcong
+    exact hcong
+  -- Map along `ℚ → ℝ`.
+  obtain ⟨t, ht⟩ := hq
+  refine ⟨t.map (algebraMap ℚ ℝ), ?_⟩
+  have hcong := congrArg (Polynomial.map (algebraMap ℚ ℝ)) ht
+  rw [← Polynomial.derivative_map, Polynomial.map_mul, ← toPolyℝ_eq_map_toPolyℚ,
+    ← toPolyℝ_eq_map_toPolyℚ] at hcong
+  exact hcong
+
+/-! ### The square-free-core root iff -/
+
+/-- **Square-free core preserves real roots.** A nonzero integer polynomial and
+its executable square-free core have exactly the same real roots, stated through
+`aeval` at real points. Shared with the `rcf` decision procedure (step 3) and
+consumed by the `isolate_roots` elaborator to reduce to square-free input. -/
+theorem aevalIff_squareFreeCore {p : Hex.ZPoly} (hp0 : p ≠ 0) (x : ℝ) :
+    aeval x (toPolynomial (Hex.ZPoly.squareFreeCore p)) = 0 ↔
+      aeval x (toPolynomial p) = 0 := by
+  rw [aeval_eq_eval_toPolyℝ, aeval_eq_eval_toPolyℝ, Hex.ZPoly.squareFreeCore_eq]
+  -- Reduce to `IsRoot` of the square-free core vs `p`.
+  rcases Hex.ZPoly.primitiveSquareFreeDecomposition_reassembly_signed p hp0 with ⟨ε, hε, hre⟩
+  have hε0 : ((ε : Int) : ℝ) ≠ 0 := by rcases hε with h | h <;> simp [h]
+  have hprim_ne : toPolyℝ (Hex.ZPoly.primitivePart p) ≠ 0 := by
+    rw [Ne, toPolyℝ_eq_zero_iff]; exact primitivePart_ne_zero hp0
+  -- The signed reassembly over `ℝ`.
+  have hreℝ : toPolyℝ (Hex.ZPoly.primitivePart p) =
+      Polynomial.C ((ε : Int) : ℝ) *
+        (toPolyℝ (Hex.ZPoly.primitiveSquareFreeDecomposition p).squareFreeCore *
+          toPolyℝ (Hex.ZPoly.primitiveSquareFreeDecomposition p).repeatedPart) := by
+    have hcong := congrArg toPolyℝ hre
+    rw [toPolyℝ_scale, toPolyℝ_mul] at hcong
+    exact hcong.symm
+  -- Apply the field-generic lemma at `q = primitivePart`, `c = C ε * core`,
+  -- `r = repeatedPart`.
+  have hqcr : toPolyℝ (Hex.ZPoly.primitivePart p) =
+      (Polynomial.C ((ε : Int) : ℝ) *
+        toPolyℝ (Hex.ZPoly.primitiveSquareFreeDecomposition p).squareFreeCore) *
+        toPolyℝ (Hex.ZPoly.primitiveSquareFreeDecomposition p).repeatedPart := by
+    rw [hreℝ, mul_assoc]
+  have hrd : toPolyℝ (Hex.ZPoly.primitiveSquareFreeDecomposition p).repeatedPart ∣
+      derivative (toPolyℝ (Hex.ZPoly.primitivePart p)) :=
+    toPolyℝ_repeatedPart_dvd_derivative p
+  have hgen := isRoot_left_iff_of_mul_of_dvd_derivative hprim_ne hqcr hrd x
+  -- Strip the `C ε` factor.
+  have hCe : (Polynomial.C ((ε : Int) : ℝ) *
+      toPolyℝ (Hex.ZPoly.primitiveSquareFreeDecomposition p).squareFreeCore).IsRoot x ↔
+      (toPolyℝ (Hex.ZPoly.primitiveSquareFreeDecomposition p).squareFreeCore).IsRoot x := by
+    constructor
+    · intro h
+      have hval : ((ε : Int) : ℝ) *
+          (toPolyℝ (Hex.ZPoly.primitiveSquareFreeDecomposition p).squareFreeCore).eval x = 0 := by
+        simpa [IsRoot, eval_mul, eval_C] using h
+      rcases mul_eq_zero.mp hval with h1 | h1
+      · exact absurd h1 hε0
+      · exact h1
+    · intro h
+      show (Polynomial.C ((ε : Int) : ℝ) *
+        toPolyℝ (Hex.ZPoly.primitiveSquareFreeDecomposition p).squareFreeCore).eval x = 0
+      rw [eval_mul, eval_C, show
+        (toPolyℝ (Hex.ZPoly.primitiveSquareFreeDecomposition p).squareFreeCore).eval x = 0 from h,
+        mul_zero]
+  -- Strip the content factor: `p` and its primitive part share roots.
+  have hcontent : (toPolyℝ (Hex.ZPoly.primitivePart p)).IsRoot x ↔ (toPolyℝ p).IsRoot x := by
+    have hpp : toPolyℝ p = Polynomial.C ((Hex.ZPoly.content p : Int) : ℝ) *
+        toPolyℝ (Hex.ZPoly.primitivePart p) :=
+      toPolyℝ_eq_C_content_mul_primitivePart p
+    constructor
+    · intro h
+      show (toPolyℝ p).eval x = 0
+      rw [hpp, eval_mul, eval_C, show (toPolyℝ (Hex.ZPoly.primitivePart p)).eval x = 0 from h,
+        mul_zero]
+    · intro h
+      have hval : ((Hex.ZPoly.content p : Int) : ℝ) *
+          (toPolyℝ (Hex.ZPoly.primitivePart p)).eval x = 0 := by
+        have h2 : (toPolyℝ p).eval x = 0 := h
+        rwa [hpp, eval_mul, eval_C] at h2
+      rcases mul_eq_zero.mp hval with h1 | h1
+      · exact absurd h1 (ne_of_gt (content_real_pos hp0))
+      · exact h1
+  -- Chain the three iffs.
+  show (toPolyℝ (Hex.ZPoly.primitiveSquareFreeDecomposition p).squareFreeCore).IsRoot x ↔
+    (toPolyℝ p).IsRoot x
+  calc (toPolyℝ (Hex.ZPoly.primitiveSquareFreeDecomposition p).squareFreeCore).IsRoot x
+      ↔ (Polynomial.C ((ε : Int) : ℝ) *
+          toPolyℝ (Hex.ZPoly.primitiveSquareFreeDecomposition p).squareFreeCore).IsRoot x := hCe.symm
+    _ ↔ (toPolyℝ (Hex.ZPoly.primitivePart p)).IsRoot x := hgen
+    _ ↔ (toPolyℝ p).IsRoot x := hcontent
+
+end
+
+end HexRealRootsMathlib

--- a/progress/20260720T000357Z-squarefree-core-root-transfer.md
+++ b/progress/20260720T000357Z-squarefree-core-root-transfer.md
@@ -1,0 +1,41 @@
+# Stage 3b: squarefree-core root transfer
+
+## Accomplished
+
+- Proved `HexRealRootsMathlib.aevalIff_squareFreeCore` (SPEC contract in
+  `SPEC/Libraries/hex-real-roots-mathlib.md`): a nonzero integer polynomial
+  and its executable square-free core share exactly the same real roots,
+  through `aeval` at real points. No `sorry`/`axiom`/`native_decide`; the
+  proof cone is `[propext, Classical.choice, Quot.sound]`.
+- New module `HexRealRootsMathlib/SquareFreeCore.lean`, added to the umbrella.
+  Contains:
+  - `isRoot_left_iff_of_mul_of_dvd_derivative` — the field-generic, Hex-free
+    lemma (char-zero field, `q = c * r`, `r ∣ q'` ⇒ `c` and `q` share roots),
+    a clean root-multiplicity argument. Upstreamable to Mathlib as stated.
+  - cast helpers `aeval_eq_eval_toPolyℝ`, `toPolyℝ_mul`,
+    `toPolyℝ_eq_map_toPolyℚ`, and `toPolyℝ_repeatedPart_dvd_derivative`
+    (executable ℚ divisibility → ℝ).
+- Executable support lemmas in `HexPolyZ/Decomposition.lean`:
+  `squareFreeCore_ne_zero`, `squareFreeRat_squareFreeCore`,
+  `toRatPoly_repeatedPart_dvd_derivative` (repeated part is a rational
+  associate of `gcd(prim, prim')`, which divides `prim'`), plus the
+  definitional bridge `squareFreeCore_eq`. Exposed `squareFreeCore` in
+  `HexPolyZ/Core.lean`.
+
+## Current frontier
+
+- `lake build` (full) verification in progress; per-module builds of
+  `HexPolyZ.Decomposition` and `HexRealRootsMathlib.SquareFreeCore` are green.
+
+## Next step
+
+- Stage 3c/elaborator work (`IsolateRoots.lean`, `IsolatedRealRoots`,
+  `isolate_roots` term elaborator) consumes `aevalIff_squareFreeCore` +
+  the two support lemmas via `congrRoots` — separate unit.
+
+## Blockers
+
+- None. Key Mathlib lemmas that did the heavy lifting:
+  `Polynomial.rootMultiplicity_mul`, `derivative_rootMultiplicity_of_root`
+  (CharZero), `rootMultiplicity_le_rootMultiplicity_of_dvd`,
+  `eq_C_of_derivative_eq_zero`.


### PR DESCRIPTION
This PR proves the squarefree-core root-transfer chain the isolate_roots SPEC requires: `aevalIff_squareFreeCore` (a nonzero integer polynomial and its executable `squareFreeCore` share the same real roots through `aeval`), via a Hex-free field-generic lemma `isRoot_left_iff_of_mul_of_dvd_derivative` over `[Field K] [CharZero K]` (given `q = c·r`, `q ≠ 0`, `r ∣ derivative q`, the roots of `c` and `q` agree — a cleaner form than the q/gcd quotient route, matching exactly what the executable signed reassembly provides, and a candidate Mathlib contribution), the executable support lemmas `squareFreeCore_ne_zero`, `squareFreeRat_squareFreeCore`, and `toRatPoly_repeatedPart_dvd_derivative` in the Mathlib-free layer, cast helpers (`toPolyℝ_mul`, `toPolyℝ_eq_map_toPolyℚ`), and `@[expose]` on `squareFreeCore` for the projection bridge. No sorry or axiom; `#print axioms` on all four public results is exactly `[propext, Classical.choice, Quot.sound]`. This closes Gap 2 of the isolate_roots plan and supplies the root-set equality hex-rcf step 3 references.

🤖 Prepared with Claude Code

https://claude.ai/code/session_01SpYSH4swVcLJbN2Bn6NfSP