### PR TITLE
feat(rcf): add reflected language

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
       # fresh against the restored libs, which is cheap.
       - name: Define the hex-dev cache + build target sets
         run: |
-          echo "HEX_LIB_TARGETS=HexBasic HexArith HexPoly HexModArith HexGF2 HexPolyZ HexRoots HexPolyFp HexGFqRing HexGFqField HexBerlekamp HexHensel HexConway HexGFq HexBerlekampZassenhaus HexRealRoots HexMatrix HexRowReduce HexDeterminant HexBareiss HexGramSchmidt HexLLL HexMatrixMathlib HexGramSchmidtMathlib HexLLLMathlib HexBerlekampZassenhausMathlib HexRealRootsMathlib HexRootsMathlib" >> "$GITHUB_ENV"
+          echo "HEX_LIB_TARGETS=HexBasic HexArith HexPoly HexModArith HexGF2 HexPolyZ HexRoots HexPolyFp HexGFqRing HexGFqField HexBerlekamp HexHensel HexConway HexGFq HexBerlekampZassenhaus HexRealRoots HexMatrix HexRowReduce HexDeterminant HexBareiss HexGramSchmidt HexLLL HexMatrixMathlib HexGramSchmidtMathlib HexLLLMathlib HexBerlekampZassenhausMathlib HexRealRootsMathlib HexRCF HexRootsMathlib" >> "$GITHUB_ENV"
           echo "HEX_EXE_TARGETS=hexarith_bench hexpoly_bench hexpolyz_bench hexpolyfp_bench hexmodarith_bench hexgf2_bench hexgfqring_bench hexgfqfield_bench hexgfq_bench hexhensel_bench hexberlekamp_bench hexbz_bench hexconway_bench hexmatrix_bench hexdeterminant_bench hexbareiss_bench hexgramschmidt_bench hexrealroots_bench hexroots_bench hexroots_demo hexlll_bench hexlll_provider_probe" >> "$GITHUB_ENV"
       # Shared build. The libraries, bench exes, conformance #guard drivers, and
       # emit-fixture exes are all elaborated here so the two verification tails

--- a/HexRCF.lean
+++ b/HexRCF.lean
@@ -1,0 +1,22 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.Language
+public import HexRCF.LanguageTests
+
+public section
+
+/-!
+The `HexRCF` library defines the reflected language used by a
+certificate-producing decision procedure for univariate real-closed-field
+sentences.
+
+The reflected language supports Boolean combinations of integer-polynomial
+comparisons under one universal or existential quantifier, either over the real
+line or over a half-open dyadic interval.
+-/

--- a/HexRCF/Language.lean
+++ b/HexRCF/Language.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRealRootsMathlib.Separation
+
+public section
+
+/-!
+# Reflected univariate real-closed-field sentences
+
+This module defines the object language consumed by the `rcf` decision
+procedure. A formula is a Boolean combination of comparisons between an
+integer polynomial evaluated at one real variable and zero. A sentence places
+exactly one universal or existential quantifier around a formula, either over
+all real numbers or over a half-open interval with dyadic endpoints.
+
+Nested quantifiers and additional variables are unrepresentable by
+construction. Rational coefficients are handled by the tactic's reifier,
+which clears denominators before constructing an `Atom`.
+-/
+
+namespace Hex.RCF
+
+/-- The six comparisons supported by reflected polynomial atoms. -/
+inductive Cmp where
+  | lt
+  | le
+  | eq
+  | ge
+  | gt
+  | ne
+  deriving DecidableEq
+
+/-- Interpret a reflected comparison between two real numbers. -/
+@[expose]
+def Cmp.toProp : Cmp → ℝ → ℝ → Prop
+  | .lt, a, b => a < b
+  | .le, a, b => a ≤ b
+  | .eq, a, b => a = b
+  | .ge, a, b => a ≥ b
+  | .gt, a, b => a > b
+  | .ne, a, b => a ≠ b
+
+/-- An atomic predicate asserting that an integer polynomial at `x` compares
+with zero according to `cmp`. -/
+structure Atom where
+  /-- The integer polynomial on the left of the comparison. -/
+  p : ZPoly
+  /-- The comparison with zero. -/
+  cmp : Cmp
+  deriving DecidableEq
+
+/-- Interpret an atomic polynomial comparison at a real point. -/
+@[expose]
+def Atom.toProp (a : Atom) (x : ℝ) : Prop :=
+  a.cmp.toProp (Polynomial.aeval x (HexPolyZMathlib.toPolynomial a.p)) 0
+
+/-- Boolean combinations of univariate polynomial atoms. -/
+inductive Formula where
+  /-- A polynomial comparison. -/
+  | atom (a : Atom)
+  /-- Truth. -/
+  | tt
+  /-- Falsity. -/
+  | ff
+  /-- Boolean negation. -/
+  | not (φ : Formula)
+  /-- Boolean conjunction. -/
+  | and (φ ψ : Formula)
+  /-- Boolean disjunction. -/
+  | or (φ ψ : Formula)
+  /-- Boolean implication. -/
+  | imp (φ ψ : Formula)
+  deriving DecidableEq
+
+/-- Interpret a reflected formula at a real point. -/
+@[expose]
+def Formula.toProp : Formula → ℝ → Prop
+  | .atom a, x => a.toProp x
+  | .tt, _ => True
+  | .ff, _ => False
+  | .not φ, x => ¬φ.toProp x
+  | .and φ ψ, x => φ.toProp x ∧ ψ.toProp x
+  | .or φ ψ, x => φ.toProp x ∨ ψ.toProp x
+  | .imp φ ψ, x => φ.toProp x → ψ.toProp x
+
+/-- A quantifier-free formula under exactly one real or bounded-real
+quantifier. Bounded quantifiers use the half-open convention `(a, b]` inherited
+from real-root isolations. -/
+inductive Sentence where
+  /-- Universal quantification over all real numbers. -/
+  | forallReal (φ : Formula)
+  /-- Existential quantification over all real numbers. -/
+  | existsReal (φ : Formula)
+  /-- Universal quantification over the half-open dyadic interval `(a, b]`. -/
+  | forallIoc (a b : Dyadic) (φ : Formula)
+  /-- Existential quantification over the half-open dyadic interval `(a, b]`. -/
+  | existsIoc (a b : Dyadic) (φ : Formula)
+  deriving DecidableEq
+
+/-- Interpret a reflected sentence as a Lean proposition. -/
+@[expose]
+def Sentence.toProp : Sentence → Prop
+  | .forallReal φ => ∀ x : ℝ, φ.toProp x
+  | .existsReal φ => ∃ x : ℝ, φ.toProp x
+  | .forallIoc a b φ =>
+      ∀ x : ℝ, x ∈ Set.Ioc (HexRealRootsMathlib.Dyadic.toReal a)
+        (HexRealRootsMathlib.Dyadic.toReal b) → φ.toProp x
+  | .existsIoc a b φ =>
+      ∃ x : ℝ, x ∈ Set.Ioc (HexRealRootsMathlib.Dyadic.toReal a)
+        (HexRealRootsMathlib.Dyadic.toReal b) ∧ φ.toProp x
+
+end Hex.RCF

--- a/HexRCF/Language.lean
+++ b/HexRCF/Language.lean
@@ -22,6 +22,11 @@ all real numbers or over a half-open interval with dyadic endpoints.
 Nested quantifiers and additional variables are unrepresentable by
 construction. Rational coefficients are handled by the tactic's reifier,
 which clears denominators before constructing an `Atom`.
+
+Reification transports atom evaluation and dyadic endpoints propositionally,
+through the `aeval` and `Dyadic.toReal` bridge lemmas. Normalisation and
+denominator clearing are not expected to make the reflected semantics
+definitionally equal to the source goal.
 -/
 
 namespace Hex.RCF

--- a/HexRCF/LanguageTests.lean
+++ b/HexRCF/LanguageTests.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.Language
+
+public section
+
+/-!
+# Tests for the reflected RCF language
+
+These examples exercise every comparison, Boolean connective, and sentence
+constructor through the public semantics.
+-/
+
+namespace Hex.RCF.Tests
+
+open Hex.RCF
+
+/-- The atom `0 = 0`. -/
+def zeroEq : Atom := ⟨0, .eq⟩
+
+/-- The atom `0 ≠ 0`. -/
+def zeroNe : Atom := ⟨0, .ne⟩
+
+/-- The real evaluation of the executable zero polynomial is zero. -/
+theorem eval_zero (x : ℝ) :
+    Polynomial.aeval x (HexPolyZMathlib.toPolynomial (0 : ZPoly)) = 0 := by
+  rw [HexPolyZMathlib.toPolynomial_zero]
+  simp
+
+example : Cmp.lt.toProp (1 : ℝ) 2 := by norm_num [Cmp.toProp]
+example : Cmp.le.toProp (1 : ℝ) 1 := by norm_num [Cmp.toProp]
+example : Cmp.eq.toProp (1 : ℝ) 1 := by norm_num [Cmp.toProp]
+example : Cmp.ge.toProp (2 : ℝ) 1 := by norm_num [Cmp.toProp]
+example : Cmp.gt.toProp (2 : ℝ) 1 := by norm_num [Cmp.toProp]
+example : Cmp.ne.toProp (1 : ℝ) 2 := by norm_num [Cmp.toProp]
+
+example (p : ZPoly) (x : ℝ) :
+    (Atom.mk p .gt).toProp x ↔
+      0 < Polynomial.aeval x (HexPolyZMathlib.toPolynomial p) :=
+  Iff.rfl
+
+example : zeroEq.toProp 2 := by
+  change Polynomial.aeval 2 (HexPolyZMathlib.toPolynomial (0 : ZPoly)) = 0
+  exact eval_zero 2
+
+example : (Formula.atom zeroEq |>.and (.not (.atom zeroNe)) |>.toProp) (1 / 2) := by
+  simp only [Formula.toProp, zeroEq, zeroNe, Atom.toProp, Cmp.toProp]
+  rw [eval_zero]
+  simp
+
+example : (Formula.not .ff).toProp 0 := by simp [Formula.toProp]
+example : (Formula.or .ff .tt).toProp 0 := by simp [Formula.toProp]
+example : (Formula.imp .ff .ff).toProp 0 := by simp [Formula.toProp]
+
+example : (Sentence.forallReal (.atom zeroEq)).toProp := by
+  simp only [Sentence.toProp, Formula.toProp]
+  intro x
+  change Polynomial.aeval x (HexPolyZMathlib.toPolynomial (0 : ZPoly)) = 0
+  exact eval_zero x
+
+example : (Sentence.existsReal (.atom zeroEq)).toProp := by
+  simp only [Sentence.toProp, Formula.toProp]
+  refine ⟨1, ?_⟩
+  change Polynomial.aeval 1 (HexPolyZMathlib.toPolynomial (0 : ZPoly)) = 0
+  exact eval_zero 1
+
+example : (Sentence.forallIoc (Dyadic.ofInt 0) (Dyadic.ofInt 1) .tt).toProp := by
+  simp [Sentence.toProp, Formula.toProp]
+
+example : (Sentence.existsIoc (Dyadic.ofInt 0) (Dyadic.ofInt 1) (.atom zeroEq)).toProp := by
+  simp only [Sentence.toProp, Formula.toProp]
+  refine ⟨1, ?_, ?_⟩
+  · rw [HexRealRootsMathlib.toReal_ofInt, HexRealRootsMathlib.toReal_ofInt]
+    norm_num [Set.mem_Ioc]
+  · change Polynomial.aeval 1 (HexPolyZMathlib.toPolynomial (0 : ZPoly)) = 0
+    exact eval_zero 1
+
+/-- Reversed endpoints make the half-open interval empty. -/
+example : (Sentence.forallIoc (Dyadic.ofInt 1) (Dyadic.ofInt 0) .ff).toProp := by
+  simp only [Sentence.toProp, Formula.toProp]
+  intro x hx
+  have hle : HexRealRootsMathlib.Dyadic.toReal (Dyadic.ofInt 1) ≤
+      HexRealRootsMathlib.Dyadic.toReal (Dyadic.ofInt 0) :=
+    le_trans (le_of_lt hx.1) hx.2
+  rw [HexRealRootsMathlib.toReal_ofInt, HexRealRootsMathlib.toReal_ofInt] at hle
+  norm_num at hle
+
+end Hex.RCF.Tests

--- a/HexRCF/LanguageTests.lean
+++ b/HexRCF/LanguageTests.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexRCF.Language
+import HexRealRootsMathlib.IsolateRoots
 
 public section
 
@@ -22,16 +23,20 @@ namespace Hex.RCF.Tests
 open Hex.RCF
 
 /-- The atom `0 = 0`. -/
-def zeroEq : Atom := ⟨0, .eq⟩
+private def zeroEq : Atom := ⟨0, .eq⟩
 
 /-- The atom `0 ≠ 0`. -/
-def zeroNe : Atom := ⟨0, .ne⟩
+private def zeroNe : Atom := ⟨0, .ne⟩
 
 /-- The real evaluation of the executable zero polynomial is zero. -/
-theorem eval_zero (x : ℝ) :
+private theorem eval_zero (x : ℝ) :
     Polynomial.aeval x (HexPolyZMathlib.toPolynomial (0 : ZPoly)) = 0 := by
   rw [HexPolyZMathlib.toPolynomial_zero]
   simp
+
+/-- The asymmetric polynomial `x³ - 1`, whose coefficient order is observable. -/
+private def cubeMinusOnePos : Atom :=
+  ⟨DensePoly.ofCoeffs #[(-1 : Int), 0, 0, 1], .gt⟩
 
 example : Cmp.lt.toProp (1 : ℝ) 2 := by norm_num [Cmp.toProp]
 example : Cmp.le.toProp (1 : ℝ) 1 := by norm_num [Cmp.toProp]
@@ -48,6 +53,16 @@ example (p : ZPoly) (x : ℝ) :
 example : zeroEq.toProp 2 := by
   change Polynomial.aeval 2 (HexPolyZMathlib.toPolynomial (0 : ZPoly)) = 0
   exact eval_zero 2
+
+example : cubeMinusOnePos.toProp 2 := by
+  simp only [cubeMinusOnePos, Atom.toProp, Cmp.toProp,
+    HexRealRootsMathlib.aeval_toPolynomial_ofCoeffs]
+  norm_num [Finset.sum_range_succ]
+
+example : ¬cubeMinusOnePos.toProp 0 := by
+  simp only [cubeMinusOnePos, Atom.toProp, Cmp.toProp,
+    HexRealRootsMathlib.aeval_toPolynomial_ofCoeffs]
+  norm_num [Finset.sum_range_succ]
 
 example : (Formula.atom zeroEq |>.and (.not (.atom zeroNe)) |>.toProp) (1 / 2) := by
   simp only [Formula.toProp, zeroEq, zeroNe, Atom.toProp, Cmp.toProp]
@@ -80,6 +95,15 @@ example : (Sentence.existsIoc (Dyadic.ofInt 0) (Dyadic.ofInt 1) (.atom zeroEq)).
     norm_num [Set.mem_Ioc]
   · change Polynomial.aeval 1 (HexPolyZMathlib.toPolynomial (0 : ZPoly)) = 0
     exact eval_zero 1
+
+/-- A genuinely fractional dyadic endpoint uses the shift exponent convention. -/
+example : (Sentence.existsIoc (Dyadic.ofInt 0)
+    ((Dyadic.ofInt 1) >>> (1 : Int)) .tt).toProp := by
+  simp only [Sentence.toProp, Formula.toProp]
+  refine ⟨1 / 2, ?_⟩
+  rw [HexRealRootsMathlib.toReal_ofInt,
+    HexRealRootsMathlib.toReal_ofInt_shiftRight]
+  norm_num [Set.mem_Ioc]
 
 /-- Reversed endpoints make the half-open interval empty. -/
 example : (Sentence.forallIoc (Dyadic.ofInt 1) (Dyadic.ofInt 0) .ff).toProp := by

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -184,6 +184,9 @@ lean_lib HexLLLMathlib where
 @[default_target]
 lean_lib HexRealRootsMathlib where
 
+@[default_target]
+lean_lib HexRCF where
+
 lean_exe hexlll_provider_probe where
   root := `HexLLL.ProviderProbe
 

--- a/libraries.yml
+++ b/libraries.yml
@@ -522,4 +522,4 @@ libraries:
     deps: [HexRealRoots, HexRealRootsMathlib, HexPolyZ, HexPolyZMathlib]
     mathlib: true
     done_through: 0
-    status: planned
+    status: active

--- a/progress/20260727T025826Z_hex-rcf-orientation.md
+++ b/progress/20260727T025826Z_hex-rcf-orientation.md
@@ -1,0 +1,37 @@
+# HexRCF orientation
+
+## Accomplished
+
+- Read `SPEC/Libraries/hex-rcf.md` in full and mapped its reflected language,
+  cell-decomposition algorithm, certificate replay boundary, tactic surface,
+  conformance requirements, and performance contract.
+- Confirmed that `HexRCF` is still planned at `done_through: 0`: there is no
+  `HexRCF/` source tree, umbrella, Lake target, or conformance target yet.
+- Traced the required downstream APIs in `HexRealRoots`,
+  `HexRealRootsMathlib`, `HexPolyZ`, and `HexPolyZMathlib`, including
+  `isolate?_isSome`, `aevalIff_squareFreeCore`,
+  `RealRootIsolations.isolates`, `SturmChainCert`, and `refineTo`.
+- Read the current phase conventions and verified that the tracker lists
+  `HexRCF` as deliberately deferred rather than ready for dispatch.
+
+## Current frontier
+
+The dependency foundations are present, including compiled isolation with
+kernel-replayable Sturm-chain certificates. All RCF-specific implementation
+layers remain: reflected syntax and semantics, cells and bounded endpoint
+classification, sign-matrix certificates and checker, soundness assembly,
+goal reification, tactic frontend, and conformance fixtures.
+
+## Next step
+
+When `HexRCF` is activated, sanity-check the SPEC's certificate data against
+the exact current polynomial gcd/divisibility APIs, then open a narrow Phase 1
+scaffolding issue beginning with the reflected language and final-form data
+structures.
+
+## Blockers
+
+- `HexRCF` is intentionally marked `status: planned`, so the normal status
+  planner skips it.
+- The pod `coordination` command was not available on `PATH` in this worktree;
+  no claim or dispatch action was needed for this orientation session.

--- a/progress/20260727T033029Z_rcf-language.md
+++ b/progress/20260727T033029Z_rcf-language.md
@@ -1,0 +1,34 @@
+# HexRCF reflected-language milestone
+
+## Accomplished
+
+- Activated `HexRCF` in `libraries.yml`, added the Lake target and root
+  umbrella, and included the library in the consolidated CI build target set.
+- Implemented the final reflected syntax and real semantics for all comparison,
+  Boolean, and single-quantifier constructors in `HexRCF/Language.lean`.
+- Added public-semantics tests covering every constructor, nonconstant
+  coefficient order, integer and fractional dyadic endpoints, and an empty
+  reversed interval.
+- Opened issue #8871 and draft PR #8878 for the milestone.
+- Audited the later checker contract and filed prerequisite issue #8877 with
+  concrete corrections for empty bounded intervals, propositional reification,
+  carrier-root witnesses, and multiplication-only Sturm/gcd replay.
+- Obtained an independent Claude Opus review of PR #8878. It found no merge
+  blocker; its two substantive test-coverage findings were implemented.
+
+## Current frontier
+
+PR #8878 contains the complete language milestone and is ready for its updated
+validation pass, review-fix commit, and merge queue. The library correctly
+remains at `done_through: 0`; later SPEC declarations have not been scaffolded.
+
+## Next step
+
+Push the review fixes, make PR #8878 ready, enable squash auto-merge, and then
+land #8877 before freezing any checker or certificate record.
+
+## Blockers
+
+None for the current milestone. Formal HexRCF Phase 4 will later require
+`HexRealRootsMathlib.done_through >= 4`; that dependency is currently at Phase
+3 and does not block the Phase 1 implementation work.


### PR DESCRIPTION
## Summary

- activate the Mathlib-facing `HexRCF` library in the dependency graph, Lake, and the consolidated CI build target list
- add the reflected comparison, atom, Boolean formula, and single-quantifier sentence types from the RCF specification
- define their real semantics using Mathlib polynomial evaluation and half-open dyadic intervals
- exercise every comparison, Boolean connective, and sentence constructor, including an empty reversed interval

## Design

This milestone intentionally adds only final-form language declarations. The cell decomposition, certificate/checker, soundness, and tactic declarations remain absent until their real implementations land; there are no data-level placeholders.

The premise audit for the later checker found specification defects outside this milestone. #8877 records the concrete counterexamples and required certificate/reifier corrections before that work begins.

## Verification

- `lake build HexRCF`
- `python3 scripts/check_dag.py`
- `python3 scripts/check_copyright_headers.py`
- `python3 scripts/check_file_line_counts.py`
- `python3 scripts/check_phase4.py`
- `python3 scripts/ci/check_benches_mathlib_free.py`
- `python3 scripts/conformance_targets.py --check`
- forbidden-token scan for `sorry`, `axiom`, `native_decide`, `TODO`, and `FIXME`
- `git diff --check`

Closes #8871
