### PR TITLE
feat(number-field): implement reduced fixed-field arithmetic

### DIFF
--- a/HexNumberField.lean
+++ b/HexNumberField.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexNumberField.Basic
+public import HexNumberField.QAdjoin
 
 public section
 

--- a/HexNumberField/Basic.lean
+++ b/HexNumberField/Basic.lean
@@ -136,7 +136,7 @@ instance : BEq AlgebraicNumber := ⟨AlgebraicNumber.beq⟩
 is `X`. -/
 @[expose]
 def AlgebraicNumber.isZero (a : AlgebraicNumber) : Bool :=
-  a.p == (DensePoly.monomial 1 1 : ZPoly)
+  a.p == ZPoly.X
 
 /-- The selected lazy root is zero exactly when its polynomial has zero
 constant coefficient and its closed isolating disc contains zero. The refined

--- a/HexNumberField/QAdjoin.lean
+++ b/HexNumberField/QAdjoin.lean
@@ -33,13 +33,6 @@ def reduce (p : ZPoly) (x : SimpleRoot p) (f : DensePoly Rat) : QAdjoin p x wher
   coeffs := reduceCoeffs p f
   degree_lt := ZPoly.rat_mod_zpoly_degree_lt _ _ x.posDegree
 
-/-- Coordinate equality in a fixed presentation. -/
-@[expose]
-def beq (a b : QAdjoin p x) : Bool :=
-  a.coeffs == b.coeffs
-
-instance : BEq (QAdjoin p x) := ⟨beq⟩
-
 /-- Fixed-presentation elements are equal when their canonical coordinates are
 equal. -/
 @[ext]
@@ -51,6 +44,10 @@ theorem ext {a b : QAdjoin p x} (h : a.coeffs = b.coeffs) : a = b := by
           change ac = bc at h
           subst bc
           rfl
+
+/-- Equality is exactly equality of canonical coordinate polynomials. -/
+theorem eq_iff_coeffs {a b : QAdjoin p x} : a = b ↔ a.coeffs = b.coeffs :=
+  ⟨fun h => congrArg QAdjoin.coeffs h, ext⟩
 
 instance : DecidableEq (QAdjoin p x) := by
   intro a b
@@ -64,9 +61,14 @@ instance : DecidableEq (QAdjoin p x) := by
 def isZero (a : QAdjoin p x) : Bool :=
   a.coeffs.isZero
 
-instance : Zero (QAdjoin p x) := ⟨reduce p x 0⟩
+instance : Zero (QAdjoin p x) where
+  zero := ⟨0, by simpa using x.posDegree⟩
 
-instance : One (QAdjoin p x) := ⟨reduce p x 1⟩
+instance : One (QAdjoin p x) where
+  one := ⟨1, by
+    change (DensePoly.C (1 : Rat)).degree?.getD 0 < p.degree?.getD 0
+    rw [DensePoly.degree?_C_getD]
+    exact x.posDegree⟩
 
 /-- Reduced coordinate addition. -/
 @[expose]
@@ -143,6 +145,8 @@ private def sqrtTwoRep : RefinedIsolation sqrtTwoPoly :=
 
 private def sqrtTwoRoot : SimpleRoot sqrtTwoPoly :=
   SimpleRoot.mk sqrtTwoRep
+
+example : LawfulBEq (QAdjoin sqrtTwoPoly sqrtTwoRoot) := inferInstance
 
 #guard
     reduceCoeffs sqrtTwoPoly (DensePoly.ofList ([0, 0, 1] : List Rat)) =

--- a/HexNumberField/QAdjoin.lean
+++ b/HexNumberField/QAdjoin.lean
@@ -1,0 +1,136 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexNumberField.Basic
+public meta import HexNumberField.Basic
+
+public section
+
+/-!
+Reduced arithmetic in a fixed rational polynomial presentation.
+
+Every public operation returns the canonical remainder modulo the integer
+defining polynomial cast to `Rat`. Inversion uses the left Bézout coefficient
+from polynomial extended gcd and normalizes by its constant gcd.
+-/
+namespace Hex.QAdjoin
+
+variable {p : ZPoly} {x : SimpleRoot p}
+
+/-- Canonical rational-polynomial remainder modulo `p`. -/
+@[expose]
+def reduceCoeffs (p : ZPoly) (f : DensePoly Rat) : DensePoly Rat :=
+  f % ZPoly.toRatPoly p
+
+/-- Package a rational polynomial after canonical modular reduction. -/
+@[expose]
+def reduce (p : ZPoly) (x : SimpleRoot p) (f : DensePoly Rat) : QAdjoin p x where
+  coeffs := reduceCoeffs p f
+  degree_lt := by
+    sorry
+
+/-- Coordinate equality in a fixed presentation. -/
+@[expose]
+def beq (a b : QAdjoin p x) : Bool :=
+  a.coeffs == b.coeffs
+
+instance : BEq (QAdjoin p x) := ⟨beq⟩
+
+/-- Boolean zero test on canonical coordinates. -/
+@[expose]
+def isZero (a : QAdjoin p x) : Bool :=
+  a.coeffs.isZero
+
+instance : Zero (QAdjoin p x) := ⟨reduce p x 0⟩
+
+instance : One (QAdjoin p x) := ⟨reduce p x 1⟩
+
+/-- Reduced coordinate addition. -/
+@[expose]
+def add (a b : QAdjoin p x) : QAdjoin p x :=
+  reduce p x (a.coeffs + b.coeffs)
+
+instance : Add (QAdjoin p x) := ⟨add⟩
+
+/-- Reduced coordinate subtraction. -/
+@[expose]
+def sub (a b : QAdjoin p x) : QAdjoin p x :=
+  reduce p x (a.coeffs - b.coeffs)
+
+instance : Sub (QAdjoin p x) := ⟨sub⟩
+
+/-- Reduced coordinate negation. -/
+@[expose]
+def neg (a : QAdjoin p x) : QAdjoin p x :=
+  reduce p x (-a.coeffs)
+
+instance : Neg (QAdjoin p x) := ⟨neg⟩
+
+/-- Reduced coordinate multiplication. -/
+@[expose]
+def mul (a b : QAdjoin p x) : QAdjoin p x :=
+  reduce p x (a.coeffs * b.coeffs)
+
+instance : Mul (QAdjoin p x) := ⟨mul⟩
+
+/-- Rational scalar action followed by canonical reduction. -/
+@[expose]
+def smul (c : Rat) (a : QAdjoin p x) : QAdjoin p x :=
+  reduce p x (DensePoly.scale c a.coeffs)
+
+instance : SMul Rat (QAdjoin p x) := ⟨smul⟩
+
+/-- Extended-gcd inverse coordinates. Zero is fixed at zero; a successful
+irreducible-field input has a nonzero constant gcd, whose inverse normalizes
+the left Bézout coefficient. -/
+@[expose]
+def invCoeffs (p : ZPoly) (f : DensePoly Rat) : DensePoly Rat :=
+  if f.isZero then
+    0
+  else
+    let r := DensePoly.xgcd f (ZPoly.toRatPoly p)
+    let c := r.gcd.leadingCoeff
+    if c = 0 then
+      0
+    else
+      reduceCoeffs p (DensePoly.scale c⁻¹ r.left)
+
+/-- Inversion in a checked irreducible presentation, with `0⁻¹ = 0`. -/
+@[expose]
+def inv [ZPoly.CheckedIrreducible p] (a : QAdjoin p x) : QAdjoin p x :=
+  reduce p x (invCoeffs p a.coeffs)
+
+instance [ZPoly.CheckedIrreducible p] : Inv (QAdjoin p x) := ⟨inv⟩
+
+/-- Division in a checked irreducible presentation. -/
+@[expose]
+def div [ZPoly.CheckedIrreducible p] (a b : QAdjoin p x) : QAdjoin p x :=
+  a * b⁻¹
+
+instance [ZPoly.CheckedIrreducible p] : Div (QAdjoin p x) := ⟨div⟩
+
+/-! Compiled arithmetic regressions in `ℚ[X]/(X²-2)`. -/
+
+private def sqrtTwoPoly : ZPoly := DensePoly.ofList [-2, 0, 1]
+
+#guard
+    reduceCoeffs sqrtTwoPoly (DensePoly.ofList ([0, 0, 1] : List Rat)) =
+      DensePoly.C 2
+
+#guard
+    let xPoly := DensePoly.ofList ([0, 1] : List Rat)
+    reduceCoeffs sqrtTwoPoly (xPoly * xPoly) = DensePoly.C 2
+
+#guard
+    let xPoly := DensePoly.ofList ([0, 1] : List Rat)
+    invCoeffs sqrtTwoPoly xPoly = DensePoly.ofList ([0, 1 / 2] : List Rat) &&
+      reduceCoeffs sqrtTwoPoly (xPoly * invCoeffs sqrtTwoPoly xPoly) = 1
+
+#guard invCoeffs sqrtTwoPoly 0 = 0
+
+end Hex.QAdjoin

--- a/HexNumberField/QAdjoin.lean
+++ b/HexNumberField/QAdjoin.lean
@@ -31,8 +31,7 @@ def reduceCoeffs (p : ZPoly) (f : DensePoly Rat) : DensePoly Rat :=
 @[expose]
 def reduce (p : ZPoly) (x : SimpleRoot p) (f : DensePoly Rat) : QAdjoin p x where
   coeffs := reduceCoeffs p f
-  degree_lt := by
-    sorry
+  degree_lt := ZPoly.rat_mod_zpoly_degree_lt _ _ x.posDegree
 
 /-- Coordinate equality in a fixed presentation. -/
 @[expose]
@@ -40,6 +39,25 @@ def beq (a b : QAdjoin p x) : Bool :=
   a.coeffs == b.coeffs
 
 instance : BEq (QAdjoin p x) := ⟨beq⟩
+
+/-- Fixed-presentation elements are equal when their canonical coordinates are
+equal. -/
+@[ext]
+theorem ext {a b : QAdjoin p x} (h : a.coeffs = b.coeffs) : a = b := by
+  cases a with
+  | mk ac ah =>
+      cases b with
+      | mk bc bh =>
+          change ac = bc at h
+          subst bc
+          rfl
+
+instance : DecidableEq (QAdjoin p x) := by
+  intro a b
+  if h : a.coeffs = b.coeffs then
+    exact isTrue (ext h)
+  else
+    exact isFalse fun hab => h (congrArg QAdjoin.coeffs hab)
 
 /-- Boolean zero test on canonical coordinates. -/
 @[expose]
@@ -85,25 +103,21 @@ def smul (c : Rat) (a : QAdjoin p x) : QAdjoin p x :=
 
 instance : SMul Rat (QAdjoin p x) := ⟨smul⟩
 
-/-- Extended-gcd inverse coordinates. Zero is fixed at zero; a successful
-irreducible-field input has a nonzero constant gcd, whose inverse normalizes
-the left Bézout coefficient. -/
-@[expose]
-def invCoeffs (p : ZPoly) (f : DensePoly Rat) : DensePoly Rat :=
-  if f.isZero then
-    0
-  else
-    let r := DensePoly.xgcd f (ZPoly.toRatPoly p)
-    let c := r.gcd.leadingCoeff
-    if c = 0 then
-      0
-    else
-      reduceCoeffs p (DensePoly.scale c⁻¹ r.left)
-
-/-- Inversion in a checked irreducible presentation, with `0⁻¹ = 0`. -/
+/-- Inversion in a checked irreducible presentation, with `0⁻¹ = 0`. The
+one-sided extended gcd tracks only the Bezout coefficient used for the inverse;
+the constant-gcd check is a defensive executable guard whose failure is
+unreachable under checked irreducibility. -/
 @[expose]
 def inv [ZPoly.CheckedIrreducible p] (a : QAdjoin p x) : QAdjoin p x :=
-  reduce p x (invCoeffs p a.coeffs)
+  if a.isZero then
+    0
+  else
+    let r := DensePoly.xgcdLeft a.coeffs (ZPoly.toRatPoly p)
+    if r.gcd.size = 1 then
+      let c := r.gcd.leadingCoeff
+      if c = 0 then 0 else reduce p x (DensePoly.scale c⁻¹ r.left)
+    else
+      0
 
 instance [ZPoly.CheckedIrreducible p] : Inv (QAdjoin p x) := ⟨inv⟩
 
@@ -118,6 +132,15 @@ instance [ZPoly.CheckedIrreducible p] : Div (QAdjoin p x) := ⟨div⟩
 
 private def sqrtTwoPoly : ZPoly := DensePoly.ofList [-2, 0, 1]
 
+private def sqrtTwoSquare : DyadicSquare :=
+  ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
+
+private def sqrtTwoRep : RefinedIsolation sqrtTwoPoly :=
+  ⟨⟨sqrtTwoSquare, by decide⟩, by decide⟩
+
+private def sqrtTwoRoot : SimpleRoot sqrtTwoPoly :=
+  SimpleRoot.mk sqrtTwoRep
+
 #guard
     reduceCoeffs sqrtTwoPoly (DensePoly.ofList ([0, 0, 1] : List Rat)) =
       DensePoly.C 2
@@ -128,9 +151,25 @@ private def sqrtTwoPoly : ZPoly := DensePoly.ofList [-2, 0, 1]
 
 #guard
     let xPoly := DensePoly.ofList ([0, 1] : List Rat)
-    invCoeffs sqrtTwoPoly xPoly = DensePoly.ofList ([0, 1 / 2] : List Rat) &&
-      reduceCoeffs sqrtTwoPoly (xPoly * invCoeffs sqrtTwoPoly xPoly) = 1
+    let x : QAdjoin sqrtTwoPoly sqrtTwoRoot := reduce sqrtTwoPoly sqrtTwoRoot xPoly
+    let two : QAdjoin sqrtTwoPoly sqrtTwoRoot :=
+      reduce sqrtTwoPoly sqrtTwoRoot (DensePoly.C 2)
+    (x * x).coeffs = two.coeffs && x != 0 &&
+      (x + x).coeffs = ((2 : Rat) • x).coeffs
 
-#guard invCoeffs sqrtTwoPoly 0 = 0
+private def nonmonicQuadratic : ZPoly := DensePoly.ofList [-1, 0, 2]
+
+#guard
+    let xPoly := DensePoly.ofList ([0, 1] : List Rat)
+    reduceCoeffs nonmonicQuadratic (xPoly * xPoly) = DensePoly.C (1 / 2)
+
+#guard
+    let xPoly := DensePoly.ofList ([0, 1] : List Rat)
+    let r := DensePoly.xgcdLeft xPoly (ZPoly.toRatPoly nonmonicQuadratic)
+    let candidate :=
+      reduceCoeffs nonmonicQuadratic
+        (DensePoly.scale r.gcd.leadingCoeff⁻¹ r.left)
+    candidate = DensePoly.ofList ([0, 2] : List Rat) &&
+      reduceCoeffs nonmonicQuadratic (xPoly * candidate) = 1
 
 end Hex.QAdjoin

--- a/HexNumberField/QAdjoin.lean
+++ b/HexNumberField/QAdjoin.lean
@@ -115,9 +115,12 @@ def inv [ZPoly.CheckedIrreducible p] (a : QAdjoin p x) : QAdjoin p x :=
     let r := DensePoly.xgcdLeft a.coeffs (ZPoly.toRatPoly p)
     if r.gcd.size = 1 then
       let c := r.gcd.leadingCoeff
-      if c = 0 then 0 else reduce p x (DensePoly.scale c⁻¹ r.left)
+      if c = 0 then
+        Hex.panicWith 0 "QAdjoin.inv: zero constant gcd"
+      else
+        reduce p x (DensePoly.scale c⁻¹ r.left)
     else
-      0
+      Hex.panicWith 0 "QAdjoin.inv: nonconstant gcd"
 
 instance [ZPoly.CheckedIrreducible p] : Inv (QAdjoin p x) := ⟨inv⟩
 
@@ -156,6 +159,21 @@ private def sqrtTwoRoot : SimpleRoot sqrtTwoPoly :=
       reduce sqrtTwoPoly sqrtTwoRoot (DensePoly.C 2)
     (x * x).coeffs = two.coeffs && x != 0 &&
       (x + x).coeffs = ((2 : Rat) • x).coeffs
+
+-- Construct the checked instance through the executable decision so this
+-- regression reaches the shipped inverse and division implementations without
+-- adding a proof axiom or a test-only `sorry`.
+#guard
+    if hirred : ZPoly.isIrreducible sqrtTwoPoly = true then
+      letI : ZPoly.CheckedIrreducible sqrtTwoPoly :=
+        ⟨hirred, by decide⟩
+      let xPoly := DensePoly.ofList ([0, 1] : List Rat)
+      let x : QAdjoin sqrtTwoPoly sqrtTwoRoot :=
+        reduce sqrtTwoPoly sqrtTwoRoot xPoly
+      x * x⁻¹ = 1 && x / x = 1 &&
+        (0 : QAdjoin sqrtTwoPoly sqrtTwoRoot)⁻¹ = 0
+    else
+      false
 
 private def nonmonicQuadratic : ZPoly := DensePoly.ofList [-1, 0, 2]
 

--- a/HexPoly/Euclid/DivGcd.lean
+++ b/HexPoly/Euclid/DivGcd.lean
@@ -1108,6 +1108,72 @@ def xgcd [One R] [Add R] [Sub R] [Mul R] [Div R]
     (p q : DensePoly R) : XGCDResult R :=
   xgcdAux p 1 0 q 0 1 (p.size + q.size + 1)
 
+/-- Result package for the one-sided extended Euclidean algorithm. -/
+structure XGCDLeftResult (R : Type u) [Zero R] [DecidableEq R] where
+  /-- Greatest common divisor returned by the Euclidean algorithm. -/
+  gcd : DensePoly R
+  /-- Bezout coefficient multiplying the left input. -/
+  left : DensePoly R
+
+/-- Tail-recursive extended Euclidean algorithm tracking only the coefficient
+of the left input. This avoids the second polynomial multiplication at every
+step when a consumer needs one inverse coefficient rather than both. -/
+@[expose]
+def xgcdLeftAux [One R] [Add R] [Sub R] [Mul R] [Div R]
+    (r₀ s₀ r₁ s₁ : DensePoly R) (fuel : Nat) : XGCDLeftResult R :=
+  match fuel with
+  | 0 => { gcd := r₀, left := s₀ }
+  | fuel + 1 =>
+      if _hr : r₁.isZero then
+        { gcd := r₀, left := s₀ }
+      else
+        let qr := divMod r₀ r₁
+        xgcdLeftAux r₁ s₁ qr.2 (s₀ - qr.1 * s₁) fuel
+
+/-- One-sided extended gcd, returning the gcd and only the Bezout coefficient
+multiplying the left input. -/
+@[expose]
+def xgcdLeft [One R] [Add R] [Sub R] [Mul R] [Div R]
+    (p q : DensePoly R) : XGCDLeftResult R :=
+  xgcdLeftAux p 1 q 0 (p.size + q.size + 1)
+
+/-- The one-sided and full extended algorithms return the same gcd. -/
+theorem xgcdLeftAux_gcd_eq [One R] [Add R] [Sub R] [Mul R] [Div R]
+    (r₀ s₀ t₀ r₁ s₁ t₁ : DensePoly R) (fuel : Nat) :
+    (xgcdLeftAux r₀ s₀ r₁ s₁ fuel).gcd =
+      (xgcdAux r₀ s₀ t₀ r₁ s₁ t₁ fuel).gcd := by
+  induction fuel generalizing r₀ s₀ t₀ r₁ s₁ t₁ with
+  | zero => rfl
+  | succ fuel ih =>
+      unfold xgcdLeftAux xgcdAux
+      split
+      · rfl
+      · exact ih _ _ _ _ _ _
+
+/-- The one-sided algorithm returns the same left Bezout coefficient as the
+full extended algorithm. -/
+theorem xgcdLeftAux_left_eq [One R] [Add R] [Sub R] [Mul R] [Div R]
+    (r₀ s₀ t₀ r₁ s₁ t₁ : DensePoly R) (fuel : Nat) :
+    (xgcdLeftAux r₀ s₀ r₁ s₁ fuel).left =
+      (xgcdAux r₀ s₀ t₀ r₁ s₁ t₁ fuel).left := by
+  induction fuel generalizing r₀ s₀ t₀ r₁ s₁ t₁ with
+  | zero => rfl
+  | succ fuel ih =>
+      unfold xgcdLeftAux xgcdAux
+      split
+      · rfl
+      · exact ih _ _ _ _ _ _
+
+/-- `xgcdLeft` returns the same gcd as `xgcd`. -/
+theorem xgcdLeft_gcd_eq_xgcd [One R] [Add R] [Sub R] [Mul R] [Div R]
+    (p q : DensePoly R) : (xgcdLeft p q).gcd = (xgcd p q).gcd :=
+  xgcdLeftAux_gcd_eq p 1 0 q 0 1 _
+
+/-- `xgcdLeft` returns the same left Bezout coefficient as `xgcd`. -/
+theorem xgcdLeft_left_eq_xgcd [One R] [Add R] [Sub R] [Mul R] [Div R]
+    (p q : DensePoly R) : (xgcdLeft p q).left = (xgcd p q).left :=
+  xgcdLeftAux_left_eq p 1 0 q 0 1 _
+
 /-- Tail-recursive Euclidean gcd tracking only the remainder sequence, **without**
 the Bezout coefficients. `xgcd`/`xgcdAux` carry the Bezout accumulators `s`, `t`
 and update them with a polynomial multiplication (`q * s₁`, `q * t₁`) at every

--- a/HexPoly/SPEC/hex-poly.md
+++ b/HexPoly/SPEC/hex-poly.md
@@ -32,6 +32,9 @@ The normalization invariant (no trailing zeros) ensures structural equality
   *separate* function for the genuine Bezout use-sites (CRT, Hensel, Berlekamp
   correctness). `gcd` agrees with `xgcd`'s gcd component (`gcd_eq_xgcd_gcd`), so
   the gcd-value lemmas transfer.
+- One-sided extended GCD (`xgcdLeft`, gcd plus the coefficient of the left
+  input) for inverse computations that need only one Bezout coefficient. It
+  skips the second growing polynomial multiplication at every Euclidean step.
 - Evaluation (Horner's method)
 - Composition, derivative
 - Content and primitive part (for `DensePoly Int`)

--- a/HexPolyZ/Core.lean
+++ b/HexPolyZ/Core.lean
@@ -170,6 +170,7 @@ theorem isUnit_of_eq_neg_one {f : ZPoly} (h : f = -1) : IsUnit f := by
   isUnit_of_eq_neg_one rfl
 
 /-- View an integer polynomial as a rational polynomial. -/
+@[expose]
 def toRatPoly (f : ZPoly) : DensePoly Rat :=
   DensePoly.ofCoeffs <| f.toArray.map fun coeff : Int => (coeff : Rat)
 

--- a/SPEC/Libraries/hex-number-field-mathlib.md
+++ b/SPEC/Libraries/hex-number-field-mathlib.md
@@ -47,6 +47,11 @@ irreducibility, so it is an embedding of fields. This file installs the
 law-bearing field structures for `QAdjoin` and canonical `AlgebraicNumber` and
 proves that their operations are the computational ones.
 
+When constructing the `Field (QAdjoin p x)` instance, set its rational scalar
+action explicitly to the computational `SMul Rat` instance shipped by
+HexNumberField. This keeps Mathlib's generated `qsmul` path definitionally
+identical and avoids a second, diamond-forming rational action.
+
 ## Equality, zero, and approximation
 
 ```lean

--- a/progress/20260727T042721Z_numberfield-qadjoin.md
+++ b/progress/20260727T042721Z_numberfield-qadjoin.md
@@ -1,0 +1,37 @@
+# HexNumberField reduced fixed-field arithmetic
+
+## Accomplished
+
+- Added one canonical rational-polynomial reduction boundary modulo the cast
+  defining polynomial.
+- Implemented coordinate equality and zero, zero/one, addition, subtraction,
+  negation, multiplication, and rational scalar action through reduced
+  representatives.
+- Implemented checked-irreducible inversion from polynomial extended gcd,
+  including gcd-scalar normalization and `0⁻¹ = 0`, plus division.
+- Added compiled regressions for reduction, multiplication, nontrivial
+  inversion, and zero inversion in `ℚ[X]/(X²-2)`.
+- Built `HexNumberField` and passed DAG, copyright, line-count,
+  forbidden-form, and whitespace checks.
+
+## Current frontier
+
+The algebraic fixed-field operations are executable and use canonical reduced
+coordinates. One propositional degree-bound obligation remains explicit. The
+threaded approximation API still needs a reusable rational-polynomial ball
+evaluator.
+
+An independent review of the parent resultant stack found a genuine
+positive-characteristic discriminant formal-degree bug; work here is
+checkpointed while that parent contract is repaired.
+
+## Next step
+
+Repair the parent discriminant contract and executable correction, propagate
+it through the stack, then publish this fixed-field milestone and implement
+rational-polynomial ball evaluation.
+
+## Blockers
+
+No local arithmetic blocker. Publication waits only for the parent resultant
+repair to be incorporated into the stacked base.

--- a/progress/20260727T050726Z_numberfield-qadjoin-review.md
+++ b/progress/20260727T050726Z_numberfield-qadjoin-review.md
@@ -1,0 +1,35 @@
+# HexNumberField QAdjoin review repair
+
+## Accomplished
+
+- Removed the data-producing `sorry` from `QAdjoin.reduce`: certified root
+  witnesses now prove positive defining-polynomial degree in HexRoots, and the
+  public rational remainder law closes the canonical degree invariant.
+- Restated the invariant with `degree?.getD 0`, matching the executable division
+  API, and added `QAdjoin.ext` plus `DecidableEq` for canonical coordinates.
+- Added a one-sided extended gcd with proved agreement to both relevant fields
+  of the existing full algorithm, then switched fixed-field inversion to it.
+- Removed the ungated inverse-coordinate footgun and the redundant second
+  reduction; inversion now checks for a constant gcd inside the checked API.
+- Added compiled guards that construct a real certified root and exercise the
+  shipped multiplication, addition, scalar, equality, zero, and one paths.
+- Added nonmonic reduction and inverse-coordinate regressions for `2X² - 1`.
+- Pinned the Mathlib companion's rational scalar action to avoid a `qsmul`
+  instance diamond.
+- Rebuilt `HexNumberField` and reran all repository structural/source checks.
+
+## Current frontier
+
+The QAdjoin data path is free of `sorry`, its canonical invariant is backed by
+kernel proofs, and the executable regressions now reach the public quotient
+operations. The core scaffold retains only its three isolated propositional
+zero-certificate obligations.
+
+## Next step
+
+Propagate the core and QAdjoin repair commits to their owning stacked branches,
+rebase the approximation PR, and resume the reviewed resultant PRS repairs.
+
+## Blockers
+
+None.

--- a/progress/20260727T053356Z_numberfield-inverse-review.md
+++ b/progress/20260727T053356Z_numberfield-inverse-review.md
@@ -1,0 +1,27 @@
+# HexNumberField inverse review follow-up
+
+## Accomplished
+
+- Changed the checked fixed-field inverse's unreachable nonconstant- and
+  zero-gcd branches from silent zero results to loud `Hex.panicWith` fallbacks.
+- Added a compiled dependent-check regression that constructs the
+  `CheckedIrreducible` instance for `X² - 2` from the executable decision and
+  reaches the shipped inverse, division, and zero-inverse implementations.
+- Rebuilt `HexNumberField.QAdjoin` successfully without adding a theorem or
+  data-level `sorry`.
+
+## Current frontier
+
+The public fixed-field arithmetic path, including inversion and division, is
+now exercised end to end. The existing three core propositional obligations
+remain the deliberately isolated Phase 1 proof frontier.
+
+## Next step
+
+Push this follow-up, rebase the approximation milestone once more, and finish
+the remaining approximation coverage/documentation items from its verification
+review.
+
+## Blockers
+
+None.

--- a/progress/20260727T054557Z_numberfield-qadjoin-verification.md
+++ b/progress/20260727T054557Z_numberfield-qadjoin-verification.md
@@ -1,0 +1,31 @@
+# HexNumberField fixed-field verification follow-up
+
+## Accomplished
+
+- Exposed `ZPoly.toRatPoly`, closing the first cross-module reduction boundary
+  used by the public fixed-field reduction path.
+- Removed the bespoke `QAdjoin` Boolean equality and now derive the lawful
+  `BEq`/`LawfulBEq` pair from canonical-coordinate `DecidableEq`.
+- Added the public `eq_iff_coeffs` characterization needed by companion field
+  proofs.
+- Made fixed-field zero and one direct canonical records instead of rebuilding
+  and reducing the rational modulus on every use.
+- Reused `ZPoly.X` in canonical algebraic-number zero recognition.
+- Confirmed the inferred `LawfulBEq` instance and rebuilt
+  `HexNumberField.QAdjoin`.
+
+## Current frontier
+
+The fixed-field review's correctness/API findings are addressed. Exposing
+`toRatPoly` alone does not make the entire rational polynomial remainder or
+squarefree decision kernel-reducible; their deeper implementation boundaries
+remain separate proof-engineering work rather than executable defects.
+
+## Next step
+
+Push the follow-up and propagate it through the approximation and conversion
+branches before continuing fixed-field minimal-polynomial work.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #8890.

## Summary

- centralize canonical reduction modulo the defining integer polynomial cast to `Rat`
- implement coordinate equality/zero, zero/one, additive operations, multiplication, and rational scalar action
- implement checked-irreducible inversion through polynomial extended gcd and constant-gcd normalization, with `0⁻¹ = 0`
- add division and compiled regressions in `ℚ[X]/(X²-2)`

This is stacked on #8889 and already includes the reviewed discriminant repair in its transitive base.

## Verification

- `lake build HexNumberField.QAdjoin`
- `lake build HexNumberField`
- compiled reduction, multiplication, inverse, inverse-product, and zero-inverse guards
- DAG, copyright, line-count, forbidden-form, and whitespace checks
