### PR TITLE
perf(bz): de-box the nullspace assembly under fixedSpaceKernel

### DIFF
--- a/HexRowReduce/Nullspace.lean
+++ b/HexRowReduce/Nullspace.lean
@@ -157,22 +157,139 @@ the matching pivot row and free column. -/
   simp [E.toIsEchelonForm.pivotCols_disjoint_freeCols i k,
     pivotIndex?_pivot E.toIsEchelonForm i]
 
+/-- Column → pivot-row lookup table: entry `c` holds the pivot-row index `i` when
+`c = D.pivotCols.get i`, and the sentinel `D.rank` when `c` is a free column. Built
+in one `O(rank)` pass, this replaces the per-entry `O(rank)` `pivotIndex?` scan the
+reference assembly used. Implementation helper for `nullspace`; the documented
+pivot/free reading holds when `D` is certified by an `IsEchelonForm` (whose pivot
+columns are distinct) — an arbitrary `RowEchelonData` with duplicate pivot columns
+has no such guarantee. -/
+@[expose]
+def pivotRowTable (D : RowEchelonData R n m) : Vector Nat m :=
+  Fin.foldl D.rank (fun t i => t.set (D.pivotCols.get i).val i.val (D.pivotCols.get i).isLt)
+    (Vector.replicate m D.rank)
+
+omit [Mul R] [Add R] [OfNat R 0] [OfNat R 1] in
+/-- A fold of `Vector.set`s at column indices distinct from `j` leaves entry `j`
+untouched. -/
+private theorem pivotRowTable_fold_ne (j : Fin m) :
+    ∀ (l : List (Fin D.rank)) (t : Vector Nat m),
+      (∀ i ∈ l, (D.pivotCols.get i).val ≠ j.val) →
+      (l.foldl (fun t i => t.set (D.pivotCols.get i).val i.val (D.pivotCols.get i).isLt) t)[j]
+        = t[j] := by
+  intro l
+  induction l with
+  | nil => intro t _; rfl
+  | cons x xs ih =>
+      intro t hne
+      rw [List.foldl_cons,
+        ih (t.set (D.pivotCols.get x).val x.val (D.pivotCols.get x).isLt)
+          (fun i hi => hne i (List.mem_cons_of_mem _ hi))]
+      exact Vector.getElem_set_ne (D.pivotCols.get x).isLt j.isLt (hne x List.mem_cons_self)
+
+/-- A fold of `Vector.set`s over a list containing `i₀` whose column indices are
+injective sets entry `(D.pivotCols.get i₀).val` to `i₀.val`. -/
+private theorem pivotRowTable_fold_mem (E : IsEchelonForm M D) (i₀ : Fin D.rank) :
+    ∀ (l : List (Fin D.rank)) (t : Vector Nat m), i₀ ∈ l →
+      (l.foldl (fun t i => t.set (D.pivotCols.get i).val i.val (D.pivotCols.get i).isLt) t)[D.pivotCols.get i₀]
+        = i₀.val := by
+  intro l
+  induction l with
+  | nil => intro t hmem; exact absurd hmem (List.not_mem_nil)
+  | cons x xs ih =>
+      intro t hmem
+      rw [List.foldl_cons]
+      rcases List.mem_cons.mp hmem with rfl | htail
+      · -- head is i₀: the tail never sets this column again (injectivity), so it survives
+        by_cases hx : i₀ ∈ xs
+        · exact ih _ hx
+        · rw [pivotRowTable_fold_ne (D.pivotCols.get i₀) xs
+              (t.set (D.pivotCols.get i₀).val i₀.val (D.pivotCols.get i₀).isLt)
+              (fun i hi hji => hx (by
+                have : i = i₀ := E.pivotCols_injective (Fin.ext hji)
+                exact this ▸ hi))]
+          exact Vector.getElem_set_self (D.pivotCols.get i₀).isLt
+      · exact ih _ htail
+
+private theorem pivotRowTable_get_pivot (E : IsEchelonForm M D) (i : Fin D.rank) :
+    (pivotRowTable D)[D.pivotCols.get i] = i.val := by
+  unfold pivotRowTable
+  rw [Fin.foldl_eq_finRange_foldl]
+  exact pivotRowTable_fold_mem E i (List.finRange D.rank)
+    (Vector.replicate m D.rank) (List.mem_finRange i)
+
+omit [Mul R] [Add R] [OfNat R 0] [OfNat R 1] in
+private theorem pivotRowTable_get_free (j : Fin m)
+    (hj : ∀ i : Fin D.rank, D.pivotCols.get i ≠ j) :
+    (pivotRowTable D)[j] = D.rank := by
+  unfold pivotRowTable
+  rw [Fin.foldl_eq_finRange_foldl,
+    pivotRowTable_fold_ne j (List.finRange D.rank) (Vector.replicate m D.rank)
+      (fun i _ hji => hj i (Fin.ext hji))]
+  exact Vector.getElem_replicate j.isLt
+
+/-- `Vector.get` of a `Vector.ofFn` is pointwise; a lightweight named form used to
+reduce `nullspace.get` without unfolding through the `Array.ofFn` backing. -/
+private theorem vector_get_ofFn {α : Type v} {N : Nat} (f : Fin N → α) (k : Fin N) :
+    (Vector.ofFn f).get k = f k := by
+  simp [Vector.get]
+
+/-- The nullspace basis assembly with the pivot-row table and free columns passed
+in, so both are computed once (in `nullspace`) rather than per basis vector.
+Implementation helper for `nullspace`; assumes the canonical arguments
+`tbl = pivotRowTable D` and `freeCols = E.freeCols` that `nullspace` supplies. -/
+@[expose]
+def nullspaceAux [Lean.Grind.Ring R] (E : IsRowReduced M D) (tbl : Vector Nat m)
+    (freeCols : Vector (Fin m) (m - D.rank)) :
+    Vector (Vector R m) (m - D.rank) :=
+  Vector.ofFn fun k =>
+    Vector.ofFn fun j =>
+      if j = freeCols.get k then (1 : R)
+      else if hi : tbl[j] < D.rank then
+        -(D.echelon[((⟨tbl[j], Nat.lt_of_lt_of_le hi E.toIsEchelonForm.rank_le_n⟩ : Fin n),
+            freeCols.get k)])
+      else (0 : R)
+
 /-- The individual nullspace basis vectors.
 
-Build the basis matrix once, then extract all of its columns. Keep
-`nullspaceMatrix` outside the per-column body so its free-column and pivot
-work remains shared. -/
+Assembled directly (no intermediate `nullspaceMatrix`, no `Matrix.col` re-read) with
+a single `O(rank)` `pivotRowTable` precomputation, giving `O(m²)` total instead of
+the `O(m³)` of a per-entry `pivotIndex?` scan. The characterization
+`nullspace_get` proves this equals the reference `Matrix.col nullspaceMatrix`
+assembly columnwise, so every downstream soundness/completeness lemma is unchanged. -/
 @[expose]
 def nullspace [Lean.Grind.Ring R] (E : IsRowReduced M D) :
     Vector (Vector R m) (m - D.rank) :=
-  let N := E.nullspaceMatrix
-  Vector.ofFn fun k => Matrix.col N k
+  nullspaceAux E (pivotRowTable D) E.toIsEchelonForm.freeCols
 
-private theorem nullspace_get [Lean.Grind.Ring R] (E : IsRowReduced M D)
+/-- The `k`-th nullspace basis vector is the `k`-th column of `nullspaceMatrix`:
+the fast direct assembly agrees columnwise with the reference. All downstream
+soundness/completeness lemmas route through this equality, so they are unaffected
+by the assembly rewrite. -/
+theorem nullspace_get [Lean.Grind.Ring R] (E : IsRowReduced M D)
     (k : Fin (m - D.rank)) :
     E.nullspace.get k = Matrix.col E.nullspaceMatrix k := by
-  unfold nullspace
-  exact Vector.getElem_ofFn _
+  simp only [nullspace, nullspaceAux, vector_get_ofFn, Matrix.col]
+  congr 1
+  funext j
+  rw [Matrix.getElem_pair_eq_nested]
+  by_cases hjfc : j = E.toIsEchelonForm.freeCols.get k
+  · -- free column of this basis vector: entry 1
+    rw [if_pos hjfc, hjfc, nullspaceMatrix_free]
+  · rw [if_neg hjfc]
+    rcases E.toIsEchelonForm.colPartition j with ⟨i, hi⟩ | ⟨l, hl⟩
+    · -- pivot column `j = D.pivotCols.get i`: entry `-echelon[pivotRow i][fc]`
+      subst hi
+      simp only [pivotRowTable_get_pivot E.toIsEchelonForm i]
+      rw [dif_pos i.isLt, nullspaceMatrix_pivot, Matrix.getElem_pair_eq_nested]
+      rfl
+    · -- other free column `j = freeCols.get l`, `l ≠ k`: entry 0
+      subst hl
+      have hlk : l ≠ k := fun h => hjfc (by rw [h])
+      simp only [pivotRowTable_get_free (E.toIsEchelonForm.freeCols.get l)
+        (fun i => E.toIsEchelonForm.pivotCols_disjoint_freeCols i l)]
+      rw [dif_neg (Nat.lt_irrefl D.rank),
+        nullspaceMatrix_free_ne E (k := k) (l := l) (fun h => hlk h.symm)]
 
 /-- On its own free column, a nullspace basis vector has entry `1`. -/
 @[grind =] theorem nullspace_get_free [Lean.Grind.Ring R] (E : IsRowReduced M D)

--- a/HexRowReduceMathlib/RankSpanNullspace.lean
+++ b/HexRowReduceMathlib/RankSpanNullspace.lean
@@ -70,8 +70,9 @@ private theorem vectorEquiv_nullspaceMatrix_mulVec [Field R]
   rw [Vector.getElem_ofFn j.isLt, foldl_finRange_eq_sum]
   apply Finset.sum_congr rfl
   intro k _
-  unfold Hex.Matrix.IsRowReduced.nullspace Hex.Matrix.col
-  simp [mul_comm, Vector.get, Vector.toArray_ofFn]
+  rw [E.nullspace_get k]
+  simp only [Hex.Matrix.getElem_col, ← Hex.Matrix.getElem_eq_getRow]
+  ring
 
 /-- Soundness of the executable `spanCoeffs`: when echelon-form data certifies
 `v` as a row combination with coefficients `c`, the Mathlib image of `v` is the

--- a/progress/2026-07-27T04-09-12Z.md
+++ b/progress/2026-07-27T04-09-12Z.md
@@ -1,0 +1,60 @@
+# issue #8669 — de-box the nullspace assembly under fixedSpaceKernel
+
+**Accomplished**
+
+- Rewrote the executable `IsRowReduced.nullspace` assembly (`HexRowReduce/Nullspace.lean`)
+  from the O(m³) reference (a per-entry `pivotIndex?` rescan over the pivot columns,
+  built as `nullspaceMatrix` then re-read column-by-column via `Matrix.col`) to an
+  O(m²) direct assembly: one `pivotRowTable` precomputation (column → pivot-row index,
+  built in one `O(rank)` pass) plus a direct per-column build, with the free-column
+  vector and the pivot table both hoisted out of the inner loops (`nullspaceAux` takes
+  them as parameters, computed once in `nullspace`). This is a **definition change**, not
+  a `@[csimp]`: the generic `Matrix.nullspace` is specialized/inlined into
+  `fixedSpaceKernelVectors` (which is `@[expose]`), so a `csimp` on it — or on
+  `fixedSpaceKernelVectors` itself — is bypassed by the specializer. A def change is
+  reflected in the specialized copies.
+- Kept the entire proof surface intact by re-proving the single bridging lemma
+  `nullspace_get` (`E.nullspace.get k = Matrix.col E.nullspaceMatrix k`); every downstream
+  soundness/completeness lemma (`nullspace_get_free`/`_free_ne`/`_pivot`,
+  `nullspace_sound`, `nullspace_complete`, `nullspaceBasisMatrix_col`, and the Berlekamp
+  `fixedSpaceKernel_sound`/RabinSoundness chain) routes through it, so they are unchanged.
+  `nullspace_get` promoted from `private` to public; the one Mathlib consumer that unfolded
+  the old `col`-based structure (`HexRowReduceMathlib/RankSpanNullspace.lean`) now rewrites
+  with it.
+- Verified sorry/axiom/native_decide-free: `#print axioms` on `nullspace_get`,
+  `nullspace_sound`, `fixedSpaceKernel_sound` all report exactly
+  `[propext, Classical.choice, Quot.sound]`.
+- Green: `HexRowReduce`, `HexBerlekamp` (incl. `Factor`, `RabinSoundness`), the CI-gated
+  `HexBerlekampZassenhausMathlib` bridge (3853 jobs), and `HexConformance` (9085 jobs — all
+  `#guard`s over `nullspace`/`Matrix.nullspace` pass, so the new assembly still
+  kernel/interpreter-reduces).
+- Perf (controlled A/B on `chungus2`, `RELIFT_PROFILE=prime`, min-of-10 interleaved,
+  byte-identical sinks/selected-primes): `choosePrimeData?` split deg8 1.35×, deg12 1.72×,
+  deg16 1.95×, deg20 2.28×, **deg24 2.60×** (10782→4154 µs); `isGoodPrime@selected` deg24
+  2.40×. Speedup grows with degree, as expected for O(m³)→O(m²).
+
+**Measurement note (baseline refresh).** The issue's ~15-22% figures predate #8702 (flat
+`Vector R (n*m)` Matrix backing) and the Montgomery fast paths. Re-measured on current
+`main`: the `nullspaceMatrix` assembly was ~13% self-time (16% inclusive subtree), and the
+dominant cost was the O(m³) assembly *algorithm* (rescans + double materialization + ofFn
+closures), not intrinsic `ZMod64` arithmetic (~6%, shared with the DensePoly gcd sweep) —
+the opposite of the `modByMonic` packing dead-end (#8642), which was `%p`-division-bound.
+
+**Scope decision (evidence-driven).** The row-reduction *loop* is only ~1.1% of the profile,
+so full end-to-end monomorphization of `rowReduce` (an enormous refinement proof) is not
+cost-justified; the whole lever is the assembly. `Array UInt64` vs `Array (ZMod64 p)` is
+neutral (Lean boxes both identically — the `HexPolyFp/Packed.lean` lesson), so the win is
+the O(m³)→O(m²) algorithm + single-computation of freeCols/pivot-table, not a word repack.
+
+**Current frontier**
+
+- Implementation + proof complete, all builds green. Two files changed: `Nullspace.lean`
+  (+~120 lines), `RankSpanNullspace.lean` (2-line reroute).
+
+**Next step**
+
+- /second-opinion, then open the PR against #8669. Watch CI.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
This PR rewrites the executable `IsRowReduced.nullspace` assembly from an O(m³) reference (a per-entry `pivotIndex?` rescan building `nullspaceMatrix`, then a per-column `Matrix.col` re-read) to an O(m²) direct assembly — one `pivotRowTable` precomputation (column → pivot-row index in a single O(rank) pass) plus a direct per-column build, with the free-column vector and the pivot table hoisted out of the inner loops — and proves the two agree columnwise so the public factorization result is byte-identical and every downstream soundness/completeness lemma is unchanged.

**Honest status on materiality.** The issue's premise (the generic nullspace being the ~15-22% "sole material lever") no longer holds on current `main`: #8879 ("share fixed-space kernel construction") landed while this was in progress and already fixed the dominant inefficiency — the old assembly recomputed `nullspaceMatrix` once per column (effectively O(m⁴)); #8879 hoisted it to compute once (O(m³)). A controlled, load-matched A/B (min-of-10, interleaved, `RELIFT_PROFILE=prime`, byte-identical outputs) of this PR against current `main` shows **1.00-1.03×** across deg 8-24, and a fresh profile puts the whole nullspace subtree at **~0.1%** of the `choosePrimeData?` path (now dominated by the `DensePoly.gcd` equal-degree sweep and `ZMod64.inv`/`extGcd`). So the further O(m³)→O(m²) step is a correct asymptotic improvement (it helps for degrees beyond the deg-24 split family and removes the `pivotIndex?` rescan permanently) but is **end-to-end neutral on the current workload**.

The change is a definition change, not a `@[csimp]`: the generic `Matrix.nullspace` is specialized/inlined into the `@[expose] fixedSpaceKernelVectors`, so a `csimp` on it is bypassed by the specializer (verified by profiling), whereas a definition change is reflected in the specialized copies. Correctness rests on re-proving the single bridging lemma `nullspace_get` (`nullspace.get k = Matrix.col nullspaceMatrix k`) with the free / other-free / pivot cases matched entrywise against `nullspaceMatrix_free` / `_free_ne` / `_pivot`; `#print axioms` reports only `[propext, Classical.choice, Quot.sound]`. All builds green including the CI-gated `HexBerlekampZassenhausMathlib` bridge and `HexConformance` `#guard`s. Independently reviewed by Codex (no correctness or semantic regression).

Given #8879 already captured the material lever, this can either land as an asymptotic-cleanup-plus-proven-correspondence or be closed; deferring that call to the maintainer.

Refs #8669.

🤖 Prepared with Claude Code