### PR TITLE
feat(berlekamp-mathlib): Polynomial (ZMod q) provider for factor_poly and irreducibility

### DIFF
--- a/HexBerlekampMathlib.lean
+++ b/HexBerlekampMathlib.lean
@@ -7,6 +7,9 @@ Authors: Kim Morrison
 module
 
 public import HexBerlekampMathlib.Basic
+public import HexBerlekampMathlib.FactorPoly
+public import HexBerlekampMathlib.FactorProvider
+public import HexBerlekampMathlib.FactorPolyTests
 
 public section
 

--- a/HexBerlekampMathlib/FactorPoly.lean
+++ b/HexBerlekampMathlib/FactorPoly.lean
@@ -1,0 +1,148 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexBerlekampMathlib.Basic
+public import HexBerlekamp.IrreducibleDecide
+
+public section
+
+/-!
+The Mathlib-side result type of `factor_poly` for `Polynomial R` inputs, and
+the kernel-decidable assemblers the `Polynomial (ZMod q)` provider emits.
+
+`FactoredPoly P` is the `Polynomial`-level counterpart of
+`Hex.FpPoly.Factored` / `Hex.ZPoly.Factored`. The assemblers `FactoredPoly.ofFp`
+and `irreducible_ofFp` take only Boolean checks on reified executable literals
+(discharged by `Eq.refl true`/`Eq.refl false` in emitted terms) plus one bridge
+equation `toMathlibPolynomial f = P` built by the provider's parser, so the
+kernel verifies emitted factorizations by reduction plus the named transport
+lemmas alone — the factorizer and certificate generator never appear in
+emitted terms.
+-/
+
+namespace Hex
+
+/-- A certified irreducible factorization of `P : Polynomial R`; Mathlib-side
+counterpart of `FpPoly.Factored`/`ZPoly.Factored`. Produced by the
+`factor_poly` elaborator via the Mathlib bridge providers. -/
+structure FactoredPoly {R : Type*} [CommRing R] (P : Polynomial R) where
+  /-- The unit scalar (the leading coefficient for nonzero `P`). -/
+  scalar : R
+  /-- The irreducible factors, with repetition. -/
+  factors : List (Polynomial R)
+  /-- The scalar times the factor product reconstructs `P`. -/
+  factors_mul : Polynomial.C scalar * factors.prod = P
+  /-- Every listed factor is irreducible. -/
+  factors_irred : ∀ q ∈ factors, Irreducible q
+
+end Hex
+
+namespace HexBerlekampMathlib
+
+variable {p : Nat} [Hex.ZMod64.Bounds p]
+
+/-- The Mathlib-free `Hex.Nat.Prime` witness yields Mathlib's `Nat.Prime`. -/
+theorem nat_prime_of_hex {p : Nat} (hp : Hex.Nat.Prime p) : Nat.Prime p :=
+  Nat.prime_def.mpr ⟨hp.1, hp.2⟩
+
+/-- The executable constant `1` transports to the Mathlib constant `1`.
+(`map_one` through `fpPolyEquiv` needs a `MulOneClass` instance `FpPoly` does
+not carry, so this is proved through `DensePoly.C`.) -/
+theorem toMathlibPolynomial_one :
+    toMathlibPolynomial (1 : Hex.FpPoly p) = 1 := by
+  have h : (1 : Hex.FpPoly p) = Hex.DensePoly.C 1 := rfl
+  rw [h, toMathlibPolynomial_C, HexModArithMathlib.ZMod64.toZMod_one, Polynomial.C_1]
+
+/-- Negation commutes with the finite-field polynomial transport. -/
+theorem toMathlibPolynomial_neg (f : Hex.FpPoly p) :
+    toMathlibPolynomial (-f) = -toMathlibPolynomial f := by
+  apply Polynomial.ext
+  intro n
+  rw [Polynomial.coeff_neg, coeff_toMathlibPolynomial, coeff_toMathlibPolynomial,
+    Hex.DensePoly.coeff_neg f n (by show (0 : Hex.ZMod64 p) - 0 = 0; grind),
+    HexModArithMathlib.ZMod64.toZMod_sub]
+  calc HexModArithMathlib.ZMod64.toZMod (0 : Hex.ZMod64 p) -
+        HexModArithMathlib.ZMod64.toZMod (Hex.DensePoly.coeff f n)
+      = 0 - HexModArithMathlib.ZMod64.toZMod (Hex.DensePoly.coeff f n) := by
+        rw [HexModArithMathlib.ZMod64.toZMod_zero]
+    _ = -HexModArithMathlib.ZMod64.toZMod (Hex.DensePoly.coeff f n) := zero_sub _
+
+/-- List products commute with the finite-field polynomial transport. -/
+theorem toMathlibPolynomial_listProd (l : List (Hex.FpPoly p)) :
+    toMathlibPolynomial l.prod = (l.map toMathlibPolynomial).prod := by
+  induction l with
+  | nil => exact toMathlibPolynomial_one
+  | cons a t ih =>
+      rw [List.prod_cons, List.map_cons, List.prod_cons, toMathlibPolynomial_mul, ih]
+
+end HexBerlekampMathlib
+
+namespace Hex
+
+open HexBerlekampMathlib
+
+/-- One-shot assembler for the `factor_poly` provider on `Polynomial (ZMod p)`:
+every certification slot is a Boolean check on reified literal data (filled by
+`Eq.refl true` in emitted terms), and `hP` is the parser-built bridge equation
+tying the reified executable polynomial to the user's Mathlib polynomial. -/
+@[expose]
+noncomputable def FactoredPoly.ofFp {p : Nat} [inst : Hex.ZMod64.Bounds p]
+    (P : Polynomial (ZMod p)) (f : Hex.FpPoly p) (s : Hex.ZMod64 p)
+    (factors : List (Hex.FpPoly p))
+    (certified : List (Hex.FpPoly p × Hex.ZMod64 p × Hex.Berlekamp.IrreducibilityCertificate))
+    (hp : Hex.Nat.isPrimeTrial p = true)
+    (hmul : Hex.DensePoly.beqCoeffs (Hex.DensePoly.C s * factors.prod) f = true)
+    (hdeg : factors.all (fun g => decide (0 < g.degree?.getD 0)) = true)
+    (hcheck : Hex.Berlekamp.checkIrredCover factors certified = true)
+    (hP : toMathlibPolynomial f = P) : Hex.FactoredPoly P where
+  scalar := HexModArithMathlib.ZMod64.toZMod s
+  factors := factors.map toMathlibPolynomial
+  factors_mul := by
+    calc Polynomial.C (HexModArithMathlib.ZMod64.toZMod s) *
+          (factors.map toMathlibPolynomial).prod
+        = toMathlibPolynomial (Hex.DensePoly.C s) * toMathlibPolynomial factors.prod := by
+          rw [toMathlibPolynomial_C, toMathlibPolynomial_listProd]
+      _ = toMathlibPolynomial (Hex.DensePoly.C s * factors.prod) :=
+          (toMathlibPolynomial_mul _ _).symm
+      _ = toMathlibPolynomial f := by rw [Hex.DensePoly.eq_of_beqCoeffs hmul]
+      _ = P := hP
+  factors_irred := by
+    haveI : Fact (_root_.Nat.Prime p) := ⟨nat_prime_of_hex (Hex.Nat.isPrimeTrial_isPrime hp)⟩
+    intro q hq
+    rw [List.mem_map] at hq
+    obtain ⟨g, hg, rfl⟩ := hq
+    have hirr := Hex.Berlekamp.irreducible_of_checkIrredCover hp factors certified hcheck g hg
+    have hdeg' := List.all_eq_true.mp hdeg g hg
+    exact irreducible_toMathlibPolynomial_of_fpPolyIrreducible
+      (natDegree_toMathlibPolynomial_pos_of_degree?_pos (of_decide_eq_true hdeg')) hirr
+
+end Hex
+
+namespace HexBerlekampMathlib
+
+/-- Kernel-decidable irreducibility endpoint for the `irreducibility` provider
+on `Polynomial (ZMod p)`: the executable side is
+`Berlekamp.irreducible_of_checkMonicCert_scale` on reified literals, the
+positive degree transports the statement out of the vacuous-constant regime,
+and `hP` is the parser-built bridge equation. -/
+theorem irreducible_ofFp {p : Nat} [Hex.ZMod64.Bounds p]
+    (P : Polynomial (ZMod p)) (f m : Hex.FpPoly p) (c : Hex.ZMod64 p)
+    (cert : Hex.Berlekamp.IrreducibilityCertificate)
+    (hp : Hex.Nat.isPrimeTrial p = true)
+    (hc : decide (c = 0) = false)
+    (hfm : Hex.DensePoly.beqCoeffs (Hex.DensePoly.scale c m) f = true)
+    (hcheck : Hex.Berlekamp.checkMonicCert m cert = true)
+    (hdeg : decide (0 < f.degree?.getD 0) = true)
+    (hP : toMathlibPolynomial f = P) : Irreducible P := by
+  haveI : Fact (Nat.Prime p) := ⟨nat_prime_of_hex (Hex.Nat.isPrimeTrial_isPrime hp)⟩
+  have hf := Hex.Berlekamp.irreducible_of_checkMonicCert_scale f m c cert hp hc hfm hcheck
+  have h := irreducible_toMathlibPolynomial_of_fpPolyIrreducible
+    (natDegree_toMathlibPolynomial_pos_of_degree?_pos (of_decide_eq_true hdeg)) hf
+  rwa [hP] at h
+
+end HexBerlekampMathlib

--- a/HexBerlekampMathlib/FactorPolyTests.lean
+++ b/HexBerlekampMathlib/FactorPolyTests.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+-- PLAIN `public import` only (plus the `public meta import` required for
+-- elaboration-time evaluation): the emitted kernel checks must reduce through
+-- the exposed closure alone.
+public meta import HexBerlekamp.IrreducibilityElab
+public meta import HexBerlekampMathlib.FactorProvider
+public import HexBerlekamp.IrreducibilityElab
+public import HexBerlekampMathlib.FactorProvider
+
+public section
+
+open Polynomial
+
+namespace HexBerlekampMathlib.FactorPolyTests
+
+/-! ## `factor_poly` on `Polynomial (ZMod 5)` -/
+
+/-- `3·(x+1)²·(x²+2)` over `F_5`: non-monic, non-square-free. -/
+noncomputable def facP :=
+  factor_poly ((X + 1) * (X + 1) * (X ^ 2 + 2) * 3 : Polynomial (ZMod 5))
+
+example : facP.factors.length = 3 := rfl
+
+example : True := by
+  obtain ⟨scalar, factors, factors_mul, factors_irred⟩ :=
+    factor_poly ((X + 1) * (X + 1) * (X ^ 2 + 2) * 3 : Polynomial (ZMod 5))
+  trivial
+
+-- Tactic form: providers emitting `FactoredPoly.ofFp` land as a single
+-- `factored` hypothesis.
+example : True := by
+  factor_poly ((X + 1) * (X + 1) * (X ^ 2 + 2) * 3 : Polynomial (ZMod 5))
+  exact True.intro
+
+-- Negation and subtraction arms; `Polynomial.C` coefficients.
+noncomputable def facNeg :=
+  factor_poly (-(X + 1) * (X - 1) * Polynomial.C 2 : Polynomial (ZMod 5))
+
+/-! ## `irreducibility` on `Polynomial (ZMod 5)` -/
+
+theorem quad_irred : Irreducible (X ^ 2 + 2 : Polynomial (ZMod 5)) :=
+  irreducibility (X ^ 2 + 2 : Polynomial (ZMod 5))
+
+-- Coefficient over the modulus (7 ≡ 2 mod 5) and a negative coefficient
+-- (X² - 3 = X² + 2 mod 5).
+theorem quad_irred_big : Irreducible (X ^ 2 + 7 : Polynomial (ZMod 5)) :=
+  irreducibility (X ^ 2 + 7 : Polynomial (ZMod 5))
+
+theorem quad_irred_negc : Irreducible (X ^ 2 - 3 : Polynomial (ZMod 5)) :=
+  irreducibility (X ^ 2 - 3 : Polynomial (ZMod 5))
+
+-- Goal form.
+example : Irreducible (X ^ 2 + 2 : Polynomial (ZMod 5)) := by irreducibility
+
+-- `h :` and `this` tactic forms.
+example : True := by
+  irreducibility (X ^ 2 + 2 : Polynomial (ZMod 5))
+  irreducibility h : (Polynomial.C 3 * X + 1 : Polynomial (ZMod 5))
+  exact True.intro
+
+/-! ## Reducible/degenerate inputs: targeted errors -/
+
+/--
+error: irreducibility: the polynomial
+  X ^ 2 + 4
+is not irreducible over F_5: factor_poly finds 2 irreducible factors (with multiplicity)
+-/
+#guard_msgs in
+example := irreducibility (X ^ 2 + 4 : Polynomial (ZMod 5))
+
+/-- error: irreducibility: the zero polynomial is not irreducible -/
+#guard_msgs in
+example := irreducibility (0 : Polynomial (ZMod 5))
+
+/--
+error: irreducibility: the polynomial
+  3
+is a nonzero constant, hence a unit over F_5, not irreducible
+-/
+#guard_msgs in
+example := irreducibility (3 : Polynomial (ZMod 5))
+
+/-! ## Composite modulus: the provider declines, the driver reports -/
+
+/--
+info: factor_poly: unsupported polynomial type
+  (ZMod 6)[X]
+Supported without further imports: Hex.FpPoly p (prime p). Importing HexBerlekampZassenhaus adds Hex.ZPoly; the Mathlib bridge libraries add Polynomial (ZMod q) and Polynomial ℤ.
+
+factor_poly: Polynomial (ZMod q) inputs need a prime modulus, but 6 is not prime
+-/
+#guard_msgs in
+#check_failure (factor_poly (X + 1 : Polynomial (ZMod 6)))
+
+/--
+info: irreducibility: unsupported polynomial type
+  (ZMod 6)[X]
+Supported without further imports: Hex.FpPoly p (prime p). Importing HexBerlekampZassenhaus adds Hex.ZPoly; the Mathlib bridge libraries add Polynomial (ZMod q) and Polynomial ℤ.
+
+irreducibility: Polynomial (ZMod q) inputs need a prime modulus, but 6 is not prime
+-/
+#guard_msgs in
+#check_failure (irreducibility (X + 1 : Polynomial (ZMod 6)))
+
+/-! ## Axiom hygiene -/
+
+/-- info: 'HexBerlekampMathlib.FactorPolyTests.facP' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms facP
+
+/-- info: 'HexBerlekampMathlib.FactorPolyTests.facNeg' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms facNeg
+
+/-- info: 'HexBerlekampMathlib.FactorPolyTests.quad_irred' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms quad_irred
+
+end HexBerlekampMathlib.FactorPolyTests

--- a/HexBerlekampMathlib/FactorProvider.lean
+++ b/HexBerlekampMathlib/FactorProvider.lean
@@ -1,0 +1,382 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public meta import HexBerlekamp.FactorPolyElab
+public meta import HexBerlekampMathlib.FactorPoly
+public import HexBerlekamp.FactorPolyElab
+public import HexBerlekampMathlib.FactorPoly
+
+public section
+
+/-!
+The `Polynomial (ZMod q)` provider for the `factor_poly`/`irreducibility`
+elaborators: importing this library upgrades the tactics (declared in
+`HexBerlekamp.TacticCore` / probed by name, see `providerNames`) to handle
+Mathlib polynomials over prime fields with a literal modulus.
+
+The heart of the provider is a parser-with-proof: a meta recursion over the
+input `Polynomial (ZMod q)` expression that simultaneously evaluates each node
+to an executable `Hex.FpPoly q` value and builds a proof that the transported
+value equals the node, combining child proofs through the named
+`toMathlibPolynomial_*` transport lemmas. The compiled Berlekamp factorizer
+then runs as untrusted search exactly as in the `FpPoly` pipeline, and the
+emitted terms apply the kernel-decidable assemblers `Hex.FactoredPoly.ofFp` /
+`HexBerlekampMathlib.irreducible_ofFp` to reified literal data: every
+certification slot is discharged by `Eq.refl true`/`Eq.refl false`, plus the
+parser-built bridge equation. The factorizer never appears in emitted terms.
+-/
+
+namespace HexBerlekampMathlib.FactorTactic
+
+open Lean Meta Elab
+open Hex.FactorTactic (ProviderResult)
+
+/-- Match a (whnfR-normalized) type against `Polynomial (ZMod q)` for a
+literal `q`, returning the modulus and its literal expression. -/
+meta def zmodInput? (ty : Expr) : MetaM (Option (Nat × Expr)) := do
+  let ty ← whnfR ty
+  let_expr Polynomial R _sem := ty | return none
+  let R ← whnfR R
+  let_expr ZMod qE := R | return none
+  let some q := qE.nat? | return none
+  return some (q, qE)
+
+/-- Extract a `Nat` literal from an exponent expression (numerals and raw
+literals). -/
+meta def getNatLit (tactic : String) (e : Expr) : MetaM Nat := do
+  match ← getNatValue? e with
+  | some n => return n
+  | none =>
+    match (← whnfR e).getAppFnArgs with
+    | (``OfNat.ofNat, #[_, n, _]) =>
+      match ← getNatValue? n with
+      | some k => return k
+      | none => throwError "{tactic}: expected a Nat literal exponent{indentExpr e}"
+    | _ => throwError "{tactic}: expected a Nat literal exponent{indentExpr e}"
+
+/-- Evaluate a closed `ZMod q` coefficient expression to its canonical `Nat`
+representative by whnf-reducing `ZMod.val c`. -/
+meta def evalZModVal (tactic : String) (pE cE : Expr) : MetaM Nat := do
+  let valE ← mkAppOptM ``ZMod.val #[some pE, some cE]
+  let r ← whnf valE
+  match ← getNatValue? r with
+  | some n => return n
+  | none =>
+      throwError "{tactic}: failed to evaluate the coefficient{indentExpr cE}\
+          \nto a canonical residue (reduction got stuck at{indentExpr r})"
+
+/-- Certify a scalar equality `toZMod (ofNat q k) = c` by `decide`, checking at
+elaboration time that the Boolean actually reduces to `true`. -/
+meta def scalarDecideProof (tactic : String) (prop : Expr) : MetaM Expr := do
+  let d ← mkDecide prop
+  let r ← whnf d
+  unless r.isConstOf ``Bool.true do
+    throwError "{tactic}: failed to certify the coefficient equality{indentExpr prop}\
+        \nby kernel reduction"
+  mkDecideProof prop
+
+/-- The partial application `toMathlibPolynomial (p := q)` as an expression. -/
+meta def tomlFn (pE boundsE : Expr) : Expr :=
+  mkApp2 (mkConst ``HexBerlekampMathlib.toMathlibPolynomial) pE boundsE
+
+/-- Combine two parsed children through a binary transport lemma: given child
+results `(va, vaE, pa)`/`(vb, vbE, pb)` with `pa : toMathlibPolynomial vaE = a`
+(and likewise `pb`), produce the node value `v`, the executable expression
+`vaE ⋄ vbE`, and the chained proof
+`toMathlibPolynomial (vaE ⋄ vbE) = a ⋄ b`. -/
+meta def combineBinary {q : Nat} [Hex.ZMod64.Bounds q]
+    (pE boundsE eOrig : Expr) (v : Hex.FpPoly q)
+    (vaE vbE pa pb : Expr) (lem op : Name) :
+    MetaM (Hex.FpPoly q × Expr × Expr) := do
+  let vE ← mkAppM op #[vaE, vbE]
+  let t1 ← mkAppOptM lem #[some pE, some boundsE, some vaE, some vbE]
+  let polyTy ← inferType eOrig
+  let fnE ← mkAppOptM op #[some polyTy, some polyTy, some polyTy, none]
+  let t2 ← mkCongr (← mkCongrArg fnE pa) pb
+  return (v, vE, ← mkEqTrans t1 t2)
+
+/-- Build a constant leaf from the canonical residue `k`: value
+`DensePoly.C (ofNat q k)`, its literal expression, and the transport proof
+against the Mathlib scalar `cRhsE` (certified by `decide`), chained through
+`hTail : Polynomial.C cRhsE = e` when the leaf is not literally a `C`
+application. -/
+meta def constLeaf {q : Nat} [Hex.ZMod64.Bounds q]
+    (tactic : String) (pE boundsE : Expr) (k : Nat) (cRhsE : Expr)
+    (hTail? : Option Expr) : MetaM (Hex.FpPoly q × Expr × Expr) := do
+  let v : Hex.FpPoly q := Hex.DensePoly.C (Hex.ZMod64.ofNat q k)
+  let zLit := Hex.CertReify.reifyZMod64 pE boundsE k
+  let vE ← mkAppM ``Hex.DensePoly.C #[zLit]
+  let t1 ← mkAppOptM ``HexBerlekampMathlib.toMathlibPolynomial_C
+    #[some pE, some boundsE, some zLit]
+  -- t1 : toMathlibPolynomial (C zLit) = Polynomial.C (toZMod zLit)
+  let toZModE ← mkAppOptM ``HexModArithMathlib.ZMod64.toZMod
+    #[some pE, some boundsE, some zLit]
+  let hc ← scalarDecideProof tactic (← mkEq toZModE cRhsE)
+  let some (_, _, rhs) := (← inferType t1).eq?
+    | throwError "{tactic}: internal error: malformed transport lemma; please report this"
+  let t2 ← mkCongrArg rhs.appFn! hc
+  let prf ← mkEqTrans t1 t2
+  match hTail? with
+  | none => return (v, vE, prf)
+  | some hTail => return (v, vE, ← mkEqTrans prf hTail)
+
+/--
+The parser-with-proof over `Polynomial (ZMod q)` expressions: interpret
+`X / C / numerals / + / - / * / neg / ^ (Nat literal)` (with named defs
+unfolded one delta step at a time under a fuel guard), returning the
+executable value `v : FpPoly q`, an executable expression `vE` denoting it
+(built from reified literals and executable operations), and a proof
+`toMathlibPolynomial vE = e` (up to definitional equality on the right).
+Structural heads are matched on the raw term: `whnf` would unfold
+`Polynomial.C`/`X`/numerals into their `Finsupp` normal form and defeat the
+match.
+-/
+meta partial def parseCore (tactic : String) (q : Nat) [Hex.ZMod64.Bounds q]
+    (pE boundsE : Expr) (fuel : Nat) (e : Expr) :
+    MetaM (Hex.FpPoly q × Expr × Expr) := do
+  match e.getAppFnArgs with
+  | (``HAdd.hAdd, #[_, _, _, _, a, b]) => do
+      let (va, vaE, pa) ← parseCore tactic q pE boundsE fuel a
+      let (vb, vbE, pb) ← parseCore tactic q pE boundsE fuel b
+      combineBinary pE boundsE e (va + vb) vaE vbE pa pb
+        ``HexBerlekampMathlib.toMathlibPolynomial_add ``HAdd.hAdd
+  | (``HSub.hSub, #[_, _, _, _, a, b]) => do
+      let (va, vaE, pa) ← parseCore tactic q pE boundsE fuel a
+      let (vb, vbE, pb) ← parseCore tactic q pE boundsE fuel b
+      combineBinary pE boundsE e (va - vb) vaE vbE pa pb
+        ``HexBerlekampMathlib.toMathlibPolynomial_sub ``HSub.hSub
+  | (``HMul.hMul, #[_, _, _, _, a, b]) => do
+      let (va, vaE, pa) ← parseCore tactic q pE boundsE fuel a
+      let (vb, vbE, pb) ← parseCore tactic q pE boundsE fuel b
+      combineBinary pE boundsE e (va * vb) vaE vbE pa pb
+        ``HexBerlekampMathlib.toMathlibPolynomial_mul ``HMul.hMul
+  | (``Neg.neg, #[_, _, a]) => do
+      let (va, vaE, pa) ← parseCore tactic q pE boundsE fuel a
+      let vE ← mkAppM ``Neg.neg #[vaE]
+      let t1 ← mkAppOptM ``HexBerlekampMathlib.toMathlibPolynomial_neg
+        #[some pE, some boundsE, some vaE]
+      let polyTy ← inferType e
+      let negFn ← mkAppOptM ``Neg.neg #[some polyTy, none]
+      let t2 ← mkCongrArg negFn pa
+      return (-va, vE, ← mkEqTrans t1 t2)
+  | (``HPow.hPow, #[_, _, _, _, a, nE]) => do
+      let (va, vaE, pa) ← parseCore tactic q pE boundsE fuel a
+      let n ← getNatLit tactic nE
+      let polyTy ← inferType e
+      let fpTy := Hex.CertReify.fpPolyType pE boundsE
+      let mulFn ← mkAppOptM ``HMul.hMul #[some polyTy, some polyTy, some polyTy, none]
+      -- `a ^ 0`: value `1`, proof through `toMathlibPolynomial_one` and `pow_zero`.
+      let mut v : Hex.FpPoly q := 1
+      let mut vE ← mkAppOptM ``One.one #[some fpTy, none]
+      let oneLem ← mkAppOptM ``HexBerlekampMathlib.toMathlibPolynomial_one
+        #[some pE, some boundsE]
+      let mut prf ← mkEqTrans oneLem (← mkEqSymm (← mkAppM ``pow_zero #[a]))
+      -- `a ^ (k+1) = a ^ k * a`, peeled by `pow_succ`.
+      for k in [0:n] do
+        let vE' ← mkAppM ``HMul.hMul #[vE, vaE]
+        let t1 ← mkAppOptM ``HexBerlekampMathlib.toMathlibPolynomial_mul
+          #[some pE, some boundsE, some vE, some vaE]
+        let t2 ← mkCongr (← mkCongrArg mulFn prf) pa
+        let t3 ← mkEqSymm (← mkAppM ``pow_succ #[a, mkNatLit k])
+        v := v * va
+        vE := vE'
+        prf ← mkEqTrans t1 (← mkEqTrans t2 t3)
+      return (v, vE, prf)
+  | (``Polynomial.X, _) => do
+      let vE := mkApp2 (mkConst ``Hex.FpPoly.X) pE boundsE
+      let prf ← mkAppOptM ``HexBerlekampMathlib.toMathlibPolynomial_X
+        #[some pE, some boundsE]
+      return (Hex.FpPoly.X (p := q), vE, prf)
+  | (``Polynomial.C, #[_, _, c]) => do
+      let k ← evalZModVal tactic pE c
+      constLeaf tactic pE boundsE k c none
+  | (``DFunLike.coe, args) =>
+      -- `Polynomial.C c` elaborates to `⇑Polynomial.C c`.
+      if args.size == 6 && args[4]!.getAppFn.isConstOf ``Polynomial.C then do
+        let c := args[5]!
+        let k ← evalZModVal tactic pE c
+        constLeaf tactic pE boundsE k c none
+      else
+        throwError "{tactic}: unsupported polynomial syntax{indentExpr e}"
+  | (``OfNat.ofNat, #[_, nE, _]) => do
+      let n ← getNatLit tactic nE
+      let zmodTy := mkApp (mkConst ``ZMod) pE
+      let cRhs ← mkAppOptM ``OfNat.ofNat #[some zmodTy, some (mkRawNatLit n), none]
+      -- `Polynomial.C (OfNat n) = OfNat n` at the polynomial level.
+      let hTail ←
+        if n == 0 then
+          mkAppOptM ``Polynomial.C_0 #[some zmodTy, none]
+        else if n == 1 then
+          mkAppOptM ``Polynomial.C_1 #[some zmodTy, none]
+        else do
+          let cHom ← mkAppOptM ``Polynomial.C #[some zmodTy, none]
+          let polyTy ← inferType e
+          mkAppOptM ``map_ofNat #[some zmodTy, some polyTy, some (← inferType cHom),
+            none, none, none, none, some cHom, some (mkRawNatLit n), none]
+      constLeaf tactic pE boundsE (n % q) cRhs (some hTail)
+  | _ =>
+      -- Unfold a named def by one delta step under the fuel guard, else fail.
+      if fuel == 0 then
+        throwError "{tactic}: unsupported polynomial syntax{indentExpr e}"
+      else
+        match ← unfoldDefinition? e with
+        | some e' => parseCore tactic q pE boundsE (fuel - 1) e'
+        | none => throwError "{tactic}: unsupported polynomial syntax{indentExpr e}"
+
+/-- Parse the full input: run `parseCore`, then recombine the parsed
+expression with the flat reified literal of its value through one
+`eq_of_beqCoeffs` kernel check, yielding `(f, fLit, hP)` with
+`hP : toMathlibPolynomial fLit = e`. -/
+meta def parseInput (tactic : String) (q : Nat) [Hex.ZMod64.Bounds q]
+    (pE boundsE : Expr) (e : Expr) :
+    MetaM (Hex.FpPoly q × Expr × Expr) := do
+  let (v, vE, prf) ← parseCore tactic q pE boundsE 16 e
+  let fLit := Hex.CertReify.reifyFpPolyOfNats pE boundsE (Hex.CertReify.fpCoeffNats v)
+  let RE := Hex.CertReify.zmodType pE boundsE
+  let zeroE ← synthInstance (← mkAppM ``Zero #[RE])
+  let decE ← synthInstance (← mkAppM ``DecidableEq #[RE])
+  let hroot := mkApp6 (mkConst ``Hex.DensePoly.eq_of_beqCoeffs [Level.zero])
+    RE zeroE decE fLit vE Hex.CertReify.reflTrue
+  let hP ← mkEqTrans (← mkCongrArg (tomlFn pE boundsE) hroot) prf
+  return (v, fLit, hP)
+
+/-- The `factor_poly` arm: parse with proof, run the shared `FpPoly` factor
+search as untrusted search, self-check, and emit a reified
+`Hex.FactoredPoly.ofFp` application. -/
+meta def elabFactorZMod (tactic : String) (q : Nat) [Hex.ZMod64.Bounds q]
+    (hpt : Hex.Nat.isPrimeTrial q = true) (pE e : Expr) :
+    Term.TermElabM Expr := do
+  let boundsE := Hex.CertReify.reifyBounds pE
+  let (f, fLit, hP) ← parseInput tactic q pE boundsE e
+  let hp : Hex.Nat.Prime q := Hex.Nat.isPrimeTrial_isPrime hpt
+  let (scalar, factors) := Hex.FactorTactic.fpFactorSearch q hp f
+  -- Untrusted-search self-checks before emitting anything.
+  unless Hex.DensePoly.beqCoeffs (Hex.DensePoly.C scalar * factors.prod) f do
+    throwError "{tactic}: internal error: the factor search product does not \
+        reconstruct the input; please report this"
+  unless factors.all (fun g => decide (0 < g.degree?.getD 0)) do
+    throwError "{tactic}: internal error: a constant factor appeared in the \
+        factor list; please report this"
+  let entries ← Hex.FactorTactic.fpCoverEntries tactic q factors
+  unless Hex.Berlekamp.checkIrredCover factors entries do
+    throwError "{tactic}: internal error: the generated certificates fail \
+        checkIrredCover; please report this"
+  let polyTy := Hex.CertReify.fpPolyType pE boundsE
+  let scalarE := Hex.CertReify.reifyZMod64 pE boundsE scalar.toNat
+  let factorsE := Hex.FactorTactic.listLit polyTy (factors.map fun g =>
+    Hex.CertReify.reifyFpPolyOfNats pE boundsE (Hex.CertReify.fpCoeffNats g))
+  let certifiedE := Hex.FactorTactic.listLit (Hex.FactorTactic.coverEntryType pE boundsE)
+    (entries.map fun (m, c, cert) => Hex.FactorTactic.reifyCoverEntry pE boundsE m c cert)
+  return mkAppN (mkConst ``Hex.FactoredPoly.ofFp)
+    #[pE, boundsE, e, fLit, scalarE, factorsE, certifiedE,
+      Hex.CertReify.reflTrue, Hex.CertReify.reflTrue, Hex.CertReify.reflTrue,
+      Hex.CertReify.reflTrue, hP]
+
+/-- The `irreducibility` arm: parse with proof, build the Rabin certificate as
+untrusted search, self-check, and emit a reified
+`HexBerlekampMathlib.irreducible_ofFp` application. -/
+meta def elabIrredZMod (tactic : String) (q : Nat) [Hex.ZMod64.Bounds q]
+    (hpt : Hex.Nat.isPrimeTrial q = true) (pE e : Expr) :
+    Term.TermElabM Expr := do
+  let boundsE := Hex.CertReify.reifyBounds pE
+  let (f, fLit, hP) ← parseInput tactic q pE boundsE e
+  if f.size = 0 then
+    throwError "{tactic}: the zero polynomial is not irreducible"
+  if f.size = 1 then
+    throwError "{tactic}: the polynomial{indentExpr e}\
+        \nis a nonzero constant, hence a unit over F_{q}, not irreducible"
+  Hex.FactorTactic.checkReplayBudget tactic q f.size
+  let (unit, m) := Hex.FpPoly.normalizeMonic f
+  if hmonic : Hex.DensePoly.leadingCoeff m = 1 then
+    match Hex.Berlekamp.buildIrreducibilityCertificate? m (by exact hmonic) with
+    | none =>
+        let hp : Hex.Nat.Prime q := Hex.Nat.isPrimeTrial_isPrime hpt
+        let (_, factors) := Hex.FactorTactic.fpFactorSearch q hp f
+        throwError "{tactic}: the polynomial{indentExpr e}\
+            \nis not irreducible over F_{q}: factor_poly finds \
+            {factors.length} irreducible factors (with multiplicity)"
+    | some cert =>
+        -- Untrusted-search self-checks before emitting anything.
+        unless decide (unit = 0) = false &&
+            Hex.DensePoly.beqCoeffs (Hex.DensePoly.scale unit m) f &&
+            Hex.Berlekamp.checkMonicCert m cert &&
+            decide (0 < f.degree?.getD 0) do
+          throwError "{tactic}: internal error: the generated certificate \
+              fails its own checks; please report this"
+        let mE := Hex.CertReify.reifyFpPolyOfNats pE boundsE (Hex.CertReify.fpCoeffNats m)
+        let cE := Hex.CertReify.reifyZMod64 pE boundsE unit.toNat
+        let certE := Hex.CertReify.reifyRabinCert cert
+        return mkAppN (mkConst ``HexBerlekampMathlib.irreducible_ofFp)
+          #[pE, boundsE, e, fLit, mE, cE, certE,
+            Hex.CertReify.reflTrue, Hex.CertReify.reflFalse, Hex.CertReify.reflTrue,
+            Hex.CertReify.reflTrue, Hex.CertReify.reflTrue, hP]
+  else
+    throwError "{tactic}: internal error: non-monic normalization; please \
+        report this"
+
+/-- Shared modulus scaffolding: match the input type, check primality and the
+`ZMod64` bounds, and run the continuation with the `Bounds` instance in
+scope. Non-`Polynomial (ZMod q)` types are `notApplicable`; composite or
+oversized moduli are declined with a diagnostic. -/
+meta def withZModInput (tactic : String) (ty : Expr)
+    (k : (q : Nat) → Hex.ZMod64.Bounds q → Hex.Nat.isPrimeTrial q = true →
+      Expr → Term.TermElabM Expr) :
+    Term.TermElabM ProviderResult := do
+  let some (q, qE) ← zmodInput? ty | return .notApplicable
+  if hpt : Hex.Nat.isPrimeTrial q = true then
+    if h1 : 0 < q then
+      if h2 : q < 2 ^ 31 then
+        return .success (← k q ⟨h1, h2⟩ hpt qE)
+      else
+        return .declined m!"{tactic}: the modulus {q} is prime but over the \
+            ZMod64 bound (2^31), so the Polynomial (ZMod q) provider cannot \
+            certify it"
+    else
+      return .notApplicable
+  else
+    return .declined m!"{tactic}: Polynomial (ZMod q) inputs need a prime \
+        modulus, but {q} is not prime"
+
+/-- Goal mode: close `Irreducible P` for `P : Polynomial (ZMod q)`. -/
+meta def goalIrredZMod (goal : MVarId) : Tactic.TacticM ProviderResult := do
+  goal.withContext do
+    let tgt ← instantiateMVars (← goal.getType)
+    unless tgt.getAppFn.isConstOf ``Irreducible && tgt.getAppNumArgs == 3 do
+      return .notApplicable
+    let args := tgt.getAppArgs
+    let eP := args[2]!
+    let some _ ← zmodInput? args[0]! | return .notApplicable
+    Hex.FactorTactic.checkClosed "irreducibility" eP
+    withZModInput "irreducibility" args[0]! fun q inst hpt qE => do
+      let proof ← @elabIrredZMod "irreducibility" q inst hpt qE eP
+      unless ← isDefEq (← inferType proof) tgt do
+        throwError "irreducibility: the certified statement\
+            {indentExpr (← inferType proof)}\
+            \nis not definitionally equal to the goal{indentExpr tgt}"
+      return proof
+
+end HexBerlekampMathlib.FactorTactic
+
+namespace HexBerlekampMathlib.FactorTactic
+
+open Lean Elab
+
+/-- The `Polynomial (ZMod q)` provider, probed by name from
+`Hex.FactorTactic.providerNames` — renaming it severs the hook (the bridge
+test suite is the liveness canary). -/
+public meta def provider : Hex.FactorTactic.Provider where
+  version := Hex.FactorTactic.Provider.abiVersion
+  factorPoly? := fun _stx eP ty _expectedType? =>
+    withZModInput "factor_poly" ty fun q inst hpt qE =>
+      @elabFactorZMod "factor_poly" q inst hpt qE eP
+  irreducibility? := fun _stx eP ty _expectedType? =>
+    withZModInput "irreducibility" ty fun q inst hpt qE =>
+      @elabIrredZMod "irreducibility" q inst hpt qE eP
+  goalIrred? := goalIrredZMod
+
+end HexBerlekampMathlib.FactorTactic

--- a/HexBerlekampMathlib/FactorProvider.lean
+++ b/HexBerlekampMathlib/FactorProvider.lean
@@ -328,19 +328,27 @@ meta def withZModInput (tactic : String) (ty : Expr)
       Expr → Term.TermElabM Expr) :
     Term.TermElabM ProviderResult := do
   let some (q, qE) ← zmodInput? ty | return .notApplicable
-  if hpt : Hex.Nat.isPrimeTrial q = true then
-    if h1 : 0 < q then
-      if h2 : q < 2 ^ 31 then
-        return .success (← k q ⟨h1, h2⟩ hpt qE)
+  -- `isPrimeTrial` is Θ(q) at elaboration time, and its emitted slot
+  -- kernel-replays at the same cost, so check the `ZMod64` bound and the
+  -- replay budget before running it.
+  if h1 : 0 < q then
+    if h2 : q < 2 ^ 31 then
+      if q ≤ Hex.FactorTactic.replayBudget then
+        if hpt : Hex.Nat.isPrimeTrial q = true then
+          return .success (← k q ⟨h1, h2⟩ hpt qE)
+        else
+          return .declined m!"{tactic}: Polynomial (ZMod q) inputs need a \
+              prime modulus, but {q} is not prime"
       else
-        return .declined m!"{tactic}: the modulus {q} is prime but over the \
-            ZMod64 bound (2^31), so the Polynomial (ZMod q) provider cannot \
-            certify it"
+        return .declined m!"{tactic}: the modulus {q} needs a kernel \
+            primality replay of roughly {q} steps, over the supported \
+            budget ({Hex.FactorTactic.replayBudget})"
     else
-      return .notApplicable
+      return .declined m!"{tactic}: the modulus {q} is over the ZMod64 \
+          bound (2^31), so the Polynomial (ZMod q) provider cannot \
+          certify it"
   else
-    return .declined m!"{tactic}: Polynomial (ZMod q) inputs need a prime \
-        modulus, but {q} is not prime"
+    return .notApplicable
 
 /-- Goal mode: close `Irreducible P` for `P : Polynomial (ZMod q)`. -/
 meta def goalIrredZMod (goal : MVarId) : Tactic.TacticM ProviderResult := do

--- a/HexBerlekampMathlib/SPEC/hex-berlekamp-mathlib.md
+++ b/HexBerlekampMathlib/SPEC/hex-berlekamp-mathlib.md
@@ -186,3 +186,32 @@ assembled from (1)+(4)):
 - Computational bridge: `rabinTest f = true` unfolds to the exact
   divisibility check `f | X^(p^n) - X` plus coprimality of
   `f` with `X^(p^(n/q)) - X` for each prime `q | n`
+
+## The `Polynomial (ZMod q)` provider for `factor_poly` / `irreducibility`
+
+`HexBerlekampMathlib/FactorProvider.lean` declares
+`HexBerlekampMathlib.FactorTactic.provider` (probed by name from
+`Hex.FactorTactic.providerNames`; renaming it severs the hook), extending
+the `factor_poly`/`irreducibility` elaborators to `Polynomial (ZMod q)`
+inputs with a literal prime modulus `q < 2^31`. Composite or oversized
+moduli are declined with a diagnostic; other types are not applicable.
+
+The provider's core is a parser-with-proof: a meta recursion over the
+input expression (`X`, `Polynomial.C`, numerals, `+`, `-`, `*`, negation,
+`^` with `Nat` literal exponents, named defs unfolded under a fuel guard)
+that evaluates each node to an executable `Hex.FpPoly q` and combines
+per-node proofs through the named `toMathlibPolynomial_*` transport
+lemmas, producing `toMathlibPolynomial fLit = P` for the reified literal
+`fLit`. Scalar coefficient equalities are certified by `decide` on
+`ZMod64.toZMod` values (checked to reduce at elaboration time before
+emission).
+
+The factor search reuses the `FpPoly` pipeline
+(`Hex.FactorTactic.fpFactorSearch` / `fpCoverEntries`) as untrusted
+search. Emitted terms apply the kernel-decidable assemblers in
+`HexBerlekampMathlib/FactorPoly.lean` — `Hex.FactoredPoly.ofFp` (result
+type `Hex.FactoredPoly P`, the `Polynomial`-level counterpart of
+`FpPoly.Factored`) and `HexBerlekampMathlib.irreducible_ofFp` — whose
+certification slots are all Boolean checks on reified literals discharged
+by `Eq.refl true`/`Eq.refl false`; the factorizer and certificate
+generator never appear in emitted terms.

--- a/progress/2026-07-22T19-55-22Z.md
+++ b/progress/2026-07-22T19-55-22Z.md
@@ -1,0 +1,57 @@
+# Polynomial (ZMod q) provider for factor_poly / irreducibility
+
+## Accomplished
+
+Plan step 5 on branch `factor-poly/zmod-provider` (stacked on
+`factor-poly/bz-provider`):
+
+- `HexBerlekampMathlib/FactorPoly.lean` (non-meta): the polymorphic
+  `Hex.FactoredPoly P` result structure; `nat_prime_of_hex`,
+  `toMathlibPolynomial_one` / `_neg` / `_listProd` transport lemmas; the
+  all-Boolean one-shot assemblers `Hex.FactoredPoly.ofFp` (`@[expose]`d so
+  field projections reduce for importers) and
+  `HexBerlekampMathlib.irreducible_ofFp`.
+- `HexBerlekampMathlib/FactorProvider.lean` (meta):
+  `HexBerlekampMathlib.FactorTactic.provider` (second probe name in
+  `Hex.FactorTactic.providerNames`). The parser-with-proof walks the
+  `Polynomial (ZMod q)` expression, evaluating each node to an `FpPoly q`
+  and chaining `toMathlibPolynomial_*` lemmas via
+  `mkCongr`/`mkCongrArg`/`mkEqTrans`; pow expands through
+  `pow_zero`/`pow_succ`; scalar coefficient equalities go by `decide`
+  on `ZMod64.toZMod` values, whnf-checked before emission; one
+  `eq_of_beqCoeffs` recombination at the root. Factor/irred arms reuse
+  `fpFactorSearch`/`fpCoverEntries`, self-check, and emit the assemblers
+  with `Eq.refl true` slots plus the parsed bridge proof.
+- `HexBerlekampMathlib/FactorPolyTests.lean`: term/obtain/tactic
+  `factor_poly` forms, `irreducibility` term/`h :`/goal forms, coefficient
+  over the modulus, negative coefficients (sub and neg arms),
+  `Polynomial.C` coefficients, composite-modulus decline pinned by
+  `#guard_msgs`, `#print axioms` guards (clean:
+  propext/Classical.choice/Quot.sound).
+- Umbrella + SPEC (`hex-berlekamp-mathlib.md`) updated.
+
+Gotchas hit: `Nat.Prime` resolves to `Hex.Nat.Prime` inside `namespace
+Hex` (use `_root_.Nat.Prime`); `Zero.zero` vs numeral spelling around
+`DensePoly.coeff_neg` (calc with defeq-tolerant head); `map_ofNat` has
+`[NonAssocSemiring R S]` before `[FunLike F R S]`, so `mkAppM` cannot
+infer R/S — use `mkAppOptM` with explicit R, S, F.
+
+`lake build HexBerlekampMathlib` and `lake build
+HexBerlekampZassenhausMathlib` green.
+
+## Current frontier
+
+The stacked provider chain: FpPoly (base) → ZPoly (BZ) → this
+`Polynomial (ZMod q)` bridge. PR opened against
+`factor-poly/bz-provider`.
+
+## Next step
+
+Plan step 6: the `Polynomial ℤ` provider, mirroring this parser design
+over `HexPolyZMathlib.toPolynomial`, with the multi-prime
+degree-obstruction certificates picking up the ZPoly provider's balanced
+declines.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR add the `Polynomial (ZMod q)` provider for the `factor_poly`/`irreducibility` elaborators, the third link in the stacked provider chain (FpPoly base → ZPoly → this Mathlib bridge). `HexBerlekampMathlib/FactorProvider.lean` declares `HexBerlekampMathlib.FactorTactic.provider` (the second probe name in `Hex.FactorTactic.providerNames`), handling inputs with a literal prime modulus below 2^31 and declining composite or oversized moduli with a diagnostic. Its core is a parser-with-proof: a meta recursion over the input expression (`X`, `Polynomial.C`, numerals, `+`, `-`, `*`, negation, `^` with literal exponents, named defs under a fuel guard) that evaluates each node to an executable `Hex.FpPoly q` while chaining the named `toMathlibPolynomial_*` transport lemmas into a bridge equation `toMathlibPolynomial fLit = P`; scalar coefficient equalities are certified by `decide` on `ZMod64.toZMod` values (whnf-checked before emission), and one `DensePoly.eq_of_beqCoeffs` kernel check recombines the flat reified literal at the root.

The non-meta half, `HexBerlekampMathlib/FactorPoly.lean`, introduces the polymorphic result structure `Hex.FactoredPoly P` (the `Polynomial`-level counterpart of `FpPoly.Factored`, shared with the upcoming `Polynomial ℤ` provider) plus the transport lemmas `nat_prime_of_hex`, `toMathlibPolynomial_one`/`_neg`/`_listProd` and the all-Boolean one-shot assemblers `Hex.FactoredPoly.ofFp` and `HexBerlekampMathlib.irreducible_ofFp`: every certification slot is a Boolean check on reified literals discharged by `Eq.refl true`/`Eq.refl false`, so the factorizer and certificate generator never appear in emitted terms. The factor search reuses `Hex.FactorTactic.fpFactorSearch`/`fpCoverEntries` as untrusted search with runtime self-checks. `HexBerlekampMathlib/FactorPolyTests.lean` exercises term/obtain/tactic `factor_poly` forms, `irreducibility` term/named/goal forms, coefficients over the modulus, negative coefficients, composite-modulus rejection pinned by `#guard_msgs`, and `#print axioms` guards. Both `HexBerlekampMathlib` and the CI-gating `HexBerlekampZassenhausMathlib` build green.

🤖 Prepared with Claude Code