### PR TITLE
Finish the HexRootsMathlib directive audit

### DIFF
--- a/HexRootsMathlib.lean
+++ b/HexRootsMathlib.lean
@@ -13,6 +13,7 @@ public import HexRootsMathlib.Bisection
 public import HexRootsMathlib.Cauchy
 public import HexRootsMathlib.Certificate
 public import HexRootsMathlib.CircleIntegralLemmas
+public import HexRootsMathlib.Completeness.DriverCompleteness
 public import HexRootsMathlib.Completeness.NKConverse
 public import HexRootsMathlib.Completeness.NKDepth
 public import HexRootsMathlib.Completeness.NKRecertification
@@ -22,7 +23,6 @@ public import HexRootsMathlib.Completeness.PelletDyadic
 public import HexRootsMathlib.Completeness.PelletTail
 public import HexRootsMathlib.Completeness.RootFreeConverse
 public import HexRootsMathlib.Completeness.SurvivorComponent
-public import HexRootsMathlib.Completeness.DriverCompleteness
 public import HexRootsMathlib.Component
 public import HexRootsMathlib.Driver
 public import HexRootsMathlib.Geometry
@@ -51,8 +51,8 @@ The `HexRootsMathlib` library is the Mathlib companion for the executable
 complex-root isolation library `HexRoots`.
 
 It connects exact dyadic witnesses to Mathlib's real and complex geometry and
-will prove soundness of the atom-path isolation driver. The initial modules
-supply the exact casts and geometric bounds used by every later correspondence
-proof. The separation layer certifies the exact executable `mahlerPrec`
-formula against distinct complex roots.
+proves soundness and completeness of the atom-path isolation driver. Its
+correspondence modules connect the exact executable witnesses to unique roots,
+root counts, coverage, separation, and refinement semantics. The completeness
+layer proves that every atom strategy succeeds on nonzero squarefree input.
 -/

--- a/HexRootsMathlib/SPEC/hex-roots-mathlib.md
+++ b/HexRootsMathlib/SPEC/hex-roots-mathlib.md
@@ -9,11 +9,12 @@ stored square's disc); every
 `DyadicRootCluster` witness implies exactly `k` roots with
 multiplicity; refinement preserves roots; `sameRoot` decides whether
 two refined isolations isolate the same root; and `mahlerPrec` meets
-its separation contract. **Completeness** (every Pellet witness
-certifies by `separationDepth`, so `isolate` never returns `none` on
-squarefree input) is a separately scoped development, described at
-the end. The soundness theorems are stated conditionally on a `some`
-result and do not depend on it.
+its separation contract. **Completeness** proves that the actual driver either
+emits an already-ready, pairwise-disjoint all-atom worklist early or reaches a
+normalized depth where every retained component certifies as one atom, so
+`isolate` never returns `none` on nonzero squarefree input under any atom
+strategy. The soundness theorems remain independently useful: they are stated
+conditionally on a `some` result and do not depend on completeness.
 
 **Scope warning.** This companion is the heaviest of the `-mathlib`
 libraries. The two theorems everything rests on, **Pellet's
@@ -313,13 +314,6 @@ developments above.
   witness holds at the base, doubled, and quadrupled radii because the
   leading-term inequality `|aₙ|·Rⁿ > Σ_{i<n}|aᵢ|·Rⁱ` only improves as
   `R` grows past the Cauchy bound.
-- `HexRootsMathlib/Newton.lean`: `newton1?` and `refineTo?`
-  soundness. When they return `some iso'`, `iso'` isolates the same
-  root and `iso'.square.prec > iso.square.prec`
-  (`sameRoot`-preservation is the statement the threading pattern in
-  hex-roots.md relies on). Uses `Polynomial.newtonMap`,
-  `aeval_pow_two_pow_dvd_aeval_iterate_newtonMap`, and the
-  `Dyadic.invAtPrec` error bounds.
 - `HexRootsMathlib/RootFree.lean`: elementary `T₀` soundness. The exact
   accumulator inequality and the Taylor coefficient bridge imply, by the
   finite triangle inequality, that a successful `rootFree` test excludes
@@ -373,7 +367,7 @@ developments above.
   by exposing the successful underlying raw refinement call; the packaged
   quotient equality remains available to Mathlib-free callers.
 
-## Completeness development (separately scoped)
+## Completeness development
 
 Soundness above never claims the drivers succeed. Completeness does,
 and it is the analytically hardest part:
@@ -464,15 +458,13 @@ Shared discriminant / separation development (candidate Mathlib contribution):
   HexPolyZMathlib/Hadamard.lean
   HexPolyZMathlib/MahlerSeparation.lean
 
-Executable complex-root specialization:
-  HexRootsMathlib/MahlerPrec.lean
-
 Rouché-on-circles development (candidate Mathlib contribution;
-the hardest slice):
+HexRoots-independent core):
   HexRootsMathlib/CircleIntegralLemmas.lean
+  HexRootsMathlib/ArgumentTopology.lean
   HexRootsMathlib/ArgumentPrinciple.lean
+  HexRootsMathlib/RoucheHomotopy.lean
   HexRootsMathlib/Rouche.lean
-  HexRootsMathlib/Pellet.lean
 
 Newton-Kantorovich development (candidate Mathlib contribution;
 port of Mehta-Macbeth, see the intro):
@@ -485,11 +477,21 @@ Correspondence theorems (depend on hex-roots data structures):
   HexRootsMathlib/Taylor.lean
   HexRootsMathlib/HasOnlySimpleRoots.lean
   HexRootsMathlib/MahlerPrec.lean
-  HexRootsMathlib/SimpleRoot.lean
+  HexRootsMathlib/RootFree.lean
+  HexRootsMathlib/NKWitness.lean
+  HexRootsMathlib/Pellet.lean
   HexRootsMathlib/Cauchy.lean
-  HexRootsMathlib/Newton.lean
   HexRootsMathlib/Bisection.lean
-  HexRootsMathlib/IsolateAll.lean
+  HexRootsMathlib/Component.lean
+  HexRootsMathlib/Glue.lean
+  HexRootsMathlib/Certificate.lean
+  HexRootsMathlib/Loop.lean
+  HexRootsMathlib/NKCertify.lean
+  HexRootsMathlib/NKDriver.lean
+  HexRootsMathlib/Driver.lean
+  HexRootsMathlib/Isolate.lean
+  HexRootsMathlib/SimpleRoot.lean
+  HexRootsMathlib/Refinement.lean
 
 Completeness development:
   HexRootsMathlib/Completeness/PelletTail.lean
@@ -504,9 +506,11 @@ Completeness development:
   HexRootsMathlib/Completeness/DriverCompleteness.lean
 ```
 
-The candidate contributions have no `HexRoots` dependence and can
-be split out or sent to Mathlib if they grow. The library is verified
-by building it. Conformance fixtures live with `hex-roots`.
+The shared separation, Rouché core, and Newton--Kantorovich candidate
+contributions have no `HexRoots` dependence and can be split out or sent to
+Mathlib. The executable correspondence and completeness layers depend on
+`HexRoots`. The library is verified by building it; conformance fixtures live
+with `hex-roots`.
 
 `Kantorovich.lean` is the attributed Mathlib-only Mehta--Macbeth core: it
 derives a quantitative contraction theorem from `ContractingWith`, proves the

--- a/progress/20260720T005211Z_issue-8755-final-audit.md
+++ b/progress/20260720T005211Z_issue-8755-final-audit.md
@@ -1,0 +1,32 @@
+# Accomplished
+
+- Audited the complete #8755 child-issue set. Closed stale #8783 with the
+  landed primitive/refinement coverage references and #8784 with the stronger
+  union-by-insertion gluing characterization from PR #8835.
+- Reconciled the companion SPEC's file organization against all 37 actual
+  `HexRootsMathlib` modules, removing nonexistent legacy module names and
+  recording the complete correspondence, Rouché, NK, and completeness layers.
+- Updated the umbrella module description and SPEC status to state the landed
+  all-strategy soundness and completeness result rather than future work.
+- Verified that every source module appears exactly once in the SPEC map and
+  umbrella imports, that the generic contribution slices have no executable
+  `HexRoots` dependency, and that the new/extracted trees contain no `sorry`,
+  `axiom`, or `native_decide`.
+- Ran the focused `HexRootsMathlib` build and all structural checks on the
+  audit patch.
+
+# Current frontier
+
+The final audit patch is complete locally. PR #8840 has merged; PR #8839 is
+rerunning CI after refreshing the intentionally changed `HexRoots` emission
+fixture.
+
+# Next step
+
+After #8839 merges, rebase this audit commit onto the resulting `main`, run
+the final full build and conformance/oracle checks, obtain Opus review, and
+publish the closing PR.
+
+# Blockers
+
+None.

--- a/progress/20260720T014528Z_issue-8755-final-validation.md
+++ b/progress/20260720T014528Z_issue-8755-final-validation.md
@@ -1,0 +1,30 @@
+# Accomplished
+
+- Merged the all-strategy driver-completeness PR #8839 after independent Opus
+  review and a fully green replacement CI run, including the external
+  conformance/BZ gate and repository-wide benchmark smoke gate.
+- Rebased the final audit commit directly onto the squash merge and reconciled
+  the SPEC summary with the guarded early all-atom emission path.
+- Re-ran the complete 9,420-job library build and the 9,225-job conformance and
+  fixture target set on the combined tree.
+- Re-ran copyright, line-count, import-DAG, Phase-4, Mathlib-free-benchmark, and
+  conformance-matrix checks. Audited `HexRootsMathlib` and `HexPolyZMathlib`
+  for `sorry`, `axiom`, and `native_decide`; none occur.
+- Obtained the required independent Opus audit. It confirmed every module
+  grouping, import-closure claim, and completeness statement, and found one
+  stale prose reference to nonexistent `Newton.lean`/`newton1?`; removed that
+  final phantom module reference.
+
+# Current frontier
+
+The closing audit patch is green, independently reviewed, and ready for its
+pull request.
+
+# Next step
+
+Publish the final audit PR, monitor exact CI state, merge it, then post the
+completed merge train on #8755 and close the umbrella.
+
+# Blockers
+
+None.


### PR DESCRIPTION
## Summary

- reconcile the HexRootsMathlib umbrella and SPEC with the landed all-strategy soundness/completeness implementation
- list all 37 companion modules exactly once and classify the Mathlib-only contribution cores versus HexRoots-dependent correspondence layers
- remove the final stale phantom `Newton.lean` / `newton1?` reference
- record the completed full-build, conformance-target, structural, and banned-construct audits

Final audit for #8755.

## Verification

- `lake build` (9,420 jobs)
- full CI conformance/emit-fixture target set (9,225 jobs)
- `lake build HexRootsMathlib`
- copyright, line-count, import-DAG, Phase-4, Mathlib-free-benchmark, and conformance-matrix checks
- no `sorry`, `axiom`, or `native_decide` in `HexRootsMathlib` or `HexPolyZMathlib`
- independent Claude Opus review; its sole minor finding was addressed