### PR TITLE
Share the Mahler separation assembly

### DIFF
--- a/HexPolyZMathlib/MahlerSeparation.lean
+++ b/HexPolyZMathlib/MahlerSeparation.lean
@@ -260,6 +260,168 @@ theorem norm_discr_eq {N : ℕ} (α : Fin N → ℂ) (hα : Function.Injective �
   simp only [norm_mul, norm_pow, norm_neg, norm_one, one_pow, one_mul]
   rw [hroots, norm_prod_roots_eq_sq α hα]
 
+/-- The exponent-independent assembly of Mahler's root-separation argument.
+For two distinct roots of a separable integral polynomial, the product of
+their distance with the Hadamard degree factor and the appropriate power of
+the Mahler measure is at least one. Executable precision specializations need
+only bound the final two factors. -/
+theorem one_le_mahlerDist (p : ℤ[X])
+    (hsep : (p.map (Int.castRingHom ℚ)).Separable) {z₁ z₂ : ℂ}
+    (hr₁ : (p.map (Int.castRingHom ℂ)).IsRoot z₁)
+    (hr₂ : (p.map (Int.castRingHom ℂ)).IsRoot z₂) (hne : z₁ ≠ z₂) :
+    (1 : ℝ) ≤ Real.sqrt p.natDegree ^ (p.natDegree + 2) *
+      (p.map (Int.castRingHom ℂ)).mahlerMeasure ^ (p.natDegree - 1) *
+        ‖z₁ - z₂‖ := by
+  classical
+  let f := p.map (Int.castRingHom ℂ)
+  suffices key : ∀ w₁ w₂ : ℂ, f.IsRoot w₁ → f.IsRoot w₂ → w₁ ≠ w₂ →
+      ‖w₁‖ ≤ ‖w₂‖ →
+      (1 : ℝ) ≤ Real.sqrt p.natDegree ^ (p.natDegree + 2) *
+        f.mahlerMeasure ^ (p.natDegree - 1) * ‖w₁ - w₂‖ by
+    rcases le_total ‖z₁‖ ‖z₂‖ with h | h
+    · exact key z₁ z₂ hr₁ hr₂ hne h
+    · simpa only [f, norm_sub_rev] using
+        key z₂ z₁ hr₂ hr₁ hne.symm h
+  intro w₁ w₂ hw₁ hw₂ hwne hnorm
+  have hp0 : p ≠ 0 := fun h => hsep.ne_zero (by rw [h, Polynomial.map_zero])
+  have hf0 : f ≠ 0 := by
+    dsimp only [f]
+    rw [ne_eq, Polynomial.map_eq_zero_iff (RingHom.injective_int _)]
+    exact hp0
+  have hsplit : f.Splits := IsAlgClosed.splits f
+  have hcomp : (algebraMap ℚ ℂ).comp (Int.castRingHom ℚ) =
+      Int.castRingHom ℂ := RingHom.ext_int _ _
+  have hsepℂ : f.Separable := by
+    have hff : f = (p.map (Int.castRingHom ℚ)).map (algebraMap ℚ ℂ) := by
+      dsimp only [f]
+      rw [Polynomial.map_map, hcomp]
+    rw [hff]
+    exact hsep.map
+  have hnd : f.roots.Nodup := nodup_roots hsepℂ
+  let roots := f.roots.toList
+  have hrootsNodup : roots.Nodup := Multiset.coe_nodup.mp (by
+    dsimp only [roots]
+    rw [Multiset.coe_toList]
+    exact hnd)
+  let α : Fin roots.length → ℂ := roots.get
+  have hαinj : Function.Injective α :=
+    List.nodup_iff_injective_get.mp hrootsNodup
+  have hroots : Multiset.map α univ.val = f.roots := by
+    rw [Fin.univ_val_map]
+    dsimp only [α]
+    rw [List.ofFn_get]
+    dsimp only [roots]
+    rw [Multiset.coe_toList]
+  have hw₁List : w₁ ∈ roots := by
+    dsimp only [roots]
+    rw [← Multiset.mem_coe, Multiset.coe_toList]
+    exact (mem_roots hf0).mpr hw₁
+  have hw₂List : w₂ ∈ roots := by
+    dsimp only [roots]
+    rw [← Multiset.mem_coe, Multiset.coe_toList]
+    exact (mem_roots hf0).mpr hw₂
+  obtain ⟨i₀, hi₀⟩ := List.mem_iff_get.mp hw₁List
+  obtain ⟨i₁, hi₁⟩ := List.mem_iff_get.mp hw₂List
+  have hαi₀ : α i₀ = w₁ := hi₀
+  have hαi₁ : α i₁ = w₂ := hi₁
+  have hii : i₀ ≠ i₁ := fun h => hwne (by rw [← hαi₀, ← hαi₁, h])
+  have hcard : Multiset.card f.roots = f.natDegree :=
+    splits_iff_card_roots.mp hsplit
+  have hlen : roots.length = f.natDegree := by
+    dsimp only [roots]
+    rw [Multiset.length_toList, hcard]
+  have hnatf : f.natDegree = roots.length := hlen.symm
+  have hnatp : p.natDegree = f.natDegree := by
+    dsimp only [f]
+    exact (Polynomial.natDegree_map_eq_of_injective
+      (RingHom.injective_int _) p).symm
+  have hN2 : 2 ≤ roots.length := by
+    have h₀ := i₀.isLt
+    have h₁ := i₁.isLt
+    have : i₀.val ≠ i₁.val := fun h => hii (Fin.ext h)
+    omega
+  have hdegf : 0 < f.degree :=
+    natDegree_pos_iff_degree_pos.mp (by omega)
+  have hdegp : 0 < p.degree :=
+    natDegree_pos_iff_degree_pos.mp (by rw [hnatp, hnatf]; omega)
+  have hdiscZ : 1 ≤ |p.discr| := Polynomial.one_le_abs_discr hdegp hsep
+  have hdiscnorm : (1 : ℝ) ≤ ‖f.discr‖ := by
+    have hmap : f.discr = ((p.discr : ℤ) : ℂ) := by
+      dsimp only [f]
+      rw [Polynomial.discr_map_of_injective (Int.castRingHom ℂ)
+        (RingHom.injective_int _) hdegp]
+      simp
+    rw [hmap, Complex.norm_intCast]
+    exact_mod_cast hdiscZ
+  have hdisceq := norm_discr_eq α hαinj hdegf hsplit hroots.symm
+  rw [hnatf] at hdisceq
+  let V := (Matrix.vandermonde α).det
+  have hAsq : (‖f.leadingCoeff‖ ^ (roots.length - 1) * ‖V‖) ^ 2 =
+      ‖f.leadingCoeff‖ ^ (2 * roots.length - 2) * ‖V‖ ^ 2 := by
+    rw [mul_pow, ← pow_mul]
+    congr 2
+    omega
+  have hAnn : (0 : ℝ) ≤
+      ‖f.leadingCoeff‖ ^ (roots.length - 1) * ‖V‖ := by positivity
+  have hA1 : (1 : ℝ) ≤
+      ‖f.leadingCoeff‖ ^ (roots.length - 1) * ‖V‖ := by
+    have hsq1 : (1 : ℝ) ≤
+        (‖f.leadingCoeff‖ ^ (roots.length - 1) * ‖V‖) ^ 2 := by
+      rw [hAsq, ← hdisceq]
+      exact hdiscnorm
+    nlinarith [hsq1, hAnn]
+  have hnormα : ‖α i₀‖ ≤ ‖α i₁‖ := by
+    rw [hαi₀, hαi₁]
+    exact hnorm
+  have hcrux := norm_det_vandermonde_le
+    hN2 f.leadingCoeff α hii hnormα
+  have hsqrtstep :
+      Real.sqrt roots.length ^ (roots.length - 1) *
+          Real.sqrt (∑ i : Fin roots.length, ((i : ℕ) : ℝ) ^ 2) ≤
+        Real.sqrt roots.length ^ (roots.length + 2) := by
+    calc
+      Real.sqrt roots.length ^ (roots.length - 1) *
+          Real.sqrt (∑ i : Fin roots.length, ((i : ℕ) : ℝ) ^ 2)
+          ≤ Real.sqrt roots.length ^ (roots.length - 1) *
+              Real.sqrt roots.length ^ 3 :=
+            mul_le_mul_of_nonneg_left (sqrt_sum_sq_le roots.length)
+              (by positivity)
+      _ = Real.sqrt roots.length ^ (roots.length + 2) := by
+            rw [← pow_add]
+            congr 1
+            omega
+  have hMprod : (f.roots.map (fun a => max 1 ‖a‖)).prod =
+      ∏ j, max 1 ‖α j‖ := by
+    rw [← hroots, Multiset.map_map]
+    rfl
+  have hM : ‖f.leadingCoeff‖ * ∏ j, max 1 ‖α j‖ =
+      f.mahlerMeasure := by
+    rw [Polynomial.mahlerMeasure_eq_leadingCoeff_mul_prod_roots, hMprod]
+  have hdiff : ‖α i₁ - α i₀‖ = ‖w₁ - w₂‖ := by
+    rw [hαi₀, hαi₁, norm_sub_rev]
+  rw [hnatp, hnatf]
+  calc
+    (1 : ℝ) ≤ ‖f.leadingCoeff‖ ^ (roots.length - 1) * ‖V‖ := hA1
+    _ ≤ Real.sqrt roots.length ^ (roots.length - 1) *
+          Real.sqrt (∑ i : Fin roots.length, ((i : ℕ) : ℝ) ^ 2) *
+          (‖f.leadingCoeff‖ * ∏ j, max 1 ‖α j‖) ^
+            (roots.length - 1) * ‖α i₁ - α i₀‖ := hcrux
+    _ = (Real.sqrt roots.length ^ (roots.length - 1) *
+          Real.sqrt (∑ i : Fin roots.length, ((i : ℕ) : ℝ) ^ 2)) *
+          ((‖f.leadingCoeff‖ * ∏ j, max 1 ‖α j‖) ^
+            (roots.length - 1) * ‖α i₁ - α i₀‖) := by ring
+    _ ≤ Real.sqrt roots.length ^ (roots.length + 2) *
+          ((‖f.leadingCoeff‖ * ∏ j, max 1 ‖α j‖) ^
+            (roots.length - 1) * ‖α i₁ - α i₀‖) :=
+        mul_le_mul_of_nonneg_right hsqrtstep
+          (mul_nonneg (pow_nonneg (mul_nonneg (norm_nonneg _)
+            (Finset.prod_nonneg (fun j _ => le_trans zero_le_one
+              (le_max_left _ _)))) _) (norm_nonneg _))
+    _ = Real.sqrt roots.length ^ (roots.length + 2) *
+          f.mahlerMeasure ^ (roots.length - 1) * ‖w₁ - w₂‖ := by
+        rw [hM, hdiff]
+        ring
+
 end
 
 end HexPolyZMathlib

--- a/HexRealRootsMathlib/Separation.lean
+++ b/HexRealRootsMathlib/Separation.lean
@@ -372,7 +372,6 @@ theorem pow_le_two_pow_sepExp (n L : ℕ) :
         apply mul_le_mul hnpow hLpow (by positivity) (by positivity)
     _ = 2 ^ (((n + 2) * cn + 1) / 2 + (n - 1) * cL) := by rw [← pow_add]
 
-open Finset Matrix in
 /-- **Mahler's separation bound.** For a `p` whose rational image is separable
 (equivalently squarefree over `ℚ`; `squareFreeRat_iff` discharges this from
 `Hex.SquareFreeRat`), any two distinct complex roots of `toPolyℂ p` are more than
@@ -383,15 +382,6 @@ theorem sepPrec_separates (p : Hex.ZPoly)
     ∀ z₁ z₂ : ℂ, (toPolyℂ p).IsRoot z₁ → (toPolyℂ p).IsRoot z₂ → z₁ ≠ z₂ →
       (2 : ℝ) ^ (-(Hex.sepPrec p : ℤ)) < ‖z₁ - z₂‖ / 4 := by
   intro z₁ z₂ hr1 hr2 hne
-  -- Symmetric in `z₁, z₂`; reduce to the case `‖z₁‖ ≤ ‖z₂‖`.
-  suffices key : ∀ w₁ w₂ : ℂ, (toPolyℂ p).IsRoot w₁ → (toPolyℂ p).IsRoot w₂ →
-      w₁ ≠ w₂ → ‖w₁‖ ≤ ‖w₂‖ → (2 : ℝ) ^ (-(Hex.sepPrec p : ℤ)) < ‖w₁ - w₂‖ / 4 by
-    rcases le_total ‖z₁‖ ‖z₂‖ with h | h
-    · exact key z₁ z₂ hr1 hr2 hne h
-    · have hh := key z₂ z₁ hr2 hr1 (Ne.symm hne) h
-      rwa [norm_sub_rev] at hh
-  clear hr1 hr2 hne z₁ z₂
-  intro z₁ z₂ hr1 hr2 hne hnorm
   classical
   set p' := toPolynomial p with hp'
   set f := toPolyℂ p with hf
@@ -400,36 +390,15 @@ theorem sepPrec_separates (p : Hex.ZPoly)
   have hp'0 : p' ≠ 0 := fun h => hsep.ne_zero (by rw [h, Polynomial.map_zero])
   have hf0 : f ≠ 0 := by
     rw [hfmap, ne_eq, Polynomial.map_eq_zero_iff (RingHom.injective_int _)]; exact hp'0
-  -- Splitting and separability over `ℂ`.
   have hsplit : f.Splits := IsAlgClosed.splits f
-  have hcomp : (algebraMap ℚ ℂ).comp (Int.castRingHom ℚ) = Int.castRingHom ℂ :=
-    RingHom.ext_int _ _
-  have hsepℂ : f.Separable := by
-    have hff : f = (p'.map (Int.castRingHom ℚ)).map (algebraMap ℚ ℂ) := by
-      rw [hfmap, Polynomial.map_map, hcomp]
-    rw [hff]; exact hsep.map
-  have hnd : f.roots.Nodup := nodup_roots hsepℂ
-  -- Enumerate the roots as `α : Fin ℓ.length → ℂ`.
   set ℓ := f.roots.toList with hℓ
-  have hℓnd : ℓ.Nodup := Multiset.coe_nodup.mp (by rw [hℓ, Multiset.coe_toList]; exact hnd)
-  set α : Fin ℓ.length → ℂ := ℓ.get with hαdef
-  have hαinj : Function.Injective α := List.nodup_iff_injective_get.mp hℓnd
-  have hroots : Multiset.map α univ.val = f.roots := by
-    rw [Fin.univ_val_map, hαdef, List.ofFn_get, hℓ, Multiset.coe_toList]
-  have hBnn : (0 : ℝ) ≤ ∏ j, max 1 ‖α j‖ :=
-    Finset.prod_nonneg (fun j _ => le_trans zero_le_one (le_max_left _ _))
-  have hlcBnn : (0 : ℝ) ≤ ‖f.leadingCoeff‖ * ∏ j, max 1 ‖α j‖ := mul_nonneg (norm_nonneg _) hBnn
-  -- Indices of `z₁, z₂`.
   have hz1L : z₁ ∈ ℓ := by
     rw [hℓ, ← Multiset.mem_coe, Multiset.coe_toList]; exact (mem_roots hf0).mpr hr1
   have hz2L : z₂ ∈ ℓ := by
     rw [hℓ, ← Multiset.mem_coe, Multiset.coe_toList]; exact (mem_roots hf0).mpr hr2
   obtain ⟨i₀, hi₀⟩ := List.mem_iff_get.mp hz1L
   obtain ⟨i₁, hi₁⟩ := List.mem_iff_get.mp hz2L
-  have hαi0 : α i₀ = z₁ := hi₀
-  have hαi1 : α i₁ = z₂ := hi₁
-  have hii : i₀ ≠ i₁ := fun h => hne (by rw [← hαi0, ← hαi1, h])
-  -- Degree facts. `m := ℓ.length = f.natDegree ≥ 2`.
+  have hii : i₀ ≠ i₁ := fun h => hne (by rw [← hi₀, ← hi₁, h])
   have hcard : Multiset.card f.roots = f.natDegree := splits_iff_card_roots.mp hsplit
   have hlen : ℓ.length = f.natDegree := by rw [hℓ, Multiset.length_toList, hcard]
   have hnatf : f.natDegree = ℓ.length := hlen.symm
@@ -437,47 +406,8 @@ theorem sepPrec_separates (p : Hex.ZPoly)
     have h0 := i₀.isLt; have h1 := i₁.isLt
     have : i₀.val ≠ i₁.val := fun h => hii (Fin.ext h)
     omega
-  have hdegf : 0 < f.degree :=
-    natDegree_pos_iff_degree_pos.mp (by omega)
-  -- Lower bound on the discriminant.
   have hnatp' : p'.natDegree = f.natDegree := by
     rw [hfmap]; exact (Polynomial.natDegree_map_eq_of_injective (RingHom.injective_int _) p').symm
-  have hdeg' : 0 < p'.degree := natDegree_pos_iff_degree_pos.mp (by rw [hnatp']; omega)
-  have hdiscZ : 1 ≤ |p'.discr| := Polynomial.one_le_abs_discr hdeg' hsep
-  have hdiscnorm : (1 : ℝ) ≤ ‖f.discr‖ := by
-    have hmap : f.discr = ((p'.discr : ℤ) : ℂ) := by
-      rw [hfmap, Polynomial.discr_map_of_injective (Int.castRingHom ℂ)
-        (RingHom.injective_int _) hdeg']; simp
-    rw [hmap, Complex.norm_intCast]; exact_mod_cast hdiscZ
-  have hdisceq := HexPolyZMathlib.norm_discr_eq α hαinj hdegf hsplit hroots.symm
-  rw [hnatf] at hdisceq
-  -- `A := ‖lc‖^{m-1}·‖det V‖ ≥ 1`.
-  set V := (Matrix.vandermonde α).det with hV
-  have hAsq : (‖f.leadingCoeff‖ ^ (ℓ.length - 1) * ‖V‖) ^ 2
-      = ‖f.leadingCoeff‖ ^ (2 * ℓ.length - 2) * ‖V‖ ^ 2 := by
-    rw [mul_pow, ← pow_mul]; congr 2; omega
-  have hAnn : (0 : ℝ) ≤ ‖f.leadingCoeff‖ ^ (ℓ.length - 1) * ‖V‖ := by positivity
-  have hA1 : (1 : ℝ) ≤ ‖f.leadingCoeff‖ ^ (ℓ.length - 1) * ‖V‖ := by
-    have hsq1 : (1 : ℝ) ≤ (‖f.leadingCoeff‖ ^ (ℓ.length - 1) * ‖V‖) ^ 2 := by
-      rw [hAsq, ← hdisceq]; exact hdiscnorm
-    nlinarith [hsq1, hAnn]
-  -- The Mahler/Hadamard bound.
-  have hnormα : ‖α i₀‖ ≤ ‖α i₁‖ := by rw [hαi0, hαi1]; exact hnorm
-  have hcrux := HexPolyZMathlib.norm_det_vandermonde_le hN2 f.leadingCoeff α hii hnormα
-  -- `√m^{m-1}·√(∑ i²) ≤ √m^{m+2}`.
-  have hsqrtstep :
-      Real.sqrt ℓ.length ^ (ℓ.length - 1) * Real.sqrt (∑ i : Fin ℓ.length, ((i : ℕ) : ℝ) ^ 2)
-        ≤ Real.sqrt ℓ.length ^ (ℓ.length + 2) := by
-    calc Real.sqrt ℓ.length ^ (ℓ.length - 1)
-          * Real.sqrt (∑ i : Fin ℓ.length, ((i : ℕ) : ℝ) ^ 2)
-        ≤ Real.sqrt ℓ.length ^ (ℓ.length - 1) * Real.sqrt ℓ.length ^ 3 :=
-          mul_le_mul_of_nonneg_left (HexPolyZMathlib.sqrt_sum_sq_le ℓ.length) (by positivity)
-      _ = Real.sqrt ℓ.length ^ (ℓ.length + 2) := by rw [← pow_add]; congr 1; omega
-  -- The Mahler measure identity `M = ‖lc‖ · ∏ max(1,‖α j‖)` and Landau bound `M ≤ L`.
-  have hMprod : (f.roots.map (fun a => max 1 ‖a‖)).prod = ∏ j, max 1 ‖α j‖ := by
-    rw [← hroots, Multiset.map_map]; rfl
-  have hM : ‖f.leadingCoeff‖ * ∏ j, max 1 ‖α j‖ = f.mahlerMeasure := by
-    rw [Polynomial.mahlerMeasure_eq_leadingCoeff_mul_prod_roots, hMprod]
   have hML : f.mahlerMeasure ≤ (Hex.ZPoly.coeffL2NormBound p : ℝ) := by
     have h1 : f.mahlerMeasure ≤ HexPolyZMathlib.l2norm p' := by
       rw [hfmap]; exact HexPolyZMathlib.mahlerMeasure_le_l2norm p'
@@ -493,33 +423,22 @@ theorem sepPrec_separates (p : Hex.ZPoly)
     have hl2nn : (0 : ℝ) ≤ HexPolyZMathlib.l2norm p' := Real.sqrt_nonneg _
     have hLnn : (0 : ℝ) ≤ (Hex.ZPoly.coeffL2NormBound p : ℝ) := Nat.cast_nonneg _
     nlinarith [h1, hl2sq, hl2nn, hLnn]
-  have hMLpow : (‖f.leadingCoeff‖ * ∏ j, max 1 ‖α j‖) ^ (ℓ.length - 1)
+  have hMLpow : f.mahlerMeasure ^ (ℓ.length - 1)
       ≤ (Hex.ZPoly.coeffL2NormBound p : ℝ) ^ (ℓ.length - 1) :=
-    pow_le_pow_left₀ hlcBnn (by rw [hM]; exact hML) (ℓ.length - 1)
-  have hdiffx : ‖α i₁ - α i₀‖ = ‖z₁ - z₂‖ := by rw [hαi0, hαi1, norm_sub_rev]
+    pow_le_pow_left₀ (Polynomial.mahlerMeasure_nonneg _) hML (ℓ.length - 1)
   -- Assemble: `1 ≤ √m^{m+2} · L^{m-1} · ‖z₁ − z₂‖`.
   have hbig : (1 : ℝ) ≤ Real.sqrt ℓ.length ^ (ℓ.length + 2)
       * (Hex.ZPoly.coeffL2NormBound p : ℝ) ^ (ℓ.length - 1) * ‖z₁ - z₂‖ := by
-    calc (1 : ℝ) ≤ ‖f.leadingCoeff‖ ^ (ℓ.length - 1) * ‖V‖ := hA1
-      _ ≤ Real.sqrt ℓ.length ^ (ℓ.length - 1)
-            * Real.sqrt (∑ i : Fin ℓ.length, ((i : ℕ) : ℝ) ^ 2)
-            * (‖f.leadingCoeff‖ * ∏ j, max 1 ‖α j‖) ^ (ℓ.length - 1) * ‖α i₁ - α i₀‖ := hcrux
-      _ = (Real.sqrt ℓ.length ^ (ℓ.length - 1)
-            * Real.sqrt (∑ i : Fin ℓ.length, ((i : ℕ) : ℝ) ^ 2))
-            * ((‖f.leadingCoeff‖ * ∏ j, max 1 ‖α j‖) ^ (ℓ.length - 1) * ‖α i₁ - α i₀‖) := by
-          ring
+    have hshared := HexPolyZMathlib.one_le_mahlerDist
+      p' hsep (by simpa only [hfmap] using hr1)
+        (by simpa only [hfmap] using hr2) hne
+    rw [hnatp', hnatf] at hshared
+    calc (1 : ℝ) ≤ Real.sqrt ℓ.length ^ (ℓ.length + 2) *
+            f.mahlerMeasure ^ (ℓ.length - 1) * ‖z₁ - z₂‖ := hshared
       _ ≤ Real.sqrt ℓ.length ^ (ℓ.length + 2)
-            * ((‖f.leadingCoeff‖ * ∏ j, max 1 ‖α j‖) ^ (ℓ.length - 1) * ‖α i₁ - α i₀‖) :=
-          mul_le_mul_of_nonneg_right hsqrtstep
-            (mul_nonneg (pow_nonneg hlcBnn _) (norm_nonneg _))
-      _ = Real.sqrt ℓ.length ^ (ℓ.length + 2)
-            * (‖f.leadingCoeff‖ * ∏ j, max 1 ‖α j‖) ^ (ℓ.length - 1) * ‖α i₁ - α i₀‖ := by ring
-      _ ≤ Real.sqrt ℓ.length ^ (ℓ.length + 2)
-            * (Hex.ZPoly.coeffL2NormBound p : ℝ) ^ (ℓ.length - 1) * ‖α i₁ - α i₀‖ := by
+            * (Hex.ZPoly.coeffL2NormBound p : ℝ) ^ (ℓ.length - 1) * ‖z₁ - z₂‖ := by
           apply mul_le_mul_of_nonneg_right _ (norm_nonneg _)
           exact mul_le_mul_of_nonneg_left hMLpow (by positivity)
-      _ = Real.sqrt ℓ.length ^ (ℓ.length + 2)
-            * (Hex.ZPoly.coeffL2NormBound p : ℝ) ^ (ℓ.length - 1) * ‖z₁ - z₂‖ := by rw [hdiffx]
   -- Convert to `1 ≤ 2^E · ‖z₁ − z₂‖` and identify `sepPrec p = E + 3`.
   have hx0 : (0 : ℝ) < ‖z₁ - z₂‖ := norm_pos_iff.mpr (sub_ne_zero.mpr hne)
   have hdeg? : p.degree? = some ℓ.length := by

--- a/HexRootsMathlib/MahlerPrec.lean
+++ b/HexRootsMathlib/MahlerPrec.lean
@@ -136,16 +136,6 @@ theorem mahlerPrec_separates (p : Hex.ZPoly)
       (2 : ℝ) ^ (-(Hex.mahlerPrec p : ℤ)) * (1449 / 1024 : ℝ) <
         ‖z₁ - z₂‖ / 4 := by
   intro z₁ z₂ hr1 hr2 hne
-  suffices key : ∀ w₁ w₂ : ℂ, (toPolyℂ p).IsRoot w₁ → (toPolyℂ p).IsRoot w₂ →
-      w₁ ≠ w₂ → ‖w₁‖ ≤ ‖w₂‖ →
-        (2 : ℝ) ^ (-(Hex.mahlerPrec p : ℤ)) * (1449 / 1024 : ℝ) <
-          ‖w₁ - w₂‖ / 4 by
-    rcases le_total ‖z₁‖ ‖z₂‖ with h | h
-    · exact key z₁ z₂ hr1 hr2 hne h
-    · have hh := key z₂ z₁ hr2 hr1 (Ne.symm hne) h
-      rwa [norm_sub_rev] at hh
-  clear hr1 hr2 hne z₁ z₂
-  intro z₁ z₂ hr1 hr2 hne hnorm
   classical
   set p' := HexPolyZMathlib.toPolynomial p with hp'
   set f := toPolyℂ p with hf
@@ -155,26 +145,7 @@ theorem mahlerPrec_separates (p : Hex.ZPoly)
     rw [hfmap, ne_eq, Polynomial.map_eq_zero_iff (RingHom.injective_int _)]
     exact hp'0
   have hsplit : f.Splits := IsAlgClosed.splits f
-  have hcomp : (algebraMap ℚ ℂ).comp (Int.castRingHom ℚ) = Int.castRingHom ℂ :=
-    RingHom.ext_int _ _
-  have hsepℂ : f.Separable := by
-    have hff : f = (p'.map (Int.castRingHom ℚ)).map (algebraMap ℚ ℂ) := by
-      rw [hfmap, Polynomial.map_map, hcomp]
-    rw [hff]
-    exact hsep.map
-  have hnd : f.roots.Nodup := nodup_roots hsepℂ
   set roots := f.roots.toList with hrootsList
-  have hrootsNodup : roots.Nodup := Multiset.coe_nodup.mp (by
-    rw [hrootsList, Multiset.coe_toList]
-    exact hnd)
-  set α : Fin roots.length → ℂ := roots.get with hαdef
-  have hαinj : Function.Injective α := List.nodup_iff_injective_get.mp hrootsNodup
-  have hroots : Multiset.map α univ.val = f.roots := by
-    rw [Fin.univ_val_map, hαdef, List.ofFn_get, hrootsList, Multiset.coe_toList]
-  have hBnn : (0 : ℝ) ≤ ∏ j, max 1 ‖α j‖ :=
-    Finset.prod_nonneg (fun j _ => le_trans zero_le_one (le_max_left _ _))
-  have hlcBnn : (0 : ℝ) ≤ ‖f.leadingCoeff‖ * ∏ j, max 1 ‖α j‖ :=
-    mul_nonneg (norm_nonneg _) hBnn
   have hz1List : z₁ ∈ roots := by
     rw [hrootsList, ← Multiset.mem_coe, Multiset.coe_toList]
     exact (mem_roots hf0).mpr hr1
@@ -183,9 +154,7 @@ theorem mahlerPrec_separates (p : Hex.ZPoly)
     exact (mem_roots hf0).mpr hr2
   obtain ⟨i₀, hi₀⟩ := List.mem_iff_get.mp hz1List
   obtain ⟨i₁, hi₁⟩ := List.mem_iff_get.mp hz2List
-  have hαi0 : α i₀ = z₁ := hi₀
-  have hαi1 : α i₁ = z₂ := hi₁
-  have hii : i₀ ≠ i₁ := fun h => hne (by rw [← hαi0, ← hαi1, h])
+  have hii : i₀ ≠ i₁ := fun h => hne (by rw [← hi₀, ← hi₁, h])
   have hcard : Multiset.card f.roots = f.natDegree := splits_iff_card_roots.mp hsplit
   have hlen : roots.length = f.natDegree := by
     rw [hrootsList, Multiset.length_toList, hcard]
@@ -195,64 +164,10 @@ theorem mahlerPrec_separates (p : Hex.ZPoly)
     have h1 := i₁.isLt
     have : i₀.val ≠ i₁.val := fun h => hii (Fin.ext h)
     omega
-  have hdegf : 0 < f.degree :=
-    natDegree_pos_iff_degree_pos.mp (by omega)
   have hnatp' : p'.natDegree = f.natDegree := by
     rw [hfmap]
     exact (Polynomial.natDegree_map_eq_of_injective
       (RingHom.injective_int _) p').symm
-  have hdeg' : 0 < p'.degree :=
-    natDegree_pos_iff_degree_pos.mp (by rw [hnatp']; omega)
-  have hdiscZ : 1 ≤ |p'.discr| := Polynomial.one_le_abs_discr hdeg' hsep
-  have hdiscnorm : (1 : ℝ) ≤ ‖f.discr‖ := by
-    have hmap : f.discr = ((p'.discr : ℤ) : ℂ) := by
-      rw [hfmap, Polynomial.discr_map_of_injective (Int.castRingHom ℂ)
-        (RingHom.injective_int _) hdeg']
-      simp
-    rw [hmap, Complex.norm_intCast]
-    exact_mod_cast hdiscZ
-  have hdisceq := HexPolyZMathlib.norm_discr_eq α hαinj hdegf hsplit hroots.symm
-  rw [hnatf] at hdisceq
-  set V := (Matrix.vandermonde α).det with hV
-  have hAsq : (‖f.leadingCoeff‖ ^ (roots.length - 1) * ‖V‖) ^ 2 =
-      ‖f.leadingCoeff‖ ^ (2 * roots.length - 2) * ‖V‖ ^ 2 := by
-    rw [mul_pow, ← pow_mul]
-    congr 2
-    omega
-  have hAnn : (0 : ℝ) ≤ ‖f.leadingCoeff‖ ^ (roots.length - 1) * ‖V‖ := by
-    positivity
-  have hA1 : (1 : ℝ) ≤ ‖f.leadingCoeff‖ ^ (roots.length - 1) * ‖V‖ := by
-    have hsq1 : (1 : ℝ) ≤
-        (‖f.leadingCoeff‖ ^ (roots.length - 1) * ‖V‖) ^ 2 := by
-      rw [hAsq, ← hdisceq]
-      exact hdiscnorm
-    nlinarith [hsq1, hAnn]
-  have hnormα : ‖α i₀‖ ≤ ‖α i₁‖ := by
-    rw [hαi0, hαi1]
-    exact hnorm
-  have hcrux := HexPolyZMathlib.norm_det_vandermonde_le
-    hN2 f.leadingCoeff α hii hnormα
-  have hsqrtstep :
-      Real.sqrt roots.length ^ (roots.length - 1) *
-          Real.sqrt (∑ i : Fin roots.length, ((i : ℕ) : ℝ) ^ 2) ≤
-        Real.sqrt roots.length ^ (roots.length + 2) := by
-    calc
-      Real.sqrt roots.length ^ (roots.length - 1) *
-          Real.sqrt (∑ i : Fin roots.length, ((i : ℕ) : ℝ) ^ 2)
-          ≤ Real.sqrt roots.length ^ (roots.length - 1) *
-              Real.sqrt roots.length ^ 3 :=
-            mul_le_mul_of_nonneg_left
-              (HexPolyZMathlib.sqrt_sum_sq_le roots.length) (by positivity)
-      _ = Real.sqrt roots.length ^ (roots.length + 2) := by
-            rw [← pow_add]
-            congr 1
-            omega
-  have hMprod : (f.roots.map (fun a => max 1 ‖a‖)).prod =
-      ∏ j, max 1 ‖α j‖ := by
-    rw [← hroots, Multiset.map_map]
-    rfl
-  have hM : ‖f.leadingCoeff‖ * ∏ j, max 1 ‖α j‖ = f.mahlerMeasure := by
-    rw [Polynomial.mahlerMeasure_eq_leadingCoeff_mul_prod_roots, hMprod]
   have hML : f.mahlerMeasure ≤
       Real.sqrt (roots.length + 1) * (p.coeffAbsMax : ℝ) := by
     calc
@@ -263,41 +178,26 @@ theorem mahlerPrec_separates (p : Hex.ZPoly)
         exact mul_le_mul_of_nonneg_left (by
           simpa only [hf] using supNorm_toPolyℂ_le p) (Real.sqrt_nonneg _)
   have hMLpow :
-      (‖f.leadingCoeff‖ * ∏ j, max 1 ‖α j‖) ^ (roots.length - 1) ≤
+      f.mahlerMeasure ^ (roots.length - 1) ≤
         (Real.sqrt (roots.length + 1) * (p.coeffAbsMax : ℝ)) ^
           (roots.length - 1) :=
-    pow_le_pow_left₀ hlcBnn (by rw [hM]; exact hML) (roots.length - 1)
-  have hdiffx : ‖α i₁ - α i₀‖ = ‖z₁ - z₂‖ := by
-    rw [hαi0, hαi1, norm_sub_rev]
+    pow_le_pow_left₀ (Polynomial.mahlerMeasure_nonneg _) hML
+      (roots.length - 1)
   have hbig : (1 : ℝ) ≤ Real.sqrt roots.length ^ (roots.length + 2) *
       (Real.sqrt (roots.length + 1) * (p.coeffAbsMax : ℝ)) ^
         (roots.length - 1) * ‖z₁ - z₂‖ := by
+    have hshared := HexPolyZMathlib.one_le_mahlerDist
+      p' hsep (by simpa only [hfmap] using hr1)
+        (by simpa only [hfmap] using hr2) hne
+    rw [hnatp', hnatf] at hshared
     calc
-      (1 : ℝ) ≤ ‖f.leadingCoeff‖ ^ (roots.length - 1) * ‖V‖ := hA1
-      _ ≤ Real.sqrt roots.length ^ (roots.length - 1) *
-            Real.sqrt (∑ i : Fin roots.length, ((i : ℕ) : ℝ) ^ 2) *
-            (‖f.leadingCoeff‖ * ∏ j, max 1 ‖α j‖) ^ (roots.length - 1) *
-            ‖α i₁ - α i₀‖ := hcrux
-      _ = (Real.sqrt roots.length ^ (roots.length - 1) *
-            Real.sqrt (∑ i : Fin roots.length, ((i : ℕ) : ℝ) ^ 2)) *
-            ((‖f.leadingCoeff‖ * ∏ j, max 1 ‖α j‖) ^ (roots.length - 1) *
-              ‖α i₁ - α i₀‖) := by ring
-      _ ≤ Real.sqrt roots.length ^ (roots.length + 2) *
-            ((‖f.leadingCoeff‖ * ∏ j, max 1 ‖α j‖) ^ (roots.length - 1) *
-              ‖α i₁ - α i₀‖) :=
-          mul_le_mul_of_nonneg_right hsqrtstep
-            (mul_nonneg (pow_nonneg hlcBnn _) (norm_nonneg _))
-      _ = Real.sqrt roots.length ^ (roots.length + 2) *
-            (‖f.leadingCoeff‖ * ∏ j, max 1 ‖α j‖) ^ (roots.length - 1) *
-              ‖α i₁ - α i₀‖ := by ring
+      (1 : ℝ) ≤ Real.sqrt roots.length ^ (roots.length + 2) *
+            f.mahlerMeasure ^ (roots.length - 1) * ‖z₁ - z₂‖ := hshared
       _ ≤ Real.sqrt roots.length ^ (roots.length + 2) *
             (Real.sqrt (roots.length + 1) * (p.coeffAbsMax : ℝ)) ^
-              (roots.length - 1) * ‖α i₁ - α i₀‖ := by
+              (roots.length - 1) * ‖z₁ - z₂‖ := by
           apply mul_le_mul_of_nonneg_right _ (norm_nonneg _)
           exact mul_le_mul_of_nonneg_left hMLpow (by positivity)
-      _ = Real.sqrt roots.length ^ (roots.length + 2) *
-            (Real.sqrt (roots.length + 1) * (p.coeffAbsMax : ℝ)) ^
-              (roots.length - 1) * ‖z₁ - z₂‖ := by rw [hdiffx]
   have hx0 : (0 : ℝ) < ‖z₁ - z₂‖ :=
     norm_pos_iff.mpr (sub_ne_zero.mpr hne)
   have hdeg? : p.degree? = some roots.length := by

--- a/progress/20260720T003051Z_issue-8755-mahler-assembly.md
+++ b/progress/20260720T003051Z_issue-8755-mahler-assembly.md
@@ -1,0 +1,26 @@
+# Accomplished
+
+- Extracted the exponent-independent Mahler root-separation assembly into the
+  HexRoots-independent theorem `HexPolyZMathlib.one_le_mahlerDist`.
+- Refactored both `HexRootsMathlib.mahlerPrec_separates` and
+  `HexRealRootsMathlib.sepPrec_separates` to retain only their distinct
+  coefficient bounds, executable exponent arithmetic, and final constants.
+- Removed the duplicated discriminant lower bound, separable-root
+  enumeration, Vandermonde/Hadamard estimate, and Mahler-product assembly from
+  both consumers (a net reduction despite adding the shared theorem).
+- Verified both focused targets, a full build, the import DAG, line-count and
+  copyright checks, and the absence of banned proof constructs.
+
+# Current frontier
+
+The shared separation assembly is complete locally and ready to rebase onto
+current `main` and receive its required independent Opus review.
+
+# Next step
+
+Rebase, rerun affected/full builds, address the review, then publish and merge
+the #8779 pull request while the driver-completeness PR is in CI.
+
+# Blockers
+
+None.

--- a/progress/20260720T003650Z_issue-8755-mahler-review.md
+++ b/progress/20260720T003650Z_issue-8755-mahler-review.md
@@ -1,0 +1,27 @@
+# Accomplished
+
+- Rebased the shared Mahler extraction onto current `main` without conflicts
+  and reran the two focused targets and the full 9,416-job build.
+- Obtained the required independent Opus review. It verified the discriminant,
+  root-enumeration, Hadamard/Vandermonde, Mahler-measure, cast, and
+  symmetrization chain and found no blocking or medium concerns.
+- Audited the unchanged consumer statements and executable constants and
+  reran all structural checks after the rebase.
+- Kept the small consumer-local degree bookkeeping local: it relates each
+  distinct executable `degree?` API to Mathlib `natDegree`, so moving it into
+  the generic analytic layer would create the dependency the extraction is
+  intended to avoid.
+
+# Current frontier
+
+The #8779 implementation is independently reviewed, fully green, and ready to
+publish.
+
+# Next step
+
+Open the pull request, monitor exact CI state, and merge it after the active
+driver-completeness PR has merged or after rebasing over that PR if needed.
+
+# Blockers
+
+None.


### PR DESCRIPTION
Closes #8779.

Part of #8755.

This extracts the exponent-independent Mahler root-separation assembly into the HexRoots-independent theorem `HexPolyZMathlib.one_le_mahlerDist`. The shared result carries the separability cast, distinct-root enumeration, integral discriminant lower bound, Vandermonde/Hadamard estimate, and Mahler-measure product.

Both consumers now retain only their genuinely distinct work:

- `HexRootsMathlib.mahlerPrec_separates`: sup-norm/`coeffAbsMax` bound, executable `ceilLog2` exponent formula, and `1449/1024` constant;
- `HexRealRootsMathlib.sepPrec_separates`: L²/`coeffL2NormBound` bound, local `ceilLog2Nat` exponent formula, and final radius constant.

The public consumer theorem statements and executable constants are unchanged. The extraction removes 202 lines of duplicated analytic setup while adding the 162-line shared theorem.

Verification:

- `lake build HexRootsMathlib.MahlerPrec HexRealRootsMathlib.Separation`
- full `lake build` (9,416 jobs)
- import-DAG, line-count, copyright, and conformance-target checks
- no `sorry`, `axiom`, or `native_decide` in changed modules
- independent Claude Opus review: no blocking or medium concerns.