### PR TITLE
feat(berlekamp): factor_poly and irreducibility elaborators for FpPoly

### DIFF
--- a/HexBerlekamp.lean
+++ b/HexBerlekamp.lean
@@ -8,6 +8,11 @@ module
 
 public import HexBerlekamp.Basic
 public import HexBerlekamp.CertReify
+public import HexBerlekamp.Factored
+public import HexBerlekamp.TacticCore
+public import HexBerlekamp.FactorPolyElab
+public import HexBerlekamp.IrreducibilityElab
+public import HexBerlekamp.FactorTacticTests
 public import HexBerlekamp.DelayedKernel
 public import HexBerlekamp.DistinctDegree
 public import HexBerlekamp.Factor

--- a/HexBerlekamp/FactorPolyElab.lean
+++ b/HexBerlekamp/FactorPolyElab.lean
@@ -77,13 +77,18 @@ meta def fpFactorSearch (p : Nat) [Hex.ZMod64.Bounds p]
     (f.coeff 0, [])
   else
     let dec := Hex.FpPoly.squareFreeDecomposition hp f
-    let factors := dec.factors.flatMap fun sf =>
+    let raw := dec.factors.flatMap fun sf =>
       let parts :=
         if hmonic : Hex.DensePoly.leadingCoeff sf.factor = 1 then
           (Hex.Berlekamp.berlekampFactor sf.factor (by exact hmonic)).factors
         else [sf.factor]
       parts.flatMap fun part => List.replicate sf.multiplicity part
-    (dec.unit, factors.mergeSort fun a b => a.size ≤ b.size)
+    -- Berlekamp leaves are raw `gcd` outputs, hence monic only up to a unit
+    -- scalar: normalize each to its monic associate and fold the removed
+    -- scalars into the leading unit.
+    let normalized := raw.map Hex.FpPoly.normalizeMonic
+    (normalized.foldl (fun u cm => u * cm.1) dec.unit,
+      (normalized.map (·.2)).mergeSort fun a b => a.size ≤ b.size)
 
 /-- Deduplicate a factor list by coefficient equality (order-preserving). -/
 meta def dedupFactors {p : Nat} [Hex.ZMod64.Bounds p]

--- a/HexBerlekamp/FactorPolyElab.lean
+++ b/HexBerlekamp/FactorPolyElab.lean
@@ -1,0 +1,256 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public meta import HexBerlekamp.TacticCore
+public meta import HexPolyFp.SquareFree
+public meta import HexBerlekamp.Factor
+public import HexBerlekamp.TacticCore
+public import HexPolyFp.SquareFree
+public import HexBerlekamp.Factor
+
+public section
+
+/-!
+The `factor_poly` term elaborator and tactic.
+
+`factor_poly f` elaborates to a `Hex.FpPoly.Factored f` value (further input
+types via providers): the compiled Yun square-free decomposition and Berlekamp
+factorizer run at elaboration time as untrusted search, and the emitted
+structure carries kernel checks on reified literal data — one
+`DensePoly.beqCoeffs` product check and one `Berlekamp.checkIrredCover` pass
+replaying each distinct factor's Rabin certificate once. The factorizer never
+runs in the kernel.
+
+The tactic form `factor_poly f` introduces `scalar` and `factors` as `let`
+bindings (transparent literals) plus `factors_mul` and `factors_irred`
+hypotheses stated over them.
+-/
+
+namespace Hex.FactorTactic
+
+open Lean Meta Elab
+
+/-- Literal `List` expression `[x₁, …, xₙ] : List ty`. -/
+meta def listLit (ty : Expr) (xs : List Expr) : Expr :=
+  let nil := mkApp (mkConst ``List.nil [Level.zero]) ty
+  xs.foldr (fun x acc => mkApp3 (mkConst ``List.cons [Level.zero]) ty x acc) nil
+
+/-- The type `FpPoly p × ZMod64 p × Berlekamp.IrreducibilityCertificate` of a
+certified-cover entry, at a reified prime and bounds instance. -/
+meta def coverEntryType (pE boundsE : Expr) : Expr :=
+  mkApp2 (mkConst ``Prod [Level.zero, Level.zero])
+    (Hex.CertReify.fpPolyType pE boundsE)
+    (mkApp2 (mkConst ``Prod [Level.zero, Level.zero])
+      (Hex.CertReify.zmodType pE boundsE)
+      (mkConst ``Hex.Berlekamp.IrreducibilityCertificate))
+
+/-- Reify one certified-cover entry `(m, c, cert)`. -/
+meta def reifyCoverEntry (pE boundsE : Expr) {p : Nat} [Hex.ZMod64.Bounds p]
+    (m : Hex.FpPoly p) (c : Hex.ZMod64 p)
+    (cert : Hex.Berlekamp.IrreducibilityCertificate) : Expr :=
+  let mE := Hex.CertReify.reifyFpPolyOfNats pE boundsE (Hex.CertReify.fpCoeffNats m)
+  let cE := Hex.CertReify.reifyZMod64 pE boundsE c.toNat
+  let certE := Hex.CertReify.reifyRabinCert cert
+  mkApp4 (mkConst ``Prod.mk [Level.zero, Level.zero])
+    (Hex.CertReify.fpPolyType pE boundsE)
+    (mkApp2 (mkConst ``Prod [Level.zero, Level.zero])
+      (Hex.CertReify.zmodType pE boundsE)
+      (mkConst ``Hex.Berlekamp.IrreducibilityCertificate))
+    mE
+    (mkApp4 (mkConst ``Prod.mk [Level.zero, Level.zero])
+      (Hex.CertReify.zmodType pE boundsE)
+      (mkConst ``Hex.Berlekamp.IrreducibilityCertificate) cE certE)
+
+/-- The untrusted factor search for `f : FpPoly p`: leading unit plus monic
+irreducible factors with repetition, in nondecreasing size order. Correctness
+is carried entirely by the emitted kernel checks. -/
+meta def fpFactorSearch (p : Nat) [Hex.ZMod64.Bounds p]
+    (hp : Hex.Nat.Prime p) (f : Hex.FpPoly p) :
+    Hex.ZMod64 p × List (Hex.FpPoly p) :=
+  letI : Hex.ZMod64.PrimeModulus p := Hex.ZMod64.primeModulusOfPrime hp
+  if f.size ≤ 1 then
+    (f.coeff 0, [])
+  else
+    let dec := Hex.FpPoly.squareFreeDecomposition hp f
+    let factors := dec.factors.flatMap fun sf =>
+      let parts :=
+        if hmonic : Hex.DensePoly.leadingCoeff sf.factor = 1 then
+          (Hex.Berlekamp.berlekampFactor sf.factor (by exact hmonic)).factors
+        else [sf.factor]
+      parts.flatMap fun part => List.replicate sf.multiplicity part
+    (dec.unit, factors.mergeSort fun a b => a.size ≤ b.size)
+
+/-- Deduplicate a factor list by coefficient equality (order-preserving). -/
+meta def dedupFactors {p : Nat} [Hex.ZMod64.Bounds p]
+    (l : List (Hex.FpPoly p)) : List (Hex.FpPoly p) :=
+  l.foldl (init := []) fun acc q =>
+    if acc.any fun r => Hex.DensePoly.beqCoeffs r q then acc else acc ++ [q]
+
+/-- Build the certified-cover entries for the distinct factors: each factor is
+monic by construction, so the entry is `(q, 1, cert)`. Errors if a Rabin
+certificate cannot be produced (the factors come from Berlekamp on square-free
+parts, so this indicates an internal error) or if a replay is over budget. -/
+meta def fpCoverEntries (tactic : String) (p : Nat) [Hex.ZMod64.Bounds p]
+    (factors : List (Hex.FpPoly p)) :
+    MetaM (List (Hex.FpPoly p × Hex.ZMod64 p ×
+      Hex.Berlekamp.IrreducibilityCertificate)) := do
+  let mut entries := []
+  for q in dedupFactors factors do
+    checkReplayBudget tactic p q.size
+    if hmonic : Hex.DensePoly.leadingCoeff q = 1 then
+      let some cert := Hex.Berlekamp.buildIrreducibilityCertificate? q (by exact hmonic)
+        | throwError "{tactic}: internal error: no Rabin certificate for a \
+            Berlekamp factor; please report this"
+      entries := entries ++ [(q, (1 : Hex.ZMod64 p), cert)]
+    else
+      throwError "{tactic}: internal error: non-monic Berlekamp factor; \
+          please report this"
+  return entries
+
+/-- Instance-carrying core of the `factor_poly` elaboration for
+`f : FpPoly p`: returns the `Hex.FpPoly.Factored f` value as a raw `Expr`
+over reified literal data. -/
+meta def elabFpFactoredCore (tactic : String) (p : Nat)
+    [Hex.ZMod64.Bounds p] (hpt : Hex.Nat.isPrimeTrial p = true)
+    (pE boundsE RE zeroE decE fE : Expr) : MetaM Expr := do
+      let hp : Hex.Nat.Prime p := Hex.Nat.isPrimeTrial_isPrime hpt
+      let f ← evalFpPoly tactic p pE boundsE fE
+      -- Opaque-input contract: the emitted checks state over the user's term,
+      -- so it must be definitionally transparent down to its literal.
+      let fLit := Hex.CertReify.reifyFpPolyOfNats pE boundsE
+        (Hex.CertReify.fpCoeffNats f)
+      unless ← isDefEq fLit fE do
+        throwError "{tactic}: the polynomial{indentExpr fE}\
+            \nevaluates to{indentExpr fLit}\
+            \nbut is not definitionally transparent to the elaborator (an \
+            imported definition without `@[expose]`?); the kernel could not \
+            check the emitted certificate against it"
+      let (scalar, factors) := fpFactorSearch p hp f
+      -- Untrusted-search self-check before emitting anything.
+      unless Hex.DensePoly.beqCoeffs
+          (Hex.DensePoly.C scalar * factors.prod) f do
+        throwError "{tactic}: internal error: the factor search product does \
+            not reconstruct the input; please report this"
+      let entries ← fpCoverEntries tactic p factors
+      unless Hex.Berlekamp.checkIrredCover factors entries do
+        throwError "{tactic}: internal error: the generated certificates fail \
+            checkIrredCover; please report this"
+      let polyTy := Hex.CertReify.fpPolyType pE boundsE
+      let scalarE := Hex.CertReify.reifyZMod64 pE boundsE scalar.toNat
+      let factorsE := listLit polyTy (factors.map fun q =>
+        Hex.CertReify.reifyFpPolyOfNats pE boundsE (Hex.CertReify.fpCoeffNats q))
+      let certifiedE := listLit (coverEntryType pE boundsE)
+        (entries.map fun (m, c, cert) => reifyCoverEntry pE boundsE m c cert)
+      let lhsE ← mkAppM ``HMul.hMul
+        #[← mkAppM ``Hex.DensePoly.C #[scalarE], ← mkAppM ``List.prod #[factorsE]]
+      let hmulE := mkApp6 (mkConst ``Hex.DensePoly.eq_of_beqCoeffs [Level.zero])
+        RE zeroE decE lhsE fE Hex.CertReify.reflTrue
+      let hirredE := mkApp6
+        (mkConst ``Hex.Berlekamp.irreducible_of_checkIrredCover)
+        pE boundsE Hex.CertReify.reflTrue factorsE certifiedE
+        Hex.CertReify.reflTrue
+      return mkApp7 (mkConst ``Hex.FpPoly.Factored.mk)
+        pE boundsE fE scalarE factorsE hmulE hirredE
+
+/-- Dispatch the `factor_poly` elaboration for `f : FpPoly p`: primality and
+bounds checks on the literal modulus, then the instance-carrying core. -/
+meta def elabFactorPolyFp (tactic : String) (p : Nat)
+    (pE boundsE RE zeroE decE fE : Expr) : MetaM Expr := do
+  if hpt : Hex.Nat.isPrimeTrial p = true then
+    if h1 : 0 < p then
+      if h2 : p < 2 ^ 31 then
+        @elabFpFactoredCore tactic p ⟨h1, h2⟩ hpt pE boundsE RE zeroE decE fE
+      else
+        throwError "{tactic}: internal error: modulus over the ZMod64 bound \
+            despite a Bounds instance"
+    else
+      throwError "{tactic}: internal error: zero modulus despite a Bounds \
+          instance"
+  else
+    throwError "{tactic}: the modulus {p} is not prime; factorization into \
+        irreducibles requires a prime field"
+
+/-- Elaborate a `factor_poly` argument and produce the structure value,
+dispatching to providers for non-`FpPoly` input types. -/
+meta def elabFactorPolyCore (stx : Syntax) (t : Syntax)
+    (expectedType? : Option Expr) : Term.TermElabM Expr := do
+  let pE ← Term.elabTerm t none
+  Term.synthesizeSyntheticMVarsNoPostponing
+  let pE ← instantiateMVars pE
+  checkClosed "factor_poly" pE
+  let ty ← inferType pE
+  match ← classify ty with
+  | .fp p pE' boundsE RE zeroE decE =>
+      elabFactorPolyFp "factor_poly" p pE' boundsE RE zeroE decE pE
+  | _ =>
+      dispatch (fun prov => prov.factorPoly? stx pE ty expectedType?)
+        (fun declines =>
+          throwError (unsupportedMessage "factor_poly" ty declines))
+
+/-- `factor_poly f` elaborates to a certified irreducible factorization of
+`f` (a `Hex.FpPoly.Factored f` for `f : FpPoly p`; providers add further
+input types), usable as
+`obtain ⟨scalar, factors, factors_mul, factors_irred⟩ := factor_poly f`. -/
+syntax (name := factorPolyTerm) "factor_poly" term:max : term
+
+@[term_elab factorPolyTerm] meta def elabFactorPoly : Term.TermElab :=
+  fun stx expectedType? => do
+    match stx with
+    | `(factor_poly $t) => do
+        let e ← elabFactorPolyCore stx t expectedType?
+        Term.ensureHasType expectedType? e
+    | _ => Elab.throwUnsupportedSyntax
+
+/-- The tactic form of `factor_poly`: introduces `scalar` and `factors` as
+`let` bindings holding the literal factorization data, plus `factors_mul` and
+`factors_irred` hypotheses stated over them. -/
+syntax (name := factorPolyTac) "factor_poly" term:max : tactic
+
+@[tactic factorPolyTac] meta def evalFactorPolyTac : Tactic.Tactic :=
+  fun stx => do
+    match stx with
+    | `(tactic| factor_poly $t) => do
+        let e ← Tactic.withMainContext do
+          elabFactorPolyCore stx t none
+        -- Destructure the emitted `Factored.mk` application.
+        let args := e.getAppArgs
+        unless e.getAppFn.isConstOf ``Hex.FpPoly.Factored.mk &&
+            args.size == 7 do
+          -- Provider-produced results: fall back to a plain `have`.
+          Tactic.liftMetaTactic fun g => do
+            let ty ← inferType e
+            let (_, g) ← (← g.assert `factored ty e).intro1P
+            return [g]
+          return
+        let (pE, boundsE, fE) := (args[0]!, args[1]!, args[2]!)
+        let (scalarE, factorsE) := (args[3]!, args[4]!)
+        let (hmulE, hirredE) := (args[5]!, args[6]!)
+        Tactic.liftMetaTactic fun g => do
+          let zmodTy := Hex.CertReify.zmodType pE boundsE
+          let polyTy := Hex.CertReify.fpPolyType pE boundsE
+          let listTy := mkApp (mkConst ``List [Level.zero]) polyTy
+          let (fvS, g) ← (← g.define `scalar zmodTy scalarE).intro1P
+          let (fvF, g) ← (← g.define `factors listTy factorsE).intro1P
+          g.withContext do
+            let sE := mkFVar fvS
+            let fsE := mkFVar fvF
+            let lhs ← mkAppM ``HMul.hMul
+              #[← mkAppM ``Hex.DensePoly.C #[sE], ← mkAppM ``List.prod #[fsE]]
+            let hmulTy ← mkAppM ``Eq #[lhs, fE]
+            let (_, g) ← (← g.assert `factors_mul hmulTy hmulE).intro1P
+            g.withContext do
+              let hirredTy ←
+                withLocalDeclD `q polyTy fun q => do
+                  let mem ← mkAppM ``Membership.mem #[fsE, q]
+                  let irred ← mkAppM ``Hex.FpPoly.Irreducible #[q]
+                  mkForallFVars #[q] (← mkArrow mem irred)
+              let (_, g) ← (← g.assert `factors_irred hirredTy hirredE).intro1P
+              return [g]
+    | _ => Elab.throwUnsupportedSyntax
+
+end Hex.FactorTactic

--- a/HexBerlekamp/FactorTacticTests.lean
+++ b/HexBerlekamp/FactorTacticTests.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+-- PLAIN `public import` only: NO `import all` (except the `public meta import`
+-- required for elaboration-time evaluation of same-library functions). The
+-- emitted kernel checks must reduce through the exposed closure alone, exactly
+-- as a downstream `module` consumer of the tactics would see them.
+public meta import HexBerlekamp.IrreducibilityElab
+public import HexBerlekamp.IrreducibilityElab
+
+public section
+
+open Hex
+
+namespace HexBerlekamp.FactorTacticTests
+
+instance : ZMod64.Bounds 5 := ⟨by decide, by decide⟩
+instance : ZMod64.Bounds 2 := ⟨by decide, by decide⟩
+
+def z (n : Nat) : ZMod64 5 := ZMod64.ofNat 5 n
+
+/-- `3 · (x+1)² · (x²+2)` over `F_5`: non-monic, non-square-free. -/
+def testF : FpPoly 5 :=
+  DensePoly.C (z 3) *
+    (FpPoly.ofCoeffs #[z 1, z 1] * FpPoly.ofCoeffs #[z 1, z 1] *
+     FpPoly.ofCoeffs #[z 2, z 0, z 1])
+
+/-! ## `factor_poly`, term form -/
+
+noncomputable def fac := factor_poly testF
+
+example : fac.factors.length = 3 := rfl
+example : fac.scalar = z 3 := rfl
+
+example : True := by
+  obtain ⟨scalar, factors, factors_mul, factors_irred⟩ := factor_poly testF
+  trivial
+
+-- Edge cases: zero, constants, and units all produce empty factor lists.
+noncomputable def facZero := factor_poly (0 : FpPoly 5)
+noncomputable def facConst := factor_poly (FpPoly.C (z 4))
+example : facZero.factors = [] := rfl
+example : facConst.factors = [] := rfl
+
+-- Characteristic-2 inseparable input: (x+1)^4 = x^4+1 over F_2.
+def w (n : Nat) : ZMod64 2 := ZMod64.ofNat 2 n
+def inseparable : FpPoly 2 := FpPoly.ofCoeffs #[w 1, w 0, w 0, w 0, w 1]
+noncomputable def facInsep := factor_poly inseparable
+example : facInsep.factors.length = 4 := rfl
+
+/-! ## `factor_poly`, tactic form -/
+
+example : True := by
+  factor_poly testF
+  -- `scalar`/`factors` are transparent `let`s; the hypotheses are usable.
+  have : factors.length = 3 := rfl
+  exact True.intro
+
+/-! ## `irreducibility` -/
+
+def irr1 : FpPoly 5 := FpPoly.ofCoeffs #[z 2, z 0, z 1]
+/-- Non-monic irreducible: `3 · (x²+2)`. -/
+def irr2 : FpPoly 5 := DensePoly.C (z 3) * irr1
+
+theorem irr1_irred : FpPoly.Irreducible irr1 := irreducibility irr1
+theorem irr2_irred : FpPoly.Irreducible irr2 := irreducibility irr2
+
+example : FpPoly.Irreducible irr1 := by irreducibility
+
+example : True := by
+  irreducibility irr1
+  irreducibility h : irr2
+  exact h.elim fun _ _ => True.intro
+
+/-! ## Negative tests -/
+
+instance : ZMod64.Bounds 6 := ⟨by decide, by decide⟩
+
+/-- error: irreducibility: the modulus 6 is not prime; irreducibility over Z/6 needs a prime field -/
+#guard_msgs in
+example := irreducibility (FpPoly.ofCoeffs #[ZMod64.ofNat 6 1, ZMod64.ofNat 6 1])
+
+/-- error: irreducibility: the zero polynomial is not irreducible -/
+#guard_msgs in
+example := irreducibility (0 : FpPoly 5)
+
+/--
+error: irreducibility: the polynomial
+  FpPoly.C (z 4)
+is a nonzero constant, hence a unit over F_5, not irreducible
+-/
+#guard_msgs in
+example := irreducibility (FpPoly.C (z 4))
+
+/--
+error: irreducibility: the polynomial
+  testF
+is not irreducible over F_5: factor_poly finds 3 irreducible factors (with multiplicity)
+-/
+#guard_msgs in
+example := irreducibility testF
+
+/-! ## Axiom hygiene -/
+
+/-- info: 'HexBerlekamp.FactorTacticTests.fac' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms fac
+
+/-- info: 'HexBerlekamp.FactorTacticTests.irr1_irred' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms irr1_irred
+
+end HexBerlekamp.FactorTacticTests

--- a/HexBerlekamp/FactorTacticTests.lean
+++ b/HexBerlekamp/FactorTacticTests.lean
@@ -53,6 +53,16 @@ def inseparable : FpPoly 2 := FpPoly.ofCoeffs #[w 1, w 0, w 0, w 0, w 1]
 noncomputable def facInsep := factor_poly inseparable
 example : facInsep.factors.length = 4 := rfl
 
+-- Raw Berlekamp leaves are only defined up to a unit scalar: over F_3,
+-- x⁴ + x³ + x produces non-monic gcd leaves, which `fpFactorSearch` must
+-- normalize into monic associates (folding the scalars into the unit).
+instance : ZMod64.Bounds 3 := ⟨by decide, by decide⟩
+def y (n : Nat) : ZMod64 3 := ZMod64.ofNat 3 n
+def rawLeaves : FpPoly 3 := FpPoly.ofCoeffs #[y 0, y 1, y 0, y 1, y 1]
+noncomputable def facRawLeaves := factor_poly rawLeaves
+example : facRawLeaves.factors.length = 3 := rfl
+example : facRawLeaves.scalar = y 1 := rfl
+
 /-! ## `factor_poly`, tactic form -/
 
 example : True := by

--- a/HexBerlekamp/Factored.lean
+++ b/HexBerlekamp/Factored.lean
@@ -1,0 +1,43 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexPolyFp.Field
+public import HexPolyFp.Ring
+public import HexPoly.Euclid
+
+public section
+
+/-!
+The result type of the `factor_poly` term elaborator for `FpPoly p`: a
+certified irreducible factorization, destructured as
+`obtain ⟨scalar, factors, factors_mul, factors_irred⟩ := factor_poly f`.
+
+The generator emits monic factors in nondecreasing degree order with the
+leading unit in `scalar`, and repeats each factor to its multiplicity — but
+those normalizations are conventions of the generator, not invariants of this
+type; users needing them on the emitted literals can `decide` them.
+-/
+
+namespace Hex
+
+/-- A certified irreducible factorization of `f : FpPoly p`: a scalar and a
+factor list (with repetition) whose product reconstructs `f`, every listed
+factor irreducible. Produced by the `factor_poly` elaborator with monic
+factors and the leading unit in `scalar`. -/
+structure FpPoly.Factored {p : Nat} [ZMod64.Bounds p] (f : FpPoly p) where
+  /-- The unit scalar (the leading coefficient for nonzero `f`). -/
+  scalar : ZMod64 p
+  /-- The irreducible factors, with repetition (monic by generator
+  convention). -/
+  factors : List (FpPoly p)
+  /-- The scalar times the factor product reconstructs `f`. -/
+  factors_mul : DensePoly.C scalar * factors.prod = f
+  /-- Every listed factor is irreducible. -/
+  factors_irred : ∀ q ∈ factors, FpPoly.Irreducible q
+
+end Hex

--- a/HexBerlekamp/Irreducibility.lean
+++ b/HexBerlekamp/Irreducibility.lean
@@ -146,6 +146,7 @@ Match a certificate's stored prime against the ambient `p`. Returns the
 same-prime view on success, or `none` if the certificate is for a different
 prime.
 -/
+@[expose]
 def IrreducibilityCertificate.toAmbient?
     (cert : IrreducibilityCertificate) (p : Nat) [ZMod64.Bounds p] :
     Option (SamePrimeIrreducibilityCertificate p) := by
@@ -159,6 +160,7 @@ def IrreducibilityCertificate.toAmbient?
         exact none
 
 /-- The Rabin difference polynomial represented by a certificate pow-chain entry. -/
+@[expose]
 def certifiedFrobeniusDiffMod (f : FpPoly p) (hmonic : DensePoly.Monic f)
     (powWitness : FpPoly p) : FpPoly p :=
   powWitness - FpPoly.modByMonic f FpPoly.X hmonic
@@ -182,6 +184,7 @@ def checkPowChainLinear (f : FpPoly p) (hmonic : DensePoly.Monic f)
       cert.powChain[k]? == some (FpPoly.frobeniusXPowModLinear f hmonic k)
 
 /-- Check one Bezout witness for a Rabin maximal-proper-divisor leg. -/
+@[expose]
 def checkRabinBezoutWitness (f : FpPoly p) (hmonic : DensePoly.Monic f)
     (cert : SamePrimeIrreducibilityCertificate p) (i d : Nat) : Bool :=
   match cert.powChain[d]?, cert.bezout[i]? with
@@ -191,6 +194,7 @@ def checkRabinBezoutWitness (f : FpPoly p) (hmonic : DensePoly.Monic f)
   | _, _ => false
 
 /-- Check all Bezout witnesses against `maximalProperDivisors cert.n`. -/
+@[expose]
 def checkRabinBezoutWitnesses (f : FpPoly p) (hmonic : DensePoly.Monic f)
     (cert : SamePrimeIrreducibilityCertificate p) : Bool :=
   let divisors := maximalProperDivisors cert.n
@@ -638,6 +642,7 @@ multiplications, dropping the total work from `Σ p^k` to `n · p`. -/
 The single-step recurrence: `powChain[k+1]` must equal
 `(powChain[k])^p mod f`.
 -/
+@[expose]
 def checkPowChainLinearIncrementalStep
     (f : FpPoly p) (hmonic : DensePoly.Monic f)
     (cert : SamePrimeIrreducibilityCertificate p) (k : Nat) : Bool :=
@@ -650,6 +655,7 @@ Kernel-reducible incremental pow-chain check.  Validates that
 `powChain[0] = X mod f` and that each successor is the previous entry's
 `p`-th power modulo `f`.  Total work is `O(n · p)` instead of `O(Σ p^k)`.
 -/
+@[expose]
 def checkPowChainLinearIncremental (f : FpPoly p) (hmonic : DensePoly.Monic f)
     (cert : SamePrimeIrreducibilityCertificate p) : Bool :=
   cert.powChain.size == cert.n + 1 &&
@@ -1197,6 +1203,7 @@ Incremental Rabin certificate checker, suitable for `(p, n)` regimes where
 `p^n` is too large for `checkIrreducibilityCertificateLinear` but `n · p`
 remains in budget (e.g. `(5, 6)` or `(7, 6)`).
 -/
+@[expose]
 def checkIrreducibilityCertificateLinearIncremental
     (f : FpPoly p) (hmonic : DensePoly.Monic f)
     (cert : IrreducibilityCertificate) : Bool :=

--- a/HexBerlekamp/IrreducibilityElab.lean
+++ b/HexBerlekamp/IrreducibilityElab.lean
@@ -1,0 +1,196 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public meta import HexBerlekamp.FactorPolyElab
+public import HexBerlekamp.FactorPolyElab
+
+public section
+
+/-!
+The `irreducibility` term elaborator and tactic.
+
+`irreducibility f` elaborates to a proof of `Hex.FpPoly.Irreducible f`
+(further input types via providers): the compiled Rabin certificate generator
+runs at elaboration time, and the emitted proof applies
+`Berlekamp.irreducible_of_checkMonicCert_scale` to reified literal data, so
+the kernel replays only the certificate check.
+
+Tactic forms: `irreducibility f` adds `this : … .Irreducible f`,
+`irreducibility h : f` names it `h`, and bare `irreducibility` closes a goal
+of the form `FpPoly.Irreducible e` (providers extend the goal shapes).
+-/
+
+namespace Hex.FactorTactic
+
+open Lean Meta Elab
+
+/-- Instance-carrying core of the `irreducibility` elaboration for
+`f : FpPoly p`: returns the proof of `Hex.FpPoly.Irreducible f` as a raw
+`Expr` over reified literal data. -/
+meta def elabFpIrredCore (tactic : String) (p : Nat)
+    [Hex.ZMod64.Bounds p] (hpt : Hex.Nat.isPrimeTrial p = true)
+    (pE boundsE fE : Expr) : MetaM Expr := do
+      let hp : Hex.Nat.Prime p := Hex.Nat.isPrimeTrial_isPrime hpt
+      let f ← evalFpPoly tactic p pE boundsE fE
+      let fLit := Hex.CertReify.reifyFpPolyOfNats pE boundsE
+        (Hex.CertReify.fpCoeffNats f)
+      unless ← isDefEq fLit fE do
+        throwError "{tactic}: the polynomial{indentExpr fE}\
+            \nevaluates to{indentExpr fLit}\
+            \nbut is not definitionally transparent to the elaborator (an \
+            imported definition without `@[expose]`?); the kernel could not \
+            check the emitted certificate against it"
+      if f.size = 0 then
+        throwError "{tactic}: the zero polynomial is not irreducible"
+      if f.size = 1 then
+        throwError "{tactic}: the polynomial{indentExpr fE}\
+            \nis a nonzero constant, hence a unit over F_{p}, not irreducible"
+      checkReplayBudget tactic p f.size
+      let (unit, m) := Hex.FpPoly.normalizeMonic f
+      if hmonic : Hex.DensePoly.leadingCoeff m = 1 then
+        match Hex.Berlekamp.buildIrreducibilityCertificate? m (by exact hmonic) with
+        | none =>
+            let (_, factors) := fpFactorSearch p hp f
+            throwError "{tactic}: the polynomial{indentExpr fE}\
+                \nis not irreducible over F_{p}: factor_poly finds \
+                {factors.length} irreducible factors (with multiplicity)"
+        | some cert =>
+            let mE := Hex.CertReify.reifyFpPolyOfNats pE boundsE
+              (Hex.CertReify.fpCoeffNats m)
+            let cE := Hex.CertReify.reifyZMod64 pE boundsE unit.toNat
+            let certE := Hex.CertReify.reifyRabinCert cert
+            -- Untrusted-search self-checks before emitting anything.
+            unless decide (unit = 0) = false &&
+                Hex.DensePoly.beqCoeffs (Hex.DensePoly.scale unit m) f &&
+                Hex.Berlekamp.checkMonicCert m cert do
+              throwError "{tactic}: internal error: the generated certificate \
+                  fails its own checks; please report this"
+            return mkApp10
+              (mkConst ``Hex.Berlekamp.irreducible_of_checkMonicCert_scale)
+              pE boundsE fE mE cE certE
+              Hex.CertReify.reflTrue Hex.CertReify.reflFalse
+              Hex.CertReify.reflTrue Hex.CertReify.reflTrue
+      else
+        throwError "{tactic}: internal error: non-monic normalization; \
+            please report this"
+
+/-- Dispatch the `irreducibility` elaboration for `f : FpPoly p`. -/
+meta def elabIrreducibilityFp (tactic : String) (p : Nat)
+    (pE boundsE fE : Expr) : MetaM Expr := do
+  if hpt : Hex.Nat.isPrimeTrial p = true then
+    if h1 : 0 < p then
+      if h2 : p < 2 ^ 31 then
+        @elabFpIrredCore tactic p ⟨h1, h2⟩ hpt pE boundsE fE
+      else
+        throwError "{tactic}: internal error: modulus over the ZMod64 bound \
+            despite a Bounds instance"
+    else
+      throwError "{tactic}: internal error: zero modulus despite a Bounds \
+          instance"
+  else
+    throwError "{tactic}: the modulus {p} is not prime; irreducibility over \
+        Z/{p} needs a prime field"
+
+/-- Elaborate an `irreducibility` argument and produce the proof, dispatching
+to providers for non-`FpPoly` input types. -/
+meta def elabIrreducibilityCore (stx : Syntax) (t : Syntax)
+    (expectedType? : Option Expr) : Term.TermElabM Expr := do
+  let pE ← Term.elabTerm t none
+  Term.synthesizeSyntheticMVarsNoPostponing
+  let pE ← instantiateMVars pE
+  checkClosed "irreducibility" pE
+  let ty ← inferType pE
+  match ← classify ty with
+  | .fp p pE' boundsE _ _ _ =>
+      elabIrreducibilityFp "irreducibility" p pE' boundsE pE
+  | _ =>
+      dispatch (fun prov => prov.irreducibility? stx pE ty expectedType?)
+        (fun declines =>
+          throwError (unsupportedMessage "irreducibility" ty declines))
+
+/-- `irreducibility f` elaborates to a proof that `f` is irreducible
+(`Hex.FpPoly.Irreducible f` for `f : FpPoly p`; providers add further input
+types). -/
+syntax (name := irreducibilityTerm) "irreducibility" term:max : term
+
+@[term_elab irreducibilityTerm] meta def elabIrreducibility : Term.TermElab :=
+  fun stx expectedType? => do
+    match stx with
+    | `(irreducibility $t) => do
+        let e ← elabIrreducibilityCore stx t expectedType?
+        Term.ensureHasType expectedType? e
+    | _ => Elab.throwUnsupportedSyntax
+
+/-- Try to close a goal of the form `Hex.FpPoly.Irreducible e` natively;
+return `false` when the goal has a different shape. -/
+meta def goalIrredFp (goal : MVarId) : Tactic.TacticM Bool := do
+  goal.withContext do
+    let tgt ← instantiateMVars (← goal.getType)
+    let fn := tgt.getAppFn
+    unless fn.isConstOf ``Hex.FpPoly.Irreducible && tgt.getAppNumArgs == 3 do
+      return false
+    let args := tgt.getAppArgs
+    let (pE, boundsE, fE) := (args[0]!, args[1]!, args[2]!)
+    let some p := pE.nat? |
+      throwError "irreducibility: the modulus in the goal{indentExpr tgt}\
+          \nis not a numeral"
+    checkClosed "irreducibility" fE
+    let proof ← elabIrreducibilityFp "irreducibility" p pE boundsE fE
+    unless ← isDefEq (← inferType proof) tgt do
+      throwError "irreducibility: the certified statement\
+          {indentExpr (← inferType proof)}\
+          \nis not definitionally equal to the goal{indentExpr tgt}"
+    goal.assign proof
+    Tactic.replaceMainGoal []
+    return true
+
+/-- Tactic forms of `irreducibility`: bare `irreducibility` closes a goal of
+the form `… .Irreducible e`; `irreducibility f` adds the proof as `this`;
+`irreducibility h : f` names it `h`. -/
+syntax (name := irreducibilityTac)
+  "irreducibility" (atomic(ident " : "))? (term:max)? : tactic
+
+@[tactic irreducibilityTac] meta def evalIrreducibilityTac : Tactic.Tactic :=
+  fun stx => do
+    match stx with
+    | `(tactic| irreducibility) => do
+        let goal ← Tactic.getMainGoal
+        if ← goalIrredFp goal then
+          return
+        -- Providers get the goal next; collect decline diagnostics.
+        let mut declines : Array MessageData := #[]
+        for prov in (← providers) do
+          match ← prov.goalIrred? goal with
+          | .success e =>
+              goal.assign e
+              Tactic.replaceMainGoal []
+              return
+          | .notApplicable => pure ()
+          | .declined why => declines := declines.push why
+          | .fatal msg => throwError msg
+        let tgt ← goal.getType
+        throwError (unsupportedMessage "irreducibility" tgt declines ++
+          m!"\n\nGoal-mode `irreducibility` expects a goal of the form \
+            `… .Irreducible e`.")
+    | `(tactic| irreducibility $t:term) => do
+        let proof ← Tactic.withMainContext do
+          elabIrreducibilityCore stx t none
+        Tactic.liftMetaTactic fun g => do
+          let ty ← inferType proof
+          let (_, g) ← (← g.assert `this ty proof).intro1P
+          return [g]
+    | `(tactic| irreducibility $h:ident : $t:term) => do
+        let proof ← Tactic.withMainContext do
+          elabIrreducibilityCore stx t none
+        Tactic.liftMetaTactic fun g => do
+          let ty ← inferType proof
+          let (_, g) ← (← g.assert h.getId ty proof).intro1P
+          return [g]
+    | _ => Elab.throwUnsupportedSyntax
+
+end Hex.FactorTactic

--- a/HexBerlekamp/IrreducibleDecide.lean
+++ b/HexBerlekamp/IrreducibleDecide.lean
@@ -74,5 +74,45 @@ theorem irreducible_of_checkMonicCert_scale
   have hscaled := FpPoly.irreducible_scale_of_ne_zero hcne hm
   rwa [DensePoly.eq_of_beqCoeffs hfm] at hscaled
 
+/-- Bulk kernel-decidable irreducibility for a factor list with repetition:
+`certified` carries one `(monic, scalar, certificate)` entry per *distinct*
+factor, and every listed factor must match some entry's `scale scalar monic`
+by `beqCoeffs`. Each certificate is replayed once regardless of multiplicity;
+repeated factors cost only a coefficient comparison. -/
+@[expose]
+def checkIrredCover (factors : List (FpPoly p))
+    (certified : List (FpPoly p × ZMod64 p × IrreducibilityCertificate)) : Bool :=
+  (certified.all fun e => !(decide (e.2.1 = 0)) && checkMonicCert e.1 e.2.2) &&
+    (factors.all fun q =>
+      certified.any fun e => DensePoly.beqCoeffs (DensePoly.scale e.2.1 e.1) q)
+
+/-- A passing `checkIrredCover` forces irreducibility of every listed factor.
+The single Boolean hypothesis is the `factors_irred` slot of a reified
+`FpPoly.Factored` value. -/
+theorem irreducible_of_checkIrredCover
+    (hp : Hex.Nat.isPrimeTrial p = true)
+    (factors : List (FpPoly p))
+    (certified : List (FpPoly p × ZMod64 p × IrreducibilityCertificate))
+    (hcheck : checkIrredCover factors certified = true) :
+    ∀ q ∈ factors, FpPoly.Irreducible q := by
+  haveI : ZMod64.PrimeModulus p :=
+    ZMod64.primeModulusOfPrime (Hex.Nat.isPrimeTrial_isPrime hp)
+  unfold checkIrredCover at hcheck
+  rw [Bool.and_eq_true] at hcheck
+  obtain ⟨hvalid, hcover⟩ := hcheck
+  rw [List.all_eq_true] at hvalid hcover
+  intro q hq
+  have hq' := hcover q hq
+  rw [List.any_eq_true] at hq'
+  obtain ⟨e, he, hbeq⟩ := hq'
+  have hv := hvalid e he
+  rw [Bool.and_eq_true] at hv
+  obtain ⟨hcne, hcert⟩ := hv
+  rw [Bool.not_eq_true'] at hcne
+  have hne : e.2.1 ≠ 0 := of_decide_eq_false hcne
+  have hm : FpPoly.Irreducible e.1 := irreducible_of_checkMonicCert e.1 e.2.2 hcert
+  have hscaled := FpPoly.irreducible_scale_of_ne_zero hne hm
+  rwa [DensePoly.eq_of_beqCoeffs hbeq] at hscaled
+
 end Berlekamp
 end Hex

--- a/HexBerlekamp/SPEC/hex-berlekamp.md
+++ b/HexBerlekamp/SPEC/hex-berlekamp.md
@@ -88,3 +88,35 @@ Python driver per `SPEC/benchmarking.md §"External comparators"
 multiple FLINT comparator families.
 
 Structured metadata in `libraries.yml: HexBerlekamp.phase4.comparators`.
+
+## The `factor_poly` and `irreducibility` tactics
+
+User-facing certificate-backed elaborators (`FactorPolyElab.lean`,
+`IrreducibilityElab.lean`), handling `FpPoly p` natively for literal prime
+moduli within the ZMod64 bounds:
+
+- `factor_poly f` (term) elaborates to an `FpPoly.Factored f`: a `scalar`,
+  a `factors` list (monic irreducible factors with repetition, nondecreasing
+  size, by generator convention), `factors_mul : C scalar * factors.prod = f`,
+  and `factors_irred : ∀ q ∈ factors, FpPoly.Irreducible q`. The tactic form
+  introduces `scalar`/`factors` as transparent `let`s plus the two hypotheses.
+- `irreducibility f` (term) elaborates to `FpPoly.Irreducible f`;
+  `irreducibility f` / `irreducibility h : f` (tactic) add it as a
+  hypothesis, and bare `irreducibility` closes an `FpPoly.Irreducible e`
+  goal.
+
+Trust model: the compiled Yun square-free decomposition, Berlekamp
+factorizer, and Rabin certificate generator run at elaboration time as
+untrusted search; the emitted terms carry only kernel checks on reified
+literal data (`DensePoly.beqCoeffs` product check, `Berlekamp.checkMonicCert`
+/ `checkIrredCover` certificate replays — one replay per distinct factor,
+budget-guarded at `deg · p ≤ 2²⁶`). The factorizer never runs in the kernel,
+and inputs must be kernel-transparent closed terms (checked, with a clear
+error, at elaboration time).
+
+Other input types dispatch through the `Hex.FactorTactic.Provider` hook
+(`TacticCore.lean`): downstream libraries declare a provider under a
+well-known name (`providerNames`), probed from the environment at
+elaboration time — no imports in this direction. `HexBerlekampZassenhaus`
+registers the `ZPoly` arms; the Mathlib bridges register the
+`Polynomial (ZMod q)` / `Polynomial ℤ` arms.

--- a/HexBerlekamp/TacticCore.lean
+++ b/HexBerlekamp/TacticCore.lean
@@ -1,0 +1,201 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public meta import HexBerlekamp.CertReify
+public meta import HexBerlekamp.IrreducibleDecide
+public meta import HexBerlekamp.Factored
+public import HexBerlekamp.CertReify
+public import HexBerlekamp.IrreducibleDecide
+public import HexBerlekamp.Factored
+public import Lean
+
+public section
+
+/-!
+Shared infrastructure for the `factor_poly` / `irreducibility` elaborators:
+input classification, compiled-evaluation shims, the kernel-replay budget, and
+the provider hook through which downstream libraries extend the tactics to
+further input types.
+
+## The provider hook
+
+The elaborators handle `Hex.FpPoly p` natively. Every other input type is
+offered to *providers*: values of `Hex.FactorTactic.Provider` declared by
+downstream libraries under one of the well-known names in `providerNames`
+(`HexBerlekampZassenhaus` adds the `Hex.ZPoly` arms; the Mathlib bridge
+libraries add `Polynomial (ZMod q)` / `Polynomial ℤ`). Nothing here imports
+those libraries — the driver probes the environment by name at elaboration
+time and evaluates the provider through the interpreter, so this library
+builds and works standalone, and importing a bridge upgrades the tactics.
+
+A provider module must `public meta import HexBerlekamp.TacticCore` (the
+constructor of `Provider` is meta code) and declare its provider as a
+`public meta def`. Renaming a probed constant silently severs the hook, so
+each provider carries a cross-referencing comment and the bridge test suites
+act as liveness canaries; the `version` field is checked against
+`Provider.abiVersion` at probe time so a stale provider fails loudly.
+-/
+
+namespace Hex.FactorTactic
+
+open Lean Meta Elab
+
+/-- Outcome of offering an input to a provider. `notApplicable` means the
+provider does not handle this input type at all (try the next silently);
+`declined` means it handles the type but cannot certify this input (try the
+next, keep the diagnostic for the final error); `fatal` aborts dispatch. -/
+meta inductive ProviderResult where
+  | notApplicable
+  | declined (why : MessageData)
+  | success (e : Expr)
+  | fatal (msg : MessageData)
+
+/-- Capabilities a downstream library registers to extend
+`factor_poly`/`irreducibility` to further input types. The arguments of the
+term hooks are the original syntax, the elaborated polynomial, its
+`whnfR`-normalized type, and the expected type of the surrounding
+elaboration. -/
+meta structure Provider where
+  /-- ABI guard, checked against `Provider.abiVersion` at probe time. -/
+  version : Nat
+  /-- Handle a `factor_poly p` term elaboration. -/
+  factorPoly? : Syntax → Expr → Expr → Option Expr → Term.TermElabM ProviderResult
+  /-- Handle an `irreducibility p` term elaboration. -/
+  irreducibility? : Syntax → Expr → Expr → Option Expr → Term.TermElabM ProviderResult
+  /-- Handle goal-closing `irreducibility` on the given goal. -/
+  goalIrred? : MVarId → Tactic.TacticM ProviderResult
+
+/-- The provider ABI version this driver expects. -/
+meta def Provider.abiVersion : Nat := 1
+
+/-- Well-known provider constants, probed in order. Downstream libraries
+declare a `public meta def` of type `Provider` under one of these names;
+adding an entry requires a `HexBerlekamp` release. -/
+meta def providerNames : List Name :=
+  [`HexBerlekampZassenhaus.FactorTactic.provider,
+   `HexBerlekampMathlib.FactorTactic.provider,
+   `HexBerlekampZassenhausMathlib.FactorTactic.provider]
+
+private meta unsafe def evalProviderUnsafe (n : Name) : MetaM Provider :=
+  evalConst Provider n
+
+@[implemented_by evalProviderUnsafe]
+private meta opaque evalProviderCore (n : Name) : MetaM Provider
+
+/-- All providers present in the current environment, in probe order, with
+the declared type and ABI version checked before use. -/
+meta def providers : MetaM (List Provider) := do
+  let env ← getEnv
+  let mut found := []
+  for n in providerNames do
+    if let some info := env.find? n then
+      unless info.type.isConstOf ``Provider do
+        throwError "factor_poly/irreducibility: provider {n} has unexpected \
+            type{indentExpr info.type}"
+      let prov ← evalProviderCore n
+      unless prov.version == Provider.abiVersion do
+        throwError "factor_poly/irreducibility: provider {n} has ABI version \
+            {prov.version}, but this driver expects {Provider.abiVersion}; \
+            rebuild the provider library against the current HexBerlekamp"
+      found := found ++ [prov]
+  return found
+
+/-- Classification of a `factor_poly`/`irreducibility` input by its
+`whnfR`-normalized type. -/
+meta inductive PolyInput where
+  /-- `Hex.FpPoly p` for a literal prime `p`, with the instance and
+  coefficient-type expressions extracted from the input's type. -/
+  | fp (p : Nat) (pE boundsE RE zeroE decE : Expr)
+  /-- `Hex.ZPoly`, with the instance expressions from the input's type. -/
+  | zpoly (RE zeroE decE : Expr)
+  /-- Anything else (offered to providers). -/
+  | other
+
+/-- Classify an input's type: `DensePoly (ZMod64 p) → .fp`,
+`DensePoly Int → .zpoly`, anything else `→ .other`. The `FpPoly`/`ZPoly`
+abbreviations are reducible, so `whnfR` exposes the `DensePoly` application;
+the instance expressions are taken from the type itself, never synthesized. -/
+meta def classify (ty : Expr) : MetaM PolyInput := do
+  let ty ← whnfR ty
+  let_expr Hex.DensePoly R zeroE decE := ty | return .other
+  let R' ← whnfR R
+  if R'.isConstOf ``Int then
+    return .zpoly R zeroE decE
+  let_expr Hex.ZMod64 pE boundsE := R' | return .other
+  let some p := pE.nat? | return .other
+  return .fp p pE boundsE R zeroE decE
+
+private meta unsafe def evalFpPolyUnsafe (p : Nat) [Hex.ZMod64.Bounds p]
+    (tyE e : Expr) : MetaM (Except String (Hex.FpPoly p)) :=
+  try
+    return .ok (← evalExpr (Hex.FpPoly p) tyE e)
+  catch ex =>
+    return .error (← ex.toMessageData.toString)
+
+@[implemented_by evalFpPolyUnsafe]
+private meta opaque evalFpPolyCore (p : Nat) [Hex.ZMod64.Bounds p]
+    (tyE e : Expr) : MetaM (Except String (Hex.FpPoly p))
+
+/-- Evaluate a closed `Hex.FpPoly p` expression to its runtime value at
+elaboration time (compiled/interpreted evaluation, not kernel reduction). -/
+meta def evalFpPoly (tactic : String) (p : Nat) [Hex.ZMod64.Bounds p]
+    (pE boundsE e : Expr) : MetaM (Hex.FpPoly p) := do
+  match ← evalFpPolyCore p (Hex.CertReify.fpPolyType pE boundsE) e with
+  | .ok f => return f
+  | .error msg =>
+      throwError "{tactic}: failed to evaluate the polynomial{indentExpr e}\
+          \n{msg}\
+          \nIf it refers to definitions from another module, that module may \
+          need to be imported with `public meta import`."
+
+/-- Ceiling on `degree · p`, the cost driver of one kernel Rabin-certificate
+replay. Inputs over budget fail at elaboration time with a clear message
+instead of emitting a proof the kernel cannot afford to check. -/
+meta def replayBudget : Nat := 1 <<< 26
+
+/-- Fail fast when a Rabin replay for a degree-`deg` factor at modulus `p`
+would exceed `replayBudget`. -/
+meta def checkReplayBudget (tactic : String) (p deg : Nat) : MetaM Unit := do
+  if deg * p > replayBudget then
+    throwError "{tactic}: certifying a degree-{deg} factor over F_{p} needs a \
+        kernel Rabin replay of roughly {deg * p} modular polynomial \
+        operations, over the supported budget ({replayBudget}); pick a \
+        smaller modulus or degree"
+
+/-- Reject inputs the compiled evaluator cannot see: free variables and
+metavariables. -/
+meta def checkClosed (tactic : String) (e : Expr) : MetaM Unit := do
+  if e.hasFVar || e.hasExprMVar then
+    throwError "{tactic}: the polynomial{indentExpr e}\
+        \nmust be a closed term (no local hypotheses or metavariables)"
+
+/-- Run provider dispatch over `providers`, accumulating decline diagnostics;
+`whenNone` renders the final error when no provider succeeds. -/
+meta def dispatch (run : Provider → Term.TermElabM ProviderResult)
+    (whenNone : Array MessageData → Term.TermElabM Expr) :
+    Term.TermElabM Expr := do
+  let mut declines : Array MessageData := #[]
+  for prov in (← providers) do
+    match ← run prov with
+    | .success e => return e
+    | .notApplicable => pure ()
+    | .declined why => declines := declines.push why
+    | .fatal msg => throwError msg
+  whenNone declines
+
+/-- The standard "unsupported input type" tail for dispatch failures,
+including any provider decline diagnostics. -/
+meta def unsupportedMessage (tactic : String) (ty : Expr)
+    (declines : Array MessageData) : MessageData :=
+  let base := m!"{tactic}: unsupported polynomial type{indentExpr ty}\
+      \nSupported without further imports: Hex.FpPoly p (prime p). \
+      Importing HexBerlekampZassenhaus adds Hex.ZPoly; the Mathlib bridge \
+      libraries add Polynomial (ZMod q) and Polynomial ℤ."
+  declines.foldl (fun acc d => acc ++ m!"\n\n{d}") base
+
+end Hex.FactorTactic

--- a/HexPoly/Dense.lean
+++ b/HexPoly/Dense.lean
@@ -37,20 +37,28 @@ namespace DensePoly
 
 variable {R : Type u} [Zero R] [DecidableEq R]
 
-instance : DecidableEq (DensePoly R) := by
-  intro a b
-  match decEq a.coeffs b.coeffs with
+/- The comparison routes through the coefficient `List`, not the `Array`:
+`Array.instDecidableEq` delegates its nonempty case to the non-`@[expose]`
+`Array.instDecidableEqImpl`, whose body is unavailable downstream under the
+module system, so `decide`/`rfl` on `DensePoly` equalities would get stuck
+(see `progress/lean4-array-decidableeq-module-repro.md`). `List` equality is
+fully exposed and kernel-reduces. -/
+instance : DecidableEq (DensePoly R) := fun a b =>
+  match decEq a.coeffs.toList b.coeffs.toList with
   | isTrue h =>
-      exact isTrue (by
-        cases a
-        cases b
+      isTrue (by
+        cases a with | mk ca na =>
+        cases b with | mk cb nb =>
+        cases ca with | mk la =>
+        cases cb with | mk lb =>
+        change la = lb at h
         cases h
-        simp)
+        rfl)
   | isFalse h =>
-      exact isFalse (by
+      isFalse (by
         intro hab
         apply h
-        exact congrArg DensePoly.coeffs hab)
+        rw [hab])
 
 /-- Remove trailing zeros from a coefficient list without disturbing the remaining order. -/
 @[expose]


### PR DESCRIPTION
This PR add the certificate-backed `factor_poly` and `irreducibility` term elaborators and tactics to HexBerlekamp (plan step 3, stacked on #8858), handling `FpPoly p` natively for literal prime moduli. `factor_poly f` elaborates to an `FpPoly.Factored f` (`scalar`, `factors` with repetition, `factors_mul : C scalar * factors.prod = f`, `factors_irred`), usable as `obtain ⟨scalar, factors, factors_mul, factors_irred⟩ := factor_poly f`; its tactic form introduces `scalar`/`factors` as transparent `let`s plus the two hypotheses. `irreducibility f` produces `FpPoly.Irreducible f` as a term, a named or anonymous hypothesis, or closes the goal in bare form. The compiled Yun square-free decomposition, Berlekamp factorizer, and Rabin certificate generator run at elaboration time as untrusted search; emitted terms carry only kernel checks on reified literal data — a `beqCoeffs` product check and one `checkMonicCert`/`checkIrredCover` certificate replay per distinct factor, budget-guarded at `deg·p ≤ 2²⁶` — so the factorizer never runs in the kernel. Non-`FpPoly` inputs dispatch through the new `Hex.FactorTactic.Provider` hook: providers are probed from the environment by well-known name with type and ABI-version checks, so HexBerlekampZassenhaus and the Mathlib bridges extend the tactics without any import in this direction.

Two enabling fixes: `DecidableEq (DensePoly R)` now routes through the coefficient `List` so polynomial equality kernel-reduces under plain module imports (the `Array.instDecidableEqImpl` exposure gap, `progress/lean4-array-decidableeq-module-repro.md`), and the incremental Rabin checker chain gains the `@[expose]` its kernel replay needs without `import all`.

`HexBerlekamp/FactorTacticTests.lean` covers both forms end-to-end under plain `public import` only — non-monic, non-square-free, characteristic-2 inseparable, zero/constant/unit inputs, `#guard_msgs` negative tests (composite modulus, zero, unit, reducible), and `#print axioms` guards showing clean cones. Full `lake build` (all Mathlib bridges, 9435 jobs) is green.

🤖 Prepared with Claude Code