### PR TITLE
doc: reflect the factor_poly/irreducibility tactic family in the top-level SPEC

### DIFF
--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -17,10 +17,10 @@
 - **hex-resultant**: polynomial resultant and discriminant via the subresultant pseudo-remainder sequence
 - **hex-number-field**: fixed fields `QAdjoin p x`, factorization-lazy `AlgebraicRoot`, canonical `AlgebraicNumber`, and roots of polynomials with algebraic coefficients
 - **hex-number-field-tower**: successive number-field extensions, Trager factorization, adjoining roots, splitting fields, and primitive-element flattening
-- **hex-berlekamp**: Berlekamp factoring and Rabin irreducibility test over `F_p`
+- **hex-berlekamp**: Berlekamp factoring and Rabin irreducibility test over `F_p`; the `factor_poly` / `irreducibility` tactic drivers (native `FpPoly p` arms plus the provider hook for other input types)
 - **hex-hensel**: Hensel lifting from `mod p` to `mod p^k`
 - **hex-lll**: LLL lattice basis reduction
-- **hex-berlekamp-zassenhaus**: complete factoring of `Z[x]`, initially with exhaustive recombination
+- **hex-berlekamp-zassenhaus**: complete factoring of `Z[x]`, initially with exhaustive recombination; the `Hex.ZPoly` provider for `factor_poly` / `irreducibility`
 - **hex-conway**: Conway polynomial database
 - **hex-gfq-ring**: canonical quotient ring `F_p[x]/(f)` by a nonconstant modulus
 - **hex-gfq-field**: field structure on top of `hex-gfq-ring` when `f` is irreducible
@@ -43,12 +43,12 @@ with Mathlib's):
 - **hex-resultant-mathlib**: executable resultant agreement with `Polynomial.resultant`, specialization, root-product, and discriminant theorems
 - **hex-number-field-mathlib**: fixed-field correspondence, exactification, lazy arithmetic, and algebraic-coefficient root completeness
 - **hex-number-field-tower-mathlib**: tower embeddings, Trager correctness, splitting fields, and primitive-element equivalence
-- **hex-berlekamp-mathlib**: `Decidable (Irreducible f)` for `Polynomial (ZMod p)`
+- **hex-berlekamp-mathlib**: `Decidable (Irreducible f)` for `Polynomial (ZMod p)`; the `Polynomial (ZMod p)` provider for `factor_poly` / `irreducibility`
 - **hex-hensel-mathlib**: Hensel correctness, uniqueness, `coprime_mod_p_lifts`
 - **hex-lll-mathlib**: lattice = `Submodule ℤ`, short vector bound
 - **hex-gf2-mathlib**: `GF2Poly ≃+* FpPoly 2`, `GF2n`/`GF2nPoly ≃+* FiniteField 2 f hf hirr`, packed-field finiteness/cardinality
 - **hex-gfq-mathlib**: finiteness/cardinality for quotient fields, and `GFq p n ≃+* GaloisField p n`
-- **hex-berlekamp-zassenhaus-mathlib**: unconditional factoring correctness, `Decidable (Irreducible f)` for `Polynomial ℤ`
+- **hex-berlekamp-zassenhaus-mathlib**: unconditional factoring correctness, `Decidable (Irreducible f)` for `Polynomial ℤ`; the `Polynomial ℤ` and strong `Hex.ZPoly` providers for `factor_poly` / `irreducibility`
 
 ## Implementation dependencies
 
@@ -196,8 +196,8 @@ for developments whose source-local move has not happened yet.
 - [hex-number-field-mathlib.md](hex-number-field-mathlib.md): fixed-field correspondence, exactification, lazy arithmetic, and root completeness
 - [hex-number-field-tower.md](hex-number-field-tower.md): successive extensions, Trager factorization, splitting fields, and flattening
 - [hex-number-field-tower-mathlib.md](hex-number-field-tower-mathlib.md): semantic towers, factorization correctness, splitting, and primitive-element equivalence
-- [hex-berlekamp](../../HexBerlekamp/SPEC/hex-berlekamp.md): Berlekamp factoring and Rabin irreducibility test
-- [hex-berlekamp-mathlib](../../HexBerlekampMathlib/SPEC/hex-berlekamp-mathlib.md): Berlekamp/Rabin correctness proofs via Euclidean domain theory
+- [hex-berlekamp](../../HexBerlekamp/SPEC/hex-berlekamp.md): Berlekamp factoring, Rabin irreducibility test, and the `factor_poly` / `irreducibility` tactic drivers
+- [hex-berlekamp-mathlib](../../HexBerlekampMathlib/SPEC/hex-berlekamp-mathlib.md): Berlekamp/Rabin correctness proofs via Euclidean domain theory, and the `Polynomial (ZMod p)` tactic provider
 - [hex-hensel](../../HexHensel/SPEC/hex-hensel.md): Hensel lifting algorithms
 - [hex-hensel-mathlib](../../HexHenselMathlib/SPEC/hex-hensel-mathlib.md): Hensel correctness, uniqueness, coprimality lifting
 - [hex-conway](../../HexConway/SPEC/hex-conway.md): Conway polynomial database
@@ -209,5 +209,5 @@ for developments whose source-local move has not happened yet.
 - [hex-gram-schmidt-mathlib](https://github.com/leanprover/hex-gram-schmidt-mathlib/blob/main/SPEC/hex-gram-schmidt-mathlib.md) (released): correspondence with Mathlib's `gramSchmidt`
 - [hex-lll](https://github.com/leanprover/hex-lll/blob/main/SPEC/hex-lll.md) (released): LLL lattice basis reduction algorithm and proofs
 - [hex-lll-mathlib](https://github.com/leanprover/hex-lll-mathlib/blob/main/SPEC/hex-lll-mathlib.md) (released): lattice = `Submodule Z`, short vector bound
-- [hex-berlekamp-zassenhaus](../../HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md): complete factoring of `Z[x]`
-- [hex-berlekamp-zassenhaus-mathlib](../../HexBerlekampZassenhausMathlib/SPEC/hex-berlekamp-zassenhaus-mathlib.md): unconditional factoring correctness
+- [hex-berlekamp-zassenhaus](../../HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md): complete factoring of `Z[x]`, and the `Hex.ZPoly` tactic provider
+- [hex-berlekamp-zassenhaus-mathlib](../../HexBerlekampZassenhausMathlib/SPEC/hex-berlekamp-zassenhaus-mathlib.md): unconditional factoring correctness, and the `Polynomial ℤ` tactic provider

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -214,7 +214,8 @@ the function the soundness theorem speaks about, but the tactic does
 not ask the kernel to evaluate it: re-running the search (bisection,
 gcds, refinement) inside the kernel would be far slower than the
 compiled search. Following the compiled-prep / kernel-verify pattern
-of `irreducible_cert` (hex-berlekamp-zassenhaus), the tactic:
+of the `factor_poly` / `irreducibility` tactics (hex-berlekamp), the
+tactic:
 
 - runs the search compiled, collecting a `Certificate`: the Sturm
   chain of `P` with the quotient of each pseudo-division step, the

--- a/SPEC/Libraries/hex-real-roots-mathlib.md
+++ b/SPEC/Libraries/hex-real-roots-mathlib.md
@@ -277,7 +277,7 @@ exponent `k` with the two literal `ring` identities
 stays invisible either way; `aevalIff_squareFreeCore` remains the
 library-level statement (and the `rcf` dependency).
 
-**Kernel replay.** Following the `irreducible_cert` pattern (and
+**Kernel replay.** Following the `factor_poly` / `irreducibility` pattern (and
 hex-rcf §Kernel replay), the elaborator never asks the kernel to
 re-run the search. Measured on the Stage-1 prototype, the naive
 per-field `decide` shape (each `count_one`/`complete` certificate

--- a/SPEC/SPEC.md
+++ b/SPEC/SPEC.md
@@ -22,6 +22,22 @@ definitions (e.g. `DensePoly R ≃+* Polynomial R`, `ZMod64 p ≃+* ZMod p`,
 Mathlib's abstract algebra without imposing Mathlib as a dependency on the
 computational code.
 
+The user surface of the factoring pipeline is the `factor_poly` /
+`irreducibility` elaborator family (term, tactic, and goal forms). The base
+drivers live in hex-berlekamp, handling `FpPoly p` natively; other input
+types dispatch to providers registered by well-known name from
+hex-berlekamp-zassenhaus (`Hex.ZPoly`) and the two Mathlib bridge layers
+(`Polynomial (ZMod p)`, `Polynomial ℤ`). The trust model is uniform across
+providers: the compiled factorizer runs as untrusted search at elaboration
+time, emitted terms carry only kernel checks on reified literal data, and
+the factorizer never runs in the kernel. Coverage is complete for
+`FpPoly p`. For integer polynomials, the computational layer certifies
+irreducibility by prime-constant, primitive-linear, single-prime modular,
+and Eisenstein-after-shift witnesses; the Mathlib layer adds multi-prime
+degree-obstruction certificates; Swinnerton-Dyer-class inputs remain
+uncovered, and the tactics decline them with a diagnostic rather than
+weakening the emitted statement.
+
 The library DAG has three independent roots — polynomial arithmetic, integer
 arithmetic, and matrix operations — meeting at the top in
 Berlekamp-Zassenhaus. This structure allows parallel development: LLL has no
@@ -69,7 +85,8 @@ SPEC names the checker soundness theorem and the provider contract.
 
 **Cryptographic field construction:** To build `GF(2^128)` for AES, you
 need an irreducible polynomial of degree 128 over `F_2`. With
-hex-berlekamp, produce a Lean proof that it's irreducible.
+hex-berlekamp's `irreducibility` tactic, produce a Lean proof that it's
+irreducible.
 
 **Coding theory:** Reed-Solomon and BCH codes need irreducible polynomials
 over finite fields. Verified factoring provides certified generator

--- a/SPEC/SPEC.md
+++ b/SPEC/SPEC.md
@@ -28,10 +28,15 @@ drivers live in hex-berlekamp, handling `FpPoly p` natively; other input
 types dispatch to providers registered by well-known name from
 hex-berlekamp-zassenhaus (`Hex.ZPoly`) and the two Mathlib bridge layers
 (`Polynomial (ZMod p)`, `Polynomial ℤ`). The trust model is uniform across
-providers: the compiled factorizer runs as untrusted search at elaboration
-time, emitted terms carry only kernel checks on reified literal data, and
-the factorizer never runs in the kernel. Coverage is complete for
-`FpPoly p`. For integer polynomials, the computational layer certifies
+providers: compiled factorization and certificate generation run as
+untrusted search at elaboration time, certification slots are Boolean
+checks on reified literal data (the Mathlib providers additionally emit
+kernel-checked bridge equations such as `toMathlibPolynomial fLit = P`),
+and the factorizer never runs in the kernel (except in the opt-in bang
+forms). Coverage for `FpPoly p` is complete within the supported-input
+contract: closed, kernel-transparent inputs at literal prime moduli inside
+the `ZMod64` bounds and the certificate replay budget. For integer
+polynomials, the computational layer certifies
 irreducibility by prime-constant, primitive-linear, single-prime modular,
 and Eisenstein-after-shift witnesses; the Mathlib layer adds multi-prime
 degree-obstruction certificates; Swinnerton-Dyer-class inputs remain
@@ -83,7 +88,8 @@ SPEC names the checker soundness theorem and the provider contract.
 
 ## Applications
 
-**Cryptographic field construction:** To build `GF(2^128)` for AES, you
+**Cryptographic field construction:** To build `GF(2^128)` for AES-GCM's
+GHASH authentication, you
 need an irreducible polynomial of degree 128 over `F_2`. With
 hex-berlekamp's `irreducibility` tactic, produce a Lean proof that it's
 irreducible.

--- a/progress/20260722T212726Z_factor-poly-spec-sweep.md
+++ b/progress/20260722T212726Z_factor-poly-spec-sweep.md
@@ -1,0 +1,34 @@
+# factor_poly / irreducibility: top-level SPEC sweep
+
+## Accomplished
+
+- Audited the top-level `SPEC/` tree against the four per-library SPEC
+  sections for the `factor_poly` / `irreducibility` tactic family
+  (hex-berlekamp, hex-berlekamp-zassenhaus, and the two Mathlib bridges).
+- `SPEC/SPEC.md`: added a "user surface" paragraph to *What we're
+  building* (elaborator forms, provider architecture, trust model,
+  coverage boundary) and pointed the `GF(2^128)` application at the
+  `irreducibility` tactic.
+- `SPEC/Libraries/README.md`: the four one-line summaries and the four
+  linked-list entries now name the tactic drivers / providers.
+- `SPEC/Libraries/hex-rcf.md`, `SPEC/Libraries/hex-real-roots-mathlib.md`:
+  retargeted the two references to the deleted `irreducible_cert` tactic
+  at the `factor_poly` / `irreducibility` compiled-prep / kernel-verify
+  pattern.
+- `SPEC/testing.md` does not catalog per-suite test files, so
+  `FactorTacticTests` / `FactorPolyTests` are intentionally not listed
+  there; `SPEC/future-work.md` had no irreducibility-tactic entry to
+  retire.
+
+## Current frontier
+
+Docs-only sweep; PR against `factor-poly/eisenstein` at the end of the
+stacked series.
+
+## Next step
+
+None for this corner once the PR merges with the stack.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR bring the top-level SPEC tree up to date with the factor_poly/irreducibility tactic family that landed across the stacked series ending at factor-poly/eisenstein. Add a user-surface paragraph to SPEC/SPEC.md (term/tactic/goal forms; base drivers in hex-berlekamp with providers registered by well-known name from hex-berlekamp-zassenhaus and the two Mathlib bridge layers; compiled search at elaboration time with kernel checks on reified literals only; coverage complete for FpPoly, with the integer-polynomial witness classes and the Swinnerton-Dyer gap stated), extend the hex-berlekamp* one-line summaries in SPEC/Libraries/README.md to name the tactic drivers and providers, and retarget the two stale references to the deleted irreducible_cert tactic in SPEC/Libraries/hex-rcf.md and SPEC/Libraries/hex-real-roots-mathlib.md at the factor_poly/irreducibility compiled-prep / kernel-verify pattern. SPEC/testing.md does not catalog per-suite test files and SPEC/future-work.md had no irreducibility-tactic entry, so neither changes.

🤖 Prepared with Claude Code