### PR TITLE
feat(real-roots): expose the Sturm closure and land the chain certificate

### DIFF
--- a/HexRealRoots.lean
+++ b/HexRealRoots.lean
@@ -11,11 +11,13 @@ public import HexRealRoots.Chain
 public import HexRealRoots.Prec
 public import HexRealRoots.Refine
 public import HexRealRoots.Var
+public import HexRealRoots.Cert
 public import HexRealRoots.IsolateSturm
 public import HexRealRoots.Mobius
 public import HexRealRoots.IsolateDescartes
 public import HexRealRoots.Isolate
 public import HexRealRoots.SimpleRealRoot
+public import HexRealRoots.ReplayTest
 
 public section
 

--- a/HexRealRoots/Basic.lean
+++ b/HexRealRoots/Basic.lean
@@ -50,6 +50,7 @@ def DyadicInterval.width (I : DyadicInterval) : Dyadic :=
 A nonzero dyadic is `ofOdd n k` with `n` odd, and its sign is the sign
 of the odd numerator `n` (the power-of-two scale `2^{-k}` is positive),
 so no evaluation is needed. -/
+@[expose]
 def dyadicSign : Dyadic → Int
   | .zero => 0
   | .ofOdd n _ _ => if n < 0 then -1 else 1
@@ -63,6 +64,7 @@ This is exact witness arithmetic: a plain fold over the coefficient
 array with no rounding, so the sign of `p(x)` at a dyadic `x` is exact.
 Coefficients are stored in ascending degree order, so folding from the
 right accumulates `c₀ + x·(c₁ + x·(⋯ + x·cₙ))`. -/
+@[expose]
 def evalDyadic (p : ZPoly) (x : Dyadic) : Dyadic :=
   p.toArray.foldr (fun c acc => Dyadic.ofInt c + x * acc) 0
 

--- a/HexRealRoots/Cert.lean
+++ b/HexRealRoots/Cert.lean
@@ -1,0 +1,263 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRealRoots.Var
+
+public section
+
+/-!
+Executable chain-validity certificate for kernel replay.
+
+The `isolate_roots` term elaborator (companion `HexRealRootsMathlib`) reifies
+the Sturm chain of `p` once as a literal `Array ZPoly`, then discharges every
+per-interval `count_one` and the `complete` field as cheap sign-variation
+`decide`s against that literal chain, rather than rebuilding `sturmChain p`
+inside each field. `SturmChainCert p chain` is the single decidable predicate
+that validates the reified chain: it verifies, by coefficient-level checks that
+kernel-reduce, that `chain` *is* the Sturm chain of `p`. Its soundness bridge
+`cert_imp_eq` proves `chain = sturmChain p` as a proposition (the ban is only on
+*deciding* an `Array ZPoly` equality in the kernel — the core
+`Array.instDecidableEqImpl` module issue — not on proving one), whence the two
+transport lemmas `sturmCount_eq_of_cert` / `rootCount_eq_of_cert` rewrite the
+certified counts onto the literal chain.
+
+`orderedAdjacent` and `ordered_of_adjacent` are the companion upgrade for the
+`RealRootIsolations.ordered` field: an engine emits its isolations sorted, so
+the elaborator checks only the `size − 1` adjacent-pair inequalities (an `O(n)`
+`decide`) and this lemma walks them up to the all-pairs `ordered` shape by
+transitivity.
+
+Everything here is Mathlib-free: coefficient extensionality, structural
+induction over the chain, and the core `Dyadic` order lemmas.
+-/
+namespace Hex
+
+namespace ZPoly
+
+/-- Coefficient-level Boolean equality of two integer polynomials: equal stored
+sizes and equal coefficients at every stored index. Because `ZPoly` is
+normalized (no trailing zeros), this decides genuine equality, and unlike the
+structural `DecidableEq (DensePoly Int)` — which delegates to the core
+`Array.instDecidableEqImpl` and does not kernel-reduce under the module system —
+it is a plain `Bool` fold that reduces. -/
+@[expose]
+def beqCoeffs (a b : ZPoly) : Bool :=
+  a.size == b.size && (List.range a.size).all (fun i => a.coeff i == b.coeff i)
+
+/-- `beqCoeffs` is sound: a `true` result forces genuine polynomial equality. -/
+theorem eq_of_beqCoeffs {a b : ZPoly} (h : beqCoeffs a b = true) : a = b := by
+  unfold beqCoeffs at h
+  rw [Bool.and_eq_true] at h
+  obtain ⟨hsize, hall⟩ := h
+  have hsz : a.size = b.size := eq_of_beq hsize
+  apply DensePoly.ext_coeff
+  intro i
+  by_cases hi : i < a.size
+  · have hi' := (List.all_eq_true.mp hall) i (List.mem_range.mpr hi)
+    exact eq_of_beq hi'
+  · have ha : a.coeff i = 0 := DensePoly.coeff_eq_zero_of_size_le a (Nat.le_of_not_lt hi)
+    have hb : b.coeff i = 0 := DensePoly.coeff_eq_zero_of_size_le b (by omega)
+    rw [ha, hb]
+
+/-- The tail validator for `SturmChainCert`: given the two most recent chain
+elements `prev`, `cur`, check that `rest` continues the Sturm chain exactly as
+`sturmChainAux` builds it. An empty tail requires the next pseudo-remainder to
+vanish (`sturmChainAux`'s stopping condition); a nonempty tail requires the
+pseudo-remainder nonzero, its next element `= −primitivePart (spem prev cur)`,
+and the rest to continue from `cur`, `next`. Mirrors `sturmChainAux`'s branch
+structure so `certTail_sound` is a direct induction. -/
+@[expose]
+def certTail : ZPoly → ZPoly → List ZPoly → Bool
+  | prev, cur, [] => (spem prev cur).isZero
+  | prev, cur, next :: rest =>
+      !(spem prev cur).isZero &&
+        beqCoeffs next (-(primitivePart (spem prev cur))) &&
+          certTail cur next rest
+
+/-- The tail validator reconstructs `sturmChainAux` exactly: if `certTail prev
+cur rest` holds and there is enough fuel, then running `sturmChainAux` from
+`prev`, `cur` with accumulator `acc` yields `acc` followed by `rest`. Induction
+on `rest`. -/
+theorem certTail_sound :
+    ∀ (fuel : Nat) (prev cur : ZPoly) (rest : List ZPoly) (acc : Array ZPoly),
+      certTail prev cur rest = true → rest.length < fuel →
+      (sturmChainAux fuel prev cur acc).toList = acc.toList ++ rest := by
+  intro fuel prev cur rest
+  induction rest generalizing fuel prev cur with
+  | nil =>
+    intro acc h hfuel
+    obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
+    simp only [certTail] at h
+    simp only [sturmChainAux, h, if_true, List.append_nil]
+  | cons next rest ih =>
+    intro acc h hfuel
+    rw [List.length_cons] at hfuel
+    obtain ⟨f, rfl⟩ : ∃ f, fuel = f + 1 := ⟨fuel - 1, by omega⟩
+    simp only [certTail, Bool.and_eq_true, Bool.not_eq_true'] at h
+    obtain ⟨⟨hnz, hbeq⟩, htail⟩ := h
+    have hnext : next = -(primitivePart (spem prev cur)) := eq_of_beqCoeffs hbeq
+    have hnz2 : ¬ ((spem prev cur).isZero = true) := by rw [hnz]; exact Bool.false_ne_true
+    have hstep := ih f cur next (acc.push next) htail (by omega)
+    simp only [sturmChainAux]
+    rw [if_neg hnz2, ← hnext, hstep]
+    simp [Array.toList_push]
+
+/-- A decidable executable certificate that `chain` is the Sturm chain of `p`,
+by coefficient-level checks that kernel-reduce.
+
+`chain` must have at least two elements, `p` must have positive degree
+(`2 ≤ p.size`) and `chain` must be no longer than `p.size` (a fuel bound that
+every genuine chain satisfies, since chain degrees strictly decrease). The head
+must be `primitivePart p`, the second `primitivePart p'`, each further element
+`−primitivePart (spem …)` of its two predecessors, and the chain must terminate
+with a vanishing pseudo-remainder — exactly `sturmChain`'s construction. All
+element comparisons go through `beqCoeffs`, never structural `Array` equality. -/
+@[expose]
+def sturmChainCertB (p : ZPoly) (chain : Array ZPoly) : Bool :=
+  match chain.toList with
+  | s₀ :: s₁ :: rest =>
+      decide (2 ≤ p.size) && decide (chain.size ≤ p.size) &&
+        beqCoeffs s₀ (primitivePart p) &&
+          beqCoeffs s₁ (primitivePart (DensePoly.derivative p)) &&
+            certTail s₀ s₁ rest
+  | _ => false
+
+end ZPoly
+
+/-- Chain-validity certificate: `chain` is the Sturm chain of `p`. A decidable
+`Prop` (the `Bool`-check `= true` pattern) verified by coefficient-level checks
+that kernel-reduce. -/
+@[expose]
+def SturmChainCert (p : ZPoly) (chain : Array ZPoly) : Prop :=
+  ZPoly.sturmChainCertB p chain = true
+
+instance (p : ZPoly) (chain : Array ZPoly) : Decidable (SturmChainCert p chain) :=
+  inferInstanceAs (Decidable (_ = true))
+
+namespace ZPoly
+
+/-- **Certificate soundness.** A valid `SturmChainCert p chain` identifies
+`chain` with `sturmChain p` as a proposition. Proving (not deciding) this
+equality sidesteps the kernel `Array.instDecidableEqImpl` block. -/
+theorem cert_imp_eq {p : ZPoly} {chain : Array ZPoly}
+    (h : SturmChainCert p chain) : chain = sturmChain p := by
+  unfold SturmChainCert sturmChainCertB at h
+  -- `chain` has at least two elements, else the match returns `false`.
+  obtain ⟨s₀, s₁, rest, hl⟩ :
+      ∃ s₀ s₁ rest, chain.toList = s₀ :: s₁ :: rest := by
+    match hm : chain.toList with
+    | [] => rw [hm] at h; simp at h
+    | [_] => rw [hm] at h; simp at h
+    | a :: b :: r => exact ⟨a, b, r, rfl⟩
+  rw [hl] at h
+  simp only [Bool.and_eq_true, decide_eq_true_eq] at h
+  obtain ⟨⟨⟨⟨hsize2, hsizele⟩, hb0⟩, hb1⟩, htail⟩ := h
+  have hs0 : s₀ = primitivePart p := eq_of_beqCoeffs hb0
+  have hs1 : s₁ = primitivePart (DensePoly.derivative p) := eq_of_beqCoeffs hb1
+  -- `chain.size = rest.length + 2`, and the fuel bound gives `rest.length < p.size`.
+  have hlen : chain.size = rest.length + 2 := by
+    have := congrArg List.length hl
+    rw [Array.length_toList] at this
+    simp at this
+    omega
+  have hfuel : rest.length < p.size := by omega
+  -- Positive degree makes `sturmChain p` unfold to the `sturmChainAux` form.
+  have hne : p.size ≠ 0 := by omega
+  have hdeg : p.degree? = some (p.size - 1) := by
+    unfold DensePoly.degree?
+    rw [dif_neg hne]
+  obtain ⟨m, hm2⟩ : ∃ m, p.size - 1 = m + 1 := ⟨p.size - 2, by omega⟩
+  have hchain_eq : sturmChain p =
+      sturmChainAux p.size (primitivePart p) (primitivePart (DensePoly.derivative p))
+        #[primitivePart p, primitivePart (DensePoly.derivative p)] := by
+    unfold sturmChain
+    rw [hdeg, hm2]
+    rfl
+  rw [hchain_eq]
+  -- Compare via `toList`.
+  apply Array.ext'
+  rw [certTail_sound p.size (primitivePart p) (primitivePart (DensePoly.derivative p)) rest
+        #[primitivePart p, primitivePart (DensePoly.derivative p)]
+        (by rw [← hs0, ← hs1]; exact htail) hfuel]
+  rw [hl, hs0, hs1]
+  simp
+
+/-- **Count transport.** Under a valid certificate, the Sturm count of `p` on
+any interval is the sign-variation gap of the *literal* certified chain at the
+two endpoints — the shape the elaborator `decide`s per emitted root. -/
+theorem sturmCount_eq_of_cert {p : ZPoly} {chain : Array ZPoly}
+    (h : SturmChainCert p chain) (I : DyadicInterval) :
+    sturmCount p I = (sturmVarAt chain I.lower : Int) - sturmVarAt chain I.upper := by
+  unfold sturmCount
+  rw [← cert_imp_eq h]
+
+/-- **Root-count transport.** Under a valid certificate, the total root count of
+`p` is the `−∞/+∞` sign-variation gap of the literal certified chain — the shape
+the elaborator `decide`s for the `complete` field. -/
+theorem rootCount_eq_of_cert {p : ZPoly} {chain : Array ZPoly}
+    (h : SturmChainCert p chain) :
+    rootCount p = sturmVarNegInf chain - sturmVarPosInf chain := by
+  unfold rootCount
+  rw [← cert_imp_eq h]
+
+end ZPoly
+
+/-- `Dyadic` version of `le_of_lt`, from `le_total` and the core `not_le`. -/
+private theorem dyadic_le_of_lt {a b : Dyadic} (h : a < b) : a ≤ b := by
+  rcases Dyadic.le_total a b with h1 | h1
+  · exact h1
+  · exact absurd h (Dyadic.not_le.mpr h1)
+
+/-- An `O(n)` adjacent-pair order check on an emitted isolation array: every
+consecutive pair has `upperᵢ ≤ lowerᵢ₊₁`. The elaborator `decide`s this in place
+of the quadratic `RealRootIsolations.ordered`, which `ordered_of_adjacent`
+recovers by transitivity. -/
+@[expose]
+def orderedAdjacent {p : ZPoly} (arr : Array (RealRootIsolation p)) : Bool :=
+  (List.range (arr.size - 1)).all (fun i =>
+    if h : i + 1 < arr.size then
+      decide ((arr[i]'(by omega)).interval.upper ≤ (arr[i + 1]'h).interval.lower)
+    else true)
+
+/-- Each adjacent inequality certified by `orderedAdjacent`. -/
+theorem adjacent_step {p : ZPoly} {arr : Array (RealRootIsolation p)}
+    (h : orderedAdjacent arr = true) (i : Nat) (hi : i + 1 < arr.size) :
+    (arr[i]'(by omega)).interval.upper ≤ (arr[i + 1]'hi).interval.lower := by
+  have hmem : i ∈ List.range (arr.size - 1) := List.mem_range.mpr (by omega)
+  have hstep := (List.all_eq_true.mp h) i hmem
+  simp only [hi, dif_pos] at hstep
+  exact of_decide_eq_true hstep
+
+/-- The transitivity walk: `orderedAdjacent` (adjacent pairs) upgrades to the
+all-pairs `RealRootIsolations.ordered` shape, using each interval's own
+`lower < upper` to bridge consecutive gaps. -/
+theorem ordered_of_adjacent {p : ZPoly} {arr : Array (RealRootIsolation p)}
+    (h : orderedAdjacent arr = true) :
+    ∀ i j : Fin arr.size, i < j →
+      arr[i].interval.upper ≤ arr[j].interval.lower := by
+  have aux : ∀ (j : Nat) (hj : j < arr.size) (i : Nat) (_hij : i < j),
+      (arr[i]'(by omega)).interval.upper ≤ (arr[j]'hj).interval.lower := by
+    intro j
+    induction j with
+    | zero => intro _ i hij; omega
+    | succ j ih =>
+      intro hj i hij
+      rcases Nat.lt_or_ge i j with hlt | hge
+      · have hjlt : j < arr.size := by omega
+        have step1 := ih hjlt i hlt
+        have step2 : (arr[j]'hjlt).interval.lower ≤ (arr[j]'hjlt).interval.upper :=
+          dyadic_le_of_lt (arr[j]'hjlt).interval.lt
+        have step3 := adjacent_step h j (by omega)
+        exact Dyadic.le_trans step1 (Dyadic.le_trans step2 step3)
+      · have hij' : i = j := by omega
+        subst hij'
+        exact adjacent_step h i (by omega)
+  intro i j hij
+  exact aux j.val j.isLt i.val hij
+
+end Hex

--- a/HexRealRoots/Chain.lean
+++ b/HexRealRoots/Chain.lean
@@ -43,8 +43,13 @@ Writing `cg = lc g`, `lr = lc r`, `|cg| = if cg < 0 then -cg else cg`, and
 The two leading terms are both at degree `deg r`, with coefficients
 `|cg|·lr` and `sign(cg)·lr·cg = |cg|·lr`, so they cancel exactly and the
 degree strictly drops. The multiplier introduced is `|cg| > 0`, so
-iterating multiplies the true rational remainder by a positive integer. -/
-private def spemStep (g r : ZPoly) : ZPoly :=
+iterating multiplies the true rational remainder by a positive integer.
+
+Engine internal, not user API: it is public (rather than `private`) only so
+the exposed `spem`/`sturmChain` closure the kernel-replay elaborator reduces
+can reference it. Callers want `spem`. -/
+@[expose]
+def spemStep (g r : ZPoly) : ZPoly :=
   let cg := DensePoly.leadingCoeff g
   let lr := DensePoly.leadingCoeff r
   let absCg := if cg < 0 then -cg else cg
@@ -59,8 +64,13 @@ otherwise it applies `spemStep` and recurses on one less fuel. Because every
 `spemStep` drops the degree by at least one, `fuel = f.size = deg f + 1` at
 the top level is always sufficient and the fuel never truncates: the loop
 reaches a genuine stopping state (zero, or degree below `deg g`) before it
-runs out. -/
-private def spemAux (g : ZPoly) : Nat → ZPoly → ZPoly
+runs out.
+
+Engine internal, not user API: public only so the exposed `spem`/`sturmChain`
+closure the kernel-replay elaborator reduces can reference it. Callers want
+`spem`. -/
+@[expose]
+def spemAux (g : ZPoly) : Nat → ZPoly → ZPoly
   | 0, r => r
   | fuel + 1, r =>
       if r.isZero then r
@@ -85,6 +95,7 @@ Junk values, per the SPEC's input-contract convention:
   everything, so the remainder is `0`).
 - `spem f g = f` when `deg f < deg g` (the loop returns `f` on its first
   test). -/
+@[expose]
 def spem (f g : ZPoly) : ZPoly :=
   match DensePoly.degree? g with
   | none => f
@@ -98,8 +109,13 @@ it computes `r := spem prev cur`; if `r = 0` the chain is complete, otherwise
 it pushes `next := −primitivePart r` and recurses. `primitivePart` divides by
 the nonnegative content without sign-normalizing, so the explicit negation
 carries exactly the SPEC's sign. The degree of `cur` strictly decreases along
-the recursion, so `fuel = p.size` at the top level never truncates. -/
-private def sturmChainAux : Nat → ZPoly → ZPoly → Array ZPoly → Array ZPoly
+the recursion, so `fuel = p.size` at the top level never truncates.
+
+Engine internal, not user API: public only so the exposed `sturmChain` closure
+the kernel-replay elaborator reduces can reference it. Callers want
+`sturmChain`. -/
+@[expose]
+def sturmChainAux : Nat → ZPoly → ZPoly → Array ZPoly → Array ZPoly
   | 0, _, _, acc => acc
   | fuel + 1, prev, cur, acc =>
       let r := spem prev cur
@@ -118,6 +134,7 @@ chain of `(p, p')` over `ℚ`, the invariant the counting theorem needs. The
 last element is a nonzero constant exactly when `p` is squarefree of positive
 degree. The structural fuel `p.size` never truncates: the degree strictly
 decreases along the chain, so it terminates before the fuel is exhausted. -/
+@[expose]
 def sturmChain (p : ZPoly) : Array ZPoly :=
   match DensePoly.degree? p with
   | none => #[]

--- a/HexRealRoots/Refine.lean
+++ b/HexRealRoots/Refine.lean
@@ -69,21 +69,48 @@ so no endpoint comparison against `m` is ever needed.
 
 If neither half certifies — impossible for squarefree `p`, proven unreachable
 by the companion `refine1_isolates_same` — the input is returned unchanged, so
-the function is total. `refine1` takes no cached chain (its SPEC signature is
-fixed), so the chain is rebuilt per call; a cached-chain variant can follow if
-profiling demands it. -/
-def refine1 (iso : RealRootIsolation p) : RealRootIsolation p :=
-  let chain := ZPoly.sturmChain p
+the function is total.
+
+The bisection logic is factored into `refine1With`, which takes an already-built
+`chain`; `refine1` supplies `ZPoly.sturmChain p` (rebuilt per call, matching its
+fixed SPEC signature), while callers refining many levels thread one chain
+through `refineToWithChain`. -/
+def refine1With (chain : Array ZPoly) (hchain : chain = ZPoly.sturmChain p)
+    (iso : RealRootIsolation p) : RealRootIsolation p :=
   let m := iso.interval.midpoint
   if hlt : iso.interval.lower < m then
     if h : (sturmVarAt chain iso.interval.lower : Int) - sturmVarAt chain m = 1 then
-      ofHalf chain rfl iso.interval.lower m hlt h
+      ofHalf chain hchain iso.interval.lower m hlt h
     else if hltu : m < iso.interval.upper then
       if h' : (sturmVarAt chain m : Int) - sturmVarAt chain iso.interval.upper = 1 then
-        ofHalf chain rfl m iso.interval.upper hltu h'
+        ofHalf chain hchain m iso.interval.upper hltu h'
       else iso
     else iso
   else iso
+
+/-- Bisect an isolation at its dyadic midpoint and keep the half whose Sturm
+count is `1`. See `refine1With` for the mechanism; this rebuilds the Sturm chain
+each call. -/
+def refine1 (iso : RealRootIsolation p) : RealRootIsolation p :=
+  refine1With (ZPoly.sturmChain p) rfl iso
+
+/-- Cached-chain refinement: iterate `refine1With` against one precomputed
+`chain` until the interval width is at most `2^{−target}`.
+
+Identical semantics to `refineTo`, but the Sturm chain is built once for the
+whole descent rather than rebuilt at every bisection level — the memoisation the
+`isolate_roots` elaborator needs when refining every root to a requested width.
+The fuel is `(ceilLog2Dyadic width + target).toNat + 1`, exactly as `refineTo`. -/
+def refineToWithChain (chain : Array ZPoly) (hchain : chain = ZPoly.sturmChain p)
+    (iso : RealRootIsolation p) (target : Int) : RealRootIsolation p :=
+  go ((ceilLog2Dyadic iso.interval.width + target).toNat + 1) iso
+where
+  /-- Structural fuel drives the loop, threading the cached `chain`. -/
+  go : Nat → RealRootIsolation p → RealRootIsolation p
+    | 0, iso => iso
+    | k + 1, iso =>
+      if iso.interval.width ≤ twoPow (-target) then iso
+      else go k (refine1With chain hchain iso)
 
 /-- Iterate `refine1` until the interval width is at most `2^{−target}`.
 
@@ -94,17 +121,12 @@ width, `ceilLog2Dyadic width + target` halvings bring the width to at most
 nonpositive gap) to `0`, and the `+ 1` covers the loop's own width test. On
 adversarial data that violates the isolation semantics `refine1` returns its
 input, and the loop then drains its fuel without shrinking — total either
-way, it cannot loop. -/
+way, it cannot loop.
+
+Delegates to `refineToWithChain` with `chain = ZPoly.sturmChain p`, so the whole
+descent shares one chain construction. -/
 def refineTo (iso : RealRootIsolation p) (target : Int) : RealRootIsolation p :=
-  go ((ceilLog2Dyadic iso.interval.width + target).toNat + 1) iso
-where
-  /-- Structural fuel drives the loop: stop at fuel `0` or once the width
-  condition holds, else refine once and recurse. -/
-  go : Nat → RealRootIsolation p → RealRootIsolation p
-    | 0, iso => iso
-    | k + 1, iso =>
-      if iso.interval.width ≤ twoPow (-target) then iso
-      else go k (refine1 iso)
+  refineToWithChain (ZPoly.sturmChain p) rfl iso target
 
 /-! Sanity checks (kept light; conformance lives in the shared sub-project).
 Polynomials are kept tiny so kernel reduction of `refine1`/`refineTo` is
@@ -168,5 +190,25 @@ example : dyadicSign (ZPoly.evalDyadic (DensePoly.ofCoeffs #[(-2 : Int), 0, 1])
 example : (refineTo (p := DensePoly.ofCoeffs #[(-2 : Int), 0, 1])
     ⟨⟨Dyadic.ofInt 1, Dyadic.ofInt 2, by decide⟩, by decide⟩ (-2)).interval.width
     ≤ twoPow 2 := by decide
+
+-- Cached-chain refinement agrees with `refineTo`: threading one precomputed
+-- Sturm chain through the loop yields the identical interval on `x² − 2`
+-- (`refineTo` delegates to `refineToWithChain`, so this locks their agreement).
+-- A `#guard`-style regression, written as a `decide` to stay in the kernel
+-- (a `#guard` would force meta evaluation of the polynomial constructors).
+example :
+    (refineToWithChain (p := DensePoly.ofCoeffs #[(-2 : Int), 0, 1])
+      (ZPoly.sturmChain (DensePoly.ofCoeffs #[(-2 : Int), 0, 1])) rfl
+      ⟨⟨Dyadic.ofInt 1, Dyadic.ofInt 2, by decide⟩, by decide⟩ 3).interval.upper
+    = (refineTo (p := DensePoly.ofCoeffs #[(-2 : Int), 0, 1])
+      ⟨⟨Dyadic.ofInt 1, Dyadic.ofInt 2, by decide⟩, by decide⟩ 3).interval.upper := by
+  decide
+example :
+    (refineToWithChain (p := DensePoly.ofCoeffs #[(-2 : Int), 0, 1])
+      (ZPoly.sturmChain (DensePoly.ofCoeffs #[(-2 : Int), 0, 1])) rfl
+      ⟨⟨Dyadic.ofInt 1, Dyadic.ofInt 2, by decide⟩, by decide⟩ 3).interval.lower
+    = (refineTo (p := DensePoly.ofCoeffs #[(-2 : Int), 0, 1])
+      ⟨⟨Dyadic.ofInt 1, Dyadic.ofInt 2, by decide⟩, by decide⟩ 3).interval.lower := by
+  decide
 
 end Hex.RealRootIsolation

--- a/HexRealRoots/ReplayTest.lean
+++ b/HexRealRoots/ReplayTest.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+-- PLAIN `public import` only: NO `import all`. This module is the regression
+-- lock for the `@[expose]` kernel-replay closure. Every `decide` below must
+-- reduce in the kernel through the exposed bodies of `sturmChain`, `sturmCount`,
+-- `rootCount`, `hasSquarefreeSturmChain`, `SturmChainCert`, and `orderedAdjacent`
+-- alone. If a future edit drops an `@[expose]` (or reintroduces a `private` in
+-- the closure), one of these `decide`s stops reducing and this module fails —
+-- surfacing the regression that a downstream `module` consumer would hit.
+public import HexRealRoots.Cert
+
+/-!
+Regression lock for the kernel-replay exposure.
+
+The `isolate_roots` term elaborator in `HexRealRootsMathlib` reifies a Sturm
+chain as a literal and discharges its certificates by `decide` against the
+exposed closure, with a plain `import` (no `import all`). This module reproduces
+that reduction discipline on small literal data, so the exposure cannot silently
+regress.
+-/
+namespace Hex.ReplayTest
+
+/-- The squarefree Sturm certificate reduces through the exposed closure. -/
+example : ZPoly.hasSquarefreeSturmChain (DensePoly.ofCoeffs #[(-1 : Int), 0, 1]) := by
+  decide
+
+/-- A `sturmCount` value: `x² − 1` has one root in `(0, 2]` (the root at `1`).
+Reduces without `import all`, unlike the same check stated in `Var.lean`. -/
+example : sturmCount (DensePoly.ofCoeffs #[(-1 : Int), 0, 1])
+    (DyadicInterval.mk (Dyadic.ofInt 0) (Dyadic.ofInt 2) (by decide)) = 1 := by
+  decide
+
+/-- A `rootCount` value: `x² − 1` has two real roots. -/
+example : rootCount (DensePoly.ofCoeffs #[(-1 : Int), 0, 1]) = 2 := by
+  decide
+
+/-- A `SturmChainCert` instance: the literal chain `[x² − 1, x, 1]` is certified
+as *the* Sturm chain of `x² − 1`, by coefficient-level checks that kernel-reduce
+(no structural `Array` equality). -/
+example : SturmChainCert (DensePoly.ofCoeffs #[(-1 : Int), 0, 1])
+    #[DensePoly.ofCoeffs #[(-1 : Int), 0, 1],
+      DensePoly.ofCoeffs #[(0 : Int), 1],
+      DensePoly.ofCoeffs #[(1 : Int)]] := by
+  decide
+
+/-- An `orderedAdjacent` check on literal isolation data: the two isolations of
+`x² − 1`, `(−2, 0]` and `(0, 2]`, are adjacent-ordered (`0 ≤ 0`). The `count_one`
+witnesses also reduce through the exposed `sturmCount`. -/
+example : orderedAdjacent (p := DensePoly.ofCoeffs #[(-1 : Int), 0, 1])
+    #[⟨DyadicInterval.mk (Dyadic.ofInt (-2)) (Dyadic.ofInt 0) (by decide), by decide⟩,
+      ⟨DyadicInterval.mk (Dyadic.ofInt 0) (Dyadic.ofInt 2) (by decide), by decide⟩] = true := by
+  decide
+
+end Hex.ReplayTest

--- a/HexRealRoots/Var.lean
+++ b/HexRealRoots/Var.lean
@@ -48,6 +48,7 @@ product is negative). The variation count of `(+, 0, −)` is `1`: the zero is
 skipped, leaving one sign change. This is the plain-`List Int` primitive
 shared by the Sturm counts below and the Descartes count in the Mobius
 layer. -/
+@[expose]
 def signVar (l : List Int) : Nat :=
   go (l.filter (· != 0))
 where
@@ -63,6 +64,7 @@ Every chain element is evaluated at `x` by exact Horner arithmetic
 (`evalDyadic`), reduced to its exact sign in `{−1, 0, 1}` (`dyadicSign`), and
 the resulting sign list is fed to `signVar`. No rounding and no error budget:
 the sign of `q(x)` at a dyadic `x` is exact. -/
+@[expose]
 def sturmVarAt (chain : Array ZPoly) (x : Dyadic) : Nat :=
   signVar (chain.toList.map (fun q => dyadicSign (q.evalDyadic x)))
 
@@ -72,6 +74,7 @@ At `+∞` the sign of each element is the sign of its leading coefficient, so
 no evaluation is needed. The zero polynomial has leading coefficient `0`,
 which the zero-skipping convention drops (it never occurs in a genuine chain
 element, but the total function tolerates it). -/
+@[expose]
 def sturmVarPosInf (chain : Array ZPoly) : Nat :=
   signVar (chain.toList.map (fun q => (DensePoly.leadingCoeff q).sign))
 
@@ -81,6 +84,7 @@ At `−∞` the sign of each element is the sign of its leading coefficient time
 `(−1)^{deg}`: the leading term dominates, and its sign flips with the parity
 of the degree. No evaluation is needed. The zero polynomial has leading
 coefficient `0`, dropped by the zero-skipping convention. -/
+@[expose]
 def sturmVarNegInf (chain : Array ZPoly) : Nat :=
   signVar (chain.toList.map (fun q =>
     (DensePoly.leadingCoeff q).sign *
@@ -91,12 +95,14 @@ def sturmVarNegInf (chain : Array ZPoly) : Nat :=
 difference between the two endpoints. An `Int` by definition. The companion
 proves it equals the root count in the interval (in particular, that it is
 nonnegative) for squarefree `p`. -/
+@[expose]
 def sturmCount (p : ZPoly) (I : DyadicInterval) : Int :=
   (sturmVarAt (ZPoly.sturmChain p) I.lower : Int) -
     sturmVarAt (ZPoly.sturmChain p) I.upper
 
 /-- The total number of real roots of `p`: the sign-variation difference of
 its Sturm chain between `−∞` and `+∞`. -/
+@[expose]
 def rootCount (p : ZPoly) : Nat :=
   sturmVarNegInf (ZPoly.sturmChain p) - sturmVarPosInf (ZPoly.sturmChain p)
 

--- a/HexRealRootsMathlib/Drivers.lean
+++ b/HexRealRootsMathlib/Drivers.lean
@@ -226,7 +226,7 @@ theorem refine1_isolates_same (hp : Hex.ZPoly.SquareFreeRat p)
         - Hex.sturmVarAt (Hex.ZPoly.sturmChain p) iso.interval.midpoint) = 1 := hCL
     have href : iso.refine1.interval = (⟨lo, m, hlm⟩ : Hex.DyadicInterval) := by
       show (Hex.RealRootIsolation.refine1 iso).interval = _
-      unfold Hex.RealRootIsolation.refine1
+      unfold Hex.RealRootIsolation.refine1 Hex.RealRootIsolation.refine1With
       rw [dif_pos hlm, dif_pos hCLraw]
       rfl
     have hCR : Hex.sturmCount p ⟨m, hi, hmh⟩ = 0 := by omega
@@ -249,7 +249,7 @@ theorem refine1_isolates_same (hp : Hex.ZPoly.SquareFreeRat p)
         - Hex.sturmVarAt (Hex.ZPoly.sturmChain p) iso.interval.upper) = 1 := hCR
     have href : iso.refine1.interval = (⟨m, hi, hmh⟩ : Hex.DyadicInterval) := by
       show (Hex.RealRootIsolation.refine1 iso).interval = _
-      unfold Hex.RealRootIsolation.refine1
+      unfold Hex.RealRootIsolation.refine1 Hex.RealRootIsolation.refine1With
       rw [dif_pos hlm, dif_neg hCLraw_neg, dif_pos hmh, dif_pos hCRraw]
       rfl
     refine ⟨fun r hr => ?_, ?_⟩

--- a/progress/20260720T001212Z-hexrealroots-replay-exposure.md
+++ b/progress/20260720T001212Z-hexrealroots-replay-exposure.md
@@ -1,0 +1,46 @@
+# Stage 3a: HexRealRoots kernel-replay enablement
+
+## Accomplished
+
+- **`@[expose]` pass** on the thirteen kernel-replay definitions across
+  `HexRealRoots/{Basic,Chain,Var}.lean` (`dyadicSign`, `evalDyadic`,
+  `spemStep`, `spemAux`, `spem`, `sturmChainAux`, `sturmChain`, `signVar`,
+  `sturmVarAt`, `sturmVarPosInf`, `sturmVarNegInf`, `sturmCount`, `rootCount`),
+  de-privatizing `spemStep`/`spemAux`/`sturmChainAux` with engine-internal
+  docstring notes.
+- **`HexRealRoots/Cert.lean`** (new): `beqCoeffs` + `eq_of_beqCoeffs`,
+  `certTail` + `certTail_sound`, `sturmChainCertB` / `SturmChainCert` +
+  `Decidable` instance, the soundness bridge `cert_imp_eq`
+  (`SturmChainCert p chain → chain = sturmChain p`, proved not decided), and the
+  transport lemmas `sturmCount_eq_of_cert` / `rootCount_eq_of_cert`. Also
+  `orderedAdjacent` + `ordered_of_adjacent` (transitivity walk to the all-pairs
+  `RealRootIsolations.ordered` shape). Mathlib-free.
+- **Cached-chain refinement** in `HexRealRoots/Refine.lean`: `refine1With`,
+  `refineToWithChain`; `refine1`/`refineTo` now delegate (one chain build for a
+  whole `refineTo` descent). `decide` regression showing agreement with
+  `refineTo`.
+- **`HexRealRoots/ReplayTest.lean`** (new, plain `public import`, NO `import
+  all`): five `decide`s locking the exposure (`hasSquarefreeSturmChain`,
+  `sturmCount`, `rootCount`, `SturmChainCert`, `orderedAdjacent`).
+- Companion touch: `HexRealRootsMathlib/Drivers.lean`'s `refine1_isolates_same`
+  now `unfold`s `refine1With` too (refine1 delegates).
+
+## Current frontier
+
+`lake build HexRealRoots` and `lake build HexRealRootsMathlib` (8765 jobs) both
+green; ReplayTest decides reduce in the kernel without `import all` (~12ms total
+elaboration). No `sorry`/`axiom`/`native_decide`/`partial`.
+
+## Next step
+
+Stage 3b: the `isolate_roots` term elaborator in
+`HexRealRootsMathlib/IsolateRoots.lean`, consuming `SturmChainCert` +
+`sturmCount_eq_of_cert` / `rootCount_eq_of_cert` + `ordered_of_adjacent` for the
+replay-shape emission.
+
+## Blockers
+
+None on the Lean side. The full `lake build` reports native dynlib failures
+(`HexBasic:shared`, `HexGF2.Basic:dynlib`) from a broken elan/nix linker wrapper
+in this environment (`ld-wrapper.sh: No such file or directory`) — environmental,
+unrelated to these Lean-only changes.


### PR DESCRIPTION
This PR enables kernel replay of Sturm certificates in HexRealRoots by exposing the thirteen-definition count-check closure and landing the chain-validity certificate the `isolate_roots` term elaborator will replay. It `@[expose]`s `dyadicSign`, `evalDyadic`, `spemStep`, `spemAux`, `spem`, `sturmChainAux`, `sturmChain`, `signVar`, `sturmVarAt`, `sturmVarPosInf`, `sturmVarNegInf`, `sturmCount`, and `rootCount` (de-privatizing the three helpers with engine-internal docstrings), so a downstream `module` consumer's `decide` over emitted certificates reduces without `import all`. It adds a new `HexRealRoots/Cert.lean` with the decidable `SturmChainCert p chain` predicate — coefficient-level checks (`beqCoeffs`, `certTail`) that kernel-reduce and verify `chain` is the Sturm chain of `p` — its soundness bridge `cert_imp_eq` proving `chain = sturmChain p` propositionally (not by deciding an `Array` equality), and the transport lemmas `sturmCount_eq_of_cert` / `rootCount_eq_of_cert` that rewrite the certified counts onto the literal chain; the whole certificate layer is Mathlib-free. It threads one precomputed chain through the refinement loop via `refine1With` / `refineToWithChain` (to which `refine1` and `refineTo` now delegate, one chain build per descent), upgrades adjacent-pair ordering to the all-pairs `RealRootIsolations.ordered` shape with `orderedAdjacent` / `ordered_of_adjacent`, and locks the exposure with a plain-`public import` regression module `HexRealRoots/ReplayTest.lean` whose five `decide`s (squarefree certificate, `sturmCount`, `rootCount`, `SturmChainCert`, `orderedAdjacent`) reduce in the kernel without `import all`. The companion's `refine1_isolates_same` is adjusted to unfold `refine1With`; `HexRealRootsMathlib` (including `ChainCorrespond` and `Drivers`) stays green.

🤖 Prepared with Claude Code