### PR TITLE
feat(bz): ZPoly provider for factor_poly and irreducibility

### DIFF
--- a/HexBerlekamp/FactorPolyElab.lean
+++ b/HexBerlekamp/FactorPolyElab.lean
@@ -222,24 +222,35 @@ syntax (name := factorPolyTac) "factor_poly" term:max : tactic
     | `(tactic| factor_poly $t) => do
         let e ← Tactic.withMainContext do
           elabFactorPolyCore stx t none
-        -- Destructure the emitted `Factored.mk` application.
+        -- Destructure the emitted `Factored.mk` application (the FpPoly
+        -- shape carries the modulus and instance; providers may emit other
+        -- `*.Factored.mk` shapes with the same final four fields, e.g.
+        -- `Hex.ZPoly.Factored.mk`).
         let args := e.getAppArgs
-        unless e.getAppFn.isConstOf ``Hex.FpPoly.Factored.mk &&
-            args.size == 7 do
-          -- Provider-produced results: fall back to a plain `have`.
+        let fields? :
+            Option (Name × Expr × Expr × Expr × Expr × Expr × Expr) :=
+          if e.getAppFn.isConstOf ``Hex.FpPoly.Factored.mk && args.size == 7 then
+            some (``Hex.FpPoly.Irreducible,
+              Hex.CertReify.zmodType args[0]! args[1]!,
+              Hex.CertReify.fpPolyType args[0]! args[1]!,
+              args[3]!, args[4]!, args[5]!, args[6]!)
+          else if e.getAppFn.isConstOf `Hex.ZPoly.Factored.mk &&
+              args.size == 5 then
+            some (`Hex.ZPoly.Irreducible, mkConst ``Int, mkConst `Hex.ZPoly,
+              args[1]!, args[2]!, args[3]!, args[4]!)
+          else
+            none
+        let some (predName, scalarTy, polyTy, scalarE, factorsE, hmulE, hirredE) :=
+            fields? |
+          -- Unrecognized provider result: fall back to a plain `have`.
           Tactic.liftMetaTactic fun g => do
             let ty ← inferType e
             let (_, g) ← (← g.assert `factored ty e).intro1P
             return [g]
-          return
-        let (pE, boundsE, fE) := (args[0]!, args[1]!, args[2]!)
-        let (scalarE, factorsE) := (args[3]!, args[4]!)
-        let (hmulE, hirredE) := (args[5]!, args[6]!)
+        let fE := args[if args.size == 7 then 2 else 0]!
         Tactic.liftMetaTactic fun g => do
-          let zmodTy := Hex.CertReify.zmodType pE boundsE
-          let polyTy := Hex.CertReify.fpPolyType pE boundsE
           let listTy := mkApp (mkConst ``List [Level.zero]) polyTy
-          let (fvS, g) ← (← g.define `scalar zmodTy scalarE).intro1P
+          let (fvS, g) ← (← g.define `scalar scalarTy scalarE).intro1P
           let (fvF, g) ← (← g.define `factors listTy factorsE).intro1P
           g.withContext do
             let sE := mkFVar fvS
@@ -252,7 +263,7 @@ syntax (name := factorPolyTac) "factor_poly" term:max : tactic
               let hirredTy ←
                 withLocalDeclD `q polyTy fun q => do
                   let mem ← mkAppM ``Membership.mem #[fsE, q]
-                  let irred ← mkAppM ``Hex.FpPoly.Irreducible #[q]
+                  let irred ← mkAppM predName #[q]
                   mkForallFVars #[q] (← mkArrow mem irred)
               let (_, g) ← (← g.assert `factors_irred hirredTy hirredE).intro1P
               return [g]

--- a/HexBerlekampZassenhaus.lean
+++ b/HexBerlekampZassenhaus.lean
@@ -19,6 +19,9 @@ public import HexBerlekampZassenhaus.Recombination
 public import HexBerlekampZassenhaus.FactorEntryPoints
 public import HexBerlekampZassenhaus.IrreducibleCore
 public import HexBerlekampZassenhaus.IrreducibleDecide
+public import HexBerlekampZassenhaus.Factored
+public import HexBerlekampZassenhaus.FactorProvider
+public import HexBerlekampZassenhaus.FactorTacticTests
 public import HexBerlekampZassenhaus.RecombineProofs
 public import HexBerlekampZassenhaus.TrialProofs
 public import HexBerlekampZassenhaus.QuadraticRootProofs

--- a/HexBerlekampZassenhaus/FactorProvider.lean
+++ b/HexBerlekampZassenhaus/FactorProvider.lean
@@ -1,0 +1,273 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public meta import HexBerlekamp.TacticCore
+public meta import HexBerlekampZassenhaus.CertReify
+public meta import HexBerlekampZassenhaus.IrreducibleDecide
+public meta import HexBerlekampZassenhaus.Factored
+public meta import HexBerlekampZassenhaus.FactorEntryPoints
+public import HexBerlekamp.TacticCore
+public import HexBerlekampZassenhaus.CertReify
+public import HexBerlekampZassenhaus.IrreducibleDecide
+public import HexBerlekampZassenhaus.Factored
+public import HexBerlekampZassenhaus.FactorEntryPoints
+
+public section
+
+/-!
+The `Hex.ZPoly` provider for the `factor_poly`/`irreducibility` elaborators:
+importing this library upgrades the tactics (declared in
+`HexBerlekamp.TacticCore` / probed by name, see `providerNames`) to handle
+integer polynomials.
+
+The compiled Berlekamp–Zassenhaus factorizer runs at elaboration time as
+untrusted search; per-factor irreducibility is certified through
+`Hex.ZPoly.IrredWitness` (prime constant / primitive linear / single-prime
+modular certificate), and the emitted terms carry only kernel checks on
+reified literal data. Factors that are irreducible over `ℤ` but reducible
+mod every candidate prime (balanced factors, e.g. Swinnerton-Dyer
+polynomials or `X⁴+1`) have no single-prime witness: this provider then
+*declines* with a diagnostic, so the Mathlib bridge provider (multi-prime
+degree-obstruction certificates) can take over when imported, and the final
+error explains the gap otherwise.
+-/
+
+namespace HexBerlekampZassenhaus.FactorTactic
+
+open Lean Meta Elab
+open Hex.FactorTactic (ProviderResult)
+
+private meta unsafe def evalZPolyUnsafe (e : Expr) :
+    MetaM (Except String Hex.ZPoly) :=
+  try
+    return .ok (← evalExpr Hex.ZPoly (mkConst ``Hex.ZPoly) e)
+  catch ex =>
+    return .error (← ex.toMessageData.toString)
+
+@[implemented_by evalZPolyUnsafe]
+private meta opaque evalZPolyCore (e : Expr) : MetaM (Except String Hex.ZPoly)
+
+/-- Evaluate a closed `Hex.ZPoly` expression to its runtime value at
+elaboration time. -/
+meta def evalZPoly (tactic : String) (e : Expr) : MetaM Hex.ZPoly := do
+  match ← evalZPolyCore e with
+  | .ok f => return f
+  | .error msg =>
+      throwError "{tactic}: failed to evaluate the polynomial{indentExpr e}\
+          \n{msg}\
+          \nIf it refers to definitions from another module, that module may \
+          need to be imported with `public meta import`."
+
+/-- Candidate primes for the single-prime witness search. -/
+meta def witnessPrimes : List Nat :=
+  (List.range 512).filter Hex.Nat.isPrimeTrial
+
+/-- Search for a single-prime modular witness for `q` (already known
+non-constant, non-linear). Returns `none` when no candidate prime works —
+either `q` is reducible, or it is balanced at every candidate prime. -/
+meta def searchModPWitness (q : Hex.ZPoly) : Option Hex.ZPoly.ModPWitness := Id.run do
+  for p in witnessPrimes do
+    if h1 : 0 < p then
+      if h2 : p < 2 ^ 31 then
+        let bounds : Hex.ZMod64.Bounds p := ⟨h1, h2⟩
+        if q.size * p ≤ Hex.FactorTactic.replayBudget then
+          if @Hex.ZPoly.leadingCoeffModP q p bounds ≠ 0 then
+            let g := @Hex.ZPoly.modP p bounds q
+            let (c, m) := @Hex.FpPoly.normalizeMonic p bounds g
+            if hmonic : Hex.DensePoly.leadingCoeff m = 1 then
+              match @Hex.Berlekamp.buildIrreducibilityCertificate? p bounds m
+                  (by exact hmonic) with
+              | some cert =>
+                  return some { p := p, bounds := bounds, m := m, c := c,
+                                cert := cert }
+              | none => pure ()
+  return none
+
+/-- Search for an irreducibility witness for `q`. -/
+meta def searchWitness (q : Hex.ZPoly) : Option Hex.ZPoly.IrredWitness := Id.run do
+  if q.size = 1 then
+    if Hex.ZPoly.isNatPrime (q.coeff 0).natAbs then
+      return some .primeConst
+    else
+      return none
+  if q.size = 2 && Hex.ZPoly.content q == 1 then
+    return some .linear
+  match searchModPWitness q with
+  | some w => return some (.modP w)
+  | none => return none
+
+/-- Reify a `ModPWitness` as a constructor application over reified pieces. -/
+meta def reifyModPWitness (w : Hex.ZPoly.ModPWitness) : Expr :=
+  letI := w.bounds
+  let pE := mkNatLit w.p
+  let boundsE := Hex.CertReify.reifyBounds pE
+  mkApp5 (mkConst ``Hex.ZPoly.ModPWitness.mk) pE boundsE
+    (Hex.CertReify.reifyFpPolyOfNats pE boundsE (Hex.CertReify.fpCoeffNats w.m))
+    (Hex.CertReify.reifyZMod64 pE boundsE w.c.toNat)
+    (Hex.CertReify.reifyRabinCert w.cert)
+
+/-- Reify an `IrredWitness`. -/
+meta def reifyWitness : Hex.ZPoly.IrredWitness → Expr
+  | .primeConst => mkConst ``Hex.ZPoly.IrredWitness.primeConst
+  | .linear => mkConst ``Hex.ZPoly.IrredWitness.linear
+  | .modP w => mkApp (mkConst ``Hex.ZPoly.IrredWitness.modP) (reifyModPWitness w)
+
+/-- Literal `List` expression (shared shape with the `FpPoly` elaborator). -/
+meta def listLit (ty : Expr) (xs : List Expr) : Expr :=
+  let nil := mkApp (mkConst ``List.nil [Level.zero]) ty
+  xs.foldr (fun x acc => mkApp3 (mkConst ``List.cons [Level.zero]) ty x acc) nil
+
+/-- Deduplicate a `ZPoly` list by coefficient equality (order-preserving). -/
+meta def dedupZPolys (l : List Hex.ZPoly) : List Hex.ZPoly :=
+  l.foldl (init := []) fun acc q =>
+    if acc.any fun r => Hex.DensePoly.beqCoeffs r q then acc else acc ++ [q]
+
+/-- The balanced-factor decline diagnostic. -/
+meta def balancedDecline (tactic : String) (q : Hex.ZPoly) : MetaM MessageData := do
+  let qE ← Hex.CertReify.reifyZPoly q
+  return m!"{tactic}: the irreducible factor{indentExpr qE}\
+      \nhas no single-prime modular witness among the candidate primes \
+      (its modular factorizations are balanced, e.g. Swinnerton-Dyer \
+      polynomials or X⁴+1); the Mathlib bridge's multi-prime \
+      degree-obstruction certificates may certify it — import \
+      HexBerlekampZassenhausMathlib."
+
+/-- The opaque-input contract check: the user's term must be definitionally
+transparent down to its evaluated literal. -/
+meta def checkTransparent (tactic : String) (f : Hex.ZPoly) (fE : Expr) :
+    MetaM Expr := do
+  let fLit ← Hex.CertReify.reifyZPoly f
+  unless ← isDefEq fLit fE do
+    throwError "{tactic}: the polynomial{indentExpr fE}\
+        \nevaluates to{indentExpr fLit}\
+        \nbut is not definitionally transparent to the elaborator (an \
+        imported definition without `@[expose]`?); the kernel could not \
+        check the emitted certificate against it"
+  return fLit
+
+/-- The `factor_poly` arm: factorize, certify each distinct factor by an
+`IrredWitness`, and emit a reified `Hex.ZPoly.Factored`. Declines when some
+factor has no free-layer witness. -/
+meta def factorPolyZPoly (zeroE decE fE : Expr) :
+    Term.TermElabM ProviderResult := do
+  let f ← evalZPoly "factor_poly" fE
+  discard <| checkTransparent "factor_poly" f fE
+  let φ := Hex.ZPoly.factorize f
+  let factors := (φ.factors.toList.flatMap fun (q, e) =>
+    List.replicate e q).mergeSort fun a b => a.size ≤ b.size
+  let scalar := φ.scalar
+  unless Hex.DensePoly.beqCoeffs (Hex.DensePoly.C scalar * factors.prod) f do
+    throwError "factor_poly: internal error: the factorization product does \
+        not reconstruct the input; please report this"
+  let mut certified : List (Hex.ZPoly × Hex.ZPoly.IrredWitness) := []
+  for q in dedupZPolys factors do
+    match searchWitness q with
+    | some w =>
+        unless Hex.ZPoly.checkIrredWitness q w do
+          throwError "factor_poly: internal error: a generated witness fails \
+              checkIrredWitness; please report this"
+        certified := certified ++ [(q, w)]
+    | none =>
+        return .declined (← balancedDecline "factor_poly" q)
+  unless Hex.ZPoly.checkIrredCover factors certified do
+    throwError "factor_poly: internal error: the generated witnesses fail \
+        checkIrredCover; please report this"
+  let intE := mkConst ``Int
+  let zpolyTy := mkApp3 (mkConst ``Hex.DensePoly [Level.zero]) intE zeroE decE
+  let scalarE := toExpr scalar
+  let factorsE := listLit zpolyTy
+    (← factors.mapM fun q => Hex.CertReify.reifyZPoly q)
+  let witnessTy := mkConst ``Hex.ZPoly.IrredWitness
+  let pairTy := mkApp2 (mkConst ``Prod [Level.zero, Level.zero]) zpolyTy witnessTy
+  let certifiedE := listLit pairTy (← certified.mapM fun (q, w) => do
+    return mkApp4 (mkConst ``Prod.mk [Level.zero, Level.zero]) zpolyTy witnessTy
+      (← Hex.CertReify.reifyZPoly q) (reifyWitness w))
+  let lhsE ← mkAppM ``HMul.hMul
+    #[← mkAppM ``Hex.DensePoly.C #[scalarE], ← mkAppM ``List.prod #[factorsE]]
+  let hmulE := mkApp6 (mkConst ``Hex.DensePoly.eq_of_beqCoeffs [Level.zero])
+    intE zeroE decE lhsE fE Hex.CertReify.reflTrue
+  let hirredE := mkApp3 (mkConst ``Hex.ZPoly.irreducible_of_checkIrredCover)
+    factorsE certifiedE Hex.CertReify.reflTrue
+  return .success (mkApp5 (mkConst ``Hex.ZPoly.Factored.mk)
+    fE scalarE factorsE hmulE hirredE)
+
+/-- The `irreducibility` proof for a runtime `ZPoly` and its expression:
+shared by the term arm and goal mode. -/
+meta def irredProof (fE : Expr) (f : Hex.ZPoly) :
+    MetaM (Except MessageData Expr) := do
+  discard <| checkTransparent "irreducibility" f fE
+  if f.size = 0 then
+    throwError "irreducibility: the zero polynomial is not irreducible"
+  if Hex.ZPoly.IsUnit f then
+    throwError "irreducibility: the polynomial{indentExpr fE}\
+        \nis a unit (±1), not irreducible"
+  match searchWitness f with
+  | some w =>
+      unless Hex.ZPoly.checkIrredWitness f w do
+        throwError "irreducibility: internal error: a generated witness \
+            fails checkIrredWitness; please report this"
+      return .ok (mkApp3 (mkConst ``Hex.ZPoly.irreducible_of_checkIrredWitness)
+        fE (reifyWitness w) Hex.CertReify.reflTrue)
+  | none =>
+      if Hex.ZPoly.isIrreducible f then
+        return .error (← balancedDecline "irreducibility" f)
+      else
+        let φ := Hex.ZPoly.factorize f
+        let count := φ.factors.foldl (fun acc (_, e) => acc + e) 0
+        throwError "irreducibility: the polynomial{indentExpr fE}\
+            \nis not irreducible over ℤ: factor_poly finds {count} \
+            irreducible factors (with multiplicity), scalar {φ.scalar}"
+
+/-- The `irreducibility` term arm. -/
+meta def irreducibilityZPoly (fE : Expr) : Term.TermElabM ProviderResult := do
+  let f ← evalZPoly "irreducibility" fE
+  match ← irredProof fE f with
+  | .ok proof => return .success proof
+  | .error why => return .declined why
+
+/-- Goal mode: close `Hex.ZPoly.Irreducible e`. -/
+meta def goalIrredZPoly (goal : MVarId) : Tactic.TacticM ProviderResult := do
+  goal.withContext do
+    let tgt ← instantiateMVars (← goal.getType)
+    unless tgt.getAppFn.isConstOf ``Hex.ZPoly.Irreducible &&
+        tgt.getAppNumArgs == 1 do
+      return .notApplicable
+    let fE := tgt.appArg!
+    Hex.FactorTactic.checkClosed "irreducibility" fE
+    let f ← evalZPoly "irreducibility" fE
+    match ← irredProof fE f with
+    | .ok proof =>
+        unless ← isDefEq (← inferType proof) tgt do
+          throwError "irreducibility: the certified statement\
+              {indentExpr (← inferType proof)}\
+              \nis not definitionally equal to the goal{indentExpr tgt}"
+        return .success proof
+    | .error why => return .declined why
+
+end HexBerlekampZassenhaus.FactorTactic
+
+namespace HexBerlekampZassenhaus.FactorTactic
+
+open Lean Elab
+
+/-- The `Hex.ZPoly` provider, probed by name from
+`Hex.FactorTactic.providerNames` — renaming it severs the hook (the free and
+bridge test suites are the liveness canaries). -/
+public meta def provider : Hex.FactorTactic.Provider where
+  version := Hex.FactorTactic.Provider.abiVersion
+  factorPoly? := fun _stx pE ty _expectedType? => do
+    match ← Hex.FactorTactic.classify ty with
+    | .zpoly _ zeroE decE => factorPolyZPoly zeroE decE pE
+    | _ => return .notApplicable
+  irreducibility? := fun _stx pE ty _expectedType? => do
+    match ← Hex.FactorTactic.classify ty with
+    | .zpoly _ _ _ => irreducibilityZPoly pE
+    | _ => return .notApplicable
+  goalIrred? := goalIrredZPoly
+
+end HexBerlekampZassenhaus.FactorTactic

--- a/HexBerlekampZassenhaus/FactorProvider.lean
+++ b/HexBerlekampZassenhaus/FactorProvider.lean
@@ -91,7 +91,10 @@ meta def searchModPWitness (q : Hex.ZPoly) : Option Hex.ZPoly.ModPWitness := Id.
 /-- Search for an irreducibility witness for `q`. -/
 meta def searchWitness (q : Hex.ZPoly) : Option Hex.ZPoly.IrredWitness := Id.run do
   if q.size = 1 then
-    if Hex.ZPoly.isNatPrime (q.coeff 0).natAbs then
+    -- The kernel replay of `isNatPrime c` costs roughly `c` steps
+    -- (`List.range c`), so budget-check before even computing it.
+    let c := (q.coeff 0).natAbs
+    if c ≤ Hex.FactorTactic.replayBudget && Hex.ZPoly.isNatPrime c then
       return some .primeConst
     else
       return none
@@ -214,6 +217,11 @@ meta def irredProof (fE : Expr) (f : Hex.ZPoly) :
       return .ok (mkApp3 (mkConst ``Hex.ZPoly.irreducible_of_checkIrredWitness)
         fE (reifyWitness w) Hex.CertReify.reflTrue)
   | none =>
+      if f.size = 1 && (f.coeff 0).natAbs > Hex.FactorTactic.replayBudget then
+        throwError "irreducibility: deciding primality of the constant\
+            {indentExpr fE}\
+            \nneeds a kernel replay of roughly {(f.coeff 0).natAbs} steps, \
+            over the supported budget ({Hex.FactorTactic.replayBudget})"
       if Hex.ZPoly.isIrreducible f then
         return .error (← balancedDecline "irreducibility" f)
       else

--- a/HexBerlekampZassenhaus/FactorTacticTests.lean
+++ b/HexBerlekampZassenhaus/FactorTacticTests.lean
@@ -89,6 +89,14 @@ is a unit (±1), not irreducible -/
 #guard_msgs in
 #check_failure (irreducibility (DensePoly.C (1 : Int)))
 
+/--
+info: irreducibility: deciding primality of the constant
+  DensePoly.C 67108879
+needs a kernel replay of roughly 67108879 steps, over the supported budget (67108864)
+-/
+#guard_msgs in
+#check_failure (irreducibility (DensePoly.C (67108879 : Int)))
+
 /-! ## Axiom hygiene -/
 
 /-- info: 'HexBerlekampZassenhaus.FactorTacticTests.facZ' depends on axioms: [propext, Classical.choice, Quot.sound] -/

--- a/HexBerlekampZassenhaus/FactorTacticTests.lean
+++ b/HexBerlekampZassenhaus/FactorTacticTests.lean
@@ -1,0 +1,102 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+-- PLAIN `public import` only (plus the `public meta import` required for
+-- elaboration-time evaluation): the emitted kernel checks must reduce through
+-- the exposed closure alone.
+public meta import HexBerlekamp.IrreducibilityElab
+public meta import HexBerlekampZassenhaus.FactorProvider
+public import HexBerlekamp.IrreducibilityElab
+public import HexBerlekampZassenhaus.FactorProvider
+
+public section
+
+open Hex
+
+namespace HexBerlekampZassenhaus.FactorTacticTests
+
+/-- `-6·(x+1)²·(x²+1)`: content, sign, and multiplicity. -/
+def testZ : ZPoly :=
+  DensePoly.C (-6) * (DensePoly.ofCoeffs #[1, 1] * DensePoly.ofCoeffs #[1, 1] *
+    DensePoly.ofCoeffs #[1, 0, 1])
+
+noncomputable def facZ := factor_poly testZ
+
+example : facZ.scalar = -6 := rfl
+example : facZ.factors.length = 3 := rfl
+
+example : True := by
+  obtain ⟨scalar, factors, factors_mul, factors_irred⟩ := factor_poly testZ
+  trivial
+
+example : True := by
+  factor_poly testZ
+  have : scalar = -6 := rfl
+  exact True.intro
+
+/-! ## `irreducibility` on ZPoly -/
+
+def linZ : ZPoly := DensePoly.ofCoeffs #[3, 2]
+def quadZ : ZPoly := DensePoly.ofCoeffs #[1, 0, 1]
+def constZ : ZPoly := DensePoly.C (-7)
+
+theorem lin_irred : ZPoly.Irreducible linZ := irreducibility linZ
+theorem quad_irred : ZPoly.Irreducible quadZ := irreducibility quadZ
+theorem const_irred : ZPoly.Irreducible constZ := irreducibility constZ
+
+example : ZPoly.Irreducible quadZ := by irreducibility
+
+example : True := by
+  irreducibility h : linZ
+  exact True.intro
+
+/-! ## Balanced inputs: no free-layer certificate, clean decline -/
+
+/-- `X⁴+1`: irreducible over ℤ but reducible mod every prime — no
+single-prime witness exists, so the free layer declines (the Mathlib bridge
+provider handles it via Eisenstein-after-shift / multi-prime certificates
+when imported). -/
+def x4p1 : ZPoly := DensePoly.ofCoeffs #[1, 0, 0, 0, 1]
+
+#check_failure (irreducibility x4p1)
+
+/-- A product with a Swinnerton-Dyer factor: `(x+1)·(x⁴−10x²+1)`. The
+factorization search succeeds but the SD factor has no free-layer witness,
+so `factor_poly` declines. -/
+def sdProd : ZPoly :=
+  DensePoly.ofCoeffs #[1, 1] * DensePoly.ofCoeffs #[1, 0, -10, 0, 1]
+
+#check_failure (factor_poly sdProd)
+
+/-! ## Reducible/unit inputs: targeted errors -/
+
+/--
+info: irreducibility: the polynomial
+  testZ
+is not irreducible over ℤ: factor_poly finds 3 irreducible factors (with multiplicity), scalar -6
+-/
+#guard_msgs in
+#check_failure (irreducibility testZ)
+
+/-- info: irreducibility: the polynomial
+  DensePoly.C 1
+is a unit (±1), not irreducible -/
+#guard_msgs in
+#check_failure (irreducibility (DensePoly.C (1 : Int)))
+
+/-! ## Axiom hygiene -/
+
+/-- info: 'HexBerlekampZassenhaus.FactorTacticTests.facZ' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms facZ
+
+/-- info: 'HexBerlekampZassenhaus.FactorTacticTests.quad_irred' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms quad_irred
+
+end HexBerlekampZassenhaus.FactorTacticTests

--- a/HexBerlekampZassenhaus/Factored.lean
+++ b/HexBerlekampZassenhaus/Factored.lean
@@ -1,0 +1,39 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexPolyZ.Core
+public import HexPoly.Euclid
+public import HexBerlekampZassenhaus.IrreducibleCore
+
+public section
+
+/-!
+The result type of the `factor_poly` term elaborator for `Hex.ZPoly`; see
+`HexBerlekamp/Factored.lean` for the `FpPoly` counterpart and the generator
+conventions.
+-/
+
+namespace Hex
+
+/-- A certified irreducible factorization of `f : ZPoly`: a scalar (the
+signed content) and a factor list (with repetition) whose product
+reconstructs `f`, every listed factor irreducible in the element sense of
+`ℤ[X]`. Produced by the `factor_poly` elaborator with primitive
+positive-leading-coefficient factors. -/
+structure ZPoly.Factored (f : ZPoly) where
+  /-- The scalar (the signed content for nonzero `f`). -/
+  scalar : Int
+  /-- The irreducible factors, with repetition (primitive, positive leading
+  coefficient, by generator convention). -/
+  factors : List ZPoly
+  /-- The scalar times the factor product reconstructs `f`. -/
+  factors_mul : DensePoly.C scalar * factors.prod = f
+  /-- Every listed factor is irreducible. -/
+  factors_irred : ∀ q ∈ factors, ZPoly.Irreducible q
+
+end Hex

--- a/HexBerlekampZassenhaus/IrreducibleCore.lean
+++ b/HexBerlekampZassenhaus/IrreducibleCore.lean
@@ -186,6 +186,7 @@ by the greedy expansion helper. -/
 def Associated (a b : ZPoly) : Prop :=
   ∃ u : ZPoly, ZPoly.IsUnit u ∧ b = a * u
 
+@[expose]
 def isNatPrime (n : Nat) : Bool :=
   2 ≤ n && !((List.range n).any fun d => 2 ≤ d && d * d ≤ n && n % d == 0)
 

--- a/HexBerlekampZassenhaus/IrreducibleDecide.lean
+++ b/HexBerlekampZassenhaus/IrreducibleDecide.lean
@@ -60,5 +60,110 @@ theorem irreducible_of_modPCert
   exact ZPoly.Irreducible_of_modP_irreducible_of_primitive_of_admissible f p
     hprime hprim hadm' (of_decide_eq_true hsize) hirr
 
+/-- A dense-size-one polynomial is the constant on its zeroth coefficient. -/
+theorem eq_C_coeff_zero_of_size_one {f : ZPoly} (h : f.size = 1) :
+    f = DensePoly.C (f.coeff 0) := by
+  apply DensePoly.ext_coeff
+  intro i
+  rw [DensePoly.coeff_C]
+  match i with
+  | 0 => rw [if_pos rfl]
+  | i + 1 =>
+      rw [if_neg (by omega)]
+      exact DensePoly.coeff_eq_zero_of_size_le f (by omega)
+
+/-- A single-prime modular irreducibility witness for a `ZPoly` factor,
+packing its own modulus and bounds instance (the `PrimeFactorData` idiom) so
+witnesses at different primes share one type. -/
+structure ModPWitness where
+  /-- The witnessing prime. -/
+  p : Nat
+  /-- Bounds instance for the modulus. -/
+  bounds : ZMod64.Bounds p
+  /-- The monic image of the reduction mod `p`. -/
+  m : @FpPoly p bounds
+  /-- The leading unit of the reduction mod `p`. -/
+  c : @ZMod64 p bounds
+  /-- Rabin certificate for `m`. -/
+  cert : Berlekamp.IrreducibilityCertificate
+
+/-- One irreducibility witness for a `ZPoly`: a prime constant, a primitive
+linear, or a single-prime modular reduction certificate. -/
+inductive IrredWitness where
+  /-- The polynomial is a constant with prime absolute value. -/
+  | primeConst
+  /-- The polynomial is linear (dense size two) and primitive. -/
+  | linear
+  /-- Single-prime route: the reduction mod `w.p` is irreducible. -/
+  | modP (w : ModPWitness)
+
+/-- Kernel-decidable check that `w` witnesses irreducibility of `f`. -/
+@[expose]
+def checkIrredWitness (f : ZPoly) : IrredWitness → Bool
+  | .primeConst => decide (f.size = 1) && isNatPrime (f.coeff 0).natAbs
+  | .linear => decide (f.size = 2) && decide (ZPoly.content f = 1)
+  | .modP w =>
+      letI := w.bounds
+      Hex.Nat.isPrimeTrial w.p && decide (ZPoly.content f = 1) &&
+        decide (ZPoly.leadingCoeffModP f w.p ≠ 0) && decide (1 < f.size) &&
+        !(decide (w.c = 0)) &&
+        DensePoly.beqCoeffs (DensePoly.scale w.c w.m) (ZPoly.modP w.p f) &&
+        Berlekamp.checkMonicCert w.m w.cert
+
+/-- A passing `checkIrredWitness` forces irreducibility. -/
+theorem irreducible_of_checkIrredWitness
+    (f : ZPoly) (w : IrredWitness)
+    (hcheck : checkIrredWitness f w = true) :
+    ZPoly.Irreducible f := by
+  match w with
+  | .primeConst =>
+      unfold checkIrredWitness at hcheck
+      rw [Bool.and_eq_true] at hcheck
+      obtain ⟨hsize, hprime⟩ := hcheck
+      rw [eq_C_coeff_zero_of_size_one (of_decide_eq_true hsize)]
+      exact irreducible_C_of_isNatPrime hprime
+  | .linear =>
+      unfold checkIrredWitness at hcheck
+      rw [Bool.and_eq_true] at hcheck
+      exact irreducible_of_linear f hcheck.1 hcheck.2
+  | .modP wit =>
+      unfold checkIrredWitness at hcheck
+      letI := wit.bounds
+      simp only [Bool.and_eq_true] at hcheck
+      obtain ⟨⟨⟨⟨⟨⟨hp, hcontent⟩, hadm⟩, hsize⟩, hc⟩, hfm⟩, hcert⟩ := hcheck
+      rw [Bool.not_eq_true'] at hc
+      exact irreducible_of_modPCert f wit.p wit.m wit.c wit.cert
+        hp (decide_eq_true (of_decide_eq_true hcontent))
+        (decide_eq_true (of_decide_eq_true hadm))
+        (decide_eq_true (of_decide_eq_true hsize)) hc hfm hcert
+
+/-- Bulk kernel-decidable irreducibility for a `ZPoly` factor list with
+repetition: `certified` carries one `(factor, witness)` entry per *distinct*
+factor, matched by `beqCoeffs`, so each witness is checked once regardless of
+multiplicity. -/
+@[expose]
+def checkIrredCover (factors : List ZPoly)
+    (certified : List (ZPoly × IrredWitness)) : Bool :=
+  (certified.all fun e => checkIrredWitness e.1 e.2) &&
+    (factors.all fun q => certified.any fun e => DensePoly.beqCoeffs e.1 q)
+
+/-- A passing `checkIrredCover` forces irreducibility of every listed factor.
+The single Boolean hypothesis is the `factors_irred` slot of a reified
+`ZPoly.Factored` value. -/
+theorem irreducible_of_checkIrredCover
+    (factors : List ZPoly) (certified : List (ZPoly × IrredWitness))
+    (hcheck : checkIrredCover factors certified = true) :
+    ∀ q ∈ factors, ZPoly.Irreducible q := by
+  unfold checkIrredCover at hcheck
+  rw [Bool.and_eq_true] at hcheck
+  obtain ⟨hvalid, hcover⟩ := hcheck
+  rw [List.all_eq_true] at hvalid hcover
+  intro q hq
+  have hq' := hcover q hq
+  rw [List.any_eq_true] at hq'
+  obtain ⟨e, he, hbeq⟩ := hq'
+  have hw := irreducible_of_checkIrredWitness e.1 e.2 (hvalid e he)
+  rwa [DensePoly.eq_of_beqCoeffs hbeq] at hw
+
 end ZPoly
 end Hex

--- a/HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md
+++ b/HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md
@@ -953,3 +953,26 @@ decision `ℤ` lacks: `rabinTest`, with
   (`checkIrreducibilityCertificate`) instead. These are the `factorCerts` of
   a `ZPolyIrreducibilityCertificate`'s `PrimeFactorData` — the per-factor
   case of the `ℤ` certificate.
+
+## The `factor_poly` / `irreducibility` provider
+
+`FactorProvider.lean` registers this library's `Hex.ZPoly` arms with the
+tactic drivers declared in hex-berlekamp (`Hex.FactorTactic.providerNames`,
+probed from the environment by name — no import in this direction). With this
+library imported, `factor_poly f` for `f : Hex.ZPoly` elaborates to a
+`ZPoly.Factored f` (scalar = signed content; primitive positive-lc factors
+with repetition), and `irreducibility` handles `ZPoly` inputs and
+`ZPoly.Irreducible` goals.
+
+Per-factor irreducibility is certified by `ZPoly.IrredWitness` (prime
+constant / primitive linear / single-prime modular Rabin certificate,
+`IrreducibleDecide.lean`), bulk-checked by the kernel via
+`ZPoly.checkIrredCover` on reified literals — one witness check per distinct
+factor. The compiled `ZPoly.factorize` runs only at elaboration time.
+
+**Partiality**: a factor that is irreducible over ℤ but reducible mod every
+candidate prime (balanced modular factorizations: Swinnerton-Dyer
+polynomials, `X⁴+1`) has no single-prime witness; the provider then declines
+with a diagnostic, deferring to the Mathlib bridge's multi-prime
+degree-obstruction certificates. This partiality is by design; the emitted
+statements never weaken.


### PR DESCRIPTION
This PR register the `Hex.ZPoly` arms of `factor_poly`/`irreducibility` (plan step 4, stacked on #8859) through the provider hook: with HexBerlekampZassenhaus imported, `factor_poly f` elaborates to a `ZPoly.Factored f` — scalar = signed content, primitive positive-leading-coefficient factors with repetition, product and per-factor irreducibility carried by kernel checks on reified literals — and `irreducibility` handles `ZPoly` terms and `ZPoly.Irreducible` goals. Certification goes through the new `ZPoly.IrredWitness` inductive (prime constant / primitive linear / single-prime modular Rabin certificate, packed with its own modulus in the `PrimeFactorData` idiom) with the bulk `ZPoly.checkIrredCover` checker, one witness per distinct factor; the compiled `ZPoly.factorize` runs only at elaboration time as untrusted search. Factors that are irreducible over ℤ but reducible mod every candidate prime (balanced: Swinnerton-Dyer, `X⁴+1`) have no single-prime witness, so the provider declines with a diagnostic that defers to the Mathlib bridge's multi-prime certificates — tested via `#check_failure` on `X⁴+1` and `(x+1)·(x⁴−10x²+1)`. Tests cover content/sign/multiplicity inputs, all tactic forms, reducible/unit error messages, and clean `#print axioms` cones, under plain `public import` only. Full `lake build` (9442 jobs) is green.

🤖 Prepared with Claude Code