### PR TITLE
feat(bz): kernel-decidable irreducibility entry points for FpPoly and ZPoly

### DIFF
--- a/HexBerlekamp.lean
+++ b/HexBerlekamp.lean
@@ -11,6 +11,7 @@ public import HexBerlekamp.DelayedKernel
 public import HexBerlekamp.DistinctDegree
 public import HexBerlekamp.Factor
 public import HexBerlekamp.Irreducibility
+public import HexBerlekamp.IrreducibleDecide
 public import HexBerlekamp.RabinSoundness
 
 public section

--- a/HexBerlekamp/IrreducibleDecide.lean
+++ b/HexBerlekamp/IrreducibleDecide.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexArith.Nat.Prime
+public import HexModArith.Prime
+public import HexPolyFp.Degree
+public import HexBerlekamp.Irreducibility
+public import HexBerlekamp.RabinSoundness
+
+public section
+
+/-!
+Kernel-decidable irreducibility entry points for `FpPoly p`, consumed by the
+`irreducibility`/`factor_poly` elaborators: every hypothesis is a Boolean check
+on literal data, so a reified application discharges each slot with
+`Eq.refl true`/`Eq.refl false` and the kernel verifies by reduction alone.
+
+The monic-guarded checker `checkMonicCert` folds the monicity side condition
+into the Boolean (the `checkCertAtFactor` idiom), so callers never construct a
+`DensePoly.Monic` proof term. The scaled entry point
+`irreducible_of_checkMonicCert_scale` additionally strips a unit scaling, so a
+non-monic polynomial is certified through its monic normalization `m` and
+leading coefficient `c` with the reconstruction check `scale c m = f` performed
+by `DensePoly.beqCoeffs`.
+-/
+
+namespace Hex
+namespace Berlekamp
+
+variable {p : Nat} [ZMod64.Bounds p]
+
+/-- Monic-guarded wrapper around the incremental linear certificate checker:
+`true` only when `m` is monic and the certificate replays. Folding the monicity
+guard into the Boolean lets reified applications avoid constructing a
+`DensePoly.Monic` proof term. -/
+@[expose]
+def checkMonicCert (m : FpPoly p) (cert : IrreducibilityCertificate) : Bool :=
+  if hmonic : DensePoly.leadingCoeff m = 1 then
+    checkIrreducibilityCertificateLinearIncremental m (by exact hmonic) cert
+  else false
+
+/-- A passing `checkMonicCert` forces irreducibility of the (necessarily monic)
+input. -/
+theorem irreducible_of_checkMonicCert [ZMod64.PrimeModulus p]
+    (m : FpPoly p) (cert : IrreducibilityCertificate)
+    (hcheck : checkMonicCert m cert = true) :
+    FpPoly.Irreducible m := by
+  unfold checkMonicCert at hcheck
+  split at hcheck
+  · exact checkIrreducibilityCertificateLinearIncremental_imp_irreducible
+      m (by assumption) cert hcheck
+  · exact absurd hcheck (by simp)
+
+/-- Kernel-decidable irreducibility for a possibly non-monic `f : FpPoly p`:
+`f` reconstructs as `scale c m` for a monic `m` whose Rabin certificate
+replays, with a nonzero scalar and a prime modulus. Every hypothesis is a
+Boolean check on literal data. -/
+theorem irreducible_of_checkMonicCert_scale
+    (f m : FpPoly p) (c : ZMod64 p) (cert : IrreducibilityCertificate)
+    (hp : Hex.Nat.isPrimeTrial p = true)
+    (hc : decide (c = 0) = false)
+    (hfm : DensePoly.beqCoeffs (DensePoly.scale c m) f = true)
+    (hcheck : checkMonicCert m cert = true) :
+    FpPoly.Irreducible f := by
+  haveI : ZMod64.PrimeModulus p :=
+    ZMod64.primeModulusOfPrime (Hex.Nat.isPrimeTrial_isPrime hp)
+  have hm : FpPoly.Irreducible m := irreducible_of_checkMonicCert m cert hcheck
+  have hcne : c ≠ 0 := of_decide_eq_false hc
+  have hscaled := FpPoly.irreducible_scale_of_ne_zero hcne hm
+  rwa [DensePoly.eq_of_beqCoeffs hfm] at hscaled
+
+end Berlekamp
+end Hex

--- a/HexBerlekampZassenhaus.lean
+++ b/HexBerlekampZassenhaus.lean
@@ -17,6 +17,7 @@ public import HexBerlekampZassenhaus.BhksRecover
 public import HexBerlekampZassenhaus.Recombination
 public import HexBerlekampZassenhaus.FactorEntryPoints
 public import HexBerlekampZassenhaus.IrreducibleCore
+public import HexBerlekampZassenhaus.IrreducibleDecide
 public import HexBerlekampZassenhaus.RecombineProofs
 public import HexBerlekampZassenhaus.TrialProofs
 public import HexBerlekampZassenhaus.QuadraticRootProofs

--- a/HexBerlekampZassenhaus/IrreducibleCore.lean
+++ b/HexBerlekampZassenhaus/IrreducibleCore.lean
@@ -951,6 +951,20 @@ theorem Irreducible_of_modP_irreducible_of_primitive_of_admissible
       · left; rw [hb_eq]; exact hone
       · right; rw [hb_eq]; exact hneg
 
+/-- Kernel-decidable irreducibility for a linear (dense size two) primitive
+integer polynomial: both hypotheses are Boolean checks on literal data, so a
+reified application discharges them with `Eq.refl true`. Public decide-slot
+form of `irreducible_of_size_two_primitive` for the
+`irreducibility`/`factor_poly` elaborators. -/
+theorem irreducible_of_linear
+    (f : ZPoly)
+    (hsize : decide (f.size = 2) = true)
+    (hcontent : decide (ZPoly.content f = 1) = true) :
+    ZPoly.Irreducible f := by
+  have hprim : ZPoly.Primitive f :=
+    of_decide_eq_true (p := ZPoly.content f = 1) hcontent
+  exact irreducible_of_size_two_primitive f (of_decide_eq_true hsize) hprim
+
 end ZPoly
 
 /-- `Hex.normalizeFactorSign` preserves `Hex.ZPoly.Irreducible`: the

--- a/HexBerlekampZassenhaus/IrreducibleDecide.lean
+++ b/HexBerlekampZassenhaus/IrreducibleDecide.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexBerlekamp.IrreducibleDecide
+public import HexBerlekampZassenhaus.IrreducibleCore
+public import HexBerlekampZassenhaus.PrimeSelection
+
+public section
+
+/-!
+Kernel-decidable irreducibility entry point for `Hex.ZPoly` via a single-prime
+modular witness, consumed by the `irreducibility`/`factor_poly` elaborators.
+
+For a primitive, non-constant `f` whose leading coefficient survives reduction
+mod a prime `p`, irreducibility of `ZPoly.modP p f` transfers to `f` by the
+Gauss-style `Irreducible_of_modP_irreducible_of_primitive_of_admissible`. The
+modular irreducibility itself is certified through the monic normalization
+`m` (with leading unit `c`) and a Rabin certificate replayed by
+`Berlekamp.checkMonicCert`. Every hypothesis is a Boolean check on literal
+data, so a reified application discharges each slot with `Eq.refl true` /
+`Eq.refl false` and the kernel verifies by reduction alone; the only
+non-trivial kernel work is one `modP` pass and the incremental Rabin pow-chain
+replay, both on literals.
+-/
+
+namespace Hex
+namespace ZPoly
+
+/-- Kernel-decidable single-prime irreducibility for `f : ZPoly`: `f` is
+primitive and non-constant, its reduction mod the trial-division prime `p`
+reconstructs as `scale c m` for a monic `m` with a passing Rabin certificate,
+and the leading coefficient survives the reduction. Fails to apply (no slot
+reduces to `true`) exactly when no single prime witnesses irreducibility —
+balanced inputs need the multi-prime degree-obstruction certificate from the
+Mathlib bridge. -/
+theorem irreducible_of_modPCert
+    (f : ZPoly) (p : Nat) [ZMod64.Bounds p]
+    (m : FpPoly p) (c : ZMod64 p) (cert : Berlekamp.IrreducibilityCertificate)
+    (hp : Hex.Nat.isPrimeTrial p = true)
+    (hcontent : decide (ZPoly.content f = 1) = true)
+    (hadm : decide (ZPoly.leadingCoeffModP f p ≠ 0) = true)
+    (hsize : decide (1 < f.size) = true)
+    (hc : decide (c = 0) = false)
+    (hfm : DensePoly.beqCoeffs (DensePoly.scale c m) (ZPoly.modP p f) = true)
+    (hcheck : Berlekamp.checkMonicCert m cert = true) :
+    ZPoly.Irreducible f := by
+  have hprime : Hex.Nat.Prime p := Hex.Nat.isPrimeTrial_isPrime hp
+  have hirr : FpPoly.Irreducible (ZPoly.modP p f) :=
+    Berlekamp.irreducible_of_checkMonicCert_scale (ZPoly.modP p f) m c cert
+      hp hc hfm hcheck
+  have hprim : ZPoly.Primitive f :=
+    of_decide_eq_true (p := ZPoly.content f = 1) hcontent
+  have hadm' : leadingCoeffAdmissible f p :=
+    of_decide_eq_true (p := ZPoly.leadingCoeffModP f p ≠ 0) hadm
+  exact ZPoly.Irreducible_of_modP_irreducible_of_primitive_of_admissible f p
+    hprime hprim hadm' (of_decide_eq_true hsize) hirr
+
+end ZPoly
+end Hex


### PR DESCRIPTION
This PR add the decide-slot lemmas the `factor_poly`/`irreducibility` elaborators will apply to reified literal data (plan step 1, stacked on #8856): `Hex.Berlekamp.checkMonicCert` — a monic-guarded wrapper over the incremental Rabin checker using the `checkCertAtFactor` dite idiom so reified applications never construct a `DensePoly.Monic` proof term — with soundness `irreducible_of_checkMonicCert` and the scaled entry point `irreducible_of_checkMonicCert_scale` for non-monic `FpPoly` inputs; `Hex.ZPoly.irreducible_of_modPCert`, the single-prime kernel-decidable route to `ZPoly.Irreducible` composing the Gauss-style mod-p transfer with the monic-normalized modular certificate; and the public `Hex.ZPoly.irreducible_of_linear` decide-slot wrapper over the private size-two lemma in `IrreducibleCore`. Every hypothesis is a Boolean check on literal data, so reified applications discharge each slot with `Eq.refl true`/`Eq.refl false` and the kernel verifies by reduction alone — the factorizer never runs in the kernel. The full slot composition (certificate generation plus all six slots) was runtime-probed green on `x²+1` at `p = 3`, and `lake build HexBerlekampZassenhausMathlib` (the CI-gating target) completes with zero errors.

🤖 Prepared with Claude Code