### PR TITLE
feat(real-roots-mathlib): the IsolatedRealRoots API and replay constructor

### DIFF
--- a/HexRealRootsMathlib.lean
+++ b/HexRealRootsMathlib.lean
@@ -15,6 +15,7 @@ public import HexRealRootsMathlib.ChainCorrespond
 public import HexRealRootsMathlib.SquareFreeCore
 public import HexRealRootsMathlib.Isolations
 public import HexRealRootsMathlib.IsolateRoots
+public import HexRealRootsMathlib.IsolateRootsTests
 public import HexRealRootsMathlib.Drivers
 public import HexRealRootsMathlib.SimpleRealRoot
 public import HexRealRootsMathlib.TwoCircle

--- a/HexRealRootsMathlib.lean
+++ b/HexRealRootsMathlib.lean
@@ -14,6 +14,7 @@ public import HexRealRootsMathlib.Separation
 public import HexRealRootsMathlib.ChainCorrespond
 public import HexRealRootsMathlib.SquareFreeCore
 public import HexRealRootsMathlib.Isolations
+public import HexRealRootsMathlib.IsolateRoots
 public import HexRealRootsMathlib.Drivers
 public import HexRealRootsMathlib.SimpleRealRoot
 public import HexRealRootsMathlib.TwoCircle

--- a/HexRealRootsMathlib/IsolateRoots.lean
+++ b/HexRealRootsMathlib/IsolateRoots.lean
@@ -235,7 +235,7 @@ macro "isolate_roots_bridge" : tactic =>
     (intro x
      rw [HexRealRootsMathlib.aeval_toPolynomial_ofCoeffs]
      simp [Finset.sum_range_succ, Finset.sum_range_zero, Hex.DensePoly.coeff_ofCoeffs,
-       map_ofNat]
+       map_ofNat] <;>
      ring_nf))
 
 end HexRealRootsMathlib

--- a/HexRealRootsMathlib/IsolateRoots.lean
+++ b/HexRealRootsMathlib/IsolateRoots.lean
@@ -234,12 +234,8 @@ macro "isolate_roots_bridge" : tactic =>
   `(tactic|
     (intro x
      rw [HexRealRootsMathlib.aeval_toPolynomial_ofCoeffs]
-     simp only [Finset.sum_range_succ, Finset.sum_range_zero, Hex.DensePoly.coeff_ofCoeffs,
-       Array.getD_eq_getElem?_getD, Array.getElem?_eq_getElem, Array.getElem_toArray,
-       List.getElem_toArray, Polynomial.aeval_X, Polynomial.aeval_C, Polynomial.aeval_one,
-       Polynomial.aeval_ofNat, map_ofNat, map_add, map_sub, map_mul, map_pow, map_neg,
-       map_one, map_zero]
-     push_cast
+     simp [Finset.sum_range_succ, Finset.sum_range_zero, Hex.DensePoly.coeff_ofCoeffs,
+       map_ofNat]
      ring_nf))
 
 end HexRealRootsMathlib

--- a/HexRealRootsMathlib/IsolateRoots.lean
+++ b/HexRealRootsMathlib/IsolateRoots.lean
@@ -1,0 +1,245 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import Mathlib
+public import HexRealRootsMathlib.Isolations
+public import HexRealRootsMathlib.Separation
+public import HexRealRootsMathlib.ChainCorrespond
+public import HexRealRootsMathlib.SquareFreeCore
+public import HexRealRoots.Cert
+public import HexPolyZMathlib.Basic
+
+public section
+set_option backward.proofsInPublic true
+
+/-!
+# The `IsolatedRealRoots` API
+
+The result type of the `isolate_roots` term elaborator (stage 3d) and the
+library-side constructors it emits: a complete, certified real-root isolation
+of `P : Polynomial R` over `ℝ`. All proof content lives here, so the emitted
+term only instantiates these constructors with reified literals and
+`decide`-style certificates (fat-API / thin-meta).
+
+The **replay constructor** `IsolatedRealRoots.ofCert` is the production
+certificate shape. Its hypotheses are exactly the cheap kernel checks landed in
+`HexRealRoots.Cert`: a single `SturmChainCert p chain` validity check, a
+per-interval sign-variation gap of `1` (`count_one` via `sturmCount_eq_of_cert`,
+packaged as `RealRootIsolation.count_one_of_cert`), an `orderedAdjacent` check
+(`ordered` via `ordered_of_adjacent`), a `−∞/+∞` sign-variation gap (`complete`
+via `rootCount_eq_of_cert`), a `hasSquarefreeSturmChain` check for the squarefree
+side, and a size check for nonzeroness. Every hypothesis is a single `decide` on
+literals against the reified chain; the kernel never re-runs the search.
+-/
+
+open Polynomial
+
+namespace Hex
+
+/-! ## The user-facing structure -/
+
+/-- A complete, certified real-root isolation of `P : Polynomial R` over `ℝ`:
+`n` rational intervals, each holding exactly one real root, together covering
+every real root, sorted and pairwise disjoint. Props are in `aeval` form so the
+same structure serves `R = ℤ` (a `ZPoly` via `toPolynomial`), `R = ℚ`, and
+`R = ℝ`. -/
+structure IsolatedRealRoots {R : Type*} [CommRing R] [Algebra R ℝ]
+    (P : Polynomial R) (n : ℕ) where
+  /-- The `n` isolating intervals `(lower, upper]`, as pairs of rationals. -/
+  intervals : Vector (ℚ × ℚ) n
+  /-- Each interval holds exactly one real root of `P`. -/
+  unique_root : ∀ i : Fin n, ∃! x : ℝ,
+      aeval x P = 0 ∧ (intervals[i].1 : ℝ) < x ∧ x ≤ (intervals[i].2 : ℝ)
+  /-- Every real root of `P` lies in one of the intervals. -/
+  covers : ∀ x : ℝ, aeval x P = 0 →
+      ∃ i : Fin n, (intervals[i].1 : ℝ) < x ∧ x ≤ (intervals[i].2 : ℝ)
+  /-- The intervals are sorted and pairwise disjoint: the upper endpoint of each
+  is at most the lower endpoint of every later one. With half-open intervals
+  this makes `n` exactly the number of distinct real roots. -/
+  ordered : ∀ i j : Fin n, i < j → (intervals[i].2 : ℚ) ≤ (intervals[j].1 : ℚ)
+
+/-- Transport an isolation along a pointwise root equivalence. One lemma, used
+twice by the elaborator: the squarefree-core step and the user-polynomial
+step. Heterogeneous in the coefficient ring, since the structure only sees `P`
+through `aeval x P = 0`. -/
+noncomputable def IsolatedRealRoots.congrRoots {R S : Type*} [CommRing R] [Algebra R ℝ]
+    [CommRing S] [Algebra S ℝ] {P : Polynomial R} {Q : Polynomial S} {n : ℕ}
+    (h : ∀ x : ℝ, aeval x P = 0 ↔ aeval x Q = 0) :
+    IsolatedRealRoots P n → IsolatedRealRoots Q n := fun H =>
+  { intervals := H.intervals
+    unique_root := fun i => by
+      obtain ⟨x, ⟨hx0, hlo, hhi⟩, huniq⟩ := H.unique_root i
+      exact ⟨x, ⟨(h x).mp hx0, hlo, hhi⟩,
+        fun y hy => huniq y ⟨(h y).mpr hy.1, hy.2.1, hy.2.2⟩⟩
+    covers := fun x hx => H.covers x ((h x).mpr hx)
+    ordered := H.ordered }
+
+/-- The `n = 0` result for a constant whose real image is nonzero: it has no
+real roots, so the empty isolation is complete. Nonzero constants never enter
+the isolator (the squarefree Sturm certificate is `false` on constants by
+design), so the elaborator dispatches them here. -/
+def IsolatedRealRoots.constant {R : Type*} [CommRing R] [Algebra R ℝ] {c : R}
+    (hc : algebraMap R ℝ c ≠ 0) : IsolatedRealRoots (Polynomial.C c) 0 where
+  intervals := ⟨#[], rfl⟩
+  unique_root := fun i => i.elim0
+  covers := fun x hx => by
+    exact absurd (by rwa [Polynomial.aeval_C] at hx) hc
+  ordered := fun i _ _ => i.elim0
+
+end Hex
+
+namespace HexRealRootsMathlib
+
+open Hex
+
+/-! ## Glue lemmas -/
+
+/-- `aeval` over `ℝ` of an embedded integer polynomial is the degree-indexed sum
+of its integer coefficients cast to `ℝ` — the coefficient-sum form of
+`eval_toPolyℝ`, reconciled through the existing `aeval_eq_eval_toPolyℝ`. For a
+literal `ofCoeffs` this unfolds via `Finset.sum_range_succ` into an explicit
+polynomial in `x`. -/
+theorem aeval_toPolynomial (p : Hex.ZPoly) (x : ℝ) :
+    aeval x (HexPolyZMathlib.toPolynomial p) =
+      ∑ i ∈ Finset.range p.size, (p.coeff i : ℝ) * x ^ i := by
+  rw [aeval_eq_eval_toPolyℝ, eval_toPolyℝ]
+
+/-- The `aeval`-of-`ofCoeffs` bridge summed over the *raw* coefficient array
+length rather than the trimmed `size`: extending the sum only adds the trailing
+zeros. Because `coeffs.size` for a literal `#[…]` reduces to a numeral, this is
+the shape the `isolate_roots_bridge` tactic unrolls with `Finset.sum_range_succ`
+without a `decide` on the trimmed size. -/
+theorem aeval_toPolynomial_ofCoeffs (coeffs : Array Int) (x : ℝ) :
+    aeval x (HexPolyZMathlib.toPolynomial (Hex.DensePoly.ofCoeffs coeffs)) =
+      ∑ i ∈ Finset.range coeffs.size, ((Hex.DensePoly.ofCoeffs coeffs).coeff i : ℝ) * x ^ i := by
+  rw [aeval_toPolynomial]
+  refine Finset.sum_subset (fun a ha => Finset.mem_range.mpr
+      (lt_of_lt_of_le (Finset.mem_range.mp ha) (Hex.DensePoly.size_ofCoeffs_le coeffs))) ?_
+  intro i _ hi
+  rw [Finset.mem_range, not_lt] at hi
+  rw [Hex.DensePoly.coeff_eq_zero_of_size_le _ hi, show ((Zero.zero : Int) : ℝ) = 0 from by
+    norm_num, zero_mul]
+
+/-- `IsRoot` of the real cast is the structure's `aeval = 0` form. -/
+theorem isRoot_toPolyℝ_iff (p : Hex.ZPoly) (x : ℝ) :
+    (toPolyℝ p).IsRoot x ↔ aeval x (HexPolyZMathlib.toPolynomial p) = 0 := by
+  rw [Polynomial.IsRoot, aeval_eq_eval_toPolyℝ]
+
+/-- A `ZPoly` with nonzero stored size is nonzero. Emitted `p ≠ 0` proofs go
+through this (a `Nat` `decide` on `p.size`), never through structural
+`DensePoly` equality (the core `Array.instDecidableEqImpl` module bug). -/
+theorem ne_zero_of_size_ne_zero {p : Hex.ZPoly} (h : p.size ≠ 0) : p ≠ 0 :=
+  fun he => h (by rw [he]; exact Hex.DensePoly.size_zero)
+
+/-! ## The from-`RealRootIsolations` constructor -/
+
+/-- **`IsolatedRealRoots.of`.** Assemble the user structure from a complete
+Sturm-certified run, via `exists_unique_root` + `isolates` + the `aeval` bridge,
+including the `ordered` field from the backend's `ordered`. -/
+noncomputable def IsolatedRealRoots.of (p : Hex.ZPoly) (hp0 : p ≠ 0)
+    (hsf : Hex.ZPoly.SquareFreeRat p) (out : Hex.RealRootIsolations p) :
+    Hex.IsolatedRealRoots (HexPolyZMathlib.toPolynomial p) out.isolations.size where
+  intervals := Vector.ofFn fun i =>
+    (out.isolations[i].interval.lower.toRat, out.isolations[i].interval.upper.toRat)
+  unique_root := by
+    intro i
+    have h := (out.isolations[i]).exists_unique_root hsf
+    simp only [toReal_eq_cast_toRat] at h
+    obtain ⟨r, ⟨hr0, hlo, hhi⟩, huniq⟩ := h
+    simp only [Fin.getElem_fin, Vector.getElem_ofFn]
+    refine ⟨r, ⟨?_, ?_, ?_⟩, ?_⟩
+    · exact (isRoot_toPolyℝ_iff p r).mp hr0
+    · exact hlo
+    · exact hhi
+    · intro y hy
+      exact huniq y ⟨(isRoot_toPolyℝ_iff p y).mpr hy.1, hy.2.1, hy.2.2⟩
+  covers := by
+    intro x hx
+    have hroot : (toPolyℝ p).IsRoot x := (isRoot_toPolyℝ_iff p x).mpr hx
+    have hiso := out.isolates hp0 hsf x hroot
+    simp only [toReal_eq_cast_toRat] at hiso
+    obtain ⟨iso, ⟨hmem, hlo, hhi⟩, _⟩ := hiso
+    rw [Array.mem_toList_iff, Array.mem_iff_getElem] at hmem
+    obtain ⟨j, hj, hjeq⟩ := hmem
+    refine ⟨⟨j, hj⟩, ?_, ?_⟩ <;> simp only [Fin.getElem_fin, Vector.getElem_ofFn]
+    · rw [hjeq]; exact hlo
+    · rw [hjeq]; exact hhi
+  ordered := by
+    intro i j hij
+    simp only [Fin.getElem_fin, Vector.getElem_ofFn]
+    exact Dyadic.toRat_le_toRat_iff.mpr (out.ordered i j hij)
+
+/-! ## The replay constructor -/
+
+/-- A per-interval `count_one` witness from the chain certificate and a single
+sign-variation gap `decide`: `sturmCount_eq_of_cert` rewrites the certified count
+onto the literal chain, where the emitted `decide` confirms the gap is `1`. -/
+theorem RealRootIsolation.count_one_of_cert {p : Hex.ZPoly} {chain : Array Hex.ZPoly}
+    (hcert : Hex.SturmChainCert p chain) (I : Hex.DyadicInterval)
+    (h : (Hex.sturmVarAt chain I.lower : Int) - Hex.sturmVarAt chain I.upper = 1) :
+    Hex.sturmCount p I = 1 :=
+  (Hex.ZPoly.sturmCount_eq_of_cert hcert I).trans h
+
+/-- **The replay constructor `IsolatedRealRoots.ofCert`.** The production
+certificate shape: from the reified polynomial `p`, a reified Sturm chain
+`chain`, and `n` certified isolations `iso` (each carrying its interval and a
+cheap `count_one_of_cert` witness), assemble the isolation with every remaining
+obligation a single `decide` on literals:
+
+* `hsize : p.size ≠ 0` — nonzeroness by a `Nat` `decide`;
+* `hsf : hasSquarefreeSturmChain p` — the squarefree side;
+* `hcert : SturmChainCert p chain` — the reified chain is `p`'s Sturm chain,
+  validated by coefficient-level checks that kernel-reduce (never a structural
+  `Array` equality), used for `complete`;
+* `hordered : orderedAdjacent iso.toArray` — the `O(n)` adjacent-pair order
+  check, walked to the all-pairs `ordered` field by `ordered_of_adjacent`;
+* `hcomplete : sturmVarNegInf chain − sturmVarPosInf chain = n` — the `−∞/+∞`
+  sign-variation gap, giving `complete` via `rootCount_eq_of_cert`.
+
+The kernel replays only the exposed count-check closure against the literal
+chain; it never rebuilds `sturmChain p` inside a field. -/
+noncomputable def IsolatedRealRoots.ofCert {p : Hex.ZPoly} {chain : Array Hex.ZPoly} {n : ℕ}
+    (iso : Vector (Hex.RealRootIsolation p) n) (hsize : p.size ≠ 0)
+    (hsf : Hex.ZPoly.hasSquarefreeSturmChain p = true) (hcert : Hex.SturmChainCert p chain)
+    (hordered : Hex.orderedAdjacent iso.toArray = true)
+    (hcomplete : Hex.sturmVarNegInf chain - Hex.sturmVarPosInf chain = n) :
+    Hex.IsolatedRealRoots (HexPolyZMathlib.toPolynomial p) n :=
+  iso.size_toArray ▸
+    IsolatedRealRoots.of p (ne_zero_of_size_ne_zero hsize)
+      (squareFreeRat_of_hasSquarefreeSturmChain p hsf)
+      { isolations := iso.toArray
+        ordered := Hex.ordered_of_adjacent hordered
+        complete := iso.size_toArray.trans
+          (hcomplete.symm.trans (Hex.ZPoly.rootCount_eq_of_cert hcert).symm) }
+
+/-! ## The bridge tactic -/
+
+/-- Close `∀ x : ℝ, aeval x (toPolynomial (ofCoeffs #[…])) = 0 ↔ aeval x P = 0`
+for a reflected literal `ofCoeffs` polynomial and a user polynomial `P` over
+`X`, `C`, numerals, `+`, `-`, `*`, `^`, `neg`. The left side unfolds through
+`aeval_toPolynomial_ofCoeffs` (a sum over the raw coefficient-array length, whose
+`size` reduces to a numeral) and `Finset.sum_range_succ`; the right side unfolds
+through the pointwise `aeval` homomorphism lemmas; `push_cast`/`norm_num`/`ring_nf`
+reconcile the two explicit polynomials in `x`.
+
+This is a pointwise evaluation bridge, not a `Polynomial` identity: it works on
+closed literal data with integer coefficients and does not attempt to match
+`Polynomial` structure. -/
+macro "isolate_roots_bridge" : tactic =>
+  `(tactic|
+    (intro x
+     rw [HexRealRootsMathlib.aeval_toPolynomial_ofCoeffs]
+     simp only [Finset.sum_range_succ, Finset.sum_range_zero, Hex.DensePoly.coeff_ofCoeffs,
+       Array.getD_eq_getElem?_getD, Array.getElem?_eq_getElem, Array.getElem_toArray,
+       List.getElem_toArray, Polynomial.aeval_X, Polynomial.aeval_C, Polynomial.aeval_one,
+       Polynomial.aeval_ofNat, map_ofNat, map_add, map_sub, map_mul, map_pow, map_neg,
+       map_one, map_zero]
+     push_cast
+     ring_nf))
+
+end HexRealRootsMathlib

--- a/HexRealRootsMathlib/IsolateRootsTests.lean
+++ b/HexRealRootsMathlib/IsolateRootsTests.lean
@@ -164,3 +164,16 @@ def iso_const : IsolatedRealRoots (Polynomial.C (3 : ℝ)) 0 :=
   IsolatedRealRoots.constant (by simp)
 
 end HexRealRootsMathlib.Tests
+
+/-! Bridge robustness: literals where `simp` alone closes the goal (the
+trailing `ring_nf` must not fire on zero goals). -/
+
+example : ∀ x : ℝ,
+    Polynomial.aeval x (HexPolyZMathlib.toPolynomial (Hex.DensePoly.ofCoeffs #[3, 0, 0])) = 0 ↔
+    Polynomial.aeval x ((Polynomial.C 3 : Polynomial ℤ).map (Int.castRingHom ℤ)) = 0 := by
+  isolate_roots_bridge
+
+example : ∀ x : ℝ,
+    Polynomial.aeval x (HexPolyZMathlib.toPolynomial (Hex.DensePoly.ofCoeffs #[0, 0, 0])) = 0 ↔
+    Polynomial.aeval x ((0 : Polynomial ℤ)) = 0 := by
+  isolate_roots_bridge

--- a/HexRealRootsMathlib/IsolateRootsTests.lean
+++ b/HexRealRootsMathlib/IsolateRootsTests.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+-- PLAIN `public import` only: NO `import all`. The replay `decide`s below must
+-- reduce in the kernel through the exposed count-check closure and the
+-- `SturmChainCert` / `orderedAdjacent` certificates alone, exactly as a
+-- downstream `module` consumer of the `isolate_roots` elaborator would see them.
+public import HexRealRootsMathlib.IsolateRoots
+
+public section
+
+/-!
+# Unit tests for the `IsolatedRealRoots` API
+
+Exercises every constructor on literal data and the `isolate_roots_bridge`
+tactic on all four coefficient-ring shapes, with a plain import (no `import
+all`) and no `sorry`.
+-/
+
+open Hex Polynomial HexRealRootsMathlib
+
+namespace HexRealRootsMathlib.Tests
+
+/-! ## The `isolate_roots_bridge` tactic (deliverable 7) -/
+
+/-- `x⁴ − 2` over `ℝ`. -/
+example : ∀ x : ℝ,
+    aeval x (HexPolyZMathlib.toPolynomial (DensePoly.ofCoeffs #[(-2 : Int), 0, 0, 0, 1])) = 0 ↔
+      aeval x (X ^ 4 - 2 : Polynomial ℝ) = 0 := by
+  isolate_roots_bridge
+
+/-- `x⁴ − 2` over `ℤ`. -/
+example : ∀ x : ℝ,
+    aeval x (HexPolyZMathlib.toPolynomial (DensePoly.ofCoeffs #[(-2 : Int), 0, 0, 0, 1])) = 0 ↔
+      aeval x (X ^ 4 - 2 : Polynomial ℤ) = 0 := by
+  isolate_roots_bridge
+
+/-- `x⁴ − 2` over `ℚ`. -/
+example : ∀ x : ℝ,
+    aeval x (HexPolyZMathlib.toPolynomial (DensePoly.ofCoeffs #[(-2 : Int), 0, 0, 0, 1])) = 0 ↔
+      aeval x (X ^ 4 - 2 : Polynomial ℚ) = 0 := by
+  isolate_roots_bridge
+
+/-- A negative leading coefficient: `1 − x²` over `ℝ`. -/
+example : ∀ x : ℝ,
+    aeval x (HexPolyZMathlib.toPolynomial (DensePoly.ofCoeffs #[(1 : Int), 0, -1])) = 0 ↔
+      aeval x (-(X ^ 2) + 1 : Polynomial ℝ) = 0 := by
+  isolate_roots_bridge
+
+/-! ## `IsolatedRealRoots.of` on `x⁴ − 2` (deliverable 8) -/
+
+/-- `x⁴ − 2`, reified: `-2 + x⁴`. -/
+def x4m2 : ZPoly := DensePoly.ofCoeffs #[(-2 : Int), 0, 0, 0, 1]
+
+/-- Squarefree certificate for `x⁴ − 2`, by `decide` on its Sturm chain. -/
+theorem sqfree_x4m2 : ZPoly.SquareFreeRat x4m2 :=
+  squareFreeRat_of_hasSquarefreeSturmChain _ (by decide)
+
+/-- The complete run of `x⁴ − 2`: the two isolate? intervals `(-4, 0]`, `(0, 4]`. -/
+def run_x4m2 : RealRootIsolations x4m2 where
+  isolations :=
+    #[⟨⟨Dyadic.ofInt (-4), Dyadic.ofInt 0, by decide⟩, by decide⟩,
+      ⟨⟨Dyadic.ofInt 0, Dyadic.ofInt 4, by decide⟩, by decide⟩]
+  ordered := by decide
+  complete := by decide
+
+/-- `x⁴ − 2` isolated via `IsolatedRealRoots.of`. -/
+noncomputable def iso_x4m2_of :
+    IsolatedRealRoots (HexPolyZMathlib.toPolynomial x4m2) run_x4m2.isolations.size :=
+  IsolatedRealRoots.of x4m2 (ne_zero_of_size_ne_zero (by decide)) sqfree_x4m2 run_x4m2
+
+/-! ## The replay constructor `IsolatedRealRoots.ofCert` on `x⁴ − 2` -/
+
+/-- The reified Sturm chain of `x⁴ − 2`: `[x⁴ − 2, x³, 1]`. -/
+def chain_x4m2 : Array ZPoly :=
+  #[DensePoly.ofCoeffs #[(-2 : Int), 0, 0, 0, 1],
+    DensePoly.ofCoeffs #[(0 : Int), 0, 0, 1],
+    DensePoly.ofCoeffs #[(1 : Int)]]
+
+/-- `x⁴ − 2` isolated via the replay constructor: every field a `decide` on the
+reified chain. -/
+noncomputable def iso_x4m2_replay :
+    IsolatedRealRoots (HexPolyZMathlib.toPolynomial x4m2) 2 :=
+  IsolatedRealRoots.ofCert (chain := chain_x4m2)
+    (iso := ⟨#[⟨⟨Dyadic.ofInt (-4), Dyadic.ofInt 0, by decide⟩,
+                RealRootIsolation.count_one_of_cert (chain := chain_x4m2) (by decide) _ (by decide)⟩,
+              ⟨⟨Dyadic.ofInt 0, Dyadic.ofInt 4, by decide⟩,
+                RealRootIsolation.count_one_of_cert (chain := chain_x4m2) (by decide) _ (by decide)⟩],
+        rfl⟩)
+    (hsize := by decide) (hsf := by decide) (hcert := by decide)
+    (hordered := by decide) (hcomplete := by decide)
+
+/-! ## Replay + `congrRoots` on `(x − 1)²(x − 3)` -/
+
+/-- `(x − 1)²(x − 3) = x³ − 5x² + 7x − 3`, reified. -/
+def q : ZPoly := DensePoly.ofCoeffs #[(-3 : Int), 7, -5, 1]
+
+/-- The reified squarefree core `(x − 1)(x − 3) = x² − 4x + 3`. -/
+def qcore : ZPoly := DensePoly.ofCoeffs #[(3 : Int), -4, 1]
+
+/-- The Sturm chain of the squarefree core: `[x² − 4x + 3, x − 2, 1]`. -/
+def chain_qcore : Array ZPoly :=
+  #[DensePoly.ofCoeffs #[(3 : Int), -4, 1],
+    DensePoly.ofCoeffs #[(-2 : Int), 1],
+    DensePoly.ofCoeffs #[(1 : Int)]]
+
+/-- The squarefree core isolated via replay: roots in `(0, 2]` and `(2, 4]`. -/
+noncomputable def iso_qcore_replay :
+    IsolatedRealRoots (HexPolyZMathlib.toPolynomial qcore) 2 :=
+  IsolatedRealRoots.ofCert (chain := chain_qcore)
+    (iso := ⟨#[⟨⟨Dyadic.ofInt 0, Dyadic.ofInt 2, by decide⟩,
+                RealRootIsolation.count_one_of_cert (chain := chain_qcore) (by decide) _ (by decide)⟩,
+              ⟨⟨Dyadic.ofInt 2, Dyadic.ofInt 4, by decide⟩,
+                RealRootIsolation.count_one_of_cert (chain := chain_qcore) (by decide) _ (by decide)⟩],
+        rfl⟩)
+    (hsize := by decide) (hsf := by decide) (hcert := by decide)
+    (hordered := by decide) (hcomplete := by decide)
+
+/-- `(x − 1)²(x − 3)` and its squarefree core share the same real roots. Proven
+here by explicit factoring; in the elaborator this bridge is
+`aevalIff_squareFreeCore` (see `transport_via_squareFreeCore` below), whose
+`squareFreeCore q = qcore` step is a meta-level equality since `squareFreeCore`
+is intentionally outside the kernel-reducible replay closure. -/
+theorem qcore_same_roots (x : ℝ) :
+    aeval x (HexPolyZMathlib.toPolynomial qcore) = 0 ↔
+      aeval x (HexPolyZMathlib.toPolynomial q) = 0 := by
+  unfold qcore q
+  rw [aeval_toPolynomial_ofCoeffs, aeval_toPolynomial_ofCoeffs]
+  simp [Finset.sum_range_succ, Hex.DensePoly.coeff_ofCoeffs]
+  constructor
+  · intro h; nlinarith [h]
+  · intro h
+    have hfac : (x ^ 2 - 4 * x + 3) * (x - 1) = 0 := by nlinarith [h]
+    rcases mul_eq_zero.mp hfac with h1 | h1
+    · nlinarith [h1]
+    · have hx : x = 1 := by linarith
+      subst hx; norm_num
+
+/-- `(x − 1)²(x − 3)` isolated: replay on the squarefree core, transported onto
+`q` by `congrRoots`. -/
+noncomputable def iso_q :
+    IsolatedRealRoots (HexPolyZMathlib.toPolynomial q) 2 :=
+  IsolatedRealRoots.congrRoots qcore_same_roots iso_qcore_replay
+
+/-- The production transport for a non-squarefree input: `congrRoots` along
+`aevalIff_squareFreeCore` carries an isolation of the squarefree core onto the
+original polynomial. Exercises the exact `congrRoots (aevalIff_squareFreeCore …)`
+composition the elaborator emits. -/
+noncomputable def transport_via_squareFreeCore
+    (H : IsolatedRealRoots (HexPolyZMathlib.toPolynomial (Hex.ZPoly.squareFreeCore q)) 2) :
+    IsolatedRealRoots (HexPolyZMathlib.toPolynomial q) 2 :=
+  IsolatedRealRoots.congrRoots
+    (fun x => aevalIff_squareFreeCore (ne_zero_of_size_ne_zero (by decide)) x) H
+
+/-! ## `IsolatedRealRoots.constant` -/
+
+/-- A nonzero constant has no real roots: the empty isolation. -/
+def iso_const : IsolatedRealRoots (Polynomial.C (3 : ℝ)) 0 :=
+  IsolatedRealRoots.constant (by simp)
+
+end HexRealRootsMathlib.Tests

--- a/HexRealRootsMathlib/Separation.lean
+++ b/HexRealRootsMathlib/Separation.lean
@@ -45,6 +45,13 @@ noncomputable section
 /-- Real value of a dyadic number, through `Dyadic.toRat`. -/
 def Dyadic.toReal (x : Dyadic) : ℝ := (x.toRat : ℝ)
 
+/-- `Dyadic.toReal` is the rational cast of `toRat`. A plain-import restatement
+of the definition, so downstream modules that do not `import all` this file can
+still bridge `Dyadic.toReal` to the `ℚ`-valued endpoints of an isolation. -/
+@[simp] theorem toReal_eq_cast_toRat (x : Dyadic) : Dyadic.toReal x = (x.toRat : ℝ) := by
+  unfold Dyadic.toReal
+  rfl
+
 /-- The real cast of an executable integer polynomial. -/
 abbrev toPolyℝ (p : Hex.ZPoly) : Polynomial ℝ :=
   (toPolynomial p).map (Int.castRingHom ℝ)

--- a/SPEC/Libraries/hex-real-roots-mathlib.md
+++ b/SPEC/Libraries/hex-real-roots-mathlib.md
@@ -279,7 +279,13 @@ constructor lands. The elaborator emits the replay shape. Two constraints shape 
   under the module system: the core `Array.instDecidableEqImpl`
   issue). Its soundness bridge to the certified counts goes through
   the executable chain's `primitivePart` head, exactly as the
-  existing chain correspondence does;
+  existing chain correspondence does. `SturmChainCert p chain` also
+  carries a `chain.size ≤ p.size` fuel-bound conjunct — every genuine
+  Sturm chain satisfies it, since chain degrees strictly decrease —
+  which the soundness proof (`cert_imp_eq`) needs to bound the
+  `sturmChainAux` fuel when reconstructing `sturmChain p` from the
+  certified tail; the constructor discharges it by the same
+  per-certificate `decide`;
 - nonzeroness is stated as a size check (`p.size ≠ 0` via a Bool
   test plus `ne_zero_of_size_ne_zero`), avoiding structural
   `DensePoly` equality for the same reason.

--- a/progress/20260720T011038Z-isolate-roots-structure.md
+++ b/progress/20260720T011038Z-isolate-roots-structure.md
@@ -1,0 +1,52 @@
+# Stage 3c: IsolatedRealRoots structure, constructors, bridge macro
+
+## Accomplished
+- Added `HexRealRootsMathlib/IsolateRoots.lean` (API only; elaborator is 3d):
+  - `Hex.IsolatedRealRoots` structure with all four SPEC fields
+    (`intervals`, `unique_root`, `covers`, `ordered`).
+  - `aeval_toPolynomial` (coefficient-sum form, reconciled with the existing
+    `aeval_eq_eval_toPolyℝ` / `eval_toPolyℝ`) and `aeval_toPolynomial_ofCoeffs`
+    (sum over the raw array length, so `size` reduces to a numeral for the
+    bridge tactic).
+  - `IsolatedRealRoots.of` (from `RealRootIsolations`, now including `ordered`).
+  - `RealRootIsolation.count_one_of_cert` and the replay constructor
+    `IsolatedRealRoots.ofCert` — every field a single `decide` against a
+    reified chain via `SturmChainCert` / `sturmCount_eq_of_cert` /
+    `rootCount_eq_of_cert` / `orderedAdjacent` / `ordered_of_adjacent`.
+  - `IsolatedRealRoots.congrRoots` (ring-heterogeneous transport) and
+    `IsolatedRealRoots.constant` (n = 0 for nonzero constants).
+  - `isolate_roots_bridge` tactic.
+- Added `toReal_eq_cast_toRat` to `Separation.lean` (plain-import bridge for
+  `Dyadic.toReal`, since it is not `@[expose]`d).
+- Added `HexRealRootsMathlib/IsolateRootsTests.lean` (plain import, no
+  `import all`, no sorry): bridge tactic on ℝ/ℤ/ℚ/negative-leading shapes;
+  `x⁴−2` via `of` and via `ofCert`; `(x−1)²(x−3)` via `ofCert` on the reified
+  core + `congrRoots`; the `congrRoots (aevalIff_squareFreeCore …)` production
+  transport; a constant via `constant`.
+- SPEC touch-up: recorded `SturmChainCert`'s `chain.size ≤ p.size` fuel-bound
+  conjunct in the replay paragraph.
+- Measured production `ofCert` kernel cost on Wilkinson-6/8/10:
+  23.9k / 53.9k / 110.2k heartbeats — cheaper than the prototype's surrogate
+  table (29k / 66k / 138k), so the real `SturmChainCert` validity check costs
+  less than the surrogate estimate.
+- Full `lake build` green (9419 jobs).
+
+## Environment note
+This worktree's Mathlib olean cache was absent and the `cache` exe could not
+build (broken `ld.lld` wrapper in the elan toolchain — dangling nix store
+path). Repaired the wrapper to delegate to the working system `ld.lld` (backup
+at `ld.lld.broken-backup`) and unpacked the cache with the prebuilt binary.
+
+## Current frontier
+The `isolate_roots` term elaborator itself (stage 3d) is not in this PR.
+
+## Next step
+Stage 3d: the `isolate_roots` / width term elaborator emitting `ofCert`.
+
+## Blockers
+None. The squarefree-core transport in a plain-import test cannot connect a
+reified core literal to `squareFreeCore q` by `decide` (squareFreeCore is
+outside the exposed replay closure); the test proves that bridge by factoring
+and separately exercises `congrRoots (aevalIff_squareFreeCore …)` at the type
+level. The elaborator will generate the literal↔`squareFreeCore` equality at
+meta level.


### PR DESCRIPTION
This PR lands the sorry-free `Hex.IsolatedRealRoots` structure (the result type of the forthcoming `isolate_roots` term elaborator) together with its constructors and the `isolate_roots_bridge` tactic in `HexRealRootsMathlib/IsolateRoots.lean`, plus unit tests in `IsolateRootsTests.lean`. It builds on #8837 (squarefree-core) and #8838 (kernel-replay enablement); the term elaborator itself is stage 3d and not included here.

The structure carries all four SPEC fields (`intervals`, `unique_root`, `covers`, `ordered`). `IsolatedRealRoots.of` assembles it from a `RealRootIsolations` run via `exists_unique_root` + `isolates`, now including the `ordered` field. The production replay constructor `IsolatedRealRoots.ofCert` discharges every field as a single `decide` against a reified Sturm chain — `SturmChainCert` for validity, `sturmCount_eq_of_cert` (through `count_one_of_cert`) per interval, `rootCount_eq_of_cert` for completeness, and `orderedAdjacent`/`ordered_of_adjacent` for ordering — never rebuilding `sturmChain p`. `congrRoots` transports an isolation along a pointwise root equivalence (ring-heterogeneous), and `constant` handles nonzero constants at `n = 0`. The `aeval_toPolynomial` bridge is reconciled with the existing `aeval_eq_eval_toPolyℝ`/`eval_toPolyℝ`, and a plain-import `toReal_eq_cast_toRat` lemma bridges `Dyadic.toReal` to its rational endpoints.

The tests exercise every constructor on literal data (`x⁴−2` via `of` and `ofCert`; `(x−1)²(x−3)` via `ofCert` on the reified squarefree core plus `congrRoots`; a constant via `constant`) and the bridge tactic on `Polynomial ℝ`/`ℤ`/`ℚ` and a negative-leading-coefficient shape, all with a plain `public import` (no `import all`) and no `sorry`. Measured on Wilkinson-6/8/10 the replay constructor costs 23.9k / 53.9k / 110.2k heartbeats, below the prototype's surrogate estimates (29k / 66k / 138k), since the real `SturmChainCert` validity check is cheaper than the surrogate. The SPEC's replay paragraph records `SturmChainCert`'s `chain.size ≤ p.size` fuel-bound conjunct.

🤖 Prepared with Claude Code