### PR TITLE
feat(bz): Eisenstein-after-shift irreducibility certificates

### DIFF
--- a/HexBerlekampZassenhaus.lean
+++ b/HexBerlekampZassenhaus.lean
@@ -17,6 +17,7 @@ public import HexBerlekampZassenhaus.BhksCandidates
 public import HexBerlekampZassenhaus.BhksRecover
 public import HexBerlekampZassenhaus.Recombination
 public import HexBerlekampZassenhaus.FactorEntryPoints
+public import HexBerlekampZassenhaus.EisensteinCore
 public import HexBerlekampZassenhaus.IrreducibleCore
 public import HexBerlekampZassenhaus.IrreducibleDecide
 public import HexBerlekampZassenhaus.Factored

--- a/HexBerlekampZassenhaus/EisensteinCore.lean
+++ b/HexBerlekampZassenhaus/EisensteinCore.lean
@@ -1,0 +1,977 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexArith.Nat.Prime
+public import HexBerlekampZassenhaus.IrreducibleCore
+
+public section
+set_option backward.proofsInPublic true
+
+/-!
+Eisenstein's criterion for `Hex.ZPoly`, plus the translation (Taylor shift)
+`f(X) ↦ f(X + s)` needed to certify polynomials that only become Eisenstein
+after a shift (e.g. `X⁴ + 1` at shift `1`, prime `2`).
+
+The file provides three layers:
+
+* `ZPoly.translate`, an executable, kernel-reducible Horner fold computing
+  `f(X + s)`, with its ring-homomorphism laws (`translate_add`,
+  `translate_mul`, `translate_C`) and the inverse identity
+  `translate_neg_translate`. Irreducibility transfers backwards through the
+  shift via `irreducible_of_translate_irreducible`.
+* `ZPoly.irreducible_of_eisenstein`, the elementary coefficient-level
+  Eisenstein criterion: a primitive non-constant `g` with a prime `q` not
+  dividing the leading coefficient, dividing every lower coefficient, and
+  with `q²` not dividing the constant term is irreducible.
+* `ZPoly.irreducible_of_eisensteinCert`, the kernel-decidable slot form on
+  the shifted polynomial `translate shift f`, consumed by the
+  `IrredWitness.eisenstein` arm of `checkIrredWitness`. Primitivity is
+  checked on the *shifted* polynomial directly, so no content-preservation
+  lemma for `translate` is needed.
+-/
+
+namespace Hex
+namespace ZPoly
+
+/-! ## The Taylor shift `translate` -/
+
+/-- Horner fold for the Taylor shift: `translateAux s cs` is
+`Σᵢ cs[i]·(X + s)^i`. Structural recursion on the coefficient list keeps the
+whole reduction closure exposed for the kernel checks in
+`checkIrredWitness`. -/
+@[expose]
+def translateAux (s : Int) : List Int → ZPoly
+  | [] => 0
+  | c :: cs => translateAux s cs * (X + DensePoly.C s) + DensePoly.C c
+
+/-- The Taylor shift `f(X) ↦ f(X + s)`. -/
+@[expose]
+def translate (s : Int) (f : ZPoly) : ZPoly :=
+  translateAux s f.toArray.toList
+
+private theorem translate_eq_aux (s : Int) (f : ZPoly) :
+    translate s f = translateAux s f.toList := rfl
+
+/-- The constant polynomial on `0` is the zero polynomial. -/
+private theorem C_zero : DensePoly.C (0 : Int) = (0 : ZPoly) := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [DensePoly.coeff_C, DensePoly.coeff_zero]
+  by_cases hn : n = 0
+  · rw [if_pos hn]
+  · rw [if_neg hn]
+    rfl
+
+/-- `C` is additive on `ZPoly`. -/
+private theorem C_add (a b : Int) :
+    (DensePoly.C (a + b) : ZPoly) = DensePoly.C a + DensePoly.C b := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [DensePoly.coeff_add _ _ n (by decide), DensePoly.coeff_C,
+    DensePoly.coeff_C, DensePoly.coeff_C]
+  by_cases hn : n = 0
+  · rw [if_pos hn, if_pos hn, if_pos hn]
+  · rw [if_neg hn, if_neg hn, if_neg hn]
+    rfl
+
+/-- `C` is multiplicative on `ZPoly`. -/
+private theorem C_mul (a b : Int) :
+    (DensePoly.C (a * b) : ZPoly) = DensePoly.C a * DensePoly.C b := by
+  rw [C_mul_eq_scale]
+  apply DensePoly.ext_coeff
+  intro n
+  rw [DensePoly.coeff_scale (R := Int) a (DensePoly.C b) n (Int.mul_zero a),
+    DensePoly.coeff_C, DensePoly.coeff_C]
+  by_cases hn : n = 0
+  · simp [hn]
+  · rw [if_neg hn, if_neg hn]
+    exact (Int.mul_zero a).symm
+
+/-- A dense polynomial of size zero is the zero polynomial. -/
+private theorem eq_zero_of_size_eq_zero {f : ZPoly} (h : f.size = 0) :
+    f = 0 := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [DensePoly.coeff_eq_zero_of_size_le f (by omega), DensePoly.coeff_zero]
+  rfl
+
+/-- The zero polynomial has the empty coefficient list. -/
+private theorem toList_zero : (0 : ZPoly).toList = [] := by
+  have hlen : (0 : ZPoly).toList.length = 0 := by
+    rw [DensePoly.length_toList, DensePoly.size_zero]
+  exact List.eq_nil_of_length_eq_zero hlen
+
+@[simp] theorem translate_zero (s : Int) : translate s (0 : ZPoly) = 0 := by
+  rw [translate_eq_aux, toList_zero]
+  rfl
+
+/-- A Horner fold over an everywhere-zero coefficient list is zero. -/
+private theorem translateAux_eq_zero_of_all_zero (s : Int) :
+    ∀ xs : List Int, (∀ n, xs.getD n 0 = 0) → translateAux s xs = 0 := by
+  intro xs
+  induction xs with
+  | nil => intro _; rfl
+  | cons c cs ih =>
+      intro h
+      have hc : c = 0 := by simpa using h 0
+      have hcs : ∀ n, cs.getD n 0 = 0 := fun n => by simpa using h (n + 1)
+      simp only [translateAux]
+      rw [ih hcs, DensePoly.zero_mul, hc, C_zero, DensePoly.add_zero_poly]
+
+/-- `translateAux` only depends on the coefficient reads of the list, so two
+lists agreeing under `getD` (in particular a list and its trailing-zero
+trimming) produce the same shift. -/
+private theorem translateAux_congr (s : Int) :
+    ∀ xs ys : List Int, (∀ n, xs.getD n 0 = ys.getD n 0) →
+      translateAux s xs = translateAux s ys := by
+  intro xs
+  induction xs with
+  | nil =>
+      intro ys h
+      have hys : ∀ n, ys.getD n 0 = 0 := fun n => by simpa using (h n).symm
+      exact (translateAux_eq_zero_of_all_zero s ys hys).symm
+  | cons c cs ih =>
+      intro ys h
+      cases ys with
+      | nil =>
+          have hxs : ∀ n, (c :: cs).getD n 0 = 0 := fun n => by simpa using h n
+          exact translateAux_eq_zero_of_all_zero s (c :: cs) hxs
+      | cons b bs =>
+          have hc : c = b := by simpa using h 0
+          have hcs : ∀ n, cs.getD n 0 = bs.getD n 0 := fun n => by
+            simpa using h (n + 1)
+          simp only [translateAux]
+          rw [ih bs hcs, hc]
+
+/-! ## The `X`-quotient decomposition -/
+
+/-- Drop the constant coefficient and shift down one degree; the structural
+recursion handle for `ZPoly` inductions (`f = C f₀ + X · divX f`). -/
+private noncomputable def divX (f : ZPoly) : ZPoly :=
+  DensePoly.ofList (f.toList.drop 1)
+
+private theorem coeff_divX (f : ZPoly) (n : Nat) :
+    (divX f).coeff n = f.coeff (n + 1) := by
+  unfold divX
+  rw [DensePoly.coeff_ofList, List.getD_eq_getElem?_getD, List.getElem?_drop,
+    ← List.getD_eq_getElem?_getD, Nat.add_comm 1 n]
+  exact DensePoly.toList_getD_eq_coeff f (n + 1)
+
+private theorem size_divX (f : ZPoly) : (divX f).size = f.size - 1 := by
+  have hle : (divX f).size ≤ f.size - 1 := by
+    have h := DensePoly.size_ofList_le (f.toList.drop 1)
+    have hlen : (f.toList.drop 1).length = f.size - 1 := by
+      rw [List.length_drop, DensePoly.length_toList]
+    unfold divX
+    omega
+  rcases Nat.lt_or_ge f.size 2 with hsmall | hbig
+  · omega
+  · have hne : (divX f).coeff (f.size - 2) ≠ 0 := by
+      rw [coeff_divX]
+      have harith : f.size - 2 + 1 = f.size - 1 := by omega
+      rw [harith]
+      exact DensePoly.coeff_last_ne_zero_of_pos_size f (by omega)
+    have hgt : f.size - 2 < (divX f).size := by
+      rcases Nat.lt_or_ge (f.size - 2) (divX f).size with h | h
+      · exact h
+      · exact absurd (DensePoly.coeff_eq_zero_of_size_le (divX f) h) hne
+    omega
+
+/-- The `X`-quotient decomposition `f = C f₀ + X · divX f`. -/
+private theorem eq_C_add_X_mul_divX (f : ZPoly) :
+    f = DensePoly.C (f.coeff 0) + X * divX f := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [DensePoly.coeff_add _ _ n (by decide)]
+  show f.coeff n = _ + (DensePoly.monomial 1 1 * divX f).coeff n
+  rw [DensePoly.monomial_one_mul_poly_eq_shift, DensePoly.coeff_shift,
+    DensePoly.coeff_C]
+  match n with
+  | 0 =>
+      rw [if_pos rfl, if_pos (by omega)]
+      show f.coeff 0 = f.coeff 0 + 0
+      omega
+  | n + 1 =>
+      rw [if_neg (by omega), if_neg (by omega), coeff_divX]
+      have harith : n + 1 - 1 = n := by omega
+      rw [harith]
+      show f.coeff (n + 1) = 0 + f.coeff (n + 1)
+      omega
+
+/-- The Horner unfolding of `translate` through the `X`-quotient:
+`translate s f = translate s (divX f) · (X + C s) + C f₀`. -/
+private theorem translate_divX_unfold (s : Int) (f : ZPoly) :
+    translate s f =
+      translate s (divX f) * (X + DensePoly.C s) + DensePoly.C (f.coeff 0) := by
+  rw [translate_eq_aux s f, translate_eq_aux s (divX f)]
+  cases htl : f.toList with
+  | nil =>
+      have hsize : f.size = 0 := by
+        have hlen := DensePoly.length_toList f
+        rw [htl] at hlen
+        simpa using hlen.symm
+      have hcoeff : f.coeff 0 = 0 :=
+        DensePoly.coeff_eq_zero_of_size_le f (by omega)
+      have hdivX : (divX f).toList = [] := by
+        have hdsize : (divX f).size = 0 := by rw [size_divX]; omega
+        have hlen : (divX f).toList.length = 0 := by
+          rw [DensePoly.length_toList]; omega
+        exact List.eq_nil_of_length_eq_zero hlen
+      rw [hdivX, hcoeff, C_zero]
+      show (0 : ZPoly) = 0 * (X + DensePoly.C s) + 0
+      rw [DensePoly.zero_mul, DensePoly.add_zero_poly]
+  | cons c cs =>
+      have hc : c = f.coeff 0 := by
+        have h := DensePoly.toList_getD_eq_coeff f 0
+        rw [htl] at h
+        simpa using h
+      have hcs : translateAux s (divX f).toList = translateAux s cs := by
+        apply translateAux_congr
+        intro n
+        have h1 := DensePoly.toList_getD_eq_coeff (divX f) n
+        rw [coeff_divX] at h1
+        have h2 := DensePoly.toList_getD_eq_coeff f (n + 1)
+        rw [htl, List.getD_cons_succ] at h2
+        exact h1.trans h2.symm
+      rw [hcs]
+      simp only [translateAux]
+      rw [hc]
+
+@[simp] theorem translate_C (s c : Int) :
+    translate s (DensePoly.C c) = DensePoly.C c := by
+  rw [translate_divX_unfold]
+  have hdivX : divX (DensePoly.C c) = 0 := by
+    apply DensePoly.ext_coeff
+    intro n
+    rw [coeff_divX, DensePoly.coeff_C, if_neg (by omega), DensePoly.coeff_zero]
+    rfl
+  have hcoeff : (DensePoly.C c : ZPoly).coeff 0 = c := by
+    rw [DensePoly.coeff_C, if_pos rfl]
+  rw [hdivX, translate_zero, DensePoly.zero_mul, hcoeff,
+    DensePoly.add_comm_poly, DensePoly.add_zero_poly]
+
+@[simp] theorem translate_one (s : Int) : translate s (1 : ZPoly) = 1 :=
+  translate_C s 1
+
+theorem translate_X (s : Int) : translate s X = X + DensePoly.C s := by
+  rw [translate_divX_unfold]
+  have hdivX : divX X = 1 := by
+    apply DensePoly.ext_coeff
+    intro n
+    rw [coeff_divX]
+    show (DensePoly.monomial 1 1 : ZPoly).coeff (n + 1) =
+      (DensePoly.C 1 : ZPoly).coeff n
+    rw [DensePoly.coeff_monomial, DensePoly.coeff_C]
+    by_cases hn : n = 0
+    · simp [hn]
+    · rw [if_neg (by omega), if_neg hn]
+  have hcoeff : (X : ZPoly).coeff 0 = 0 := by
+    show (DensePoly.monomial 1 1 : ZPoly).coeff 0 = 0
+    rw [DensePoly.coeff_monomial, if_neg (by omega)]
+    rfl
+  rw [hdivX, translate_one, hcoeff, C_zero, DensePoly.add_zero_poly,
+    DensePoly.mul_comm_poly, DensePoly.mul_one_right_poly]
+
+/-! ## `translate` is a ring homomorphism -/
+
+private theorem divX_add (p q : ZPoly) : divX (p + q) = divX p + divX q := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [DensePoly.coeff_add _ _ n (by decide), coeff_divX, coeff_divX, coeff_divX,
+    DensePoly.coeff_add _ _ (n + 1) (by decide)]
+
+private theorem translate_add_bounded (s : Int) :
+    ∀ (n : Nat) (p q : ZPoly), p.size + q.size ≤ n →
+      translate s (p + q) = translate s p + translate s q := by
+  intro n
+  induction n with
+  | zero =>
+      intro p q hbound
+      have hp : p = 0 := eq_zero_of_size_eq_zero (by omega)
+      have hq : q = 0 := eq_zero_of_size_eq_zero (by omega)
+      subst hp; subst hq
+      rw [DensePoly.add_zero_poly, translate_zero, DensePoly.add_zero_poly]
+  | succ n ih =>
+      intro p q hbound
+      by_cases hp0 : p.size = 0
+      · have hp : p = 0 := eq_zero_of_size_eq_zero hp0
+        subst hp
+        rw [DensePoly.add_comm_poly (0 : ZPoly) q, DensePoly.add_zero_poly,
+          translate_zero, DensePoly.add_comm_poly (0 : ZPoly) (translate s q),
+          DensePoly.add_zero_poly]
+      by_cases hq0 : q.size = 0
+      · have hq : q = 0 := eq_zero_of_size_eq_zero hq0
+        subst hq
+        rw [DensePoly.add_zero_poly, translate_zero, DensePoly.add_zero_poly]
+      -- Both sizes positive: recurse through the `X`-quotient.
+      have hcoeff0 : (p + q).coeff 0 = p.coeff 0 + q.coeff 0 :=
+        DensePoly.coeff_add p q 0 (by decide)
+      rw [translate_divX_unfold s (p + q), divX_add, hcoeff0,
+        ih (divX p) (divX q) (by rw [size_divX, size_divX]; omega),
+        translate_divX_unfold s p, translate_divX_unfold s q,
+        DensePoly.mul_add_left_poly, C_add]
+      -- (A + B) + (Ca + Cb) = (A + Ca) + (B + Cb)
+      rw [DensePoly.add_assoc_poly
+          (translate s (divX p) * (X + DensePoly.C s))
+          (translate s (divX q) * (X + DensePoly.C s)) _,
+        ← DensePoly.add_assoc_poly
+          (translate s (divX q) * (X + DensePoly.C s))
+          (DensePoly.C (p.coeff 0)) (DensePoly.C (q.coeff 0)),
+        DensePoly.add_comm_poly
+          (translate s (divX q) * (X + DensePoly.C s))
+          (DensePoly.C (p.coeff 0)),
+        DensePoly.add_assoc_poly (DensePoly.C (p.coeff 0))
+          (translate s (divX q) * (X + DensePoly.C s))
+          (DensePoly.C (q.coeff 0)),
+        ← DensePoly.add_assoc_poly
+          (translate s (divX p) * (X + DensePoly.C s))
+          (DensePoly.C (p.coeff 0)) _]
+
+/-- `translate` is additive. -/
+theorem translate_add (s : Int) (p q : ZPoly) :
+    translate s (p + q) = translate s p + translate s q :=
+  translate_add_bounded s (p.size + q.size) p q (Nat.le_refl _)
+
+private theorem divX_C_mul (c : Int) (b : ZPoly) :
+    divX (DensePoly.C c * b) = DensePoly.C c * divX b := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [coeff_divX, C_mul_eq_scale, C_mul_eq_scale,
+    DensePoly.coeff_scale (R := Int) c b (n + 1) (Int.mul_zero c),
+    DensePoly.coeff_scale (R := Int) c (divX b) n (Int.mul_zero c), coeff_divX]
+
+private theorem coeff0_C_mul (c : Int) (b : ZPoly) :
+    (DensePoly.C c * b).coeff 0 = c * b.coeff 0 := by
+  rw [C_mul_eq_scale, DensePoly.coeff_scale (R := Int) c b 0 (Int.mul_zero c)]
+
+private theorem translate_C_mul_bounded (s c : Int) :
+    ∀ (n : Nat) (b : ZPoly), b.size ≤ n →
+      translate s (DensePoly.C c * b) = DensePoly.C c * translate s b := by
+  intro n
+  induction n with
+  | zero =>
+      intro b hbound
+      have hb : b = 0 := eq_zero_of_size_eq_zero (by omega)
+      subst hb
+      have hz : DensePoly.C c * (0 : ZPoly) = 0 := by
+        rw [DensePoly.mul_comm_poly, DensePoly.zero_mul]
+      rw [translate_zero, hz, translate_zero]
+  | succ n ih =>
+      intro b hbound
+      by_cases hb0 : b.size = 0
+      · have hb : b = 0 := eq_zero_of_size_eq_zero hb0
+        subst hb
+        have hz : DensePoly.C c * (0 : ZPoly) = 0 := by
+          rw [DensePoly.mul_comm_poly, DensePoly.zero_mul]
+        rw [translate_zero, hz, translate_zero]
+      rw [translate_divX_unfold s (DensePoly.C c * b), divX_C_mul, coeff0_C_mul,
+        ih (divX b) (by rw [size_divX]; omega), C_mul,
+        DensePoly.mul_assoc_poly (S := Int) (DensePoly.C c) (translate s (divX b))
+          (X + DensePoly.C s),
+        ← DensePoly.mul_add_right_poly, ← translate_divX_unfold]
+
+private theorem divX_X_mul (p : ZPoly) : divX (X * p) = p := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [coeff_divX]
+  show (DensePoly.monomial 1 1 * p).coeff (n + 1) = p.coeff n
+  rw [DensePoly.monomial_one_mul_poly_eq_shift, DensePoly.coeff_shift,
+    if_neg (by omega)]
+  have harith : n + 1 - 1 = n := by omega
+  rw [harith]
+
+private theorem coeff0_X_mul (p : ZPoly) : (X * p).coeff 0 = 0 := by
+  show (DensePoly.monomial 1 1 * p).coeff 0 = 0
+  rw [DensePoly.monomial_one_mul_poly_eq_shift, DensePoly.coeff_shift,
+    if_pos (by omega)]
+  rfl
+
+private theorem translate_X_mul (s : Int) (p : ZPoly) :
+    translate s (X * p) = (X + DensePoly.C s) * translate s p := by
+  rw [translate_divX_unfold s (X * p), divX_X_mul, coeff0_X_mul, C_zero,
+    DensePoly.add_zero_poly, DensePoly.mul_comm_poly]
+
+private theorem translate_mul_bounded (s : Int) :
+    ∀ (n : Nat) (a b : ZPoly), a.size ≤ n →
+      translate s (a * b) = translate s a * translate s b := by
+  intro n
+  induction n with
+  | zero =>
+      intro a b hbound
+      have ha : a = 0 := eq_zero_of_size_eq_zero (by omega)
+      subst ha
+      rw [DensePoly.zero_mul, translate_zero, DensePoly.zero_mul]
+  | succ n ih =>
+      intro a b hbound
+      by_cases ha0 : a.size = 0
+      · have ha : a = 0 := eq_zero_of_size_eq_zero ha0
+        subst ha
+        rw [DensePoly.zero_mul, translate_zero, DensePoly.zero_mul]
+      -- Split `a * b` along the `X`-quotient decomposition of `a`.
+      have h1 : a * b =
+          DensePoly.C (a.coeff 0) * b + X * (divX a * b) := by
+        have h0 : a * b = (DensePoly.C (a.coeff 0) + X * divX a) * b := by
+          rw [← eq_C_add_X_mul_divX a]
+        rw [h0, DensePoly.mul_add_left_poly,
+          DensePoly.mul_assoc_poly (S := Int) X (divX a) b]
+      rw [h1, translate_add,
+        translate_C_mul_bounded s (a.coeff 0) b.size b (Nat.le_refl _),
+        translate_X_mul,
+        ih (divX a) b (by rw [size_divX]; omega)]
+      -- Reassemble: C a₀ · Tb + u · (Ta' · Tb) = (Ta' · u + C a₀) · Tb.
+      have hswap : (X + DensePoly.C s) * (translate s (divX a) * translate s b)
+          = translate s (divX a) * (X + DensePoly.C s) * translate s b := by
+        rw [DensePoly.mul_assoc_poly (S := Int) (translate s (divX a))
+            (X + DensePoly.C s) (translate s b),
+          DensePoly.mul_comm_poly (X + DensePoly.C s) (translate s b),
+          ← DensePoly.mul_assoc_poly (S := Int) (translate s (divX a))
+            (translate s b) (X + DensePoly.C s),
+          DensePoly.mul_comm_poly (X + DensePoly.C s)
+            (translate s (divX a) * translate s b)]
+      rw [translate_divX_unfold s a,
+        DensePoly.mul_add_left_poly (translate s (divX a) * (X + DensePoly.C s))
+          (DensePoly.C (a.coeff 0)) (translate s b),
+        DensePoly.add_comm_poly
+          (translate s (divX a) * (X + DensePoly.C s) * translate s b)
+          (DensePoly.C (a.coeff 0) * translate s b),
+        hswap]
+
+/-- `translate` is multiplicative. -/
+theorem translate_mul (s : Int) (a b : ZPoly) :
+    translate s (a * b) = translate s a * translate s b :=
+  translate_mul_bounded s a.size a b (Nat.le_refl _)
+
+/-! ## The inverse shift -/
+
+private theorem translate_neg_translate_bounded (s : Int) :
+    ∀ (n : Nat) (f : ZPoly), f.size ≤ n →
+      translate (-s) (translate s f) = f := by
+  intro n
+  induction n with
+  | zero =>
+      intro f hbound
+      have hf : f = 0 := eq_zero_of_size_eq_zero (by omega)
+      subst hf
+      rw [translate_zero, translate_zero]
+  | succ n ih =>
+      intro f hbound
+      by_cases hf0 : f.size = 0
+      · have hf : f = 0 := eq_zero_of_size_eq_zero hf0
+        subst hf
+        rw [translate_zero, translate_zero]
+      have hshift : translate (-s) (X + DensePoly.C s) = X := by
+        rw [translate_add, translate_X, translate_C,
+          DensePoly.add_assoc_poly, ← C_add]
+        have harith : -s + s = 0 := by omega
+        rw [harith, C_zero, DensePoly.add_zero_poly]
+      rw [translate_divX_unfold s f, translate_add, translate_mul, translate_C,
+        hshift, ih (divX f) (by rw [size_divX]; omega),
+        DensePoly.mul_comm_poly (divX f) X,
+        DensePoly.add_comm_poly (X * divX f) (DensePoly.C (f.coeff 0)),
+        ← eq_C_add_X_mul_divX f]
+
+/-- Shifting by `s` then by `-s` is the identity: `f(X + s)(X - s) = f`. -/
+theorem translate_neg_translate (s : Int) (f : ZPoly) :
+    translate (-s) (translate s f) = f :=
+  translate_neg_translate_bounded s f.size f (Nat.le_refl _)
+
+/-! ## Size preservation and unit reflection -/
+
+/-- Addition cannot escape a common size bound. -/
+private theorem size_add_le_of_le {p q : ZPoly} {k : Nat}
+    (hp : p.size ≤ k) (hq : q.size ≤ k) : (p + q).size ≤ k := by
+  rcases Nat.eq_zero_or_pos (p + q).size with h0 | hpos
+  · omega
+  rcases Nat.lt_or_ge k (p + q).size with hgt | hle
+  · exfalso
+    have hlast := DensePoly.coeff_last_ne_zero_of_pos_size (p + q) hpos
+    apply hlast
+    rw [DensePoly.coeff_add p q _ (by decide),
+      DensePoly.coeff_eq_zero_of_size_le p (by omega),
+      DensePoly.coeff_eq_zero_of_size_le q (by omega)]
+    decide
+  · exact hle
+
+/-- The shift target `X + C s` has size exactly `2`. -/
+private theorem size_X_add_C (s : Int) : (X + DensePoly.C s : ZPoly).size = 2 := by
+  have hle : (X + DensePoly.C s : ZPoly).size ≤ 2 := by
+    apply size_add_le_of_le
+    · show (DensePoly.monomial 1 1 : ZPoly).size ≤ 2
+      rw [DensePoly.size_monomial_of_ne_zero (by decide)]
+      omega
+    · exact Nat.le_trans (DensePoly.size_C_le_one s) (by omega)
+  have hcoeff : (X + DensePoly.C s : ZPoly).coeff 1 ≠ 0 := by
+    rw [DensePoly.coeff_add _ _ 1 (by decide)]
+    show (DensePoly.monomial 1 1 : ZPoly).coeff 1 + (DensePoly.C s).coeff 1 ≠ 0
+    rw [DensePoly.coeff_monomial, if_pos rfl, DensePoly.coeff_C,
+      if_neg (by omega)]
+    decide
+  have hgt : 1 < (X + DensePoly.C s : ZPoly).size := by
+    rcases Nat.lt_or_ge 1 (X + DensePoly.C s : ZPoly).size with h | h
+    · exact h
+    · exact absurd (DensePoly.coeff_eq_zero_of_size_le _ h) hcoeff
+  omega
+
+private theorem size_translate_le_bounded (s : Int) :
+    ∀ (n : Nat) (f : ZPoly), f.size ≤ n → (translate s f).size ≤ f.size := by
+  intro n
+  induction n with
+  | zero =>
+      intro f hbound
+      have hf : f = 0 := eq_zero_of_size_eq_zero (by omega)
+      subst hf
+      rw [translate_zero]
+      exact Nat.le_refl _
+  | succ n ih =>
+      intro f hbound
+      by_cases hf0 : f.size = 0
+      · have hf : f = 0 := eq_zero_of_size_eq_zero hf0
+        subst hf
+        rw [translate_zero]
+        exact Nat.le_refl _
+      rw [translate_divX_unfold s f]
+      apply size_add_le_of_le
+      · by_cases hzero : translate s (divX f) = 0
+        · rw [hzero, DensePoly.zero_mul, DensePoly.size_zero]
+          omega
+        · have hsize := ZPoly.mul_size_eq_top_succ_of_nonzero
+            (translate s (divX f)) (X + DensePoly.C s)
+            (ZPoly.size_pos_of_ne_zero _ hzero) (by rw [size_X_add_C]; omega)
+          have hbound' := ih (divX f) (by rw [size_divX]; omega)
+          rw [size_X_add_C] at hsize
+          rw [size_divX] at hbound'
+          omega
+      · exact Nat.le_trans (DensePoly.size_C_le_one (f.coeff 0)) (by omega)
+
+/-- The Taylor shift preserves the dense size (hence the degree). -/
+theorem size_translate (s : Int) (f : ZPoly) :
+    (translate s f).size = f.size := by
+  have hle : (translate s f).size ≤ f.size :=
+    size_translate_le_bounded s f.size f (Nat.le_refl _)
+  have hge : f.size ≤ (translate s f).size := by
+    have h := size_translate_le_bounded (-s) (translate s f).size
+      (translate s f) (Nat.le_refl _)
+    rw [translate_neg_translate] at h
+    exact h
+  omega
+
+/-- The Taylor shift preserves units (`C 1` and `C (-1)` are fixed points in
+both directions). -/
+theorem isUnit_translate_iff (s : Int) (f : ZPoly) :
+    ZPoly.IsUnit (translate s f) ↔ ZPoly.IsUnit f := by
+  constructor
+  · rintro (h | h)
+    · left
+      have := congrArg (translate (-s)) h
+      rw [translate_neg_translate, translate_C] at this
+      exact this
+    · right
+      have := congrArg (translate (-s)) h
+      rw [translate_neg_translate, translate_C] at this
+      exact this
+  · rintro (h | h)
+    · left; rw [h, translate_C]
+    · right; rw [h, translate_C]
+
+/-- Irreducibility transfers backwards through the Taylor shift: any
+factorization of `f` shifts to a factorization of `translate s f`, whose unit
+factor reflects back through the inverse shift. -/
+theorem irreducible_of_translate_irreducible (s : Int) (f : ZPoly)
+    (h : ZPoly.Irreducible (translate s f)) : ZPoly.Irreducible f := by
+  refine
+    { not_zero := ?_
+      not_unit := ?_
+      no_factors := ?_ }
+  · intro h0
+    apply h.not_zero
+    rw [h0, translate_zero]
+  · intro hu
+    exact h.not_unit ((isUnit_translate_iff s f).mpr hu)
+  · intro a b hab
+    have hshift : translate s f = translate s a * translate s b := by
+      rw [hab, translate_mul]
+    rcases h.no_factors _ _ hshift with ha | hb
+    · exact Or.inl ((isUnit_translate_iff s a).mp ha)
+    · exact Or.inr ((isUnit_translate_iff s b).mp hb)
+
+/-! ## Eisenstein's criterion -/
+
+private theorem int_dvd_add {d x y : Int} (hx : d ∣ x) (hy : d ∣ y) :
+    d ∣ x + y := by
+  rcases hx with ⟨u, hu⟩
+  rcases hy with ⟨v, hv⟩
+  exact ⟨u + v, by rw [hu, hv, Int.mul_add]⟩
+
+private theorem int_dvd_mul_right {d x : Int} (h : d ∣ x) (y : Int) :
+    d ∣ x * y := by
+  rcases h with ⟨u, hu⟩
+  exact ⟨u * y, by rw [hu, Int.mul_assoc]⟩
+
+/-- Euclid's lemma over `Int` for the elementary prime predicate, routed
+through `natAbs` and the `Nat`-level `Hex.Nat.Prime.dvd_mul`. -/
+private theorem prime_int_dvd_mul {q : Nat} (hq : Hex.Nat.Prime q) {x y : Int}
+    (h : (q : Int) ∣ x * y) : (q : Int) ∣ x ∨ (q : Int) ∣ y := by
+  have hnat : q ∣ (x * y).natAbs := by
+    have habs := Int.natAbs_dvd_natAbs.mpr h
+    rwa [Int.natAbs_natCast] at habs
+  rw [Int.natAbs_mul] at hnat
+  rcases (Hex.Nat.Prime.dvd_mul hq).mp hnat with h1 | h1
+  · left
+    apply Int.natAbs_dvd_natAbs.mp
+    rwa [Int.natAbs_natCast]
+  · right
+    apply Int.natAbs_dvd_natAbs.mp
+    rwa [Int.natAbs_natCast]
+
+/-- Among indices carrying a coefficient not divisible by `d`, there is a
+first one. -/
+private theorem exists_first_not_dvd (d : Int) (g : Nat → Int) :
+    ∀ n, (∃ m, m ≤ n ∧ ¬ d ∣ g m) →
+      ∃ k, k ≤ n ∧ ¬ d ∣ g k ∧ ∀ i, i < k → d ∣ g i := by
+  intro n
+  induction n with
+  | zero =>
+      rintro ⟨m, hm, hmd⟩
+      have hm0 : m = 0 := by omega
+      subst hm0
+      exact ⟨0, Nat.le_refl 0, hmd, fun i hi => absurd hi (by omega)⟩
+  | succ n ih =>
+      rintro ⟨m, hm, hmd⟩
+      by_cases hex : ∃ m', m' ≤ n ∧ ¬ d ∣ g m'
+      · rcases ih hex with ⟨k, hk, hkd, hkmin⟩
+        exact ⟨k, by omega, hkd, hkmin⟩
+      · have hm_eq : m = n + 1 := by
+          rcases Nat.lt_or_ge m (n + 1) with hlt | hge
+          · exact absurd ⟨m, by omega, hmd⟩ hex
+          · omega
+        subst hm_eq
+        refine ⟨n + 1, Nat.le_refl _, hmd, fun i hi => ?_⟩
+        exact Classical.byContradiction fun hnd => hex ⟨i, by omega, hnd⟩
+
+/-- A fold of integer terms that vanish beyond index `0` collapses to the
+first term. -/
+private theorem foldl_add_int_eq_first (g : Nat → Int) :
+    ∀ m, 0 < m → (∀ i, 0 < i → g i = 0) →
+      (List.range m).foldl (fun acc i => acc + g i) 0 = g 0 := by
+  intro m
+  induction m with
+  | zero => omega
+  | succ m ih =>
+      intro _ hz
+      rw [List.range_succ, List.foldl_append]
+      simp only [List.foldl_cons, List.foldl_nil]
+      rcases Nat.eq_zero_or_pos m with h0 | hpos
+      · subst h0
+        simp
+      · rw [ih hpos hz, hz m hpos]
+        omega
+
+/-- A fold of integer terms each divisible by `d` is divisible by `d`. -/
+private theorem foldl_add_int_dvd (d : Int) (g : Nat → Int) :
+    ∀ m, (∀ i, i < m → d ∣ g i) →
+      d ∣ (List.range m).foldl (fun acc i => acc + g i) 0 := by
+  intro m
+  induction m with
+  | zero =>
+      intro _
+      exact ⟨0, by rw [Int.mul_zero]; rfl⟩
+  | succ m ih =>
+      intro h
+      rw [List.range_succ, List.foldl_append]
+      simp only [List.foldl_cons, List.foldl_nil]
+      exact int_dvd_add (ih fun i hi => h i (by omega)) (h m (by omega))
+
+/-- Congruence collapse of a diagonal fold: when every term except the one at
+index `k` is divisible by `d`, the fold is congruent to that term mod `d`. -/
+private theorem foldl_add_int_dvd_sub (d : Int) (g : Nat → Int) :
+    ∀ m, ∀ k, k < m → (∀ i, i < m → i ≠ k → d ∣ g i) →
+      d ∣ (List.range m).foldl (fun acc i => acc + g i) 0 - g k := by
+  intro m
+  induction m with
+  | zero => omega
+  | succ m ih =>
+      intro k hk hdvd
+      rw [List.range_succ, List.foldl_append]
+      simp only [List.foldl_cons, List.foldl_nil]
+      by_cases hkm : k = m
+      · subst hkm
+        have hSm : d ∣ (List.range k).foldl (fun acc i => acc + g i) 0 :=
+          foldl_add_int_dvd d g k fun i hi => hdvd i (by omega) (by omega)
+        have harith :
+            (List.range k).foldl (fun acc i => acc + g i) 0 + g k - g k =
+              (List.range k).foldl (fun acc i => acc + g i) 0 := by omega
+        rw [harith]
+        exact hSm
+      · have h1 := ih k (by omega) fun i hi hne => hdvd i (by omega) hne
+        have h2 : d ∣ g m := hdvd m (by omega) fun he => hkm he.symm
+        rcases h1 with ⟨u, hu⟩
+        rcases h2 with ⟨v, hv⟩
+        refine ⟨u + v, ?_⟩
+        rw [Int.mul_add, ← hu, ← hv]
+        omega
+
+/-- The constant term of a product is the product of constant terms. -/
+private theorem coeff_mul_zero_int (p q : ZPoly) :
+    (p * q).coeff 0 = p.coeff 0 * q.coeff 0 := by
+  rw [DensePoly.coeff_mul, DensePoly.mulCoeffSum_eq_diagonal]
+  rcases Nat.eq_zero_or_pos p.size with h0 | hpos
+  · rw [h0, DensePoly.coeff_eq_zero_of_size_le p (by omega)]
+    show (0 : Int) = 0 * q.coeff 0
+    rw [Int.zero_mul]
+  · have hterm : ∀ i, 0 < i → DensePoly.diagonalMulCoeffTerm p q 0 i = 0 := by
+      intro i hi
+      unfold DensePoly.diagonalMulCoeffTerm
+      rw [if_pos hi]
+    rw [foldl_add_int_eq_first _ p.size hpos hterm]
+    unfold DensePoly.diagonalMulCoeffTerm
+    rw [if_neg (by omega)]
+
+/-- Below the leading coefficient, the product coefficient at the first
+`d`-unbroken index of `p` is congruent to `p_k · q₀` mod `d`. -/
+private theorem coeff_mul_congr_first (p q : ZPoly) (k : Nat) (d : Int)
+    (hk : k < p.size) (hmin : ∀ i, i < k → d ∣ p.coeff i) :
+    d ∣ (p * q).coeff k - p.coeff k * q.coeff 0 := by
+  rw [DensePoly.coeff_mul, DensePoly.mulCoeffSum_eq_diagonal]
+  have hgk : DensePoly.diagonalMulCoeffTerm p q k k = p.coeff k * q.coeff 0 := by
+    unfold DensePoly.diagonalMulCoeffTerm
+    rw [if_neg (by omega), Nat.sub_self]
+  rw [← hgk]
+  apply foldl_add_int_dvd_sub d _ p.size k hk
+  intro i hi hne
+  unfold DensePoly.diagonalMulCoeffTerm
+  by_cases hik : k < i
+  · rw [if_pos hik]
+    exact ⟨0, by rw [Int.mul_zero]⟩
+  · rw [if_neg hik]
+    exact int_dvd_mul_right (hmin i (by omega)) _
+
+/-- A constant integer factor of a primitive polynomial is a unit: it divides
+the content, which is `1`. -/
+private theorem isUnit_C_of_const_factor_of_primitive
+    (g h : ZPoly) (c : Int) (hg_eq : g = DensePoly.C c * h) (hc_ne : c ≠ 0)
+    (hcontent_one : ZPoly.content g = 1) :
+    ZPoly.IsUnit (DensePoly.C c) := by
+  have hc_dvd_content : ((c.natAbs : Int) : Int) ∣ ZPoly.content g := by
+    apply ZPoly.dvd_content_of_nat_dvd_coeff
+    intro n
+    have hcoeff : g.coeff n = c * h.coeff n := by
+      rw [hg_eq, ZPoly.C_mul_eq_scale,
+        DensePoly.coeff_scale (R := Int) c h n (Int.mul_zero _)]
+    refine Int.natAbs_dvd.mpr ?_
+    rw [hcoeff]
+    exact ⟨h.coeff n, rfl⟩
+  rw [hcontent_one] at hc_dvd_content
+  have hnat_dvd : c.natAbs ∣ (1 : Nat) :=
+    Int.ofNat_dvd.mp (show (c.natAbs : Int) ∣ ((1 : Nat) : Int) from hc_dvd_content)
+  have hnat_le : c.natAbs ≤ 1 := Nat.le_of_dvd (by omega) hnat_dvd
+  have hnat_pos : 1 ≤ c.natAbs := by
+    rcases Nat.eq_zero_or_pos c.natAbs with hzero | hpos
+    · exact absurd (Int.natAbs_eq_zero.mp hzero) hc_ne
+    · exact hpos
+  have hnat_eq : c.natAbs = 1 := by omega
+  rcases Int.natAbs_eq c with heq | heq
+  · left
+    rw [heq, hnat_eq]
+    rfl
+  · right
+    rw [heq, hnat_eq]
+    rfl
+
+/-- The one-sided Eisenstein contradiction: if `g = a·b` with `q ∤ b₀`, `b`
+non-constant, and the Eisenstein coefficient conditions hold on `g`, we reach
+`False` at the first index of `a` whose coefficient escapes `q` (that index
+exists because `q` misses the leading coefficient, and it is positive because
+`q ∣ g₀ = a₀·b₀` forces `q ∣ a₀`). -/
+private theorem eisenstein_aux
+    (g a b : ZPoly) (q : Nat) (hq : Hex.Nat.Prime q)
+    (hg : g = a * b)
+    (ha_pos : 0 < a.size) (hb2 : 2 ≤ b.size)
+    (hlead : ¬ (q : Int) ∣ g.coeff (g.size - 1))
+    (hlow : ∀ i, i < g.size - 1 → (q : Int) ∣ g.coeff i)
+    (hb0 : ¬ (q : Int) ∣ b.coeff 0) :
+    False := by
+  have hb_pos : 0 < b.size := by omega
+  have hsize : g.size = a.size + b.size - 1 := by
+    rw [hg]
+    exact ZPoly.mul_size_eq_top_succ_of_nonzero a b ha_pos hb_pos
+  -- The leading coefficient of `a` escapes `q`.
+  have htop : g.coeff (g.size - 1) =
+      a.coeff (a.size - 1) * b.coeff (b.size - 1) := by
+    have h := DensePoly.coeff_mul_top_int a b ha_pos hb_pos
+    have harith : g.size - 1 = a.size - 1 + (b.size - 1) := by omega
+    rw [harith, hg]
+    exact h
+  have hlead_a : ¬ (q : Int) ∣ a.coeff (a.size - 1) := by
+    intro h
+    apply hlead
+    rw [htop]
+    exact int_dvd_mul_right h _
+  -- Take the first index of `a` whose coefficient escapes `q`.
+  rcases exists_first_not_dvd (q : Int) (fun i => a.coeff i) (a.size - 1)
+      ⟨a.size - 1, Nat.le_refl _, hlead_a⟩ with ⟨k, hk_le, hk_not, hk_min⟩
+  have hk_lt : k < g.size - 1 := by omega
+  have hgk : (q : Int) ∣ g.coeff k := hlow k hk_lt
+  have hcong : (q : Int) ∣ g.coeff k - a.coeff k * b.coeff 0 := by
+    rw [hg]
+    exact coeff_mul_congr_first a b k _ (by omega) hk_min
+  have hprod : (q : Int) ∣ a.coeff k * b.coeff 0 := by
+    rcases hgk with ⟨u, hu⟩
+    rcases hcong with ⟨v, hv⟩
+    refine ⟨u - v, ?_⟩
+    rw [Int.mul_sub, ← hu, ← hv]
+    omega
+  rcases prime_int_dvd_mul hq hprod with h | h
+  · exact hk_not h
+  · exact hb0 h
+
+/-- **Eisenstein's criterion** for integer polynomials, Mathlib-free: a
+primitive non-constant `g` is irreducible when some prime `q` divides every
+coefficient below the leading one, does not divide the leading coefficient,
+and its square does not divide the constant term. -/
+theorem irreducible_of_eisenstein
+    (g : ZPoly) (q : Nat)
+    (hq : Hex.Nat.Prime q)
+    (hprim : ZPoly.Primitive g)
+    (hsize : 1 < g.size)
+    (hlead : ¬ (q : Int) ∣ g.coeff (g.size - 1))
+    (hlow : ∀ i, i < g.size - 1 → (q : Int) ∣ g.coeff i)
+    (hsq : ¬ ((q : Int) * (q : Int)) ∣ g.coeff 0) :
+    ZPoly.Irreducible g := by
+  have hg_ne : g ≠ 0 := by
+    intro hzero
+    rw [hzero] at hsize
+    change 1 < (0 : Nat) at hsize
+    omega
+  refine
+    { not_zero := hg_ne
+      not_unit := ?_
+      no_factors := ?_ }
+  · intro hunit
+    rcases hunit with hone | hneg
+    · rw [hone] at hsize
+      have h1 : (DensePoly.C (1 : Int)).size = 1 := rfl
+      omega
+    · rw [hneg] at hsize
+      have hneg_size : (DensePoly.C (-1 : Int)).size = 1 := rfl
+      omega
+  · intro a b hab
+    have ha_ne : a ≠ 0 := by
+      intro h
+      apply hg_ne
+      rw [hab, h, DensePoly.zero_mul]
+    have hb_ne : b ≠ 0 := by
+      intro h
+      apply hg_ne
+      rw [hab, h, DensePoly.mul_comm_poly, DensePoly.zero_mul]
+    have ha_pos : 0 < a.size := ZPoly.size_pos_of_ne_zero a ha_ne
+    have hb_pos : 0 < b.size := ZPoly.size_pos_of_ne_zero b hb_ne
+    -- Constant factors are units by primitivity.
+    by_cases ha1 : a.size = 1
+    · left
+      have ha_eq : a = DensePoly.C (a.coeff 0) := eq_C_of_size_eq_one a ha1
+      have hac_ne : a.coeff 0 ≠ 0 := by
+        intro h
+        apply ha_ne
+        rw [ha_eq, h]
+        rfl
+      have hg_eq : g = DensePoly.C (a.coeff 0) * b :=
+        hab.trans (congrArg (· * b) ha_eq)
+      have hunit := isUnit_C_of_const_factor_of_primitive g b (a.coeff 0)
+        hg_eq hac_ne hprim
+      rcases hunit with hone | hneg
+      · left; rw [ha_eq]; exact hone
+      · right; rw [ha_eq]; exact hneg
+    by_cases hb1 : b.size = 1
+    · right
+      have hb_eq : b = DensePoly.C (b.coeff 0) := eq_C_of_size_eq_one b hb1
+      have hbc_ne : b.coeff 0 ≠ 0 := by
+        intro h
+        apply hb_ne
+        rw [hb_eq, h]
+        rfl
+      have hg_eq : g = DensePoly.C (b.coeff 0) * a :=
+        (hab.trans (DensePoly.mul_comm_poly a b)).trans
+          (congrArg (· * a) hb_eq)
+      have hunit := isUnit_C_of_const_factor_of_primitive g a (b.coeff 0)
+        hg_eq hbc_ne hprim
+      rcases hunit with hone | hneg
+      · left; rw [hb_eq]; exact hone
+      · right; rw [hb_eq]; exact hneg
+    -- Both factors non-constant: derive the Eisenstein contradiction.
+    exfalso
+    have ha2 : 2 ≤ a.size := by omega
+    have hb2 : 2 ≤ b.size := by omega
+    have hg0 : (q : Int) ∣ g.coeff 0 := hlow 0 (by omega)
+    have hg0ab : g.coeff 0 = a.coeff 0 * b.coeff 0 := by
+      rw [hab]
+      exact coeff_mul_zero_int a b
+    rw [hg0ab] at hg0
+    rcases prime_int_dvd_mul hq hg0 with ha0 | hb0
+    · have hb0 : ¬ (q : Int) ∣ b.coeff 0 := by
+        intro hb0
+        apply hsq
+        rw [hg0ab]
+        rcases ha0 with ⟨u, hu⟩
+        rcases hb0 with ⟨v, hv⟩
+        refine ⟨u * v, ?_⟩
+        rw [hu, hv]
+        grind
+      exact eisenstein_aux g a b q hq hab ha_pos hb2 hlead hlow hb0
+    · have ha0 : ¬ (q : Int) ∣ a.coeff 0 := by
+        intro ha0
+        apply hsq
+        rw [hg0ab]
+        rcases ha0 with ⟨u, hu⟩
+        rcases hb0 with ⟨v, hv⟩
+        refine ⟨u * v, ?_⟩
+        rw [hu, hv]
+        grind
+      exact eisenstein_aux g b a q hq (hab.trans (DensePoly.mul_comm_poly a b))
+        hb_pos ha2 hlead hlow ha0
+
+/-! ## The kernel-decidable certificate form -/
+
+/-- Kernel-decidable Eisenstein-after-shift irreducibility: every hypothesis
+is a Boolean check on the literal shifted polynomial `translate shift f`,
+whose computation is itself part of the kernel check (the `translate`
+reduction closure is exposed). Primitivity is checked on the shifted
+polynomial, and the resulting irreducibility transfers back through
+`irreducible_of_translate_irreducible`. Divisibility is checked through
+`%` because the free layer carries no `Decidable ((q : Int) ∣ x)` instance. -/
+theorem irreducible_of_eisensteinCert
+    (f : ZPoly) (q : Nat) (shift : Int)
+    (hp : Hex.Nat.isPrimeTrial q = true)
+    (hcontent : decide (ZPoly.content (translate shift f) = 1) = true)
+    (hsize : decide (1 < (translate shift f).size) = true)
+    (hlead : decide ((translate shift f).coeff ((translate shift f).size - 1) %
+      (q : Int) = 0) = false)
+    (hlow : ((List.range ((translate shift f).size - 1)).all fun i =>
+      decide ((translate shift f).coeff i % (q : Int) = 0)) = true)
+    (hsq : decide ((translate shift f).coeff 0 %
+      ((q : Int) * (q : Int)) = 0) = false) :
+    ZPoly.Irreducible f := by
+  have hq : Hex.Nat.Prime q := Hex.Nat.isPrimeTrial_isPrime hp
+  apply irreducible_of_translate_irreducible shift
+  apply irreducible_of_eisenstein _ q hq
+  · exact of_decide_eq_true (p := ZPoly.content (translate shift f) = 1) hcontent
+  · exact of_decide_eq_true hsize
+  · intro hdvd
+    have hmod := Int.emod_eq_zero_of_dvd hdvd
+    rw [decide_eq_true hmod] at hlead
+    exact Bool.noConfusion hlead
+  · intro i hi
+    have hmem := List.mem_range.mpr hi
+    have hall := List.all_eq_true.mp hlow i hmem
+    exact Int.dvd_of_emod_eq_zero (of_decide_eq_true hall)
+  · intro hdvd
+    have hmod := Int.emod_eq_zero_of_dvd hdvd
+    rw [decide_eq_true hmod] at hsq
+    exact Bool.noConfusion hsq
+
+end ZPoly
+end Hex

--- a/HexBerlekampZassenhaus/FactorProvider.lean
+++ b/HexBerlekampZassenhaus/FactorProvider.lean
@@ -94,20 +94,28 @@ meta def searchModPWitness (q : Hex.ZPoly) : Option Hex.ZPoly.ModPWitness := Id.
 meta def eisensteinShifts : List Int :=
   [0, 1, -1, 2, -2, 3, -3]
 
-/-- Prime divisors of `n` up to `10^6`, by trial division. Any cofactor
-above the bound is dropped: a huge witnessing prime would also make the
-kernel-side `isPrimeTrial` replay too expensive. -/
+/-- Ceiling on Eisenstein witness primes. The emitted certificate
+kernel-replays `Hex.Nat.isPrimeTrial q`, whose `List.range q` reduction is
+recursion-depth linear in `q` and hits the default `maxRecDepth` a little
+above 150, so a larger witness prime would elaborate to a proof the kernel
+cannot check. `128` leaves margin below that boundary (the boundary replay
+`checkIrredWitness (X² − 127) (.eisenstein 127 0)` is locked by a test). -/
+meta def eisensteinPrimeCap : Nat := 128
+
+/-- Prime divisors of `n` up to `eisensteinPrimeCap`, by trial division. Any
+cofactor above the cap is dropped: its `isPrimeTrial` replay would blow the
+kernel recursion depth. -/
 meta def smallPrimeDivisors (n : Nat) : List Nat := Id.run do
   let mut n := n
   let mut acc : List Nat := []
-  for d in [2:1000001] do
+  for d in [2:eisensteinPrimeCap + 1] do
     if d * d > n then
       break
     if n % d == 0 then
       acc := acc ++ [d]
       while n % d == 0 do
         n := n / d
-  if 1 < n && n ≤ 1000000 then
+  if 1 < n && n ≤ eisensteinPrimeCap then
     acc := acc ++ [n]
   return acc
 

--- a/HexBerlekampZassenhaus/FactorProvider.lean
+++ b/HexBerlekampZassenhaus/FactorProvider.lean
@@ -28,13 +28,15 @@ integer polynomials.
 The compiled Berlekamp–Zassenhaus factorizer runs at elaboration time as
 untrusted search; per-factor irreducibility is certified through
 `Hex.ZPoly.IrredWitness` (prime constant / primitive linear / single-prime
-modular certificate), and the emitted terms carry only kernel checks on
-reified literal data. Factors that are irreducible over `ℤ` but reducible
-mod every candidate prime (balanced factors, e.g. Swinnerton-Dyer
-polynomials or `X⁴+1`) have no single-prime witness: this provider then
-*declines* with a diagnostic, so the Mathlib bridge provider (multi-prime
-degree-obstruction certificates) can take over when imported, and the final
-error explains the gap otherwise.
+modular certificate / Eisenstein-after-shift), and the emitted terms carry
+only kernel checks on reified literal data. Factors that are irreducible
+over `ℤ` but reducible mod every candidate prime (balanced factors) fall to
+the Eisenstein-after-shift search (which covers e.g. `X⁴+1` at shift `1`,
+prime `2`); when that also fails (e.g. Swinnerton-Dyer polynomials, which
+are not shift-Eisenstein), this provider *declines* with a diagnostic, so
+the Mathlib bridge provider (multi-prime degree-obstruction certificates)
+can take over when imported, and the final error explains the gap
+otherwise.
 -/
 
 namespace HexBerlekampZassenhaus.FactorTactic
@@ -88,6 +90,42 @@ meta def searchModPWitness (q : Hex.ZPoly) : Option Hex.ZPoly.ModPWitness := Id.
               | none => pure ()
   return none
 
+/-- The shifts tried by the Eisenstein-after-shift search, in order. -/
+meta def eisensteinShifts : List Int :=
+  [0, 1, -1, 2, -2, 3, -3]
+
+/-- Prime divisors of `n` up to `10^6`, by trial division. Any cofactor
+above the bound is dropped: a huge witnessing prime would also make the
+kernel-side `isPrimeTrial` replay too expensive. -/
+meta def smallPrimeDivisors (n : Nat) : List Nat := Id.run do
+  let mut n := n
+  let mut acc : List Nat := []
+  for d in [2:1000001] do
+    if d * d > n then
+      break
+    if n % d == 0 then
+      acc := acc ++ [d]
+      while n % d == 0 do
+        n := n / d
+  if 1 < n && n ≤ 1000000 then
+    acc := acc ++ [n]
+  return acc
+
+/-- Search for an Eisenstein-after-shift witness for `f`: for each candidate
+shift `s`, the candidate primes are the small prime divisors of the constant
+term of `translate s f`, and each candidate is validated by running the full
+`checkIrredWitness` Boolean check. First hit wins. -/
+meta def searchEisenstein (f : Hex.ZPoly) : Option Hex.ZPoly.IrredWitness := Id.run do
+  for shift in eisensteinShifts do
+    let g := Hex.ZPoly.translate shift f
+    let c0 := (g.coeff 0).natAbs
+    if c0 != 0 then
+      for q in smallPrimeDivisors c0 do
+        let w := Hex.ZPoly.IrredWitness.eisenstein q shift
+        if Hex.ZPoly.checkIrredWitness f w then
+          return some w
+  return none
+
 /-- Search for an irreducibility witness for `q`. -/
 meta def searchWitness (q : Hex.ZPoly) : Option Hex.ZPoly.IrredWitness := Id.run do
   if q.size = 1 then
@@ -102,7 +140,7 @@ meta def searchWitness (q : Hex.ZPoly) : Option Hex.ZPoly.IrredWitness := Id.run
     return some .linear
   match searchModPWitness q with
   | some w => return some (.modP w)
-  | none => return none
+  | none => return searchEisenstein q
 
 /-- Reify a `ModPWitness` as a constructor application over reified pieces. -/
 meta def reifyModPWitness (w : Hex.ZPoly.ModPWitness) : Expr :=
@@ -119,6 +157,9 @@ meta def reifyWitness : Hex.ZPoly.IrredWitness → Expr
   | .primeConst => mkConst ``Hex.ZPoly.IrredWitness.primeConst
   | .linear => mkConst ``Hex.ZPoly.IrredWitness.linear
   | .modP w => mkApp (mkConst ``Hex.ZPoly.IrredWitness.modP) (reifyModPWitness w)
+  | .eisenstein q shift =>
+      mkApp2 (mkConst ``Hex.ZPoly.IrredWitness.eisenstein) (mkNatLit q)
+        (toExpr shift)
 
 /-- Literal `List` expression (shared shape with the `FpPoly` elaborator). -/
 meta def listLit (ty : Expr) (xs : List Expr) : Expr :=
@@ -136,9 +177,9 @@ meta def balancedDecline (tactic : String) (q : Hex.ZPoly) : MetaM MessageData :
   return m!"{tactic}: the irreducible factor{indentExpr qE}\
       \nhas no single-prime modular witness among the candidate primes \
       (its modular factorizations are balanced, e.g. Swinnerton-Dyer \
-      polynomials or X⁴+1); the Mathlib bridge's multi-prime \
-      degree-obstruction certificates may certify it — import \
-      HexBerlekampZassenhausMathlib."
+      polynomials) and is not Eisenstein at any small shift; the Mathlib \
+      bridge's multi-prime degree-obstruction certificates may certify it \
+      — import HexBerlekampZassenhausMathlib."
 
 /-- The opaque-input contract check: the user's term must be definitionally
 transparent down to its evaluated literal. -/

--- a/HexBerlekampZassenhaus/FactorTacticTests.lean
+++ b/HexBerlekampZassenhaus/FactorTacticTests.lean
@@ -74,6 +74,14 @@ example : ZPoly.checkIrredWitness x2m2 (.eisenstein 2 0) = true := rfl
 theorem x2m2_irred : ZPoly.Irreducible x2m2 :=
   ZPoly.irreducible_of_checkIrredWitness x2m2 (.eisenstein 2 0) rfl
 
+/-- The largest admissible Eisenstein prime (`eisensteinPrimeCap = 128`, so
+prime `127`) still kernel-replays within the default `maxRecDepth`: the
+`isPrimeTrial` reduction is depth-linear in the prime, and stalls a little
+above 150, which is why the search caps its candidates. -/
+def x2m127 : ZPoly := DensePoly.ofCoeffs #[-127, 0, 1]
+
+example : ZPoly.checkIrredWitness x2m127 (.eisenstein 127 0) = true := rfl
+
 /-! ## Balanced inputs: no free-layer certificate, clean decline -/
 
 /-- A product with a Swinnerton-Dyer factor: `(x+1)·(x⁴−10x²+1)`. The

--- a/HexBerlekampZassenhaus/FactorTacticTests.lean
+++ b/HexBerlekampZassenhaus/FactorTacticTests.lean
@@ -55,19 +55,31 @@ example : True := by
   irreducibility h : linZ
   exact True.intro
 
-/-! ## Balanced inputs: no free-layer certificate, clean decline -/
+/-! ## Eisenstein-after-shift certificates -/
 
-/-- `X⁴+1`: irreducible over ℤ but reducible mod every prime — no
-single-prime witness exists, so the free layer declines (the Mathlib bridge
-provider handles it via Eisenstein-after-shift / multi-prime certificates
-when imported). -/
+/-- `X⁴+1`: irreducible over ℤ but reducible mod every prime, so there is no
+single-prime witness; the Eisenstein-after-shift search certifies it at
+shift `1`, prime `2` (`(X+1)⁴+1 = X⁴+4X³+6X²+4X+2`). -/
 def x4p1 : ZPoly := DensePoly.ofCoeffs #[1, 0, 0, 0, 1]
 
-#check_failure (irreducibility x4p1)
+theorem x4p1_irred : ZPoly.Irreducible x4p1 := irreducibility x4p1
+
+/-- `X²-2`: plain Eisenstein at prime `2`, shift `0`. The tactic itself
+certifies this via the mod-3 route, so the shift-`0` Eisenstein witness is
+exercised directly through the checker and its soundness theorem. -/
+def x2m2 : ZPoly := DensePoly.ofCoeffs #[-2, 0, 1]
+
+example : ZPoly.checkIrredWitness x2m2 (.eisenstein 2 0) = true := rfl
+
+theorem x2m2_irred : ZPoly.Irreducible x2m2 :=
+  ZPoly.irreducible_of_checkIrredWitness x2m2 (.eisenstein 2 0) rfl
+
+/-! ## Balanced inputs: no free-layer certificate, clean decline -/
 
 /-- A product with a Swinnerton-Dyer factor: `(x+1)·(x⁴−10x²+1)`. The
-factorization search succeeds but the SD factor has no free-layer witness,
-so `factor_poly` declines. -/
+factorization search succeeds but the SD factor has no free-layer witness
+(it is reducible mod every prime and not Eisenstein at any small shift), so
+`factor_poly` declines. -/
 def sdProd : ZPoly :=
   DensePoly.ofCoeffs #[1, 1] * DensePoly.ofCoeffs #[1, 0, -10, 0, 1]
 
@@ -106,5 +118,13 @@ needs a kernel replay of roughly 67108879 steps, over the supported budget (6710
 /-- info: 'HexBerlekampZassenhaus.FactorTacticTests.quad_irred' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in
 #print axioms quad_irred
+
+/-- info: 'HexBerlekampZassenhaus.FactorTacticTests.x4p1_irred' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms x4p1_irred
+
+/-- info: 'HexBerlekampZassenhaus.FactorTacticTests.x2m2_irred' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms x2m2_irred
 
 end HexBerlekampZassenhaus.FactorTacticTests

--- a/HexBerlekampZassenhaus/IrreducibleDecide.lean
+++ b/HexBerlekampZassenhaus/IrreducibleDecide.lean
@@ -7,14 +7,16 @@ Authors: Kim Morrison
 module
 
 public import HexBerlekamp.IrreducibleDecide
+public import HexBerlekampZassenhaus.EisensteinCore
 public import HexBerlekampZassenhaus.IrreducibleCore
 public import HexBerlekampZassenhaus.PrimeSelection
 
 public section
 
 /-!
-Kernel-decidable irreducibility entry point for `Hex.ZPoly` via a single-prime
-modular witness, consumed by the `irreducibility`/`factor_poly` elaborators.
+Kernel-decidable irreducibility entry points for `Hex.ZPoly` — a single-prime
+modular witness or an Eisenstein-after-shift certificate — consumed by the
+`irreducibility`/`factor_poly` elaborators.
 
 For a primitive, non-constant `f` whose leading coefficient survives reduction
 mod a prime `p`, irreducibility of `ZPoly.modP p f` transfers to `f` by the
@@ -88,7 +90,8 @@ structure ModPWitness where
   cert : Berlekamp.IrreducibilityCertificate
 
 /-- One irreducibility witness for a `ZPoly`: a prime constant, a primitive
-linear, or a single-prime modular reduction certificate. -/
+linear, a single-prime modular reduction certificate, or an
+Eisenstein-after-shift certificate. -/
 inductive IrredWitness where
   /-- The polynomial is a constant with prime absolute value. -/
   | primeConst
@@ -96,6 +99,9 @@ inductive IrredWitness where
   | linear
   /-- Single-prime route: the reduction mod `w.p` is irreducible. -/
   | modP (w : ModPWitness)
+  /-- Eisenstein route: `ZPoly.translate shift f` satisfies Eisenstein's
+  criterion at the prime `q`. -/
+  | eisenstein (q : Nat) (shift : Int)
 
 /-- Kernel-decidable check that `w` witnesses irreducibility of `f`. -/
 @[expose]
@@ -109,6 +115,14 @@ def checkIrredWitness (f : ZPoly) : IrredWitness → Bool
         !(decide (w.c = 0)) &&
         DensePoly.beqCoeffs (DensePoly.scale w.c w.m) (ZPoly.modP w.p f) &&
         Berlekamp.checkMonicCert w.m w.cert
+  | .eisenstein q shift =>
+      let g := ZPoly.translate shift f
+      Hex.Nat.isPrimeTrial q && decide (ZPoly.content g = 1) &&
+        decide (1 < g.size) &&
+        !(decide (g.coeff (g.size - 1) % (q : Int) = 0)) &&
+        ((List.range (g.size - 1)).all fun i =>
+          decide (g.coeff i % (q : Int) = 0)) &&
+        !(decide (g.coeff 0 % ((q : Int) * (q : Int)) = 0))
 
 /-- A passing `checkIrredWitness` forces irreducibility. -/
 theorem irreducible_of_checkIrredWitness
@@ -136,6 +150,13 @@ theorem irreducible_of_checkIrredWitness
         hp (decide_eq_true (of_decide_eq_true hcontent))
         (decide_eq_true (of_decide_eq_true hadm))
         (decide_eq_true (of_decide_eq_true hsize)) hc hfm hcert
+  | .eisenstein q shift =>
+      unfold checkIrredWitness at hcheck
+      simp only [Bool.and_eq_true] at hcheck
+      obtain ⟨⟨⟨⟨⟨hp, hcontent⟩, hsize⟩, hlead⟩, hlow⟩, hsq⟩ := hcheck
+      rw [Bool.not_eq_true'] at hlead hsq
+      exact irreducible_of_eisensteinCert f q shift hp hcontent hsize
+        hlead hlow hsq
 
 /-- Bulk kernel-decidable irreducibility for a `ZPoly` factor list with
 repetition: `certified` carries one `(factor, witness)` entry per *distinct*

--- a/HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md
+++ b/HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md
@@ -965,14 +965,19 @@ with repetition), and `irreducibility` handles `ZPoly` inputs and
 `ZPoly.Irreducible` goals.
 
 Per-factor irreducibility is certified by `ZPoly.IrredWitness` (prime
-constant / primitive linear / single-prime modular Rabin certificate,
-`IrreducibleDecide.lean`), bulk-checked by the kernel via
+constant / primitive linear / single-prime modular Rabin certificate /
+Eisenstein-after-shift, `IrreducibleDecide.lean`; the Eisenstein core theorem
+and the `ZPoly.translate` Taylor-shift algebra live in
+`EisensteinCore.lean`), bulk-checked by the kernel via
 `ZPoly.checkIrredCover` on reified literals — one witness check per distinct
 factor. The compiled `ZPoly.factorize` runs only at elaboration time.
 
 **Partiality**: a factor that is irreducible over ℤ but reducible mod every
-candidate prime (balanced modular factorizations: Swinnerton-Dyer
-polynomials, `X⁴+1`) has no single-prime witness; the provider then declines
-with a diagnostic, deferring to the Mathlib bridge's multi-prime
-degree-obstruction certificates. This partiality is by design; the emitted
-statements never weaken.
+candidate prime (a balanced modular factorization) has no single-prime
+witness. The Eisenstein-after-shift search (shifts `0, ±1, ±2, ±3`, prime
+candidates from the shifted constant term) covers some such inputs — e.g.
+`X⁴+1` at shift `1`, prime `2` — but not all: Swinnerton-Dyer polynomials
+are neither single-prime witnessable nor shift-Eisenstein, so the provider
+still declines on them with a diagnostic, deferring to the Mathlib bridge's
+multi-prime degree-obstruction certificates. This partiality is by design;
+the emitted statements never weaken.

--- a/HexBerlekampZassenhausMathlib/FactorPolyTests.lean
+++ b/HexBerlekampZassenhausMathlib/FactorPolyTests.lean
@@ -158,8 +158,8 @@ End-to-end tests for the `Polynomial ℤ` / strong `Hex.ZPoly` provider of
 deleted `irreducible_cert` tactic (its generator guard polynomials from
 #8552 Part 1 migrate here), the certificate reification round-trips, the
 decline→multi-prime handover on an A4 quartic the free provider cannot
-certify, and the decline diagnostics for balanced inputs outside both
-certificate languages.
+certify, the free-layer Eisenstein handover on `x⁴ + 1`, and the decline
+diagnostic for balanced inputs outside every certificate language.
 -/
 
 namespace HexBerlekampZassenhausMathlib.FactorPolyTests
@@ -325,12 +325,13 @@ example : True := by
 /-! ### The decline→multi-prime handover on `Hex.ZPoly`
 
 `x⁴ + 8x + 12` has Galois group `A₄`: no 4-cycle, so it is reducible mod
-every prime and `searchWitness` finds no single-prime witness — the free
-provider declines. Its mod-p degree splittings `{1,3}` and `{2,2}` jointly
-obstruct every proper factor degree, so `certifyIrreducible?` produces a
-multi-prime certificate and this provider certifies it. -/
+every prime and `searchWitness` finds no single-prime witness; it is not
+Eisenstein at any small shift either, so the free provider declines. Its
+mod-p degree splittings `{1,3}` and `{2,2}` jointly obstruct every proper
+factor degree, so `certifyIrreducible?` produces a multi-prime certificate
+and this provider certifies it. -/
 
-/-- `x⁴ + 8x + 12`, irreducible with Galois group `A₄`: no single-prime
+/-- `x⁴ + 8x + 12`, irreducible with Galois group `A₄`: no free-layer
 witness exists, only the multi-prime degree obstruction. -/
 def quarticA4 : Hex.ZPoly := Hex.DensePoly.ofCoeffs #[12, 8, 0, 0, 1]
 
@@ -404,11 +405,33 @@ is a unit (±1), not irreducible
 #guard_msgs in
 example := irreducibility (1 : Polynomial ℤ)
 
-/-! ### Balanced beyond both certificate languages: the decline diagnostic
+/-! ### The Eisenstein handover: `x⁴ + 1` never reaches this provider
 
 `x⁴ + 1` is reducible mod every prime *and* a degree-2 factor sum is
 available in every mod-p splitting (`{1,1,1,1}` or `{2,2}`), so neither the
-single-prime witness nor the multi-prime degree obstruction applies. -/
+single-prime witness nor the multi-prime degree obstruction applies. The
+free layer's Eisenstein-after-shift search certifies it (shift `1`,
+prime `2`) before either bridge certificate language is consulted. -/
+
+def x4p1 : Hex.ZPoly := Hex.DensePoly.ofCoeffs #[1, 0, 0, 0, 1]
+
+theorem x4p1_irred : Hex.ZPoly.Irreducible x4p1 := irreducibility x4p1
+
+/--
+info: 'HexBerlekampZassenhausMathlib.FactorPolyTests.x4p1_irred' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms x4p1_irred
+
+-- The transported `Polynomial ℤ` statement.
+example : Irreducible (X ^ 4 + 1 : Polynomial ℤ) := by irreducibility
+
+/-! ### Balanced beyond every certificate language: the decline diagnostic
+
+`x⁴ - 10x² + 1` (Swinnerton-Dyer for `√2 + √3`) is reducible mod every
+prime, not Eisenstein at any small shift, and every mod-p splitting leaves
+a degree-2 factor sum available, so the multi-prime degree obstruction
+fails as well: no kernel-checkable certificate exists in the tree. -/
 
 /--
 error: irreducibility: unsupported polynomial type
@@ -416,25 +439,27 @@ error: irreducibility: unsupported polynomial type
 Supported without further imports: Hex.FpPoly p (prime p). Importing HexBerlekampZassenhaus adds Hex.ZPoly; the Mathlib bridge libraries add Polynomial (ZMod q) and Polynomial ℤ.
 
 irreducibility: the irreducible factor
-  Hex.DensePoly.ofCoeffs #[1, 0, 0, 0, 1]
-has no single-prime modular witness among the candidate primes (its modular factorizations are balanced, e.g. Swinnerton-Dyer polynomials or X⁴+1); the Mathlib bridge's multi-prime degree-obstruction certificates may certify it — import HexBerlekampZassenhausMathlib.
+  Hex.DensePoly.ofCoeffs #[1, 0, -10, 0, 1]
+has no single-prime modular witness among the candidate primes (its modular factorizations are balanced, e.g. Swinnerton-Dyer polynomials) and is not Eisenstein at any small shift; the Mathlib bridge's multi-prime degree-obstruction certificates may certify it — import HexBerlekampZassenhausMathlib.
 
 irreducibility: the irreducible factor
-  Hex.DensePoly.ofCoeffs #[1, 0, 0, 0, 1]
-has no single-prime modular witness, and its balanced modular factorizations also fall outside the multi-prime per-prime degree-sum obstruction language (e.g. Swinnerton-Dyer polynomials or X⁴+1); no certificate-backed proof is available, but the kernel-decide fallbacks `irreducibility!` / `factor_poly!` can still certify small inputs by re-running the factorizer in the kernel
+  Hex.DensePoly.ofCoeffs #[1, 0, -10, 0, 1]
+has no single-prime modular witness, is not Eisenstein at any small shift, and its balanced modular factorizations fall outside the multi-prime per-prime degree-sum obstruction language (e.g. Swinnerton-Dyer polynomials); no certificate-backed proof is available, but the kernel-decide fallbacks `irreducibility!` / `factor_poly!` can still certify small inputs by re-running the factorizer in the kernel
 -/
 #guard_msgs in
-example := irreducibility (Hex.DensePoly.ofCoeffs #[1, 0, 0, 0, 1] : Hex.ZPoly)
+example := irreducibility (Hex.DensePoly.ofCoeffs #[1, 0, -10, 0, 1] : Hex.ZPoly)
 
 /-! ### The kernel-decide fallbacks `irreducibility!` / `factor_poly!`
 
-`x⁴ + 1` and the Swinnerton-Dyer quartic `x⁴ - 10x² + 1` are exactly the
-decline cases above, so the bang forms exercise the genuine fallback path:
-the emitted proofs make the kernel re-run the factorizer (which is why this
-file carries the `import all` closure block). On inputs the certificate
-pipeline handles, the bang forms are pass-throughs. -/
+The Swinnerton-Dyer quartic `x⁴ - 10x² + 1` is exactly the decline case
+above, so the bang forms exercise the genuine fallback path: the emitted
+proofs make the kernel re-run the factorizer (which is why this file
+carries the `import all` closure block). On inputs the certificate
+pipeline handles — including `x⁴ + 1`, now Eisenstein-certified at shift
+`1` — the bang forms are pass-throughs. -/
 
-/-- `x⁴ + 1`, irreducible but balanced beyond both certificate languages. -/
+/-- `x⁴ + 1`, certified by the Eisenstein-after-shift witness, so a bang
+pass-through. -/
 def cyc8 : Hex.ZPoly := Hex.DensePoly.ofCoeffs #[1, 0, 0, 0, 1]
 
 /-- The Swinnerton-Dyer quartic `x⁴ - 10x² + 1`. -/

--- a/HexBerlekampZassenhausMathlib/FactorProvider.lean
+++ b/HexBerlekampZassenhausMathlib/FactorProvider.lean
@@ -43,12 +43,13 @@ kernel-decidable assemblers `Hex.FactoredPoly.ofZ` / `irreducible_ofZ` to
 reified literal data with every certification slot discharged by
 `Eq.refl true`. The factorizer never appears in emitted terms.
 
-Balanced factors whose modular factorizations also fall outside the
-per-prime degree-sum obstruction language (e.g. Swinnerton-Dyer polynomials
-or `X⁴+1`) have no certificate in either language; the provider declines
-with a diagnostic pointing at the kernel-decide fallbacks `irreducibility!`
-/ `factor_poly!` (`BangElab.lean`), which certify small such inputs by
-re-running the factorizer in the kernel.
+Balanced factors that are not Eisenstein at any small shift (the free
+layer certifies e.g. `X⁴+1` that way) and whose modular factorizations also
+fall outside the per-prime degree-sum obstruction language (e.g.
+Swinnerton-Dyer polynomials) have no certificate in either language; the
+provider declines with a diagnostic pointing at the kernel-decide fallbacks
+`irreducibility!` / `factor_poly!` (`BangElab.lean`), which certify small
+such inputs by re-running the factorizer in the kernel.
 -/
 
 namespace HexBerlekampZassenhausMathlib.FactorTactic
@@ -232,12 +233,13 @@ meta def parseInput (tactic : String) (e : Expr) :
 meta def coverDecline (tactic : String) (q : Hex.ZPoly) : MetaM MessageData := do
   let qE ← Hex.CertReify.reifyZPoly q
   return m!"{tactic}: the irreducible factor{indentExpr qE}\
-      \nhas no single-prime modular witness, and its balanced modular \
-      factorizations also fall outside the multi-prime per-prime degree-sum \
-      obstruction language (e.g. Swinnerton-Dyer polynomials or X⁴+1); no \
-      certificate-backed proof is available, but the kernel-decide fallbacks \
-      `irreducibility!` / `factor_poly!` can still certify small inputs by \
-      re-running the factorizer in the kernel"
+      \nhas no single-prime modular witness, is not Eisenstein at any small \
+      shift, and its balanced modular factorizations fall outside the \
+      multi-prime per-prime degree-sum obstruction language (e.g. \
+      Swinnerton-Dyer polynomials); no certificate-backed proof is \
+      available, but the kernel-decide fallbacks `irreducibility!` / \
+      `factor_poly!` can still certify small inputs by re-running the \
+      factorizer in the kernel"
 
 /-- Search a mixed certificate cover for a factor list: a free-layer
 `IrredWitness` per distinct factor where one exists, a multi-prime

--- a/HexBerlekampZassenhausMathlib/SPEC/hex-berlekamp-zassenhaus-mathlib.md
+++ b/HexBerlekampZassenhausMathlib/SPEC/hex-berlekamp-zassenhaus-mathlib.md
@@ -132,11 +132,12 @@ Goal-mode `irreducibility` closes `Hex.ZPoly.Irreducible f`,
 parseable `P : Polynomial ℤ`. The `toPolynomial` goal shape subsumes the
 old `irreducible_cert` tactic, which is deleted.
 
-Inputs whose modular factorizations are balanced at every candidate prime
-*and* whose proper factor degrees are not jointly obstructed by the
-per-prime degree-sum language (e.g. Swinnerton-Dyer polynomials, `X⁴+1`)
-have no certificate in either language; the provider declines with a
-diagnostic pointing at the kernel-decide fallbacks.
+Inputs whose modular factorizations are balanced at every candidate prime,
+that are not Eisenstein at any small shift (the free layer certifies e.g.
+`X⁴+1` that way), *and* whose proper factor degrees are not jointly
+obstructed by the per-prime degree-sum language (e.g. Swinnerton-Dyer
+polynomials) have no certificate in either language; the provider declines
+with a diagnostic pointing at the kernel-decide fallbacks.
 
 ## The kernel-decide fallbacks `irreducibility!` / `factor_poly!`
 

--- a/progress/2026-07-22T20-30-00Z.md
+++ b/progress/2026-07-22T20-30-00Z.md
@@ -1,0 +1,48 @@
+# Eisenstein-after-shift certificates (Milestone E, branch factor-poly/eisenstein)
+
+## Accomplished
+
+- New `HexBerlekampZassenhaus/EisensteinCore.lean` (Mathlib-free):
+  - `ZPoly.translate` / `translateAux`, an `@[expose]` executable Horner fold
+    computing the Taylor shift `f(X + s)`, with the full transfer algebra
+    proved by strong induction over the `divX` (`X`-quotient) decomposition:
+    `translate_add`, `translate_mul`, `translate_C`, `translate_X`,
+    `translate_neg_translate` (inverse pair), `size_translate`,
+    `isUnit_translate_iff`, and `irreducible_of_translate_irreducible`.
+  - `ZPoly.irreducible_of_eisenstein`: elementary coefficient-level
+    Eisenstein criterion over `Hex.ZPoly`, built on
+    `mulCoeffSum_eq_diagonal` fold collapses, a first-index-not-divisible
+    extractor, and `Hex.Nat.Prime.dvd_mul` routed to `Int` via `natAbs`.
+    Note: the one-sided aux lemma does not need `q ∣ a₀` as a hypothesis —
+    it is forced by `hlow 0` + `q ∤ b₀`.
+  - `ZPoly.irreducible_of_eisensteinCert`: the decide-slot form on the
+    shifted polynomial (`%`-based divisibility checks; primitivity checked
+    on the shifted literal, so no content-preservation lemma is needed).
+- `IrredWitness.eisenstein (q : Nat) (shift : Int)` constructor +
+  `checkIrredWitness` arm + soundness case (`IrreducibleDecide.lean`).
+- Generator: `searchEisenstein` in `FactorProvider.lean` (shifts
+  `0, ±1, ±2, ±3`; candidate primes from small prime divisors of the shifted
+  constant term, bounded at `10^6`; validated by re-running
+  `checkIrredWitness`), tried after the modP search declines; `reifyWitness`
+  arm added. Decline diagnostics updated (X⁴+1 no longer declines).
+- Tests: `x4p1_irred : ZPoly.Irreducible x4p1 := irreducibility x4p1` now
+  succeeds (shift 1, prime 2) with an axioms guard; plain shift-0 Eisenstein
+  exercised on `X²-2` via `checkIrredWitness … = true := rfl` plus the
+  soundness application; SD product still `#check_failure` (not
+  shift-Eisenstein). SPEC partiality paragraph updated.
+
+## Current frontier
+
+`lake build HexBerlekampZassenhaus` green including the tactic tests.
+`HexBerlekampZassenhausMathlib` build running (no `IrredWitness` consumers
+in the Mathlib layer, so only a rebuild-check).
+
+## Next step
+
+Full `lake build` sweep, then PR against `factor-poly/bz-provider`.
+
+## Blockers
+
+None. Swinnerton-Dyer inputs remain out of scope for the free layer by
+design (multi-prime degree-obstruction certificates live in the Mathlib
+bridge).


### PR DESCRIPTION
This PR adds Eisenstein-after-shift certificates to the free-layer `ZPoly` irreducibility pipeline (Milestone E of the factor_poly/irreducibility roadmap). The new `HexBerlekampZassenhaus/EisensteinCore.lean` provides the executable Taylor shift `ZPoly.translate` (an `@[expose]` Horner fold, so its computation is part of the kernel check) with its full Mathlib-free transfer algebra — `translate_add`, `translate_mul`, `translate_C`, the inverse identity `translate_neg_translate`, `size_translate`, `isUnit_translate_iff`, and `irreducible_of_translate_irreducible` — proved by strong induction over an `X`-quotient decomposition. On top of that it proves the elementary coefficient-level Eisenstein criterion `ZPoly.irreducible_of_eisenstein` (diagonal product-coefficient formula, first-unbroken-index extraction, Euclid's lemma for `Hex.Nat.Prime` transported to `Int` via `natAbs`) and packages it as the decide-slot theorem `irreducible_of_eisensteinCert` on the shifted literal; primitivity is checked on the shifted polynomial directly, so no content-preservation lemma is needed, and divisibility slots use `%`-checks since the free layer carries no `Decidable` instance for `Int` divisibility.

`ZPoly.IrredWitness` gains an `.eisenstein (q : Nat) (shift : Int)` constructor with the corresponding kernel-decidable `checkIrredWitness` arm and soundness case, and the `FactorProvider` witness search tries shifts `0, ±1, ±2, ±3` (candidate primes from the small prime divisors of the shifted constant term, each candidate validated by re-running `checkIrredWitness`) after the single-prime modular search declines. `X⁴+1` is now certified by the free layer at shift `1`, prime `2`: the balanced-decline test becomes `theorem x4p1_irred : ZPoly.Irreducible x4p1 := irreducibility x4p1` with a `#print axioms` guard, and a plain shift-`0` witness is exercised on `X²−2` through the checker and its soundness theorem. Swinnerton-Dyer inputs remain a documented decline (they are not shift-Eisenstein); the SPEC partiality paragraph and the decline diagnostics are updated to match. `lake build` and `lake build HexBerlekampZassenhausMathlib` are green; no `sorry`, no `axiom`, no `native_decide`.

🤖 Prepared with Claude Code
