### PR TITLE
spec(rcf): repair certificate replay contract

### DIFF
--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -3,15 +3,24 @@
 A Lean tactic, `rcf`, deciding the univariate fragment of
 real-closed-field arithmetic: Boolean combinations of polynomial
 (in)equalities in one real variable under a single quantifier over
-`ℝ` or over a half-open dyadic interval. The procedure is complete on
-this fragment in the following sense: `isolate?` succeeds on
-squarefree input by `isolate?_isSome` from
-[hex-real-roots-mathlib](hex-real-roots-mathlib.md), so the compiled
-search reaches a verdict on every in-fragment sentence, and every
-`true` verdict becomes a kernel-checked proof. On a `false` verdict
-the tactic fails with a message naming a witness cell. It never
-proves a negation: no theorem turns a `false` verdict into a proof,
-so only the `true` direction is trusted.
+`ℝ` or over a half-open dyadic interval. For an in-fragment sentence
+the compiled builder constructs a squarefree carrier, isolates its
+roots, and must return a verdict. Builder failure has a separate
+`Except`/`Option` channel and is never reported as `false`. Every
+`true` verdict is accompanied by a certificate which a small kernel
+checker turns into a proof. A `false` verdict is diagnostic only: the
+tactic never proves a negation, and no theorem turns `false` into a
+proof.
+
+For a false universal sentence the diagnostic names a cell on which
+the body is false. For a false existential there is no single
+counterexample witness; the diagnostic instead reports that every
+relevant cell was checked and found false. Operational totality of the
+compiled builder follows from the squarefree carrier and
+`isolate?_isSome`, together with the structurally fuel-bounded
+separation pass, from
+[hex-real-roots-mathlib](hex-real-roots-mathlib.md). It is not exposed
+as a kernel-side completeness theorem for false verdicts.
 
 This is the user-facing payoff of the real-root machinery: neither
 `polyrith` nor `nlinarith` is complete on this fragment, and `decide`
@@ -68,15 +77,22 @@ anything outside the fragment:
 - **Nested quantifiers.** The `Sentence` type has exactly one
   quantifier, so `∀ x, ∃ y, …` does not reify.
 - **`Set.Icc` / `Set.Ioo` quantifiers.** Only `Set.Ioc` matches the
-  half-open isolation convention. The error message shows the
-  rewrite: `∀ x ∈ Set.Icc a b, φ` is `φ(a) ∧ ∀ x ∈ Set.Ioc a b, φ`,
-  and `∃ x ∈ Set.Ioo a b, φ` is `∃ x ∈ Set.Ioc a b, φ ∧ x ≠ b`
-  handled by adding the atom.
-- **Sentences that are false.** `decide` returns `false` and the
-  tactic fails, reporting a cell on which the body evaluates to `false`
-  (a concrete dyadic test point, or an isolating interval for a root
-  cell), so the user sees a counterexample region rather than a bare
-  failure.
+  half-open isolation convention. The error message shows valid
+  rewrites, including the empty/reversed-interval cases:
+  `∀ x ∈ Set.Icc a b, φ` is
+  `(a ≤ b → φ(a)) ∧ ∀ x ∈ Set.Ioc a b, φ`, and
+  `∃ x ∈ Set.Icc a b, φ` is
+  `a ≤ b ∧ (φ(a) ∨ ∃ x ∈ Set.Ioc a b, φ)`;
+  `∀ x ∈ Set.Ioo a b, φ` is
+  `∀ x ∈ Set.Ioc a b, x ≠ b → φ`, and
+  `∃ x ∈ Set.Ioo a b, φ` is
+  `∃ x ∈ Set.Ioc a b, φ ∧ x ≠ b`. The added `x ≠ b` remains a
+  polynomial atom after denominator clearing.
+- **Sentences that are false.** `decide` returns `some false` and the
+  tactic fails. A false universal reports a cell on which the body is
+  false (a concrete dyadic test point, or an isolating interval for a
+  root cell). A false existential reports that no relevant cell
+  satisfies the body.
 
 Fall-through is a `MetaM` failure with the reason, so downstream
 tactics can take over.
@@ -119,164 +135,329 @@ end Hex.RCF
 ```
 
 The reifier (`Qq` / `Lean.Meta`) produces a `Sentence` together with
-a proof that `Sentence.toProp` of it is definitionally the goal.
+a kernel proof
+
+```lean
+Sentence.toProp sentence ↔ goal
+```
+
+and the tactic uses the forward direction after checking the
+sentence. This is propositional transport, not definitional equality:
+normalising `s ⊳ t` to `(s - t) ⊳ 0`, clearing denominators, and
+relating `ZPoly` evaluation to the original expression all require
+proved equivalences.
 
 ## Algorithm
 
 1. **Reify** the goal to a `Sentence`. Refuse anything out of
-   fragment.
+   fragment. Normalisation records the positive/nonzero scalar facts
+   used when clearing denominators, and produces the equivalence with
+   the original goal described above.
 
 2. **Collect** the atom polynomials. Constant atoms (degree ≤ 0,
-   including the zero polynomial) are evaluated to `tt`/`ff` during
-   reification and never reach the decomposition.
+   including the zero polynomial) are evaluated to `tt`/`ff` by the
+   decision pipeline and never reach the decomposition. The reifier
+   may perform the same fold as an optimisation, but `decide` and
+   `check` must also handle arbitrary directly constructed
+   `Sentence`s containing constant atoms.
 
-3. **Decompose.** Let `P := Hex.ZPoly.squareFreeCore (∏ᵢ pᵢ)` over
-   the nonconstant atom polynomials. `P` is squarefree and its real
-   roots are exactly the union of the atoms' real roots. Run
-   `Hex.isolate? P` and eliminate the `Option` with
-   `isolate?_isSome` (squarefreeness of `squareFreeCore` is a lemma
-   here, through hex-poly-z-mathlib's gcd correspondence; the
-   root-set equality is `aevalIff_squareFreeCore` from the
-   hex-real-roots companion's `isolate_roots` development). If there
-   are no nonconstant atoms, the decomposition is the single cell
-   `ℝ` and steps 4-6 degenerate to one test-point evaluation.
+3. **Handle empty bounded domains.** Before any cell reasoning, compare
+   the dyadic endpoints. If `a < b` is false, `(a,b]` is empty:
+   `forallIoc` returns `true` and `existsIoc` returns `false`. Every
+   later bounded-domain argument therefore has the explicit hypothesis
+   `a < b`.
 
-4. **Separate.** Refine the isolations (`refineTo`) until
-   consecutive intervals have a nonempty gap between them
-   (`upperᵢ < lowerᵢ₊₁`). Bisection can emit touching intervals, and
-   the open cells between roots need interior dyadic test points, so
-   this step is not optional. It terminates because distinct roots
-   have positive gaps. For bounded sentences over `(a, b]`, also
-   refine until every interval lies inside `(a, b]` or outside it:
-   first test `P(a) = 0` and `P(b) = 0` exactly (an isolation whose
-   root *is* an endpoint is classified by that test), then refinement
-   separates every other interval from the endpoints.
+4. **Build and certify the carrier.** Let
+   `Q := ∏ᵢ pᵢ` over the nonconstant atom polynomials and let the
+   compiled builder choose `P := Hex.ZPoly.squareFreeCore Q`. The
+   runtime uses the existing square-free-core implementation, but the
+   kernel checker does not recompute it. Instead the certificate
+   supplies polynomials `R`, `S` and nonzero integers `k`, `d` with
 
-5. **Build cells.** With isolations `I₁ < … < I_k` (roots
-   `r₁ < … < r_k`) and `M := rootBound P`:
+   ```text
+   Q = scale k (P * R)
+   scale d (derivative Q) = R * S.
+   ```
+
+   The checker derives the atom list from `s`, verifies that these
+   atoms have positive degree, and recomputes `Q`; the certificate
+   cannot choose a different product. It also checks that `Q` has
+   positive degree, `R ≠ 0`, and `k,d ≠ 0`. A replay certificate for
+   `P` proves that it is nonzero and
+   squarefree. The two identities then prove that the real roots of
+   `P` are exactly the real roots of `Q`: the first inclusion is
+   immediate, and the converse is the standard squarefree-factor
+   lemma for `Q = P*R` with `R ∣ Q'`. Since `Q` is the atom product,
+   these are exactly the union of the atom root sets.
+
+   Run `Hex.isolate? P`; the compiled builder knows this succeeds from
+   the squarefreeness theorem. If there are no nonconstant atoms, do
+   not construct a carrier: the decomposition is the single cell `ℝ`
+   and the sign matrix is the already-folded constant formula.
+
+5. **Separate.** Scan consecutive isolations in order. Already-strict
+   pairs are left unchanged. For a touching pair, repeatedly apply
+   cached-chain `refine1With` once to **both** intervals until
+   `upperᵢ < lowerᵢ₊₁`. The helper is structurally fuel-bounded by the
+   maximum of the two `refineTo` bounds
+
+   ```text
+   (ceilLog2Dyadic initialWidth + sepPrec P).toNat + 1.
+   ```
+
+   At that bound both widths are at most `2^(-sepPrec P)`, and the
+   separation theorem forces a strict gap; honest isolations therefore
+   cannot exhaust the fuel while still touching. Refining a later pair
+   only shrinks its intervals and cannot destroy an earlier strict gap.
+   This retains a structural termination argument without paying the
+   worst-case separation precision for every already-separated root.
+   The kernel certificate checks only the emitted strict dyadic gaps;
+   it does not evaluate `sepPrec` or certify interval widths.
+
+   Each of the two bounded endpoints is compared with every carrier
+   root. For an isolation `I = (l,u]`, if `e ≤ l`, the root is greater
+   than `e`; if `u < e`, it is less. In the remaining case
+   `l < e ≤ u`, compute the literal carrier-chain count on `(l,e]`,
+   which must be `0` or `1`. Count `0` means the root is greater than
+   `e`. Count `1` means the root is at most `e`; exact evaluation of
+   `P(e)` distinguishes equality from strict inequality.
+   `Sturm.sturm_half_open` has no endpoint-nonroot premise, so this is
+   valid even when the dyadic lower endpoint `l` is itself a root.
+
+6. **Build cells.** With isolations `I₁ < … < I_k` (roots
+   `r₁ < … < r_k`):
 
    ```
-   Cell = tailLeft            -- semantic (−∞, r₁),   test point −M − 1
+   Cell = tailLeft            -- semantic (−∞, r₁),   point lower₁ − 1
         | root i              -- semantic {rᵢ},       data Iᵢ
         | gap i               -- semantic (rᵢ, rᵢ₊₁), test point in
-                              --   (upperᵢ, lowerᵢ₊₁], which step 4
+                              --   (upperᵢ, lowerᵢ₊₁), which step 5
                               --   made nonempty
-        | tailRight           -- semantic (rₖ, +∞),   test point M + 1
+        | tailRight           -- semantic (rₖ, +∞),   point upperₖ + 1
    ```
 
+   Use the dyadic midpoint of `upperᵢ` and `lowerᵢ₊₁` for a gap.
+   With no roots, use the sole open cell `ℝ` and test point `0`.
    The semantic cells partition `ℝ`. Every `pⱼ` is sign-constant on
    each open cell: a sign change would put a root of `pⱼ`, hence of
    `P`, strictly between consecutive roots of `P`.
 
-6. **Sign matrix.** For each cell and each atom polynomial `pⱼ`:
+7. **Prepare common-root packages.** Do the expensive work once per
+   distinct nonconstant atom, not once per root cell. For each `pⱼ`,
+   the builder computes a rational gcd representative `gⱼ` and emits
+   `aⱼ`, `bⱼ`, `uⱼ`, `vⱼ` and a nonzero integer `cⱼ` satisfying
+
+   ```text
+   pⱼ = gⱼ * aⱼ
+   P  = gⱼ * bⱼ
+   uⱼ * pⱼ + vⱼ * P = scale cⱼ gⱼ.
+   ```
+
+   These multiplication-checkable identities prove that the real
+   roots of `gⱼ` are exactly the common real roots of `pⱼ` and `P`.
+   No executable `gcdZ` API is assumed. A nonzero constant `gⱼ` has
+   count zero; each distinct nonconstant `gⱼ` carries one cached
+   generalized Sturm replay used for all carrier roots.
+
+8. **Sign matrix.** For each cell and each atom polynomial `pⱼ`:
    - Open cells: exact Horner evaluation at the cell's dyadic test
      point. The value is nonzero (the test point is in no isolation,
      and roots of `pⱼ` are roots of `P`). A zero value would refute
      the library's own invariants, and the driver fails rather than
      guesses.
    - Root cells: whether `pⱼ(rᵢ) = 0` is exactly
-     `sturmCount gⱼ Iᵢ = 1` for `gⱼ := gcdZ pⱼ P` (the integer gcd
-     through hex-poly-z's rational gcd and `ratPolyPrimitivePart`):
-     `gⱼ` divides `P`, so it has at most one root in `Iᵢ`, and its
-     Sturm count decides whether that root exists, which happens
-     exactly when `pⱼ` and `P` share the root `rᵢ`. When
-     `pⱼ(rᵢ) ≠ 0`, its sign at `rᵢ` equals its sign on the two
-     adjacent open cells, which always exist (a gap or a tail on
-     each side) and agree: in that case `pⱼ` has no root anywhere
-     strictly between the neighbouring `P`-roots (taking `±∞` at the
-     ends).
+     the generalized Sturm count of `gⱼ` on `Iᵢ` being `1`.
+     Since `gⱼ ∣ P`, the interval contains at most one such root; the
+     common-root identities make that root exist exactly when
+     `pⱼ(rᵢ) = 0`. When `pⱼ(rᵢ) ≠ 0`, its sign at `rᵢ` equals its sign
+     on either adjacent open cell. The two adjacent signs agree,
+     because otherwise `pⱼ` would have another root before the next
+     carrier root.
 
-7. **Evaluate.** Substitute each cell's signs into the atoms, fold
+9. **Evaluate.** Substitute each cell's signs into the atoms, fold
    the Boolean structure: one truth value per cell.
 
-8. **Quantify.**
-   - `forallReal`: every cell true. `existsReal`: some cell true.
-   - `forallIoc a b`: every cell whose semantics meets `(a, b]`
-     true; `existsIoc`: some such cell true. Step 4 made "meets
-     `(a, b]`" decidable, case by case: root cell `i` meets `(a, b]`
-     iff `a < rᵢ ∧ rᵢ ≤ b`, where the endpoint tests identify
-     `rᵢ = a` and `rᵢ = b` exactly and otherwise the separated
-     interval lies strictly inside or strictly outside; the gap
-     `(rᵢ, rᵢ₊₁)` meets `(a, b]` iff `rᵢ < b ∧ a < rᵢ₊₁`;
-     `tailLeft` iff `a < r₁`; `tailRight` iff `rₖ < b`; each
-     conjunct decided by the same endpoint-test and
-     interval-position analysis. With no roots at all, the single
-     cell `ℝ` always meets `(a, b]`.
+10. **Quantify.**
 
-9. **Reflect.** `decide s = true` closes the goal through
-   `decide_sound` (below). `false` produces the witness-cell failure
-   message.
+    - `forallReal`: every cell true. `existsReal`: some cell true.
+    - `forallIoc a b`: every cell whose semantics meets `(a, b]`
+      true; `existsIoc`: some such cell true. Under the step-3
+      hypothesis `a < b`, meeting the domain is decided exactly:
+      a root cell meets iff `a < rᵢ ∧ rᵢ ≤ b`; a gap meets iff
+      `rᵢ < b ∧ a < rᵢ₊₁`; `tailLeft` iff `a < r₁`; and `tailRight`
+      iff `rₖ < b`. The endpoint comparisons from step 5 decide every
+      conjunct. With no roots, the single cell `ℝ` meets `(a,b]`.
+
+11. **Reflect.** A successful kernel replay gives
+    `Sentence.toProp s`; the reifier's equivalence transports that
+    proof to the original goal. A false result produces the diagnostic
+    described above.
 
 ## Kernel replay
 
-`Sentence.decide : Sentence → Bool` runs the whole pipeline and is
-the function the soundness theorem speaks about, but the tactic does
-not ask the kernel to evaluate it: re-running the search (bisection,
-gcds, refinement) inside the kernel would be far slower than the
-compiled search. Following the compiled-prep / kernel-verify pattern
-of the `factor_poly` / `irreducibility` tactics (hex-berlekamp), the
-tactic:
+The tactic does not ask the kernel to evaluate the compiled decision
+pipeline: re-running the search (bisection, gcds, refinement) inside
+the kernel would be far slower. Following the compiled-prep /
+kernel-verify pattern of the `factor_poly` / `irreducibility` tactics
+(hex-berlekamp), the tactic runs the search compiled, embeds a
+`Certificate`, and emits a proof of
+`Sentence.check s cert = true` by kernel reduction.
 
-- runs the search compiled, collecting a `Certificate`: the Sturm
-  chain of `P` with the quotient of each pseudo-division step, the
-  separated isolations, the test points, the sign matrix, and for
-  each root-cell test the gcd `gⱼ` (primitive, positive leading
-  coefficient) with three multiplication-checkable witnesses:
-  quotients for `gⱼ ∣ pⱼ` and `gⱼ ∣ P`, and a denominator-cleared
-  Bézout identity `u·pⱼ + v·P = c·gⱼ` with `u, v ∈ ℤ[x]` and a
-  nonzero `c : ℤ`;
-- emits a proof of `Sentence.check s cert = true` by kernel
-  reduction, where `check` only *replays*: it verifies each chain
-  step by one polynomial multiply-subtract against the provided
-  quotient, re-evaluates the variation counts at the given endpoints
-  and test points, re-checks the counts, orderings, and totals, and
-  re-folds the Boolean and quantifier steps. No division, no gcd, no
-  search in the kernel.
+### Generalized Sturm replay
+
+The existing `SturmChainCert` identifies a supplied array with the
+library's executable pseudo-remainder chain, so its checker recomputes
+`spem` and primitive parts. RCF instead needs a generalized,
+multiplication-only replay shared by the carrier and the atom gcds.
+For a positive-degree `f`, a replay contains
+
+```lean
+structure SturmStep where
+  leftScale  : Int
+  quotient   : ZPoly
+  rightScale : Int
+
+structure SturmReplay where
+  chain      : Array ZPoly
+  derivScale : Int
+  steps      : Array SturmStep
+```
+
+Writing the literal chain as `[f, s₁, ..., sₙ]`, the Boolean checker
+verifies with `DensePoly.beqCoeffs`:
+
+- the chain has at least two entries, its head is `f`, every entry is
+  nonzero, degrees strictly decrease, and `sₙ` is a nonzero constant;
+- `derivScale > 0` and
+  `derivative f = scale derivScale s₁`;
+- `steps.size + 2 = chain.size`; and for each step `i`, both scales
+  are positive and
+
+  ```text
+  scale leftScale sᵢ = quotient * sᵢ₊₁ - scale rightScale sᵢ₊₂.
+  ```
+
+The recurrence propagates coprimality backwards from the terminal
+constant, gives alternating flanks at every interior zero, and the
+positive derivative seed gives the root flank. Consequently the
+literal cast chain satisfies `Sturm.IsSturmChain`; in particular `f`
+is squarefree. Its interval count is the variation difference of
+this literal chain, not a call to `sturmCount f`, and its total count
+is the corresponding `−∞/+∞` difference. The proof factors through
+`Sturm.sturm_half_open` and `Sturm.sturm_line`. Constants are handled
+separately because the interval-count theorem requires positive
+degree.
+
+Three existing private lemmas in
+`HexRealRootsMathlib/ChainCorrespond.lean` transfer directly and should
+be exported: `coprime_step_rev`, `flank_of_key`, and
+`eval_ne_zero_of_isCoprime`. The current
+`isSturmChain_of_seeds` does **not** transfer directly: its conclusion
+and four supporting inductions are tied to the executable `chainList`.
+The shared foundation must instead prove one abstract-list theorem from
+a per-triple recurrence hypothesis, terminal-constant hypothesis, and
+degree/nonzero hypotheses. Both the executable pseudo-remainder chain
+and the RCF literal array then instantiate that theorem. The public
+`sturmVarAt_eq` and generalized/exported versions of the currently
+private `sturmVarNegInf_eq` and `sturmVarPosInf_eq` connect executable
+variation reads to `Sturm.sturmVar` at finite endpoints and infinity.
+
+### Certificate contents
+
+The certificate contains:
+
+- when needed, the carrier `P`, its generalized replay, and the
+  carrier identities from algorithm step 4; the atom list and product
+  `Q` are recomputed from `s`, not trusted from certificate data;
+- isolating intervals whose `count_one`, ordering, and completeness
+  fields are expressed using the literal carrier replay, plus the
+  strict-gap checks;
+- all endpoint classifications, open-cell test points and their exact
+  polynomial evaluations, per-cell formula values, and the quantified
+  result; `check` re-evaluates these fields and derives every root-cell
+  sign from a `gⱼ` count (zero) or an adjacent open-cell sign
+  (nonzero), rather than trusting a supplied sign;
+- one common-root package per distinct nonconstant atom, with its
+  three identities and at most one generalized replay for its `gⱼ`.
+
+These are generalized isolation records: they must not be presented
+as the current `RealRootIsolation P` / `RealRootIsolations P` types,
+whose fields are definitionally tied to the executable `sturmCount P`
+and `sturmChain P`. Their semantic theorems parallel
+`RealRootIsolation.exists_unique_root` and
+`RealRootIsolations.isolates`, but consume the literal replay counts,
+`Squarefree (toPolyℝ P)`, and `P ≠ 0`; they do not require the
+executable predicate `Hex.ZPoly.SquareFreeRat P`.
+
+`check` performs coefficient equality, multiplication/subtraction,
+integer scaling, formal differentiation, degree and leading-coefficient
+reads, dyadic comparison, Horner evaluation, sign variation, and
+Boolean folding only. It performs no pseudo-division, primitive-part
+normalisation, gcd, square-free-core computation, root search, or
+refinement. The kernel reduces the specification implementation of
+`DensePoly.scale`; compiled acceleration is irrelevant to replay
+soundness.
 
 ```lean
 theorem check_sound (s : Sentence) (cert : Certificate) :
     check s cert = true → s.toProp
 ```
 
-`check_sound` is the library's one trusted theorem. `decide` is a
-convenience wrapper (it builds the certificate and calls `check`)
-used by conformance and the external oracle, with
+`decide : Sentence → Option Bool` is a convenience wrapper used by
+conformance and the external oracle. Internally, the builder returns
+either a diagnostic false result or a candidate true certificate.
+`decide` returns `some false` for the former; for the latter it runs
+`check s cert` and returns `some true` only when that check succeeds,
+otherwise `none`. An internal builder or certificate failure therefore
+cannot pass a fixture expecting either verdict. The required one-way
+connections are
 
 ```lean
-theorem decide_eq_true_iff_exists_cert :
-    decide s = true ↔ ∃ cert, check s cert = true
+theorem decide_eq_some_true_imp_exists_cert :
+    decide s = some true → ∃ cert, check s cert = true
+
+theorem decide_sound (s : Sentence) :
+    decide s = some true → s.toProp
 ```
 
-tying the two together.
+The reverse implication would assert completeness of this particular
+builder from the mere existence of some certificate and is neither
+needed by the tactic nor part of this contract. The trust boundary is
+Lean's kernel: it checks `check_sound`, the reduction proof
+`check s cert = true`, and the reifier-produced equivalence with the
+original goal. No unverified result of the compiled builder or reifier
+is accepted as a proof.
 
 ## Soundness theorem structure
 
 `check_sound` factors exactly along the algorithm:
 
-- **Chain and count replay.** The certificate's chain satisfies the
-  step relation, so it is the Sturm chain up to positive scalars, so
-  the replayed counts are root counts
-  (`sturmChain_isSturmChain`, `sturmCount_eq_card_roots` from
-  hex-real-roots-mathlib).
-- **Cell partition.** The replayed isolations form a
-  `RealRootIsolations P` value, so its semantic theorem
-  (`RealRootIsolations.isolates`) makes the semantic cells a
-  partition of `ℝ`.
+- **Chain, carrier, and count replay.** The generalized recurrence
+  proves `Sturm.IsSturmChain` for each literal chain. The carrier
+  identities prove that `P` is nonzero and squarefree and that its
+  real roots are exactly the union of the atom roots. Literal
+  variation differences are therefore the required root counts.
+- **Cell partition.** The generalized isolation theorem proves that
+  every carrier root occurs in exactly one certified interval. Strict
+  gaps and the endpoint-comparison theorem then make the root and
+  open cells a partition of `ℝ`, with exact intersection tests for
+  `(a,b]`. Empty and reversed bounded intervals were discharged
+  before this step.
 - **Sign matrix.** On open cells: sign constancy from
   root-containment (roots of `pⱼ` are roots of `P`) plus the exact
-  test-point evaluation. On root cells: the `gⱼ` count argument of
-  step 6. The divisibility witnesses give that every root of `gⱼ` is
-  a common root of `pⱼ` and `P`, the Bézout identity gives the
-  converse, and `gⱼ` is squarefree because it divides the squarefree
-  `P`, which is what lets `sturmCount_eq_card_roots` apply to it.
+  test-point evaluation. On root cells: the cached `gⱼ` count
+  argument of step 8. The divisibility identities give that every
+  root of `gⱼ` is a common root of `pⱼ` and `P`; the scaled Bézout
+  identity gives the converse; and the literal `gⱼ` replay (or the
+  nonzero-constant case) justifies its count.
 - **Boolean and quantifier steps.** The per-cell fold computes
   `Formula.toProp` at every point of the cell (signs determine
   atoms), and the quantifier step lifts cell-wise truth to `ℝ` or to
   `(a, b]` because the cells partition and the classification of
-  step 8 is exact.
+  step 10 is exact.
 
-No completeness theorem is stated for `decide` (that `false` implies
-the negation): the tactic never uses a `false` verdict as a proof,
+No completeness theorem is stated for `decide` (that `some false`
+implies the negation): the tactic never uses a false verdict as a proof,
 and Tarski-style completeness of the fragment is not a consumer-facing
 obligation.
 
@@ -294,7 +475,10 @@ free to change.
 
 ## File organisation
 
-- `HexRCF/Language.lean`: `Atom`, `Formula`, `Sentence`, `toProp`.
+- `HexRCF/Language.lean`: `Atom`, `Formula`, `Sentence`, `toProp`;
+  `HexRCF/LanguageTests.lean`: executable language-semantics tests.
+- `HexRCF/SturmReplay.lean`: generalized multiplication-only chain
+  replay and literal root counts.
 - `HexRCF/Certificate.lean`: `Certificate`, `check`, `decide`.
 - `HexRCF/Cells.lean`: separation refinement, cell construction,
   endpoint classification for bounded sentences.
@@ -323,14 +507,45 @@ Per [SPEC/testing.md](../testing.md):
   - Bounded quantifiers: `∃ x ∈ Set.Ioc (1 : ℝ) 2, x³ − x − 1 = 0`,
     and a `forallIoc` case whose truth depends on an endpoint being
     a root (exercising the `P(b) = 0` classification).
+  - Equal and reversed dyadic endpoints for both bounded quantifiers,
+    using constant/no-root bodies and nonconstant polynomial bodies;
+    these assert that the empty-domain universal is true and the
+    empty-domain existential is false.
+  - Generalized-replay rejection tests for a wrong head, derivative
+    scale, recurrence scale/sign, quotient, degree order, terminal
+    constant, isolation count, and carrier/common-root identity.
   - Fall-through, asserted to fail: the two-variable example, a
     `sin` example, a division example, an `Icc` example, and one
-    false sentence (`∃ x : ℝ, x² + 1 = 0`) checking the witness-cell
-    message.
-- *ci* (external oracle): 30 sentences over random small-coefficient
+    false universal plus a false existential
+    (`∃ x : ℝ, x² + 1 = 0`), checking their distinct diagnostics.
+- *ci* (external oracle, `python-flint`, mode `if_available`): 30
+  sentences over random small-coefficient
   polynomials from a deterministic seed, serialised with expected
-  verdicts. The oracle evaluates them in SageMath (`QQbar` real
-  roots plus interval evaluation) against `decide`'s output.
+  verdicts. `scripts/oracle/rcf_flint.py` uses python-flint as required
+  by [testing.md](../testing.md). It independently forms and
+  squarefrees the atom product. Following
+  `scripts/oracle/realroots_flint.py`, its exact tier extracts rational
+  roots from `fmpz_poly.factor()` and compares them with `Fraction`;
+  its ball tier uses `fmpz_poly.complex_roots()`, accepting a real root
+  only when FLINT gives its imaginary part as exact zero. Precision
+  escalation separates real-part enclosures, proves nonreal imaginary
+  balls away from zero, and resolves ordering/cell membership; it does
+  not attempt to infer realness merely from a narrowing ball. Open
+  samples are evaluated exactly over `Fraction`; FLINT gcd/root
+  matching and sign-definite Arb evaluation handle root cells; dyadic
+  endpoints are exact. The oracle consumes only the sentence AST,
+  never Lean's carrier, certificate, cells, or signs. Missing
+  python-flint is `SKIP`; unresolved enclosure ambiguity after the
+  finite precision ladder is a hard failure. Fixtures require
+  `decide = some expected`, so builder failure never passes a false
+  case. They cover every comparison and Boolean form, true and false
+  quantifiers, constants, no-root cases, shared and endpoint roots,
+  close roots, and equal/reversed intervals. CI cases stay around
+  degrees 8–12; the degree-50 stress case remains local. Phase-3
+  wiring adds the `hex-rcf` assignment to `SPEC/testing.md`, the
+  conformance/oracle block to `libraries.yml`, and one tuple to
+  `scripts/ci/run_oracles.sh`; it adds no job, matrix, workflow, or
+  dependency beyond the existing python-flint install.
 - *local*: Mignotte-cluster atoms and degree-50 sentences, timing
   the pipeline where the isolation layer is under stress.
 
@@ -341,12 +556,16 @@ For a sentence with `m` atoms of degrees summing to `n`:
 - Reification: linear in the goal.
 - `P`: one product and one `squareFreeCore`, `deg P ≤ n`.
 - Isolation: hex-real-roots' contract at degree `deg P`.
-- Separation refinement: `O(k)` chain evaluations per level of extra
-  precision, `k ≤ n` roots.
-- Sign matrix: `k` root cells × `m` atoms, one `gⱼ` gcd and count
-  each, plus `(k + 1)·m` open-cell evaluations.
-- Certificate replay in the kernel: linear in the certificate, all
-  multiplication and comparison.
+- Separation refinement: an adaptive, structurally fuel-bounded pass
+  over touching adjacent pairs, reusing the carrier chain; already
+  strict pairs pay no bisection cost and `k ≤ n` roots.
+- Common-root preparation: one gcd and one generalized chain per
+  distinct nonconstant `gⱼ`, reused across all `k` root cells.
+- Sign matrix: `k·m` literal variation-count reads plus
+  `(k + 1)·m` open-cell evaluations; no per-root gcd computation.
+- Certificate replay in the kernel: one pass over the certificate,
+  using polynomial multiplication/subtraction, evaluation, and
+  comparison only.
 
 For typical goals (`m ≤ 5`, `deg ≤ 10`, small coefficients) the whole
 pipeline is dominated by elaboration overhead, not arithmetic.

--- a/SPEC/Libraries/hex-real-roots-mathlib.md
+++ b/SPEC/Libraries/hex-real-roots-mathlib.md
@@ -134,6 +134,44 @@ bridges (`coeff_toPolyℝ` / `coeff_toPolyℚ`, `eval_toPolyℝ` /
 polynomial equation, and `toReal_ofInt_shiftRight` normalizes `n / 2ⁱ`
 dyadic endpoints.
 
+### Literal-chain replay API
+
+Consumers such as [hex-rcf](hex-rcf.md) certify a supplied chain by
+multiplication identities without identifying it with the executable
+`sturmChain`. The companion therefore exposes a second bridge from
+literal integer-polynomial chains to the same abstract theorem.
+
+The reusable proof is an induction over an abstract nonempty list
+`[f, s₁, ..., sₙ]` with these hypotheses:
+
+- every entry is nonzero, degrees strictly descend, and `sₙ` is a
+  nonzero constant;
+- `derivative f = scale δ s₁` for a positive integer `δ`;
+- every consecutive triple satisfies
+  `scale α sᵢ = q * sᵢ₊₁ - scale β sᵢ₊₂` for positive integers
+  `α`, `β` and a supplied `q`.
+
+It concludes that the cast list is an `IsSturmChain (toPolyℝ f)` and
+that `toPolyℝ f` is squarefree. The induction is independent of
+`chainList`; the existing executable correspondence instantiates it,
+as does RCF's Boolean literal-chain checker. The generic supporting
+lemmas for reverse coprimality, derivative flanks, and exclusion of a
+common zero are public short APIs, not duplicated consumer proofs.
+
+The finite-point bridge `sturmVarAt_eq` and the infinity bridges
+`sturmVarNegInf_eq` / `sturmVarPosInf_eq` are public for an arbitrary
+literal `Array ZPoly`. Together with `Sturm.sturm_half_open` and
+`Sturm.sturm_line`, they turn literal executable variation reads into
+root counts without calling `sturmCount` or `rootCount`.
+
+The same layer supplies generalized isolation semantics parameterized
+by those literal counts: count-one gives a unique root in `(lower,
+upper]`, while an ordered complete array captures every root exactly
+once. These statements consume `Squarefree (toPolyℝ f)` and `f ≠ 0`,
+not the executable `SquareFreeRat f` predicate, and do not reuse the
+current `RealRootIsolation` fields that are definitionally tied to
+`sturmCount`.
+
 ### Consequences for the executable counts
 
 ```lean
@@ -506,14 +544,16 @@ Status and boundaries:
 HexRealRootsMathlib/
   SturmChainDefs.lean  -- IsSturmChain, sturmVar over Polynomial ℝ
   SturmTheorem.lean    -- the counting theorem and the line form
-  ChainCorrespond.lean -- sturmChain_isSturmChain, sturmVarAt_eq,
-                          sturmCount_eq_card_roots; compatibility aliases for
-                          HexPolyZMathlib.Squarefree
+  ChainCorrespond.lean -- executable-chain correspondence plus the abstract
+                          literal-recurrence bridge and finite/infinity
+                          variation casts; sturmCount_eq_card_roots;
+                          compatibility aliases for HexPolyZMathlib.Squarefree
   Discr.lean            -- compatibility import of the shared discriminant API
   Hadamard.lean         -- compatibility import of the shared determinant bound
   Separation.lean      -- sepPrec_separates, rootBound_bounds_roots;
                           specializes shared Mahler/Vandermonde analysis
-  Isolations.lean      -- exists_unique_root, isolates
+  Isolations.lean      -- executable and literal-count forms of
+                          exists_unique_root and isolates
   IsolateRoots.lean    -- IsolatedRealRoots, its constructors, the
                           bridge tactic, and the isolate_roots
                           term elaborator

--- a/progress/20260727T041705Z_rcf-spec-contract.md
+++ b/progress/20260727T041705Z_rcf-spec-contract.md
@@ -1,0 +1,33 @@
+# RCF certificate-contract milestone
+
+## Accomplished
+
+- Repaired `SPEC/Libraries/hex-rcf.md` so reversed/equal `Ioc` domains,
+  reifier transport, carrier root-set evidence, literal Sturm replay,
+  cached per-atom common-root packages, bounded separation, diagnostics,
+  and oracle independence have sound and implementable contracts.
+- Added the required literal-chain replay and generalized-isolation
+  surface to `SPEC/Libraries/hex-real-roots-mathlib.md`.
+- Incorporated two independent Claude Opus reviews. The final review
+  found no remaining mathematical unsoundness and confirmed the seven
+  original implementation blockers were resolved.
+- Built `HexRCF` and passed the repository copyright, line-count, DAG,
+  phase-4, Mathlib-free bench, conformance-target, diff, and forbidden-
+  token checks.
+
+## Current frontier
+
+Issue #8877 is ready to publish as the specification prerequisite for
+the certificate/checker implementation. The first code dependency is
+the abstract literal-list Sturm recurrence theorem and its finite and
+infinity variation bridges in `HexRealRootsMathlib`.
+
+## Next step
+
+Open and merge the #8877 PR, then implement the shared literal-chain
+foundation before defining the RCF certificate records and Boolean
+checker.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #8877.

## Why this prerequisite is needed

The original RCF contract had several premises that cannot support a sound implementation:

- bounded quantification treated the sole no-root cell as meeting `(a,b]` even for `a >= b`; for example `(2,1]` is empty, so its universal must be true and existential false;
- normalizing `s ⊳ t`, clearing denominators, and moving between `ZPoly` evaluation and the source expression cannot make the reflected proposition definitionally equal to the goal;
- the certificate neither proved that its supplied carrier had exactly the atom-product roots nor supplied the distinct literal chains needed for per-atom common-root counts;
- the existing `SturmChainCert` recomputes pseudo-remainders and primitive parts, contrary to the multiplication-only kernel-replay promise;
- open-ended separation and a Sage oracle contradicted the repository's totality and testing policies.

## Contract after this change

- handles equal/reversed `Ioc` domains before cell decomposition;
- transports a checked sentence through a kernel proof `Sentence.toProp s ↔ goal`;
- certifies the carrier with explicit factor/derivative identities and recomputes the atom product from the sentence;
- defines generalized Sturm replay through positive-scaled multiplication identities, with cached per-atom common-root packages;
- uses adaptive, structurally fuel-bounded separation while the kernel checks only emitted strict gaps;
- distinguishes `some false` from builder failure and rechecks a candidate true certificate before returning `some true`;
- specifies an independent python-flint oracle in `if_available` mode;
- records the shared literal-chain and generalized-isolation API in the HexRealRootsMathlib SPEC.

## Validation

- `lake build HexRCF`
- copyright, line-count, DAG, phase-4, Mathlib-free bench, and conformance-target checks
- `git diff --check`
- forbidden `axiom` / `native_decide` scan in `HexRCF`

Two independent Claude Opus reviews challenged the algebra, Sturm recurrence, interval logic, trust boundary, performance shape, and FLINT protocol. The first found implementation blockers that were incorporated; the focused final review confirmed those blockers resolved and found no remaining mathematical unsoundness. Its last contract clarifications (`decide` rechecks true certificates, both touching intervals refine, root signs are derived) are included here.
