### PR TITLE
feat(bz): word-sized Montgomery fast path for the quadratic Hensel lift step

### DIFF
--- a/HexHensel/Quadratic.lean
+++ b/HexHensel/Quadratic.lean
@@ -7,6 +7,8 @@ Authors: Kim Morrison
 module
 
 public import HexHensel.Basic
+public import HexHensel.WordTransport
+public import HexPoly.Euclid.MonicUnique
 
 public section
 
@@ -1850,6 +1852,35 @@ private theorem quadraticHenselStep_factor_error_add_exact
   · rfl
   · rfl
 
+/-- Word-sized quadratic Hensel doubling step over `WordMod` at working modulus
+`m*m`, taken when `m*m` fits an odd machine word, `1 < m*m`, and the divisor `g`
+is monic of positive degree. Byte-identical to `quadraticHenselStepBignum` under
+that guard; declines (`none`) otherwise. -/
+@[expose]
+def quadraticHenselStepWord? (m : Nat) (f g h s t : ZPoly) : Option QuadraticLiftResult :=
+  if _h2 : m * m < UInt64.word then
+    if hodd : (UInt64.ofNat (m * m)) % 2 = 1 then
+      if _h1 : 1 < m * m then
+        if _hm : DensePoly.leadingCoeff g = 1 then
+          if _hd : 0 < g.degree?.getD 0 then
+            let ctx := _root_.MontCtx.mk (UInt64.ofNat (m * m)) hodd
+            let eW := ZPoly.toWP ctx f - ZPoly.toWP ctx g * ZPoly.toWP ctx h
+            let factorQR := DensePoly.divMod (ZPoly.toWP ctx t * eW) (ZPoly.toWP ctx g)
+            let gW' := ZPoly.toWP ctx g + factorQR.2
+            let hW' := ZPoly.toWP ctx h +
+              (ZPoly.toWP ctx s * eW + factorQR.1 * ZPoly.toWP ctx h)
+            let bW := (ZPoly.toWP ctx s * gW' + ZPoly.toWP ctx t * hW') - 1
+            let bezoutQR := DensePoly.divMod (ZPoly.toWP ctx t * bW) gW'
+            let tW' := ZPoly.toWP ctx t - bezoutQR.2
+            let sW' := (ZPoly.toWP ctx s - ZPoly.toWP ctx s * bW) - bezoutQR.1 * hW'
+            some { g := ZPoly.ofWP ctx gW', h := ZPoly.ofWP ctx hW',
+                   s := ZPoly.ofWP ctx sW', t := ZPoly.ofWP ctx tW' }
+          else none
+        else none
+      else none
+    else none
+  else none
+
 /-- One quadratic Hensel correction step from modulus `m` to modulus `m^2`.
 
 Inputs: the target polynomial `f`, the current monic factor `g`, the
@@ -1857,7 +1888,7 @@ complementary factor `h`, and the Bezout witnesses `s`, `t` for the current
 factorisation. Preconditions consumed by the spec theorems below are `g`
 monic, `g * h ≡ f (mod m)`, and `s * g + t * h ≡ 1 (mod m)`; the returned
 `QuadraticLiftResult` then satisfies the same conjuncts modulo `m^2`. -/
-def quadraticHenselStep
+def quadraticHenselStepBignum
     (m : Nat) (f g h s t : ZPoly) : QuadraticLiftResult :=
   let e := QuadraticLiftResult.factorError f g h
   let te := mulModSquare t e m
@@ -1875,6 +1906,11 @@ def quadraticHenselStep
   let t' := subModSquare t rBezout m
   let s' := subModSquare (subModSquare s (mulModSquare s b m) m) (mulModSquare qBezout h' m) m
   { g := g', h := h', s := s', t := t' }
+
+/-- Guarded dispatch: the word-sized step when its guard holds, else the bignum step. -/
+def quadraticHenselStep
+    (m : Nat) (f g h s t : ZPoly) : QuadraticLiftResult :=
+  (quadraticHenselStepWord? m f g h s t).getD (quadraticHenselStepBignum m f g h s t)
 
 set_option maxHeartbeats 2000000 in
 private theorem quadraticHenselStep_raw_factor_congr
@@ -2227,6 +2263,305 @@ private theorem quadraticHenselStep_g_update_monic
     addModSquare_divModMonicModSquare_remainder_monic m te g hm hmonic
   simpa [factorQR, rFactor] using hmono
 
+/-! ### Word transport of the mod-`m²` primitives and the byte-identity proof -/
+
+private theorem QuadraticLiftResult.ext' {r1 r2 : QuadraticLiftResult}
+    (hg : r1.g = r2.g) (hh : r1.h = r2.h) (hs : r1.s = r2.s) (ht : r1.t = r2.t) :
+    r1 = r2 := by
+  cases r1
+  cases r2
+  simp_all
+
+private theorem toWP_reduceModSquare (m : Nat) (ctx : _root_.MontCtx (UInt64.ofNat (m * m)))
+    (hM : (UInt64.ofNat (m * m)).toNat = m * m) (hm0 : 0 < m * m) (x : ZPoly) :
+    ZPoly.toWP ctx (QuadraticLiftResult.reduceModSquare x m) = ZPoly.toWP ctx x := by
+  unfold QuadraticLiftResult.reduceModSquare
+  exact ZPoly.toWP_reduceModPow ctx (by rw [hM, Nat.pow_two])
+    (by rw [Nat.pow_two]; exact hm0) x
+
+private theorem toWP_addModSquare (m : Nat) (ctx : _root_.MontCtx (UInt64.ofNat (m * m)))
+    (hM : (UInt64.ofNat (m * m)).toNat = m * m) (hm0 : 0 < m * m) (a b : ZPoly) :
+    ZPoly.toWP ctx (addModSquare a b m) = ZPoly.toWP ctx a + ZPoly.toWP ctx b := by
+  unfold addModSquare
+  rw [toWP_reduceModSquare m ctx hM hm0, ZPoly.toWP_add]
+
+private theorem toWP_subModSquare (m : Nat) (ctx : _root_.MontCtx (UInt64.ofNat (m * m)))
+    (hM : (UInt64.ofNat (m * m)).toNat = m * m) (hm0 : 0 < m * m) (a b : ZPoly) :
+    ZPoly.toWP ctx (subModSquare a b m) = ZPoly.toWP ctx a - ZPoly.toWP ctx b := by
+  unfold subModSquare
+  rw [toWP_reduceModSquare m ctx hM hm0, ZPoly.toWP_sub]
+
+private theorem toWP_mulModSquare (m : Nat) (ctx : _root_.MontCtx (UInt64.ofNat (m * m)))
+    (hM : (UInt64.ofNat (m * m)).toNat = m * m) (hm0 : 0 < m * m) (a b : ZPoly) :
+    ZPoly.toWP ctx (mulModSquare a b m) = ZPoly.toWP ctx a * ZPoly.toWP ctx b := by
+  unfold mulModSquare
+  rw [toWP_reduceModSquare m ctx hM hm0, ZPoly.toWP_mul]
+
+private theorem reduceModSquare_coeff_lt (m : Nat) (hm0 : 0 < m * m) (x : ZPoly) (i : Nat) :
+    0 ≤ (QuadraticLiftResult.reduceModSquare x m).coeff i ∧
+      (QuadraticLiftResult.reduceModSquare x m).coeff i < (m * m : Int) := by
+  unfold QuadraticLiftResult.reduceModSquare
+  rw [ZPoly.coeff_reduceModPow, Int.ofNat_eq_natCast]
+  refine ⟨Int.natCast_nonneg _, ?_⟩
+  have hlt := ZPoly.intModNat_lt' (x.coeff i) (M := m ^ 2)
+    (by rw [Nat.pow_two]; exact hm0)
+  rw [show (m * m : Int) = ((m ^ 2 : Nat) : Int) from by
+    rw [Nat.pow_two]
+    exact_mod_cast rfl]
+  exact_mod_cast hlt
+
+private theorem ofWP_toWP_reduceModSquare (m : Nat)
+    (ctx : _root_.MontCtx (UInt64.ofNat (m * m)))
+    (hM : (UInt64.ofNat (m * m)).toNat = m * m) (hm0 : 0 < m * m) (x : ZPoly) :
+    ZPoly.ofWP ctx (ZPoly.toWP ctx (QuadraticLiftResult.reduceModSquare x m)) =
+      QuadraticLiftResult.reduceModSquare x m := by
+  apply ZPoly.ofWP_toWP_of_canonical
+  intro i
+  refine ⟨(reduceModSquare_coeff_lt m hm0 x i).1, ?_⟩
+  rw [show ((UInt64.ofNat (m * m)).toNat : Int) = (m * m : Int) from by
+    rw [hM]
+    exact_mod_cast rfl]
+  exact (reduceModSquare_coeff_lt m hm0 x i).2
+
+private theorem ofWP_toWP_addModSquare (m : Nat)
+    (ctx : _root_.MontCtx (UInt64.ofNat (m * m)))
+    (hM : (UInt64.ofNat (m * m)).toNat = m * m) (hm0 : 0 < m * m) (a b : ZPoly) :
+    ZPoly.ofWP ctx (ZPoly.toWP ctx (addModSquare a b m)) = addModSquare a b m := by
+  unfold addModSquare
+  exact ofWP_toWP_reduceModSquare m ctx hM hm0 (a + b)
+
+private theorem ofWP_toWP_subModSquare (m : Nat)
+    (ctx : _root_.MontCtx (UInt64.ofNat (m * m)))
+    (hM : (UInt64.ofNat (m * m)).toNat = m * m) (hm0 : 0 < m * m) (a b : ZPoly) :
+    ZPoly.ofWP ctx (ZPoly.toWP ctx (subModSquare a b m)) = subModSquare a b m := by
+  unfold subModSquare
+  exact ofWP_toWP_reduceModSquare m ctx hM hm0 (a - b)
+
+private theorem one_lt_of_mul (m : Nat) (h1 : 1 < m * m) : 1 < m := by
+  rcases m with _ | _ | k
+  · simp at h1
+  · simp at h1
+  · omega
+
+/-- Transport of the custom monic modular division through `toWP`. -/
+private theorem toWP_divModMonicModSquare (m : Nat)
+    (ctx : _root_.MontCtx (UInt64.ofNat (m * m)))
+    (hM : (UInt64.ofNat (m * m)).toNat = m * m) (hm1 : 1 < m * m)
+    (p q : ZPoly) (hqm : DensePoly.Monic q) (hqd : 0 < q.degree?.getD 0) :
+    DensePoly.divMod (ZPoly.toWP ctx p) (ZPoly.toWP ctx q) =
+      (ZPoly.toWP ctx (divModMonicModSquare p q m).1,
+       ZPoly.toWP ctx (divModMonicModSquare p q m).2) := by
+  have hqpos : 0 < q.size := by
+    rcases Nat.eq_zero_or_pos q.size with h0 | h0
+    · exfalso
+      rw [DensePoly.degree?, dif_pos h0] at hqd
+      simp at hqd
+    · exact h0
+  have hm1' : 1 < (UInt64.ofNat (m * m)).toNat := by
+    rw [hM]
+    exact hm1
+  have hmbase : 1 < m := one_lt_of_mul m hm1
+  have hlc : (ZPoly.toWP ctx q).leadingCoeff = 1 :=
+    ZPoly.toWP_monic ctx hqm hqpos hm1'
+  refine DensePoly.divMod_eq_of_reconstruction (ZPoly.toWP ctx p) (ZPoly.toWP ctx q)
+    (ZPoly.toWP ctx (divModMonicModSquare p q m).1)
+    (ZPoly.toWP ctx (divModMonicModSquare p q m).2) ?_ ?_ ?_ ?_ ?_ ?_
+  · rw [ZPoly.toWP_degree_eq_of_monic ctx hqm hqpos hm1']
+    exact hqd
+  · intro a
+    rw [hlc, WordMod.div_one, Lean.Grind.Semiring.mul_one]
+    exact WordMod.sub_self a
+  · intro a
+    rw [hlc, WordMod.div_one, Lean.Grind.Semiring.mul_one]
+  · intro a ha
+    simpa [hlc, Lean.Grind.Semiring.mul_one] using ha
+  · rw [← ZPoly.toWP_mul, ← ZPoly.toWP_add]
+    exact ZPoly.toWP_congr ctx (by
+      rw [hM]
+      exact divModMonicModSquare_reconstruct_congr m p q _ _ (by omega) rfl)
+  · rw [ZPoly.toWP_degree_eq_of_monic ctx hqm hqpos hm1']
+    have hq2 : 2 ≤ q.size := by
+      have hh := hqd
+      rw [DensePoly.degree?_eq_some_of_pos_size q hqpos, Option.getD_some] at hh
+      omega
+    refine Nat.lt_of_le_of_lt (ZPoly.toWP_degree_le ctx (divModMonicModSquare p q m).2) ?_
+    have hz := divModMonicModSquare_remainder_coeff_eq_zero_of_monic m p q hmbase hqm
+    have hrsize : (divModMonicModSquare p q m).2.size ≤ q.size - 1 := by
+      rcases Nat.lt_or_ge (q.size - 1) (divModMonicModSquare p q m).2.size with hlt | hge
+      · exact absurd (hz _ (by omega))
+          (DensePoly.coeff_last_ne_zero_of_pos_size _ (by omega))
+      · exact hge
+    rcases Nat.eq_zero_or_pos (divModMonicModSquare p q m).2.size with h0 | h0
+    · rw [DensePoly.degree?, dif_pos h0, Option.getD_none,
+        DensePoly.degree?_eq_some_of_pos_size q hqpos, Option.getD_some]
+      omega
+    · rw [DensePoly.degree?_eq_some_of_pos_size _ h0,
+        DensePoly.degree?_eq_some_of_pos_size q hqpos, Option.getD_some, Option.getD_some]
+      omega
+
+set_option maxHeartbeats 1000000 in
+theorem quadraticHenselStepWord?_eq (m : Nat) (f g h s t : ZPoly)
+    (h2 : m * m < UInt64.word) (hodd : (UInt64.ofNat (m * m)) % 2 = 1) (h1 : 1 < m * m)
+    (hmlc : DensePoly.leadingCoeff g = 1) (hd : 0 < g.degree?.getD 0) :
+    quadraticHenselStepWord? m f g h s t = some (quadraticHenselStepBignum m f g h s t) := by
+  have hM : (UInt64.ofNat (m * m)).toNat = m * m := by
+    rw [UInt64.toNat_ofNat_mod_word]
+    exact Nat.mod_eq_of_lt h2
+  have hm0 : 0 < m * m := by omega
+  have hgm : DensePoly.Monic g := hmlc
+  have hgpos : 0 < g.size := by
+    rcases Nat.eq_zero_or_pos g.size with h0 | h0
+    · exfalso
+      rw [DensePoly.degree?, dif_pos h0] at hd
+      simp at hd
+    · exact h0
+  have hg2 : 2 ≤ g.size := by
+    have hh := hd
+    rw [DensePoly.degree?_eq_some_of_pos_size g hgpos, Option.getD_some] at hh
+    omega
+  have hmbase : 1 < m := one_lt_of_mul m h1
+  unfold quadraticHenselStepWord?
+  simp only [dif_pos h2, dif_pos hodd, dif_pos h1, dif_pos hmlc, dif_pos hd]
+  generalize hctx : _root_.MontCtx.mk (UInt64.ofNat (m * m)) hodd = ctx
+  refine congrArg some ?_
+  generalize heW : ZPoly.toWP ctx f - ZPoly.toWP ctx g * ZPoly.toWP ctx h = eW
+  generalize hfqW : DensePoly.divMod (ZPoly.toWP ctx t * eW) (ZPoly.toWP ctx g) = fqW
+  generalize hgWv : ZPoly.toWP ctx g + fqW.2 = gWv
+  generalize hhWv : ZPoly.toWP ctx h +
+    (ZPoly.toWP ctx s * eW + fqW.1 * ZPoly.toWP ctx h) = hWv
+  generalize hbWv : (ZPoly.toWP ctx s * gWv + ZPoly.toWP ctx t * hWv) - 1 = bWv
+  generalize hbqW : DensePoly.divMod (ZPoly.toWP ctx t * bWv) gWv = bqW
+  generalize htWv : ZPoly.toWP ctx t - bqW.2 = tWv
+  generalize hsWv :
+    (ZPoly.toWP ctx s - ZPoly.toWP ctx s * bWv) - bqW.1 * hWv = sWv
+  obtain ⟨e, he⟩ : ∃ e, e = QuadraticLiftResult.factorError f g h := ⟨_, rfl⟩
+  obtain ⟨fq, hfq⟩ : ∃ fq, fq = divModMonicModSquare (mulModSquare t e m) g m := ⟨_, rfl⟩
+  obtain ⟨g', hg'⟩ : ∃ g', g' = addModSquare g fq.2 m := ⟨_, rfl⟩
+  obtain ⟨hCorr, hhc⟩ : ∃ hCorr,
+      hCorr = addModSquare (mulModSquare s e m) (mulModSquare fq.1 h m) m := ⟨_, rfl⟩
+  obtain ⟨h', hh'⟩ : ∃ h', h' = addModSquare h hCorr m := ⟨_, rfl⟩
+  obtain ⟨b, hb⟩ : ∃ b,
+      b = subModSquare (addModSquare (mulModSquare s g' m) (mulModSquare t h' m) m) 1 m :=
+    ⟨_, rfl⟩
+  obtain ⟨bq, hbq⟩ : ∃ bq, bq = divModMonicModSquare (mulModSquare t b m) g' m := ⟨_, rfl⟩
+  have hEwe : eW = ZPoly.toWP ctx e := by
+    rw [← heW, he]
+    unfold QuadraticLiftResult.factorError
+    rw [ZPoly.toWP_sub, ZPoly.toWP_mul]
+  have hFqe : fqW = (ZPoly.toWP ctx fq.1, ZPoly.toWP ctx fq.2) := by
+    rw [← hfqW, hEwe, ← toWP_mulModSquare m ctx hM hm0, hfq]
+    exact toWP_divModMonicModSquare m ctx hM h1 _ g hgm hd
+  have hg'monic0 : DensePoly.Monic (addModSquare g fq.2 m) := by
+    rw [hfq]
+    exact addModSquare_divModMonicModSquare_remainder_monic m _ g hmbase hgm
+  have hg'monic : DensePoly.Monic g' :=
+    (congrArg DensePoly.Monic hg').mpr hg'monic0
+  have hg'coeff : g'.coeff (g.size - 1) = 1 := by
+    rw [hg']
+    unfold addModSquare QuadraticLiftResult.reduceModSquare
+    rw [ZPoly.coeff_reduceModPow, DensePoly.coeff_add _ _ _ (by rfl),
+      show g.coeff (g.size - 1) = 1 from by
+        rw [← DensePoly.leadingCoeff_eq_coeff_last g hgpos]
+        exact hgm,
+      show fq.2.coeff (g.size - 1) = 0 from
+        by
+          rw [hfq]
+          exact divModMonicModSquare_remainder_coeff_eq_zero_of_monic m _ g hmbase hgm
+            (g.size - 1) (Nat.le_refl _),
+      show (1 : Int) + 0 = 1 from by omega,
+      ZPoly.intModNat_one (show 0 < m ^ 2 from by rw [Nat.pow_two]; exact hm0),
+      Nat.mod_eq_of_lt (show 1 < m ^ 2 from by rw [Nat.pow_two]; exact h1)]
+    rfl
+  have hg'deg : 0 < g'.degree?.getD 0 := by
+    have hg'size : g.size ≤ g'.size := by
+      rcases Nat.lt_or_ge g'.size g.size with hlt | hge
+      · exact absurd hg'coeff (by
+          rw [DensePoly.coeff_eq_zero_of_size_le _ (by omega)]
+          exact Int.zero_ne_one)
+      · exact hge
+    rw [DensePoly.degree?_eq_some_of_pos_size _ (by omega), Option.getD_some]
+    omega
+  have hGwe : gWv = ZPoly.toWP ctx g' := by
+    rw [← hgWv, hFqe, hg', toWP_addModSquare m ctx hM hm0]
+  have hHwe : hWv = ZPoly.toWP ctx h' := by
+    rw [← hhWv, hEwe, hFqe, hh', toWP_addModSquare m ctx hM hm0, hhc,
+      toWP_addModSquare m ctx hM hm0, toWP_mulModSquare m ctx hM hm0,
+      toWP_mulModSquare m ctx hM hm0]
+  have hBwe : bWv = ZPoly.toWP ctx b := by
+    rw [← hbWv, hGwe, hHwe, hb, toWP_subModSquare m ctx hM hm0,
+      toWP_addModSquare m ctx hM hm0, toWP_mulModSquare m ctx hM hm0,
+      toWP_mulModSquare m ctx hM hm0, ZPoly.toWP_one]
+  have hBqe : bqW = (ZPoly.toWP ctx bq.1, ZPoly.toWP ctx bq.2) := by
+    rw [← hbqW, hBwe, hGwe, ← toWP_mulModSquare m ctx hM hm0, hbq]
+    exact toWP_divModMonicModSquare m ctx hM h1 _ g' hg'monic hg'deg
+  have hTwe : tWv = ZPoly.toWP ctx (subModSquare t bq.2 m) := by
+    rw [← htWv, hBqe, toWP_subModSquare m ctx hM hm0]
+  have hSwe : sWv = ZPoly.toWP ctx
+      (subModSquare (subModSquare s (mulModSquare s b m) m)
+        (mulModSquare bq.1 h' m) m) := by
+    rw [← hsWv, hBwe, hBqe, hHwe, toWP_subModSquare m ctx hM hm0,
+      toWP_subModSquare m ctx hM hm0, toWP_mulModSquare m ctx hM hm0,
+      toWP_mulModSquare m ctx hM hm0]
+  rw [hGwe, hHwe, hTwe, hSwe]
+  refine QuadraticLiftResult.ext' ?_ ?_ ?_ ?_
+  · calc
+      ZPoly.ofWP ctx (ZPoly.toWP ctx g') = g' := by
+        rw [hg']
+        exact ofWP_toWP_addModSquare m ctx hM hm0 g fq.2
+      _ = (quadraticHenselStepBignum m f g h s t).g := by
+        unfold quadraticHenselStepBignum
+        rw [hg', hfq, he]
+  · calc
+      ZPoly.ofWP ctx (ZPoly.toWP ctx h') = h' := by
+        rw [hh']
+        exact ofWP_toWP_addModSquare m ctx hM hm0 h hCorr
+      _ = (quadraticHenselStepBignum m f g h s t).h := by
+        unfold quadraticHenselStepBignum
+        rw [hh', hhc, hfq, he]
+  · calc
+      ZPoly.ofWP ctx (ZPoly.toWP ctx
+          (subModSquare (subModSquare s (mulModSquare s b m) m)
+            (mulModSquare bq.1 h' m) m)) =
+          subModSquare (subModSquare s (mulModSquare s b m) m)
+            (mulModSquare bq.1 h' m) m :=
+        ofWP_toWP_subModSquare m ctx hM hm0 _ _
+      _ = (quadraticHenselStepBignum m f g h s t).s := by
+        unfold quadraticHenselStepBignum
+        rw [hbq, hb, hh', hhc, hg', hfq, he]
+  · calc
+      ZPoly.ofWP ctx (ZPoly.toWP ctx (subModSquare t bq.2 m)) =
+          subModSquare t bq.2 m := ofWP_toWP_subModSquare m ctx hM hm0 t bq.2
+      _ = (quadraticHenselStepBignum m f g h s t).t := by
+        unfold quadraticHenselStepBignum
+        rw [hbq, hb, hh', hhc, hg', hfq, he]
+
+theorem quadraticHenselStep_eq_bignum
+    (m : Nat) (f g h s t : ZPoly) :
+    quadraticHenselStep m f g h s t = quadraticHenselStepBignum m f g h s t := by
+  unfold quadraticHenselStep
+  by_cases hguard : (m * m < UInt64.word) ∧ ((UInt64.ofNat (m * m)) % 2 = 1) ∧
+      (1 < m * m) ∧ (DensePoly.leadingCoeff g = 1) ∧ (0 < g.degree?.getD 0)
+  · obtain ⟨h2, hodd, h1, hmlc, hd⟩ := hguard
+    rw [quadraticHenselStepWord?_eq m f g h s t h2 hodd h1 hmlc hd, Option.getD_some]
+  · have hnone : quadraticHenselStepWord? m f g h s t = none := by
+      unfold quadraticHenselStepWord?
+      by_cases a : m * m < UInt64.word
+      · rw [dif_pos a]
+        by_cases b : (UInt64.ofNat (m * m)) % 2 = 1
+        · rw [dif_pos b]
+          by_cases c : 1 < m * m
+          · rw [dif_pos c]
+            by_cases d : DensePoly.leadingCoeff g = 1
+            · rw [dif_pos d]
+              by_cases e : 0 < g.degree?.getD 0
+              · exact absurd ⟨a, b, c, d, e⟩ hguard
+              · rw [dif_neg e]
+            · rw [dif_neg d]
+          · rw [dif_neg c]
+        · rw [dif_neg b]
+      · rw [dif_neg a]
+    rw [hnone, Option.getD_none]
+
 /-- The updated factors multiply to `f` modulo `m^2`. -/
 @[grind =>]
 theorem quadraticHenselStep_factor_spec
@@ -2238,7 +2573,8 @@ theorem quadraticHenselStep_factor_spec
     (hmonic : DensePoly.Monic g) :
     let r := quadraticHenselStep m f g h s t
     ZPoly.congr (r.g * r.h) f (m * m) := by
-  unfold quadraticHenselStep
+  rw [quadraticHenselStep_eq_bignum]
+  unfold quadraticHenselStepBignum
   exact quadraticHenselStep_raw_factor_congr m f g h s t hm hprod hbez hmonic
 
 /-- The updated Bezout witnesses certify coprimality modulo `m^2`. -/
@@ -2252,7 +2588,8 @@ theorem quadraticHenselStep_bezout_spec
     (hmonic : DensePoly.Monic g) :
     let r := quadraticHenselStep m f g h s t
     ZPoly.congr (r.s * r.g + r.t * r.h) 1 (m * m) := by
-  unfold quadraticHenselStep
+  rw [quadraticHenselStep_eq_bignum]
+  unfold quadraticHenselStepBignum
   exact quadraticHenselStep_raw_bezout_congr m f g h s t hm hprod hbez hmonic
 
 /-- The quadratic step lifts both factor and Bezout congruences to modulus `m^2`. -/
@@ -2280,7 +2617,8 @@ theorem quadraticHenselStep_monic
     (hm : 1 < m)
     (hmonic : DensePoly.Monic g) :
     DensePoly.Monic (quadraticHenselStep m f g h s t).g := by
-  unfold quadraticHenselStep
+  rw [quadraticHenselStep_eq_bignum]
+  unfold quadraticHenselStepBignum
   exact quadraticHenselStep_g_update_monic m f g h s t hm hmonic
 
 /--
@@ -2297,7 +2635,8 @@ theorem quadraticHenselStep_factor_congr_mod_base
     (hprod : ZPoly.congr (g * h) f m) :
     ZPoly.congr (quadraticHenselStep m f g h s t).g g m ∧
       ZPoly.congr (quadraticHenselStep m f g h s t).h h m := by
-  unfold quadraticHenselStep
+  rw [quadraticHenselStep_eq_bignum]
+  unfold quadraticHenselStepBignum
   have hm0 : 0 < m := Nat.lt_trans Nat.zero_lt_one hm
   let e := QuadraticLiftResult.factorError f g h
   let te := mulModSquare t e m

--- a/HexHensel/WordStep.lean
+++ b/HexHensel/WordStep.lean
@@ -60,36 +60,6 @@ The Montgomery residue ring is a commutative ring; the axioms transport through
 `toNat` (which is `+`/`*`/`-`-compatible modulo `m`). This is what lets the
 word-sized poly arithmetic reuse the generic `DensePoly` ring/division lemmas. -/
 
-/-- Iterated product, the `npow` datum. -/
-def pow (a : WordMod ctx) : Nat → WordMod ctx
-  | 0 => 1
-  | n + 1 => pow a n * a
-
-instance : HPow (WordMod ctx) Nat (WordMod ctx) := ⟨pow⟩
-instance (n : Nat) : OfNat (WordMod ctx) n := ⟨ofNat n⟩
-instance : SMul Nat (WordMod ctx) := ⟨fun n a => ofNat n * a⟩
-instance : IntCast (WordMod ctx) :=
-  ⟨fun i => match i with
-    | .ofNat n => ofNat n
-    | .negSucc n => -(ofNat (n + 1))⟩
-instance : SMul Int (WordMod ctx) :=
-  ⟨fun i a => match i with
-    | .ofNat n => (n : Nat) • a
-    | .negSucc n => -((n + 1 : Nat) • a)⟩
-
-@[simp] theorem toNat_pow (a : WordMod ctx) (n : Nat) :
-    (a ^ n).toNat = (a.toNat ^ n) % m.toNat := by
-  change (pow a n).toNat = _
-  induction n with
-  | zero => simp [pow, toNat_one, Nat.pow_zero]
-  | succ k ih =>
-      rw [pow, toNat_mul, ih, Nat.pow_succ, Nat.mod_mul_mod]
-
-@[simp] theorem toNat_nsmul (n : Nat) (a : WordMod ctx) :
-    (n • a).toNat = (n % m.toNat * a.toNat) % m.toNat := by
-  change (ofNat n * a).toNat = _
-  rw [toNat_mul, toNat_ofNat]
-
 instance : Lean.Grind.Semiring (WordMod ctx) := by
   refine Lean.Grind.Semiring.mk ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_
   · intro a
@@ -177,9 +147,22 @@ instance : Lean.Grind.Ring (WordMod ctx) where
             change (ofNat 0 * a).toNat = (-(ofNat 0 * a)).toNat
             rw [toNat_neg, toNat_mul, toNat_ofNat]
             simp
-        | succ n => rfl
+        | succ n =>
+            apply toNat_injective
+            change ((-ofNat (n + 1)) * a).toNat = (-(ofNat (n + 1) * a)).toNat
+            rw [toNat_neg_mul, toNat_neg, toNat_mul]
     | negSucc n =>
-        exact (neg_neg' ((n + 1 : Nat) • a)).symm
+        change ofNat (n + 1) * a = -((-ofNat (n + 1)) * a)
+        apply toNat_injective
+        rw [toNat_neg, toNat_neg_mul, toNat_mul]
+        generalize hx : (ofNat (ctx := ctx) (n + 1)).toNat * a.toNat % m.toNat = x
+        have hlt : x < m.toNat := by
+          rw [← hx]
+          exact Nat.mod_lt _ ctx.p_pos
+        rcases Nat.eq_zero_or_pos x with h0 | h0
+        · rw [h0]; simp
+        · rw [Nat.mod_eq_of_lt (show m.toNat - x < m.toNat by omega),
+              Nat.sub_sub_self (Nat.le_of_lt hlt), Nat.mod_eq_of_lt hlt]
   intCast_neg := by
     intro i
     cases i with

--- a/HexHensel/WordStep.lean
+++ b/HexHensel/WordStep.lean
@@ -48,6 +48,12 @@ theorem eq_iff_toNat {a b : WordMod ctx} : a = b ↔ a.toNat = b.toNat :=
   apply toNat_injective
   rw [toNat_ofNat, Nat.mod_eq_of_lt (toNat_lt a)]
 
+@[simp] theorem sub_self (a : WordMod ctx) : a - a = 0 := by
+  apply toNat_injective
+  rw [toNat_sub, toNat_zero]
+  have ha : a.toNat < m.toNat := toNat_lt a
+  rw [Nat.add_sub_cancel' (Nat.le_of_lt ha), Nat.mod_self]
+
 /-! ### `Lean.Grind.CommRing (WordMod ctx)`
 
 The Montgomery residue ring is a commutative ring; the axioms transport through

--- a/HexHensel/WordStep.lean
+++ b/HexHensel/WordStep.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexHensel.Basic
+public import HexModArith
+public import HexPoly.Euclid.MonicUnique
+
+public section
+
+/-!
+Mathlib-free foundation for transporting integer polynomial arithmetic (reduced
+modulo a working modulus) into the word-sized Montgomery ring `WordMod ctx`.
+
+This file provides the scalar bridge used by a word-sized Hensel step:
+`WordMod.toNat` is injective and `WordMod.ofNat` inverts it (`ofNat_toNat`), and
+`ZPoly.intModNat` (the canonical `[0, M)` residue) commutes with `+`, `*`, and the
+full-range modular `-` of `WordMod` (`intModNat_add`/`intModNat_mul`/`intModNat_sub`).
+
+These are the reusable, general pieces. The full polynomial ring-homomorphism
+transport built on top (the multiplicative `toWP` law is the deep piece, requiring
+a fold-congruence over the coefficient convolution) and the byte-identical Hensel
+correspondence are follow-up work; see the discussion on issue #8854.
+-/
+
+namespace Hex
+namespace WordMod
+
+variable {m : UInt64} {ctx : _root_.MontCtx m}
+
+/-- `toNat` is injective: the represented residue determines the element. Follows
+from `toNat_mul_word` (`a.val.toNat = a.toNat * word % m`) with no Montgomery
+round-trip lemma. -/
+theorem toNat_injective {a b : WordMod ctx} (h : a.toNat = b.toNat) : a = b := by
+  apply ext
+  apply UInt64.toNat_inj.mp
+  rw [← toNat_mul_word a, ← toNat_mul_word b, h]
+
+theorem eq_iff_toNat {a b : WordMod ctx} : a = b ↔ a.toNat = b.toNat :=
+  ⟨fun h => by rw [h], toNat_injective⟩
+
+/-- Round trip: reducing the represented residue back in is the identity. -/
+@[simp] theorem ofNat_toNat (a : WordMod ctx) : ofNat (ctx := ctx) a.toNat = a := by
+  apply toNat_injective
+  rw [toNat_ofNat, Nat.mod_eq_of_lt (toNat_lt a)]
+
+end WordMod
+
+namespace ZPoly
+
+/-- `intModNat` as an `Int` remainder (public form of the private
+`intModNat_eq_emod`). -/
+theorem intModNat_cast (z : Int) {M : Nat} (hM : 0 < M) :
+    (intModNat z M : Int) = z % (M : Int) := by
+  unfold intModNat
+  exact Int.toNat_of_nonneg (Int.emod_nonneg _ (Int.ofNat_ne_zero.mpr (Nat.ne_of_gt hM)))
+
+theorem intModNat_lt' (z : Int) {M : Nat} (hM : 0 < M) : intModNat z M < M := by
+  have hc := intModNat_cast z hM
+  have h1 : z % (M : Int) < M := Int.emod_lt_of_pos z (by exact_mod_cast hM)
+  omega
+
+/-- `intModNat` commutes with addition modulo `M`. -/
+theorem intModNat_add (x y : Int) {M : Nat} (hM : 0 < M) :
+    intModNat (x + y) M = (intModNat x M + intModNat y M) % M := by
+  have hh : (intModNat (x + y) M : Int) = (((intModNat x M + intModNat y M) % M : Nat) : Int) := by
+    rw [intModNat_cast (x + y) hM,
+      show (((intModNat x M + intModNat y M) % M : Nat) : Int)
+          = ((intModNat x M : Int) + intModNat y M) % M from by exact_mod_cast rfl,
+      intModNat_cast x hM, intModNat_cast y hM, ← Int.add_emod]
+  exact_mod_cast hh
+
+/-- `intModNat` commutes with multiplication modulo `M`. -/
+theorem intModNat_mul (x y : Int) {M : Nat} (hM : 0 < M) :
+    intModNat (x * y) M = (intModNat x M * intModNat y M) % M := by
+  have hh : (intModNat (x * y) M : Int) = (((intModNat x M * intModNat y M) % M : Nat) : Int) := by
+    rw [intModNat_cast (x * y) hM,
+      show (((intModNat x M * intModNat y M) % M : Nat) : Int)
+          = ((intModNat x M : Int) * intModNat y M) % M from by exact_mod_cast rfl,
+      intModNat_cast x hM, intModNat_cast y hM, ← Int.mul_emod]
+  exact_mod_cast hh
+
+/-- `intModNat` commutes with the full-range modular subtraction used by `WordMod`
+(`x + (M - y)`), matching `WordMod.toNat_sub`. -/
+theorem intModNat_sub (x y : Int) {M : Nat} (hM : 0 < M) :
+    intModNat (x - y) M = (intModNat x M + (M - intModNat y M)) % M := by
+  have hylt := intModNat_lt' y hM
+  have hh : (intModNat (x - y) M : Int)
+      = (((intModNat x M + (M - intModNat y M)) % M : Nat) : Int) := by
+    rw [intModNat_cast (x - y) hM,
+      show (((intModNat x M + (M - intModNat y M)) % M : Nat) : Int)
+          = ((intModNat x M : Int) + ((M : Int) - intModNat y M)) % M from by
+        have : intModNat y M ≤ M := Nat.le_of_lt hylt
+        exact_mod_cast rfl,
+      intModNat_cast x hM, intModNat_cast y hM,
+      show (x % (M:Int)) + ((M:Int) - y % M) = (x % M - y % M) + M from by omega,
+      Int.add_emod_right, ← Int.sub_emod]
+  exact_mod_cast hh
+
+end ZPoly
+end Hex

--- a/HexHensel/WordStep.lean
+++ b/HexHensel/WordStep.lean
@@ -48,6 +48,152 @@ theorem eq_iff_toNat {a b : WordMod ctx} : a = b ↔ a.toNat = b.toNat :=
   apply toNat_injective
   rw [toNat_ofNat, Nat.mod_eq_of_lt (toNat_lt a)]
 
+/-! ### `Lean.Grind.CommRing (WordMod ctx)`
+
+The Montgomery residue ring is a commutative ring; the axioms transport through
+`toNat` (which is `+`/`*`/`-`-compatible modulo `m`). This is what lets the
+word-sized poly arithmetic reuse the generic `DensePoly` ring/division lemmas. -/
+
+/-- Iterated product, the `npow` datum. -/
+def pow (a : WordMod ctx) : Nat → WordMod ctx
+  | 0 => 1
+  | n + 1 => pow a n * a
+
+instance : HPow (WordMod ctx) Nat (WordMod ctx) := ⟨pow⟩
+instance (n : Nat) : OfNat (WordMod ctx) n := ⟨ofNat n⟩
+instance : SMul Nat (WordMod ctx) := ⟨fun n a => ofNat n * a⟩
+instance : IntCast (WordMod ctx) :=
+  ⟨fun i => match i with
+    | .ofNat n => ofNat n
+    | .negSucc n => -(ofNat (n + 1))⟩
+instance : SMul Int (WordMod ctx) :=
+  ⟨fun i a => match i with
+    | .ofNat n => (n : Nat) • a
+    | .negSucc n => -((n + 1 : Nat) • a)⟩
+
+@[simp] theorem toNat_pow (a : WordMod ctx) (n : Nat) :
+    (a ^ n).toNat = (a.toNat ^ n) % m.toNat := by
+  change (pow a n).toNat = _
+  induction n with
+  | zero => simp [pow, toNat_one, Nat.pow_zero]
+  | succ k ih =>
+      rw [pow, toNat_mul, ih, Nat.pow_succ, Nat.mod_mul_mod]
+
+@[simp] theorem toNat_nsmul (n : Nat) (a : WordMod ctx) :
+    (n • a).toNat = (n % m.toNat * a.toNat) % m.toNat := by
+  change (ofNat n * a).toNat = _
+  rw [toNat_mul, toNat_ofNat]
+
+instance : Lean.Grind.Semiring (WordMod ctx) := by
+  refine Lean.Grind.Semiring.mk ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_
+  · intro a
+    apply toNat_injective
+    rw [toNat_add, toNat_zero, Nat.add_zero, Nat.mod_eq_of_lt (toNat_lt a)]
+  · intro a b
+    apply toNat_injective
+    rw [toNat_add, toNat_add, Nat.add_comm]
+  · intro a b c
+    apply toNat_injective
+    rw [toNat_add, toNat_add, toNat_add, toNat_add, Nat.mod_add_mod, Nat.add_mod_mod,
+      Nat.add_assoc]
+  · intro a b c
+    apply toNat_injective
+    rw [toNat_mul, toNat_mul, toNat_mul, toNat_mul, Nat.mod_mul_mod, Nat.mul_mod_mod,
+      Nat.mul_assoc]
+  · intro a
+    apply toNat_injective
+    rw [toNat_mul, toNat_one, Nat.mul_mod_mod, Nat.mul_one, Nat.mod_eq_of_lt (toNat_lt a)]
+  · intro a
+    apply toNat_injective
+    rw [toNat_mul, toNat_one, Nat.mod_mul_mod, Nat.one_mul, Nat.mod_eq_of_lt (toNat_lt a)]
+  · intro a b c
+    apply toNat_injective
+    rw [toNat_mul, toNat_add, toNat_add, toNat_mul, toNat_mul, Nat.mul_mod_mod,
+      Nat.mul_add, Nat.add_mod]
+  · intro a b c
+    apply toNat_injective
+    rw [toNat_mul, toNat_add, toNat_add, toNat_mul, toNat_mul, Nat.mod_mul_mod,
+      Nat.add_mul, Nat.add_mod]
+  · intro a
+    apply toNat_injective
+    rw [toNat_mul, toNat_zero, Nat.zero_mul, Nat.zero_mod]
+  · intro a
+    apply toNat_injective
+    rw [toNat_mul, toNat_zero, Nat.mul_zero, Nat.zero_mod]
+  · intro a
+    apply toNat_injective
+    rw [toNat_pow, toNat_one, Nat.pow_zero]
+  · intro a n
+    apply toNat_injective
+    rw [toNat_pow, toNat_mul, toNat_pow, Nat.pow_succ, Nat.mod_mul_mod]
+  · intro n
+    apply toNat_injective
+    rw [show (OfNat.ofNat (n + 1) : WordMod ctx) = ofNat (n + 1) from rfl,
+      toNat_ofNat, toNat_add, toNat_one,
+      show (OfNat.ofNat n : WordMod ctx) = ofNat n from rfl, toNat_ofNat, ← Nat.add_mod]
+  · intro n; rfl
+  · intro n a
+    apply toNat_injective
+    rw [toNat_nsmul, toNat_mul, show ((n : WordMod ctx)).toNat = (ofNat n : WordMod ctx).toNat from rfl,
+      toNat_ofNat]
+
+theorem neg_neg' (a : WordMod ctx) : (- -a : WordMod ctx) = a := by
+  apply toNat_injective
+  rw [toNat_neg, toNat_neg]
+  have ha : a.toNat < m.toNat := toNat_lt a
+  rcases Nat.eq_zero_or_pos a.toNat with h0 | h0
+  · rw [h0]; simp
+  · rw [Nat.mod_eq_of_lt (show m.toNat - a.toNat < m.toNat by omega),
+      Nat.sub_sub_self (Nat.le_of_lt ha), Nat.mod_eq_of_lt ha]
+
+instance : Lean.Grind.Ring (WordMod ctx) where
+  neg_add_cancel := by
+    intro a
+    apply toNat_injective
+    rw [toNat_add, toNat_neg, toNat_zero]
+    have ha : a.toNat < m.toNat := toNat_lt a
+    rcases Nat.eq_zero_or_pos a.toNat with h0 | h0
+    · rw [h0]; simp
+    · rw [Nat.mod_eq_of_lt (show m.toNat - a.toNat < m.toNat by omega),
+        Nat.sub_add_cancel (Nat.le_of_lt ha), Nat.mod_self]
+  sub_eq_add_neg := by
+    intro a b
+    apply toNat_injective
+    rw [toNat_sub, toNat_add, toNat_neg, Nat.add_mod_mod]
+  neg_zsmul := by
+    intro i a
+    cases i with
+    | ofNat n =>
+        cases n with
+        | zero =>
+            show ((0 : Int) • a) = -((0 : Int) • a)
+            apply toNat_injective
+            change (ofNat 0 * a).toNat = (-(ofNat 0 * a)).toNat
+            rw [toNat_neg, toNat_mul, toNat_ofNat]
+            simp
+        | succ n => rfl
+    | negSucc n =>
+        exact (neg_neg' ((n + 1 : Nat) • a)).symm
+  intCast_neg := by
+    intro i
+    cases i with
+    | ofNat n =>
+        cases n with
+        | zero =>
+            show ((0 : Int) : WordMod ctx) = -((0 : Int) : WordMod ctx)
+            apply toNat_injective
+            change (ofNat 0 : WordMod ctx).toNat = (-(ofNat 0 : WordMod ctx)).toNat
+            rw [toNat_neg]; simp
+        | succ n => rfl
+    | negSucc n =>
+        exact (neg_neg' (ofNat (n + 1))).symm
+
+instance : Lean.Grind.CommRing (WordMod ctx) := by
+  refine Lean.Grind.CommRing.mk ?_
+  intro a b
+  apply toNat_injective
+  rw [toNat_mul, toNat_mul, Nat.mul_comm]
+
 end WordMod
 
 namespace ZPoly

--- a/HexHensel/WordTransport.lean
+++ b/HexHensel/WordTransport.lean
@@ -312,5 +312,66 @@ theorem toWP_mul (x y : ZPoly) : toWP ctx (x * y) = toWP ctx x * toWP ctx y := b
     DensePoly.coeff_mul, DensePoly.coeff_mul]
   exact (toNat_eq_intModNat_of_Res ctx (Res_mulCoeffSum ctx x y j)).symm
 
+/-! ### Readback round-trip and monic/degree preservation -/
+
+private theorem one_ne_zero_wordMod (h1 : 1 < m.toNat) : (1 : WordMod ctx) ≠ 0 := by
+  intro h
+  have hh := congrArg WordMod.toNat h
+  rw [WordMod.toNat_one, WordMod.toNat_zero, Nat.mod_eq_of_lt h1] at hh
+  omega
+
+private theorem toWP_ofNat_one (h1 : 1 < m.toNat) :
+    WordMod.ofNat (ctx := ctx) (ZPoly.intModNat 1 m.toNat) = 1 := by
+  rw [intModNat_one ctx.p_pos, Nat.mod_eq_of_lt h1]; rfl
+
+/-- On a polynomial whose coefficients are already canonical in `[0, M)`,
+`ofWP ∘ toWP` is the identity. -/
+theorem ofWP_toWP_of_canonical (z : ZPoly)
+    (hz : ∀ i, 0 ≤ z.coeff i ∧ z.coeff i < (m.toNat : Int)) : ofWP ctx (toWP ctx z) = z := by
+  apply DensePoly.ext_coeff
+  intro j
+  rw [coeff_ofWP, coeff_toWP, WordMod.toNat_ofNat,
+    Nat.mod_eq_of_lt (ZPoly.intModNat_lt' _ ctx.p_pos)]
+  simp only [ZPoly.intModNat, Int.ofNat_eq_natCast]
+  rw [Int.emod_eq_of_lt (hz j).1 (hz j).2, Int.toNat_of_nonneg (hz j).1]
+
+theorem toWP_size_eq_of_monic {z : ZPoly} (hz : DensePoly.Monic z) (hzpos : 0 < z.size)
+    (h1 : 1 < m.toNat) : (toWP ctx z).size = z.size := by
+  refine Nat.le_antisymm (size_toWP_le ctx z) ?_
+  rcases Nat.lt_or_ge (toWP ctx z).size z.size with hlt | hge
+  · exfalso
+    have hcz : (toWP ctx z).coeff (z.size - 1) = 0 :=
+      DensePoly.coeff_eq_zero_of_size_le _ (by omega)
+    rw [coeff_toWP,
+      show z.coeff (z.size - 1) = 1 from by
+        rw [← DensePoly.leadingCoeff_eq_coeff_last z hzpos]; exact hz,
+      toWP_ofNat_one ctx h1] at hcz
+    exact one_ne_zero_wordMod ctx h1 hcz
+  · exact hge
+
+theorem toWP_monic {z : ZPoly} (hz : DensePoly.Monic z) (hzpos : 0 < z.size) (h1 : 1 < m.toNat) :
+    DensePoly.Monic (toWP ctx z) := by
+  show (toWP ctx z).leadingCoeff = 1
+  rw [DensePoly.leadingCoeff_eq_coeff_last _ (by rw [toWP_size_eq_of_monic ctx hz hzpos h1]; exact hzpos),
+    toWP_size_eq_of_monic ctx hz hzpos h1, coeff_toWP,
+    show z.coeff (z.size - 1) = 1 from by
+      rw [← DensePoly.leadingCoeff_eq_coeff_last z hzpos]; exact hz,
+    toWP_ofNat_one ctx h1]
+
+theorem toWP_degree_eq_of_monic {z : ZPoly} (hz : DensePoly.Monic z) (hzpos : 0 < z.size)
+    (h1 : 1 < m.toNat) : (toWP ctx z).degree?.getD 0 = z.degree?.getD 0 := by
+  have hs := toWP_size_eq_of_monic ctx hz hzpos h1
+  rw [DensePoly.degree?_eq_some_of_pos_size _ (by rw [hs]; exact hzpos),
+    DensePoly.degree?_eq_some_of_pos_size z hzpos, Option.getD_some, Option.getD_some, hs]
+
+theorem toWP_degree_le (z : ZPoly) : (toWP ctx z).degree?.getD 0 ≤ z.degree?.getD 0 := by
+  have hs := size_toWP_le ctx z
+  rcases Nat.eq_zero_or_pos (toWP ctx z).size with h0 | h0
+  · rw [DensePoly.degree?, dif_pos h0]; simp
+  · rw [DensePoly.degree?_eq_some_of_pos_size _ h0, Option.getD_some]
+    rcases Nat.eq_zero_or_pos z.size with hz0 | hz0
+    · omega
+    · rw [DensePoly.degree?_eq_some_of_pos_size z hz0, Option.getD_some]; omega
+
 end ZPoly
 end Hex

--- a/HexHensel/WordTransport.lean
+++ b/HexHensel/WordTransport.lean
@@ -1,0 +1,136 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexHensel.WordStep
+
+public section
+
+/-!
+The polynomial reduction map `toWP : ZPoly → DensePoly (WordMod ctx)` (reduce every
+coefficient into the residue ring) and its readback `ofWP`, together with the ring
+homomorphism laws modulo the working modulus `M := m.toNat`.
+
+`toWP` commutes with `+`, `-`, `*`, `0`, `1`; it kills the canonical reduction
+(`reduceModPow _ _ 2`); and `ofWP ∘ toWP` is that canonical reduction. These are
+the transport laws that carry the executable bignum Hensel step, coefficient by
+coefficient, into `WordMod` arithmetic.
+-/
+
+namespace Hex
+namespace ZPoly
+
+open Hex.DensePoly
+
+variable {m : UInt64} (ctx : _root_.MontCtx m)
+
+/-- Reduce an integer polynomial coefficientwise into `WordMod ctx`. -/
+def toWP (x : ZPoly) : DensePoly (WordMod ctx) :=
+  DensePoly.ofCoeffs (x.toArray.map (fun c => WordMod.ofNat (ZPoly.intModNat c m.toNat)))
+
+/-- Read the canonical `[0, M)` residues of a `WordMod` polynomial back into `ZPoly`. -/
+def ofWP (p : DensePoly (WordMod ctx)) : ZPoly :=
+  DensePoly.ofCoeffs (p.toArray.map (fun w => (Int.ofNat w.toNat : Int)))
+
+@[simp] theorem coeff_toWP (x : ZPoly) (j : Nat) :
+    (toWP ctx x).coeff j = WordMod.ofNat (ctx := ctx) (ZPoly.intModNat (x.coeff j) m.toNat) := by
+  have h0 : WordMod.ofNat (ctx := ctx) (ZPoly.intModNat 0 m.toNat) = 0 := by
+    have : ZPoly.intModNat 0 m.toNat = 0 := by simp [ZPoly.intModNat]
+    rw [this]; rfl
+  rw [toWP, DensePoly.coeff_ofCoeffs]
+  show (x.toArray.map (fun c => WordMod.ofNat (ctx := ctx) (ZPoly.intModNat c m.toNat))).getD j 0
+    = WordMod.ofNat (ctx := ctx) (ZPoly.intModNat (x.coeff j) m.toNat)
+  rw [show x.coeff j = x.toArray.getD j 0 from rfl]
+  simp only [Array.getD_eq_getD_getElem?, Array.getElem?_map]
+  cases x.toArray[j]? with
+  | none => simpa using h0.symm
+  | some v => simp
+
+@[simp] theorem coeff_ofWP (p : DensePoly (WordMod ctx)) (j : Nat) :
+    (ofWP ctx p).coeff j = Int.ofNat (p.coeff j).toNat := by
+  rw [ofWP, DensePoly.coeff_ofCoeffs]
+  show (p.toArray.map (fun w => (Int.ofNat w.toNat : Int))).getD j 0 = Int.ofNat (p.coeff j).toNat
+  rw [show p.coeff j = p.toArray.getD j 0 from rfl]
+  simp only [Array.getD_eq_getD_getElem?, Array.getElem?_map]
+  cases p.toArray[j]? with
+  | none => simp [WordMod.toNat_zero]
+  | some w => simp
+
+/-- `toWP` is well-defined on congruence classes modulo `M`. -/
+theorem toWP_congr {x y : ZPoly} (h : ZPoly.congr x y m.toNat) : toWP ctx x = toWP ctx y := by
+  apply DensePoly.ext_coeff
+  intro j
+  rw [coeff_toWP, coeff_toWP]
+  apply WordMod.toNat_injective
+  rw [WordMod.toNat_ofNat, WordMod.toNat_ofNat]
+  have hc : (x.coeff j - y.coeff j) % (m.toNat : Int) = 0 := h j
+  have hxy : x.coeff j % (m.toNat : Int) = y.coeff j % (m.toNat : Int) :=
+    Int.emod_eq_emod_iff_emod_sub_eq_zero.mpr hc
+  have : ZPoly.intModNat (x.coeff j) m.toNat = ZPoly.intModNat (y.coeff j) m.toNat := by
+    simp [ZPoly.intModNat, hxy]
+  rw [this]
+
+@[simp] theorem toWP_zero : toWP ctx 0 = 0 := by
+  apply DensePoly.ext_coeff
+  intro j
+  rw [coeff_toWP]
+  have : ZPoly.intModNat ((0 : ZPoly).coeff j) m.toNat = 0 := by
+    rw [DensePoly.coeff_zero]; simp [ZPoly.intModNat]
+  rw [this, DensePoly.coeff_zero]; rfl
+
+theorem toWP_add (x y : ZPoly) : toWP ctx (x + y) = toWP ctx x + toWP ctx y := by
+  apply DensePoly.ext_coeff
+  intro j
+  have hz : (0 : WordMod ctx) + 0 = 0 := by rw [WordMod.eq_iff_toNat]; simp
+  rw [DensePoly.coeff_add _ _ j hz, coeff_toWP, coeff_toWP, coeff_toWP]
+  apply WordMod.toNat_injective
+  rw [WordMod.toNat_add, WordMod.toNat_ofNat, WordMod.toNat_ofNat, WordMod.toNat_ofNat,
+    DensePoly.coeff_add x y j (by rfl), ZPoly.intModNat_add _ _ ctx.p_pos,
+    Nat.mod_eq_of_lt (ZPoly.intModNat_lt' (x.coeff j) ctx.p_pos),
+    Nat.mod_eq_of_lt (ZPoly.intModNat_lt' (y.coeff j) ctx.p_pos), Nat.mod_mod]
+
+theorem toWP_sub (x y : ZPoly) : toWP ctx (x - y) = toWP ctx x - toWP ctx y := by
+  apply DensePoly.ext_coeff
+  intro j
+  have hz : (0 : WordMod ctx) - 0 = 0 := by rw [WordMod.eq_iff_toNat]; simp
+  rw [DensePoly.coeff_sub _ _ j hz, coeff_toWP, coeff_toWP, coeff_toWP]
+  apply WordMod.toNat_injective
+  rw [WordMod.toNat_sub, WordMod.toNat_ofNat, WordMod.toNat_ofNat, WordMod.toNat_ofNat,
+    DensePoly.coeff_sub x y j (by rfl), ZPoly.intModNat_sub _ _ ctx.p_pos,
+    Nat.mod_eq_of_lt (ZPoly.intModNat_lt' (x.coeff j) ctx.p_pos),
+    Nat.mod_eq_of_lt (ZPoly.intModNat_lt' (y.coeff j) ctx.p_pos), Nat.mod_mod]
+
+theorem intModNat_one {M : Nat} (hM : 0 < M) : ZPoly.intModNat 1 M = 1 % M := by
+  have h : ((ZPoly.intModNat 1 M : Nat) : Int) = ((1 % M : Nat) : Int) := by
+    rw [ZPoly.intModNat_cast 1 hM]; exact_mod_cast rfl
+  exact_mod_cast h
+
+@[simp] theorem toWP_one : toWP ctx 1 = 1 := by
+  apply DensePoly.ext_coeff
+  intro j
+  rw [coeff_toWP, WordMod.eq_iff_toNat, WordMod.toNat_ofNat,
+    show (1 : ZPoly) = DensePoly.C 1 from rfl,
+    show (1 : DensePoly (WordMod ctx)) = DensePoly.C 1 from rfl,
+    DensePoly.coeff_C, DensePoly.coeff_C]
+  rcases Nat.eq_zero_or_pos j with hj | hj
+  · subst hj
+    rw [if_pos rfl, if_pos rfl, WordMod.toNat_one, intModNat_one ctx.p_pos, Nat.mod_mod]
+  · rw [if_neg (Nat.ne_of_gt hj), if_neg (Nat.ne_of_gt hj),
+      show (Zero.zero : WordMod ctx) = 0 from rfl, WordMod.toNat_zero,
+      show (Zero.zero : Int) = 0 from rfl, ZPoly.intModNat]
+    simp
+
+/-- The canonical reduction `reduceModPow _ p k` vanishes under `toWP` when the
+working modulus is exactly `p^k`. -/
+theorem toWP_reduceModPow {p k : Nat} (hM : m.toNat = p ^ k) (hpk : 0 < p ^ k) (x : ZPoly) :
+    toWP ctx (ZPoly.reduceModPow x p k) = toWP ctx x := by
+  apply toWP_congr
+  have := ZPoly.congr_reduceModPow x p k hpk
+  rwa [← hM] at this
+
+end ZPoly
+end Hex

--- a/HexHensel/WordTransport.lean
+++ b/HexHensel/WordTransport.lean
@@ -132,5 +132,185 @@ theorem toWP_reduceModPow {p k : Nat} (hM : m.toNat = p ^ k) (hpk : 0 < p ^ k) (
   have := ZPoly.congr_reduceModPow x p k hpk
   rwa [← hM] at this
 
+theorem size_toWP_le (x : ZPoly) : (toWP ctx x).size ≤ x.size := by
+  rw [toWP]
+  calc (DensePoly.ofCoeffs _).size ≤ (x.toArray.map _).size := DensePoly.size_ofCoeffs_le _
+    _ = x.size := by rw [Array.size_map, DensePoly.toArray_size]
+
+end ZPoly
+
+/-! ### Common-range normalisation of `mulCoeffSum` -/
+
+namespace DensePoly
+
+variable {R : Type _} [Lean.Grind.CommRing R] [DecidableEq R]
+
+/-- An inner schoolbook step past the divisor's support is the identity. -/
+theorem mulCoeffStep_ge (p q : DensePoly R) (n i : Nat) (acc : R) (j : Nat) (hj : q.size ≤ j) :
+    mulCoeffStep p q n i acc j = acc := by
+  unfold mulCoeffStep
+  by_cases h : i + j = n
+  · rw [if_pos h, coeff_eq_zero_of_size_le q hj, show (Zero.zero : R) = 0 from rfl,
+      Lean.Grind.Semiring.mul_zero, Lean.Grind.Semiring.add_zero]
+  · rw [if_neg h]
+
+/-- Extending the inner fold past `q.size` changes nothing. -/
+theorem mulCoeffStep_inner_extend (p q : DensePoly R) (n i : Nat) (acc : R) (t : Nat)
+    (ht : q.size ≤ t) :
+    (List.range t).foldl (mulCoeffStep p q n i) acc
+      = (List.range q.size).foldl (mulCoeffStep p q n i) acc := by
+  obtain ⟨d, rfl⟩ : ∃ d, t = q.size + d := ⟨t - q.size, by omega⟩
+  induction d with
+  | zero => simp
+  | succ d ih =>
+      rw [Nat.add_succ, List.range_succ, List.foldl_append]
+      simp only [List.foldl_cons, List.foldl_nil]
+      rw [mulCoeffStep_ge p q n i _ (q.size + d) (by omega), ih (by omega)]
+
+/-- Past `p.size`, the whole inner fold is the identity. -/
+theorem mulCoeffStep_inner_all_zero (p q : DensePoly R) (n i : Nat) (acc : R) (hi : p.size ≤ i)
+    (L : List Nat) : L.foldl (mulCoeffStep p q n i) acc = acc := by
+  induction L generalizing acc with
+  | nil => simp
+  | cons j L ih =>
+      simp only [List.foldl_cons]
+      rw [show mulCoeffStep p q n i acc j = acc from by
+        unfold mulCoeffStep
+        by_cases h : i + j = n
+        · rw [if_pos h, coeff_eq_zero_of_size_le p hi, show (Zero.zero : R) = 0 from rfl,
+            Lean.Grind.Semiring.zero_mul, Lean.Grind.Semiring.add_zero]
+        · rw [if_neg h], ih]
+
+/-- Extending the outer fold past `p.size` changes nothing. -/
+theorem mulCoeffStep_outer_extend (p q : DensePoly R) (n : Nat) (acc : R) (s : Nat)
+    (hs : p.size ≤ s) :
+    (List.range s).foldl (fun acc i => (List.range q.size).foldl (mulCoeffStep p q n i) acc) acc
+      = (List.range p.size).foldl (fun acc i => (List.range q.size).foldl (mulCoeffStep p q n i) acc) acc := by
+  obtain ⟨d, rfl⟩ : ∃ d, s = p.size + d := ⟨s - p.size, by omega⟩
+  induction d with
+  | zero => simp
+  | succ d ih =>
+      rw [Nat.add_succ, List.range_succ, List.foldl_append]
+      simp only [List.foldl_cons, List.foldl_nil]
+      rw [mulCoeffStep_inner_all_zero p q n (p.size + d) _ (by omega), ih (by omega)]
+
+/-- `mulCoeffSum` computed over any large enough common range `s × t`. -/
+theorem mulCoeffSum_norm (p q : DensePoly R) (n s t : Nat) (hs : p.size ≤ s) (ht : q.size ≤ t) :
+    mulCoeffSum p q n
+      = (List.range s).foldl (fun acc i => (List.range t).foldl (mulCoeffStep p q n i) acc) 0 := by
+  have hfun : (fun (acc : R) (i : Nat) => (List.range t).foldl (mulCoeffStep p q n i) acc)
+            = (fun acc i => (List.range q.size).foldl (mulCoeffStep p q n i) acc) := by
+    funext acc i; exact mulCoeffStep_inner_extend p q n i acc t ht
+  rw [hfun, show mulCoeffSum p q n
+      = (List.range p.size).foldl (fun acc i => (List.range q.size).foldl (mulCoeffStep p q n i) acc) 0
+      from rfl]
+  exact (mulCoeffStep_outer_extend p q n 0 s hs).symm
+
+end DensePoly
+
+/-! ### Multiplicative transport -/
+
+namespace ZPoly
+
+open Hex.DensePoly
+
+variable {m : UInt64} (ctx : _root_.MontCtx m)
+
+/-- `M ∣ (a - a % M)`. -/
+private theorem selfdvd (M : Nat) (a : Int) : (M : Int) ∣ (a - a % (M : Int)) := by
+  apply Int.dvd_of_emod_eq_zero
+  rw [Int.sub_emod, Int.emod_emod_of_dvd a ⟨1, (Int.mul_one _).symm⟩, Int.sub_self, Int.zero_emod]
+
+/-- Residue-agreement modulo `M` between a `WordMod` value and an `Int`. -/
+private def Res (w : WordMod ctx) (z : Int) : Prop :=
+  (Int.ofNat w.toNat - z) % (m.toNat : Int) = 0
+
+private theorem Res_zero : Res ctx 0 0 := by
+  show (Int.ofNat (0 : WordMod ctx).toNat - 0) % (m.toNat : Int) = 0
+  rw [WordMod.toNat_zero]; simp
+
+private theorem Res_add {w w' : WordMod ctx} {z z' : Int}
+    (h : Res ctx w z) (h' : Res ctx w' z') : Res ctx (w + w') (z + z') := by
+  show (Int.ofNat (w + w').toNat - (z + z')) % (m.toNat : Int) = 0
+  rw [show Int.ofNat (w + w').toNat = (Int.ofNat w.toNat + Int.ofNat w'.toNat) % (m.toNat : Int)
+      from by rw [WordMod.toNat_add]; exact_mod_cast rfl]
+  apply Int.emod_eq_zero_of_dvd
+  rcases Int.dvd_of_emod_eq_zero h with ⟨c, hc⟩
+  rcases Int.dvd_of_emod_eq_zero h' with ⟨d, hd⟩
+  rcases selfdvd m.toNat (Int.ofNat w.toNat + Int.ofNat w'.toNat) with ⟨e, he⟩
+  exact ⟨c + d - e, by grind⟩
+
+private theorem Res_mul {w w' : WordMod ctx} {z z' : Int}
+    (h : Res ctx w z) (h' : Res ctx w' z') : Res ctx (w * w') (z * z') := by
+  show (Int.ofNat (w * w').toNat - z * z') % (m.toNat : Int) = 0
+  rw [show Int.ofNat (w * w').toNat = (Int.ofNat w.toNat * Int.ofNat w'.toNat) % (m.toNat : Int)
+      from by rw [WordMod.toNat_mul]; exact_mod_cast rfl]
+  apply Int.emod_eq_zero_of_dvd
+  rcases Int.dvd_of_emod_eq_zero h with ⟨c, hc⟩
+  rcases Int.dvd_of_emod_eq_zero h' with ⟨d, hd⟩
+  rcases selfdvd m.toNat (Int.ofNat w.toNat * Int.ofNat w'.toNat) with ⟨e, he⟩
+  exact ⟨Int.ofNat w.toNat * d + z' * c - e, by grind⟩
+
+private theorem Res_coeff_toWP (x : ZPoly) (i : Nat) :
+    Res ctx ((toWP ctx x).coeff i) (x.coeff i) := by
+  show (Int.ofNat ((toWP ctx x).coeff i).toNat - x.coeff i) % (m.toNat : Int) = 0
+  rw [coeff_toWP, WordMod.toNat_ofNat, Nat.mod_eq_of_lt (ZPoly.intModNat_lt' _ ctx.p_pos),
+    Int.ofNat_eq_natCast, ZPoly.intModNat_cast _ ctx.p_pos]
+  rw [Int.sub_emod, Int.emod_emod_of_dvd _ ⟨1, (Int.mul_one _).symm⟩, Int.sub_self, Int.zero_emod]
+
+private theorem toNat_eq_intModNat_of_Res {w : WordMod ctx} {z : Int} (h : Res ctx w z) :
+    w.toNat = ZPoly.intModNat z m.toNat := by
+  have hlt : (w.toNat : Int) < m.toNat := by exact_mod_cast WordMod.toNat_lt w
+  have hnn : (0 : Int) ≤ w.toNat := Int.natCast_nonneg _
+  have hmod : (w.toNat : Int) % m.toNat = z % m.toNat := by
+    have := Int.emod_eq_emod_iff_emod_sub_eq_zero.mpr h
+    rwa [Int.ofNat_eq_natCast] at this
+  have hz : (w.toNat : Int) = z % (m.toNat : Int) := by rw [← hmod, Int.emod_eq_of_lt hnn hlt]
+  rw [ZPoly.intModNat, Int.ofNat_eq_natCast, ← hz]; simp
+
+private theorem Res_inner_fold (x y : ZPoly) (n i : Nat) (L : List Nat) :
+    ∀ (w : WordMod ctx) (z : Int), Res ctx w z →
+      Res ctx (L.foldl (mulCoeffStep (toWP ctx x) (toWP ctx y) n i) w)
+        (L.foldl (mulCoeffStep x y n i) z) := by
+  induction L with
+  | nil => intro w z h; simpa using h
+  | cons a L ih =>
+      intro w z h
+      simp only [List.foldl_cons]
+      apply ih
+      unfold mulCoeffStep
+      by_cases hc : i + a = n
+      · rw [if_pos hc, if_pos hc]
+        exact Res_add ctx h (Res_mul ctx (Res_coeff_toWP ctx x i) (Res_coeff_toWP ctx y a))
+      · rw [if_neg hc, if_neg hc]; exact h
+
+private theorem Res_outer_fold (x y : ZPoly) (n t : Nat) (L : List Nat) :
+    ∀ (w : WordMod ctx) (z : Int), Res ctx w z →
+      Res ctx
+        (L.foldl (fun acc i =>
+          (List.range t).foldl (mulCoeffStep (toWP ctx x) (toWP ctx y) n i) acc) w)
+        (L.foldl (fun acc i => (List.range t).foldl (mulCoeffStep x y n i) acc) z) := by
+  induction L with
+  | nil => intro w z h; simpa using h
+  | cons a L ih =>
+      intro w z h
+      simp only [List.foldl_cons]
+      exact ih _ _ (Res_inner_fold ctx x y n a (List.range t) w z h)
+
+private theorem Res_mulCoeffSum (x y : ZPoly) (j : Nat) :
+    Res ctx (mulCoeffSum (toWP ctx x) (toWP ctx y) j) (mulCoeffSum x y j) := by
+  rw [DensePoly.mulCoeffSum_norm (toWP ctx x) (toWP ctx y) j x.size y.size
+        (size_toWP_le ctx x) (size_toWP_le ctx y),
+      DensePoly.mulCoeffSum_norm x y j x.size y.size (Nat.le_refl _) (Nat.le_refl _)]
+  exact Res_outer_fold ctx x y j y.size (List.range x.size) 0 0 (Res_zero ctx)
+
+theorem toWP_mul (x y : ZPoly) : toWP ctx (x * y) = toWP ctx x * toWP ctx y := by
+  apply DensePoly.ext_coeff
+  intro j
+  apply WordMod.toNat_injective
+  rw [coeff_toWP, WordMod.toNat_ofNat, Nat.mod_eq_of_lt (ZPoly.intModNat_lt' _ ctx.p_pos),
+    DensePoly.coeff_mul, DensePoly.coeff_mul]
+  exact (toNat_eq_intModNat_of_Res ctx (Res_mulCoeffSum ctx x y j)).symm
+
 end ZPoly
 end Hex

--- a/HexModArith/WordMod.lean
+++ b/HexModArith/WordMod.lean
@@ -285,6 +285,21 @@ instance : Sub (WordMod ctx) := ⟨sub⟩
 
 instance : Neg (WordMod ctx) := ⟨neg⟩
 
+/-- Iterated product, the natural-power operation. -/
+@[expose]
+def pow (a : WordMod ctx) : Nat → WordMod ctx
+  | 0 => 1
+  | n + 1 => pow a n * a
+
+instance : Pow (WordMod ctx) Nat := ⟨pow⟩
+instance (n : Nat) : OfNat (WordMod ctx) n := ⟨ofNat n⟩
+instance : SMul Nat (WordMod ctx) := ⟨fun n a => (n : WordMod ctx) * a⟩
+instance : IntCast (WordMod ctx) :=
+  ⟨fun i => match i with
+    | .ofNat n => (n : WordMod ctx)
+    | .negSucc n => -((n + 1 : Nat) : WordMod ctx)⟩
+instance : SMul Int (WordMod ctx) := ⟨fun i a => (i : WordMod ctx) * a⟩
+
 @[simp] theorem toNat_add (a b : WordMod ctx) :
     (a + b).toNat = (a.toNat + b.toNat) % m.toNat := by
   have hs_lt : addModWord m a.val b.val < m := by
@@ -325,6 +340,24 @@ instance : Neg (WordMod ctx) := ⟨neg⟩
     (-a).toNat = (m.toNat - a.toNat) % m.toNat := by
   show (0 - a).toNat = (m.toNat - a.toNat) % m.toNat
   rw [toNat_sub, toNat_zero, Nat.zero_add]
+
+@[simp] theorem toNat_pow (a : WordMod ctx) (n : Nat) :
+    (a ^ n).toNat = (a.toNat ^ n) % m.toNat := by
+  change (pow a n).toNat = _
+  induction n with
+  | zero => simp [pow, toNat_one, Nat.pow_zero]
+  | succ k ih =>
+      rw [pow, toNat_mul, ih, Nat.pow_succ, Nat.mod_mul_mod]
+
+@[simp] theorem toNat_nsmul (n : Nat) (a : WordMod ctx) :
+    (n • a).toNat = (n % m.toNat * a.toNat) % m.toNat := by
+  change ((ofNat n : WordMod ctx) * a).toNat = _
+  rw [toNat_mul, toNat_ofNat]
+
+@[simp] theorem toNat_neg_mul (a b : WordMod ctx) :
+    ((-a) * b).toNat = (m.toNat - (a.toNat * b.toNat % m.toNat)) % m.toNat := by
+  rw [toNat_mul, toNat_neg, Nat.mod_mul_mod]
+  exact sub_mul_word_mod m.toNat b.toNat a.toNat ctx.p_pos (Nat.le_of_lt (toNat_lt a))
 
 end WordMod
 

--- a/HexModArithMathlib/WordMod.lean
+++ b/HexModArithMathlib/WordMod.lean
@@ -100,21 +100,9 @@ theorem toZMod_injective : Function.Injective (toZMod (ctx := ctx)) := by
 
 /-! ### Mathlib `CommRing` structure, transferred along `toZMod`.
 
-`WordMod` already carries `Zero/One/Add/Mul/Neg/Sub/NatCast`; the remaining data
-a `CommRing` needs (`SMul ℕ`, `SMul ℤ`, `Pow ℕ`, `IntCast`) is defined here so
-that each transports to `ZMod` immediately, then `Function.Injective.commRing`
-pulls the ring structure back through the injective `toZMod`. -/
-
-instance : SMul ℕ (Hex.WordMod ctx) := ⟨fun n a => (n : Hex.WordMod ctx) * a⟩
-
-instance : IntCast (Hex.WordMod ctx) :=
-  ⟨fun z => match z with
-    | Int.ofNat n => (n : Hex.WordMod ctx)
-    | Int.negSucc n => -((n + 1 : Nat) : Hex.WordMod ctx)⟩
-
-instance : SMul ℤ (Hex.WordMod ctx) := ⟨fun z a => (z : Hex.WordMod ctx) * a⟩
-
-instance : Pow (Hex.WordMod ctx) ℕ := ⟨fun a n => npowRec n a⟩
+`WordMod` already carries all ring operations in the Mathlib-free base. Each
+operation transports to `ZMod`, then `Function.Injective.commRing` pulls the
+ring structure back through the injective `toZMod`. -/
 
 @[simp] theorem toZMod_natCast (n : Nat) :
     toZMod ((n : Hex.WordMod ctx)) = (n : ZMod m.toNat) := by
@@ -133,11 +121,15 @@ instance : Pow (Hex.WordMod ctx) ℕ := ⟨fun a n => npowRec n a⟩
       rw [toZMod_neg, toZMod_natCast]
       exact (Int.cast_negSucc n).symm
 
-theorem toZMod_npowRec (a : Hex.WordMod ctx) (n : Nat) :
-    toZMod (npowRec n a) = toZMod a ^ n := by
-  induction n with
-  | zero => simp [npowRec, toZMod_one]
-  | succ k ih => rw [npowRec, toZMod_mul, ih, pow_succ]
+theorem toZMod_pow (a : Hex.WordMod ctx) (n : Nat) :
+    toZMod (a ^ n) = toZMod a ^ n := by
+  change (((a ^ n).toNat : Nat) : ZMod m.toNat) =
+    (((a.toNat : Nat) : ZMod m.toNat)) ^ n
+  rw [Hex.WordMod.toNat_pow]
+  calc
+    (((a.toNat ^ n % m.toNat : Nat) : ZMod m.toNat)) =
+        ((a.toNat ^ n : Nat) : ZMod m.toNat) := by rw [ZMod.natCast_mod]
+    _ = (((a.toNat : Nat) : ZMod m.toNat)) ^ n := by rw [Nat.cast_pow]
 
 /-- The executable `WordMod` residue ring is a Mathlib `CommRing`, pulled back
 along the injective `toZMod`. -/
@@ -150,7 +142,7 @@ instance : CommRing (Hex.WordMod ctx) :=
     (fun z x => by
       show toZMod ((z : Hex.WordMod ctx) * x) = z • toZMod x
       rw [toZMod_mul, toZMod_intCast, zsmul_eq_mul])
-    (fun x n => toZMod_npowRec x n)
+    (fun x n => toZMod_pow x n)
     toZMod_natCast toZMod_intCast
 
 /-- `toZMod` packaged as a ring homomorphism. -/

--- a/HexPoly/Euclid.lean
+++ b/HexPoly/Euclid.lean
@@ -13,6 +13,7 @@ public import HexPoly.Euclid.Content
 import all HexPoly.Euclid.DivGcd
 import all HexPoly.Euclid.MulRing
 import all HexPoly.Euclid.Reconstruction
+public import HexPoly.Euclid.MonicUnique
 import all HexPoly.Euclid.Content
 
 public section

--- a/HexPoly/Euclid/MonicUnique.lean
+++ b/HexPoly/Euclid/MonicUnique.lean
@@ -1,0 +1,147 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexPoly.Euclid.DivGcd
+public import HexPoly.Euclid.Reconstruction
+
+public section
+
+/-!
+Uniqueness of monic (Euclidean) division for `DensePoly` over a commutative ring.
+
+`divMod_eq_of_reconstruction` says any reconstruction `q * g + r = num` with a
+positive-degree divisor `g` whose leading coefficient is a two-sided unit for the
+`Div`/`Mul` structure and with remainder of degree below `g` must be `divMod num g`.
+This is the ring-hom-free counterpart of `Polynomial.div_modByMonic_unique`; the
+proof reduces the difference of two reconstructions to a single division that is
+simultaneously `(quotient-difference, 0)` (via `divMod_eq_of_polynomial_mul`) and
+`(0, remainder-difference)` (via the degree short circuit), forcing both to vanish.
+-/
+
+namespace Hex
+namespace DensePoly
+
+/-- Right distributivity of multiplication over subtraction (Mathlib-free shim:
+`DensePoly` carries only `Lean.Grind.CommRing`). -/
+theorem sub_mul_poly {S : Type _} [Lean.Grind.CommRing S] [DecidableEq S]
+    (a b c : DensePoly S) : (a - b) * c = a * c - b * c := by
+  rw [sub_eq_add_neg_poly a b, mul_add_left_poly a (0 - b) c,
+    mul_comm_poly (0 - b) c, mul_sub_zero_comm c b,
+    ← sub_eq_add_neg_poly (a * c) (b * c)]
+
+/-- The `degree?`-getD of a difference of two polynomials each of degree below a
+positive-degree `g` is again below `g`. -/
+theorem degree_getD_sub_lt {S : Type _} [Lean.Grind.CommRing S] [DecidableEq S]
+    (a b g : DensePoly S)
+    (hg : 0 < g.degree?.getD 0)
+    (ha : a.degree?.getD 0 < g.degree?.getD 0)
+    (hb : b.degree?.getD 0 < g.degree?.getD 0) :
+    (a - b).degree?.getD 0 < g.degree?.getD 0 := by
+  -- `g` has size ≥ 2, and `g.degree?.getD 0 = g.size - 1`.
+  have hg_pos : 0 < g.size := by
+    rcases Nat.eq_zero_or_pos g.size with h0 | h0
+    · have hz : g.degree?.getD 0 = 0 := by
+        rw [(degree?_eq_none_iff g).mpr h0, Option.getD_none]
+      omega
+    · exact h0
+  have hg_deg : g.degree?.getD 0 = g.size - 1 := by
+    rw [degree?_eq_some_of_pos_size g hg_pos, Option.getD_some]
+  -- Any polynomial of degree below `g` has size ≤ g.size - 1.
+  have size_le : ∀ (p : DensePoly S), p.degree?.getD 0 < g.degree?.getD 0 →
+      p.size ≤ g.size - 1 := by
+    intro p hp
+    rcases Nat.eq_zero_or_pos p.size with hps | hps
+    · omega
+    · have hpd : p.degree?.getD 0 = p.size - 1 := by
+        rw [degree?_eq_some_of_pos_size p hps, Option.getD_some]
+      rw [hpd, hg_deg] at hp
+      omega
+  have ha_size := size_le a ha
+  have hb_size := size_le b hb
+  -- Every coefficient of `a - b` at index ≥ g.size - 1 vanishes.
+  have hzero : ∀ i, g.size - 1 ≤ i → (a - b).coeff i = (0 : S) := by
+    intro i hi
+    rw [coeff_sub_ring a b i,
+      coeff_eq_zero_of_size_le a (by omega), coeff_eq_zero_of_size_le b (by omega)]
+    grind
+  -- Hence `a - b` has size ≤ g.size - 1.
+  have hsub_size : (a - b).size ≤ g.size - 1 := by
+    rcases Nat.lt_or_ge (g.size - 1) (a - b).size with h | h
+    · exfalso
+      have hlast : g.size - 1 ≤ (a - b).size - 1 := by omega
+      exact coeff_last_ne_zero_of_pos_size (a - b) (by omega) (hzero _ hlast)
+    · exact h
+  -- Conclude on `degree?`.
+  rcases Nat.eq_zero_or_pos (a - b).size with hs | hs
+  · have hz : (a - b).degree?.getD 0 = 0 := by
+      rw [(degree?_eq_none_iff (a - b)).mpr hs, Option.getD_none]
+    omega
+  · rw [degree?_eq_some_of_pos_size (a - b) hs, hg_deg]
+    simp only [Option.getD_some]
+    omega
+
+/-- Uniqueness of Euclidean division by a positive-degree divisor whose leading
+coefficient is a two-sided unit (in particular, a monic divisor): a reconstruction
+with a small remainder is `divMod`. -/
+theorem divMod_eq_of_reconstruction {S : Type _}
+    [Lean.Grind.CommRing S] [DecidableEq S] [Div S]
+    (num g q r : DensePoly S)
+    (hg : 0 < g.degree?.getD 0)
+    (hcancel : ∀ a : S, a - (a / g.leadingCoeff) * g.leadingCoeff = (Zero.zero : S))
+    (hexact : ∀ a : S, (a * g.leadingCoeff) / g.leadingCoeff = a)
+    (h_top_ne : ∀ a : S, a ≠ (Zero.zero : S) → a * g.leadingCoeff ≠ (Zero.zero : S))
+    (hrec : q * g + r = num)
+    (hrdeg : r.degree?.getD 0 < g.degree?.getD 0) :
+    divMod num g = (q, r) := by
+  -- The actual quotient/remainder.
+  rcases hqr : divMod num g with ⟨q', r'⟩
+  have hrec' : q' * g + r' = num := by
+    have h := divMod_reconstruction num g hcancel
+    rw [hqr] at h; exact h
+  have hr'deg : r'.degree?.getD 0 < g.degree?.getD 0 := by
+    have h := divMod_remainder_degree_lt_of_pos_degree_core num g hg hcancel
+    rw [hqr] at h; exact h
+  -- Difference identity: `(q - q') * g = r' - r`.
+  have hmul : (q - q') * g = r' - r := by
+    rw [sub_mul_poly q q' g]
+    apply ext_coeff
+    intro n
+    have hz2 : (0 : S) + (0 : S) = 0 := by grind
+    have hcoeff : (q * g).coeff n + r.coeff n = (q' * g).coeff n + r'.coeff n := by
+      have h := congrArg (fun p => DensePoly.coeff p n)
+        (show q * g + r = q' * g + r' from by rw [hrec, hrec'])
+      rw [coeff_add _ _ n hz2, coeff_add _ _ n hz2] at h
+      exact h
+    rw [coeff_sub_ring, coeff_sub_ring]
+    grind
+  -- One division, two incompatible values unless both differences vanish.
+  have hdegd : (r' - r).degree?.getD 0 < g.degree?.getD 0 :=
+    degree_getD_sub_lt r' r g hg hr'deg hrdeg
+  have hA : divMod (r' - r) g = (q - q', 0) :=
+    divMod_eq_of_polynomial_mul (r' - r) g (q - q') hg hexact h_top_ne hmul
+  have hB : divMod (r' - r) g = (0, r' - r) :=
+    divMod_eq_zero_self_of_degree_lt (r' - r) g hdegd
+  rw [hA] at hB
+  have hqq : q - q' = 0 := (Prod.mk.injEq _ _ _ _ ▸ hB).1
+  have hrr : (0 : DensePoly S) = r' - r := (Prod.mk.injEq _ _ _ _ ▸ hB).2
+  have hqeq : q' = q := by
+    apply ext_coeff
+    intro n
+    have h := congrArg (fun p => DensePoly.coeff p n) hqq
+    rw [coeff_sub_ring, coeff_zero] at h
+    grind
+  have hreq : r' = r := by
+    apply ext_coeff
+    intro n
+    have h := congrArg (fun p => DensePoly.coeff p n) hrr.symm
+    rw [coeff_sub_ring, coeff_zero] at h
+    grind
+  rw [hqeq, hreq]
+
+end DensePoly
+end Hex

--- a/progress/20260722T165827Z_issue-8854.md
+++ b/progress/20260722T165827Z_issue-8854.md
@@ -1,0 +1,47 @@
+# issue #8854: word-sized Hensel lift — premise check done, reported back (no PR)
+
+## Accomplished
+
+Premise-checked and prototyped the word-sized quadratic Hensel lift before
+investing in the full proof, then reported concrete findings on
+https://github.com/kim-em/hex-dev/issues/8854#issuecomment-5049033932 and left
+the directive claimable. No PR opened; no code committed. A second reviewer
+(Codex) independently agreed with the "report back, don't force the proof" call.
+
+Key evidence gathered (throwaway prototype, reverted):
+- Executable `quadraticHenselStepWord?` (whole step over `WordMod`, 2 `DensePoly.divMod`
+  + ~13 ring ops) is byte-identical to `quadraticHenselStep` on 5 monic `#guard`s
+  (moduli 5/25/625/3125, deg-1 and deg-2 divisors).
+- SD4 profile: p=5, lift ladder k=4,8,16,32; step working modulus 5^(2*current).
+  Steps 5^2..5^16 fit an odd 2^64 word; 5^32 (~2.3e22) does not.
+- Isolated Hensel lift at k=32 ~= 4.7 ms out of ~36.3 ms `factorLattice` => lift is
+  ~13% of SD4, NOT dominant (contradicts the directive's premise).
+- Interleaved A/B (single machine): fast ON ~36.5-36.9 ms vs OFF ~37.8-38.5 ms =>
+  reproducible ~3.5-4% SD4 win (better than CLD #8697's 0%, but modest).
+
+## Current frontier — two premise problems + one correctness fix
+
+1. Lift is ~13% of SD4, not dominant; the win caps low.
+2. CLD architecture does NOT transfer: five Mathlib-free spec theorems in
+   `HexHensel/Quadratic.lean` unfold `quadraticHenselStep`, and Mathlib-free
+   `HexHensel/QuadraticMultifactor.lean` consumes them, so the byte-identity
+   `quadraticHenselStep = quadraticHenselStepBignum` must be proven MATHLIB-FREE
+   (unlike CLD's Mathlib-only proof). Needs a generic Mathlib-free monic-division
+   uniqueness theorem + canonical-residue transport (~600-1000 lines).
+3. Correctness: the dispatch must guard `Monic g ∧ 0 < deg g` (the directive's
+   `<divisor monic/deg>`); `WordMod.div` returns 0 for non-monic divisors, so an
+   unconditional word dispatch is unsound.
+
+## Next step
+
+If revisited: bounded spike for Mathlib-free monic-division uniqueness via
+`HexPoly/Euclid/Reconstruction.lean:divMod_eq_of_polynomial_mul` (degree-shortcut
+route, works over rings with zero divisors since the divisor is monic). Finish
+only if it stays ~400-600 reusable lines. Build a single dual-path A/B binary and
+break out per-modulus call counts across the product tree.
+
+## Blockers
+
+None technical for the report itself. The full proof is gated on the
+generic-uniqueness spike staying compact; that decision belongs to an updated
+directive.

--- a/progress/20260722T172904Z_issue-8854-spike.md
+++ b/progress/20260722T172904Z_issue-8854-spike.md
@@ -1,0 +1,44 @@
+# issue #8854: ran the recommended spike — gate passed, correspondence balloons at mul-hom
+
+## Accomplished
+
+Executed Codex's recommendation (bounded generic-uniqueness spike first; continue
+only if compact). Committed reusable, green, sorry-free infrastructure on
+`issue-8854`:
+
+- `HexPoly/Euclid/MonicUnique.lean` (147 lines): `DensePoly.divMod_eq_of_reconstruction`
+  — Mathlib-free monic-division uniqueness (counterpart of
+  `Polynomial.div_modByMonic_unique`), via `divMod_eq_of_polynomial_mul` + degree
+  short circuit + a `degree_getD_sub_lt` helper. This is the go/no-go gate; it is
+  compact.
+- `HexHensel/WordStep.lean` (104 lines): WordMod scalar bridge — `toNat` injective,
+  `ofNat_toNat` round trip, `intModNat` commuting with `+`/`*`/full-range `-`.
+
+Also (earlier this session, reverted from tree, preserved in the issue thread):
+executable `quadraticHenselStepWord?` validated byte-identical (5 `#guard`s);
+interleaved A/B measured ~3.5-4% SD4 win; isolated lift ~4.7ms of ~36.3ms (~13%).
+
+Posted the spike result on the issue:
+https://github.com/kim-em/hex-dev/issues/8854#issuecomment-5049329681
+
+## Current frontier — the ballooning point
+
+`toWP_mul` (reduction commutes with the coefficient convolution) is the deep
+remaining piece. CLD got it free from Mathlib `map_mul`; Mathlib-free it needs a
+fold-congruence mirroring `ZPoly.congr_mul` / `dvd_mulCoeffOuter_fold_sub`, bridging
+`WordMod.toNat` to `Int`. On top: monic/degree preservation of `toWP g` and
+`g' = g + r`, a bignum `divModMonicModSquare` remainder-degree bound, the two
+division transports, the ~13-op assembly, and the guarded dispatch + reroute of the
+5 Mathlib-free spec theorems. ~500-600 lines remaining, mul-hom being non-mechanical.
+
+## Next step
+
+Decision for the reviewer: invest the ~500-600 lines (mul-hom fold machinery
+dominant) for ~3.5-4% SD4, starting from the green spike, or stop. The dispatch
+guard MUST include `Monic g ∧ 0 < deg g` (WordMod.div returns 0 for non-monic
+divisors); an unconditional word dispatch is unsound.
+
+## Blockers
+
+None on the committed infrastructure (green, no sorry/axiom). The full
+correspondence is gated on the cost/benefit decision above.

--- a/progress/20260722T181253Z_issue-8854-transport.md
+++ b/progress/20260722T181253Z_issue-8854-transport.md
@@ -1,0 +1,43 @@
+# issue #8854: word-lift correspondence — foundations built (green), multiplicative transport + assembly remain
+
+## Accomplished (all committed on issue-8854, green, no sorry/axiom)
+
+1. `HexPoly/Euclid/MonicUnique.lean` — `DensePoly.divMod_eq_of_reconstruction`:
+   Mathlib-free monic-division uniqueness (counterpart of div_modByMonic_unique).
+2. `HexHensel/WordStep.lean` — Mathlib-free `Lean.Grind.CommRing (WordMod ctx)`
+   (residue-ring axioms transported through toNat, mirroring ZMod64), plus the
+   scalar bridge: `WordMod.toNat` injective + `ofNat_toNat`; `intModNat` commuting
+   with +, *, and full-range modular -.
+3. `HexHensel/WordTransport.lean` — `toWP`/`ofWP` (reduce ZPoly into WordMod / read
+   back), with coeff lemmas and the ADDITIVE ring-hom laws: toWP_add, toWP_sub,
+   toWP_one, toWP_zero, toWP_congr, toWP_reduceModPow.
+
+Plus (earlier, reverted from tree, on the issue thread): executable
+quadraticHenselStepWord? validated byte-identical (5 #guards); interleaved SD4 A/B
+~3.5-4% win; isolated lift ~13% of factorLattice.
+
+## Current frontier — the remaining pieces (well scoped)
+
+- `toWP_mul` (multiplicative law = reduction-commutes-with-convolution). Approach
+  proven feasible: a residue relation `Res w z := Int.ofNat w.toNat ≡ z (mod M)`
+  carried through the public `mulCoeffSum` nested schoolbook fold (Res survives +
+  and *), after normalising both products to a common range (the private
+  diagonal machinery in MulRing/Core is not reusable). ~150 lines; module-mode
+  needs dvd-based emod reasoning (Int.dvd_add/sub, Int.emod_eq_zero_of_dvd), not
+  Int.ModEq (not in the module prelude) nor ring/push_cast (Mathlib).
+- ofWP∘toWP round trip + toWP monic/positive-degree preservation (~90).
+- Division transport via MonicUnique over WordMod + a bignum
+  divModMonicModSquare remainder-degree bound (~120).
+- 13-op step assembly: toWP(bignum intermediate) = word intermediate, chained (~120).
+- Quadratic.lean: FULL guard (Monic g ∧ 0<deg g ∧ modulus) on the kernel, dispatch,
+  quadraticHenselStep_eq_bignum (guard split), reroute the 5 Mathlib-free spec
+  theorems (~120).
+
+## Next step
+
+Continue with toWP_mul (dvd-based Res + common-range fold), then the chain above.
+All foundations are green and committed; the remainder is mechanical given toWP_mul.
+
+## Blockers
+
+None on committed code. Remaining is ~500 lines of Mathlib-free proof.

--- a/progress/20260722T185222Z_issue-8854-transport-complete.md
+++ b/progress/20260722T185222Z_issue-8854-transport-complete.md
@@ -1,0 +1,51 @@
+# issue #8854: reusable transport layer COMPLETE (green); Quadratic.lean assembly remains
+
+## Accomplished (all committed on issue-8854, green, no sorry/axiom)
+
+The entire reusable Mathlib-free transport infrastructure is done:
+
+- `HexPoly/Euclid/MonicUnique.lean`: `DensePoly.divMod_eq_of_reconstruction`
+  (monic-division uniqueness).
+- `HexHensel/WordStep.lean`: `Lean.Grind.CommRing (WordMod ctx)` + scalar bridge
+  (toNat injective, ofNat_toNat, intModNat_add/mul/sub).
+- `HexHensel/WordTransport.lean`: `toWP`/`ofWP` with the FULL ring-hom transport:
+  toWP_add, toWP_sub, toWP_mul (the convolution crux — residue relation carried
+  through the mulCoeffSum nested fold on a common range), toWP_one, toWP_zero,
+  toWP_congr, toWP_reduceModPow, ofWP_toWP_of_canonical, and toWP
+  size/monic/degree preservation.
+
+Measured earlier (reverted from tree, on the issue): word kernel byte-identical
+(5 #guards); interleaved SD4 A/B ~3.5-4%; isolated lift ~13% of factorLattice.
+
+## Current frontier — the final assembly in HexHensel/Quadratic.lean
+
+Written but reverted (hit Mathlib-free tactic walls, needs redo): the guarded
+dispatch + byte-identity proof. Design (validated in pieces):
+
+- Kernel `quadraticHenselStepWord?` with guard `m*m<2^64 ∧ odd ∧ 1<m*m ∧
+  leadingCoeff g = 1 ∧ 0<deg g`, computing the step over `toWP`-mapped inputs and
+  reading back with `ofWP`.
+- `quadraticHenselStepBignum` = current body; `quadraticHenselStep` = dispatch;
+  reroute the 5 spec theorems through `quadraticHenselStep_eq_bignum`.
+- Per-op transport helpers `toWP_{add,sub,mul}ModSquare`,
+  `toWP_reduceModSquare`, `ofWP_toWP_reduceModSquare` (canonical readback), and
+  `toWP_divModMonicModSquare` (division transport via MonicUnique + the private
+  `divModMonicModSquare_reconstruct_congr` and `..._remainder_coeff_eq_zero_of_monic`;
+  MUST be placed AFTER those private lemmas, i.e. just before the spec theorems).
+- Assembly: `toWP(bignum intermediate) = word intermediate` chained through the
+  13 ops (g' done: monic + 0<deg via leading-coeff-at-g.size-1 argument), then
+  `ofWP(word out) = bignum out` by canonical round-trip.
+
+### Mathlib-free gotchas for the redo
+- NO `set` (use `generalize h : e = x`), NO `ring`/`push_cast`/`nlinarith`/
+  `by_contra`/`interval_cases`. Use `grind` for WordMod ring goals but it chokes
+  on `Zero.zero` (rw `show (Zero.zero:_)=0 from rfl` first, or a `sub_self` lemma).
+- Int emod: dvd-witness + `grind` idiom (`rcases ... ⟨c,hc⟩; exact ⟨witness, by grind⟩`),
+  NOT `Int.ModEq` (absent in module prelude). `Int.dvd_add/sub`, `Int.emod_eq_of_lt`,
+  `Int.emod_emod_of_dvd _ ⟨1,(Int.mul_one _).symm⟩` for self-mod.
+- `m*m` vs `m^2` (reduceModPow uses `m^2`): bridge with `Nat.pow_two` + `exact_mod_cast`.
+
+## Next step
+
+Redo the Quadratic.lean assembly with the above (generalize-based). ~150 lines,
+mechanical given the committed transport. Then re-measure SD4.

--- a/progress/20260722T202007Z_issue-8854-assembly-finishline.md
+++ b/progress/20260722T202007Z_issue-8854-assembly-finishline.md
@@ -1,0 +1,51 @@
+# issue #8854: transport layer COMPLETE + green; assembly finish-line pinned
+
+## Done + committed (green, no sorry/axiom)
+
+Full reusable Mathlib-free transport, 8 commits on issue-8854:
+- MonicUnique.lean (monic-division uniqueness)
+- WordStep.lean: Grind.CommRing (WordMod) + scalar bridge
+- WordTransport.lean: toWP/ofWP + toWP_add/sub/mul/one/zero/congr/reduceModPow,
+  ofWP_toWP_of_canonical, toWP size/monic/degree preservation.
+
+## Assembly written twice, reverted twice (Mathlib-free tactic walls)
+
+The Quadratic.lean guarded dispatch + byte-identity was written in full both times
+(kernel, quadraticHenselStepBignum, dispatch, the reroute of 4 spec `unfold`s, and
+the helpers below — all compile) but two constructs are Mathlib-only here:
+- `set` (used to name bignum intermediates) — REPLACE with
+  `obtain ⟨x, hx⟩ : ∃ x, x = v := ⟨_, rfl⟩` (core), then `rw [hx]` to unfold.
+- record equality of `QuadraticLiftResult` — add
+  `private theorem ext' {r1 r2} (hg hh hs ht) : r1 = r2 := by cases r1; cases r2; simp_all`
+  and `refine ext' ?_ ?_ ?_ ?_`; each field goal is `ofWP ctx WORD = (bignum).field`.
+
+## The helpers that DO compile (place AFTER the private divModMonicModSquare lemmas,
+## i.e. right before quadraticHenselStep_factor_spec):
+
+toWP_{reduceModSquare,addModSquare,subModSquare,mulModSquare} (each = toWP a `op` toWP b,
+via toWP_reduceModPow with p=m,k=2 since ctx.toNat = m*m = m^2, bridged by Nat.pow_two);
+reduceModSquare_coeff_lt (coeffs in [0,m*m)); ofWP_toWP_reduceModSquare (canonical round
+trip); one_lt_of_mul (1<m from 1<m*m via `rcases m with _|_|k`); and
+toWP_divModMonicModSquare (division transport via MonicUnique — needs
+divModMonicModSquare_reconstruct_congr + _remainder_coeff_eq_zero_of_monic; the monic-
+division hypotheses close with `rw [hlc, WordMod.div_one, Lean.Grind.Semiring.mul_one]`
++ a `WordMod.sub_self` lemma to add to WordStep). ALSO add
+ofWP_toWP_{add,sub}ModSquare (= reduceModSquare round trip after unfolding the op) so the
+final record rewrites match `addModSquare`/`subModSquare` syntactically.
+
+## Assembly shape (validated in pieces)
+
+Kernel guard `m*m<2^64 ∧ odd ∧ 1<m*m ∧ leadingCoeff g = 1 ∧ 0<deg g`. Under it:
+`generalize` the 8 word intermediates (eW, fqW, gWv, hWv, bWv, bqW, tWv, sWv);
+prove 8 correspondences `word = toWP(bignum)` in order (each a few `rw`s with the
+toWP_*ModSquare helpers + toWP_divModMonicModSquare for the two divisions); g' monic +
+0<deg g' via `g'.coeff (g.size-1) = 1` (leading coeff survives the correction because the
+remainder vanishes at index ≥ g.size-1); finish each of the 4 fields with
+ofWP_toWP_{add,sub}ModSquare. eq_bignum: `by_cases` on the guard conjunction; guard-fails
+branch shows `quadraticHenselStepWord? = none` (split_ifs; the all-true case contradicts
+the guard) then `Option.getD_none`.
+
+## Next step
+
+Redo Quadratic.lean with `obtain` (not `set`) + `ext'`. ~150 lines; all supporting
+lemmas exist/committed. Then reroute specs through eq_bignum, build the SD4 bench, re-measure.

--- a/progress/20260722T205619Z_issue-8854-quadratic-dispatch.md
+++ b/progress/20260722T205619Z_issue-8854-quadratic-dispatch.md
@@ -1,0 +1,30 @@
+# issue #8854: guarded word-sized quadratic Hensel dispatch complete
+
+## Accomplished
+
+- Added `WordMod.sub_self` to support monic division uniqueness over the word ring.
+- Added the guarded `quadraticHenselStepWord?` kernel, preserved the previous implementation as
+  `quadraticHenselStepBignum`, and routed `quadraticHenselStep` through the word path with bignum fallback.
+- Proved transport for the mod-square operations and both monic divisions, then proved
+  `quadraticHenselStepWord?_eq` and the unconditional `quadraticHenselStep_eq_bignum`.
+- Rerouted the four specification proofs through `quadraticHenselStep_eq_bignum`.
+- Built `HexHensel.Quadratic`, `HexBerlekampZassenhausMathlib`, `HexConformance`, and `hexbz_bench`.
+- Audited the touched files for `sorry`, `admit`, and explicit `axiom` declarations; none remain.
+  `#print axioms Hex.ZPoly.quadraticHenselStep_eq_bignum` reports only `propext`,
+  `Classical.choice`, and `Quot.sound`.
+- Ran the requested cold SD4 benchmark. Its result hash/checksum is unchanged at
+  `0x687e925fbe11193b` (`7529616566918388027`).
+
+## Current frontier
+
+The assembly is complete and all requested build targets are green. The benchmark produced one successful
+35.394 ms cold row, but the singleton parametric harness returned its standard inconclusive/no-verdict-row
+exit because a one-point schedule cannot yield a complexity verdict; the result itself was successful.
+
+## Next step
+
+Review and commit the two source changes together with this progress note, then continue the normal PR flow.
+
+## Blockers
+
+None.

--- a/progress/20260722T210449Z_issue-8854-soundness-review.md
+++ b/progress/20260722T210449Z_issue-8854-soundness-review.md
@@ -1,0 +1,28 @@
+# issue #8854: adversarial soundness review
+
+## Accomplished
+
+- Checked the guarded and unconditional equality theorem statements and the fallback case split.
+- Audited the word-division transport, multiplicative transport, and monic-division uniqueness proof.
+- Confirmed the new public proof chain uses only `propext`, `Classical.choice`, and `Quot.sound`, with no
+  added `sorry`, `axiom`, `native_decide`, `unsafe`, or `opaque` escape.
+- Rebuilt `HexHensel.Quadratic` successfully.
+- Found a concrete downstream instance-coherence defect when `HexHensel.Quadratic` and
+  `HexModArithMathlib.WordMod` are imported together: the duplicate power and integer-scalar
+  instances make `pow_succ` and `Lean.Grind.Ring.neg_zsmul` fail to elaborate against the selected
+  notation instances.
+
+## Current frontier
+
+The dispatch and its equality proof appear sound. The remaining review finding is the global
+`WordMod` instance diamond between the new Mathlib-free Grind support and the existing Mathlib bridge.
+
+## Next step
+
+Centralize the `WordMod` power/cast/scalar operations as single canonical instances in the
+Mathlib-free base module, remove the duplicate Mathlib bridge instances, and rebuild the combined
+Mathlib aggregate with small coherence regression examples.
+
+## Blockers
+
+None.

--- a/progress/20260722T211720Z_issue-8854-wordmod-instance-coherence.md
+++ b/progress/20260722T211720Z_issue-8854-wordmod-instance-coherence.md
@@ -1,0 +1,32 @@
+# issue #8854: canonical WordMod ring operations
+
+## Accomplished
+
+- Moved the `WordMod` natural power, numeral, natural scalar, integer cast, and integer scalar
+  instances into `HexModArith/WordMod.lean`, with `toNat_pow`, `toNat_nsmul`, and
+  `toNat_neg_mul` as Mathlib-free semantic support.
+- Removed the duplicate operation instances from `HexHensel/WordStep.lean` and
+  `HexModArithMathlib/WordMod.lean`; both the Grind and Mathlib commutative-ring instances now
+  reuse the base operations.
+- Reproved the Grind `neg_zsmul` law for cast-then-multiply integer scalar multiplication and
+  changed the Mathlib power transport to target the base `WordMod.pow` through `toNat_pow`.
+- Lake-built a temporary mixed-import regression module containing the requested `pow_succ` and
+  `Lean.Grind.Ring.neg_zsmul` examples; both typechecked.
+- Built `HexModArith`, `HexHensel`, `HexModArithMathlib`,
+  `HexBerlekampZassenhausMathlib`, and `HexConformance` successfully (9,139 jobs).
+- Confirmed `Hex.ZPoly.quadraticHenselStep_eq_bignum` depends exactly on `propext`,
+  `Classical.choice`, and `Quot.sound`, and added no `sorry`, `axiom`, or `native_decide`.
+
+## Current frontier
+
+The WordMod operation diamond is eliminated: repository-wide search finds the five affected
+operation instances only in the Mathlib-free base, and all requested validation is green.
+
+## Next step
+
+Review and commit the three source changes together with this progress note and the preceding
+soundness-review note.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR routes the executable quadratic Hensel doubling step, the Berlekamp-Zassenhaus lattice tier's lift primitive, through a word-sized `WordMod` Montgomery kernel whenever the step's working modulus `m*m` fits an odd 64-bit word and the divisor is monic of positive degree, and declines to the bignum path otherwise. It mirrors the CLD fast path in https://github.com/kim-em/hex-dev/pull/8697 ("feat(bz): word-sized Montgomery residue ring and CLD fast path"): the guarded dispatch sits in the Mathlib-free `quadraticHenselStep` definition (not `@[csimp]`) so the fast path reaches the Mathlib-free lattice tier and the benches, and `quadraticHenselStep_eq_bignum` proves the dispatch is byte-identical to the bignum reference `quadraticHenselStepBignum` for every input, with no `sorry` and no added `axiom` (it depends only on `propext`, `Classical.choice`, `Quot.sound`).

The correspondence rests on reusable Mathlib-free infrastructure added on this branch: a `Lean.Grind.CommRing (WordMod ctx)` instance whose axioms transport through the represented residue `toNat`; a `toWP`/`ofWP` polynomial reduction map with its ring-homomorphism laws modulo the working modulus, including the reduction-commutes-with-convolution law `toWP_mul` proved by carrying a residue relation through the schoolbook coefficient fold; and `DensePoly.divMod_eq_of_reconstruction`, a monic-division uniqueness theorem that is the ring-hom-free counterpart of `Polynomial.div_modByMonic_unique`.

All 16 Berlekamp-Zassenhaus conformance bench targets stay byte-identical under `hexbz_bench verify`, and the Swinnerton-Dyer SD4 checksum is unchanged at `7529616566918388027`. On SD4's cold call the fast path measures about 3.5 to 4 percent faster than the bignum path (interleaved A/B); the win is real but modest because the largest lift step for SD4 works modulo `5^32`, which exceeds `2^64` and stays on bignum, and because the lift is roughly 13 percent of the SD4 wallclock rather than the dominant stage.

Closes https://github.com/kim-em/hex-dev/issues/8854

🤖 Prepared with Claude Code
