### PR TITLE
feat(real-roots-mathlib): the isolate_roots term elaborator

### DIFF
--- a/HexRealRootsMathlib.lean
+++ b/HexRealRootsMathlib.lean
@@ -16,6 +16,8 @@ public import HexRealRootsMathlib.SquareFreeCore
 public import HexRealRootsMathlib.Isolations
 public import HexRealRootsMathlib.IsolateRoots
 public import HexRealRootsMathlib.IsolateRootsTests
+public import HexRealRootsMathlib.IsolateRootsElab
+public import HexRealRootsMathlib.IsolateRootsElabTests
 public import HexRealRootsMathlib.Drivers
 public import HexRealRootsMathlib.SimpleRealRoot
 public import HexRealRootsMathlib.TwoCircle

--- a/HexRealRootsMathlib/IsolateRootsElab.lean
+++ b/HexRealRootsMathlib/IsolateRootsElab.lean
@@ -90,14 +90,6 @@ theorem aevalIff_radical {orig core a b : Hex.ZPoly} {t : ℤ} {k : ℕ} (ht : t
         · exact h
       exact pow_eq_zero_iff (Nat.succ_ne_zero k) |>.mp hck
 
-/-- The empty isolation for a polynomial with no real roots. -/
-def IsolatedRealRoots.ofNoRoots {R : Type*} [CommRing R] [Algebra R ℝ] {P : Polynomial R}
-    (h : ∀ x : ℝ, aeval x P ≠ 0) : Hex.IsolatedRealRoots P 0 where
-  intervals := ⟨#[], rfl⟩
-  unique_root := fun i => i.elim0
-  covers := fun x hx => absurd hx (h x)
-  ordered := fun i _ _ => i.elim0
-
 /-- Reconcile two closed reified polynomial evaluations `aeval x (…) = aeval x (…)`
 by expanding every `aeval`-of-`ofCoeffs` into its explicit coefficient sum and
 pushing `aeval` through the user polynomial's `X / C / + / − / * / ^ / neg`
@@ -427,12 +419,13 @@ meta def emitCore (f : Hex.ZPoly) (widthK : Option Int) : MetaM (TSyntax `term) 
     throwError "isolate_roots: the zero polynomial (every real number is a root, \
       so there is no finite isolation)"
   else if f.size == 1 then
-    -- nonzero constant: no real roots
-    `(HexRealRootsMathlib.IsolatedRealRoots.ofNoRoots
-        (P := HexPolyZMathlib.toPolynomial $fStx)
-        (by intro x hx
-            rw [HexRealRootsMathlib.aeval_toPolynomial_ofCoeffs] at hx
-            simp [Finset.sum_range_succ, Finset.sum_range_zero, Hex.DensePoly.coeff_ofCoeffs] at hx))
+    -- nonzero constant: no real roots, via the landed `IsolatedRealRoots.constant`
+    -- transported onto `toPolynomial fLit`.
+    let cStx ← intStx (f.coeff 0)
+    `(Hex.IsolatedRealRoots.congrRoots (Q := HexPolyZMathlib.toPolynomial $fStx)
+        (by aeval_iff_bridge)
+        (Hex.IsolatedRealRoots.constant (c := ($cStx : Int))
+          (by simp only [eq_intCast, ne_eq, Int.cast_eq_zero]; decide)))
   else if Hex.ZPoly.hasSquarefreeSturmChain f then
     let d ← runBackend f widthK
     emitOfCert d

--- a/HexRealRootsMathlib/IsolateRootsElab.lean
+++ b/HexRealRootsMathlib/IsolateRootsElab.lean
@@ -479,6 +479,10 @@ meta def elabIsolate (widthStx : Option (TSyntax `term)) (pStx : TSyntax `term)
       pure (← evalZPoly pE, false)
     else if isPoly then do
       let R := tyArgs[0]!
+      unless R.isConstOf ``Int || R.isConstOf ``Rat || R.isConstOf ``Real do
+        throwError "isolate_roots: unsupported coefficient ring{indentExpr R}\n\
+          expected `Polynomial ℤ`, `Polynomial ℚ`, or `Polynomial ℝ` \
+          (with integer coefficients)"
       let isRatRing := R.isConstOf ``Rat
       pure (← parsePoly isRatRing 8 pE, true)
     else
@@ -489,7 +493,19 @@ meta def elabIsolate (widthStx : Option (TSyntax `term)) (pStx : TSyntax `term)
     if isPolyInput then
       `(Hex.IsolatedRealRoots.congrRoots (Q := $pStx) (by aeval_iff_bridge) $coreTerm)
     else
-      pure coreTerm
+      -- Certify the DTO: restate over the USER'S term. The transport
+      -- hypothesis closes by `rfl` exactly when the supplied term is
+      -- definitionally the evaluated polynomial, so a faulty evaluation
+      -- fails elaboration rather than silently changing the theorem's
+      -- subject. Irreducible inputs fail with a clear message.
+      `(Hex.IsolatedRealRoots.congrRoots
+          (Q := HexPolyZMathlib.toPolynomial $pStx)
+          (by first
+            | exact fun x => Iff.rfl
+            | fail "isolate_roots: cannot certify that the evaluated \
+                polynomial is definitionally the supplied term (is the \
+                definition irreducible?)")
+          $coreTerm)
   Term.elabTermEnsuringType term expectedType?
 
 /-! ## Syntax -/

--- a/HexRealRootsMathlib/IsolateRootsElab.lean
+++ b/HexRealRootsMathlib/IsolateRootsElab.lean
@@ -207,7 +207,11 @@ meta def evalCoeff (isRat : Bool) (e : Expr) : MetaM Int := do
 unfolded by `whnf` under a depth guard, to a `Hex.ZPoly` value. `isRat` selects
 the `ℚ`-style non-integer rejection. -/
 meta partial def parsePoly (isRat : Bool) (fuel : Nat) (e : Expr) : MetaM Hex.ZPoly := do
-  match (← whnfR e).getAppFnArgs with
+  -- Match structural heads on the *raw* term first: `whnf` would unfold
+  -- `Polynomial.C`/`X`/numerals into their `Finsupp` normal form and defeat the
+  -- match. Only if no structural head applies do we `whnf` once (to unfold a
+  -- named local def) under the fuel guard.
+  match e.getAppFnArgs with
   | (``HAdd.hAdd, #[_, _, _, _, a, b]) => return (← parsePoly isRat fuel a) + (← parsePoly isRat fuel b)
   | (``HSub.hSub, #[_, _, _, _, a, b]) => return (← parsePoly isRat fuel a) - (← parsePoly isRat fuel b)
   | (``HMul.hMul, #[_, _, _, _, a, b]) => return (← parsePoly isRat fuel a) * (← parsePoly isRat fuel b)
@@ -221,6 +225,16 @@ meta partial def parsePoly (isRat : Bool) (fuel : Nat) (e : Expr) : MetaM Hex.ZP
   | (``Polynomial.X, _) => return Hex.DensePoly.ofCoeffs #[(0 : Int), 1]
   | (``Polynomial.C, #[_, _, c]) => return Hex.DensePoly.C (← evalCoeff isRat c)
   | (``OfNat.ofNat, #[_, n, _]) => return Hex.DensePoly.C (Int.ofNat (← getNat n))
+  | (``DFunLike.coe, args) =>
+    -- `Polynomial.C c` elaborates to `⇑Polynomial.C c = DFunLike.coe … Polynomial.C c`.
+    if args.size == 6 && args[4]!.getAppFn.isConstOf ``Polynomial.C then
+      return Hex.DensePoly.C (← evalCoeff isRat args[5]!)
+    else if fuel == 0 then
+      throwError "isolate_roots: unsupported polynomial syntax{indentExpr e}"
+    else
+      let e' ← whnf e
+      if e' == e then throwError "isolate_roots: unsupported polynomial syntax{indentExpr e}"
+      else parsePoly isRat (fuel - 1) e'
   | _ =>
     -- Unfold a named local/def by one whnf step under the fuel guard, else fail.
     if fuel == 0 then

--- a/HexRealRootsMathlib/IsolateRootsElab.lean
+++ b/HexRealRootsMathlib/IsolateRootsElab.lean
@@ -1,0 +1,509 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRealRootsMathlib.IsolateRoots
+public import HexRealRootsMathlib.SquareFreeCore
+public meta import HexRealRoots.Isolate
+public meta import HexRealRoots.Refine
+public meta import HexRealRoots.Cert
+public meta import HexPolyZ.Core
+public import Lean
+
+public section
+set_option backward.proofsInPublic true
+
+/-!
+# The `isolate_roots` term elaborator
+
+The production front-end that automates the `x⁴ − 2` worked example: it runs the
+executable real-root isolator at elaboration time and emits a single certified
+`Hex.IsolatedRealRoots` term the caller can `obtain`, `have`, or feed to `grind`.
+
+Fat-API / thin-meta: every proof obligation the emitted term carries is a single
+`decide` on literal data against the reified Sturm chain (the replay constructor
+`IsolatedRealRoots.ofCert` from `HexRealRootsMathlib.IsolateRoots`), or a
+pointwise ring identity closed by `isolate_roots_bridge`. The kernel never re-runs
+the search; it only replays the exposed count-check closure against the reified
+chain.
+
+## Squarefree-core transport (`aevalIff_radical`)
+
+Non-squarefree input is isolated on its square-free core, then transported back
+onto the original polynomial. The core is reified as a *literal* `ofCoeffs`
+polynomial (so the emitted certificate `decide`s reduce), but a literal core
+cannot be identified with `Hex.ZPoly.squareFreeCore f` by any kernel-checkable
+proof — `squareFreeCore` is deliberately outside the kernel-reducible closure
+(its rational-arithmetic helpers are unexposed), so neither `rfl` (not
+definitionally equal) nor `decide` (reduction gets stuck) closes
+`squareFreeCore f = coreLit`. Instead the elaborator emits a **divisibility
+certificate** relating the two *literal* polynomials directly: reified cofactors
+`a`, `b`, a scalar `t`, and an exponent so that `orig = core * a` and
+`t · core ^ (k+1) = a * b`. `aevalIff_radical` turns these two pointwise ring
+identities into the real-root equivalence, which `congrRoots` uses to carry the
+core's isolation onto the original polynomial. This is fully sound and needs no
+`squareFreeCore` reduction; see the report note on the SPEC's original
+`aevalIff_squareFreeCore (by decide)` suggestion.
+-/
+
+open Polynomial
+
+namespace HexRealRootsMathlib
+
+/-! ## The square-free-radical transport lemma -/
+
+/-- **Radical root-equivalence from a divisibility certificate.** Given reified
+integer polynomials `orig`, `core`, `a`, `b`, a nonzero integer scalar `t`, and
+an exponent `k`, the two pointwise identities
+
+* `orig = core * a` (so every root of `core` is a root of `orig`), and
+* `t · core ^ (k+1) = a * b` (so every root of `a` is a root of `core`, since `t ≠ 0`
+  and `ℝ` has no zero divisors),
+
+pin the real roots of `orig` and `core` to the same set. Used by the elaborator to
+transport a square-free-core isolation onto the original non-squarefree
+polynomial without ever reducing `Hex.ZPoly.squareFreeCore`. -/
+theorem aevalIff_radical {orig core a b : Hex.ZPoly} {t : ℤ} {k : ℕ} (ht : t ≠ 0)
+    (h1 : ∀ x : ℝ, aeval x (HexPolyZMathlib.toPolynomial orig) =
+      aeval x (HexPolyZMathlib.toPolynomial core) * aeval x (HexPolyZMathlib.toPolynomial a))
+    (h2 : ∀ x : ℝ, (t : ℝ) * (aeval x (HexPolyZMathlib.toPolynomial core)) ^ (k + 1) =
+      aeval x (HexPolyZMathlib.toPolynomial a) * aeval x (HexPolyZMathlib.toPolynomial b)) :
+    ∀ x : ℝ, aeval x (HexPolyZMathlib.toPolynomial core) = 0 ↔
+      aeval x (HexPolyZMathlib.toPolynomial orig) = 0 := by
+  intro x
+  constructor
+  · intro hc
+    rw [h1 x, hc, zero_mul]
+  · intro ho
+    rw [h1 x] at ho
+    rcases mul_eq_zero.mp ho with hc | ha
+    · exact hc
+    · have hz : (t : ℝ) * (aeval x (HexPolyZMathlib.toPolynomial core)) ^ (k + 1) = 0 := by
+        rw [h2 x, ha, zero_mul]
+      have hck : (aeval x (HexPolyZMathlib.toPolynomial core)) ^ (k + 1) = 0 := by
+        rcases mul_eq_zero.mp hz with h | h
+        · exact absurd h (Int.cast_ne_zero.mpr ht)
+        · exact h
+      exact pow_eq_zero_iff (Nat.succ_ne_zero k) |>.mp hck
+
+/-- The empty isolation for a polynomial with no real roots. -/
+def IsolatedRealRoots.ofNoRoots {R : Type*} [CommRing R] [Algebra R ℝ] {P : Polynomial R}
+    (h : ∀ x : ℝ, aeval x P ≠ 0) : Hex.IsolatedRealRoots P 0 where
+  intervals := ⟨#[], rfl⟩
+  unique_root := fun i => i.elim0
+  covers := fun x hx => absurd hx (h x)
+  ordered := fun i _ _ => i.elim0
+
+/-- Reconcile two closed reified polynomial evaluations `aeval x (…) = aeval x (…)`
+by expanding every `aeval`-of-`ofCoeffs` into its explicit coefficient sum and
+pushing `aeval` through the user polynomial's `X / C / + / − / * / ^ / neg`
+structure, then closing with `ring`. Deliberately avoids `mul_eq_zero`, so a
+factored user polynomial (e.g. Wilkinson) does not collapse into a root
+disjunction. -/
+macro "aeval_ring_eq" : tactic =>
+  `(tactic|
+    (simp only [HexRealRootsMathlib.aeval_toPolynomial_ofCoeffs]
+     simp [Hex.DensePoly.coeff_ofCoeffs, Finset.sum_range_succ, Finset.sum_range_zero,
+       Polynomial.aeval_X, Polynomial.aeval_C, map_add, map_sub, map_mul, map_pow, map_neg,
+       map_ofNat, map_one] <;> push_cast <;> ring))
+
+/-- Prove `∀ x, aeval x P = 0 ↔ aeval x Q = 0` for reified/closed literal
+polynomials by reducing to the underlying evaluation equality. -/
+macro "aeval_iff_bridge" : tactic =>
+  `(tactic| (intro x; refine Iff.of_eq (congrArg (· = 0) ?_); aeval_ring_eq))
+
+/-- Bridge tactic for the reified product identities `aevalIff_radical` consumes. -/
+macro "isolate_roots_prod" : tactic =>
+  `(tactic| (intro x; aeval_ring_eq))
+
+namespace IsolateRoots
+
+open Lean Elab Meta Term
+
+/-! ## Elaboration-time evaluation shims -/
+
+private meta unsafe def evalZPolyUnsafe (e : Expr) : MetaM (Except String Hex.ZPoly) :=
+  try return .ok (← evalExpr Hex.ZPoly (mkConst ``Hex.ZPoly) e)
+  catch ex => return .error (← ex.toMessageData.toString)
+
+@[implemented_by evalZPolyUnsafe]
+private meta opaque evalZPolyCore (e : Expr) : MetaM (Except String Hex.ZPoly)
+
+/-- Evaluate a closed `Hex.ZPoly` expression to its runtime value at elaboration
+time (compiled evaluation, not kernel reduction). -/
+meta def evalZPoly (e : Expr) : MetaM Hex.ZPoly := do
+  match ← evalZPolyCore e with
+  | .ok f => return f
+  | .error msg => throwError "isolate_roots: failed to evaluate the ZPoly{indentExpr e}\n{msg}"
+
+private meta unsafe def evalRatUnsafe (e : Expr) : MetaM (Except String Rat) :=
+  try return .ok (← evalExpr Rat (mkConst ``Rat) e)
+  catch ex => return .error (← ex.toMessageData.toString)
+
+@[implemented_by evalRatUnsafe]
+private meta opaque evalRatCore (e : Expr) : MetaM (Except String Rat)
+
+/-- Evaluate a closed `Rat`-typed (or `ℚ`) expression to a `Rat` at elaboration
+time. `Rat` is computable, so `2 ^ (-20)`, `1 / 1000`, `10 ^ (-2)` all reduce. -/
+meta def evalRat (e : Expr) : MetaM Rat := do
+  match ← evalRatCore e with
+  | .ok q => return q
+  | .error msg => throwError "isolate_roots: failed to evaluate the rational{indentExpr e}\n{msg}"
+
+/-! ## The integer-polynomial interpreter -/
+
+/-- Extract a `Nat` literal from an `Expr` (numerals and raw literals). -/
+meta def getNat (e : Expr) : MetaM Nat := do
+  match ← getNatValue? e with
+  | some n => return n
+  | none =>
+    match (← whnfR e).getAppFnArgs with
+    | (``OfNat.ofNat, #[_, n, _]) =>
+      match ← getNatValue? n with
+      | some k => return k
+      | none => throwError "isolate_roots: not a Nat literal{indentExpr e}"
+    | _ => throwError "isolate_roots: not a Nat literal{indentExpr e}"
+
+/-- Interpret an integer scalar-coefficient leaf (`OfNat`, `Neg`, `+`, `-`, `*`,
+`Int.ofNat`, `Nat.cast`, `Int.cast`, raw literals). Throws the dedicated
+non-integer-coefficient error on anything else (e.g. a genuine `ℚ`/`ℝ`
+non-integer). -/
+meta partial def evalIntLit (e : Expr) : MetaM Int := do
+  match (← whnfR e).getAppFnArgs with
+  | (``OfNat.ofNat, #[_, n, _]) => return Int.ofNat (← getNat n)
+  | (``Neg.neg, #[_, _, a]) => return - (← evalIntLit a)
+  | (``HMul.hMul, #[_, _, _, _, a, b]) => return (← evalIntLit a) * (← evalIntLit b)
+  | (``HAdd.hAdd, #[_, _, _, _, a, b]) => return (← evalIntLit a) + (← evalIntLit b)
+  | (``HSub.hSub, #[_, _, _, _, a, b]) => return (← evalIntLit a) - (← evalIntLit b)
+  | (``Int.ofNat, #[n]) => return Int.ofNat (← getNat n)
+  | (``Nat.cast, #[_, _, n]) => return Int.ofNat (← getNat n)
+  | (``Int.cast, #[_, _, z]) => evalIntLit z
+  | _ =>
+    match ← getIntValue? e with
+    | some z => return z
+    | none => throwError "isolate_roots: non-integer coefficient{indentExpr e}"
+
+/-- Interpret a coefficient leaf of ring `R`. For `ℚ` (and `ℤ`), a leaf that is
+not structurally an integer is evaluated to a `Rat` and accepted only when its
+denominator is `1`; otherwise the dedicated non-integer-coefficient error fires.
+For `ℝ` (not evaluable to `Rat`), only structurally integer leaves are accepted. -/
+meta def evalCoeff (isRat : Bool) (e : Expr) : MetaM Int := do
+  try
+    evalIntLit e
+  catch _ =>
+    if isRat then
+      let q ← evalRat e
+      if q.den == 1 then return q.num
+      else throwError "isolate_roots: non-integer coefficient{indentExpr e}"
+    else
+      throwError "isolate_roots: non-integer coefficient{indentExpr e}"
+
+/-- Recursive interpreter from a `Polynomial R` expression over
+`X / C / numerals (OfNat) / + / - / * / ^ (Nat) / neg`, with named local defs
+unfolded by `whnf` under a depth guard, to a `Hex.ZPoly` value. `isRat` selects
+the `ℚ`-style non-integer rejection. -/
+meta partial def parsePoly (isRat : Bool) (fuel : Nat) (e : Expr) : MetaM Hex.ZPoly := do
+  match (← whnfR e).getAppFnArgs with
+  | (``HAdd.hAdd, #[_, _, _, _, a, b]) => return (← parsePoly isRat fuel a) + (← parsePoly isRat fuel b)
+  | (``HSub.hSub, #[_, _, _, _, a, b]) => return (← parsePoly isRat fuel a) - (← parsePoly isRat fuel b)
+  | (``HMul.hMul, #[_, _, _, _, a, b]) => return (← parsePoly isRat fuel a) * (← parsePoly isRat fuel b)
+  | (``Neg.neg, #[_, _, a]) => return - (← parsePoly isRat fuel a)
+  | (``HPow.hPow, #[_, _, _, _, a, n]) => do
+      let base ← parsePoly isRat fuel a
+      let k ← getNat n
+      let mut acc : Hex.ZPoly := Hex.DensePoly.C 1
+      for _ in [0:k] do acc := acc * base
+      return acc
+  | (``Polynomial.X, _) => return Hex.DensePoly.ofCoeffs #[(0 : Int), 1]
+  | (``Polynomial.C, #[_, _, c]) => return Hex.DensePoly.C (← evalCoeff isRat c)
+  | (``OfNat.ofNat, #[_, n, _]) => return Hex.DensePoly.C (Int.ofNat (← getNat n))
+  | _ =>
+    -- Unfold a named local/def by one whnf step under the fuel guard, else fail.
+    if fuel == 0 then
+      throwError "isolate_roots: unsupported polynomial syntax{indentExpr e}"
+    else
+      let e' ← whnf e
+      if e' == e then
+        throwError "isolate_roots: unsupported polynomial syntax{indentExpr e}"
+      else
+        parsePoly isRat (fuel - 1) e'
+
+/-! ## Exact integer-polynomial arithmetic (for the radical certificate) -/
+
+/-- `base ^ k` for `Hex.ZPoly`, via the executable `Mul` (`csimp` to `mulImpl`). -/
+meta def powZ (base : Hex.ZPoly) (k : Nat) : Hex.ZPoly := Id.run do
+  let mut acc : Hex.ZPoly := Hex.DensePoly.C 1
+  for _ in [0:k] do acc := acc * base
+  return acc
+
+/-- Exact long division of integer coefficient arrays (ascending degree),
+returning the quotient coefficients when the division is exact, else `none`. -/
+meta def divExactInt (num den : Array Int) : Option (Array Int) := Id.run do
+  -- trim trailing zeros
+  let trim (a : Array Int) : Array Int := Id.run do
+    let mut a := a
+    while a.size > 0 && a[a.size - 1]! == 0 do a := a.pop
+    return a
+  let num := trim num
+  let den := trim den
+  if den.size == 0 then return none
+  let ld := den[den.size - 1]!
+  if num.size < den.size then
+    return if num.size == 0 then some #[0] else none
+  let qdeg := num.size - den.size
+  let mut rem := num
+  let mut q : Array Int := Array.replicate (qdeg + 1) 0
+  let mut i := qdeg
+  let mut ok := true
+  for _ in [0:qdeg + 1] do
+    let hi := rem[i + den.size - 1]!
+    if hi % ld != 0 then
+      ok := false
+    else
+      let qc := hi / ld
+      q := q.set! i qc
+      for j in [0:den.size] do
+        rem := rem.set! (i + j) (rem[i + j]! - qc * den[j]!)
+    if i == 0 then pure () else i := i - 1
+  if !ok then return none
+  -- remainder must be zero
+  for r in rem do
+    if r != 0 then return none
+  return some (trim q)
+
+/-! ## Backend run -/
+
+/-- The certified isolation data extracted at elaboration time: a reified
+polynomial (the square-free core, when a swap happened), its Sturm chain, and the
+per-root dyadic endpoints. -/
+structure IsoData where
+  poly       : Hex.ZPoly
+  chain      : Array Hex.ZPoly
+  endpoints  : Array (Dyadic × Dyadic)
+
+/-- Run the compiled isolator on `f` (assumed square-free with a nonzero
+constant Sturm tail), optionally refining every root to width `2 ^ (-widthK)`
+through the cached-chain `refineToWithChain`. -/
+meta def runBackend (f : Hex.ZPoly) (widthK : Option Int) : MetaM IsoData := do
+  let some out := Hex.isolate? f
+    | throwError "isolate_roots: internal error: the backend isolate? returned none on \
+        square-free input (please report this as a bug)"
+  let chain := Hex.ZPoly.sturmChain f
+  let isos := out.isolations
+  let refined := match widthK with
+    | some k => isos.map (fun iso : Hex.RealRootIsolation f =>
+        Hex.RealRootIsolation.refineToWithChain chain rfl iso k)
+    | none => isos
+  let endpoints := refined.map
+    (fun iso : Hex.RealRootIsolation f => (iso.interval.lower, iso.interval.upper))
+  return { poly := f, chain, endpoints }
+
+/-! ## Reification helpers (term syntax) -/
+
+/-- Term syntax for an `Int` literal. -/
+meta def intStx (c : Int) : MetaM (TSyntax `term) := do
+  let numLit := Syntax.mkNumLit (toString c.natAbs)
+  if c < 0 then `((-$numLit : Int)) else `(($numLit : Int))
+
+/-- Term syntax for a `Nat` literal. -/
+meta def natStx (n : Nat) : TSyntax `term := Syntax.mkNumLit (toString n)
+
+/-- Term syntax for a reified `Hex.ZPoly` as `Hex.DensePoly.ofCoeffs #[…]`. -/
+meta def zpolyStx (f : Hex.ZPoly) : MetaM (TSyntax `term) := do
+  let elems ← f.toArray.mapM intStx
+  `(Hex.DensePoly.ofCoeffs #[$elems,*])
+
+/-- Term syntax for a `Dyadic` endpoint as `Dyadic.ofInt m` or
+`Dyadic.ofInt m >>> (s : Int)` (the denominator is a power of two). -/
+meta def dyadicStx (d : Dyadic) : MetaM (TSyntax `term) := do
+  let q := d.toRat
+  let mStx ← intStx q.num
+  if q.den == 1 then
+    `(Dyadic.ofInt $mStx)
+  else
+    let s := q.den.log2
+    let sStx ← intStx (Int.ofNat s)
+    `(Dyadic.ofInt $mStx >>> ($sStx : Int))
+
+/-! ## Emission -/
+
+/-- Emit the replay term `IsolatedRealRoots.ofCert` for `d.poly` (a square-free
+polynomial), stated over `HexPolyZMathlib.toPolynomial d.poly`. Every field is a
+`decide` on literals against the reified chain. -/
+meta def emitOfCert (d : IsoData) : MetaM (TSyntax `term) := do
+  let fStx ← zpolyStx d.poly
+  let chainStxs ← d.chain.mapM zpolyStx
+  let chainStx ← `((#[$chainStxs,*] : Array Hex.ZPoly))
+  let nLit := natStx d.endpoints.size
+  let isoStxs ← d.endpoints.mapM fun (lo, hi) => do
+    let loStx ← dyadicStx lo
+    let hiStx ← dyadicStx hi
+    `(term| (⟨⟨$loStx, $hiStx, by decide⟩,
+        HexRealRootsMathlib.RealRootIsolation.count_one_of_cert (chain := $chainStx)
+          (by decide) _ (by decide)⟩ : Hex.RealRootIsolation $fStx))
+  `(HexRealRootsMathlib.IsolatedRealRoots.ofCert (chain := $chainStx)
+      (iso := (⟨#[$isoStxs,*], rfl⟩ : Vector (Hex.RealRootIsolation $fStx) $nLit))
+      (hsize := by decide) (hsf := by decide) (hcert := by decide)
+      (hordered := by decide) (hcomplete := by decide))
+
+/-! ## Width target -/
+
+/-- Convert a positive rational width `q` to the bit target `k = max 0 ⌈log₂ q⁻¹⌉`
+in exact integer arithmetic: the least `k ≥ 0` with `2 ^ (-k) ≤ q`. Widths above
+`1` give `k = 0` (they never coarsen the natural intervals). Targets finer than
+`2 ^ (-4096)` are rejected as pathological. -/
+meta def widthTarget (q : Rat) : MetaM Int := do
+  let inv := q⁻¹
+  let mut k : Nat := 0
+  let mut pw : Rat := 1
+  while pw < inv do
+    if k ≥ 4096 then
+      throwError "isolate_roots: pathological width (finer than 2^-4096); the isolation \
+        would be astronomically large. Refine the result manually if you truly need this."
+    k := k + 1
+    pw := pw * 2
+  return Int.ofNat k
+
+/-! ## The square-free-radical divisibility certificate -/
+
+/-- Trimmed coefficient array (drop trailing zeros). -/
+private meta def trimArr (a : Array Int) : Array Int := Id.run do
+  let mut a := a
+  while a.size > 0 && a[a.size - 1]! == 0 do a := a.pop
+  return a
+
+/-- Compute the divisibility certificate `(a, b, t, k)` witnessing that `orig`
+and `core` share their real roots: `orig = core * a` and `t · core ^ (k+1) = a * b`
+with `t ≠ 0`, all as integer-polynomial identities. Throws the internal
+certificate-mismatch error if the executable decomposition does not reassemble
+(a bug). -/
+meta def radicalCert (orig core : Hex.ZPoly) :
+    MetaM (Hex.ZPoly × Hex.ZPoly × Int × Nat) := do
+  let msg := "isolate_roots: internal certificate mismatch in the square-free-core \
+     transport (please report this as a bug)"
+  let some aC := divExactInt orig.toArray core.toArray | throwError msg
+  let a := Hex.DensePoly.ofCoeffs aC
+  let rep := Hex.ZPoly.primitivePart a
+  let repArr := rep.toArray
+  let aArr := a.toArray
+  if repArr.size == 0 || aArr.size == 0 then throwError msg
+  let t := aArr[aArr.size - 1]! / repArr[repArr.size - 1]!
+  let mut found : Option (Hex.ZPoly × Nat) := none
+  for ee in [1:orig.size + 2] do
+    if found.isNone then
+      match divExactInt (powZ core ee).toArray repArr with
+      | some bC => found := some (Hex.DensePoly.ofCoeffs bC, ee)
+      | none => pure ()
+  let some (b, e) := found | throwError msg
+  -- sanity: core * a = orig, t • rep = a, rep * b = core ^ e
+  if trimArr (core * a).toArray != trimArr orig.toArray then throwError msg
+  if trimArr (Hex.DensePoly.scale t rep).toArray != trimArr aArr then throwError msg
+  if trimArr (rep * b).toArray != trimArr (powZ core e).toArray then throwError msg
+  if t == 0 then throwError msg
+  return (a, b, t, e - 1)
+
+/-! ## The driver -/
+
+/-- Emit `coreTerm : IsolatedRealRoots (toPolynomial fLit) n` for the reflected
+integer polynomial `f` (the reflection of the user's input), classifying it as
+zero / nonzero constant / square-free / non-squarefree and routing accordingly. -/
+meta def emitCore (f : Hex.ZPoly) (widthK : Option Int) : MetaM (TSyntax `term) := do
+  let fStx ← zpolyStx f
+  if f.size == 0 then
+    throwError "isolate_roots: the zero polynomial (every real number is a root, \
+      so there is no finite isolation)"
+  else if f.size == 1 then
+    -- nonzero constant: no real roots
+    `(HexRealRootsMathlib.IsolatedRealRoots.ofNoRoots
+        (P := HexPolyZMathlib.toPolynomial $fStx)
+        (by intro x hx
+            rw [HexRealRootsMathlib.aeval_toPolynomial_ofCoeffs] at hx
+            simp [Finset.sum_range_succ, Finset.sum_range_zero, Hex.DensePoly.coeff_ofCoeffs] at hx))
+  else if Hex.ZPoly.hasSquarefreeSturmChain f then
+    let d ← runBackend f widthK
+    emitOfCert d
+  else
+    -- non-squarefree: isolate the square-free core, transport by the radical cert
+    let core := Hex.ZPoly.squareFreeCore f
+    let d ← runBackend core widthK
+    let coreCert ← emitOfCert d
+    let coreStx ← zpolyStx core
+    let (a, b, t, k) ← radicalCert f core
+    let aStx ← zpolyStx a
+    let bStx ← zpolyStx b
+    let tStx ← intStx t
+    let kStx := natStx k
+    `(Hex.IsolatedRealRoots.congrRoots
+        (HexRealRootsMathlib.aevalIff_radical (orig := $fStx) (core := $coreStx)
+          (a := $aStx) (b := $bStx) (t := $tStx) (k := $kStx)
+          (by decide) (by isolate_roots_prod) (by isolate_roots_prod))
+        $coreCert)
+
+/-- Shared driver for the `isolate_roots` term elaborator. -/
+meta def elabIsolate (widthStx : Option (TSyntax `term)) (pStx : TSyntax `term)
+    (expectedType? : Option Expr) : TermElabM Expr := do
+  -- width
+  let widthK ← match widthStx with
+    | none => pure none
+    | some w => do
+      let wE ← elabTermEnsuringType w (some (mkConst ``Rat))
+      Term.synthesizeSyntheticMVarsNoPostponing
+      let wE ← instantiateMVars wE
+      if wE.hasFVar || wE.hasExprMVar then
+        throwError "isolate_roots: the width must be a closed rational \
+          (no free variables or metavariables){indentExpr wE}"
+      let q ← evalRat wE
+      if q ≤ 0 then throwError "isolate_roots: the width must be strictly positive"
+      pure (some (← widthTarget q))
+  -- polynomial: elaborate and dispatch on its type
+  let pE ← elabTerm pStx none
+  Term.synthesizeSyntheticMVarsNoPostponing
+  let pE ← instantiateMVars pE
+  if pE.hasFVar || pE.hasExprMVar then
+    throwError "isolate_roots: the polynomial must be a closed term \
+      (no free variables or metavariables){indentExpr pE}"
+  let ty ← whnfR (← inferType pE)
+  let tyFn := ty.getAppFn
+  let tyArgs := ty.getAppArgs
+  let isZPoly := tyFn.isConstOf ``Hex.DensePoly && tyArgs.size ≥ 1 && tyArgs[0]!.isConstOf ``Int
+  let isPoly := tyFn.isConstOf ``Polynomial
+  let (f, isPolyInput) ←
+    if isZPoly then
+      pure (← evalZPoly pE, false)
+    else if isPoly then do
+      let R := tyArgs[0]!
+      let isRatRing := R.isConstOf ``Rat
+      pure (← parsePoly isRatRing 8 pE, true)
+    else
+      throwError "isolate_roots: expected a closed `Hex.ZPoly` or `Polynomial ℤ/ℚ/ℝ` \
+        term, but the argument has type{indentExpr ty}"
+  let coreTerm ← emitCore f widthK
+  let term ←
+    if isPolyInput then
+      `(Hex.IsolatedRealRoots.congrRoots (Q := $pStx) (by aeval_iff_bridge) $coreTerm)
+    else
+      pure coreTerm
+  Term.elabTermEnsuringType term expectedType?
+
+/-! ## Syntax -/
+
+/-- `isolate_roots p` / `isolate_roots (width := x) p`. The `atomic` lookahead on
+`"(" "width" ":="` lets a parenthesised polynomial argument (e.g.
+`(X^4 - 2 : Polynomial ℝ)`) parse as the polynomial rather than the width group. -/
+syntax (name := isolateRoots) "isolate_roots"
+  (atomic("(" "width" ":=") term ")")? term : term
+
+@[term_elab isolateRoots]
+meta def elabIsolateRoots : TermElab := fun stx expectedType? => do
+  match stx with
+  | `(isolate_roots (width := $wt:term) $p:term) => elabIsolate (some wt) p expectedType?
+  | `(isolate_roots $p:term) => elabIsolate none p expectedType?
+  | _ => throwUnsupportedSyntax
+
+end IsolateRoots
+
+end HexRealRootsMathlib

--- a/HexRealRootsMathlib/IsolateRootsElab.lean
+++ b/HexRealRootsMathlib/IsolateRootsElab.lean
@@ -229,22 +229,18 @@ meta partial def parsePoly (isRat : Bool) (fuel : Nat) (e : Expr) : MetaM Hex.ZP
     -- `Polynomial.C c` elaborates to `⇑Polynomial.C c = DFunLike.coe … Polynomial.C c`.
     if args.size == 6 && args[4]!.getAppFn.isConstOf ``Polynomial.C then
       return Hex.DensePoly.C (← evalCoeff isRat args[5]!)
-    else if fuel == 0 then
-      throwError "isolate_roots: unsupported polynomial syntax{indentExpr e}"
     else
-      let e' ← whnf e
-      if e' == e then throwError "isolate_roots: unsupported polynomial syntax{indentExpr e}"
-      else parsePoly isRat (fuel - 1) e'
+      throwError "isolate_roots: unsupported polynomial syntax{indentExpr e}"
   | _ =>
-    -- Unfold a named local/def by one whnf step under the fuel guard, else fail.
+    -- Unfold a named def by one delta step under the fuel guard, else fail. Uses
+    -- `unfoldDefinition?` rather than `whnf`, which would normalise past the
+    -- structural `+/−/*` heads into the `Finsupp` form and defeat the match.
     if fuel == 0 then
       throwError "isolate_roots: unsupported polynomial syntax{indentExpr e}"
     else
-      let e' ← whnf e
-      if e' == e then
-        throwError "isolate_roots: unsupported polynomial syntax{indentExpr e}"
-      else
-        parsePoly isRat (fuel - 1) e'
+      match ← unfoldDefinition? e with
+      | some e' => parsePoly isRat (fuel - 1) e'
+      | none => throwError "isolate_roots: unsupported polynomial syntax{indentExpr e}"
 
 /-! ## Exact integer-polynomial arithmetic (for the radical certificate) -/
 

--- a/HexRealRootsMathlib/IsolateRootsElabTests.lean
+++ b/HexRealRootsMathlib/IsolateRootsElabTests.lean
@@ -38,6 +38,9 @@ noncomputable def iso_w1000 := isolate_roots (width := 1 / 1000) (X ^ 4 - 2 : Po
 /-- `x⁴ − 2`, width `10^(-2)`. -/
 noncomputable def iso_w100 := isolate_roots (width := 10 ^ (-2 : ℤ)) (X ^ 4 - 2 : Polynomial ℝ)
 
+/-- `x⁴ − 2` as a `ZPoly`, refined to width `2^(-20)`. -/
+noncomputable def iso_zpoly_w20 := isolate_roots (width := 2 ^ (-20 : ℤ)) x4m2
+
 /-! ## Coefficient rings -/
 
 /-- Wilkinson-6 `∏_{i=1}^{6}(x − i)` over `Polynomial ℤ`. -/
@@ -104,7 +107,7 @@ info: isolate_roots: non-integer coefficient
 
 /--
 info: isolate_roots: unsupported polynomial syntax
-  { toFinsupp := AddMonoidAlgebra.single 2 3 }
+  (monomial 2) 3
 -/
 #guard_msgs in
 #check_failure (isolate_roots (Polynomial.monomial 2 3 : Polynomial ℤ))

--- a/HexRealRootsMathlib/IsolateRootsElabTests.lean
+++ b/HexRealRootsMathlib/IsolateRootsElabTests.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+-- PLAIN `public import` only: NO `import all`. The emitted `decide`s must reduce
+-- in the kernel through the exposed count-check closure and the `SturmChainCert` /
+-- `orderedAdjacent` certificates alone, exactly as a downstream `module` consumer
+-- of the `isolate_roots` elaborator would see them.
+public import HexRealRootsMathlib.IsolateRootsElab
+
+public section
+
+open Hex Polynomial HexRealRootsMathlib
+
+namespace HexRealRootsMathlib.ElabTests
+
+/-! ## `x⁴ − 2` -/
+
+/-- `x⁴ − 2` as a `Hex.ZPoly`. -/
+def x4m2 : ZPoly := DensePoly.ofCoeffs #[(-2 : Int), 0, 0, 0, 1]
+
+/-- Bare isolation of `x⁴ − 2` as a `ZPoly`. -/
+noncomputable def iso_zpoly := isolate_roots x4m2
+
+/-- `x⁴ − 2` over `Polynomial ℝ`, bare. -/
+noncomputable def iso_real := isolate_roots (X ^ 4 - 2 : Polynomial ℝ)
+
+/-- `x⁴ − 2`, every root refined to width `2^(-20)`. -/
+noncomputable def iso_w20 := isolate_roots (width := 2 ^ (-20 : ℤ)) (X ^ 4 - 2 : Polynomial ℝ)
+
+/-- `x⁴ − 2`, width `1/1000`. -/
+noncomputable def iso_w1000 := isolate_roots (width := 1 / 1000) (X ^ 4 - 2 : Polynomial ℝ)
+
+/-- `x⁴ − 2`, width `10^(-2)`. -/
+noncomputable def iso_w100 := isolate_roots (width := 10 ^ (-2 : ℤ)) (X ^ 4 - 2 : Polynomial ℝ)
+
+/-! ## Coefficient rings -/
+
+/-- Wilkinson-6 `∏_{i=1}^{6}(x − i)` over `Polynomial ℤ`. -/
+noncomputable def iso_wilkinson :=
+  isolate_roots ((X - 1) * (X - 2) * (X - 3) * (X - 4) * (X - 5) * (X - 6) : Polynomial ℤ)
+
+/-- A `Polynomial ℚ` case: `2x² − 3x + 1 = (2x − 1)(x − 1)`. -/
+noncomputable def iso_rat := isolate_roots (2 * X ^ 2 - 3 * X + 1 : Polynomial ℚ)
+
+/-! ## Non-squarefree (exercises the core transport) -/
+
+/-- `(x − 1)²(x − 3)` over `Polynomial ℤ`: two distinct real roots. -/
+noncomputable def iso_nonsqfree :=
+  isolate_roots ((X - 1) ^ 2 * (X - 3) : Polynomial ℤ)
+
+/-! ## Nonzero constant -/
+
+/-- A nonzero constant has no real roots: the empty isolation. -/
+noncomputable def iso_const := isolate_roots (7 : Polynomial ℝ)
+
+end HexRealRootsMathlib.ElabTests

--- a/HexRealRootsMathlib/IsolateRootsElabTests.lean
+++ b/HexRealRootsMathlib/IsolateRootsElabTests.lean
@@ -137,3 +137,41 @@ info: isolate_roots: the width must be a closed rational (no free variables or m
 end Errors
 
 end HexRealRootsMathlib.ElabTests
+
+/-! ### Review-hardening tests: dispatch, certification link, and taxonomy
+completeness (from the Codex review of #8843). -/
+
+/-- error: isolate_roots: expected a closed `Hex.ZPoly` or `Polynomial ℤ/ℚ/ℝ` term, but the argument has type
+  ℕ -/
+#guard_msgs in
+noncomputable example := isolate_roots (37 : Nat)
+
+/-- error: isolate_roots: unsupported coefficient ring
+  ℕ
+expected `Polynomial ℤ`, `Polynomial ℚ`, or `Polynomial ℝ` (with integer coefficients) -/
+#guard_msgs in
+noncomputable example := isolate_roots ((Polynomial.X : Polynomial ℕ) + 1)
+
+@[irreducible] private def secretExp : Nat := 2
+
+/-- error: isolate_roots: not a Nat literal
+  secretExp -/
+#guard_msgs in
+noncomputable example := isolate_roots ((Polynomial.X : Polynomial ℤ) ^ secretExp - 2)
+
+@[irreducible] private def hiddenZ : Hex.ZPoly := Hex.DensePoly.ofCoeffs #[-2, 0, 0, 0, 1]
+
+/-- error: isolate_roots: cannot certify that the evaluated polynomial is definitionally the supplied term (is the definition irreducible?)
+⊢ ∀ (x : ℝ),
+    (aeval x) (HexPolyZMathlib.toPolynomial (DensePoly.ofCoeffs #[-2, 0, 0, 0, 1])) = 0 ↔
+      (aeval x) (HexPolyZMathlib.toPolynomial hiddenZ) = 0 -/
+#guard_msgs in
+noncomputable example := isolate_roots hiddenZ
+
+/-- A plain (delta-reducible) named `ZPoly` def: the result is stated over
+the USER'S name, with the evaluation certified by the kernel's defeq check. -/
+private def openZ : Hex.ZPoly := Hex.DensePoly.ofCoeffs #[-2, 0, 0, 0, 1]
+
+noncomputable example :
+    Hex.IsolatedRealRoots (HexPolyZMathlib.toPolynomial openZ) 2 :=
+  isolate_roots openZ

--- a/HexRealRootsMathlib/IsolateRootsElabTests.lean
+++ b/HexRealRootsMathlib/IsolateRootsElabTests.lean
@@ -58,4 +58,79 @@ noncomputable def iso_nonsqfree :=
 /-- A nonzero constant has no real roots: the empty isolation. -/
 noncomputable def iso_const := isolate_roots (7 : Polynomial ℝ)
 
+/-! ## Consumption demos -/
+
+/-- `obtain` the four fields directly out of the elaborator's result. -/
+example : True := by
+  obtain ⟨v, hu, hc, ho⟩ := isolate_roots (X ^ 4 - 2 : Polynomial ℝ)
+  trivial
+
+/-- A `have` binding of the result, then use of a field. -/
+example : True := by
+  have H := isolate_roots x4m2
+  have := H.covers
+  trivial
+
+/-- Feed the isolation's fields to `grind`. `grind` digests the `ordered` field
+into the pairwise-disjointness statement (the `covers`/`unique_root` existentials
+are consumed with `exact`, as `grind` does not synthesise their witnesses). -/
+example : True := by
+  have H := isolate_roots (X ^ 4 - 2 : Polynomial ℝ)
+  have hord := H.ordered
+  have _key : ∀ i j : Fin H.intervals.toArray.size, i < j →
+      (H.intervals[i].2 : ℚ) ≤ (H.intervals[j].1 : ℚ) := by grind
+  trivial
+
+/-! ## Error taxonomy (deliverable 6)
+
+Each distinct diagnostic is pinned with `#guard_msgs`. The internal
+certificate-mismatch path (`radicalCert` reassembly failure) is a defensive code
+assertion that cannot fire on valid input without a contrived hook, so it is
+documented rather than tested. -/
+
+section Errors
+variable (p : Hex.ZPoly) (w : ℚ)
+
+/-- info: isolate_roots: the zero polynomial (every real number is a root, so there is no finite isolation) -/
+#guard_msgs in
+#check_failure (isolate_roots (0 : Polynomial ℤ))
+
+/--
+info: isolate_roots: non-integer coefficient
+  1 / 2
+-/
+#guard_msgs in
+#check_failure (isolate_roots (X + Polynomial.C (1 / 2 : ℚ) : Polynomial ℚ))
+
+/--
+info: isolate_roots: unsupported polynomial syntax
+  { toFinsupp := AddMonoidAlgebra.single 2 3 }
+-/
+#guard_msgs in
+#check_failure (isolate_roots (Polynomial.monomial 2 3 : Polynomial ℤ))
+
+/--
+info: isolate_roots: the polynomial must be a closed term (no free variables or metavariables)
+  p
+-/
+#guard_msgs in
+#check_failure (isolate_roots p)
+
+/--
+info: isolate_roots: the width must be a closed rational (no free variables or metavariables)
+  w
+-/
+#guard_msgs in
+#check_failure (isolate_roots (width := w) (X ^ 2 - 2 : Polynomial ℤ))
+
+/-- info: isolate_roots: the width must be strictly positive -/
+#guard_msgs in
+#check_failure (isolate_roots (width := 0) (X ^ 2 - 2 : Polynomial ℤ))
+
+/-- info: isolate_roots: pathological width (finer than 2^-4096); the isolation would be astronomically large. Refine the result manually if you truly need this. -/
+#guard_msgs in
+#check_failure (isolate_roots (width := 2 ^ (-5000 : ℤ)) (X ^ 2 - 2 : Polynomial ℤ))
+
+end Errors
+
 end HexRealRootsMathlib.ElabTests

--- a/SPEC/Libraries/hex-real-roots-mathlib.md
+++ b/SPEC/Libraries/hex-real-roots-mathlib.md
@@ -256,6 +256,17 @@ as sets; proven through the `primitiveSquareFreeDecomposition`
 bridge and a root-multiplicity argument, and shared with the `rcf`
 tactic's step 3).
 
+The elaborator's own transport does not identify the reified core
+with `squareFreeCore p` in the kernel — that identification would
+need to reduce `squareFreeCore`'s rational-arithmetic helpers, which
+are deliberately outside the replay closure. It instead emits a
+radical certificate: reified cofactors `a`, `b`, a scalar `t`, and an
+exponent `k` with the two literal `ring` identities
+`orig = core * a` and `t · core^(k+1) = a * b`, from which
+`aevalIff_radical` derives the shared real root set. Squarefreeness
+stays invisible either way; `aevalIff_squareFreeCore` remains the
+library-level statement (and the `rcf` dependency).
+
 **Kernel replay.** Following the `irreducible_cert` pattern (and
 hex-rcf §Kernel replay), the elaborator never asks the kernel to
 re-run the search. Measured on the Stage-1 prototype, the naive

--- a/progress/20260720T021702Z-isolate-roots-elab.md
+++ b/progress/20260720T021702Z-isolate-roots-elab.md
@@ -1,0 +1,59 @@
+# Stage 3d: the `isolate_roots` term elaborator
+
+## Accomplished
+
+- `HexRealRootsMathlib/IsolateRootsElab.lean`: the production `isolate_roots`
+  term elaborator over the landed `ofCert` replay API. Syntax exactly as the
+  SPEC/prototype validated:
+  `syntax (name := isolateRoots) "isolate_roots" (atomic("(" "width" ":=") term ")")? term : term`.
+  - Input dispatch: closed `Hex.ZPoly` via the `evalExpr` DTO shim;
+    `Polynomial ℤ/ℚ/ℝ` via a recursive interpreter (`X`, `C`, `OfNat`/numerals,
+    `Nat.cast`/`Int.cast`, `+ − * ^`(Nat), `neg`; named defs unfolded one delta
+    step under a fuel guard; integer-coefficient enforcement — for `ℚ` leaves,
+    evaluate to `Rat` and reject non-integers). Closedness checked with
+    `synthesizeSyntheticMVarsNoPostponing` first, for both polynomial and width.
+  - Width: evaluated as `ℚ` via the `evalExpr` path; `k = max 0 ⌈log₂ x⁻¹⌉` in
+    Int arithmetic; refinement through the cached-chain `refineToWithChain`
+    (#8838); pathological cap at `2^-4096` with the dedicated diagnostic.
+  - Emission: `ofCert` with reified polynomial + Sturm chain + interval dyadics
+    as literals, every hypothesis `by decide` against the reified chain
+    (fat-API/thin-meta); `congrRoots (by aeval_iff_bridge)` for `Polynomial`
+    inputs; `IsolatedRealRoots.constant` for nonzero constants.
+  - Non-squarefree: isolate `squareFreeCore` (computed in-process, reified as a
+    literal) and transport with a new sound divisibility bridge
+    `aevalIff_radical` (see below), *not* `aevalIff_squareFreeCore (by decide)`.
+  - Full error taxonomy, each with a user-grade message.
+- `HexRealRootsMathlib/IsolateRootsElabTests.lean`: end-to-end demos (ZPoly and
+  `Polynomial ℝ`, three widths, ZPoly width, Wilkinson-6 over `ℤ`, a `ℚ` case,
+  non-squarefree `(X-1)^2*(X-3)`, nonzero constant), obtain/have/grind
+  consumption, and `#guard_msgs` coverage of every distinct diagnostic.
+- Both modules wired into the `HexRealRootsMathlib` umbrella. Full `lake build`
+  green (9421 jobs).
+
+## Current frontier
+
+Branch `isolate-roots/elab` pushed; no PR opened yet (per instructions, no merge).
+
+## Key finding: deliverable 5's core transport is infeasible as specified
+
+`aevalIff_squareFreeCore (by decide)` cannot compose with a reified *literal*
+square-free core: identifying the literal `coreLit` with `squareFreeCore f`
+needs a kernel proof, but `rfl` fails (not defeq) and `decide` gets stuck
+(`squareFreeCore`'s rational helpers are unexposed — the SPEC's own "outside the
+kernel-reducible replay closure" choice). Implemented the sound alternative
+`aevalIff_radical`: from reified cofactors `a`, `b`, a scalar `t`, exponent `k`
+with `orig = core * a` and `t·core^(k+1) = a*b` (two `ring` identities on
+literals, no `squareFreeCore` reduction), the real roots of `orig` and `core`
+coincide. The cofactors are computed at elaboration time by exact
+integer-polynomial division.
+
+## Next step
+
+Open the PR when ready. Possible follow-up: a smarter Polynomial→user bridge so
+a *top-level opaque named `Polynomial` def* is accepted (currently the interpreter
+unfolds defs for the value, but the ℝ-bridge needs the surface polynomial
+structurally expandable).
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR delivers the production `isolate_roots` term elaborator per the SPEC: the `atomic`-lookahead syntax with optional `(width := x)`, input dispatch over closed `ZPoly` terms (compiled-DTO shim) and `Polynomial ℤ/ℚ/ℝ` expressions (recursive interpreter matching `C` in its `DFunLike.coe` form, one-step named-def unfolding under fuel, integer-coefficient enforcement, closedness checks), width handling through the cached-chain `refineToWithChain` with the `2^-4096` pathological cap, and fat-API emission through `IsolatedRealRoots.ofCert` with every obligation a literal `decide`. Squarefree transparency lands via a radical certificate (`aevalIff_radical` on reified cofactors with two literal `ring` identities) since kernel-identifying the reified core with `squareFreeCore p` is deliberately impossible outside the replay closure — the SPEC paragraph is updated to record this, with `aevalIff_squareFreeCore` remaining the library statement. The full error taxonomy is `#guard_msgs`-tested except the defensive internal-mismatch assertion (documented). Measured elaboration: x⁴−2 at 29 ms bare and 27 ms refined to `2^-20`, Wilkinson-6 at 160 ms, the non-squarefree `(X−1)²(X−3)` at 34 ms. Consumption demos cover `obtain`, `have`, and `grind` (which digests `ordered` directly). Known follow-up: an opaque top-level `Polynomial` def passed by name fails the final ℝ-bridge (the interpreter computes its value, but `simp`/`ring` cannot unfold it in the bridge goal).

🤖 Prepared with Claude Code

https://claude.ai/code/session_01SpYSH4swVcLJbN2Bn6NfSP