### PR TITLE
docs(bz): tighten SD seam comparator verdict

### DIFF
--- a/progress/20260727T030925Z.md
+++ b/progress/20260727T030925Z.md
@@ -1,0 +1,31 @@
+# #8868 second-opinion follow-up
+
+**Accomplished**
+
+- Re-ran the requested `$second-opinion` review on the PR #8870 diff after the
+  earlier wrapper limit cleared.
+- Verified the substantive review findings against the SPEC, sweep artefact, and
+  git history.
+- Tightened the SD5/SD6 seam report wording:
+  - SD5 is now recorded as a `10.86x` classical-regime parity miss.
+  - SD6 is now described as isolated `hex-lattice` evidence, not a production
+    hybrid win, because `hex-factor` timed out in the artefact.
+  - The July 3 artefact is date-scoped and marked stale pending refresh.
+  - The SD6 `hex-lattice` time is marked as a single call near the 10s cap.
+  - The `r` column is explicitly sourced from the #8867 spike, not the sweep
+    JSON.
+- Aligned `reports/hexbz-factor-sweep.md` with the committed curated artefact:
+  removed stale `hex-fast` result prose from the July 3 record, documented the
+  #8596 row stripping, and corrected PARI provenance.
+
+**Current frontier**
+
+- Documentation follow-up branch `issue-8868-second-opinion` is ready to commit.
+
+**Next step**
+
+- Commit the corrections, open a follow-up PR, and run/check CI.
+
+**Blockers**
+
+- None.

--- a/reports/hex-berlekamp-zassenhaus-performance.md
+++ b/reports/hex-berlekamp-zassenhaus-performance.md
@@ -132,22 +132,25 @@ that lattice-backed tail: hex should solve under the declared cap where the
 verified classical Isabelle BZ reference times out or is slower, not merely
 match it.
 
-### Scheduled Swinnerton-Dyer seam comparator (#8868)
+### Dedicated-hardware Swinnerton-Dyer seam comparator (#8868)
 
-The SD5/SD6 seam is now recorded outside the spike-only workflow by the
-scheduled factor-sweep systems:
+As measured at commit `bc958d84c72236948ebc96eaaed44e9cfecd05c8` on
+`2026-07-03`, the SD5/SD6 seam is recorded outside the spike-only workflow by
+the dedicated-hardware factor-sweep systems:
 
 - `hex-factor`: production cost-based `factor` hybrid.
 - `hex-lattice`: lattice tier service.
 - `hex-classical-nodecline`: classical recombination with the early lattice
   decline disabled.
 - `isabelle-bz`: verified classical Isabelle/AFP BZ reference.
+- `isabelle-lll`: verified Isabelle/AFP LLL factorization reference.
+- `flint`, `ntl`, `pari`: unverified C/CAS implementation context.
 
 The traceable artefact is
 `reports/bench-results/hexbz-factor-sweep-bc958d84-carica.json`, SHA-256
 `a1452db9f3aa4d9c86c6ece4a716d17483f3734caf632c5baf9085a8e463ce23`.
-It was recorded on `carica` (Apple M2 Ultra, macOS/darwin arm64, 24 cores)
-at `2026-07-03T08:22:20Z`, commit
+It was recorded on `carica` (darwin arm64, 24 cores) at
+`2026-07-03T08:22:20Z`, commit
 `bc958d84c72236948ebc96eaaed44e9cfecd05c8` with a dirty worktree, using
 toolchain `leanprover/lean4:v4.32.0-rc1` and AFP release
 `afp-2026-05-29`. The corpus was
@@ -157,18 +160,23 @@ The declared cap was `--cutoff 10` seconds per system/instance; the sweep used
 median-of-5 for first calls under 1s and a single call otherwise. Its
 `cross_check` block has `ok: true` and an empty `mismatches` list, so all
 systems that solved a shared instance agreed on the factor-degree multiset.
+The committed artefact is the post-#8596 eight-system record: the retired
+`hex-fast` rows were stripped from the JSON after the original July 3 run, and
+the digest above is for that committed curated file.
 
 Sweep command:
 
 ```sh
 python3 scripts/bench/factor_sweep.py \
-    --systems hex-factor,hex-lattice,hex-fast,hex-classical-nodecline,flint,ntl,pari,isabelle-bz,isabelle-lll \
+    --systems hex-factor,hex-lattice,hex-classical-nodecline,flint,ntl,pari,isabelle-bz,isabelle-lll \
     --cutoff 10 \
     --no-early-terminate \
     --skip-unavailable
 ```
 
-Relevant result rows:
+Relevant result rows. The `r` column is carried over from the #8867 spike
+measurement at commit `afc8ca4d`; the sweep artefact records degree/status/time,
+but not the selected prime or modular-factor count.
 
 | rung | degree | measured `r` | system | status | median | factor count | verdict |
 | --- | ---: | ---: | --- | --- | ---: | ---: | --- |
@@ -176,18 +184,36 @@ Relevant result rows:
 | SD5 | 32 | 16 | `hex-classical-nodecline` | `ok` | 335.010 ms | 1 | classical side solves under cap |
 | SD5 | 32 | 16 | `hex-lattice` | `ok` | 508.589 ms | 1 | lattice side solves, slower than classical at the seam |
 | SD5 | 32 | 16 | `isabelle-bz` | `ok` | 30.562 ms | 1 | verified classical reference solves; no tail timeout yet |
+| SD5 | 32 | 16 | `isabelle-lll` | `timeout` | -- | -- | verified direct-LLL reference times out one rung before hex-lattice's SD6 solve |
+| SD5 | 32 | 16 | `flint` | `ok` | 1.604 ms | 1 | unverified C implementation context |
+| SD5 | 32 | 16 | `ntl` | `ok` | 3.131 ms | 1 | unverified C implementation context |
+| SD5 | 32 | 16 | `pari` | `ok` | 1.205 ms | 1 | unverified CAS implementation context |
 | SD6 | 64 | 32 | `hex-factor` | `timeout` | -- | -- | production hybrid did not finish inside this 10s sweep cap |
 | SD6 | 64 | 32 | `hex-classical-nodecline` | `timeout` | -- | -- | classical no-decline hits the exponential wall |
-| SD6 | 64 | 32 | `hex-lattice` | `ok` | 8922.642 ms | 1 | lattice-backed tier solves under the declared cap |
+| SD6 | 64 | 32 | `hex-lattice` | `ok` | 8922.642 ms (single call) | 1 | isolated lattice tier solved at 89% of the cap |
 | SD6 | 64 | 32 | `isabelle-bz` | `timeout` | -- | -- | verified classical reference has no finite wall-clock ratio |
+| SD6 | 64 | 32 | `isabelle-lll` | `timeout` | -- | -- | verified direct-LLL reference also times out |
+| SD6 | 64 | 32 | `flint` | `ok` | 7.470 ms | 1 | unverified C implementation context |
+| SD6 | 64 | 32 | `ntl` | `ok` | 13.286 ms | 1 | unverified C implementation context |
+| SD6 | 64 | 32 | `pari` | `ok` | 6.269 ms | 1 | unverified CAS implementation context |
 
-This is the scheduled-hardware comparator evidence for the seam. SD5 is still a
-small/medium-`r` classical rung: the verified classical Isabelle BZ reference is
-faster than hex on this input, so the row is a regime marker rather than a
-large-tail win. SD6 is the first recorded lattice-backed rung: `hex-lattice`
-solves under the 10s cap while `isabelle-bz` and
-`hex-classical-nodecline` both time out, so the result is recorded as
-solved-under-cap versus timeout rather than as a finite wall-clock ratio.
+This is dedicated-hardware comparator evidence for the seam, not a Phase-4 goal
+discharge. SD5 is the last small/medium-`r` classical rung; `hex-factor /
+isabelle-bz = 331.832 / 30.562 = 10.86x` on this artefact, so it misses the
+SPEC's parity target for the classical regime. SD6 is the first recorded rung
+where the isolated lattice tier solves while the verified classical Isabelle BZ
+reference times out, but the production hybrid `hex-factor` also timed out in
+this sweep. Therefore the large-`r` hybrid comparator goal is still not met by
+this artefact; the row records isolated `factorLattice` solved-under-cap versus
+verified classical timeout, with no finite wall-clock ratio.
+
+This artefact is also stale for current performance: it predates the later
+factor-path work called out by the 2026-07-27 spike re-measure above. That
+single-shot spike at commit `afc8ca4d` recorded SD6 lattice core at
+`11481.444 ms` and hybrid wall at `13926.582 ms` under high load, both above
+the 10s sweep cap. The July 3 SD6 `hex-lattice` under-cap result should
+therefore be treated as historical seam evidence pending a refreshed
+dedicated-hardware sweep on the current factor path.
 
 ### Per-call comparator overhead
 

--- a/reports/hexbz-factor-sweep.md
+++ b/reports/hexbz-factor-sweep.md
@@ -167,7 +167,7 @@ alongside these under `reports/figures/`.
 - **Artifact:** `reports/bench-results/hexbz-factor-sweep-bc958d84-carica.json`
   SHA-256 `a1452db9f3aa4d9c86c6ece4a716d17483f3734caf632c5baf9085a8e463ce23`
 - **Command:**
-  `python3 scripts/bench/factor_sweep.py --systems hex-factor,hex-lattice,hex-fast,hex-classical-nodecline,flint,ntl,pari,isabelle-bz,isabelle-lll --cutoff 10 --no-early-terminate --skip-unavailable`
+  `python3 scripts/bench/factor_sweep.py --systems hex-factor,hex-lattice,hex-classical-nodecline,flint,ntl,pari,isabelle-bz,isabelle-lll --cutoff 10 --no-early-terminate --skip-unavailable`
   (full-fidelity: no monotonic early termination, so the conway curves include
   every prime-lucky high-degree solve)
 - **Corpus:** `bench/corpus/hexbz-factor-corpus.jsonl`
@@ -176,7 +176,11 @@ alongside these under `reports/figures/`.
   branch's corpus regeneration; the corpus SHA above is the reproducible pin),
   toolchain `leanprover/lean4:v4.32.0-rc1`, arm64, 24 cores, 2026-07-03T08:22:20Z;
   AFP release `afp-2026-05-29` for both Isabelle systems.
-- **Cross-check:** all nine answering systems agree — hex's factor degree
+- **Provenance note:** the original July 3 run also measured the retired
+  `hex-fast` curve, but #8596 stripped those result rows from the committed JSON
+  before this digest was updated. The hash above is the digest of the committed
+  eight-system artefact, not the pre-#8596 raw export.
+- **Cross-check:** all eight answering systems agree — hex's factor degree
   multisets match FLINT, NTL, PARI/GP, verified Isabelle BZ and verified Isabelle
   LLL on every instance any two solved (differential correctness across 391
   instances, six independent implementations). In particular every one of the
@@ -187,18 +191,17 @@ alongside these under `reports/figures/`.
 | --- | ---: | ---: | ---: | ---: | ---: |
 | hex-factor | 366 | 25 | 0 | 0 | 35.8 |
 | hex-lattice | 363 | 28 | 0 | 0 | 49.0 |
-| hex-fast | 198 | 137 | 56 | 0 | 51.0 |
 | hex-classical-nodecline | 366 | 25 | 0 | 0 | 50.7 |
 | flint | 390 | 1 | 0 | 0 | 30.4 |
 | ntl | 390 | 1 | 0 | 0 | 13.4 |
-| pari&nbsp;† | 390 | 1 | 0 | 0 | 32.8 |
+| pari | 390 | 1 | 0 | 0 | 32.8 |
 | isabelle-bz | 370 | 21 | 0 | 0 | 19.5 |
 | isabelle-lll | 309 | 82 | 0 | 0 | 17.2 |
 
-† PARI/GP is measured in the companion record below (same corpus SHA and 10 s
-cutoff, with the auto-growing-stack driver from #8558); the plotter merges it
-into every chart newest-per-system, so its row sits in this table while its
-curve is added to every plot.
+The committed full-board artefact includes the post-refresh PARI/GP rows. The
+single-system companion record below is retained as provenance for the
+auto-growing-stack PARI refresh from #8558 and for the plotter's
+newest-per-system merge workflow.
 
 The C-implementation ceiling (FLINT, NTL, PARI) solves 390/391, all missing only
 `hoeij_S9` (Swinnerton-Dyer SD₉, degree 512) at the 10 s cutoff.
@@ -209,18 +212,12 @@ irreducible over ℤ, so this family is a pure recombination stress test. Yet
 verified `isabelle-bz` each solve **all 186** — because a monic polynomial that
 stays irreducible modulo a well-chosen prime is proved irreducible immediately,
 with no recombination at all. The family therefore does not stress recombination
-so much as *prime selection*: it separates the paths with adaptive prime choice
-(everything above) from the two that lack it. `hex-fast`, the proof-facing path
-whose bounded prime search can exhaust before finding a prime that keeps the
-polynomial irreducible, solves only **82/186** — and, tellingly, its solves are
-spread across every degree 1–40, not a clean low-degree prefix: it times out on
-`C_{2,12}` yet solves `C_{2,16}` in milliseconds, because difficulty here tracks
-the *prime choice*, not the degree. `isabelle-lll`, whose full-degree direct-LLL
+so much as *prime selection*. `isabelle-lll`, whose full-degree direct-LLL
 lattice grows expensive with degree independently of the modular factor count,
-solves **167/186**, timing out on the higher-degree small-prime lifts. This
-non-monotonicity is exactly why the sweep's monotonic early termination treats
-conway with a consecutive-timeout threshold rather than stopping at the first
-timeout (see Methodology).
+solves **167/186**, timing out on the higher-degree small-prime lifts. The
+retired `hex-fast` curve formerly recorded here showed the same prime-selection
+sensitivity, but those rows are no longer present in the committed artefact
+(see the provenance note above).
 
 **The verified-vs-verified headline is the point of the two Isabelle curves.**
 On the corpus as a whole the counts are close (hex-factor 366, isabelle-bz 370,
@@ -249,14 +246,13 @@ The `hex-classical-nodecline` curve runs the classical recombination to
 completion or cutoff with the level-aware early decline disabled, so its 25
 timeouts are the classical exponential wall made visible on the same charts (it
 never declines — 0 declined — it either completes correctly or times out).
-`hex-fast` (the proof-facing path) is the weakest hex tier here. PARI/GP sits
-with FLINT and NTL at the C-implementation ceiling — 390/391 overall, reaching
-Swinnerton-Dyer and sd-products degree 128 (double hex-lattice's 64, and far
-past both verified Isabelle systems). Longer-cutoff (60 s / 300 s) sweeps record
-alongside this one, each carrying its own cutoff; the only instance no system
-solves at 10 s is `hoeij_S9` (degree 512), and the hardest hoeij-zimmermann
-entries fall only to the three C libraries (FLINT, NTL, PARI) — the natural
-target for those longer sweeps.
+PARI/GP sits with FLINT and NTL at the C-implementation ceiling — 390/391
+overall, reaching Swinnerton-Dyer and sd-products degree 128 (double
+hex-lattice's 64, and far past both verified Isabelle systems). Longer-cutoff
+(60 s / 300 s) sweeps record alongside this one, each carrying its own cutoff;
+the only instance no system solves at 10 s is `hoeij_S9` (degree 512), and the
+hardest hoeij-zimmermann entries fall only to the three C libraries (FLINT, NTL,
+PARI) — the natural target for those longer sweeps.
 
 ### carica, 10 s cutoff — PARI/GP refresh (2026-07-03)
 
@@ -267,15 +263,15 @@ target for those longer sweeps.
 - **Corpus:** `bench/corpus/hexbz-factor-corpus.jsonl`
   SHA-256 `0ef7574769d9161d8e3bda3b8c193b05191d75b4b473279520db4513e533b2df` (391 instances) —
   identical to the full-board record above, so the two merge cleanly.
-- **Why a companion record.** The full-board record above measured PARI with the
-  pre-#8558 8 MB-stack driver, which errors (rather than factoring) on the two
-  largest hoeij instances. This single-system record re-measures PARI with the
+- **Why a companion record.** The original full-board run measured PARI with the
+  pre-#8558 8 MB-stack driver, which errored rather than factoring on the two
+  largest hoeij instances. This single-system record re-measured PARI with the
   merged auto-growing-stack driver (`cypari2.Pari(size, sizemax)`), which solves
   `hoeij_F630` (degree 630) and leaves only `hoeij_S9` (degree 512) unsolved at
-  10 s: 390/391, no errors. The plotter takes the newest measurement of each
-  system (guarded by a matching corpus SHA), so this record supplies PARI's curve
-  to every chart while the other eight systems carry over from the full-board
-  record — the single-system workflow documented under [Reproducing](#reproducing).
+  10 s: 390/391, no errors. The current committed full-board artefact already
+  carries those post-refresh PARI rows; the companion record remains the
+  single-system provenance for that refresh and documents the workflow under
+  [Reproducing](#reproducing).
 
 ## Reproducing
 


### PR DESCRIPTION
Follow-up to #8870 / #8868 after the requested second-opinion review.\n\n## Summary\n- marks SD5 as a 10.86x classical-regime parity miss instead of a neutral regime marker\n- distinguishes isolated hex-lattice SD6 evidence from the production hybrid, which timed out in the artefact\n- date-scopes the July 3 sweep, records the single-call near-cap caveat, and marks the result stale pending refresh\n- aligns the factor-sweep report with the committed eight-system artefact after #8596 stripped retired hex-fast rows\n- corrects PARI provenance now that the committed full-board JSON contains PARI rows\n\n## Validation\n- git diff --check\n- JSON consistency script checked the artefact hash, eight-system config, absence of hex-fast result rows, PARI row count, and the SD5/SD6 verdict text against reports/bench-results/hexbz-factor-sweep-bc958d84-carica.json\n\n## Second opinion\n- Claude Opus found substantive framing/provenance concerns in #8870. I verified and addressed the in-scope issues in this PR.