### PR TITLE
refactor(hex-poly): hoist kernel-reducible polynomial equality to DensePoly.beqCoeffs

### DIFF
--- a/HexPoly/Dense.lean
+++ b/HexPoly/Dense.lean
@@ -448,6 +448,46 @@ is forced (via `size_eq_of_coeff_eq`). -/
   intro i _hi
   exact hcoeff i
 
+/-- Coefficient-level Boolean equality of two dense polynomials: equal stored
+sizes and equal coefficients at every stored index. Because `DensePoly` is
+normalized (no trailing zeros), this decides genuine equality, and unlike the
+structural `DecidableEq (DensePoly R)` — which delegates to the core
+`Array.instDecidableEqImpl` and does not kernel-reduce under the module system
+(see `progress/lean4-array-decidableeq-module-repro.md`) — it is a plain
+`Bool` fold that reduces on literal data under plain `public import`. -/
+@[expose]
+def beqCoeffs (a b : DensePoly R) : Bool :=
+  a.size == b.size && (List.range a.size).all fun i => decide (a.coeff i = b.coeff i)
+
+/-- `beqCoeffs` is sound: a `true` result forces genuine polynomial equality. -/
+theorem eq_of_beqCoeffs {a b : DensePoly R} (h : beqCoeffs a b = true) : a = b := by
+  unfold beqCoeffs at h
+  rw [Bool.and_eq_true] at h
+  obtain ⟨hsize, hall⟩ := h
+  have hsz : a.size = b.size := eq_of_beq hsize
+  apply ext_coeff
+  intro i
+  by_cases hi : i < a.size
+  · exact of_decide_eq_true ((List.all_eq_true.mp hall) i (List.mem_range.mpr hi))
+  · have ha : a.coeff i = 0 := coeff_eq_zero_of_size_le a (Nat.le_of_not_lt hi)
+    have hb : b.coeff i = 0 := coeff_eq_zero_of_size_le b (by omega)
+    rw [ha, hb]
+
+/-- `beqCoeffs` decides equality: the checker returns `true` exactly on equal
+polynomials. -/
+theorem beqCoeffs_iff_eq {a b : DensePoly R} : beqCoeffs a b = true ↔ a = b := by
+  constructor
+  · exact eq_of_beqCoeffs
+  · intro h
+    subst h
+    unfold beqCoeffs
+    rw [Bool.and_eq_true]
+    constructor
+    · exact beq_self_eq_true a.size
+    · rw [List.all_eq_true]
+      intro i _
+      exact decide_eq_true rfl
+
 /-- The largest exponent with a stored coefficient, or `none` for the zero polynomial. -/
 @[expose]
 def degree? (p : DensePoly R) : Option Nat :=

--- a/HexRealRoots/Cert.lean
+++ b/HexRealRoots/Cert.lean
@@ -39,30 +39,17 @@ namespace Hex
 
 namespace ZPoly
 
-/-- Coefficient-level Boolean equality of two integer polynomials: equal stored
-sizes and equal coefficients at every stored index. Because `ZPoly` is
-normalized (no trailing zeros), this decides genuine equality, and unlike the
-structural `DecidableEq (DensePoly Int)` — which delegates to the core
-`Array.instDecidableEqImpl` and does not kernel-reduce under the module system —
-it is a plain `Bool` fold that reduces. -/
+/-- Coefficient-level Boolean equality for `ZPoly`: the generic
+`DensePoly.beqCoeffs` at `R = Int`. Kept as an `abbrev` so the Sturm-chain
+checkers below read at the `ZPoly` level; see `DensePoly.beqCoeffs` for why
+this is used instead of the structural `DecidableEq`. -/
 @[expose]
-def beqCoeffs (a b : ZPoly) : Bool :=
-  a.size == b.size && (List.range a.size).all (fun i => a.coeff i == b.coeff i)
+abbrev beqCoeffs (a b : ZPoly) : Bool :=
+  DensePoly.beqCoeffs a b
 
 /-- `beqCoeffs` is sound: a `true` result forces genuine polynomial equality. -/
-theorem eq_of_beqCoeffs {a b : ZPoly} (h : beqCoeffs a b = true) : a = b := by
-  unfold beqCoeffs at h
-  rw [Bool.and_eq_true] at h
-  obtain ⟨hsize, hall⟩ := h
-  have hsz : a.size = b.size := eq_of_beq hsize
-  apply DensePoly.ext_coeff
-  intro i
-  by_cases hi : i < a.size
-  · have hi' := (List.all_eq_true.mp hall) i (List.mem_range.mpr hi)
-    exact eq_of_beq hi'
-  · have ha : a.coeff i = 0 := DensePoly.coeff_eq_zero_of_size_le a (Nat.le_of_not_lt hi)
-    have hb : b.coeff i = 0 := DensePoly.coeff_eq_zero_of_size_le b (by omega)
-    rw [ha, hb]
+theorem eq_of_beqCoeffs {a b : ZPoly} (h : beqCoeffs a b = true) : a = b :=
+  DensePoly.eq_of_beqCoeffs h
 
 /-- The tail validator for `SturmChainCert`: given the two most recent chain
 elements `prev`, `cur`, check that `rest` continues the Sturm chain exactly as

--- a/progress/2026-07-22T18-31-36Z.md
+++ b/progress/2026-07-22T18-31-36Z.md
@@ -1,0 +1,60 @@
+# factor_poly / irreducibility: plan approved, spikes done, step 1a landed
+
+Session context: interactive planning session with Kim for the `factor_poly` /
+`irreducibility` tactic family. Approved plan:
+`~/.claude/plans/i-d-like-to-prepare-magical-sutherland.md` (Codex review
+findings in `progress/20260722T180701Z_factor-poly-plan-review.md`).
+
+## Accomplished
+
+- Full design: 4-field `Factored` structures (scalar + factors + product proof +
+  per-factor irreducibility); named-provider-probe layer split (base in
+  HexBerlekamp, ZPoly arms in HexBerlekampZassenhaus, Mathlib arms in the two
+  bridge libs); certificate-backed proofs only (kernel never runs `factorize`
+  except opt-in bang forms); Eisenstein-after-shift certificate planned for the
+  balanced gap; `irreducible_cert` to be subsumed and deleted.
+- Step 0 feasibility spikes (scratch files, not committed), all conclusive:
+  - (a) Cross-module provider discovery via `Name`-probe + `evalExpr` of a
+    `public meta def` works, including graceful miss and type-guard. Constraint:
+    provider modules need `public meta import` of the core defining `Provider`.
+  - (b) `beqCoeffs`-style Bool checkers kernel-reduce under plain
+    `public import` for both `Int` and `ZMod64` coefficients, including the
+    `C s * factors.prod = p` emission shape, by `rfl` and `decide`. The derived
+    structural `DecidableEq` confirmed stuck (known
+    `Array.instDecidableEqImpl` module-system issue,
+    `progress/lean4-array-decidableeq-module-repro.md`).
+  - (d) Compiled evaluation sees non-`@[expose]` imported def bodies (given
+    `public meta import`) but `isDefEq` does not — so the planned
+    defeq-guarded input contract fails cleanly on opaque inputs. Also: the
+    interpreter respects meta accessibility, so evaluating *imported* user
+    defs needs the user to `public meta import` their defining module
+    (same-module defs, the common case, just work).
+  - (c) (goal-mode ring bridge) treated as validated by the in-tree
+    `aeval_ring_eq` precedent in `HexRealRootsMathlib/IsolateRootsElab.lean`.
+- Step 1a: generalized the kernel-reducible coefficient-equality checker to
+  `DensePoly.beqCoeffs` / `eq_of_beqCoeffs` / `beqCoeffs_iff_eq` in
+  `HexPoly/Dense.lean`; `HexRealRoots/Cert.lean` now delegates via an `abbrev`.
+  Verified: `lake build` of HexPoly, HexRealRoots, HexRealRootsMathlib (8775
+  jobs, includes the plain-import Sturm replay tests), Hex, HexPolyZ, HexPolyFp,
+  HexBerlekamp, HexBerlekampZassenhaus all green; scratch plain-import probes
+  for the ZPoly and FpPoly product-check shapes pass.
+
+## Current frontier
+
+Branch `factor-poly/densepoly-beqcoeffs` holds step 1a, ready for PR. Remaining
+step 1 work not started: `fpIrreducible_of_cert` (HexBerlekamp),
+`irreducible_of_modP_cert` + public linear wrapper (HexBerlekampZassenhaus),
+`Decidable` instances for `DensePoly.Monic` / `leadingCoeffAdmissible` if
+missing.
+
+## Next step
+
+PR step 1a. Then the decide-slot lemmas (plan step 1 remainder), using
+`SmallModSingleton.lean` as the template for `irreducible_of_modP_cert`.
+
+## Blockers
+
+None. Design constraint to carry forward: provider/bridge modules need
+`public meta import` of the tactic core; user-facing error messages should
+mention `public meta import` (imported defs, evaluation) and `@[expose]`
+(defeq transparency) when the input contract fails.


### PR DESCRIPTION
This PR generalize the kernel-reducible coefficient-equality checker from HexRealRoots' `ZPoly.beqCoeffs` to `DensePoly.beqCoeffs` over any coefficient type, adding `eq_of_beqCoeffs` and `beqCoeffs_iff_eq`, and refactor `HexRealRoots.Cert` onto it via an `abbrev`. This is step 1a of the `factor_poly`/`irreducibility` tactic plan: the tactics will emit `C scalar * factors.prod = p` product checks for both `ZPoly` and `FpPoly p` literals, and those must kernel-reduce under plain `public import` — the derived structural `DecidableEq (DensePoly R)` delegates to `Array.instDecidableEqImpl`, whose body is unavailable downstream under the module system (see `progress/lean4-array-decidableeq-module-repro.md`). Verified by building HexPoly, HexRealRoots, HexRealRootsMathlib (including the plain-import Sturm replay tests), and the Berlekamp/BZ free libraries, plus plain-import scratch probes of the ZPoly and FpPoly product-check shapes.

🤖 Prepared with Claude Code