### PR TITLE
doc: manual chapter for the factor_poly and irreducibility tactics

### DIFF
--- a/HexBerlekampMathlib/FactorPoly.lean
+++ b/HexBerlekampMathlib/FactorPoly.lean
@@ -31,7 +31,8 @@ namespace Hex
 counterpart of `FpPoly.Factored`/`ZPoly.Factored`. Produced by the
 `factor_poly` elaborator via the Mathlib bridge providers. -/
 structure FactoredPoly {R : Type*} [CommRing R] (P : Polynomial R) where
-  /-- The unit scalar (the leading coefficient for nonzero `P`). -/
+  /-- The scalar factored out of `P`: over a finite field the leading unit of
+  nonzero `P`; over `ℤ` the signed content. -/
   scalar : R
   /-- The irreducible factors, with repetition. -/
   factors : List (Polynomial R)

--- a/HexManual.lean
+++ b/HexManual.lean
@@ -26,6 +26,7 @@ import HexManual.Chapters.HexGFqField
 import HexManual.Chapters.HexConway
 import HexManual.Chapters.HexGFq
 import HexManual.Chapters.HexRealRoots
+import HexManual.Chapters.FactorTactics
 import HexManual.Chapters.HexRoots
 -- Tutorials (application-first capstone pages, see SPEC/tutorials.md).
 import HexManual.Tutorials.Coppersmith
@@ -111,6 +112,8 @@ here to keep the reference chapters above focused on the released libraries.
 {include 2 HexManual.Chapters.HexGFq}
 
 {include 2 HexManual.Chapters.HexRealRoots}
+
+{include 2 HexManual.Chapters.FactorTactics}
 
 {include 2 HexManual.Chapters.HexRoots}
 

--- a/HexManual/Chapters/FactorTactics.lean
+++ b/HexManual/Chapters/FactorTactics.lean
@@ -1,0 +1,422 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import VersoManual
+
+import HexBerlekampMathlib
+import HexBerlekampZassenhausMathlib
+
+open Verso.Genre Manual
+open Verso.Genre.Manual.InlineLean
+
+set_option pp.rawOnError true
+
+#doc (Manual) "`factor_poly` and `irreducibility`: certified factoring" =>
+%%%
+tag := "factor-tactics"
+%%%
+
+# Introduction
+%%%
+tag := "factor-tactics-intro"
+%%%
+
+`factor_poly` and `irreducibility` factor a concrete polynomial, or
+prove one irreducible, in a single call. The factorization runs as
+compiled, untrusted search while the file elaborates; the emitted proof
+term carries only certificate checks the kernel replays on literal
+data. One call site, no visible certificates, no `native_decide`, and
+no axioms beyond the standard three.
+
+The tactics accept four input types, enabled by imports. The drivers
+live in `HexBerlekamp` and handle {name}`Hex.FpPoly` (dense
+polynomials over a prime field) natively. Importing
+`HexBerlekampZassenhaus` adds {name}`Hex.ZPoly` (dense integer
+polynomials); the correspondence libraries `HexBerlekampMathlib` and
+`HexBerlekampZassenhausMathlib` add `Polynomial (ZMod q)` and
+`Polynomial ℤ`. Each library registers its arm as a provider probed by
+name at elaboration time, so the drivers need no imports in that
+direction; with everything imported the tactics simply accept all four
+types.
+
+# Proving irreducibility
+%%%
+tag := "factor-tactics-irreducibility"
+%%%
+
+The bare tactic form closes an `Irreducible` goal. Here it proves
+that `x² − 2` does not factor over `ℤ`, the algebraic core of the
+irrationality of `√2`, in its Mathlib form over `Polynomial ℤ`:
+
+```lean
+open Polynomial
+
+example : Irreducible (X ^ 2 - 2 : Polynomial ℤ) := by
+  irreducibility
+```
+
+The same name is a term elaborator, so the proof can be a definition's
+entire body:
+
+```lean
+open Polynomial
+
+theorem sqrt2_irred :
+    Irreducible (X ^ 2 - 2 : Polynomial ℤ) :=
+  irreducibility (X ^ 2 - 2 : Polynomial ℤ)
+```
+
+Behind the call, the input expression is parsed to an executable
+integer polynomial together with a proof that the parse is faithful,
+the compiled factorizer confirms there is exactly one irreducible
+factor, and a per-factor certificate (for `x² − 2`, a single-prime
+modular witness) is reified into the proof term for the kernel to
+check.
+
+# Factoring: `factor_poly`
+%%%
+tag := "factor-tactics-factor-poly"
+%%%
+
+When the polynomial is not irreducible, `factor_poly f` produces the
+whole certified factorization at once. For a `Polynomial ℤ` input the
+result is a {name}`Hex.FactoredPoly`: a scalar, the list of
+irreducible factors with multiplicity, and the two theorems that make
+those fields a genuine factorization.
+
+{docstring Hex.FactoredPoly}
+
+```lean
+open Polynomial
+
+noncomputable def facSplit :=
+  factor_poly ((X ^ 2 - 1) * (X + 2) : Polynomial ℤ)
+
+example : facSplit.factors.length = 3 := rfl
+example : facSplit.scalar = 1 := rfl
+```
+
+The structure unpacks with `obtain`, so the fields can be named and
+used however a proof needs them:
+
+```lean
+open Polynomial
+
+example : True := by
+  obtain ⟨scalar, factors, factors_mul, factors_irred⟩ :=
+    factor_poly (X ^ 2 - 2 : Polynomial ℤ)
+  trivial
+```
+
+# The executable types
+%%%
+tag := "factor-tactics-executable"
+%%%
+
+The Mathlib-facing forms above are transports of the same machinery
+working on the executable types, which are user surfaces in their
+own right. Over a prime field the input is a {name}`Hex.FpPoly`
+(see the {ref "hex-poly-fp"}[HexPolyFp chapter]) and the result is an
+{name}`Hex.FpPoly.Factored`:
+
+{docstring Hex.FpPoly.Factored}
+
+The example below factors `3 · (x+1)² · (x²+2)` over `F₅`: non-monic
+and non-square-free, so the scalar, multiplicity, and normalization
+conventions are all visible. The factors come back monic, in
+nondecreasing degree order, repeated to multiplicity, with the leading
+unit in `scalar`:
+
+```lean
+open Hex
+
+instance : ZMod64.Bounds 5 := ⟨by decide, by decide⟩
+
+def z (n : Nat) : ZMod64 5 := ZMod64.ofNat 5 n
+
+/-- `3 · (x+1)² · (x²+2)` over `F₅`: non-monic and
+non-square-free. -/
+def testF : FpPoly 5 :=
+  DensePoly.C (z 3) *
+    (FpPoly.ofCoeffs #[z 1, z 1] *
+     FpPoly.ofCoeffs #[z 1, z 1] *
+     FpPoly.ofCoeffs #[z 2, z 0, z 1])
+
+noncomputable def facF := factor_poly testF
+
+example : facF.factors.length = 3 := rfl
+example : facF.scalar = z 3 := rfl
+
+def irrF : FpPoly 5 := FpPoly.ofCoeffs #[z 2, z 0, z 1]
+
+theorem irrF_irred : FpPoly.Irreducible irrF :=
+  irreducibility irrF
+```
+
+Over the integers the input is a {name}`Hex.ZPoly` (see the
+{ref "hex-poly-z"}[HexPolyZ chapter]) and the result is a
+{name}`Hex.ZPoly.Factored`, with the signed content in `scalar` and
+primitive positive-leading-coefficient factors:
+
+{docstring Hex.ZPoly.Factored}
+
+```lean
+open Hex
+
+def quadZ : ZPoly := DensePoly.ofCoeffs #[1, 0, 1]
+
+theorem quadZ_irred : ZPoly.Irreducible quadZ :=
+  irreducibility quadZ
+```
+
+Irreducibility of a `ZPoly` is stated with the Mathlib-free class
+{name}`Hex.ZPoly.Irreducible`, which the correspondence library proves
+equivalent to Mathlib's `Irreducible` under `toPolynomial`. Goal-mode
+`irreducibility` closes all three spellings: `Hex.ZPoly.Irreducible f`,
+`Irreducible (HexPolyZMathlib.toPolynomial f)`, and `Irreducible P` for
+a parseable `P : Polynomial ℤ`.
+
+Finally, `Polynomial (ZMod q)` inputs (literal prime `q < 2³¹`) reuse
+the prime-field pipeline through the parser-with-proof of
+`HexBerlekampMathlib`, producing the same
+{name}`Hex.FactoredPoly` shape as the integer case:
+
+```lean
+open Polynomial
+
+theorem quad_irred :
+    Irreducible (X ^ 2 + 2 : Polynomial (ZMod 5)) :=
+  irreducibility (X ^ 2 + 2 : Polynomial (ZMod 5))
+
+noncomputable def facP :=
+  factor_poly
+    ((X + 1) ^ 2 * (X ^ 2 + 2) * 3 : Polynomial (ZMod 5))
+
+example : facP.factors.length = 3 := rfl
+```
+
+# Tactic forms
+%%%
+tag := "factor-tactics-tactic-forms"
+%%%
+
+Both names are also tactics. For the executable types,
+`factor_poly f` introduces `scalar` and `factors` as transparent `let`
+bindings plus the two hypotheses `factors_mul` and `factors_irred`;
+because the `let`s are transparent, facts about them are available by
+`rfl`:
+
+```lean
+open Hex
+
+example : True := by
+  factor_poly testF
+  have : factors.length = 3 := rfl
+  exact True.intro
+```
+
+(For the `Polynomial` input types the tactic form instead lands the
+whole structure as a single `factored` hypothesis.)
+
+The `irreducibility` tactic has three forms: bare, closing an
+`Irreducible` goal as in the {ref "factor-tactics-irreducibility"}[lead
+example]; `irreducibility f`, adding the fact as an anonymous
+hypothesis; and `irreducibility h : f`, naming it:
+
+```lean
+open Hex Polynomial
+
+example : FpPoly.Irreducible irrF := by irreducibility
+
+example : True := by
+  irreducibility (X ^ 2 - 2 : Polynomial ℤ)
+  irreducibility h : (X ^ 2 + X + 1 : Polynomial ℤ)
+  exact True.intro
+```
+
+# What the proofs cost, and what to trust
+%%%
+tag := "factor-tactics-trust"
+%%%
+
+The trust model is uniform across all four input types. The Yun
+square-free decomposition, the Berlekamp and Berlekamp-Zassenhaus
+factorizers, and the certificate generators run only at elaboration
+time, as compiled untrusted search. What lands in the proof term is a
+reified literal factorization plus Boolean certificate checks on that
+literal data, each discharged by `Eq.refl true`: a coefficient-level
+product check reconstructing the input, and one certificate replay per
+distinct factor (a Rabin certificate over `Fₚ`, or an integer witness
+as described in {ref "factor-tactics-coverage"}[Coverage]). The
+Mathlib providers additionally emit one kernel-checked transport
+equation identifying the reified literal with the input polynomial.
+The factorizer itself never runs in the kernel, except in the opt-in
+{ref "factor-tactics-bang"}[bang forms].
+
+Kernel time therefore scales with the certificate replays, not with
+the search: it does not matter how many candidate recombinations the
+elaboration-time factorizer explored. And because everything is an
+ordinary proof term, the axiom cone stays clean:
+
+```lean (name := axiomsCheck)
+#print axioms sqrt2_irred
+```
+```leanOutput axiomsCheck
+'sqrt2_irred' depends on axioms: [propext, Classical.choice, Quot.sound]
+```
+
+# Coverage and failure modes
+%%%
+tag := "factor-tactics-coverage"
+%%%
+
+Inputs must be closed, kernel-transparent terms: the compiled
+evaluator has to see the actual coefficients at elaboration time, so a
+polynomial mentioning a local hypothesis or metavariable is rejected
+with `must be a closed term (no local hypotheses or metavariables)`,
+and a definition whose body the evaluator cannot access produces an
+evaluation error suggesting a `public meta import` of its module.
+Degenerate inputs get targeted messages rather than proofs: the zero
+polynomial and units are reported as not irreducible, and a reducible
+input to `irreducibility` reports the factor count that `factor_poly`
+found.
+
+For `FpPoly p` coverage is complete within that contract: any closed
+input at a literal prime modulus inside the `ZMod64` bounds factors,
+subject to the certificate replay budget `deg · p ≤ 2²⁶` (each Rabin
+replay costs roughly `deg · p` modular polynomial operations in the
+kernel; over-budget inputs fail at elaboration time with a clear
+message instead of emitting a proof the kernel cannot afford). A
+composite modulus is declined: `Polynomial (ZMod 6)` inputs report
+that the modulus is not prime, and `FpPoly 6` likewise.
+
+Over the integers, the factor *search* always succeeds, but the
+emitted proof needs a kernel-checkable irreducibility witness for each
+factor, and the witness languages do not cover all of `ℤ[X]`. The free
+layer
+certifies four classes: prime constants, primitive linear polynomials,
+factors irreducible modulo a single good prime (a reified Rabin
+certificate), and Eisenstein-after-shift. The last deserves a story:
+`x⁴ + 1` is irreducible over `ℤ` yet reducible modulo *every* prime,
+so no single-prime witness exists, but shifting by `1` gives
+`(x+1)⁴ + 1 = x⁴ + 4x³ + 6x² + 4x + 2`, Eisenstein at `2`, and the
+shift search (shifts `0, ±1, ±2, ±3`) finds exactly that certificate:
+
+```lean
+open Hex Polynomial
+
+def x4p1 : ZPoly := DensePoly.ofCoeffs #[1, 0, 0, 0, 1]
+
+theorem x4p1_irred : ZPoly.Irreducible x4p1 :=
+  irreducibility x4p1
+
+example : Irreducible (X ^ 4 + 1 : Polynomial ℤ) := by
+  irreducibility
+```
+
+When no free-layer witness exists, `HexBerlekampZassenhausMathlib`
+adds multi-prime degree-obstruction certificates: several primes whose
+modular factor-degree splittings jointly rule out every proper factor
+degree. The quartic `x⁴ + 8x + 12` has Galois group `A₄`, so it is
+reducible mod every prime and not Eisenstein at any small shift, but
+its mod-`p` splittings `{1,3}` and `{2,2}` together obstruct all
+proper degrees:
+
+```lean
+open Hex Polynomial
+
+/-- `x⁴ + 8x + 12`, with Galois group `A₄`: certified by a
+multi-prime degree obstruction, since no single-prime or
+Eisenstein witness exists. -/
+def quarticA4 : ZPoly :=
+  DensePoly.ofCoeffs #[12, 8, 0, 0, 1]
+
+theorem quarticA4_irred : ZPoly.Irreducible quarticA4 :=
+  irreducibility quarticA4
+
+example :
+    Irreducible (X ^ 4 + C 8 * X + 12 : Polynomial ℤ) := by
+  irreducibility
+```
+
+One class remains out of reach of every certificate language:
+polynomials whose modular splittings are balanced at every candidate
+prime, which are not Eisenstein at any small shift, *and* whose proper
+factor degrees survive the multi-prime obstruction. Swinnerton-Dyer
+polynomials such as `x⁴ − 10x² + 1` (the minimal polynomial of
+`√2 + √3`) are the canonical case. The plain tactics decline these
+with a diagnostic naming the failing factor and pointing at the
+kernel-decide fallbacks below; they never weaken the emitted statement
+to make a proof go through.
+
+# The kernel-decide fallbacks `irreducibility!` and `factor_poly!`
+%%%
+tag := "factor-tactics-bang"
+%%%
+
+`irreducibility!` and `factor_poly!` (all the same term, tactic, and
+goal forms) first run the normal certificate pipeline and fall back,
+only when it declines, to a proof by `decide`: the kernel re-runs the
+full factorization to verify the claim. This is the one exception to
+"the factorizer never runs in the kernel", and it covers exactly the
+inputs the certificate languages cannot, including the Swinnerton-Dyer
+quartic:
+
+```lean
+open Hex Polynomial
+
+def swinDyer : ZPoly :=
+  DensePoly.ofCoeffs #[1, 0, -10, 0, 1]
+
+theorem swinDyer_irred : ZPoly.Irreducible swinDyer := by
+  irreducibility!
+
+theorem sd_poly_irred :
+    Irreducible (X ^ 4 - 10 * X ^ 2 + 1 : Polynomial ℤ) :=
+  irreducibility! (X ^ 4 - 10 * X ^ 2 + 1 : Polynomial ℤ)
+```
+
+On inputs the certificate pipeline serves, the bang forms are plain
+pass-throughs and cost nothing extra. On genuine fallbacks the kernel
+replay costs real time (quartics are sub-second, degree 8 takes
+seconds, degree 12 tens of seconds), so a dense-size budget of 13
+rejects larger inputs at elaboration time with a message quoting the
+budget. Two further costs land on the calling file when it uses the
+module system: the kernel can only re-run definitions whose bodies it
+can see, so a `module`-based caller must `import all` the executable
+closure (the `HexBerlekampZassenhausMathlib.BangElab` module docstring
+and `FactorPolyTests.lean` carry the working block). The examples in
+this chapter need no such block because the manual's chapters are not
+`module`-based, so every imported body is visible. The elaborator
+prechecks kernel reducibility before emitting anything, so a missing
+closure fails with a clear message rather than a kernel type
+mismatch.
+
+# Cross-references
+%%%
+tag := "factor-tactics-cross-references"
+%%%
+
+The tactic family is the user surface of the factoring pipeline, whose
+pieces have their own chapters and libraries:
+
+* {ref "hex-poly-fp"}[HexPolyFp] provides the prime-field polynomials
+  {name}`Hex.FpPoly` and the square-free (Yun) decomposition the
+  factor search starts from; {ref "hex-poly-z"}[HexPolyZ] provides
+  {name}`Hex.ZPoly`, content and primitive parts.
+* `HexBerlekamp` implements the finite-field factorizer and the Rabin
+  irreducibility certificates, and declares the `factor_poly` /
+  `irreducibility` drivers with their provider hook.
+* {ref "hex-hensel"}[HexHensel] lifts modular factorizations to prime
+  powers, and `HexBerlekampZassenhaus` builds the integer factorizer
+  on top of it (with the {ref "hex-lll"}[HexLLL] lattice tier for
+  adversarial recombination cases), registering the `Hex.ZPoly`
+  provider and the free-layer witness classes.
+* `HexBerlekampMathlib` and `HexBerlekampZassenhausMathlib` are the
+  correspondence libraries: they identify the executable results with
+  `Polynomial (ZMod q)` and `Polynomial ℤ` statements, register those
+  providers, add the multi-prime certificates, and declare the bang
+  forms.

--- a/HexManual/Chapters/FactorTactics.lean
+++ b/HexManual/Chapters/FactorTactics.lean
@@ -71,10 +71,11 @@ theorem sqrt2_irred :
 
 Behind the call, the input expression is parsed to an executable
 integer polynomial together with a proof that the parse is faithful,
-the compiled factorizer confirms there is exactly one irreducible
-factor, and a per-factor certificate (for `x² − 2`, a single-prime
-modular witness) is reified into the proof term for the kernel to
-check.
+and a compiled witness search finds a certificate: for `x² − 2` the
+reduction mod `3` is irreducible, a single-prime modular witness,
+which is reified into the proof term for the kernel to check. The
+factorizer itself only runs when no witness exists, to report whether
+the input is actually reducible or merely uncertifiable.
 
 # Factoring: `factor_poly`
 %%%
@@ -179,10 +180,14 @@ equivalent to Mathlib's `Irreducible` under `toPolynomial`. Goal-mode
 `Irreducible (HexPolyZMathlib.toPolynomial f)`, and `Irreducible P` for
 a parseable `P : Polynomial ℤ`.
 
-Finally, `Polynomial (ZMod q)` inputs (literal prime `q < 2³¹`) reuse
-the prime-field pipeline through the parser-with-proof of
-`HexBerlekampMathlib`, producing the same
-{name}`Hex.FactoredPoly` shape as the integer case:
+Finally, `Polynomial (ZMod q)` inputs reuse the prime-field pipeline
+through the parser-with-proof of `HexBerlekampMathlib`, producing the
+same {name}`Hex.FactoredPoly` shape as the integer case. The modulus
+must be a literal prime with `q ≤ 2²⁶`: the emitted term kernel-replays
+a trial-division primality check costing roughly `q` steps, so larger
+moduli are declined even inside the `ZMod64` bound, and the per-factor
+`(degree + 1) · q` replay budget of the
+{ref "factor-tactics-coverage"}[coverage section] applies as well:
 
 ```lean
 open Polynomial
@@ -273,12 +278,22 @@ ordinary proof term, the axiom cone stays clean:
 tag := "factor-tactics-coverage"
 %%%
 
-Inputs must be closed, kernel-transparent terms: the compiled
-evaluator has to see the actual coefficients at elaboration time, so a
-polynomial mentioning a local hypothesis or metavariable is rejected
-with `must be a closed term (no local hypotheses or metavariables)`,
-and a definition whose body the evaluator cannot access produces an
-evaluation error suggesting a `public meta import` of its module.
+All inputs must be closed terms: a polynomial mentioning a local
+hypothesis or metavariable is rejected with `must be a closed term
+(no local hypotheses or metavariables)`. Beyond that the contract
+splits by input type. The executable types (`FpPoly p`, `ZPoly`) must
+be evaluable and definitionally transparent: the compiled evaluator
+has to see the actual coefficients at elaboration time (a definition
+whose body it cannot access produces an evaluation error suggesting a
+`public meta import` of its module), and the kernel must be able to
+unfold the input to its literal coefficients. The `Polynomial` types
+instead go through a syntax-directed parser covering `X`,
+`Polynomial.C`, numerals, `+`, `-`, `*`, negation, `^` with literal
+`Nat` exponents, and named definitions unfolded under a fuel guard;
+an expression outside that grammar, say a raw `Polynomial.monomial`
+application, is rejected as unsupported even when it is closed and
+transparent.
+
 Degenerate inputs get targeted messages rather than proofs: the zero
 polynomial and units are reported as not irreducible, and a reducible
 input to `irreducibility` reports the factor count that `factor_poly`
@@ -286,24 +301,33 @@ found.
 
 For `FpPoly p` coverage is complete within that contract: any closed
 input at a literal prime modulus inside the `ZMod64` bounds factors,
-subject to the certificate replay budget `deg · p ≤ 2²⁶` (each Rabin
-replay costs roughly `deg · p` modular polynomial operations in the
-kernel; over-budget inputs fail at elaboration time with a clear
-message instead of emitting a proof the kernel cannot afford). A
-composite modulus is declined: `Polynomial (ZMod 6)` inputs report
-that the modulus is not prime, and `FpPoly 6` likewise.
+subject to the certificate replay budget: each Rabin-certified factor
+must satisfy `(degree + 1) · p ≤ 2²⁶`, checked once per distinct
+factor for `factor_poly` and against the input itself for
+`irreducibility` (a replay costs roughly that many modular polynomial
+operations in the kernel; over-budget inputs fail at elaboration time
+with a clear message instead of emitting a proof the kernel cannot
+afford). A composite modulus is declined: `Polynomial (ZMod 6)`
+inputs report that the modulus is not prime, and `FpPoly 6` likewise.
 
 Over the integers, the factor *search* always succeeds, but the
 emitted proof needs a kernel-checkable irreducibility witness for each
 factor, and the witness languages do not cover all of `ℤ[X]`. The free
-layer
-certifies four classes: prime constants, primitive linear polynomials,
-factors irreducible modulo a single good prime (a reified Rabin
-certificate), and Eisenstein-after-shift. The last deserves a story:
-`x⁴ + 1` is irreducible over `ℤ` yet reducible modulo *every* prime,
-so no single-prime witness exists, but shifting by `1` gives
+layer supports four witness kinds: prime constants, primitive linear
+polynomials, single-prime modular reduction (a reified Rabin
+certificate for a prime where the factor stays irreducible), and
+Eisenstein-after-shift. Each is found by a bounded search, so an
+input can lie inside a certificate language yet outside the
+implemented search: the single-prime search tries primes below `512`
+(those within the replay budget), the Eisenstein search tries shifts
+`0, ±1, ±2, ±3` with witness primes capped at `128` (a larger prime's
+trial-division replay would exceed the kernel's recursion depth), and
+a prime-constant witness must itself fit the replay budget. The
+Eisenstein kind deserves a story: `x⁴ + 1` is irreducible over `ℤ`
+yet reducible modulo *every* prime, so no single-prime witness
+exists, but shifting by `1` gives
 `(x+1)⁴ + 1 = x⁴ + 4x³ + 6x² + 4x + 2`, Eisenstein at `2`, and the
-shift search (shifts `0, ±1, ±2, ±3`) finds exactly that certificate:
+shift search finds exactly that certificate:
 
 ```lean
 open Hex Polynomial
@@ -318,8 +342,9 @@ example : Irreducible (X ^ 4 + 1 : Polynomial ℤ) := by
 ```
 
 When no free-layer witness exists, `HexBerlekampZassenhausMathlib`
-adds multi-prime degree-obstruction certificates: several primes whose
-modular factor-degree splittings jointly rule out every proper factor
+adds multi-prime degree-obstruction certificates: several primes
+(drawn from a fixed pool, `3` through `71`) whose modular
+factor-degree splittings jointly rule out every proper factor
 degree. The quartic `x⁴ + 8x + 12` has Galois group `A₄`, so it is
 reducible mod every prime and not Eisenstein at any small shift, but
 its mod-`p` splittings `{1,3}` and `{2,2}` together obstruct all
@@ -342,9 +367,10 @@ example :
   irreducibility
 ```
 
-One class remains out of reach of every certificate language:
-polynomials whose modular splittings are balanced at every candidate
-prime, which are not Eisenstein at any small shift, *and* whose proper
+One class remains out of reach of every implemented search *and*
+every certificate language: polynomials whose modular splittings are
+balanced at every candidate prime, which are not Eisenstein at any
+small shift, and whose proper
 factor degrees survive the multi-prime obstruction. Swinnerton-Dyer
 polynomials such as `x⁴ − 10x² + 1` (the minimal polynomial of
 `√2 + √3`) are the canonical case. The plain tactics decline these
@@ -357,12 +383,15 @@ to make a proof go through.
 tag := "factor-tactics-bang"
 %%%
 
-`irreducibility!` and `factor_poly!` (all the same term, tactic, and
-goal forms) first run the normal certificate pipeline and fall back,
-only when it declines, to a proof by `decide`: the kernel re-runs the
-full factorization to verify the claim. This is the one exception to
-"the factorizer never runs in the kernel", and it covers exactly the
-inputs the certificate languages cannot, including the Swinnerton-Dyer
+`irreducibility!` and `factor_poly!` first run the normal certificate
+pipeline; whenever the plain form fails, they fall back to a proof by
+`decide`, making the kernel re-run the full factorization to verify
+the claim. `irreducibility!` has all the plain forms: term, bare goal
+mode, and the `irreducibility! f` / `irreducibility! h : f` tactics.
+`factor_poly!` has the term form and the argument-taking tactic form.
+This is the one exception to "the factorizer never runs in the
+kernel": a kernel-decide fallback for small inputs whose replay stays
+in the kernel-reducible classical tier, including the Swinnerton-Dyer
 quartic:
 
 ```lean
@@ -384,7 +413,10 @@ pass-throughs and cost nothing extra. On genuine fallbacks the kernel
 replay costs real time (quartics are sub-second, degree 8 takes
 seconds, degree 12 tens of seconds), so a dense-size budget of 13
 rejects larger inputs at elaboration time with a message quoting the
-budget. Two further costs land on the calling file when it uses the
+budget. Inputs whose factorization is routed to the native-LLL
+lattice tier cannot be certified this way at any size: the FFI
+`lllNative` has no kernel-reducible body for the kernel to re-run.
+Two further costs land on the calling file when it uses the
 module system: the kernel can only re-run definitions whose bodies it
 can see, so a `module`-based caller must `import all` the executable
 closure (the `HexBerlekampZassenhausMathlib.BangElab` module docstring

--- a/progress/2026-07-24T06-01-19Z.md
+++ b/progress/2026-07-24T06-01-19Z.md
@@ -1,0 +1,38 @@
+# Manual chapter for the factor_poly / irreducibility tactic family
+
+## Accomplished
+
+- Wrote `HexManual/Chapters/FactorTactics.lean`, a single cross-cutting
+  chapter documenting the `factor_poly` / `irreducibility` family (term,
+  tactic, and goal forms) across all four input types (`Hex.FpPoly p`,
+  `Hex.ZPoly`, `Polynomial (ZMod q)`, `Polynomial ℤ`), plus the trust
+  model, the coverage/witness-class story (Eisenstein-after-shift on
+  `x⁴+1`, the A₄ quartic multi-prime handover, the Swinnerton-Dyer
+  decline), and the `irreducibility!` / `factor_poly!` fallbacks.
+- Chose one chapter rather than per-library Berlekamp/BZ pages: the
+  family is a single user surface with pluggable providers, and the
+  manual has no Berlekamp chapters yet to attach per-library sections
+  to. Registered it in `HexManual.lean` after HexRealRoots and before
+  HexRoots (hex-roots consumes the irreducibility obligations, so this
+  respects the include ordering as a topological sort).
+- All examples are checked Verso `lean` blocks, adapted from the four
+  FactorTacticTests/FactorPolyTests files, including the bang forms:
+  the manual's chapters are legacy (non-`module`) files, so every
+  imported body is kernel-visible and no `import all` closure block is
+  needed. Error messages are described in prose (the manual has no
+  error-block idiom).
+- `lake build HexManual` green with zero warnings from the new chapter.
+
+## Current frontier
+
+The chapter documents the tactic surface as of the Eisenstein PR
+(#8862) and the top-level SPEC wording (#8865).
+
+## Next step
+
+Render check via the Pages workflow happens automatically on merge to
+main; nothing further planned for this arc.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR adds a HexManual chapter documenting the `factor_poly` / `irreducibility` tactic family: the term, tactic, and goal forms across all four input types (`Hex.FpPoly p`, `Hex.ZPoly`, `Polynomial (ZMod q)`, `Polynomial ℤ`), the trust model (compiled search at elaboration time, kernel replay of certificate checks on literal data only), the coverage story (complete `FpPoly` coverage under the replay budget; the integer witness classes including Eisenstein-after-shift on `x⁴+1` and the multi-prime degree obstruction on the `A₄` quartic; the Swinnerton-Dyer decline), and the kernel-decide fallbacks `irreducibility!` / `factor_poly!`. It is one cross-cutting chapter rather than per-library pages, since the family is a single user surface with pluggable providers; every example is a checked Verso block adapted from the tactic test files, including the bang forms, which need no `import all` closure because manual chapters are legacy (non-`module`) files. The chapter is registered in `HexManual.lean` after HexRealRoots and before HexRoots, and `lake build HexManual` is green with no warnings from the new chapter.

🤖 Prepared with Claude Code
