### PR TITLE
feat(real-roots-mathlib): emit pretty rational interval literals from isolate_roots

### DIFF
--- a/HexRealRootsMathlib/IsolateRoots.lean
+++ b/HexRealRootsMathlib/IsolateRoots.lean
@@ -67,7 +67,7 @@ structure IsolatedRealRoots {R : Type*} [CommRing R] [Algebra R ℝ]
 twice by the elaborator: the squarefree-core step and the user-polynomial
 step. Heterogeneous in the coefficient ring, since the structure only sees `P`
 through `aeval x P = 0`. -/
-noncomputable def IsolatedRealRoots.congrRoots {R S : Type*} [CommRing R] [Algebra R ℝ]
+@[expose] noncomputable def IsolatedRealRoots.congrRoots {R S : Type*} [CommRing R] [Algebra R ℝ]
     [CommRing S] [Algebra S ℝ] {P : Polynomial R} {Q : Polynomial S} {n : ℕ}
     (h : ∀ x : ℝ, aeval x P = 0 ↔ aeval x Q = 0) :
     IsolatedRealRoots P n → IsolatedRealRoots Q n := fun H =>
@@ -216,6 +216,73 @@ noncomputable def IsolatedRealRoots.ofCert {p : Hex.ZPoly} {chain : Array Hex.ZP
         ordered := Hex.ordered_of_adjacent hordered
         complete := iso.size_toArray.trans
           (hcomplete.symm.trans (Hex.ZPoly.rootCount_eq_of_cert hcert).symm) }
+
+/-! ## Pretty interval literals -/
+
+/-- Re-express an isolation over different interval literals: any vector whose
+endpoints agree with the originals **as reals** carries the same three
+theorems. Stating the agreement over `ℝ` matters: it never normalizes a
+rational (no `Rat` gcd anywhere near the kernel), so the elaborator can
+discharge it by `norm_num` through the dyadic cast lemmas and present the
+intervals as pretty `m / 2^k` literals. With a literal `intervals` field,
+user-side extraction is a definitional step:
+`show H.intervals = #v[…] from rfl`. -/
+@[expose] noncomputable def IsolatedRealRoots.withIntervals {R : Type*} [CommRing R] [Algebra R ℝ]
+    {P : Polynomial R} {n : ℕ} (H : IsolatedRealRoots P n) (w : Vector (ℚ × ℚ) n)
+    (hw : ∀ i : Fin n,
+      ((w[i].1 : ℚ) : ℝ) = ((H.intervals[i].1 : ℚ) : ℝ) ∧
+      ((w[i].2 : ℚ) : ℝ) = ((H.intervals[i].2 : ℚ) : ℝ)) :
+    IsolatedRealRoots P n where
+  intervals := w
+  unique_root i := by
+    rw [(hw i).1, (hw i).2]
+    exact H.unique_root i
+  covers x hx := by
+    obtain ⟨i, h1, h2⟩ := H.covers x hx
+    exact ⟨i, by rw [(hw i).1]; exact h1, by rw [(hw i).2]; exact h2⟩
+  ordered i j hij := by
+    have h := H.ordered i j hij
+    have hr : ((w[i].2 : ℚ) : ℝ) ≤ ((w[j].1 : ℚ) : ℝ) := by
+      rw [(hw i).2, (hw j).1]
+      exact_mod_cast h
+    exact_mod_cast hr
+
+/-- The `intervals` of `ofCert` are the `toRat` images of the supplied
+isolations' dyadic endpoints. -/
+theorem IsolatedRealRoots.ofCert_intervals {p : Hex.ZPoly} {chain : Array Hex.ZPoly} {n : ℕ}
+    (iso : Vector (Hex.RealRootIsolation p) n) (hsize : p.size ≠ 0)
+    (hsf : Hex.ZPoly.hasSquarefreeSturmChain p = true) (hcert : Hex.SturmChainCert p chain)
+    (hordered : Hex.orderedAdjacent iso.toArray = true)
+    (hcomplete : Hex.sturmVarNegInf chain - Hex.sturmVarPosInf chain = n) (i : Fin n) :
+    (IsolatedRealRoots.ofCert iso hsize hsf hcert hordered hcomplete).intervals[i] =
+      ((iso[i]).interval.lower.toRat, (iso[i]).interval.upper.toRat) := by
+  obtain ⟨arr, rfl⟩ := iso
+  simp [IsolatedRealRoots.ofCert, IsolatedRealRoots.of]
+
+/-- `ofCert`, re-based on pretty rational interval literals. `w`'s endpoints
+are tied to the isolations' dyadics by ℝ-level identities against the literal
+`iso` argument — a shape user modules can check without reducing any of this
+library's definitions, and with no `Rat` normalization near the kernel. This
+is the constructor the `isolate_roots` elaborator emits: with `intervals`
+definitionally the literal `w`, user-side extraction is
+`show H.intervals = #v[…] from rfl`. -/
+@[expose] noncomputable def IsolatedRealRoots.ofCertPretty {p : Hex.ZPoly} {chain : Array Hex.ZPoly}
+    {n : ℕ} (iso : Vector (Hex.RealRootIsolation p) n) (w : Vector (ℚ × ℚ) n)
+    (hsize : p.size ≠ 0)
+    (hsf : Hex.ZPoly.hasSquarefreeSturmChain p = true) (hcert : Hex.SturmChainCert p chain)
+    (hordered : Hex.orderedAdjacent iso.toArray = true)
+    (hcomplete : Hex.sturmVarNegInf chain - Hex.sturmVarPosInf chain = n)
+    (hw : ∀ i : Fin n,
+      ((w[i].1 : ℚ) : ℝ) = Dyadic.toReal (iso[i]).interval.lower ∧
+      ((w[i].2 : ℚ) : ℝ) = Dyadic.toReal (iso[i]).interval.upper) :
+    Hex.IsolatedRealRoots (HexPolyZMathlib.toPolynomial p) n :=
+  IsolatedRealRoots.withIntervals
+    (IsolatedRealRoots.ofCert iso hsize hsf hcert hordered hcomplete) w (by
+    intro i
+    have he := IsolatedRealRoots.ofCert_intervals iso hsize hsf hcert hordered hcomplete i
+    constructor
+    · rw [(hw i).1, he, toReal_eq_cast_toRat]
+    · rw [(hw i).2, he, toReal_eq_cast_toRat])
 
 /-! ## The bridge tactic -/
 

--- a/HexRealRootsMathlib/IsolateRootsElab.lean
+++ b/HexRealRootsMathlib/IsolateRootsElab.lean
@@ -347,10 +347,42 @@ meta def emitOfCert (d : IsoData) : MetaM (TSyntax `term) := do
     `(term| (⟨⟨$loStx, $hiStx, by decide⟩,
         HexRealRootsMathlib.RealRootIsolation.count_one_of_cert (chain := $chainStx)
           (by decide) _ (by decide)⟩ : Hex.RealRootIsolation $fStx))
-  `(HexRealRootsMathlib.IsolatedRealRoots.ofCert (chain := $chainStx)
+  -- Present the intervals as pretty rational literals (`m` or `m / 2^k`), so
+  -- the `intervals` field is definitionally a `#v[…]` literal and user-side
+  -- extraction is `show … from rfl`. Each endpoint identity is stated over ℝ
+  -- against the literal `iso` argument itself (`Dyadic.toReal` of the reified
+  -- dyadic — pure structure/literal reductions in the user module), and
+  -- discharged through the dyadic `toReal` cast lemmas: no `Rat`
+  -- normalization anywhere near the kernel.
+  let ratStx (d : Dyadic) : MetaM (TSyntax `term) := do
+    let q := d.toRat
+    let mStx ← intStx q.num
+    if q.den == 1 then `(($mStx : ℚ)) else
+      let sStx := natStx q.den.log2
+      `((($mStx : ℚ) / 2 ^ ($sStx : ℕ) : ℚ))
+  let endpointPf (d : Dyadic) : MetaM (TSyntax `term) := do
+    let dStx ← dyadicStx d
+    let qStx ← ratStx d
+    `((by
+        simp only [HexRealRootsMathlib.toReal_ofInt,
+          HexRealRootsMathlib.toReal_ofInt_shiftRight]
+        push_cast
+        norm_num :
+      (($qStx : ℝ) = HexRealRootsMathlib.Dyadic.toReal $dStx)))
+  let pairStxs ← d.endpoints.mapM fun (lo, hi) => do
+    let loQ ← ratStx lo
+    let hiQ ← ratStx hi
+    `(term| ($loQ, $hiQ))
+  let pairPfs ← d.endpoints.mapM fun (lo, hi) => do
+    let loPf ← endpointPf lo
+    let hiPf ← endpointPf hi
+    `(term| ⟨$loPf, $hiPf⟩)
+  `(HexRealRootsMathlib.IsolatedRealRoots.ofCertPretty (chain := $chainStx)
       (iso := (⟨#[$isoStxs,*], rfl⟩ : Vector (Hex.RealRootIsolation $fStx) $nLit))
+      (w := (⟨#[$pairStxs,*], rfl⟩ : Vector (ℚ × ℚ) $nLit))
       (hsize := by decide) (hsf := by decide) (hcert := by decide)
-      (hordered := by decide) (hcomplete := by decide))
+      (hordered := by decide) (hcomplete := by decide)
+      (hw := by intro i; fin_cases i <;> first $[| exact $pairPfs]*))
 
 /-! ## Width target -/
 

--- a/HexRealRootsMathlib/IsolateRootsElabTests.lean
+++ b/HexRealRootsMathlib/IsolateRootsElabTests.lean
@@ -192,3 +192,18 @@ example :
       Hex.IsolatedRealRoots (X ^ 4 - 2 : Polynomial ℝ) 2).intervals =
     #v[((-1246975 / 2 ^ 20 : ℚ), (-623487 / 2 ^ 19 : ℚ)),
        ((623487 / 2 ^ 19 : ℚ), (1246975 / 2 ^ 20 : ℚ))] := rfl
+
+/-- A nonconstant polynomial with no real roots: `n = 0`, and the empty
+interval vector still extracts by `rfl`. -/
+example :
+    (isolate_roots ((X : Polynomial ℝ) ^ 2 + 1) :
+      Hex.IsolatedRealRoots ((X : Polynomial ℝ) ^ 2 + 1) 0).intervals =
+    #v[] := rfl
+
+/-- `rfl` extraction through BOTH `congrRoots` layers: a non-squarefree
+input takes the radical-certificate transport and the Polynomial input
+takes the evaluation transport, and the intervals stay literal. -/
+example :
+    (isolate_roots ((X - 1) ^ 2 * (X - 3) : Polynomial ℝ) :
+      Hex.IsolatedRealRoots ((X - 1) ^ 2 * (X - 3) : Polynomial ℝ) 2).intervals =
+    #v[((0 : ℚ), (2 : ℚ)), ((2 : ℚ), (4 : ℚ))] := rfl

--- a/HexRealRootsMathlib/IsolateRootsElabTests.lean
+++ b/HexRealRootsMathlib/IsolateRootsElabTests.lean
@@ -175,3 +175,20 @@ private def openZ : Hex.ZPoly := Hex.DensePoly.ofCoeffs #[-2, 0, 0, 0, 1]
 noncomputable example :
     Hex.IsolatedRealRoots (HexPolyZMathlib.toPolynomial openZ) 2 :=
   isolate_roots openZ
+
+/-- The `intervals` field is definitionally a literal vector of pretty
+rationals: extraction is `rfl`, even for refined (fractional) endpoints.
+No `Rat` normalization stands between the user and the endpoints. -/
+noncomputable example : Hex.IsolatedRealRoots (X ^ 4 - 2 : Polynomial ℝ) 2 :=
+  isolate_roots (X ^ 4 - 2 : Polynomial ℝ)
+
+example :
+    (isolate_roots (X ^ 4 - 2 : Polynomial ℝ) :
+      Hex.IsolatedRealRoots (X ^ 4 - 2 : Polynomial ℝ) 2).intervals =
+    #v[((-4 : ℚ), (0 : ℚ)), ((0 : ℚ), (4 : ℚ))] := rfl
+
+example :
+    (isolate_roots (width := 2 ^ (-20 : ℤ)) (X ^ 4 - 2 : Polynomial ℝ) :
+      Hex.IsolatedRealRoots (X ^ 4 - 2 : Polynomial ℝ) 2).intervals =
+    #v[((-1246975 / 2 ^ 20 : ℚ), (-623487 / 2 ^ 19 : ℚ)),
+       ((623487 / 2 ^ 19 : ℚ), (1246975 / 2 ^ 20 : ℚ))] := rfl

--- a/SPEC/Libraries/hex-real-roots-mathlib.md
+++ b/SPEC/Libraries/hex-real-roots-mathlib.md
@@ -311,6 +311,23 @@ de-privatized (an exposed public definition may not reference a
 `private` one); see the hex-real-roots SPEC. `Dyadic.toReal`'s unfolding is provided by a
 cast lemma rather than cross-module defeq.
 
+**Interval literals.** The emitted term re-bases `intervals` on
+pretty rational literals (`m`, or `m / 2^k` in lowest terms) via
+`IsolatedRealRoots.ofCertPretty`, which wraps the replay constructor
+in `withIntervals`: any interval vector whose endpoints agree with
+the isolator's **as reals** carries the same three theorems. The
+endpoint identities are stated against the literal `iso` argument
+itself (`Dyadic.toReal` of each reified dyadic — a shape user
+modules check without reducing any of this library's definitions)
+and discharged through the `toReal` cast lemmas, so no `Rat`
+normalization (and hence no `Nat.gcd`) comes near the kernel. With
+`intervals` definitionally a `#v[…]` literal, user-side endpoint
+extraction is a definitional step:
+`rw [show H.intervals = #v[…] from rfl]`. The wrappers this step
+unfolds (`withIntervals`, `ofCertPretty`, `congrRoots`) are
+`@[expose]`d so the reduction works from module-system files; it
+never reaches `ofCert` itself.
+
 **Errors** are user-grade and distinguish: the zero polynomial
 ("every real number is a root"), non-integer coefficients,
 unsupported polynomial syntax, non-closed input (free variables or


### PR DESCRIPTION
This PR makes the `intervals` field of an `isolate_roots` result definitionally a literal vector of pretty rationals (`m` or `m / 2^k` in lowest terms), so user-side endpoint extraction is a definitional step — `rw [show H.intervals = #v[…] from rfl]` — even for refined fractional endpoints. Previously `intervals` was derived inside `ofCert` via `Vector.ofFn` over `Dyadic.toRat`, whose `Rat.normalize`/`Nat.gcd` blocked `rfl`, `decide`, and `norm_num` alike, making tight endpoints inaccessible. New API in `IsolateRoots.lean`: `withIntervals` re-bases an isolation on any interval vector whose endpoints agree with the originals **as reals** (stating the identities over ℝ keeps `Rat` normalization away from the kernel); `ofCert_intervals` identifies `ofCert`'s intervals with the `toRat` images of the supplied dyadics; `ofCertPretty` composes the two, with the endpoint identities stated against the literal `iso` argument (`Dyadic.toReal` of each reified dyadic — a shape user modules check without reducing `ofCert`). The elaborator now emits `ofCertPretty`, discharging each endpoint identity via the `toReal` cast lemmas plus `push_cast`/`norm_num`; the wrappers the extraction step unfolds (`withIntervals`, `ofCertPretty`, `congrRoots`) are `@[expose]`d so the reduction works from module-system files. Two `rfl` extraction tests (natural intervals and width-`2^(-20)` fractional endpoints) lock the behaviour in a `public import` module, and the SPEC's elaborator section gains an "Interval literals" paragraph.

🤖 Prepared with Claude Code

https://claude.ai/code/session_01SpYSH4swVcLJbN2Bn6NfSP