### PR TITLE
perf(bz): modular square-free fast path for normalizeForFactor

### DIFF
--- a/HexBerlekampZassenhaus/Records.lean
+++ b/HexBerlekampZassenhaus/Records.lean
@@ -300,9 +300,11 @@ def normalizeForFactor (f : ZPoly) : FactorNormalizationData :=
     repeatedPart := sqData.repeatedPart }
 
 set_option maxRecDepth 4000 in
-/-- Certified prime for the modular square-free fast path.  `499` exceeds every
-practical input degree, so a distinct-root input reduces square-free at this
-prime in a single probe. -/
+/-- Certified probe prime for the modular square-free fast path.  `499` is a
+cheap fixed choice: it is large enough that a distinct-root input rarely reduces
+non-square-free at it, but it carries no guarantee (a rationally square-free
+input whose discriminant is divisible by `499` reduces non-square-free and simply
+takes the exact fallback -- never a wrong answer). -/
 theorem prime_499 : Hex.Nat.Prime 499 :=
   Hex.Nat.isPrimeTrial_isPrime (by decide)
 

--- a/HexBerlekampZassenhaus/Records.lean
+++ b/HexBerlekampZassenhaus/Records.lean
@@ -28,6 +28,7 @@ public import HexLLL.Basic
 import all Init.Data.Array.DecidableEq
 
 public import HexBerlekampZassenhaus.PrimeSelection
+public import HexBerlekampZassenhaus.SquareFreeModularCert
 public meta import HexBerlekampZassenhaus.PrimeSelection
 import all HexBerlekampZassenhaus.PrimeSelection
 
@@ -297,6 +298,75 @@ def normalizeForFactor (f : ZPoly) : FactorNormalizationData :=
     xFreePrimitive := xData.core
     squareFreeCore := sqData.squareFreeCore
     repeatedPart := sqData.repeatedPart }
+
+set_option maxRecDepth 4000 in
+/-- Certified prime for the modular square-free fast path.  `499` exceeds every
+practical input degree, so a distinct-root input reduces square-free at this
+prime in a single probe. -/
+theorem prime_499 : Hex.Nat.Prime 499 :=
+  Hex.Nat.isPrimeTrial_isPrime (by decide)
+
+instance bounds_499 : ZMod64.Bounds 499 := ⟨by decide, by decide⟩
+
+/-- Boolean guard for the modular square-free fast path: the primitive `x`-free
+core is nonzero, admissible at the probe prime, and separable over `𝔽_p`. -/
+@[expose]
+def modularSquareFreeFires (f : ZPoly) : Bool :=
+  let q := ZPoly.primitivePart (ZPoly.extractXPower (ZPoly.primitivePart f)).core
+  !q.isZero && (ZPoly.leadingCoeffModP q 499 != 0) && ZPoly.separableModP q 499
+
+/-- Fast implementation of `normalizeForFactor`: a machine-word `𝔽_p`
+square-freeness probe on the primitive `x`-free core.  When it fires (the input
+is square-free over `ℚ`) the decomposition is trivial; otherwise it falls back to
+the exact rational computation, inlined rather than a self-call so the `@[csimp]`
+rewrite below does not make the fallback recurse.  Proven equal to
+`normalizeForFactor`. -/
+@[expose]
+def normalizeForFactorFast (f : ZPoly) : FactorNormalizationData :=
+  let primitive := ZPoly.primitivePart f
+  let xData := ZPoly.extractXPower primitive
+  if modularSquareFreeFires f then
+    { content := ZPoly.content f
+      primitive
+      xPower := xData.power
+      xFreePrimitive := xData.core
+      squareFreeCore := ZPoly.normalizePrimitiveSign (ZPoly.primitivePart xData.core)
+      repeatedPart := 1 }
+  else
+    let sqData := ZPoly.primitiveSquareFreeDecomposition xData.core
+    { content := ZPoly.content f
+      primitive
+      xPower := xData.power
+      xFreePrimitive := xData.core
+      squareFreeCore := sqData.squareFreeCore
+      repeatedPart := sqData.repeatedPart }
+
+@[csimp]
+theorem normalizeForFactor_eq_normalizeForFactorFast :
+    normalizeForFactor = normalizeForFactorFast := by
+  funext f
+  simp only [normalizeForFactor, normalizeForFactorFast]
+  by_cases hcond : modularSquareFreeFires f = true
+  · rw [if_pos hcond]
+    simp only [modularSquareFreeFires, Bool.and_eq_true, Bool.not_eq_true', bne_iff_ne] at hcond
+    obtain ⟨⟨hq_isZero, hadm⟩, hsep⟩ := hcond
+    have hq_ne : ZPoly.primitivePart (ZPoly.extractXPower (ZPoly.primitivePart f)).core ≠ 0 := by
+      intro h
+      have hpos := (DensePoly.isZero_eq_false_iff _).1 hq_isZero
+      rw [h, DensePoly.size_zero] at hpos
+      omega
+    have hcore_ne : (ZPoly.extractXPower (ZPoly.primitivePart f)).core ≠ 0 := by
+      intro h
+      apply hq_ne
+      change ZPoly.primitivePart (ZPoly.extractXPower (ZPoly.primitivePart f)).core = 0
+      rw [h]
+      exact DensePoly.primitivePart_eq_zero_of_content_eq_zero 0 DensePoly.content_zero
+    have hsq : ZPoly.SquareFreeRat
+        (ZPoly.primitivePart (ZPoly.extractXPower (ZPoly.primitivePart f)).core) :=
+      ZPoly.squareFreeRat_of_separableModP _ 499 prime_499 hadm hsep
+    rw [ZPoly.primitiveSquareFreeDecomposition_squareFreeCore_eq_of_squareFreeRat _ hcore_ne hsq,
+        ZPoly.primitiveSquareFreeDecomposition_repeatedPart_eq_one_of_squareFreeRat _ hcore_ne hsq]
+  · rw [if_neg hcond]
 
 private def contentFactorArray (content : Int) : Array ZPoly :=
   if content = 1 then

--- a/HexBerlekampZassenhaus/SquareFreeModularCert.lean
+++ b/HexBerlekampZassenhaus/SquareFreeModularCert.lean
@@ -1,0 +1,237 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexBerlekampZassenhaus.PrimeSelection
+public import HexPolyZ.Decomposition
+import all HexPolyZ.Core
+import all HexPolyZ.Rational
+import all HexPolyZ.Decomposition
+import all HexBerlekampZassenhaus.PrimeSelection
+
+public section
+
+/-!
+Soundness of a modular square-freeness certificate.
+
+The classical Berlekamp-Zassenhaus square-free-core extraction runs an exact
+`gcd(f, f')` over `ℚ`, whose rational coefficient blow-up dominates
+`normalizeForFactor`.  For the common (square-free) input the whole computation
+collapses to a trivial decomposition; a cheap machine-word modular test decides
+square-freeness far faster.
+
+`separableModP f p` reduces `f` and its (integer) derivative modulo a prime `p`
+and checks that their `𝔽_p` gcd is a unit.  When `p` is prime and does not
+divide the leading coefficient of `f` (admissible), passing this test is a
+*sufficient* condition for `f` to be square-free over `ℚ`
+(`squareFreeRat_of_separableModP`): a nontrivial rational gcd of `f, f'` clears
+via Gauss's lemma to a positive-degree primitive integer common factor, whose
+modular image is a positive-degree common factor of `modP f, modP f'`,
+contradicting the unit gcd.  This is the soundness the modular fast path rests
+on; failing the test simply falls back to the exact computation.
+-/
+
+namespace Hex
+
+namespace ZPoly
+
+/-- `toRatPoly` commutes with the formal derivative. -/
+theorem toRatPoly_derivative (f : ZPoly) :
+    toRatPoly (DensePoly.derivative f) = DensePoly.derivative (toRatPoly f) := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [coeff_toRatPoly, DensePoly.coeff_derivative f n (Lean.Grind.Semiring.mul_zero _),
+      DensePoly.coeff_derivative (toRatPoly f) n (Lean.Grind.Semiring.mul_zero _), coeff_toRatPoly]
+  exact_mod_cast rfl
+
+/-- Reduction modulo `p` preserves divisibility of integer polynomials. -/
+theorem modP_dvd_of_dvd {p : Nat} [ZMod64.Bounds p] {a b : ZPoly} (h : a ∣ b) :
+    ZPoly.modP p a ∣ ZPoly.modP p b := by
+  rcases h with ⟨c, hc⟩
+  exact ⟨ZPoly.modP p c, by rw [hc, modP_mul]⟩
+
+/-- Reduction modulo `p` never increases the dense size. -/
+private theorem size_modP_le (p : Nat) [ZMod64.Bounds p] (f : ZPoly) :
+    (ZPoly.modP p f).size ≤ f.size := by
+  show (ZPoly.modP p f).coeffs.size ≤ f.size
+  unfold ZPoly.modP FpPoly.ofCoeffs
+  have h := DensePoly.size_ofCoeffs_le (R := ZMod64 p)
+    ((List.range f.size).map
+      (fun i => ZMod64.ofNat p (ZPoly.intModNat (f.coeff i) p))).toArray
+  have hlen : ((List.range f.size).map
+      (fun i => ZMod64.ofNat p (ZPoly.intModNat (f.coeff i) p))).toArray.size = f.size := by simp
+  simpa [DensePoly.size, hlen] using h
+
+/-- Divisibility of rational polynomials is transitive. -/
+private theorem rat_dvd_trans {a b c : DensePoly Rat} (hab : a ∣ b) (hbc : b ∣ c) : a ∣ c := by
+  rcases hab with ⟨x, hx⟩
+  rcases hbc with ⟨y, hy⟩
+  exact ⟨x * y, by rw [hy, hx, DensePoly.mul_assoc_poly]⟩
+
+/-- Divisibility of rational polynomials is reflexive. -/
+private theorem rat_dvd_refl (a : DensePoly Rat) : a ∣ a :=
+  ⟨1, (DensePoly.mul_one_right_poly a).symm⟩
+
+/-- The `𝔽_p`-separability certificate: the reduction of `f` and of its integer
+derivative are coprime over `𝔽_p`. -/
+@[expose]
+def separableModP (f : ZPoly) (p : Nat) [ZMod64.Bounds p] : Bool :=
+  gcdIsUnit (DensePoly.gcd (ZPoly.modP p f) (ZPoly.modP p (DensePoly.derivative f)))
+
+/-- Admissibility is inherited by an integer factor: if `p` does not divide the
+leading coefficient of `f = r * s`, the modular image of `r` keeps its full
+degree. -/
+private theorem size_modP_eq_of_factor
+    {p : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
+    (f r s : ZPoly) (hf : f = r * s) (hr_ne : r ≠ 0) (hs_ne : s ≠ 0)
+    (hadm : leadingCoeffAdmissible f p) :
+    (ZPoly.modP p r).size = r.size := by
+  have hr_pos : 0 < r.size := size_pos_of_ne_zero r hr_ne
+  have hs_pos : 0 < s.size := size_pos_of_ne_zero s hs_ne
+  have hf_size : f.size = r.size + s.size - 1 := by
+    rw [hf]; exact mul_size_eq_top_succ_of_nonzero r s hr_pos hs_pos
+  have hmodf_ne : ZPoly.modP p f ≠ 0 := modP_ne_zero_of_leadingCoeffAdmissible f p hadm
+  have hmodf_size : (ZPoly.modP p f).size = f.size :=
+    size_modP_eq_of_leadingCoeffAdmissible f p hadm
+  have hmodf_mul : ZPoly.modP p f = ZPoly.modP p r * ZPoly.modP p s := by
+    rw [hf, modP_mul]
+  have hmodr_ne : ZPoly.modP p r ≠ 0 := by
+    intro h0
+    apply hmodf_ne
+    rw [hmodf_mul, h0]
+    exact DensePoly.zero_mul _
+  have hmods_ne : ZPoly.modP p s ≠ 0 := by
+    intro h0
+    apply hmodf_ne
+    rw [hmodf_mul, h0]
+    exact (DensePoly.mul_comm_poly _ _).trans (DensePoly.zero_mul _)
+  have hmodf_prod_size :
+      (ZPoly.modP p f).size = (ZPoly.modP p r).size + (ZPoly.modP p s).size - 1 := by
+    rw [hmodf_mul]
+    exact FpPoly.size_mul_eq_add_sub_one _ _ hmodr_ne hmods_ne
+  have hmodr_le : (ZPoly.modP p r).size ≤ r.size := size_modP_le p r
+  have hmods_le : (ZPoly.modP p s).size ≤ s.size := size_modP_le p s
+  have hmodr_pos : 0 < (ZPoly.modP p r).size := FpPoly.size_pos_of_ne_zero hmodr_ne
+  have hmods_pos : 0 < (ZPoly.modP p s).size := FpPoly.size_pos_of_ne_zero hmods_ne
+  omega
+
+/-- **Modular square-freeness certificate soundness.**  For a prime `p` not
+dividing the leading coefficient of `f`, if `modP f` and `modP f'` are coprime
+over `𝔽_p`, then `f` is square-free over `ℚ`. -/
+theorem squareFreeRat_of_separableModP
+    (f : ZPoly) (p : Nat) [ZMod64.Bounds p] (hp : Hex.Nat.Prime p)
+    (hadm : leadingCoeffAdmissible f p)
+    (hsep : separableModP f p = true) :
+    SquareFreeRat f := by
+  letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
+  -- Contrapositive: a positive-degree rational gcd yields a positive-degree
+  -- modular common factor, contradicting the unit gcd.
+  apply Classical.byContradiction
+  intro hnsq
+  unfold SquareFreeRat at hnsq
+  -- Name the rational gcd `g`.
+  obtain ⟨g, hg_eq⟩ :
+      ∃ g, g = DensePoly.gcd (toRatPoly f) (DensePoly.derivative (toRatPoly f)) := ⟨_, rfl⟩
+  rw [← hg_eq] at hnsq
+  have hgt : 1 < g.size := Nat.lt_of_not_ge hnsq
+  have hg_dvd_f : g ∣ toRatPoly f := hg_eq ▸ DensePoly.gcd_dvd_left _ _
+  have hg_dvd_df : g ∣ DensePoly.derivative (toRatPoly f) := hg_eq ▸ DensePoly.gcd_dvd_right _ _
+  have hg_ne : g ≠ 0 := by
+    intro h0
+    rw [h0, DensePoly.size_zero] at hgt
+    omega
+  -- `f ≠ 0` (else the gcd would be `gcd 0 0 = 0`).
+  have hderiv0 : DensePoly.derivative (0 : DensePoly Rat) = 0 := by
+    apply DensePoly.ext_coeff
+    intro n
+    rw [DensePoly.coeff_derivative _ n (Lean.Grind.Semiring.mul_zero _), DensePoly.coeff_zero,
+        DensePoly.coeff_zero]
+    exact Lean.Grind.Semiring.mul_zero _
+  have hf_ne : f ≠ 0 := by
+    intro h0
+    apply hg_ne
+    rw [hg_eq, h0, toRatPoly_zero, hderiv0, DensePoly.gcd_zero_zero]
+  -- The primitive integer clearing `r` of `g`.
+  rcases ratPolyPrimitivePart_rational_associate g with ⟨u, hu⟩
+  have hr_prim : Primitive (ratPolyPrimitivePart g) :=
+    ratPolyPrimitivePart_primitive g
+      (content_ne_zero_of_ne_zero _ (ratPolyPrimitivePart_ne_zero_of_ne_zero g hg_ne))
+  have hr_ne : ratPolyPrimitivePart g ≠ 0 := ratPolyPrimitivePart_ne_zero_of_ne_zero g hg_ne
+  have hu_ne : u ≠ 0 := by
+    intro h0
+    apply hg_ne
+    rw [hu, h0, rat_scale_zero]
+  -- `size (ratPolyPrimitivePart g) = size g ≥ 2`.
+  have hr_size : 2 ≤ (ratPolyPrimitivePart g).size := by
+    have hscale := rat_scale_size_of_ne_zero hu_ne (toRatPoly (ratPolyPrimitivePart g))
+    rw [← hu] at hscale
+    rw [← size_toRatPoly (ratPolyPrimitivePart g)]
+    omega
+  -- `toRatPoly (ratPolyPrimitivePart g) ∣ g`, hence `∣ toRatPoly f` and `∣ toRatPoly f'`.
+  have htoR_dvd_g : toRatPoly (ratPolyPrimitivePart g) ∣ g := by
+    have hd := rat_dvd_scale_of_dvd u (rat_dvd_refl (toRatPoly (ratPolyPrimitivePart g)))
+    rw [← hu] at hd
+    exact hd
+  have htoR_dvd_f : toRatPoly (ratPolyPrimitivePart g) ∣ toRatPoly f :=
+    rat_dvd_trans htoR_dvd_g hg_dvd_f
+  have htoR_dvd_df : toRatPoly (ratPolyPrimitivePart g) ∣ DensePoly.derivative (toRatPoly f) :=
+    rat_dvd_trans htoR_dvd_g hg_dvd_df
+  -- Descend to integer divisibility via Gauss.
+  have hr_dvd_f : ratPolyPrimitivePart g ∣ f :=
+    dvd_of_toRatPoly_dvd_of_primitive hr_prim htoR_dvd_f
+  have hr_dvd_df : ratPolyPrimitivePart g ∣ DensePoly.derivative f := by
+    apply dvd_of_toRatPoly_dvd_of_primitive hr_prim
+    rw [toRatPoly_derivative]
+    exact htoR_dvd_df
+  -- `f = r * s`.
+  obtain ⟨s, hs⟩ := hr_dvd_f
+  have hr_dvd_f : ratPolyPrimitivePart g ∣ f := ⟨s, hs⟩
+  have hs_ne : s ≠ 0 := by
+    intro h0
+    apply hf_ne
+    rw [hs, h0]
+    exact (DensePoly.mul_comm_poly _ _).trans (DensePoly.zero_mul _)
+  -- The modular image of `r` keeps its full degree.
+  have hmodr_size : (ZPoly.modP p (ratPolyPrimitivePart g)).size = (ratPolyPrimitivePart g).size :=
+    size_modP_eq_of_factor f (ratPolyPrimitivePart g) s hs hr_ne hs_ne hadm
+  -- `modP r` is a common divisor of `modP f` and `modP f'`.
+  have hmodr_dvd_f : ZPoly.modP p (ratPolyPrimitivePart g) ∣ ZPoly.modP p f :=
+    modP_dvd_of_dvd hr_dvd_f
+  have hmodr_dvd_df :
+      ZPoly.modP p (ratPolyPrimitivePart g) ∣ ZPoly.modP p (DensePoly.derivative f) :=
+    modP_dvd_of_dvd hr_dvd_df
+  have hmodr_dvd_gcd :
+      ZPoly.modP p (ratPolyPrimitivePart g) ∣
+        DensePoly.gcd (ZPoly.modP p f) (ZPoly.modP p (DensePoly.derivative f)) :=
+    DensePoly.dvd_gcd _ _ _ hmodr_dvd_f hmodr_dvd_df
+  -- The gcd is nonzero (it divides the nonzero `modP f`).
+  have hmodf_ne : ZPoly.modP p f ≠ 0 := modP_ne_zero_of_leadingCoeffAdmissible f p hadm
+  have hgcd_ne :
+      DensePoly.gcd (ZPoly.modP p f) (ZPoly.modP p (DensePoly.derivative f)) ≠ 0 := by
+    intro h0
+    apply hmodf_ne
+    rcases DensePoly.gcd_dvd_left (ZPoly.modP p f) (ZPoly.modP p (DensePoly.derivative f)) with
+      ⟨c, hc⟩
+    rw [h0] at hc
+    rw [show (0 : FpPoly p) * c = 0 from DensePoly.zero_mul c] at hc
+    exact hc
+  -- Its size is at least the (≥ 2) size of `modP r`, so it is not a unit.
+  have hgcd_size :
+      (ZPoly.modP p (ratPolyPrimitivePart g)).size ≤
+        (DensePoly.gcd (ZPoly.modP p f) (ZPoly.modP p (DensePoly.derivative f))).size :=
+    FpPoly.size_le_of_dvd_of_ne_zero hmodr_dvd_gcd hgcd_ne
+  have hgcd_ge_two :
+      2 ≤ (DensePoly.gcd (ZPoly.modP p f) (ZPoly.modP p (DensePoly.derivative f))).size := by
+    omega
+  -- Contradiction with the unit gcd hypothesis.
+  unfold separableModP gcdIsUnit at hsep
+  have : (DensePoly.gcd (ZPoly.modP p f) (ZPoly.modP p (DensePoly.derivative f))).size = 1 :=
+    beq_iff_eq.mp hsep
+  omega
+
+end ZPoly
+end Hex

--- a/HexPolyZ/Decomposition.lean
+++ b/HexPolyZ/Decomposition.lean
@@ -682,6 +682,132 @@ theorem coprimeModP_of_bezout
     coprimeModP f g p := by
   exact ⟨s, t, hbez⟩
 
+/-- Divisibility of integer polynomials is transitive. -/
+private theorem dvd_trans_zpoly {a b c : ZPoly} (hab : a ∣ b) (hbc : b ∣ c) :
+    a ∣ c := by
+  rcases hab with ⟨x, hx⟩
+  rcases hbc with ⟨y, hy⟩
+  exact ⟨x * y, by rw [hy, hx, DensePoly.mul_assoc_poly]⟩
+
+/-- Scale composition over `ℤ`: `scale a (scale b p) = scale (a * b) p`. -/
+private theorem int_scale_scale (a b : Int) (p : ZPoly) :
+    DensePoly.scale a (DensePoly.scale b p) = DensePoly.scale (a * b) p := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [DensePoly.coeff_scale (R := Int) a _ n (Int.mul_zero _),
+      DensePoly.coeff_scale (R := Int) b p n (Int.mul_zero _),
+      DensePoly.coeff_scale (R := Int) (a * b) p n (Int.mul_zero _), Int.mul_assoc]
+
+/-- Scaling by `1` over `ℤ` is the identity. -/
+private theorem int_scale_one (p : ZPoly) : DensePoly.scale (1 : Int) p = p := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [DensePoly.coeff_scale (R := Int) 1 p n (Int.mul_zero _), Int.one_mul]
+
+/-- Scaling commutes into the right factor of a product over `ℤ`. -/
+private theorem int_scale_mul_right (c : Int) (a b : ZPoly) :
+    DensePoly.scale c (a * b) = a * DensePoly.scale c b := by
+  rw [← C_mul_eq_scale, ← C_mul_eq_scale, ← DensePoly.mul_assoc_poly,
+      DensePoly.mul_comm_poly (DensePoly.C c) a, DensePoly.mul_assoc_poly]
+
+/-- The primitive part of an integer polynomial divides it over `ℤ`. -/
+private theorem primitivePart_dvd (f : ZPoly) : primitivePart f ∣ f := by
+  refine ⟨DensePoly.C (content f), ?_⟩
+  rw [DensePoly.mul_comm_poly, C_mul_eq_scale]
+  exact (content_mul_primitivePart f).symm
+
+/-- Gauss descent: if a primitive integer polynomial `r` divides `f` over the
+rationals (`ℚ[x]`), then it divides `f` over the integers (`ℤ[x]`).  The rational
+cofactor is cleared to a primitive integer polynomial via
+`ratPolyPrimitivePart`, and `rational_associate_primitive_unit` forces the
+leftover rational scalar to be `±1`, so the integer product recovers `f`'s
+primitive part exactly. -/
+theorem dvd_of_toRatPoly_dvd_of_primitive
+    {r f : ZPoly} (hr : Primitive r) (hr_ne : r ≠ 0)
+    (hdvd : toRatPoly r ∣ toRatPoly f) : r ∣ f := by
+  by_cases hf : f = 0
+  · refine ⟨0, ?_⟩
+    rw [hf]
+    exact ((DensePoly.mul_comm_poly r 0).trans (DensePoly.zero_mul r)).symm
+  · have hcontent_ne : content f ≠ 0 := content_ne_zero_of_ne_zero f hf
+    have hg_prim : Primitive (primitivePart f) := primitivePart_primitive f hcontent_ne
+    have hg_ne : primitivePart f ≠ 0 := by
+      intro h0
+      apply hf
+      have h := content_mul_primitivePart f
+      rw [h0, DensePoly.scale_zero_right] at h
+      exact h.symm
+    -- Extract the rational cofactor and clear its denominators to a fresh
+    -- primitive integer polynomial `s`.
+    rcases hdvd with ⟨K, hK⟩
+    have hK_ne : K ≠ 0 := by
+      intro h0
+      apply hf
+      apply toRatPoly_injective
+      rw [toRatPoly_zero, hK, h0]
+      exact (DensePoly.mul_comm_poly (toRatPoly r) 0).trans (DensePoly.zero_mul (toRatPoly r))
+    obtain ⟨u, s, hs_prim, hs_ne, hu⟩ :
+        ∃ u s, Primitive s ∧ s ≠ 0 ∧ K = DensePoly.scale u (toRatPoly s) := by
+      rcases ratPolyPrimitivePart_rational_associate K with ⟨u, hu⟩
+      have hs_ne : ratPolyPrimitivePart K ≠ 0 :=
+        ratPolyPrimitivePart_ne_zero_of_ne_zero K hK_ne
+      exact ⟨u, ratPolyPrimitivePart K,
+        ratPolyPrimitivePart_primitive K (content_ne_zero_of_ne_zero _ hs_ne), hs_ne, hu⟩
+    -- `toRatPoly f = scale u (toRatPoly (r * s))`.
+    have hf_rs : toRatPoly f = DensePoly.scale u (toRatPoly (r * s)) := by
+      rw [toRatPoly_mul, hK, hu]
+      have hsm := rat_scale_mul_scale 1 u (toRatPoly r) (toRatPoly s)
+      rw [rat_scale_one, Rat.one_mul] at hsm
+      exact hsm
+    -- `toRatPoly f = scale (content f) (toRatPoly (primitivePart f))`.
+    have hf_g :
+        toRatPoly f =
+          DensePoly.scale ((content f : Int) : Rat) (toRatPoly (primitivePart f)) := by
+      rw [← toRatPoly_scale_int, content_mul_primitivePart]
+    -- `f ≠ 0 ⟹ u ≠ 0` and `r * s ≠ 0`.
+    have hu_ne : u ≠ 0 := by
+      intro hu0
+      apply hf
+      apply toRatPoly_injective
+      rw [toRatPoly_zero, hf_rs, hu0]
+      exact rat_scale_zero _
+    have hrs_prim : Primitive (r * s) := primitive_mul r _ hr hs_prim
+    have hrs_ne : r * s ≠ 0 := by
+      intro h0
+      apply hf
+      apply toRatPoly_injective
+      rw [toRatPoly_zero, hf_rs, h0, toRatPoly_zero]
+      exact rat_scale_zero_right _
+    -- Equate the two scaled forms and cancel to a single rational unit.
+    have hscale_eq :
+        DensePoly.scale ((content f : Int) : Rat) (toRatPoly (primitivePart f)) =
+          DensePoly.scale u (toRatPoly (r * s)) := by
+      rw [← hf_g, hf_rs]
+    have hassoc :
+        toRatPoly (r * s) =
+          DensePoly.scale (((content f : Int) : Rat) / u)
+            (toRatPoly (primitivePart f)) :=
+      rat_scale_div_of_scale_eq hu_ne hscale_eq
+    -- Enough to show `r ∣ primitivePart f`, since `primitivePart f ∣ f`.
+    suffices hr_dvd_g : r ∣ primitivePart f from dvd_trans_zpoly hr_dvd_g (primitivePart_dvd f)
+    rcases rational_associate_primitive_unit hrs_prim hrs_ne hg_prim hg_ne hassoc with
+      hpos | hneg
+    · -- unit = 1 : `r * s = primitivePart f`.
+      rw [hpos, rat_scale_one] at hassoc
+      exact ⟨s, (toRatPoly_injective hassoc).symm⟩
+    · -- unit = -1 : `r * s = scale (-1) (primitivePart f)`.
+      rw [hneg] at hassoc
+      have heq : r * s = DensePoly.scale (-1 : Int) (primitivePart f) := by
+        apply toRatPoly_injective
+        rw [hassoc, toRatPoly_scale_int]
+        rfl
+      -- `primitivePart f = r * scale (-1) s`.
+      have hinvol : DensePoly.scale (-1 : Int) (r * s) = primitivePart f := by
+        rw [heq, int_scale_scale]
+        show DensePoly.scale (1 : Int) (primitivePart f) = primitivePart f
+        exact int_scale_one _
+      refine ⟨DensePoly.scale (-1 : Int) s, ?_⟩
+      rw [← hinvol, int_scale_mul_right]
 
 end ZPoly
 end Hex

--- a/HexPolyZ/Decomposition.lean
+++ b/HexPolyZ/Decomposition.lean
@@ -723,7 +723,7 @@ cofactor is cleared to a primitive integer polynomial via
 leftover rational scalar to be `±1`, so the integer product recovers `f`'s
 primitive part exactly. -/
 theorem dvd_of_toRatPoly_dvd_of_primitive
-    {r f : ZPoly} (hr : Primitive r) (hr_ne : r ≠ 0)
+    {r f : ZPoly} (hr : Primitive r)
     (hdvd : toRatPoly r ∣ toRatPoly f) : r ∣ f := by
   by_cases hf : f = 0
   · refine ⟨0, ?_⟩
@@ -808,6 +808,101 @@ theorem dvd_of_toRatPoly_dvd_of_primitive
         exact int_scale_one _
       refine ⟨DensePoly.scale (-1 : Int) s, ?_⟩
       rw [← hinvol, int_scale_mul_right]
+
+/-- `ratPolyPrimitivePart` of a nonzero rational polynomial of size at most one
+(a nonzero rational constant) is `1`. -/
+private theorem ratPolyPrimitivePart_eq_one_of_size_le_one
+    (p : DensePoly Rat) (hne : p ≠ 0) (hsize : p.size ≤ 1) :
+    ratPolyPrimitivePart p = 1 := by
+  rcases ratPolyPrimitivePart_rational_associate p with ⟨u, hu⟩
+  have hu_ne : u ≠ 0 := by
+    intro h0
+    apply hne
+    rw [hu, h0, rat_scale_zero]
+  have hq_ne : ratPolyPrimitivePart p ≠ 0 := ratPolyPrimitivePart_ne_zero_of_ne_zero p hne
+  have hq_prim : Primitive (ratPolyPrimitivePart p) :=
+    ratPolyPrimitivePart_primitive p (content_ne_zero_of_ne_zero _ hq_ne)
+  have hsize_q : (ratPolyPrimitivePart p).size ≤ 1 := by
+    have hscale := rat_scale_size_of_ne_zero hu_ne (toRatPoly (ratPolyPrimitivePart p))
+    rw [← hu] at hscale
+    rw [← size_toRatPoly]
+    omega
+  have hself : normalizePrimitiveSign (ratPolyPrimitivePart p) = ratPolyPrimitivePart p :=
+    normalizePrimitiveSign_eq_self_of_leadingCoeff_nonneg _
+      (leadingCoeff_ratPolyPrimitivePart_nonneg p)
+  rw [← hself]
+  exact normalizePrimitiveSign_eq_one_of_primitive_size_le_one _ hq_prim hsize_q
+
+/-- On a nonzero input whose primitive part is square-free over `ℚ`, the
+repeated part of the primitive square-free decomposition is `1`. -/
+theorem primitiveSquareFreeDecomposition_repeatedPart_eq_one_of_squareFreeRat
+    (core : ZPoly) (hne : core ≠ 0)
+    (hsq : SquareFreeRat (primitivePart core)) :
+    (primitiveSquareFreeDecomposition core).repeatedPart = 1 := by
+  have hprimitive_ne : primitivePart core ≠ 0 :=
+    ne_zero_of_primitive _ (primitivePart_primitive core (content_ne_zero_of_ne_zero core hne))
+  have hnot_isZero : (primitivePart core).isZero = false := by
+    cases hz : (primitivePart core).isZero
+    · rfl
+    · exact absurd (densePoly_eq_zero_of_isZero_true _ hz) hprimitive_ne
+  unfold primitiveSquareFreeDecomposition
+  rw [if_neg (by simpa using hnot_isZero)]
+  by_cases hderiv : (DensePoly.derivative (toRatPoly (primitivePart core))).isZero = true
+  · rw [if_pos hderiv]
+  · rw [if_neg hderiv]
+    have hratPrim_ne : toRatPoly (primitivePart core) ≠ 0 :=
+      toRatPoly_ne_zero_of_ne_zero _ hprimitive_ne
+    apply ratPolyPrimitivePart_eq_one_of_size_le_one
+    · intro h0
+      exact rat_gcd_size_ne_zero_of_left_ne_zero (toRatPoly (primitivePart core))
+        (DensePoly.derivative (toRatPoly (primitivePart core))) hratPrim_ne
+        (by rw [h0]; exact DensePoly.size_zero)
+    · exact hsq
+
+/-- On a nonzero input whose primitive part is square-free over `ℚ`, the
+square-free core of the primitive square-free decomposition is exactly the
+sign-normalized primitive part.  Together with
+`primitiveSquareFreeDecomposition_repeatedPart_eq_one_of_squareFreeRat`, this is
+the trivial decomposition that the modular square-free fast path returns. -/
+theorem primitiveSquareFreeDecomposition_squareFreeCore_eq_of_squareFreeRat
+    (core : ZPoly) (hne : core ≠ 0)
+    (hsq : SquareFreeRat (primitivePart core)) :
+    (primitiveSquareFreeDecomposition core).squareFreeCore =
+      normalizePrimitiveSign (primitivePart core) := by
+  have hprimitive_ne : primitivePart core ≠ 0 :=
+    ne_zero_of_primitive _ (primitivePart_primitive core (content_ne_zero_of_ne_zero core hne))
+  have hrep : (primitiveSquareFreeDecomposition core).repeatedPart = 1 :=
+    primitiveSquareFreeDecomposition_repeatedPart_eq_one_of_squareFreeRat core hne hsq
+  rcases primitiveSquareFreeDecomposition_reassembly_signed core hne with ⟨ε, hε, hre⟩
+  rw [hrep, DensePoly.mul_one_right_poly] at hre
+  have hlead_nonneg :
+      0 ≤ DensePoly.leadingCoeff (primitiveSquareFreeDecomposition core).squareFreeCore :=
+    leadingCoeff_squareFreeCore_nonneg core
+  rcases hε with h1 | hm1
+  · -- ε = 1 : squareFreeCore = primitivePart core, already sign-normalized.
+    rw [h1, int_scale_one] at hre
+    rw [← hre]
+    exact (normalizePrimitiveSign_eq_self_of_leadingCoeff_nonneg _ hlead_nonneg).symm
+  · -- ε = -1 : primitivePart core = scale (-1) squareFreeCore, so it has negative leading.
+    rw [hm1] at hre
+    have hsq_ne : (primitiveSquareFreeDecomposition core).squareFreeCore ≠ 0 := by
+      intro h0
+      apply hprimitive_ne
+      rw [← hre, h0, DensePoly.scale_zero_right]
+    have hsize_pos : 0 < (primitiveSquareFreeDecomposition core).squareFreeCore.size :=
+      size_pos_of_ne_zero _ hsq_ne
+    have hlead_ne :
+        DensePoly.leadingCoeff (primitiveSquareFreeDecomposition core).squareFreeCore ≠ 0 := by
+      rw [DensePoly.leadingCoeff_eq_coeff_last _ hsize_pos]
+      exact DensePoly.coeff_last_ne_zero_of_pos_size _ hsize_pos
+    have hlead_prim_neg : DensePoly.leadingCoeff (primitivePart core) < 0 := by
+      rw [← hre, leadingCoeff_scale_of_nonzero (-1 : Int) _ (by decide)]
+      omega
+    unfold normalizePrimitiveSign
+    rw [if_pos hlead_prim_neg, ← hre, int_scale_scale]
+    show (primitiveSquareFreeDecomposition core).squareFreeCore =
+      DensePoly.scale (1 : Int) (primitiveSquareFreeDecomposition core).squareFreeCore
+    exact (int_scale_one _).symm
 
 end ZPoly
 end Hex

--- a/progress/20260722T143242Z_issue-8701.md
+++ b/progress/20260722T143242Z_issue-8701.md
@@ -1,0 +1,47 @@
+# Issue 8701: speed up normalizeForFactor square-free-core extraction
+
+## Accomplished
+
+- Profiled `normalizeForFactor`. Confirmed the premise is sound: the cost is
+  dominated by the exact `gcd(f, f')` over `ℚ` (42-60% of the call, superlinear
+  from rational coefficient blow-up; 24 µs at deg 8 to 421 µs at deg 24). This
+  is a genuine non-redundant common-path cost, matching the issue's table.
+- Measured the lever: a bare modular square-free test (reduce mod a prime,
+  gcd over F_p in machine words, check unit) decides the common square-free
+  case ~40x faster (25 µs vs 1005 µs at deg 24). `choosePrimeData?` is NOT
+  usable inside the fast path (runs Berlekamp, 9 ms at deg 24).
+- Validated the design with a Codex second opinion and adopted its reduced
+  plan: one fixed certified prime (499), inline fallback (not a call to
+  `normalizeForFactor`, to avoid csimp self-recursion), csimp co-located in
+  `Records.lean`, test `primitivePart core`.
+- Proved and committed the linchpin (the highest-risk lemma per Codex and the
+  scout): `ZPoly.dvd_of_toRatPoly_dvd_of_primitive` (Gauss descent, rational
+  divisibility to integer for primitive divisors), in `HexPolyZ/Decomposition.lean`.
+  Reusable Gauss-lemma infrastructure that was missing.
+- Opened PR https://github.com/kim-em/hex-dev/pull/8849 with the foundation
+  lemma; posted a full findings + design comment on issue #8701.
+
+## Current frontier
+
+- The reusable linchpin (Gauss descent) is green and landed on the branch.
+  The full modular fast path is NOT yet wired; the perf win is not yet realised.
+
+## Next step
+
+Remaining lemmas (each with a concrete route on committed/existing infra):
+1. `derivative` commutes with `modP` (coeff formula + `modP_mul`).
+2. int-divisibility to modP-divisibility (one line from `modP_mul`).
+3. admissibility inherited by an integer factor of `core` (exact `core=r*s`,
+   `lc` multiplicative, primality).
+4. crux `squareFreeModP ⟹ SquareFreeRat` (assemble 1-3 + committed Gauss
+   descent + F_p common-divisor-is-unit, mirroring `rat_squareFree_of_rational_associate`).
+5. trivial-decomposition equality (`ratPolyPrimitivePart` associate-invariance
+   via `rational_associate_primitive_unit`; constant to 1).
+6. `normalizeForFactorFast` + `@[csimp]` in `Records.lean` + a compiled
+   fallback-recursion regression; bench/FLINT conformance unchanged.
+
+## Blockers
+
+- None technical. Remaining work is a focused but non-trivial Mathlib-free
+  formalization (no `ring`/`grind`/`omega`-through-`Int.ofNat`), larger than
+  fits one session on top of the analysis + linchpin already done.

--- a/progress/20260722T151451Z_issue-8701-complete.md
+++ b/progress/20260722T151451Z_issue-8701-complete.md
@@ -1,0 +1,38 @@
+# Issue 8701: normalizeForFactor modular square-free fast path — COMPLETE
+
+## Accomplished
+
+Delivered the full modular square-free fast path for `normalizeForFactor`,
+proven equal to the exact computation and registered `@[csimp]`. Measured
+~23x speedup on square-free deg24 (1005 -> 43 us); the whole ~5% classical-tier
+cost of the square-free-core extraction is largely eliminated on the common
+(square-free) corpus, with a cheap probe + exact fallback otherwise.
+
+Landed lemmas (all Mathlib-free, sorry/axiom-free):
+- `ZPoly.dvd_of_toRatPoly_dvd_of_primitive` (Gauss descent, HexPolyZ/Decomposition).
+- `primitiveSquareFreeDecomposition_{repeatedPart_eq_one,squareFreeCore_eq}_of_squareFreeRat`
+  (trivial decomposition, HexPolyZ/Decomposition).
+- `ZPoly.toRatPoly_derivative`, `ZPoly.modP_dvd_of_dvd`, `separableModP`,
+  `ZPoly.squareFreeRat_of_separableModP` (crux, new HexBerlekampZassenhaus/SquareFreeModularCert.lean).
+- `normalizeForFactorFast` + `@[csimp] normalizeForFactor_eq_normalizeForFactorFast`
+  (HexBerlekampZassenhaus/Records.lean), fixed certified prime 499, inline fallback.
+
+Verified: HexBerlekampZassenhaus lib builds; merge-gating HexBerlekampZassenhausMathlib
+builds (3826 jobs, 0 errors); BZ conformance guards build; runtime spot-checks
+correct on square-free (trivial decomposition fires) and non-square-free (exact
+fallback) inputs.
+
+PR https://github.com/kim-em/hex-dev/pull/8849 (updated to the full feature).
+
+## Current frontier
+
+Feature complete and pushed. Awaiting CI + a final second-opinion pass on the
+completed diff.
+
+## Next step
+
+Address any second-opinion findings; confirm CI green.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR speeds up `normalizeForFactor`, whose square-free-core extraction measured at ~5% of every classical Berlekamp-Zassenhaus factorization. The cost is dominated by an exact `gcd(f, f')` over `ℚ`, whose rational coefficient blow-up grows super-linearly with degree (24 µs at deg 8 rising to 421 µs at deg 24). It replaces the common (square-free) case with a machine-word `𝔽_p` probe: `normalizeForFactor` is `@[csimp]`-rewritten to a fast path that reduces the primitive `x`-free core and its integer derivative modulo the certified prime `499` and checks that their `𝔽_p` gcd is a unit. When the probe fires the whole decomposition collapses to `normalizePrimitiveSign` of the core with trivial repeated part; otherwise it falls back to the exact rational computation (inlined, not a self-call, so the `csimp` rewrite does not make the fallback recurse).

The fast path is proven equal to `normalizeForFactor`, so downstream proofs and outputs are unchanged. Soundness rests on `squareFreeRat_of_separableModP`: for a prime not dividing the leading coefficient, a passing `𝔽_p` separability test implies square-freeness over `ℚ`. Its contrapositive clears a positive-degree rational gcd of `f, f'` via Gauss's lemma (`dvd_of_toRatPoly_dvd_of_primitive`, new reusable infrastructure) to a positive-degree primitive integer common factor of `f` and `f'`, whose modular image is a positive-degree common factor of the reductions, contradicting the unit gcd. The trivial-decomposition equality and the `toRatPoly`/derivative and `modP`/divisibility commutations are likewise added as reusable lemmas. Everything is Mathlib-free; the merge-gating `HexBerlekampZassenhausMathlib` bridge and the BZ conformance guards build unchanged.

Measured on distinct-input split families (`normalizeForFactor`, square-free): deg 8 40→8 µs, deg 12 112→13 µs, deg 16 266→22 µs, deg 20 601→33 µs, deg 24 1005→43 µs (~23x). Genuinely non-square-free inputs pay one cheap probe (~25 µs) then the exact fallback.

🤖 Prepared with Claude Code
