### PR TITLE
feat(real-roots-mathlib): infer isolate_roots argument ring, add simp extraction, document

### DIFF
--- a/HexManual.lean
+++ b/HexManual.lean
@@ -25,6 +25,7 @@ import HexManual.Chapters.HexGFqRing
 import HexManual.Chapters.HexGFqField
 import HexManual.Chapters.HexConway
 import HexManual.Chapters.HexGFq
+import HexManual.Chapters.HexRealRoots
 -- Tutorials (application-first capstone pages, see SPEC/tutorials.md).
 import HexManual.Tutorials.Coppersmith
 
@@ -107,4 +108,6 @@ here to keep the reference chapters above focused on the released libraries.
 {include 2 HexManual.Chapters.HexConway}
 
 {include 2 HexManual.Chapters.HexGFq}
+
+{include 2 HexManual.Chapters.HexRealRoots}
 

--- a/HexManual/Chapters/HexRealRoots.lean
+++ b/HexManual/Chapters/HexRealRoots.lean
@@ -212,13 +212,14 @@ tag := "hex-real-roots-certificate"
 The elaborator does the search at elaboration time with the compiled
 isolator, then emits a term the kernel re-checks. It does not ask the
 kernel to redo the search. The emitted term reifies the Sturm chain once
-as an array of integer-coefficient polynomials, and each field reduces to
-a sign-variation count against that fixed chain: one count per interval
-for `unique_root`, an endpoint-at-infinity count for the root total, and
-an adjacent-pair comparison for `ordered`. These are `decide`-checked
-polynomial evaluations over the integers, so the cost the kernel pays
-grows with the degree and the endpoint sizes, not with the number of
-bisections the search performed.
+as an array of integer-coefficient polynomials. The root-count fields
+reduce to sign-variation counts against that fixed chain: one count per
+interval for `unique_root`, and an endpoint-at-infinity count for the root
+total. These are `decide`-checked polynomial evaluations over the
+integers, so their kernel cost grows with the degree and the endpoint
+sizes, not with the number of bisections the search performed. The
+`ordered` field is cheaper still — an adjacent-pair comparison of the
+dyadic endpoints, no polynomial evaluation at all.
 
 The interval endpoints are presented as reduced rational literals, and
 the identification of the emitted literals with the isolator's dyadic

--- a/HexManual/Chapters/HexRealRoots.lean
+++ b/HexManual/Chapters/HexRealRoots.lean
@@ -1,0 +1,248 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import VersoManual
+
+import HexRealRootsMathlib
+
+open Verso.Genre Manual
+open Verso.Genre.Manual.InlineLean
+
+set_option pp.rawOnError true
+
+#doc (Manual) "HexRealRoots: certified real-root isolation" =>
+%%%
+tag := "hex-real-roots"
+%%%
+
+# Introduction
+%%%
+tag := "hex-real-roots-intro"
+%%%
+
+`HexRealRoots` isolates the real roots of a polynomial with integer
+coefficients: it returns disjoint rational intervals, one per real root,
+each certified to contain exactly one. The isolation is exact. There are
+no floats and no error budget anywhere in the computation; the endpoints
+are dyadic rationals and the certificate is a Sturm sign-variation count
+checked in the kernel.
+
+The computational core is Mathlib-free. It builds the Sturm chain of a
+polynomial by exact integer arithmetic, evaluates sign variations at
+dyadic points, and bisects until each root is alone in its interval. The
+correspondence library `HexRealRootsMathlib` is the Mathlib bridge: it
+proves that the isolated intervals really do capture the roots of the
+polynomial as an element of `Polynomial ℝ`, and it packages the whole
+workflow behind a single term elaborator.
+
+The user-facing entry point is {ref "hex-real-roots-isolate"}[`isolate_roots`].
+One call inspects a polynomial, runs the exact isolator while the file
+elaborates, and produces a term whose type records the certified
+statements. No knowledge of Sturm chains, dyadic arithmetic, or
+squarefreeness is needed at the call site.
+
+# The `isolate_roots` elaborator
+%%%
+tag := "hex-real-roots-isolate"
+%%%
+
+`isolate_roots p` takes a polynomial `p` and elaborates to a value of
+type {name}`Hex.IsolatedRealRoots`. The polynomial may be a `Polynomial ℤ`,
+`Polynomial ℚ`, or `Polynomial ℝ` with integer coefficients, or a raw
+{name}`Hex.ZPoly` (the Mathlib-free dense integer polynomial). The result
+structure carries the intervals and the three theorems that make them a
+genuine isolation.
+
+{docstring Hex.IsolatedRealRoots}
+
+Take `x⁴ − 2`, whose two real roots are `±2^{1/4} ≈ ±1.189`. One call
+isolates them. When the expected type is given — here through the
+definition's type ascription — it pins the coefficient ring, so the
+argument itself needs no annotation, and the type records the certified
+count `2`:
+
+```lean
+open Hex Polynomial
+
+/-- Both real roots of `x⁴ − 2`, certified. -/
+noncomputable def x4roots :
+    IsolatedRealRoots (X ^ 4 - 2 : Polynomial ℝ) 2 :=
+  isolate_roots (X ^ 4 - 2)
+```
+
+The `intervals` field is an ordinary literal vector, so reading it back
+is definitional. With no width request the intervals are whatever the
+isolator's separation produced; here `(-4, 0]` and `(0, 4]`:
+
+```lean
+open Hex Polynomial
+
+example : x4roots.intervals = #v[(-4, 0), (0, 4)] :=
+  rfl
+```
+
+# What the fields say
+%%%
+tag := "hex-real-roots-fields"
+%%%
+
+The three propositional fields are the isolation contract, stated in
+`aeval` form so they read uniformly across the coefficient rings. Project
+`unique_root` at an index for the existence-and-uniqueness statement of
+that interval; `simp [x4roots]` computes the interval endpoints to their
+literal values, turning it into a self-contained theorem about `x⁴ − 2`:
+
+```lean
+open Hex Polynomial
+
+/-- One real root of `x⁴ − 2` in `(0, 4]`. -/
+theorem root_pos :
+    ∃! x : ℝ, x ^ 4 - 2 = 0 ∧ (0 : ℝ) < x ∧ x ≤ 4 := by
+  simpa [x4roots] using x4roots.unique_root 1
+```
+
+The `covers` field runs the other way: every real root lies in one of the
+intervals, so listing them is a complete case analysis of the roots. Here
+it proves that `x⁴ − 2` has no real root outside the two intervals:
+
+```lean
+open Hex Polynomial
+
+theorem roots_complete (x : ℝ) (hx : x ^ 4 - 2 = 0) :
+    (-4 < x ∧ x ≤ 0) ∨ (0 < x ∧ x ≤ 4) := by
+  obtain ⟨i, hlo, hhi⟩ :=
+    x4roots.covers x (by simpa using hx)
+  simp only [x4roots] at hlo hhi
+  fin_cases i
+  · exact .inl ⟨by simpa using hlo, by simpa using hhi⟩
+  · exact .inr ⟨by simpa using hlo, by simpa using hhi⟩
+```
+
+The `ordered` field says the intervals are sorted and pairwise disjoint.
+Because the intervals are half-open, this is what makes the index count
+`n` equal to the number of distinct real roots, and it gives disjointness
+as a one-liner:
+
+```lean
+open Hex Polynomial
+
+example : (x4roots.intervals[0]).2
+    ≤ (x4roots.intervals[1]).1 := by
+  simpa using x4roots.ordered 0 1 (by decide)
+```
+
+The whole structure unpacks with `obtain`, so the fields can be named and
+fed to later tactics however a proof needs them:
+
+```lean
+open Hex Polynomial
+
+example : True := by
+  obtain ⟨ivals, uniq, cov, ord⟩ := x4roots
+  trivial
+```
+
+# Requesting tighter intervals
+%%%
+tag := "hex-real-roots-width"
+%%%
+
+The natural intervals are only as tight as the isolator needed to
+separate the roots. Passing `(width := x)` refines every interval to width
+at most `x`, still with exact rational endpoints. The width may be written
+as a fraction, a power of two, or a decimal power: `1/1000`, `2^(-20)`,
+`10^(-2)` all work. Refining `x⁴ − 2` to width `2⁻²⁰` places the positive
+root in an interval of width exactly `2⁻²⁰`:
+
+```lean
+open Hex Polynomial
+
+/-- The same two roots, isolated to width `2⁻²⁰`. -/
+noncomputable def x4rootsTight :
+    IsolatedRealRoots (X ^ 4 - 2 : Polynomial ℝ) 2 :=
+  isolate_roots (width := 2 ^ (-20 : ℤ)) (X ^ 4 - 2)
+
+/-- One real root in `(623487/2¹⁹, 1246975/2²⁰]`. -/
+theorem root_pos_tight :
+    ∃! x : ℝ, x ^ 4 - 2 = 0 ∧
+      (623487 : ℝ) / 2 ^ 19 < x ∧ x ≤ 1246975 / 2 ^ 20 := by
+  simpa [x4rootsTight] using x4rootsTight.unique_root 1
+```
+
+Width is an operational promise about the intervals the elaborator emits,
+not a field of the structure. Reading the refined endpoints back is still
+`rfl`, exactly as for the natural intervals; the refinement does not push
+`Rat` normalization into the kernel.
+
+# Squarefreeness is invisible
+%%%
+tag := "hex-real-roots-squarefree"
+%%%
+
+Sturm isolation needs a squarefree polynomial, but the user never has to
+supply one. When the input has repeated roots the elaborator isolates its
+squarefree core and transports the certificate back to the original
+polynomial, so a polynomial like `(x − 1)²(x − 3)` isolates as its two
+distinct roots with no bookkeeping at the call site:
+
+```lean
+open Hex Polynomial
+
+noncomputable def cubeRoots :
+    IsolatedRealRoots
+      ((X - 1) ^ 2 * (X - 3) : Polynomial ℝ) 2 :=
+  isolate_roots ((X - 1) ^ 2 * (X - 3))
+
+example : cubeRoots.intervals = #v[(0, 2), (2, 4)] :=
+  rfl
+```
+
+A polynomial with no real roots isolates as the empty vector, and a
+nonzero constant isolates as `n = 0` without ever entering the isolator.
+The zero polynomial is rejected, since every real number is a root.
+
+# How the certificate is checked
+%%%
+tag := "hex-real-roots-certificate"
+%%%
+
+The elaborator does the search at elaboration time with the compiled
+isolator, then emits a term the kernel re-checks. It does not ask the
+kernel to redo the search. The emitted term reifies the Sturm chain once
+as an array of integer-coefficient polynomials, and each field reduces to
+a sign-variation count against that fixed chain: one count per interval
+for `unique_root`, an endpoint-at-infinity count for the root total, and
+an adjacent-pair comparison for `ordered`. These are `decide`-checked
+polynomial evaluations over the integers, so the cost the kernel pays
+grows with the degree and the endpoint sizes, not with the number of
+bisections the search performed.
+
+The interval endpoints are presented as reduced rational literals, and
+the identification of the emitted literals with the isolator's dyadic
+endpoints is stated over `ℝ`. This keeps rational normalization, and its
+`Nat.gcd`, away from the kernel, which is what makes endpoint extraction a
+plain `rfl` even for the refined fractional endpoints above.
+
+# Cross-references
+%%%
+tag := "hex-real-roots-cross-references"
+%%%
+
+`HexRealRoots` sits at the top of the polynomial stack and is consumed
+through its Mathlib bridge:
+
+* {ref "hex-poly-z"}[HexPolyZ] provides the dense integer polynomial
+  {name}`Hex.ZPoly` that the isolator operates on, together with the
+  content, primitive-part, and squarefree-decomposition operations the
+  squarefree-core step relies on.
+* `HexRealRootsMathlib` is the correspondence library. It identifies the
+  executable Sturm certificate with the root theory of `Polynomial ℝ`,
+  proves that the squarefree core shares the real roots of the original
+  polynomial, and provides {name}`Hex.IsolatedRealRoots` and the
+  {ref "hex-real-roots-isolate"}[`isolate_roots`] elaborator documented
+  here. The Mathlib dependency lives entirely in this bridge; a `ZPoly`
+  input keeps every emitted statement Mathlib-facing only through
+  `toPolynomial`.

--- a/HexRealRootsMathlib/IsolateRoots.lean
+++ b/HexRealRootsMathlib/IsolateRoots.lean
@@ -79,6 +79,13 @@ through `aeval x P = 0`. -/
     covers := fun x hx => H.covers x ((h x).mpr hx)
     ordered := H.ordered }
 
+/-- `congrRoots` leaves the intervals untouched, so `simp` reduces a transported
+isolation's intervals to the underlying ones. -/
+@[simp] theorem IsolatedRealRoots.congrRoots_intervals {R S : Type*} [CommRing R]
+    [Algebra R ℝ] [CommRing S] [Algebra S ℝ] {P : Polynomial R} {Q : Polynomial S} {n : ℕ}
+    (h : ∀ x : ℝ, aeval x P = 0 ↔ aeval x Q = 0) (H : IsolatedRealRoots P n) :
+    (IsolatedRealRoots.congrRoots h H).intervals = H.intervals := rfl
+
 /-- The `n = 0` result for a constant whose real image is nonzero: it has no
 real roots, so the empty isolation is complete. Nonzero constants never enter
 the isolator (the squarefree Sturm certificate is `false` on constants by
@@ -141,7 +148,7 @@ theorem ne_zero_of_size_ne_zero {p : Hex.ZPoly} (h : p.size ≠ 0) : p ≠ 0 :=
 /-- **`IsolatedRealRoots.of`.** Assemble the user structure from a complete
 Sturm-certified run, via `exists_unique_root` + `isolates` + the `aeval` bridge,
 including the `ordered` field from the backend's `ordered`. -/
-noncomputable def IsolatedRealRoots.of (p : Hex.ZPoly) (hp0 : p ≠ 0)
+noncomputable def _root_.Hex.IsolatedRealRoots.of (p : Hex.ZPoly) (hp0 : p ≠ 0)
     (hsf : Hex.ZPoly.SquareFreeRat p) (out : Hex.RealRootIsolations p) :
     Hex.IsolatedRealRoots (HexPolyZMathlib.toPolynomial p) out.isolations.size where
   intervals := Vector.ofFn fun i =>
@@ -203,7 +210,7 @@ obligation a single `decide` on literals:
 
 The kernel replays only the exposed count-check closure against the literal
 chain; it never rebuilds `sturmChain p` inside a field. -/
-noncomputable def IsolatedRealRoots.ofCert {p : Hex.ZPoly} {chain : Array Hex.ZPoly} {n : ℕ}
+noncomputable def _root_.Hex.IsolatedRealRoots.ofCert {p : Hex.ZPoly} {chain : Array Hex.ZPoly} {n : ℕ}
     (iso : Vector (Hex.RealRootIsolation p) n) (hsize : p.size ≠ 0)
     (hsf : Hex.ZPoly.hasSquarefreeSturmChain p = true) (hcert : Hex.SturmChainCert p chain)
     (hordered : Hex.orderedAdjacent iso.toArray = true)
@@ -227,7 +234,7 @@ discharge it by `norm_num` through the dyadic cast lemmas and present the
 intervals as pretty `m / 2^k` literals. With a literal `intervals` field,
 user-side extraction is a definitional step:
 `show H.intervals = #v[…] from rfl`. -/
-@[expose] noncomputable def IsolatedRealRoots.withIntervals {R : Type*} [CommRing R] [Algebra R ℝ]
+@[expose] noncomputable def _root_.Hex.IsolatedRealRoots.withIntervals {R : Type*} [CommRing R] [Algebra R ℝ]
     {P : Polynomial R} {n : ℕ} (H : IsolatedRealRoots P n) (w : Vector (ℚ × ℚ) n)
     (hw : ∀ i : Fin n,
       ((w[i].1 : ℚ) : ℝ) = ((H.intervals[i].1 : ℚ) : ℝ) ∧
@@ -247,9 +254,19 @@ user-side extraction is a definitional step:
       exact_mod_cast h
     exact_mod_cast hr
 
+/-- `withIntervals` sets the intervals to the supplied literal vector, so `simp`
+reduces a re-based isolation's intervals to that literal. -/
+@[simp] theorem _root_.Hex.IsolatedRealRoots.withIntervals_intervals {R : Type*} [CommRing R]
+    [Algebra R ℝ] {P : Polynomial R} {n : ℕ} (H : IsolatedRealRoots P n)
+    (w : Vector (ℚ × ℚ) n)
+    (hw : ∀ i : Fin n,
+      ((w[i].1 : ℚ) : ℝ) = ((H.intervals[i].1 : ℚ) : ℝ) ∧
+      ((w[i].2 : ℚ) : ℝ) = ((H.intervals[i].2 : ℚ) : ℝ)) :
+    (IsolatedRealRoots.withIntervals H w hw).intervals = w := rfl
+
 /-- The `intervals` of `ofCert` are the `toRat` images of the supplied
 isolations' dyadic endpoints. -/
-theorem IsolatedRealRoots.ofCert_intervals {p : Hex.ZPoly} {chain : Array Hex.ZPoly} {n : ℕ}
+theorem _root_.Hex.IsolatedRealRoots.ofCert_intervals {p : Hex.ZPoly} {chain : Array Hex.ZPoly} {n : ℕ}
     (iso : Vector (Hex.RealRootIsolation p) n) (hsize : p.size ≠ 0)
     (hsf : Hex.ZPoly.hasSquarefreeSturmChain p = true) (hcert : Hex.SturmChainCert p chain)
     (hordered : Hex.orderedAdjacent iso.toArray = true)
@@ -266,7 +283,7 @@ library's definitions, and with no `Rat` normalization near the kernel. This
 is the constructor the `isolate_roots` elaborator emits: with `intervals`
 definitionally the literal `w`, user-side extraction is
 `show H.intervals = #v[…] from rfl`. -/
-@[expose] noncomputable def IsolatedRealRoots.ofCertPretty {p : Hex.ZPoly} {chain : Array Hex.ZPoly}
+@[expose] noncomputable def _root_.Hex.IsolatedRealRoots.ofCertPretty {p : Hex.ZPoly} {chain : Array Hex.ZPoly}
     {n : ℕ} (iso : Vector (Hex.RealRootIsolation p) n) (w : Vector (ℚ × ℚ) n)
     (hsize : p.size ≠ 0)
     (hsf : Hex.ZPoly.hasSquarefreeSturmChain p = true) (hcert : Hex.SturmChainCert p chain)
@@ -283,6 +300,22 @@ definitionally the literal `w`, user-side extraction is
     constructor
     · rw [(hw i).1, he, toReal_eq_cast_toRat]
     · rw [(hw i).2, he, toReal_eq_cast_toRat])
+
+/-- `ofCertPretty`'s intervals are the supplied literal vector `w`. The
+elaborator emits `ofCertPretty` directly, so this `simp` lemma lets a user
+`simp`/`simpa`/`grind` compute an isolation's intervals to their literal
+endpoints without unfolding the constructor by hand. -/
+@[simp] theorem _root_.Hex.IsolatedRealRoots.ofCertPretty_intervals {p : Hex.ZPoly}
+    {chain : Array Hex.ZPoly} {n : ℕ} (iso : Vector (Hex.RealRootIsolation p) n)
+    (w : Vector (ℚ × ℚ) n) (hsize : p.size ≠ 0)
+    (hsf : Hex.ZPoly.hasSquarefreeSturmChain p = true) (hcert : Hex.SturmChainCert p chain)
+    (hordered : Hex.orderedAdjacent iso.toArray = true)
+    (hcomplete : Hex.sturmVarNegInf chain - Hex.sturmVarPosInf chain = n)
+    (hw : ∀ i : Fin n,
+      ((w[i].1 : ℚ) : ℝ) = Dyadic.toReal (iso[i]).interval.lower ∧
+      ((w[i].2 : ℚ) : ℝ) = Dyadic.toReal (iso[i]).interval.upper) :
+    (IsolatedRealRoots.ofCertPretty iso w hsize hsf hcert hordered hcomplete hw).intervals = w :=
+  rfl
 
 /-! ## The bridge tactic -/
 

--- a/HexRealRootsMathlib/IsolateRootsElab.lean
+++ b/HexRealRootsMathlib/IsolateRootsElab.lean
@@ -377,7 +377,7 @@ meta def emitOfCert (d : IsoData) : MetaM (TSyntax `term) := do
     let loPf ← endpointPf lo
     let hiPf ← endpointPf hi
     `(term| ⟨$loPf, $hiPf⟩)
-  `(HexRealRootsMathlib.IsolatedRealRoots.ofCertPretty (chain := $chainStx)
+  `(Hex.IsolatedRealRoots.ofCertPretty (chain := $chainStx)
       (iso := (⟨#[$isoStxs,*], rfl⟩ : Vector (Hex.RealRootIsolation $fStx) $nLit))
       (w := (⟨#[$pairStxs,*], rfl⟩ : Vector (ℚ × ℚ) $nLit))
       (hsize := by decide) (hsf := by decide) (hcert := by decide)
@@ -494,8 +494,39 @@ meta def elabIsolate (widthStx : Option (TSyntax `term)) (pStx : TSyntax `term)
       let q ← evalRat wE
       if q ≤ 0 then throwError "isolate_roots: the width must be strictly positive"
       pure (some (← widthTarget q))
-  -- polynomial: elaborate and dispatch on its type
-  let pE ← elabTerm pStx none
+  -- When the expected type is `IsolatedRealRoots (P : Polynomial R) n`, the
+  -- coefficient ring `R` pins the argument's type, so `isolate_roots (X^4 - 2)`
+  -- elaborates without a type ascription. A `ZPoly` argument cannot take a
+  -- `Polynomial R` expected type, so this is a hint with a fallback, not a
+  -- requirement.
+  let expectedPolyTy? : Option Expr ← do
+    match expectedType? with
+    | none => pure none
+    | some et =>
+      let et ← whnfR (← instantiateMVars et)
+      let args := et.getAppArgs
+      if et.getAppFn.isConstOf ``Hex.IsolatedRealRoots && args.size ≥ 5 then
+        -- the type of the expected `P` argument is `Polynomial R`, the hint we want
+        pure (some (← inferType args[3]!))
+      else pure none
+  -- polynomial: elaborate and dispatch on its type. A `ZPoly` argument and a
+  -- type-ascribed polynomial both elaborate with no expected type; only a bare
+  -- `X^4 - 2` needs the expected `Polynomial R` to pin its ring, so that hint is
+  -- a fallback used exactly when the unhinted elaboration fails or stays
+  -- ambiguous.
+  let s ← saveState
+  let pE ←
+    try
+      let e ← elabTerm pStx none
+      Term.synthesizeSyntheticMVarsNoPostponing
+      let e ← instantiateMVars e
+      if e.hasExprMVar then throwError "isolate_roots: ambiguous argument"
+      pure e
+    catch _ =>
+      s.restore
+      match expectedPolyTy? with
+      | some pt => elabTermEnsuringType pStx (some pt)
+      | none => elabTerm pStx none
   Term.synthesizeSyntheticMVarsNoPostponing
   let pE ← instantiateMVars pE
   if pE.hasFVar || pE.hasExprMVar then

--- a/HexRealRootsMathlib/IsolateRootsElab.lean
+++ b/HexRealRootsMathlib/IsolateRootsElab.lean
@@ -523,7 +523,7 @@ meta def elabIsolate (widthStx : Option (TSyntax `term)) (pStx : TSyntax `term)
       if e.hasExprMVar then throwError "isolate_roots: ambiguous argument"
       pure e
     catch _ =>
-      s.restore
+      s.restore (restoreInfo := true)
       match expectedPolyTy? with
       | some pt => elabTermEnsuringType pStx (some pt)
       | none => elabTerm pStx none

--- a/HexRealRootsMathlib/IsolateRootsElabTests.lean
+++ b/HexRealRootsMathlib/IsolateRootsElabTests.lean
@@ -207,3 +207,27 @@ example :
     (isolate_roots ((X - 1) ^ 2 * (X - 3) : Polynomial ℝ) :
       Hex.IsolatedRealRoots ((X - 1) ^ 2 * (X - 3) : Polynomial ℝ) 2).intervals =
     #v[((0 : ℚ), (2 : ℚ)), ((2 : ℚ), (4 : ℚ))] := rfl
+
+/-- **Expected-type inference.** When the expected type pins the coefficient
+ring, the polynomial argument needs no type ascription: `X ^ 4 - 2` alone
+elaborates as a `Polynomial ℝ`. -/
+noncomputable def x4_inferred : Hex.IsolatedRealRoots (X ^ 4 - 2 : Polynomial ℝ) 2 :=
+  isolate_roots (X ^ 4 - 2)
+
+/-- A `ZPoly` argument still elaborates under an expected type (the ring hint
+does not force it to `Polynomial ℤ`). -/
+private def infZ : Hex.ZPoly := Hex.DensePoly.ofCoeffs #[-2, 0, 0, 0, 1]
+
+noncomputable example :
+    Hex.IsolatedRealRoots (HexPolyZMathlib.toPolynomial infZ) 2 :=
+  isolate_roots infZ
+
+/-- **`simp` extraction.** With the `intervals` projection simp lemmas, `simp`
+computes an isolation's endpoints to their literals, so `unique_root` closes a
+concrete theorem with one `simpa`. -/
+example : ∃! x : ℝ, x ^ 4 - 2 = 0 ∧ (0 : ℝ) < x ∧ x ≤ 4 := by
+  simpa [x4_inferred] using x4_inferred.unique_root 1
+
+/-- The `ordered` field, consumed with bare `Nat` indices. -/
+example : (x4_inferred.intervals[0]).2 ≤ (x4_inferred.intervals[1]).1 := by
+  simpa using x4_inferred.ordered 0 1 (by decide)

--- a/SPEC/Libraries/hex-real-roots-mathlib.md
+++ b/SPEC/Libraries/hex-real-roots-mathlib.md
@@ -200,6 +200,16 @@ operational promise about the emitted intervals, not a field of the
 result. The syntax uses an `atomic` lookahead on `"(" "width" ":="`
 so a parenthesised polynomial argument parses as the polynomial.
 
+When an expected type `Hex.IsolatedRealRoots (P : Polynomial R) n` is
+available at the call site, the coefficient ring `R` is used as the
+elaboration hint for the argument, so `isolate_roots (X ^ 4 - 2)` (no
+type ascription on the argument) elaborates as a `Polynomial ℝ` under
+`… : IsolatedRealRoots (X ^ 4 - 2 : Polynomial ℝ) 2`. The hint is a
+fallback: the argument is first elaborated with no expected type (a
+`ZPoly` argument, or an already-ascribed polynomial, resolves this way
+and is unaffected), and the ring hint is applied only when that leaves
+the argument's type ambiguous.
+
 The result type, uniform over the input rings through `aeval`:
 
 ```lean
@@ -326,7 +336,16 @@ extraction is a definitional step:
 `rw [show H.intervals = #v[…] from rfl]`. The wrappers this step
 unfolds (`withIntervals`, `ofCertPretty`, `congrRoots`) are
 `@[expose]`d so the reduction works from module-system files; it
-never reaches `ofCert` itself.
+never reaches `ofCert` itself. Their `intervals` projections also
+carry `@[simp]` lemmas (`ofCertPretty_intervals`,
+`withIntervals_intervals`, `congrRoots_intervals`), so `simp`,
+`simpa`, and `grind` compute an isolation's endpoints to their
+literals without naming the constructors: a `unique_root i`
+projection closes a concrete-endpoint theorem with a single
+`simpa [H]`. The whole `IsolatedRealRoots` API (`of`, `ofCert`,
+`withIntervals`, `ofCertPretty`, `congrRoots`, `constant`) lives in
+the `Hex.IsolatedRealRoots` namespace alongside the structure, so
+dot notation reaches every constructor and lemma.
 
 **Errors** are user-grade and distinguish: the zero polynomial
 ("every real number is a root"), non-integer coefficients,


### PR DESCRIPTION
This PR polishes the `isolate_roots` call site and adds its manual chapter. When an expected type `IsolatedRealRoots (P : Polynomial R) n` is present, the coefficient ring `R` now hints the argument's elaboration, so `isolate_roots (X ^ 4 - 2)` needs no type ascription on the argument. The hint is a fallback: the argument is first elaborated with no expected type, so a `ZPoly` argument or an already-ascribed polynomial resolves unchanged, and the ring hint is applied only when that leaves the argument's type ambiguous. The whole `IsolatedRealRoots` constructor API (`of`, `ofCert`, `withIntervals`, `ofCertPretty`, `congrRoots`, `constant`) now lives in the `Hex.IsolatedRealRoots` namespace beside the structure, so dot notation reaches every constructor and lemma uniformly. New `@[simp]` projection lemmas (`ofCertPretty_intervals`, `withIntervals_intervals`, `congrRoots_intervals`) let `simp`, `simpa`, and `grind` compute an isolation's endpoints to their literals, so a `unique_root` projection closes a concrete-endpoint theorem with a single `simpa [H]`. A new `HexManual` chapter documents the elaborator with live-checked snippets, and the SPEC records the ring-inference and simp-extraction behaviour. Codex reviewed the elaborator control flow, the namespace move, and the projection lemmas and found no soundness issue; its two low-severity notes (restore the info-tree on the speculative-elaboration rollback, and qualify the certificate-cost prose so the ordered field's dyadic comparison is not described as a polynomial evaluation) are folded in.

🤖 Prepared with Claude Code

https://claude.ai/code/session_01SpYSH4swVcLJbN2Bn6NfSP