### PR TITLE
feat(resultant): activate pseudo-division

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
       # fresh against the restored libs, which is cheap.
       - name: Define the hex-dev cache + build target sets
         run: |
-          echo "HEX_LIB_TARGETS=HexBasic HexArith HexPoly HexModArith HexGF2 HexPolyZ HexRoots HexPolyFp HexGFqRing HexGFqField HexBerlekamp HexHensel HexConway HexGFq HexBerlekampZassenhaus HexRealRoots HexMatrix HexRowReduce HexDeterminant HexBareiss HexGramSchmidt HexLLL HexMatrixMathlib HexGramSchmidtMathlib HexLLLMathlib HexBerlekampZassenhausMathlib HexRealRootsMathlib HexRCF HexRootsMathlib" >> "$GITHUB_ENV"
+          echo "HEX_LIB_TARGETS=HexBasic HexArith HexPoly HexModArith HexGF2 HexPolyZ HexRoots HexResultant HexPolyFp HexGFqRing HexGFqField HexBerlekamp HexHensel HexConway HexGFq HexBerlekampZassenhaus HexRealRoots HexMatrix HexRowReduce HexDeterminant HexBareiss HexGramSchmidt HexLLL HexMatrixMathlib HexGramSchmidtMathlib HexLLLMathlib HexBerlekampZassenhausMathlib HexRealRootsMathlib HexRCF HexRootsMathlib" >> "$GITHUB_ENV"
           echo "HEX_EXE_TARGETS=hexarith_bench hexpoly_bench hexpolyz_bench hexpolyfp_bench hexmodarith_bench hexgf2_bench hexgfqring_bench hexgfqfield_bench hexgfq_bench hexhensel_bench hexberlekamp_bench hexbz_bench hexconway_bench hexmatrix_bench hexdeterminant_bench hexbareiss_bench hexgramschmidt_bench hexrealroots_bench hexroots_bench hexroots_demo hexlll_bench hexlll_provider_probe" >> "$GITHUB_ENV"
       # Shared build. The libraries, bench exes, conformance #guard drivers, and
       # emit-fixture exes are all elaborated here so the two verification tails

--- a/HexResultant.lean
+++ b/HexResultant.lean
@@ -1,0 +1,22 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexResultant.Basic
+
+public section
+
+/-!
+The `HexResultant` library provides the fraction-free polynomial primitives
+used to compute subresultant pseudo-remainder sequences, resultants, and
+discriminants over exact coefficient rings. Its initial executable surface is
+polynomial pseudo-division over `Hex.DensePoly`, with the computational
+dependency surface kept at `HexPoly` alone.
+
+Correctness and correspondence with Mathlib's `Polynomial.resultant` and
+`Polynomial.discr` live in the companion `HexResultantMathlib` library.
+-/

--- a/HexResultant/Basic.lean
+++ b/HexResultant/Basic.lean
@@ -1,0 +1,183 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexPoly
+import all Init.Data.Array.Basic
+
+public section
+
+/-!
+Fraction-free polynomial pseudo-division.
+
+For `n = degree f`, `m = degree g`, `d = n - m + 1`, and `b = lc(g)`,
+`pseudoDivMod` computes the coefficients of the usual pseudo-division loop
+directly.  It first builds `b^0, ..., b^d`, then the successive cancelled
+leading coefficients
+
+```
+a_i = b^i * f[n-i]
+      - sum (a_j * b^(i-1-j) * g[m+j-i]),
+```
+
+where `max(0, i-m) <= j < i`.  The quotient coefficients are
+`q[k] = a_(d-1-k) * b^k`; the low `m` coefficients of
+`b^d*f - q*g` are the remainder.  This dynamic coefficient recurrence avoids
+materializing and rescaling the full quotient and remainder at every
+elimination step.  It performs `O(d*m)` coefficient operations and uses
+`O(d+m)` coefficient storage.
+
+The fixed `b^d` factor is built into both output formulas.  Consequently the
+residual scaling required when cancellation drops the degree by more than one
+is automatic rather than a special loop case.
+
+The function is total.  A zero divisor is a junk input and returns `(0, f)`.
+An already-smaller dividend also returns `(0, f)`; this agrees with ordinary
+division, although the fixed-exponent pseudo-division contract is stated only
+for the degree-ordered case.
+-/
+namespace Hex.DensePoly
+
+universe u
+
+variable {R : Type u} [Zero R] [DecidableEq R]
+
+/--
+Polynomial pseudo-division without coefficient division.
+
+For `g != 0` and `g.degree? <= f.degree?`, let
+`d = f.degree - g.degree + 1`.  Over a commutative ring its result `(q, r)`
+satisfies
+
+```
+lc(g) ^ (f.degree - g.degree + 1) * f = q * g + r
+```
+
+with `r.degree? < g.degree?`.  The implementation asks only for the concrete
+operations it executes; algebraic laws belong to the correctness theorems.
+Its nested array folds have `O(d*m)` summands, matching the
+pseudo-division complexity contract.
+
+For the two inputs outside that contract, behavior is deliberately simple and
+stable: `pseudoDivMod f 0 = (0, f)`, and if `f` is already smaller than a
+nonzero `g`, then `pseudoDivMod f g = (0, f)`.
+-/
+@[expose]
+def pseudoDivMod [One R] [Add R] [Sub R] [Mul R]
+    (f g : DensePoly R) : DensePoly R × DensePoly R :=
+  if g.isZero then
+    (0, f)
+  else if f.size < g.size then
+    (0, f)
+  else
+    let n := f.size - 1
+    let m := g.size - 1
+    let d := f.size - g.size + 1
+    let b := g.leadingCoeff
+    let powers :=
+      (Array.range d).foldl
+        (fun powers _ =>
+          powers.push (powers.getD (powers.size - 1) 1 * b))
+        #[1]
+    let active :=
+      (Array.range d).foldl
+        (fun active i =>
+          let first := i - m
+          let correction :=
+            (Array.range (i - first)).foldl
+              (fun acc offset =>
+                let j := first + offset
+                acc + active.getD j 0 * powers.getD (i - 1 - j) 0 *
+                  g.coeff (m + j - i))
+              0
+          active.push (powers.getD i 0 * f.coeff (n - i) - correction))
+        #[]
+    let quotient :=
+      (Array.range d).foldl
+        (fun coeffs k =>
+          coeffs.push (active.getD (d - 1 - k) 0 * powers.getD k 0))
+        #[]
+    let remainder :=
+      (Array.range m).foldl
+        (fun coeffs t =>
+          let correction :=
+            (Array.range (min (t + 1) d)).foldl
+              (fun acc k =>
+                acc + quotient.getD k 0 * g.coeff (t - k))
+              0
+          coeffs.push (powers.getD d 0 * f.coeff t - correction))
+        #[]
+    (ofCoeffs quotient, ofCoeffs remainder)
+
+/-- A zero divisor takes the documented junk branch and leaves the dividend unchanged. -/
+@[simp, grind =]
+theorem pseudoDivMod_zero_right [One R] [Add R] [Sub R] [Mul R] (f : DensePoly R) :
+    pseudoDivMod f 0 = (0, f) := by
+  rfl
+
+/-- If the dividend is already smaller, pseudo-division is ordinary division by inspection. -/
+theorem pseudoDivMod_of_size_lt [One R] [Add R] [Sub R] [Mul R]
+    (f g : DensePoly R) (h : f.size < g.size) :
+    pseudoDivMod f g = (0, f) := by
+  have hg : g.isZero = false :=
+    (isZero_eq_false_iff g).2 (by omega)
+  simp [pseudoDivMod, hg, h]
+
+/-- Pseudo-division reconstructs the fixed leading-coefficient multiple of the dividend. -/
+theorem pseudoDivMod_reconstruct [Lean.Grind.CommRing R]
+    (f g : DensePoly R) (hg : g ≠ 0) (hfg : g.size ≤ f.size) :
+    let qr := pseudoDivMod f g
+    scale (g.leadingCoeff ^ (f.size - g.size + 1)) f = qr.1 * g + qr.2 := by
+  sorry
+
+/-- Under the pseudo-division preconditions, the remainder is smaller than the divisor. -/
+theorem pseudoDivMod_remainder_lt [Lean.Grind.CommRing R]
+    (f g : DensePoly R) (hg : g ≠ 0) (hfg : g.size ≤ f.size) :
+    (pseudoDivMod f g).2.size < g.size := by
+  sorry
+
+/-! Small kernel-reduced regressions for the pseudo-division loop. -/
+
+/-- `4 * (X^2 + 1) = (2*X - 1) * (2*X + 1) + 5`. -/
+example :
+    pseudoDivMod
+        (ofList ([1, 0, 1] : List Int))
+        (ofList ([1, 2] : List Int)) =
+      (ofList ([-1, 2] : List Int), ofList ([5] : List Int)) := by
+  decide
+
+/-- Monic pseudo-division specializes to ordinary monic division. -/
+example :
+    pseudoDivMod
+        (ofList ([1, 0, 1] : List Int))
+        (ofList ([1, 1] : List Int)) =
+      (ofList ([-1, 1] : List Int), ofList ([2] : List Int)) := by
+  decide
+
+/-- Early cancellation still scales the quotient for every unused round. -/
+example :
+    pseudoDivMod
+        (ofList ([0, 0, 1] : List Int))
+        (ofList ([0, 2] : List Int)) =
+      (ofList ([0, 2] : List Int), 0) := by
+  decide
+
+/-- An already-smaller dividend is returned unchanged as the remainder. -/
+example :
+    pseudoDivMod
+        (ofList ([3] : List Int))
+        (ofList ([1, 1] : List Int)) =
+      (0, ofList ([3] : List Int)) := by
+  decide
+
+/-- The documented zero-divisor junk case is total and leaves the dividend alone. -/
+example :
+    pseudoDivMod (ofList ([1, 0, 1] : List Int)) 0 =
+      (0, ofList ([1, 0, 1] : List Int)) := by
+  decide
+
+end Hex.DensePoly

--- a/HexResultant/Basic.lean
+++ b/HexResultant/Basic.lean
@@ -7,7 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexPoly
-import all Init.Data.Array.Basic
+public meta import HexPoly.Dense
 
 public section
 
@@ -28,7 +28,7 @@ where `max(0, i-m) <= j < i`.  The quotient coefficients are
 `q[k] = a_(d-1-k) * b^k`; the low `m` coefficients of
 `b^d*f - q*g` are the remainder.  This dynamic coefficient recurrence avoids
 materializing and rescaling the full quotient and remainder at every
-elimination step.  It performs `O(d*m)` coefficient operations and uses
+elimination step.  Its nested folds have `O(d*m)` summands and it uses
 `O(d+m)` coefficient storage.
 
 The fixed `b^d` factor is built into both output formulas.  Consequently the
@@ -127,57 +127,86 @@ theorem pseudoDivMod_of_size_lt [One R] [Add R] [Sub R] [Mul R]
     (isZero_eq_false_iff g).2 (by omega)
   simp [pseudoDivMod, hg, h]
 
-/-- Pseudo-division reconstructs the fixed leading-coefficient multiple of the dividend. -/
-theorem pseudoDivMod_reconstruct [Lean.Grind.CommRing R]
-    (f g : DensePoly R) (hg : g ≠ 0) (hfg : g.size ≤ f.size) :
+/-- Pseudo-division reconstructs the fixed leading-coefficient multiple of the dividend.
+
+This theorem deliberately uses a fresh coefficient type: an ambient `Zero`
+instance is not necessarily coherent with the zero supplied by
+`Lean.Grind.CommRing`. -/
+theorem pseudoDivMod_reconstruct_core {S : Type u}
+    [Lean.Grind.CommRing S] [DecidableEq S]
+    (f g : DensePoly S) (hg : g ≠ 0) (hfg : g.size ≤ f.size) :
     let qr := pseudoDivMod f g
     scale (g.leadingCoeff ^ (f.size - g.size + 1)) f = qr.1 * g + qr.2 := by
   sorry
 
 /-- Under the pseudo-division preconditions, the remainder is smaller than the divisor. -/
-theorem pseudoDivMod_remainder_lt [Lean.Grind.CommRing R]
-    (f g : DensePoly R) (hg : g ≠ 0) (hfg : g.size ≤ f.size) :
+theorem pseudoDivMod_remainder_lt_core {S : Type u}
+    [Lean.Grind.CommRing S] [DecidableEq S]
+    (f g : DensePoly S) (hg : g ≠ 0) (hfg : g.size ≤ f.size) :
     (pseudoDivMod f g).2.size < g.size := by
   sorry
 
-/-! Small kernel-reduced regressions for the pseudo-division loop. -/
+/-! Small compiled regressions for the pseudo-division loop. -/
 
-/-- `4 * (X^2 + 1) = (2*X - 1) * (2*X + 1) + 5`. -/
-example :
-    pseudoDivMod
+-- `4 * (X^2 + 1) = (2*X - 1) * (2*X + 1) + 5`.
+#guard
+    let qr := pseudoDivMod
         (ofList ([1, 0, 1] : List Int))
-        (ofList ([1, 2] : List Int)) =
-      (ofList ([-1, 2] : List Int), ofList ([5] : List Int)) := by
-  decide
+        (ofList ([1, 2] : List Int))
+    qr.1.toArray.toList = [-1, 2] ∧ qr.2.toArray.toList = [5]
 
-/-- Monic pseudo-division specializes to ordinary monic division. -/
-example :
-    pseudoDivMod
+-- Monic pseudo-division specializes to ordinary monic division.
+#guard
+    let qr := pseudoDivMod
         (ofList ([1, 0, 1] : List Int))
-        (ofList ([1, 1] : List Int)) =
-      (ofList ([-1, 1] : List Int), ofList ([2] : List Int)) := by
-  decide
+        (ofList ([1, 1] : List Int))
+    qr.1.toArray.toList = [-1, 1] ∧ qr.2.toArray.toList = [2]
 
-/-- Early cancellation still scales the quotient for every unused round. -/
-example :
-    pseudoDivMod
+-- Early cancellation still scales the quotient for every unused round.
+#guard
+    let qr := pseudoDivMod
         (ofList ([0, 0, 1] : List Int))
-        (ofList ([0, 2] : List Int)) =
-      (ofList ([0, 2] : List Int), 0) := by
-  decide
+        (ofList ([0, 2] : List Int))
+    qr.1.toArray.toList = [0, 2] ∧ qr.2.toArray.toList = []
 
-/-- An already-smaller dividend is returned unchanged as the remainder. -/
-example :
-    pseudoDivMod
+-- A degree drop greater than one retains the residual leading-coefficient scaling.
+-- `4*X^3 = (2*X)*(2*X^2 + 1) - 2*X`.
+#guard
+    let qr := pseudoDivMod
+        (ofList ([0, 0, 0, 1] : List Int))
+        (ofList ([1, 0, 2] : List Int))
+    qr.1.toArray.toList = [0, 2] ∧ qr.2.toArray.toList = [0, -2]
+
+-- Division by a constant uses all `degree(f) + 1` scaling rounds.
+-- `27*(X^2 + 1) = (9*X^2 + 9)*3`.
+#guard
+    let qr := pseudoDivMod
+        (ofList ([1, 0, 1] : List Int))
         (ofList ([3] : List Int))
-        (ofList ([1, 1] : List Int)) =
-      (0, ofList ([3] : List Int)) := by
-  decide
+    qr.1.toArray.toList = [9, 0, 9] ∧ qr.2.toArray.toList = []
 
-/-- The documented zero-divisor junk case is total and leaves the dividend alone. -/
-example :
-    pseudoDivMod (ofList ([1, 0, 1] : List Int)) 0 =
-      (0, ofList ([1, 0, 1] : List Int)) := by
-  decide
+-- Equal-degree inputs take one round: `2*(X + 1) = 2*X + 3 - 1`.
+#guard
+    let qr := pseudoDivMod
+        (ofList ([1, 1] : List Int))
+        (ofList ([3, 2] : List Int))
+    qr.1.toArray.toList = [1] ∧ qr.2.toArray.toList = [-1]
+
+-- An already-smaller dividend is returned unchanged as the remainder.
+#guard
+    let qr := pseudoDivMod
+        (ofList ([3] : List Int))
+        (ofList ([1, 1] : List Int))
+    qr.1.toArray.toList = [] ∧ qr.2.toArray.toList = [3]
+
+-- The zero dividend takes the smaller-degree branch for a nonconstant divisor.
+#guard
+    let qr := pseudoDivMod 0 (ofList ([1, 1] : List Int))
+    qr.1.toArray.toList = ([] : List Int) ∧ qr.2.toArray.toList = []
+
+-- The documented zero-divisor junk case is total and leaves the dividend alone.
+#guard
+    let qr := pseudoDivMod (ofList ([1, 0, 1] : List Int)) 0
+    qr.1.toArray.toList = ([] : List Int) ∧ qr.2.toArray.toList = [1, 0, 1]
 
 end Hex.DensePoly

--- a/HexResultant/SPEC/hex-resultant.md
+++ b/HexResultant/SPEC/hex-resultant.md
@@ -40,6 +40,11 @@ namespace Hex.DensePoly
     coefficient division occurs. -/
 def pseudoDivMod (f g : DensePoly R) : DensePoly R × DensePoly R := ...
 
+/- The operation is total. Its two out-of-contract branches are stable public
+   behavior: `pseudoDivMod f 0 = (0, f)`, and if nonzero `g` has larger degree
+   than `f`, then `pseudoDivMod f g = (0, f)`. Both have corresponding rewrite
+   lemmas. -/
+
 /-- Subresultant pseudo-remainder sequence:
     `r₀ = f`, `r₁ = g`, and `r_{k+1}` is the pseudo-remainder of
     `r_{k-1}` by `r_k`, divided by the scale factor `β_k` (the division

--- a/HexResultant/SPEC/hex-resultant.md
+++ b/HexResultant/SPEC/hex-resultant.md
@@ -111,7 +111,7 @@ ground.
 - `bench/HexResultant/Bench.lean`: bench driver, in the shared
   `bench/` sub-project. Benches time `resultant` and `disc` on
   committed fixture families of increasing degree. They are
-  Mathlib-free, per [SPEC/benchmarking.md](../benchmarking.md); there
+  Mathlib-free, per [SPEC/benchmarking.md](../../SPEC/benchmarking.md); there
   is nothing to compare against in-process, since Mathlib's
   `Polynomial.resultant` is noncomputable. Cross-checking values
   against external systems happens in the conformance oracle, not in
@@ -119,7 +119,7 @@ ground.
 
 ## Conformance fixtures
 
-Per [SPEC/testing.md](../testing.md), fixtures are tiered into
+Per [SPEC/testing.md](../../SPEC/testing.md), fixtures are tiered into
 `core` / `ci` / `local`:
 
 - *core* (Lean-only):

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -190,7 +190,7 @@ for developments whose source-local move has not happened yet.
 - [hex-real-roots.md](hex-real-roots.md): certified real root isolation for `Z[x]`, Sturm-count witnesses, Descartes search with Sturm fallback
 - [hex-real-roots-mathlib.md](hex-real-roots-mathlib.md): Sturm's theorem, chain correspondence, soundness and completeness of `isolate?`
 - [hex-rcf.md](hex-rcf.md): the `rcf` tactic for univariate real-closed-field sentences
-- [hex-resultant.md](hex-resultant.md): polynomial resultant and discriminant via the subresultant pseudo-remainder sequence
+- [hex-resultant](../../HexResultant/SPEC/hex-resultant.md): polynomial resultant and discriminant via the subresultant pseudo-remainder sequence
 - [hex-resultant-mathlib.md](hex-resultant-mathlib.md): executable resultant agreement, specialization, root-product, and discriminant theorems
 - [hex-number-field.md](hex-number-field.md): `QAdjoin`, factorization-lazy `AlgebraicRoot`, canonical `AlgebraicNumber`, and algebraic-coefficient roots
 - [hex-number-field-mathlib.md](hex-number-field-mathlib.md): fixed-field correspondence, exactification, lazy arithmetic, and root completeness

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -95,6 +95,8 @@ lean_lib HexPolyZ where
 
 lean_lib HexRoots where
 
+lean_lib HexResultant where
+
 lean_lib HexPolyFp where
 
 lean_lib HexGFqRing where

--- a/libraries.yml
+++ b/libraries.yml
@@ -478,7 +478,7 @@ libraries:
     deps: [HexPoly]
     mathlib: false
     done_through: 0
-    status: planned
+    status: active
   HexResultantMathlib:
     deps: [HexResultant, HexPolyMathlib]
     mathlib: true

--- a/progress/20260727T025930Z_number-field-orientation.md
+++ b/progress/20260727T025930Z_number-field-orientation.md
@@ -1,0 +1,35 @@
+# Resultant and number-field orientation
+
+## Accomplished
+
+- Read the current repository roadmap, library DAG, conventions, and latest
+  progress handoff.
+- Read `SPEC/Libraries/hex-resultant.md` and
+  `SPEC/Libraries/hex-number-field.md` in full.
+- Read the two Mathlib companion SPECs and
+  `SPEC/hex-number-field-expansion-plan.md` to understand the proof staging and
+  downstream contracts.
+- Confirmed that `HexResultant`, `HexResultantMathlib`, `HexNumberField`, and
+  `HexNumberFieldMathlib` are all planned at `done_through: 0`, with no source
+  trees or Lake entries yet.
+
+## Current frontier
+
+The resultant and number-field designs are SPEC-ready but deliberately not
+activated. `hex-resultant` is the first new computational dependency;
+`hex-number-field` then consumes its executable eliminants together with the
+existing root-isolation, factorization, matrix, and row-reduction libraries.
+The resultant Mathlib bridge is explicitly staged: common-root/vanishing facts
+support early lazy arithmetic, while full value correspondence is required for
+root completeness and later tower work.
+
+## Next step
+
+Await a concrete directive about activation, planning, or implementation. If
+activated, begin with Phase 1 for `HexResultant` before dispatching dependent
+number-field work.
+
+## Blockers
+
+None for orientation. Implementation remains gated only by the libraries'
+intentional `planned` status.

--- a/progress/20260727T030155Z_number-field-tower-orientation.md
+++ b/progress/20260727T030155Z_number-field-tower-orientation.md
@@ -1,0 +1,34 @@
+# Number-field tower orientation
+
+## Accomplished
+
+- Read `SPEC/Libraries/hex-number-field-tower.md` in full and connected its
+  representation, arithmetic, Trager factorization, adjoining, splitting, and
+  primitive-element flattening contracts to the already reviewed resultant and
+  base number-field designs.
+- Confirmed that the tower pair is indexed in `SPEC/Libraries/README.md` but is
+  not yet registered in `libraries.yml`; consequently `scripts/status.py` does
+  not recognize `HexNumberFieldTower` or `HexNumberFieldTowerMathlib`.
+- Confirmed that there are no tower implementation source trees or Lake targets.
+
+## Current frontier
+
+The tower design specifies a validated fixed embedding into `Complex` and a
+flattened mixed-radix rational representation indexed by `NumberTower`. Its
+main algorithms are recursive one-level Trager factorization, certified root
+adjoining, splitting by degree-reducing extensions, and bounded
+primitive-element flattening with exact row reduction. Unlike the base
+resultant and number-field pairs, the tower pair has not yet entered even the
+informational `libraries.yml` graph.
+
+## Next step
+
+Await a concrete directive. Tower implementation planning must follow the base
+number-field/resultant work and should first register the tower libraries in the
+project graph at the appropriate status.
+
+## Blockers
+
+None for orientation. Tower implementation is structurally downstream of the
+unimplemented resultant and base number-field libraries, and its full proofs
+require Stage 2 resultant correspondence.

--- a/progress/20260727T032300Z_hexresultant-m1.md
+++ b/progress/20260727T032300Z_hexresultant-m1.md
@@ -1,0 +1,40 @@
+# HexResultant milestone 1: activation and pseudo-division
+
+## Accomplished
+
+- Audited local and GitHub state; found no duplicate resultant, number-field,
+  or tower implementation work.
+- Opened #8873 for the first `HexResultant` milestone and #8874–#8876 for the
+  exact contract repair, subresultant chain, resultant, and discriminant work.
+- Activated `HexResultant`, added its Lake/CI/umbrella wiring, and relocated its
+  SPEC to the source-local layout.
+- Implemented `DensePoly.pseudoDivMod` as a direct dynamic coefficient
+  recurrence with `O((n - m + 1) * m)` coefficient operations and no
+  coefficient division.
+- Added total zero-divisor and lower-degree behavior, five executable integer
+  regressions, and the reconstruction/remainder proof obligations.
+- Validated the dynamic recurrence against the standard scaling loop on 39,000
+  deterministic random integer cases.
+- Ran the DAG, copyright, line-count, targeted `HexResultant`, full repository,
+  status, diff, and forbidden-form checks successfully. The only new warnings
+  are the two expected propositional Phase 1 `sorry` obligations.
+
+## Current frontier
+
+The #8873 diff is ready for independent review and publication. The executable
+pseudo-division data path is complete; its generic reconstruction and strict
+remainder-size proofs remain explicit theorem obligations for later proof work.
+`HexResultant.done_through` correctly remains 0.
+
+## Next step
+
+Obtain the required Claude second opinion, address substantive findings, open
+the milestone PR, enable squash auto-merge, and merge after CI. Then execute
+#8874 to repair the exact-division, recurrence, chain-terminal, constant
+discriminant, and Mathlib-signature premises before implementing the PRS.
+
+## Blockers
+
+No blocker for #8873. The downstream PRS is intentionally gated by #8874:
+the current SPEC does not yet provide a sufficient executable exact-division
+contract and contains mathematically incorrect constant-discriminant prose.

--- a/progress/20260727T034304Z_hexresultant-m1-review.md
+++ b/progress/20260727T034304Z_hexresultant-m1-review.md
@@ -1,0 +1,34 @@
+# HexResultant milestone 1 review repair
+
+## Accomplished
+
+- Collected the independent Claude Opus review while CI continued in parallel.
+- Verified that the ambient `Zero` on the two pseudo-division correctness
+  theorems was not forced to agree with `Lean.Grind.CommRing`'s zero, and
+  restated the obligations over a fresh coefficient type.
+- Moved pseudo-division regressions from kernel `decide` to compiled `#guard`
+  checks, preserving the efficient array implementation without putting its
+  indexed loops on a kernel-reduction path.
+- Added independent regressions for residual scaling after a large degree
+  drop, constant divisors, equal-degree inputs, the zero dividend, and both
+  documented totality branches.
+- Recorded the totality branches in the library SPEC and rebuilt
+  `HexResultant` successfully.
+
+## Current frontier
+
+PR #8880 remains open with auto-merge temporarily disabled while this review
+repair is committed and pushed. Its original CI run is still in progress.
+The next-stage exact-division and Brown--Traub recurrence research is running
+in parallel on the stacked `ResultantContract` branch.
+
+## Next step
+
+Push the review repair, restore squash auto-merge after the replacement CI is
+green, rebase the stacked contract branch onto the reviewed milestone, and pin
+the executable exact-division and subresultant recurrence contracts.
+
+## Blockers
+
+No implementation blocker. PR #8880 must not merge without the theorem-instance
+coherence repair.


### PR DESCRIPTION
Closes #8873.

## What changed

- activates the Mathlib-free `HexResultant` library in `libraries.yml`, Lake, and the existing single CI job;
- relocates the resultant SPEC to `HexResultant/SPEC/hex-resultant.md` and adds the umbrella module;
- implements `Hex.DensePoly.pseudoDivMod` using a direct dynamic coefficient recurrence;
- keeps the fixed `lc(g)^(deg f - deg g + 1)` scaling without coefficient division while using `O((n-m+1) * m)` coefficient operations and `O(n-m+m)` storage;
- documents total zero-divisor and lower-degree behavior and adds five executable integer regressions;
- states the reconstruction and strict remainder-size proof obligations as the two permitted Phase 1 propositional `sorry`s.

The exact-division contract and the remaining PRS/resultant/discriminant declarations are deliberately absent rather than stubbed. Follow-ups #8874, #8875, and #8876 capture those milestones. `HexResultant.done_through` therefore remains 0.

## Why

`HexResultant` is the first dependency in the resultant → number-field → tower implementation chain. Pseudo-division is the only public computation whose current SPEC contract is executable without first resolving the missing exact coefficient-division interface and edge conventions.

## Verification

- `python3 scripts/check_dag.py`
- `python3 scripts/check_copyright_headers.py`
- `python3 scripts/check_file_line_counts.py`
- `lake build HexResultant`
- `lake build` (9456 jobs)
- `python3 scripts/status.py HexResultant`
- `git diff --check`
- deterministic comparison of the optimized recurrence with the standard scaling loop on 39,000 random integer cases
- forbidden-form audit: no `axiom`, data-level `sorry`, `native_decide`, `TODO`, or `FIXME`
