### PR TITLE
doc: progress note closing the matrix-performance arc

### DIFF
--- a/progress/2026-07-22T14-41-57Z.md
+++ b/progress/2026-07-22T14-41-57Z.md
@@ -1,0 +1,44 @@
+# Submatrix views land; the matrix-performance arc closes
+
+## Accomplished
+
+Completed and merged the final deliverable of #8652: the `Submatrix` view
+type (named for `Subarray`/`Substring`; base matrix + offsets + real-data
+extents, with the zero-pad fringe carried in the view so padding is a
+reshape, not a copy) and the rewired `mulStrassen` recursion over views
+(#8734). Quadrant splitting no longer materializes or copies quadrant
+buffers (generated-C verified; only O(1) view records, the operand sums,
+and leaf materialization allocate). `mulStrassen`'s signature and
+`mulStrassen_eq_mul`'s statement are byte-identical; correctness reduces
+through view-to-Matrix abstraction lemmas to the unchanged wave-1
+decomposition. The colAdd family moved to flat per-entry column engines.
+Measurement was honestly neutral again — the removed copies are O(n²)
+per level against O(n^2.81) work — so the measured cutoff 96 stands,
+with the sweep and scaling exports committed. Review round (session +
+Codex) found no correctness issues and four precision fixes (allocation
+wording, empty-window doc, column-snapshot wording, baseRows/baseCols
+field names). An eleven-day gap between review and merge left the PR
+semantically adrift of a 107-commit main; the merge build was green and
+CI passed on the updated head.
+
+## Current frontier
+
+The matrix-performance arc is fully closed: Strassen SPEC (#8665, nine
+PRs), the caller survey and SPEC correction (#8688/#8694), the
+delayed-reduction kernel win (#8687/#8699, 1.4–3.2× over the default),
+the flat backing (#8702), and the Submatrix views (#8734). No open
+issues remain from this line of work.
+
+## Next step
+
+Possible future work, none filed as blocking: the two-buffer
+Boyer-Dumas-Pernet-Zhou storage schedule for the operand sums, a
+symmetry-aware Gram product kernel if that ever matters, and a
+bit-packed GF(2) four-Russians base kernel as the strongest possible
+config showcase. The merged agent worktrees under ~/worktrees/hex-dev/
+(issue-8666..8681*, 8652*, 8687) are disposable but hold untracked
+review-session notes.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR add the session progress note for the Submatrix-views merge (#8734), closing the matrix-performance arc: the Strassen SPEC implementation, the caller survey, the delayed-reduction kernel win, the flat backing, and the copy-free view recursion.

🤖 Prepared with Claude Code