### PR TITLE
feat(HexRootsMathlib): add certified Pisot isolation demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Define the hex-dev cache + build target sets
         run: |
           echo "HEX_LIB_TARGETS=HexBasic HexArith HexPoly HexModArith HexGF2 HexPolyZ HexRoots HexPolyFp HexGFqRing HexGFqField HexBerlekamp HexHensel HexConway HexGFq HexBerlekampZassenhaus HexRealRoots HexMatrix HexRowReduce HexDeterminant HexBareiss HexGramSchmidt HexLLL HexMatrixMathlib HexGramSchmidtMathlib HexLLLMathlib HexBerlekampZassenhausMathlib HexRealRootsMathlib HexRootsMathlib" >> "$GITHUB_ENV"
-          echo "HEX_EXE_TARGETS=hexarith_bench hexpoly_bench hexpolyz_bench hexpolyfp_bench hexmodarith_bench hexgf2_bench hexgfqring_bench hexgfqfield_bench hexgfq_bench hexhensel_bench hexberlekamp_bench hexbz_bench hexconway_bench hexmatrix_bench hexdeterminant_bench hexbareiss_bench hexgramschmidt_bench hexrealroots_bench hexroots_bench hexlll_bench hexlll_provider_probe" >> "$GITHUB_ENV"
+          echo "HEX_EXE_TARGETS=hexarith_bench hexpoly_bench hexpolyz_bench hexpolyfp_bench hexmodarith_bench hexgf2_bench hexgfqring_bench hexgfqfield_bench hexgfq_bench hexhensel_bench hexberlekamp_bench hexbz_bench hexconway_bench hexmatrix_bench hexdeterminant_bench hexbareiss_bench hexgramschmidt_bench hexrealroots_bench hexroots_bench hexroots_demo hexlll_bench hexlll_provider_probe" >> "$GITHUB_ENV"
       # Shared build. The libraries, bench exes, conformance #guard drivers, and
       # emit-fixture exes are all elaborated here so the two verification tails
       # below only *run* things, never rebuild them -- which is what lets the

--- a/HexRootsMathlib.lean
+++ b/HexRootsMathlib.lean
@@ -25,6 +25,7 @@ public import HexRootsMathlib.Completeness.RootFreeConverse
 public import HexRootsMathlib.Completeness.SurvivorComponent
 public import HexRootsMathlib.Component
 public import HexRootsMathlib.Driver
+public import HexRootsMathlib.Examples
 public import HexRootsMathlib.Geometry
 public import HexRootsMathlib.Glue
 public import HexRootsMathlib.HasOnlySimpleRoots

--- a/HexRootsMathlib/Completeness/DriverCompleteness.lean
+++ b/HexRootsMathlib/Completeness/DriverCompleteness.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexRootsMathlib.Completeness.SurvivorComponent
+public import HexRootsMathlib.Isolate
 public import HexRootsMathlib.Loop
 
 public section
@@ -1165,6 +1166,24 @@ theorem isolate_exists (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
   · refine ⟨#[], ?_⟩
     rw [Hex.isolate, dif_neg hd]
     simp [hpSize]
+
+/-- A nonzero squarefree polynomial has a successful isolation whose atoms
+enumerate its complex roots exactly, without duplicates, at the requested
+precision.  This bundles driver completeness with the principal soundness
+contracts for proof-facing clients. -/
+theorem isolate_spec (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
+    (hp : p ≠ 0) (atomPrec : Int)
+    (strategy : Hex.AtomStrategy := .nkThenPellet) :
+    ∃ atoms : Array (Hex.DyadicRootIsolation p),
+      Hex.isolate p h atomPrec strategy = some atoms ∧
+      atoms.size = (toPolyℂ p).natDegree ∧
+      (atoms.toList.map HexRootsMathlib.DyadicRootIsolation.root).toFinset =
+        (toPolyℂ p).roots.toFinset ∧
+      ∀ iso ∈ atoms.toList, atomPrec ≤ iso.square.prec := by
+  obtain ⟨atoms, hrun⟩ := isolate_exists p h hp atomPrec strategy
+  obtain ⟨hroots, hprec⟩ := isolate_sound p h atomPrec strategy hrun
+  exact ⟨atoms, hrun, isolate_count p h atomPrec strategy hrun,
+    hroots, hprec⟩
 
 /-- Boolean `isSome` form of full driver completeness. -/
 theorem isolate_isSome (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)

--- a/HexRootsMathlib/Examples.lean
+++ b/HexRootsMathlib/Examples.lean
@@ -1,0 +1,301 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRootsMathlib.Completeness.DriverCompleteness
+
+public section
+
+/-!
+# Certified complex-root isolation example
+
+This proof-facing example isolates all roots of `z³ - z - 1`.  Its real root
+is the plastic constant (the smallest Pisot number): the certificates locate
+it between `1.32471795` and `1.32471796`, locate the conjugate pair to eight
+decimal places, and prove that both nonreal roots lie strictly inside the unit
+disc. See `examples/HexRootsDemo.lean` for the corresponding runnable demo.
+-/
+
+namespace HexRootsMathlib.Examples
+
+open Polynomial
+open Hex
+
+noncomputable section
+
+/-- `x³ - x - 1`, whose real root is the smallest Pisot number. -/
+def pisot : ZPoly :=
+  DensePoly.monomial 3 1 - DensePoly.monomial 1 1 - DensePoly.C 1
+
+theorem toPolyℂ_pisot : toPolyℂ pisot = X ^ 3 - X - 1 := by
+  simp [pisot, toPolyℂ, monomial_one_right_eq_X_pow]
+
+theorem toPolyℚ_pisot : HexPolyZMathlib.toPolyℚ pisot = X ^ 3 - X - 1 := by
+  simp [pisot, HexPolyZMathlib.toPolyℚ, monomial_one_right_eq_X_pow]
+
+theorem natDegree_pisot : (toPolyℂ pisot).natDegree = 3 := by
+  rw [toPolyℂ_pisot,
+    natDegree_sub_eq_left_of_natDegree_lt (by
+      rw [natDegree_sub_eq_left_of_natDegree_lt] <;> norm_num),
+    natDegree_sub_eq_left_of_natDegree_lt] <;> norm_num
+
+theorem pisot_ne_zero : pisot ≠ 0 := by
+  intro h
+  have hcoeff := congrArg (fun p : ZPoly => p.coeff 3) h
+  norm_num [pisot] at hcoeff
+
+/-- The rational polynomial `x³ - x - 1` is separable, discharging the
+executable isolator's simple-root precondition. -/
+theorem pisot_simple : HasOnlySimpleRoots pisot := by
+  rw [hasOnlySimpleRoots_iff_separable pisot pisot_ne_zero, toPolyℚ_pisot,
+    separable_def']
+  let a : Polynomial ℚ := 18 * X - 27
+  let b : Polynomial ℚ := -(6 * X ^ 2) + 9 * X + 4
+  have hbezout :
+      a * (X ^ 3 - X - 1) + b * derivative (X ^ 3 - X - 1) = 23 := by
+    simp only [a, b, derivative_sub, derivative_pow, derivative_X, derivative_one,
+      map_natCast]
+    ring
+  refine ⟨C (23⁻¹) * a, C (23⁻¹) * b, ?_⟩
+  calc
+    _ = C (23⁻¹) *
+        (a * (X ^ 3 - X - 1) + b * derivative (X ^ 3 - X - 1)) := by ring
+    _ = C (23⁻¹) * 23 := by rw [hbezout]
+    _ = C (23⁻¹) * C 23 := by rw [C_ofNat]
+    _ = C (23⁻¹ * 23) := by rw [map_mul]
+    _ = 1 := by norm_num
+
+def pisotLowerSquare : DyadicSquare where
+  re := .ofIntWithPrec (-91033924845) 37
+  im := .ofIntWithPrec (-77279107697) 37
+  prec := 33
+
+def pisotUpperSquare : DyadicSquare where
+  re := .ofIntWithPrec (-91033924845) 37
+  im := .ofIntWithPrec 4829944231 33
+  prec := 33
+
+def pisotRealSquare : DyadicSquare where
+  re := .ofIntWithPrec 182067849689 37
+  im := 0
+  prec := 33
+
+theorem pisotLower_witness : nkWitness pisot pisotLowerSquare := by decide
+
+theorem pisotUpper_witness : nkWitness pisot pisotUpperSquare := by decide
+
+theorem pisotReal_witness : nkWitness pisot pisotRealSquare := by decide
+
+noncomputable def pisotLowerRoot : ℂ :=
+  (NKData.existsUnique_root pisotLower_witness).exists.choose
+
+noncomputable def pisotUpperRoot : ℂ :=
+  (NKData.existsUnique_root pisotUpper_witness).exists.choose
+
+noncomputable def pisotRealRoot : ℂ :=
+  (NKData.existsUnique_root pisotReal_witness).exists.choose
+
+theorem pisotLowerRoot_spec :
+    (toPolyℂ pisot).eval pisotLowerRoot = 0 ∧
+      pisotLowerRoot ∈ DyadicSquare.closedSquare pisotLowerSquare :=
+  (NKData.existsUnique_root pisotLower_witness).exists.choose_spec
+
+theorem pisotUpperRoot_spec :
+    (toPolyℂ pisot).eval pisotUpperRoot = 0 ∧
+      pisotUpperRoot ∈ DyadicSquare.closedSquare pisotUpperSquare :=
+  (NKData.existsUnique_root pisotUpper_witness).exists.choose_spec
+
+theorem pisotRealRoot_spec :
+    (toPolyℂ pisot).eval pisotRealRoot = 0 ∧
+      pisotRealRoot ∈ DyadicSquare.closedSquare pisotRealSquare :=
+  (NKData.existsUnique_root pisotReal_witness).exists.choose_spec
+
+theorem pisotLowerRoot_bounds :
+    (-66235899 / 100000000 : ℝ) < pisotLowerRoot.re ∧
+      pisotLowerRoot.re < (-66235897 / 100000000 : ℝ) ∧
+      (-56227953 / 100000000 : ℝ) < pisotLowerRoot.im ∧
+      pisotLowerRoot.im < (-56227950 / 100000000 : ℝ) := by
+  obtain ⟨hre, him⟩ :=
+    (DyadicSquare.mem_closedSquare_iff_re_im pisotLowerSquare pisotLowerRoot).mp
+      pisotLowerRoot_spec.2
+  rw [abs_le] at hre him
+  norm_num [pisotLowerSquare, DyadicSquare.halfWidth,
+    Hex.DyadicSquare.halfWidth, Dyadic.toReal_ofIntWithPrec] at hre him
+  constructor
+  · linarith
+  constructor
+  · linarith
+  constructor <;> linarith
+
+theorem pisotUpperRoot_bounds :
+    (-66235899 / 100000000 : ℝ) < pisotUpperRoot.re ∧
+      pisotUpperRoot.re < (-66235897 / 100000000 : ℝ) ∧
+      (56227950 / 100000000 : ℝ) < pisotUpperRoot.im ∧
+      pisotUpperRoot.im < (56227953 / 100000000 : ℝ) := by
+  obtain ⟨hre, him⟩ :=
+    (DyadicSquare.mem_closedSquare_iff_re_im pisotUpperSquare pisotUpperRoot).mp
+      pisotUpperRoot_spec.2
+  rw [abs_le] at hre him
+  norm_num [pisotUpperSquare, DyadicSquare.halfWidth,
+    Hex.DyadicSquare.halfWidth, Dyadic.toReal_ofIntWithPrec] at hre him
+  constructor
+  · linarith
+  constructor
+  · linarith
+  constructor <;> linarith
+
+theorem pisotRealRoot_bounds :
+    (132471795 / 100000000 : ℝ) < pisotRealRoot.re ∧
+      pisotRealRoot.re < (132471796 / 100000000 : ℝ) := by
+  have hre :=
+    (DyadicSquare.mem_closedSquare_iff_re_im pisotRealSquare pisotRealRoot).mp
+      pisotRealRoot_spec.2 |>.1
+  rw [abs_le] at hre
+  norm_num [pisotRealSquare, DyadicSquare.halfWidth,
+    Hex.DyadicSquare.halfWidth, Dyadic.toReal_ofIntWithPrec] at hre
+  constructor <;> linarith
+
+/-- The root in the real-centred certificate is genuinely real: conjugation
+preserves both its equation and its certified square, so uniqueness fixes it. -/
+theorem pisotRealRoot_im : pisotRealRoot.im = 0 := by
+  have hconjRoot :
+      (toPolyℂ pisot).eval (starRingEnd ℂ pisotRealRoot) = 0 := by
+    have hroot := pisotRealRoot_spec.1
+    rw [toPolyℂ_pisot] at hroot ⊢
+    simpa using congrArg (starRingEnd ℂ) hroot
+  have hcoords :=
+    (DyadicSquare.mem_closedSquare_iff_re_im pisotRealSquare pisotRealRoot).mp
+      pisotRealRoot_spec.2
+  have hconjMem : starRingEnd ℂ pisotRealRoot ∈
+      DyadicSquare.closedSquare pisotRealSquare := by
+    rw [DyadicSquare.mem_closedSquare_iff_re_im]
+    constructor
+    · simpa using hcoords.1
+    · simpa [pisotRealSquare] using hcoords.2
+  have hfixed : starRingEnd ℂ pisotRealRoot = pisotRealRoot :=
+    (NKData.existsUnique_root pisotReal_witness).unique
+      ⟨hconjRoot, hconjMem⟩ pisotRealRoot_spec
+  exact Complex.conj_eq_iff_im.mp hfixed
+
+theorem pisotLowerRoot_norm : ‖pisotLowerRoot‖ < 1 := by
+  have hb := pisotLowerRoot_bounds
+  have hre : |pisotLowerRoot.re| < (663 / 1000 : ℝ) := by
+    rw [abs_of_neg (by linarith [hb.2.1])]
+    linarith [hb.1]
+  have him : |pisotLowerRoot.im| < (563 / 1000 : ℝ) := by
+    rw [abs_of_neg (by linarith [hb.2.2.2])]
+    linarith [hb.2.2.1]
+  have hreSq : pisotLowerRoot.re ^ 2 < (663 / 1000 : ℝ) ^ 2 := by
+    nlinarith [sq_abs pisotLowerRoot.re]
+  have himSq : pisotLowerRoot.im ^ 2 < (563 / 1000 : ℝ) ^ 2 := by
+    nlinarith [sq_abs pisotLowerRoot.im]
+  apply (sq_lt_sq₀ (norm_nonneg _) (by norm_num)).mp
+  rw [Complex.sq_norm, Complex.normSq_apply]
+  nlinarith
+
+theorem pisotUpperRoot_norm : ‖pisotUpperRoot‖ < 1 := by
+  have hb := pisotUpperRoot_bounds
+  have hre : |pisotUpperRoot.re| < (663 / 1000 : ℝ) := by
+    rw [abs_of_neg (by linarith [hb.2.1])]
+    linarith [hb.1]
+  have him : |pisotUpperRoot.im| < (563 / 1000 : ℝ) := by
+    rw [abs_of_pos (by linarith [hb.2.2.1])]
+    linarith [hb.2.2.2]
+  have hreSq : pisotUpperRoot.re ^ 2 < (663 / 1000 : ℝ) ^ 2 := by
+    nlinarith [sq_abs pisotUpperRoot.re]
+  have himSq : pisotUpperRoot.im ^ 2 < (563 / 1000 : ℝ) ^ 2 := by
+    nlinarith [sq_abs pisotUpperRoot.im]
+  apply (sq_lt_sq₀ (norm_nonneg _) (by norm_num)).mp
+  rw [Complex.sq_norm, Complex.normSq_apply]
+  nlinarith
+
+/-- The three explicit Newton certificates account for every complex root of
+`x³ - x - 1`. -/
+theorem pisot_roots :
+    (toPolyℂ pisot).roots.toFinset =
+      {pisotRealRoot, pisotLowerRoot, pisotUpperRoot} := by
+  have hp : toPolyℂ pisot ≠ 0 := by
+    rw [toPolyℂ_pisot]
+    intro h
+    have hcoeff := congrArg (fun p : Polynomial ℂ => p.coeff 3) h
+    norm_num at hcoeff
+    rw [coeff_X, coeff_one] at hcoeff
+    norm_num at hcoeff
+  have hlower : pisotLowerRoot ∈ (toPolyℂ pisot).roots.toFinset :=
+    Multiset.mem_toFinset.mpr <| (mem_roots hp).mpr pisotLowerRoot_spec.1
+  have hupper : pisotUpperRoot ∈ (toPolyℂ pisot).roots.toFinset :=
+    Multiset.mem_toFinset.mpr <| (mem_roots hp).mpr pisotUpperRoot_spec.1
+  have hreal : pisotRealRoot ∈ (toPolyℂ pisot).roots.toFinset :=
+    Multiset.mem_toFinset.mpr <| (mem_roots hp).mpr pisotRealRoot_spec.1
+  have hlu : pisotLowerRoot ≠ pisotUpperRoot := by
+    intro h
+    have him := congrArg Complex.im h
+    linarith [pisotLowerRoot_bounds.2.2.2, pisotUpperRoot_bounds.2.2.1]
+  have hlr : pisotLowerRoot ≠ pisotRealRoot := by
+    intro h
+    have him := congrArg Complex.im h
+    rw [pisotRealRoot_im] at him
+    linarith [pisotLowerRoot_bounds.2.2.2]
+  have hur : pisotUpperRoot ≠ pisotRealRoot := by
+    intro h
+    have him := congrArg Complex.im h
+    rw [pisotRealRoot_im] at him
+    linarith [pisotUpperRoot_bounds.2.2.1]
+  let certified : Finset ℂ :=
+    {pisotRealRoot, pisotLowerRoot, pisotUpperRoot}
+  have hsubset : certified ⊆ (toPolyℂ pisot).roots.toFinset := by
+    intro z hz
+    simp only [certified, Finset.mem_insert, Finset.mem_singleton] at hz
+    rcases hz with (rfl | rfl | rfl)
+    · exact hreal
+    · exact hlower
+    · exact hupper
+  have hcertified : certified.card = 3 := by
+    simp [certified, Ne.symm hlr, Ne.symm hur, hlu]
+  have hrootsCard : (toPolyℂ pisot).roots.toFinset.card ≤ 3 := by
+    calc
+      _ ≤ (toPolyℂ pisot).roots.card := Multiset.toFinset_card_le _
+      _ ≤ (toPolyℂ pisot).natDegree := card_roots' _
+      _ = 3 := natDegree_pisot
+  exact (Finset.eq_of_subset_of_card_le hsubset
+    (by simpa [hcertified] using hrootsCard)).symm
+
+/-- The full driver succeeds, returns three atoms, and its semantic roots are
+the three explicitly bounded roots above. -/
+theorem isolate_pisot :
+    ∃ atoms : Array (DyadicRootIsolation pisot),
+      isolate pisot pisot_simple 32 .nk = some atoms ∧
+      atoms.size = 3 ∧
+      (atoms.toList.map HexRootsMathlib.DyadicRootIsolation.root).toFinset =
+        {pisotRealRoot, pisotLowerRoot, pisotUpperRoot} ∧
+      ∀ iso ∈ atoms.toList, 32 ≤ iso.square.prec := by
+  obtain ⟨atoms, hrun, hcount, hroots, hprec⟩ :=
+    isolate_spec pisot pisot_simple pisot_ne_zero 32 .nk
+  exact ⟨atoms, hrun, hcount.trans natDegree_pisot,
+    hroots.trans pisot_roots, hprec⟩
+
+/-- A compact statement of the Pisot example: the real root is pinned to
+eight decimal places and every other root lies strictly inside the unit disc. -/
+theorem pisot_property :
+    (132471795 / 100000000 : ℝ) < pisotRealRoot.re ∧
+      pisotRealRoot.re < (132471796 / 100000000 : ℝ) ∧
+      pisotRealRoot.im = 0 ∧
+      ∀ z ∈ (toPolyℂ pisot).roots.toFinset,
+        z ≠ pisotRealRoot → ‖z‖ < 1 := by
+  refine ⟨pisotRealRoot_bounds.1, pisotRealRoot_bounds.2,
+    pisotRealRoot_im, ?_⟩
+  intro z hz hne
+  rw [pisot_roots] at hz
+  simp only [Finset.mem_insert, Finset.mem_singleton] at hz
+  rcases hz with (rfl | rfl | rfl)
+  · exact (hne rfl).elim
+  · exact pisotLowerRoot_norm
+  · exact pisotUpperRoot_norm
+
+end
+
+end HexRootsMathlib.Examples

--- a/HexRootsMathlib/Geometry.lean
+++ b/HexRootsMathlib/Geometry.lean
@@ -248,6 +248,16 @@ theorem center_mem_closedSquare (s : Hex.DyadicSquare) : center s ∈ closedSqua
   rw [halfWidth_eq]
   exact (zpow_pos (by norm_num) _).le
 
+/-- Membership in a closed dyadic square is exactly the pair of coordinate
+bounds around its centre. -/
+theorem mem_closedSquare_iff_re_im (s : Hex.DyadicSquare) (z : ℂ) :
+    z ∈ closedSquare s ↔
+      |z.re - Dyadic.toReal s.re| ≤ halfWidth s ∧
+      |z.im - Dyadic.toReal s.im| ≤ halfWidth s := by
+  rw [closedSquare, supClosedBall, Set.mem_setOf_eq, supDist, supNorm,
+    max_le_iff]
+  simp [center, Hex.DyadicSquare.center]
+
 theorem radiusLo_eq (s : Hex.DyadicSquare) :
     Dyadic.toReal s.radiusLo = halfWidth s * Dyadic.toReal Hex.sqrt2Lo := by
   simp only [Hex.DyadicSquare.radiusLo, Hex.sqrt2Lo, Dyadic.toReal_ofIntWithPrec,

--- a/examples/HexRootsDemo.lean
+++ b/examples/HexRootsDemo.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRoots
+
+public section
+
+/-!
+# Certified complex-root isolation demo
+
+Run from the repository root with:
+
+```text
+lake exe hexroots_demo
+```
+
+The polynomial is `p(x) = x³ - x - 1`. The executable first decides that all
+roots are simple, isolates all three roots in pairwise-disjoint dyadic squares,
+then finds the positive-real isolation and refines it to at least 80 bits of
+square precision.
+
+The proof-facing companion `HexRootsMathlib.Examples.pisot` denotes the same
+polynomial by an algebraic expression. It gives explicit bounds for all three
+roots and proves that the two nonreal roots lie in the open unit disc. Its real
+root is the plastic constant, commonly known as the smallest Pisot number; the
+companion formalizes its Pisot property, not the global minimality theorem.
+-/
+
+namespace HexRootsDemo
+
+open Hex
+
+/-- `p(x) = x³ - x - 1`, with coefficients stored constant-term first. -/
+def p : ZPoly := DensePoly.ofCoeffs #[-1, -1, 0, 1]
+
+/-- A display-only conversion. Certification itself uses exact dyadic
+arithmetic; floats appear only in the human-readable output. -/
+def dyadicToFloat (x : Dyadic) : Float :=
+  let q := x.toRat
+  Float.ofInt q.num / Float.ofNat q.den
+
+def showSquare {q : ZPoly} (label : String)
+    (iso : DyadicRootIsolation q) : IO Unit := do
+  let s := iso.square
+  IO.println s!"{label}:"
+  IO.println s!"  centre ≈ {dyadicToFloat s.re} {if s.im < 0 then "-" else "+"} \
+    {dyadicToFloat (Hex.Dyadic.abs s.im)} i"
+  IO.println s!"  certified square: |Δre|, |Δim| ≤ 2^(-{s.prec})"
+
+def showAtoms {q : ZPoly}
+    (atoms : Array (DyadicRootIsolation q)) : IO Unit := do
+  let mut index := 1
+  for iso in atoms do
+    showSquare s!"root {index}" iso
+    index := index + 1
+
+def main : IO Unit := do
+  IO.println "Certified isolation for p(x) = x^3 - x - 1"
+  if h : HasOnlySimpleRoots p then
+    match isolate p h 32 .nk with
+    | none =>
+        IO.eprintln "isolation unexpectedly exhausted its certified fuel"
+    | some atoms =>
+        IO.println s!"\nFound {atoms.size} pairwise-disjoint certified roots:\n"
+        showAtoms atoms
+        IO.println "\nThe accompanying Lean theorems prove:"
+        IO.println "  1.32471795 < β < 1.32471796"
+        IO.println "  -0.66235899 < Re(conjugates) < -0.66235897"
+        IO.println "  0.56227950 < |Im(conjugates)| < 0.56227953"
+        IO.println "  |conjugate roots| < 1"
+        match atoms.toList.find? (fun iso => decide (0 < iso.square.re)) with
+        | none => pure ()
+        | some realIso =>
+            match realIso.refineTo? 80 with
+            | none => IO.eprintln "refinement unexpectedly failed"
+            | some refined =>
+                IO.println "\nThe real root refined to at least 80 bits:"
+                showSquare "refined real root" refined
+  else
+    IO.eprintln "the polynomial has a repeated root"
+
+end HexRootsDemo
+
+def main : IO Unit := HexRootsDemo.main

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -242,6 +242,10 @@ lean_exe hexroots_bench where
   srcDir := "bench"
   root := `HexRoots.Bench
 
+lean_exe hexroots_demo where
+  srcDir := "examples"
+  root := `HexRootsDemo
+
 lean_exe hexmatrix_bench where
   srcDir := "bench"
   root := `HexMatrix.Bench

--- a/progress/20260720T095901Z_hexroots-demo.md
+++ b/progress/20260720T095901Z_hexroots-demo.md
@@ -1,0 +1,24 @@
+# Accomplished
+
+- Added a runnable `hexroots_demo` executable for the squarefree polynomial
+  `x^5 - x + 1`.
+- The demo decides the simple-root hypothesis at runtime, isolates all five
+  roots, prints their approximate complex centres and exact certified dyadic
+  square widths, and refines the first root to at least 80 bits.
+- Verified the executable end to end. The initial isolations have precision
+  31; the requested 80-bit refinement reaches precision 109 through the
+  speculative Newton step.
+- Ran copyright, line-count, import-DAG, conformance-matrix, and diff checks.
+
+# Current frontier
+
+The demo is complete and runnable with `lake exe hexroots_demo`.
+
+# Next step
+
+Optionally add further examples for clustered/multiple roots or consume the
+certified roots from `HexRootsMathlib` in a proof-oriented demo.
+
+# Blockers
+
+None.

--- a/progress/20260720T103725Z_hexroots-theorem-demo.md
+++ b/progress/20260720T103725Z_hexroots-theorem-demo.md
@@ -1,0 +1,25 @@
+# Accomplished
+
+- Added the generic `HexRootsMathlib.isolate_spec` proof-facing API. It
+  bundles driver completeness with the returned atom count, exact complex-root
+  enumeration, and requested-precision guarantee.
+- Added `HexRootsMathlib.Examples.isolate_q` for `q(x) = x⁴ - 1`. The theorem
+  proves that isolation succeeds, returns four atoms, and that their selected
+  roots are exactly `{1, -1, i, -i}`.
+- Kept the runnable `x⁵ - x + 1` demonstration and linked its documentation to
+  the proof-facing example.
+- Built `HexRootsMathlib`, built and ran `hexroots_demo`, and ran the repository
+  DAG, copyright, line-count, conformance-target, and diff checks.
+
+# Current frontier
+
+The executable and theorem demonstrations are complete. The generic bundled
+API keeps downstream isolation proofs to one completeness/soundness call.
+
+# Next step
+
+Publish the demo and bundled API in the next HexRootsMathlib PR.
+
+# Blockers
+
+None.

--- a/progress/20260721T011228Z_pisot-demo.md
+++ b/progress/20260721T011228Z_pisot-demo.md
@@ -1,0 +1,31 @@
+# Accomplished
+
+- Replaced the introductory isolation example with the plastic constant, the
+  real root of `z^3 - z - 1`.
+- Added exact Newton--Kantorovich certificates for all three roots and proved
+  explicit eight-decimal coordinate bounds from their certified squares.
+- Proved that the real certified root lies in
+  `(1.32471795, 1.32471796)`, that it is real, and that both other roots lie
+  strictly inside the unit disk.
+- Proved that these three certified values exhaust the polynomial's complex
+  root finset, and connected them to the generic `isolate` driver theorem.
+- Added `mem_closedSquare_iff_re_im` as an ergonomic geometry API for turning
+  certified-square membership into coordinate inequalities.
+- Updated the executable demo to print the three Pisot-polynomial certificates
+  and refine the real root further.
+- Ran the full `lake build`, the demo executable, DAG/copyright/line-count/
+  conformance checks, and `git diff --check`; all passed.
+
+# Current frontier
+
+The certified Pisot example and its supporting public API are complete and
+build cleanly.
+
+# Next step
+
+Publish or review the demo change together with the rest of the issue-8755
+work when desired.
+
+# Blockers
+
+None.

--- a/progress/20260721T134344Z_pisot-review.md
+++ b/progress/20260721T134344Z_pisot-review.md
@@ -1,0 +1,29 @@
+# Accomplished
+
+- Obtained the requested independent Claude Opus review of the complete Pisot
+  demo diff. The review found no blocking correctness or soundness concern.
+- Added `hexroots_demo` to the existing single CI job's executable targets so
+  API drift cannot silently break the runnable example.
+- Removed the executable's reliance on atom ordering: it now identifies the
+  positive-real isolation before refinement and labels the refined output
+  directly.
+- Renamed the bundled proof-facing contract from the near-homonymous
+  `exists_isolation` to `isolate_spec`.
+- Clarified that the companion formalizes the plastic constant's Pisot
+  property, not the separate global theorem that it is the smallest Pisot
+  number.
+- Rebuilt `HexRootsMathlib` and `hexroots_demo` and ran the executable
+  successfully after the review fixes.
+
+# Current frontier
+
+The reviewed follow-up is ready to publish and merge through CI. Issue #8755
+itself is already closed with all planned child work recorded complete.
+
+# Next step
+
+Open the Pisot demo PR, wait for the consolidated `build` check, and merge it.
+
+# Blockers
+
+None.


### PR DESCRIPTION
## Summary

- add a proof-facing isolation specification bundling completeness, exact root enumeration, and requested precision
- certify all three roots of z^3 - z - 1 with explicit decimal bounds
- prove the real root is real and every other root lies strictly inside the unit disk
- add a runnable plastic-constant demo with refinement to at least 80 bits
- add coordinate-bound geometry API and gate the demo executable in the consolidated CI job

## Review

Claude Opus found no blocking correctness or soundness concerns. Its maintainability feedback was addressed by CI-gating the executable, removing atom-order dependence, clarifying the minimality claim, and distinguishing the bundled API as isolate_spec.

## Validation

- lake build
- lake build HexRootsMathlib hexroots_demo
- lake exe hexroots_demo
- structural DAG, copyright, line-count, conformance-target, banned-construct, and diff checks