### PR TITLE
style: drop sorry-free/axiom-free self-commentary from docstrings

### DIFF
--- a/HexBareissMathlib.lean
+++ b/HexBareissMathlib.lean
@@ -32,8 +32,8 @@ theorem bareissDet_eq_det (M : Hex.Matrix Int n n) :
 
 /-- The row-pivoted Bareiss determinant equals the executable Leibniz
 determinant on integer square matrices. Proven Mathlib-side by composing
-`bareiss_eq_mathlib_det` with `det_eq`, so it holds outright (no sorry-bound
-hypothesis) and is the preferred surface for downstream Mathlib-side callers. -/
+`bareiss_eq_mathlib_det` with `det_eq`, so it holds unconditionally (with no
+side hypothesis) and is the preferred surface for downstream Mathlib-side callers. -/
 theorem bareiss_eq_det (M : Hex.Matrix Int n n) :
     Hex.Matrix.bareiss M = Hex.Matrix.det M :=
   (bareiss_eq_mathlib_det M).trans (det_eq M).symm

--- a/HexRealRootsMathlib.lean
+++ b/HexRealRootsMathlib.lean
@@ -49,6 +49,5 @@ root-identity theorems (overlap classes are the real roots); and `TwoCircle`
 proves Descartes-engine termination (`isolateDescartes?_isSome`) behind its
 Obreshkoff two-circle prerequisite (the λ-graded sector bound in
 `TwoCircleSector`, the region geometry in `TwoCircleRegion`, and the Descartes
-parity in `DescartesParity`). Every theorem in the library is now proven; there
-are no `sorry`s.
+parity in `DescartesParity`).
 -/

--- a/HexRealRootsMathlib/IsolateRootsTests.lean
+++ b/HexRealRootsMathlib/IsolateRootsTests.lean
@@ -18,8 +18,8 @@ public section
 # Unit tests for the `IsolatedRealRoots` API
 
 Exercises every constructor on literal data and the `isolate_roots_bridge`
-tactic on all four coefficient-ring shapes, with a plain import (no `import
-all`) and no `sorry`.
+tactic on all four coefficient-ring shapes, through the public API only (a plain
+import, no `import all`).
 -/
 
 open Hex Polynomial HexRealRootsMathlib

--- a/HexRealRootsMathlib/TwoCircle.lean
+++ b/HexRealRootsMathlib/TwoCircle.lean
@@ -32,8 +32,7 @@ public section
 
 This module proves `isolateDescartes?_isSome`: the *Descartes* isolation engine
 alone returns `some` on every nonzero square-free input, so the runtime never
-needs the Sturm fallback. It is the last theorem of `HexRealRootsMathlib`, and
-with it the companion is fully `sorry`-free.
+needs the Sturm fallback.
 
 ## What the two-circle theorem actually says
 

--- a/progress/20260722T134442Z_drop-sorry-free-boasts.md
+++ b/progress/20260722T134442Z_drop-sorry-free-boasts.md
@@ -1,0 +1,33 @@
+# Drop "sorry-free"/"axiom-free" self-commentary from shipped docstrings
+
+## Accomplished
+
+- Removed docstring boasts asserting a deliverable is `sorry`-free (bare
+  minimum for release; reads as unprofessional to comment on):
+  - `HexRealRootsMathlib.lean`: dropped "Every theorem in the library is now
+    proven; there are no `sorry`s."
+  - `HexRealRootsMathlib/TwoCircle.lean`: dropped "It is the last theorem of
+    `HexRealRootsMathlib`, and with it the companion is fully `sorry`-free."
+  - `HexRealRootsMathlib/IsolateRootsTests.lean`: reworded to keep the real
+    content (public-API-only, no `import all`) and drop "and no `sorry`".
+  - `HexBareissMathlib.lean`: reworded "no sorry-bound hypothesis" to
+    "holds unconditionally (with no side hypothesis)", preserving the meaning
+    (the theorem is unconditional).
+- Comment-only changes; diff confined to doc-comment prose.
+- Left legitimate technical/requirement uses of the terms in PLAN/ and SPEC/
+  (review checklists, phase entry conditions, proof-discipline prose) untouched;
+  left progress/ and reports/ journals as history.
+
+## Current frontier
+
+Local `lake build` cannot link the `hexmodarithffi` shared library in this
+checkout (broken elan/nix `ld-wrapper.sh` path), so oleans could not be produced
+locally. CI links on its own runner; relying on it as the authoritative check.
+
+## Next step
+
+Merge once CI is green.
+
+## Blockers
+
+None (local FFI linker breakage is environmental, unrelated to this change).


### PR DESCRIPTION
This PR removes docstring remarks that assert a deliverable is `sorry`-free or `axiom`-free. That is the bare minimum for release, and commenting on it reads as unprofessional. The changes are comment-only: the `HexRealRootsMathlib` umbrella drops "Every theorem in the library is now proven; there are no `sorry`s", `TwoCircle` drops "with it the companion is fully `sorry`-free", `IsolateRootsTests` keeps its real point (public-API-only, no `import all`) while dropping "and no `sorry`", and `HexBareissMathlib` rewords "no sorry-bound hypothesis" to state plainly that the theorem holds unconditionally. Legitimate technical and requirement uses of the terms in `PLAN/` and `SPEC/` are left in place.

🤖 Prepared with Claude Code