### PR TITLE
Specify interval arithmetic engine and tactic

### DIFF
--- a/SPEC/CI.md
+++ b/SPEC/CI.md
@@ -30,7 +30,7 @@ agent/feature branch even before a PR exists. Restricting `push:` to
 PR commit fire each workflow exactly once.
 
 `workflow_dispatch:` is allowed wherever an ad-hoc manual run is
-useful (currently `conformance.yml`).
+useful (currently the consolidated `ci.yml`).
 
 Other triggers (`schedule:`, `repository_dispatch:`, `release:`,
 `merge_group:`) are case-by-case; they must be documented in the

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -13,6 +13,7 @@
 - **hex-poly-z**: polynomials over `Z`, content/primitive part, Mignotte bound
 - **hex-roots**: certified complex root isolation for `Z[x]` via dyadic squares, Pellet tests, and speculative Newton iteration
 - **hex-real-roots**: certified real root isolation for `Z[x]`: Sturm-count witnesses, a Descartes bisection search with a proven-complete Sturm fallback
+- **hex-interval**: exact open, closed, empty, and unbounded dyadic intervals; a shared expression program; and a budgeted scheduler for propagation, refinement, and subdivision
 - **hex-rcf**: the `rcf` tactic, a complete decision procedure for univariate real-closed-field sentences (Boolean combinations of polynomial inequalities under one `∀`/`∃` over `ℝ`); `mathlib: true`, soundness theorem in the same library
 - **hex-resultant**: polynomial resultant and discriminant via the subresultant pseudo-remainder sequence
 - **hex-number-field**: fixed fields `QAdjoin p x`, factorization-lazy `AlgebraicRoot`, canonical `AlgebraicNumber`, and roots of polynomials with algebraic coefficients
@@ -26,9 +27,8 @@
 - **hex-gfq-field**: field structure on top of `hex-gfq-ring` when `f` is irreducible
 - **hex-gfq**: convenience wrapper, canonical `GFq p n` plus optimized `GF2q n` using Conway polynomials
 
-**Mathlib companion libraries** (each depends on a computational
-library and Mathlib, and proves that the executable definitions agree
-with Mathlib's):
+**Mathlib companion libraries** (each depends on a computational library and
+Mathlib, and supplies correspondence proofs or Mathlib-facing APIs):
 
 - **hex-mod-arith-mathlib**: `ZMod64 p ≃+* ZMod p`
 - **hex-poly-mathlib**: `DensePoly R ≃+* Polynomial R`
@@ -40,6 +40,7 @@ with Mathlib's):
 - **hex-poly-z-mathlib**: `DensePoly Int ≃+* Polynomial ℤ`, Mignotte bound (via Mathlib's Mahler measure)
 - **hex-roots-mathlib**: Pellet's test on circles (built from `circleIntegral`), the Mahler separation bound, soundness of refinement and `isolate`
 - **hex-real-roots-mathlib**: Sturm's theorem (counting form over `Polynomial ℝ`), chain correspondence, soundness and completeness of `isolate?`
+- **hex-interval-mathlib**: real semantics, verified arithmetic and elementary-function propagators, certificate replay, and the `interval` tactic
 - **hex-resultant-mathlib**: executable resultant agreement with `Polynomial.resultant`, specialization, root-product, and discriminant theorems
 - **hex-number-field-mathlib**: fixed-field correspondence, exactification, lazy arithmetic, and algebraic-coefficient root completeness
 - **hex-number-field-tower-mathlib**: tower embeddings, Trager correctness, splitting fields, and primitive-element equivalence
@@ -67,6 +68,7 @@ Each library with its immediate dependencies:
 - **hex-poly-z**: hex-poly
 - **hex-roots**: hex-poly-z
 - **hex-real-roots**: hex-poly-z
+- **hex-interval**: (none)
 - **hex-rcf**: hex-real-roots, hex-real-roots-mathlib, hex-poly-z, hex-poly-z-mathlib (mathlib: true)
 - **hex-resultant**: hex-poly
 - **hex-number-field**: hex-poly-z, hex-roots, hex-resultant, hex-berlekamp-zassenhaus, hex-matrix, hex-row-reduce
@@ -87,6 +89,7 @@ Mathlib companion libraries (each also depends on Mathlib):
 - **hex-poly-z-mathlib**: hex-poly-z, hex-poly-mathlib
 - **hex-roots-mathlib**: hex-roots, hex-poly-z-mathlib
 - **hex-real-roots-mathlib**: hex-real-roots, hex-poly-z-mathlib
+- **hex-interval-mathlib**: hex-interval
 - **hex-resultant-mathlib**: hex-resultant, hex-poly-mathlib
 - **hex-number-field-mathlib**: hex-number-field, hex-resultant-mathlib, hex-berlekamp-zassenhaus-mathlib, hex-roots-mathlib, hex-poly-z-mathlib
 - **hex-number-field-tower-mathlib**: hex-number-field-tower, hex-number-field-mathlib, hex-resultant-mathlib, hex-berlekamp-zassenhaus-mathlib, hex-row-reduce-mathlib
@@ -157,6 +160,12 @@ hex-berlekamp-zassenhaus ────┤
 hex-row-reduce ──────────────┘
 ```
 
+Interval arithmetic is an independent library pair:
+
+```text
+hex-interval ── hex-interval-mathlib
+```
+
 ## Index
 
 Libraries marked **(released)** are published as standalone
@@ -189,6 +198,8 @@ for developments whose source-local move has not happened yet.
 - [hex-roots-mathlib](../../HexRootsMathlib/SPEC/hex-roots-mathlib.md): Pellet's test on circles, the Mahler separation bound, soundness of refinement and `isolate`
 - [hex-real-roots.md](hex-real-roots.md): certified real root isolation for `Z[x]`, Sturm-count witnesses, Descartes search with Sturm fallback
 - [hex-real-roots-mathlib.md](hex-real-roots-mathlib.md): Sturm's theorem, chain correspondence, soundness and completeness of `isolate?`
+- [hex-interval.md](hex-interval.md): exact interval data, shared programs, and budgeted propagation search
+- [hex-interval-mathlib.md](hex-interval-mathlib.md): real semantics, verified propagators, proof replay, and the `interval` tactic
 - [hex-rcf.md](hex-rcf.md): the `rcf` tactic for univariate real-closed-field sentences
 - [hex-resultant.md](hex-resultant.md): polynomial resultant and discriminant via the subresultant pseudo-remainder sequence
 - [hex-resultant-mathlib.md](hex-resultant-mathlib.md): executable resultant agreement, specialization, root-product, and discriminant theorems

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -6,8 +6,9 @@ propagators, and provides the `interval` tactic. It depends on Mathlib and
 `hex-interval`. There is no separate proof-only companion beyond this library.
 
 The tactic proves bounds for ordinary Lean expressions over `ℝ`. It reads
-bounds from the local context, reifies shared expressions to a static
-single-assignment program, runs the compiled `hex-interval` search, and turns
+bounds from the local context, reifies shared expressions to an immutable
+single-assignment base plus validated bounded extensions, runs the compiled
+`hex-interval` search, and turns
 the successful trace into an ordinary Lean proof. Search is untrusted. A rule
 can affect the generated theorem only by supplying a proof through its
 registered soundness theorem or verified certificate checker.
@@ -87,7 +88,7 @@ def Upper.Holds : Upper → ℝ → Prop
 end Interval
 
 def Interval.Mem (I : Interval) (x : ℝ) : Prop :=
-  match I.repr with
+  match I.view with
   | .empty        => False
   | .bounds lo hi => lo.Holds x ∧ hi.Holds x
 
@@ -158,12 +159,25 @@ The planner is never reduced in the kernel. The compiler does not certify any
 mathematical fact. A compiler error may cause search to fail or propose bad
 data, but bad data cannot satisfy the replay theorem.
 
-Every kernel-facing checker uses structural recursion or an explicit natural
-fuel whose decrease is visible after reduction. A checker must not hide a
-well-founded recursion whose proof terms block ordinary kernel evaluation.
-This applies in particular to logarithm and bit-precision helpers. Compiled
+Every kernel-facing checker must demonstrably reduce in the module that emits
+the proof. Structural recursion is preferred, but explicit natural fuel and
+well-founded recursion with an explicit `Nat` measure are permitted when
+`decide +kernel` and `Lean.Kernel.whnf` probes show that the complete exposure
+closure reduces and replay benchmarks remain acceptable. Auto-derived
+lexicographic measures on multi-clause recursion are rejected when those probes
+stick. A checker path must not contain an `@[extern]`-backed opaque constant,
+and the emitting module must expose transitive helper bodies rather than assume
+that an umbrella import recursively exposes them.
+
+When the kernel-friendly specification and fast runtime shape differ, the
+public name follows the repository's proved `@[csimp]` `*Impl`-twin policy,
+never `@[implemented_by]`. A compiled precheck runs first, but raw proof
+emission constructs the equivalent of
+`of_decide_eq_true (Eq.refl true)` with the decision instance explicit and
+without asking elaborator `isDefEq` to normalize the reflexivity slot. Compiled
 and kernel evaluation are benchmarked separately before a checker is admitted
-to generated proofs.
+to generated proofs. This applies in particular to logarithm, bit-precision,
+fold, and trace-validation helpers.
 
 A compiled call to a Boolean checker is only a preflight optimization. It is
 never converted into a proof. Every premise such as
@@ -208,12 +222,18 @@ scheme below rather than one enormous kernel reduction.
 
 ## Program semantics and the golden theorem
 
+The design below is the primary D2 candidate. The fixed requirement is a
+generic soundness theorem over a validated shared program with semantic links
+back to the quoted Lean terms. D2 selects the checker granularity, exact
+`Natural.Prim` encoding, and balance between reflected regions and direct
+theorem leaves before this representation is frozen.
+
 The reified program is an array of typed instructions whose arguments refer to
 earlier entries. A valuation assigns real values to free-variable nodes. The
 program's `OpKey` table gives each instruction its real meaning; a chosen
 `RuleKey` is only a method for enclosing that meaning.
 
-The natural checker does not interpret arbitrary operation keys from the
+In this candidate, the natural checker does not interpret arbitrary operation keys from the
 extension registry. It has a fixed, kernel-visible `Natural.Prim` language for
 variables, exact constants, negation, addition, subtraction, multiplication,
 and natural powers. A validated natural region records the translation from
@@ -246,6 +266,13 @@ checked program value and the original goal expression. Goal closure composes
 about an internal program. A missing or ill-typed link is a reification
 failure, not an unchecked assumption.
 
+Every accepted instantiation extends this same contract. The extension is a
+new immutable, topologically validated snapshot; each generated instruction
+has either fixed natural semantics or an explicit semantic-link recipe, and
+each new equality edge has a scoped equality proof. `Natural.eval_mem` is
+applied to the validated snapshot actually referenced by the retained trace.
+No theorem observes an in-place mutation of a previously checked program.
+
 This theorem is the fast path for straight natural evaluation. Adaptive
 derivations use additional theorem nodes for intersection, centered forms,
 rewrites, contractors, and branches. The result is a hybrid proof:
@@ -276,6 +303,8 @@ A registration supplies:
   theorem;
 - optional backward contractor, rewrite, local-refinement, and split-suggestion
   declarations;
+- optional bounded-instantiation triggers, generated-operation schemas, and
+  semantic/equality proof recipes;
 - a stable rule name and natural certificate-schema version, together forming
   the `RuleKey` used in diagnostics and replay traces.
 
@@ -334,13 +363,14 @@ The first arithmetic language contains:
 - real variables and exact integer, rational, and decimal constants;
 - negation, addition, subtraction, multiplication, division, inverse, and
   natural powers;
-- `abs`, `min`, `max`, and `Real.sqrt`;
+- `abs`, `min`, `max`, and the syntax of `Real.sqrt` (whose first enclosure
+  rule arrives at D7, so earlier use safely reports no applicable rule);
 - named real constants with registered nullary rules;
 - registered unary and binary functions.
 
-The first elementary-function milestone adds `Real.exp`, `Real.log`,
-`Real.sin`, `Real.cos`, `Real.atan`, and `Real.rpow` on proved positive bases.
-The LeanCert compatibility milestone then audits the rest of the expression
+The D5 elementary-function milestone adds `Real.sin` and `Real.cos`. D7 adds
+`Real.exp`, `Real.log`, `Real.sqrt`, `Real.atan`, and `Real.rpow` on proved
+positive bases. The LeanCert compatibility milestone then audits the rest of the expression
 heads its downstream users need, including hyperbolic functions, `arsinh`,
 `atanh`, `sinc`, and `erf`. A name in the reified language is not considered
 supported until at least one sound propagator covers its stated domain.
@@ -353,11 +383,17 @@ The frontend recognizes:
 - equality as two closed bounds;
 - all finite and one-sided `Set.Ixx` membership forms;
 - conjunctions of recognized facts;
-- local definitions that are definitionally equal after elaboration.
+- local definitions that are definitionally equal after elaboration;
+- the intrinsic fact `0 ≤ (n : ℝ)` for every reified cast from `n : ℕ`, proved
+  by `Nat.cast_nonneg` even when no local hypothesis states it. Casts from `ℤ`
+  contribute no sign fact by themselves.
 
 Facts about arbitrary derived terms are retained. They are not restricted to
 free variables. Unknown hypotheses remain in the context but do not enter the
 interval program.
+
+`interval only [...]` restricts user hypotheses, not intrinsic type-driven
+facts such as nonnegativity of a natural-number cast.
 
 A propositional hypothesis `h : s = t` does not merge SSA nodes. It becomes a
 source constraint with `SourceId h` and bidirectional bound transfer. This
@@ -378,6 +414,11 @@ Normalization is a portfolio, not one irreversible simplification pass.
 - Polynomial fragments may keep the original form, a Horner form, a centered
   form, and a normalized polynomial form. Each alternate has a proof of
   equality to the original node.
+- A source equality may justify a contextual alternate. The first required
+  case reduces the target `x^4 + y^4` modulo `x^2 + y^2 = 1` to
+  `1 - 2*x^2*y^2`, with a `ring` or `linear_combination` proof recipe. How far
+  to extend polynomial ideal reduction is an explicit experiment; the tactic
+  does not silently normalize every goal modulo every equality.
 - Repeated finite sums use a fold instruction instead of an expanded chain of
   additions.
 - Function-specific rewrites such as `exp (-log N / k)` or trigonometric range
@@ -392,6 +433,40 @@ fails safely with a budget diagnostic. If alternate generation reaches either
 limit, the original DAG remains valid, skipped alternates are reported, and
 search continues without them.
 
+### Instantiation frontend
+
+The frontend supports versioned instantiation rules whose triggers match
+expressions, source facts, or newly proved bounds and propose additional
+expressions for the shared program. A rule can return:
+
+- new typed SSA instructions with a canonical expression key;
+- equality edges to existing nodes;
+- derived interval facts about a generated residual or difference node;
+- side conditions and a theorem or certificate recipe for replay;
+- suggestions for contractors or local partitions that become applicable to
+  the new node.
+
+For example, a monotonicity rule may need the shaped expression `a*b ≤ a*c`
+even though neither product appears in the original goal; it can instead add
+the difference node `a*b - a*c` and derive its upper bound from `0 ≤ a` and
+`b ≤ c`. An inverse exponential contractor may introduce `log y` while
+processing `y = exp x`. These are not trusted e-matching consequences: the
+program extension and every first fact about it are replayed from the rule's
+registered theorem.
+
+Triggers are indexed by head symbols and explicit patterns rather than
+recursive typeclass search. The engine deduplicates substitutions and generated
+expressions, enforces generation and node budgets, and records why a tempting
+trigger was suppressed. Branch-local inputs produce branch-scoped facts and
+edges. The companion validates each new program snapshot before assigning any
+goal metavariable.
+
+The first prototype compares eager bounded closure, propagation-epoch
+instantiation, and fully lazy append-only generation. It also compares
+`grind`-style E-matching, a structural `apply_rules` loop, and rule-supplied
+direct proposals. Success rate, useless instances, program growth, proof size,
+and deterministic work decide the production default.
+
 ## Tactic interface
 
 The planned syntax is:
@@ -404,6 +479,12 @@ interval (config := { maxSplits := 8, maxEffort := 80 })
 interval?
 interval_bound e
 ```
+
+The tactic parser interprets the partial record in `(config := { ... })` as an
+update of the fully populated `Hex.Interval.defaultConfig`; users need not
+supply every budget field. `interval?` prints a complete versioned
+configuration when exact search reproducibility matters. Default budget values
+may be tuned before release and are benchmark data, not soundness constants.
 
 `interval [h₁, h₂]` adds the named facts to the local facts already recognized.
 `only` restricts hypothesis ingestion to the supplied facts. `interval?` runs
@@ -420,9 +501,12 @@ branch tree to prove that hull even when the original search result is
 `unknown`.
 
 The programmatic frontend exposes a `deriveBound` entry point for other
-tactics. It returns the dyadic search interval, any stronger exact rational
-source cuts, proof expressions for the selected global bounds, and search
-diagnostics.
+tactics. It returns an exact proof-facing bound bundle, including its endpoint
+encoding, a dyadic projection when requested, proof expressions for the
+selected global cuts, and search diagnostics. Under the dyadic prototype it
+also retains stronger exact rational source cuts; under a rational working
+backend, propagated rational cuts are first-class rather than mislabeled as
+sources.
 This is the future integration seam. This SPEC does not register it with
 `grind`.
 
@@ -431,10 +515,14 @@ This is the future integration seam. This SPEC does not register it with
 The stable configuration fields are:
 
 ```lean
-structure Interval.Config where
+structure Hex.Interval.Config where
   policy         : Name := `balancedV1
   maxProgramNodes : Nat
   maxFormsPerNode : Nat
+  maxGeneratedNodes : Nat
+  maxEqualityEdges : Nat
+  maxInstantiations : Nat
+  maxGenerationDepth : Nat
   maxSteps       : Nat
   maxRuleCalls   : Nat
   maxEffort      : Nat
@@ -452,8 +540,19 @@ structure Interval.Config where
   rules          : RuleFilter
 ```
 
+The displayed `balancedV1` value is the D4 prototype default, not a promise to
+make it the first public release default. The versioned name remains available
+for pinned experiments if measurements select a different default alias.
+
 The implementation also has an emergency timeout, but test expectations and
 successful replay do not depend on a particular machine reaching it.
+
+`Config.policy` is resolved in the fixed importing environment through the
+companion's versioned registry to a pure `Policy` implementation. A missing,
+ambiguous, or wrong-kind name is a configuration error before search starts;
+it never falls back to an environment-dependent arbitrary choice. Determinism
+claims quantify over a fixed import closure and registry contents as well as a
+fixed program and configuration.
 
 Effort is a natural-number precision tier. Rules are encouraged to interpret
 effort `p` as an error target near `2^-p`, but no monotonicity or error law is
@@ -470,9 +569,9 @@ planner may intersect several results.
 The required initial rules are constants, identity, negation, addition,
 subtraction, multiplication, natural powers, `abs`, `min`, and `max`. Inverse
 and division use the precision-indexed outward operations, with sign-specific
-rules and a sound coarse fallback. Square root uses monotonicity on nonnegative
-inputs and accounts for Mathlib's value on negative inputs when the interval
-is not known nonnegative.
+rules and a sound coarse fallback. The `D7` elementary portfolio adds square
+root using monotonicity on nonnegative inputs and accounts for Mathlib's value
+on negative inputs when the interval is not known nonnegative.
 
 Exact arithmetic primitives preserve their tight endpoint-attainment flags.
 An approximate elementary or user rule may deliberately close a cut when that
@@ -566,7 +665,9 @@ A point algorithm works only with exact dyadic or rational data:
 2. evaluate a convergent series or rational approximation on a small domain;
 3. prove an outward remainder bound;
 4. reconstruct the original function with proved identities;
-5. round the final cut outward to the requested dyadic precision.
+5. in the dyadic prototype, round the final cut outward to the requested
+   dyadic precision; a selected rational backend supplies its corresponding
+   exact projection contract.
 
 The certificate contains the reduction parameters, approximation order,
 endpoint values, and remainder witness. The planner selects them. The checker
@@ -575,9 +676,10 @@ verifies them.
 ### Sine and cosine
 
 The initial sine rule follows the existing experiment on `[-1,1]`: evaluate a
-rational Taylor polynomial and bound the Lagrange remainder. The implementation
-uses dyadic endpoints in its hot arithmetic and retains the experiment's
-Mathlib proof of the analytic remainder.
+rational Taylor polynomial and bound the Lagrange remainder. Its dyadic D2
+candidate uses dyadic endpoints in hot arithmetic and retains the experiment's
+Mathlib proof of the analytic remainder; the backend comparison measures the
+same certificate with rational working endpoints.
 
 Outside that range, two proved methods may coexist:
 
@@ -658,15 +760,23 @@ certificate contains the element enclosures and a balanced aggregation tree.
 A generic theorem proves the fold bound.
 
 Large batches are checked in measured chunks and combined by a balanced proof
-tree. The initial chunk ceiling is selected by batch-replay measurements. It is not
-hard-coded by this SPEC. This avoids both a linear-depth proof term and one
+tree. The initial chunk ceiling is selected by batch-replay measurements. It is
+not hard-coded by this SPEC. This avoids both a linear-depth proof term and one
 enormous Boolean reduction. Kernel-facing recursive checkers use exposed
 definitions and reduction-stable payload types. They do not rely on opaque
 array equality reduction across module boundaries.
 
 The BKLNW sums with upper limits 29, 37, 63, 145, 289, and 433 are the scaling
 ladder. Their index set is `Icc 3 N`, so they contain `N - 2` summands. The
-13,590-cell FKS2 corpus is the large-batch acceptance test.
+13,590-cell FKS2 corpus is the full `local` acceptance test used by the
+replacement and release gates. Per-PR
+`core` uses a small deterministic sample, while per-PR `ci` uses a measured
+medium shard. The complete data is streamed from split JSONL fixtures; it is
+not generated as one enormous Lean source file. JSONL is only data transport:
+the runner turns each measured chunk into the same proof/checker invocation,
+elaborates it, kernel-replays it, and includes the resulting theorems in the
+axiom audit. A compiled pass over all cells without those proof obligations
+does not satisfy the replacement criterion.
 
 ### Failure during replay
 
@@ -739,8 +849,10 @@ failure cases.
   includes `exp 1 < 2.7182818284591`, a logarithm product, nested `exp` and
   `log`, and real powers. It also records ordinary reduction getting stuck on
   a well-founded `Nat.log2`, then succeeding after a structural or fueled
-  implementation replaced it. This is the reason for the checker recursion
-  rule above.
+  implementation replaced it. Later repository experiments show that explicit
+  `Nat`-measure well-founded recursion can itself kernel-reduce when definitions
+  are exposed; the durable requirement is the mechanical reducibility probe
+  above, not a blanket ban on that recursion style.
 - A newer
   [transcendental `norm_num` discussion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/norm_num.20extension.20for.20Real.2Eexp.2C.20Real.2Elog.2C.20sin.2C.20cos/near/612728678)
   links the kernel-clean
@@ -763,6 +875,15 @@ failure cases.
   `x^2 + y^2 = 1 ⊢ x^4 + y^4 ≤ 1`. It also exposed awkward definitional
   interactions between `WithTop` and `WithBot`. Dedicated lower and upper cut
   types avoid making those implementation details part of the theorem API.
+- A public
+  [`grind` failure analysis](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/grind.20failures/near/599591286)
+  gives a concrete expression-generation failure: a theorem's E-matching
+  pattern has the shape `a*b ≤ a*c`, but those product expressions are absent
+  from the local expression database, so no instance is produced; a useful
+  distributive equality can likewise remain outside the relevant congruence
+  classes. This is the direct regression for the bounded instantiation
+  frontend above. Saturating bounds only on syntax that happened to occur in
+  the original goal is not enough.
 - The
   [sharp inequalities thread](https://leanprover.zulipchat.com/#narrow/channel/239415-metaprogramming-.2F-tactics/topic/Proving.20sharp.20inequalities.20using.20interval.20arithmetic/near/446334247)
   supplies an entropy inequality with a sharp endpoint and singular derivative,
@@ -786,13 +907,13 @@ certificates, and test nonlinear-equality handoffs plus active-subset split
 planning. Public artifacts linked by that discussion are cited in the corpus
 below; the unpublished planner case is represented by a synthetic generator.
 
-The working endpoint choice remains empirical. This SPEC selects arbitrary
-dyadics for propagated facts and preserves exact rational source facts. The
-backend-comparison milestone compares that hybrid against a separate exact
-rational search prototype with deliberate regularization on tactic-scale
-examples. The public search protocol and certificate concepts should not
-prevent a later representation revision if measured proof cost favors the
-rational variant.
+The working endpoint choice remains empirical. The primary D2 candidate uses
+arbitrary dyadics for propagated facts and preserves exact rational source
+facts. The backend-comparison milestone compares that hybrid against a
+separate exact-rational search prototype with deliberate regularization on
+tactic-scale examples. D2 records a selection before endpoint-dependent trace
+formats are frozen; the public search protocol and certificate concepts do not
+prejudge the outcome.
 
 ### Existing `bound` tactic
 
@@ -908,6 +1029,94 @@ replacement. A few translated README examples are also insufficient.
   endpoints, adaptive partitions, and verified integration. Integration
   itself is not part of the first interval tactic release.
 
+### RealPaver
+
+RealPaver is the closest operational model for the constraint-solving half of
+this design. The inspected historical description is
+[Algorithm 852](https://hal.science/hal-00480813); the current
+implementation is
+[`realpaver/realpaver` at `f9d4223`](https://github.com/realpaver/realpaver/tree/f9d422354c67daf9fcc292ff599acbe8d66cceec),
+described by the
+[RealPaver 1.1 JOSS paper](https://doi.org/10.21105/joss.09331). It does not
+provide Lean certificates, but its decomposition supplies concrete scheduler
+and contractor hypotheses to test.
+
+- RealPaver builds a shared DAG of constraint expressions, records parent and
+  child links, variable dependencies, and occurrence counts, and attaches one
+  contractor per constraint. This supports the shared SSA program and suggests
+  that repeated-occurrence count is useful policy input.
+- Its HC4 path evaluates a constraint forward and applies inverse operations
+  backward. A dependency queue reactivates only contractors mentioning a
+  variable whose domain improved past a configurable relative threshold. The
+  first Lean contractor milestone implements this recognizable baseline before
+  more elaborate learning policies.
+- Box-consistency contractors perform a one-variable search when repeated
+  occurrences make direct inversion weak. RealPaver's 3B contractor scans
+  boundary slices until it finds a survivor on each side; CID contracts every
+  slice and hulls all nonempty contracted boxes in its scope. Both temporarily
+  run another contractor on slices. They map to local `shave` actions with
+  branch certificates, not automatically to global proof-state splits.
+- ACID orders variable contractors by derivative-based smear and alternates
+  learning and exploitation phases, adapting how many expensive contractors it
+  applies from observed contraction gain. This is a particularly relevant
+  comparison for `balancedV1`: learning from gain is promising, but RealPaver's
+  constants and phase lengths are benchmark inputs, not Lean defaults.
+- RealPaver combines HC4 or BC4 propagation with interval Newton, interval
+  Gauss-Seidel, affine or Taylor linear relaxations, and polytope-hull
+  contraction. These become separately registered actions so the policy can
+  compare cost, contraction, and generated proof size.
+- It separates node exploration order from split-variable selection and offers
+  depth-first, breadth-first, distant-most, largest-domain, round-robin, and
+  derivative-smear choices. Even its ordinary split point is configurable and
+  need not be the midpoint. Lean therefore benchmarks these choices instead of
+  baking one tree discipline into soundness.
+- Its result lattice distinguishes proved empty, proved feasible/existence,
+  wholly inner, and unresolved boxes. The first interval tactic needs only
+  universal closure, contradiction, and `unknown`, but later root isolation and
+  verified graphing should preserve room for existence and inner-box
+  certificates.
+- Current RealPaver supports real variables with interval unions plus integer,
+  Boolean, conditional, table, and piecewise constraints. Those domains do not
+  enter the first release, but the operation-key and scoped-constraint design
+  must not assume every future fact is one closed real interval.
+
+One historical profile is especially instructive: inverse propagation applied
+`log` while solving constraints whose input syntax used `exp`, so the inverse
+operator did not occur in the original expression. This is a direct precedent
+for bounded expression instantiation. The Lean design compares keeping such an
+inverse expression inside a rule payload against adding a reusable validated
+node to the network.
+
+What does not translate is equally important. RealPaver relies on GAOL and
+directed hardware floating-point rounding, represents closed numerical boxes,
+and reports numerical solver status rather than proof objects. Lean uses exact
+certificate endpoints and ordinary kernel replay, retains open and unbounded
+cuts, and charges local branching and contractor work by proof size as well as
+runtime.
+
+The source-pinned comparison corpus starts with:
+
+- [`DescartesFolium.rp`](https://github.com/realpaver/realpaver/blob/f9d422354c67daf9fcc292ff599acbe8d66cceec/benchmarks/csp/DescartesFolium.rp),
+  a small polynomial-plus-exponential dependency case;
+- [`Caprasse.rp`](https://github.com/realpaver/realpaver/blob/f9d422354c67daf9fcc292ff599acbe8d66cceec/benchmarks/csp/Caprasse.rp),
+  a four-variable polynomial system;
+- [`Transistor.rp`](https://github.com/realpaver/realpaver/blob/f9d422354c67daf9fcc292ff599acbe8d66cceec/benchmarks/csp/Transistor.rp),
+  a repeated-occurrence exponential system for HC4 versus shaving;
+- the sparse
+  [`BroydenBanded-10.rp`](https://github.com/realpaver/realpaver/blob/f9d422354c67daf9fcc292ff599acbe8d66cceec/benchmarks/csp/BroydenBanded-10.rp)
+  and larger generated variants for worklist scaling;
+- [`Bratu-10.rp`](https://github.com/realpaver/realpaver/blob/f9d422354c67daf9fcc292ff599acbe8d66cceec/benchmarks/csp/Bratu-10.rp),
+  [`Troesch-10.rp`](https://github.com/realpaver/realpaver/blob/f9d422354c67daf9fcc292ff599acbe8d66cceec/benchmarks/csp/Troesch-10.rp),
+  and their larger discretizations as bridges toward certified differential
+  equations;
+- [`Trigexp1-10.rp`](https://github.com/realpaver/realpaver/blob/f9d422354c67daf9fcc292ff599acbe8d66cceec/benchmarks/csp/Trigexp1-10.rp)
+  for sparse mixed trigonometric/exponential propagation.
+
+Early translated fixtures prove contraction and contradiction for small boxes.
+Whole-system root enumeration and existence certificates are later milestones;
+the benchmark statements are not misleadingly marked as first-release tactic
+successes.
+
 ### Lessons from other systems
 
 | System or method | Adopted lesson | Deliberate limit |
@@ -918,6 +1127,7 @@ replacement. A few translated README examples are also insufficient.
 | MPFR and MPFI | Arbitrary precision, directed rounding, and argument reduction guide endpoint algorithms. | Hardware rounding state and foreign results are not trusted. |
 | Arb | Midpoint-radius balls and cached high-precision point evaluation are efficient for narrow inputs. | Balls are an internal candidate representation. Public semantics remain endpoint intervals because balls do not express open or half-infinite sets. |
 | IBEX HC4 | Dependency worklists, forward-backward contractors, contraction thresholds, smear scores, and split policies transfer directly. | Constraint solving heuristics never justify a Lean fact by themselves. |
+| RealPaver | HC4/BC4, 3B/CID shaving, gain-adaptive ACID, interval Newton, and independent choices of node order, split variable, and split point form a concrete contractor-policy ladder. | Hardware-directed rounding, closed numerical boxes, and numerical status codes are replaced by exact replayable certificates and open/unbounded cuts. |
 | HOL Light nonlinear verification | Monotonicity, convexity, boundary reuse, and certificate DAGs can scale to hard inequalities. | Full Flyspeck-style second-order verification is a later milestone. |
 | Affine arithmetic | Noise symbols retain first-order correlations and are formally verifiable. | Open and unbounded sets stay in the endpoint layer. Affine forms are a later method. |
 | Taylor models | Polynomial plus rigorous remainder is the strongest planned dependency-control method. | Full multivariate Taylor models do not block the first release. |
@@ -930,11 +1140,23 @@ selected policy, search statistics, replay time, certificate size, and axiom
 set. Exact imported statements are pinned to upstream commits when licensing
 permits copying them into test modules.
 
+Every executable fixture also records its earliest development milestone
+`D1`–`D10`, the exact rule set and budget configuration, and one of
+`success`, `unknown`, or `rejectedCertificate`. An expected `unknown` belongs
+to that pinned configuration, not to the mathematical statement forever; a
+later milestone may promote the same statement to `success` without deleting
+the diagnostic fixture. This prevents an aspirational challenge from silently
+becoming a per-PR release gate, and prevents a current limitation from being
+mistaken for an architectural prohibition.
+
 ### Endpoint semantics
 
-- all four closure combinations at finite ends;
-- both one-sided unbounded shapes and the whole interval;
-- singleton normalization and the three empty equal-endpoint shapes;
+The endpoint-shape and exact-operation cases below default to `D1`; logarithm
+domain behavior is the `D7` override.
+
+- `[D1]` all four closure combinations at finite ends;
+- `[D1]` both one-sided unbounded shapes and the whole interval;
+- `[D1]` singleton normalization and the three empty equal-endpoint shapes;
 - strict conclusion from one open summand, such as
   `x ∈ (0,1), y ∈ [0,1] ⟹ x + y < 2`;
 - reciprocal on positive open and half-open intervals, including the outward
@@ -943,11 +1165,24 @@ permits copying them into test modules.
 - logarithm at, below, and just above zero;
 - a split whose cut equals a parent endpoint.
 
+The `D1` table is exhaustive about emptiness: every unary operation preserves
+empty; arithmetic binary image and intersection operations absorb empty; hull
+uses empty as an identity; an empty split returns two empty pieces; and
+`pow empty n = empty`, including `n = 0`, while `pow I 0 = {1}` for every
+nonempty `I`. It separately checks `{0} * whole = {0}` so an
+implementation cannot confuse an empty operand with a zero singleton, and
+checks `whole * {0} = {0}` independently to catch operand-order mistakes in
+sign partitioning.
+
 ### Arithmetic and dependency
+
+Unless a later override is stated, the shared arithmetic cases in this block
+are `D3` fixtures.
 
 ```lean
 x - x = 0
 x ∈ [0,1]             ⟹ x * (1 - x) ≤ 1/4
+x ∈ [0,1]             ⟹ x * (2 - 3*x) ≤ 1/3
 x ∈ [-1,1]            ⟹ x^2 ≤ 1
 x ∈ (0,+∞)            ⟹ 0 < x / (x + 1)
 x ∈ [0,1], y ∈ [0,1]  ⟹ (x+y)*x + (x+y) ≥ 0
@@ -956,20 +1191,43 @@ x ∈ [0,1], y ∈ [0,1]  ⟹ (x+y)*x + (x+y) ≥ 0
 These cases distinguish proved same-node cancellation, centered forms,
 contractors, and subdivision from naive repeated interval evaluation. Sharing
 alone does not prove `x - x = 0`; the exact cancellation alternate does.
+The first sharp quadratic is a `D6` success without a global split, through
+the exact centered identity `x*(1-x) = 1/4 - (x-1/2)^2`; merely observing that
+its extremum is dyadic is not the certificate. The second is retained as
+`unknown` under a pinned `D9` diagnostic using `bisectV1`, exactly the natural
+and derivative-sign rule filters, `maxSplits := 16`, `maxDepth := 16`,
+`maxSteps := 1000`, and `maxEffort := 32`, with no symbolic square completion
+or polynomial certificate. Its sharp maximizer is `1/3`, so every finite
+dyadic partition leaves one cell containing it. It becomes an expected `D10`
+success through exact square completion/SOS or a certified symbolic rational
+critical-point partition. Bernstein remains a comparison method; by itself on
+finite dyadic cells it is not promised to attain the sharp nondyadic maximum.
 
 Additional coordination and handoff cases are:
 
-- `x^2 + y^2 = 1 ⟹ x^4 + y^4 ≤ 1`, which needs information to move from a
-  nonlinear equality into the forward bounds;
-- `y * 2 - y * Real.sqrt 2 ^ 2 ≤ 0`, using
+- `[D4]` `x^2 + y^2 = 1 ⟹ x^4 + y^4 ≤ 1`, using a certified contextual
+  alternate such as `x^4 + y^4 = 1 - 2*x^2*y^2`; this is not advertised as a
+  natural-interval consequence;
+- `[D4]` a sparse-registry instantiation regression modeled on the public
+  `grind` case: the input program contains `a*(b-c)` with facts `0 ≤ a` and
+  `b ≤ c`, while a registered trigger proposes `a*b`, `a*c`, and a proved
+  distributive equality edge. With instantiation disabled the pinned registry
+  returns `unknown`; with it enabled the generated nodes are deduplicated and
+  replay closes the same goal;
+- `[D7]` `y * 2 - y * Real.sqrt 2 ^ 2 ≤ 0`, using
   `Real.sq_sqrt zero_le_two` before the linear arithmetic handoff;
-- the four-corner multiplication theorem: from `a ≤ u ≤ b`, `c ≤ v ≤ d`,
+- `[D3]` the four-corner multiplication theorem: from `a ≤ u ≤ b`,
+  `c ≤ v ≤ d`,
   and a lower bound below all four products `a*c`, `a*d`, `b*c`, `b*d`, prove
   that it is below `u*v`;
-- `0 ≤ 1 - 3*x^2*y^2 + x^2*y^4 + x^4*y^2` as a handoff case. A polynomial
-  certificate tactic can solve the residual, while plain intervals over
-  unbounded variables should decline it;
-- a deterministic synthetic generator parameterized by variable count,
+- `[D10 unknown]` `0 ≤ 1 - 3*x^2*y^2 + x^2*y^4 + x^4*y^2` as a handoff
+  case. This is the
+  Motzkin polynomial, which is nonnegative but not a sum of polynomial
+  squares; an ordinary SOS certificate is therefore not an honest expected
+  solver. Plain intervals over unbounded variables must decline it. A later
+  multiplier/Positivstellensatz-style or dedicated polynomial certificate may
+  solve the residual;
+- `[D9]` a deterministic synthetic generator parameterized by variable count,
   irrelevant linear constraints, and constraints of the form `ν ≤ max a b`.
   Its known solution uses a small active subset while the number of apparent
   max branches grows rapidly. It tests split planning without reproducing an
@@ -977,9 +1235,11 @@ Additional coordination and handoff cases are:
 
 ### Elementary functions
 
-- the sine experiment's point bounds
+These are `D7` fixtures unless marked otherwise.
+
+- `[D5]` the sine experiment's point bounds
   `-25/48 ≤ sin (-1/2)` and `sin (1/3) ≤ 637/1944`;
-- `|sin x| ≤ 1` on an unbounded input;
+- `[D5]` `|sin x| ≤ 1` on an unbounded input;
 - a narrow sine interval crossing a critical point;
 - a large-argument sine that uses periodic reduction;
 - exact `sin π = 0` through a symbolic rewrite;
@@ -998,7 +1258,7 @@ Additional coordination and handoff cases are:
 
 ### PNT+ compatibility
 
-The committed compatibility subset includes:
+The committed compatibility subset is `D8` unless marked `D9`:
 
 - two-sided `log 2` and `log 3` bounds;
 - the one-sided nested bound `0.633415 < log (log 6.58)` and the two-sided
@@ -1008,10 +1268,12 @@ The committed compatibility subset includes:
   `10^9 ≤ exp 22`;
 - representative `10^-20` and `10^-100` tail bounds;
 - BKLNW sums with upper limits 29, 37, 63, 145, 289, and 433;
-- one Table 10 shard and the recorded false target as an expected failure;
-- the approximately 135-case Table 12 batch, plus one of its four false
+- `[D9]` one Table 10 shard and the recorded false target as an expected
+  failure;
+- `[D9]` the approximately 135-case Table 12 batch, plus one of its four false
   original boundary rows as an expected failure;
-- a small, medium, and complete 13,590-cell FKS2 batch;
+- `[D9]` a small deterministic FKS2 sample in per-PR `core`, a measured medium
+  shard in per-PR `ci`, and all 13,590 cells in the `local`/release profile;
 - mutated Taylor, range-reduction, fold, and split certificates, all rejected.
 
 The [PNT+ log-table generator](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/be5e07e04cde20c5ceabf63759bd097a9c88173f/scripts/gen_log_tables.py)
@@ -1223,6 +1485,107 @@ g/v * tan (35*d) ∈ [3*d, 3.1*d].
 These cases do not enlarge the trusted base. A new method must still finish by
 producing ordinary interval facts and replay the same branch theorem.
 
+## Downstream applications
+
+The following applications are not gates for the first tactic release. They
+do constrain a few interfaces now: best-bound queries must return proofs,
+batch certificates and subdivision must be reusable outside goal closure, and
+the result type must leave room for existence as well as universal enclosure.
+
+### Verified raster graphs
+
+A verified graphing layer takes a function `f : ℝ → ℝ`, a proved input
+domain, an exact dyadic viewport, and a finite pixel grid. Pixel ownership is
+defined mathematically, using a canonical half-open partition with an explicit
+convention for the outermost edges; it is not inferred from a graphics
+library's floating-point coordinate conversion. For horizontal cell `X_j` and
+vertical cell `Y_i`, its proof-facing result is initially three-valued:
+
+```lean
+inductive PixelClass
+  | miss
+  | hit
+  | unknown
+```
+
+The raster certificate associates each `miss` with a proof that no
+`x ∈ domain ∩ X_j` has `f x ∈ Y_i`, and each `hit` with a proof that some
+such `x` exists. `unknown` is an honest unresolved cell, not a colored guess.
+Direct exact witnesses, a certified point enclosure wholly inside a pixel, an
+intermediate-value bracket, or a root-isolation certificate may establish a
+hit. Ordinary range enclosure most naturally proves misses.
+
+Two useful output contracts are deliberately distinct:
+
+1. An **outer raster** marks a set of pixels whose union provably contains the
+   graph in the viewport. It guarantees no missing graph point but may contain
+   false-positive pixels. Column-wise range enclosures already provide this.
+2. An **exact raster** proves for every pixel that it is lit if and only if its
+   mathematical cell intersects the graph. It can be emitted only when every
+   cell has a `hit` or `miss` certificate. A three-valued raster remains fully
+   verified even when this stronger binary projection is unavailable.
+
+The planner may use adaptive horizontal subdivision, a quadtree, derivative
+and monotonicity bounds, continuity, and batched evaluation of shared
+subexpressions. It should refine only pixels or columns whose classification
+can change. The proof object binds the exact row-major classification array,
+grid dimensions, viewport transform, and boundary convention. PNG encoding,
+color selection, antialiasing, and display remain untrusted presentation; a
+renderer is correct only insofar as it is shown or independently checked to
+render that certified array. A hash may identify an exported array, but a hash
+alone is not a theorem about a decoded image.
+
+The first graphing milestone should target proved outer rasters plus explicit
+misses and a small set of easy hits. Exact binary rasters, discontinuities,
+implicit curves, and antialiased coverage are later experiments. RealPaver's
+empty/feasible/inner/maybe distinction is evidence that retaining these result
+classes is operationally useful.
+
+### Certified differential equations
+
+A later ODE layer can reuse the interval program, automatic differentiation,
+Taylor payloads, local subdivision, batch checking, and gain-based policy. Its
+basic certificate concerns an initial-value problem `u' = F(t,u)`. The API
+distinguishes three claims: existence of at least one solution inside a tube;
+an enclosure of the unique flow when an applicable uniqueness theorem covers
+all solutions with the given initial data; and a universal reachable-set
+enclosure for a set of initial data. Only the latter two justify saying that a
+tube contains every solution of interest. A certified endpoint enclosure is
+tagged by which claim proved it before adjacent step theorems are composed.
+
+The additional mathematics is substantial and is not smuggled into the first
+release requirements:
+
+- a Picard or related inclusion proving that a solution exists in the proposed
+  tube; a Lipschitz/contraction argument covering the ambient solution class
+  when uniqueness is claimed; or a separate all-solutions a-priori containment
+  theorem when a universal reachable tube is claimed;
+- certified Taylor coefficients and a truncation/remainder enclosure over the
+  whole step, not only a numerical endpoint evaluation;
+- interval Jacobians, matrix bounds, and eventually affine or Taylor-model
+  state to control the wrapping effect;
+- exact composition of time-step domains and endpoint enclosures, including
+  rejected steps and adaptive changes of step size and order;
+- certified event isolation and preservation of invariants when a solver
+  crosses a guard or changes regimes.
+
+Step size, method order, preconditioning, and subdivision are untrusted search
+choices. Their certificates replay through ordinary Lean theorems. The Bratu,
+Troesch, and Broyden benchmark families are useful contractor and scaling
+proxies before a full ODE certificate format exists, but passing their static
+discretizations is not evidence by itself for existence, uniqueness, or a
+validated flow. The current architecture should therefore preserve reusable
+rule state and typed payloads without prematurely fixing an ODE-specific trace
+format.
+
+Step composition respects the claim tag. Two existence-only certificates do
+not compose merely because their endpoint intervals overlap: the first may end
+at a state different from the initial witness chosen by the second. The next
+existence theorem must be uniform over every admitted predecessor endpoint, or
+carry a dependent continuation theorem for the actual endpoint witness.
+Unique-flow and universal-reachable certificates instead require the previous
+output enclosure to be contained in the next step's certified input set.
+
 ## Conformance
 
 The required Lean-only checks include:
@@ -1230,31 +1593,69 @@ The required Lean-only checks include:
 - semantic theorems for every interval operation and endpoint shape;
 - one direct and one certificate-backed propagator registration;
 - failure of a deliberately corrupted registration payload;
+- `[D4]` a dishonest compiled evaluator whose proposal is accepted into an
+  untrusted retained trace and is then rejected by replay before goal
+  assignment. The fixture uses a singleton whose true value lies outside the
+  proposed interval, so an early heuristic rejection cannot accidentally be
+  the only trust-boundary test;
 - rejection of out-of-range operation, node, fact, and payload identifiers;
+- `[D4]` rejection of a generated program extension with a bad topological order,
+  invisible scope, duplicate canonical key, or equality edge whose proof
+  recipe has different endpoints;
 - rejection of a wrong input side or fact version, sibling or non-ancestor
   dependencies, cyclic or multiply-parented scopes, a mismatched split
   assumption, and a `Close.goal` whose facts do not imply the target;
 - raw-expression reification for casts, decimals, powers, `abs`, shared terms,
   and finite folds;
+- `[D4]` a cast regression in which intrinsic `0 ≤ (n : ℝ)` for `n : ℕ` is
+  necessary inside a larger product, both normally and under `interval only`;
 - goal closure for strict, non-strict, equality, disequality, membership,
   contradiction, and conjunction targets;
 - safe refusal for an unsupported function and an exhausted budget;
 - a proof axiom audit excluding compiler trust and `sorryAx`;
 - proof sharing across repeated subexpressions and split branches;
-- chunked fold replay at every chunk boundary.
+- chunked fold replay at every chunk boundary;
+- `[D2]` a `Lean.Kernel.whnf` and `decide +kernel` reduction probe in a
+  downstream module for every registered kernel-facing checker, with one small
+  case covering each recursive route and the complete transitive exposure
+  closure rather than only the defining module;
+- `[D4]` metamorphic determinism checks for `balancedV1` at a fixed step budget.
+  Alpha-renaming and permutation of independent hypotheses compare normalized
+  action keys and mathematical outputs, not unstable source identifiers. An
+  inserted disconnected consistent fact is required to preserve only the
+  result status and mathematical bound, because it legitimately changes the
+  reified program and falls outside fixed-program trace determinism;
+- `[D4]` one deliberately false target, `x ≤ 1` from `x ∈ [0,2]`, whose same
+  exhausted `SearchResult` records a counterexample scope narrowed to `(1,2]`
+  yet extracts the global best bound `[0,2]` under `ProofPlan.direct`; no fresh
+  second search may satisfy the fixture, and no fact learned under the
+  temporary negated target may appear in that plan.
 
 Every malformed-trace case must fail before the tactic assigns the user's
 goal metavariable.
 
 The external oracle profile uses `python-flint` Arb for independently computed
-point and elementary-function enclosures. A fixture fixes an input box and a
-coarse rational target. Lean proves that the function image lies in the target.
-Arb independently encloses the complete closed input ball at higher precision
-and checks that its enclosure also lies in the same target. Separate fixtures
-sample deterministic rational points and exercise known extrema and domain
-boundaries. This is bug-finding evidence, not a proof and not a runtime
-dependency. CoqInterval or MPFI comparison runs may be local informational
-tests.
+point and elementary-function enclosures. For designated point, monotone, or
+range fixtures where the pinned high-precision Arb computation is
+independently known to enclose the complete original closed box more tightly
+than the expected Lean result, Arb starts again from those exact inputs; after
+an explicit outward conversion and stated rounding slack, its enclosure must
+lie inside the enclosure returned by Lean. A separate assertion requires
+Lean's enclosure to meet the fixture's width or endpoint target. Generic ball
+evaluation is not required to fit inside a dependency-aware Lean enclosure:
+fixtures where that premise is not justified instead use deterministic
+rational samples, certified known extrema, and domain-boundary checks. Merely
+placing both results inside the same coarse target is not an oracle check.
+This is bug-finding evidence, not a proof and not a runtime dependency.
+CoqInterval or MPFI comparison runs may be local informational tests.
+
+The `core` profile runs on every PR. The medium FKS2 shard and available Arb
+checks form `ci`; the complete 13,590-cell stream, complete translated solver
+families, and expensive comparison campaigns are `local`/release tests. Split
+JSONL fixtures keep generation and comparison streaming and avoid a single
+large generated Lean module. “Release” means a pinned mandatory invocation of
+that `local` profile, including chunked elaboration, kernel replay, and the
+axiom audit; it is not a separate testing profile.
 
 ## Performance acceptance
 
@@ -1282,9 +1683,11 @@ validation, are:
   depth;
 - batch replay: no linear elaboration-depth growth and no chunk requiring an
   increased recursion limit;
-- the complete FKS2 corpus: bounded per-cell certificate size, shared static
-  data, and no theorem or object-file blowup proportional to duplicated
-  transcendental tables.
+- the per-PR FKS2 shard: bounded per-cell certificate size, shared static data,
+  and no theorem or object-file blowup proportional to duplicated
+  transcendental tables;
+- the complete 13,590-cell FKS2 `local` run as a replacement/release criterion,
+  with the same per-cell metrics and a reported total wall-clock time.
 
 The LeanCert version pinned by PNT+ is a migration baseline. The new tactic is
 not declared a replacement until it proves the selected downstream corpus,
@@ -1293,36 +1696,74 @@ size on every large tier without a serious regression on the other measure.
 
 ## Development order
 
-1. Prove interval semantics, normalization, arithmetic enclosure, rational
-   projection, regularization, and split coverage.
-2. Before freezing checker or trace formats, build a narrow vertical
-   feasibility prototype for one small arithmetic DAG, the BKLNW fold with
+1. **D1 — endpoint kernel.** Prove interval semantics, normalization,
+   arithmetic enclosure, rational projection, regularization, split coverage,
+   and the complete empty-operation table.
+2. **D2 — replay feasibility.** Before freezing representation, checker, or
+   trace formats, build a narrow vertical feasibility prototype for one small
+   arithmetic DAG, one bounded instantiation that adds a node and transports a
+   fact across its equality edge, the BKLNW fold with
    upper limit 433, and one high-precision `exp` or `log` certificate. For each,
    record compiled checking, proof construction, kernel replay, transitive
    axioms, proof and object bytes, and incremental import time. Failure to make
    ordinary kernel replay practical changes the architecture before wider
-   implementation.
-3. Implement the production shared program, natural evaluator, generic
-   soundness theorem, reifier, and scoped proof slicer for arithmetic over
-   `ℝ`.
-4. Add the explicit rule registry, multiple methods per head, diagnostics, and
-   the `interval` and `interval_bound` frontends.
-5. Port the sine experiment to dyadic endpoints. Add stateful Taylor
-   certificates and the triple-angle rewrite.
-6. Add centered automatic differentiation, derivative-sign monotonicity, and
-   dependency-aware backward propagation.
-7. Add `π`, `exp`, `log`, square root, `atan`, positive-base real powers,
-   certified range reduction, and symbolic special values.
-8. Add production chunked folds and the PNT+ point and sum corpus. Remove every
-   need for a `native_decide` proof path in the selected compatibility files.
-9. Add arbitrary and function-suggested subdivision, then the Table 10, Table
-   12, FKS2, and complete IMO partition tiers.
-10. Compare Bernstein, second-order, affine, and Taylor-model methods on the
-    challenge corpus before selecting further defaults.
+   implementation. Compare bundled versus externally checked interval
+   invariants, dyadic versus rational working facts, the branch-storage
+   candidates, and direct versus reflected trace leaves. Install downstream
+   kernel-reduction probes at this milestone and retain them thereafter. The
+   trace schema remains provisional through D4 if this tiny extension case has
+   not yet selected a representation.
+3. **D3 — shared arithmetic.** Implement the production shared program,
+   natural evaluator, generic soundness theorem, reifier, and scoped proof
+   slicer for arithmetic over `ℝ`.
+4. **D4 — extensible network.** Add the explicit rule registry, multiple
+   methods per head, bounded expression instantiation, equality transport,
+   contextual polynomial alternates, diagnostics, and the `interval` and
+   `interval_bound` frontends. Compare eager, epoch-based, and lazy generation
+   before selecting a default.
+5. **D5 — first analytic rules.** Port the sine experiment to exact endpoints,
+   add the paired cosine enclosure, stateful Taylor certificates, and the
+   triple-angle rewrite.
+6. **D6 — contractors.** Add centered automatic differentiation,
+   derivative-sign monotonicity, and a recognizable HC4 forward/backward
+   baseline with event-driven reactivation. Prototype 3B/CID-style local
+   shaving and compare relative-improvement thresholds against unconditional
+   worklist wakeups.
+7. **D7 — elementary portfolio.** Add `π`, `exp`, `log`, square root, `atan`,
+   positive-base real powers, certified range reduction, and symbolic special
+   values.
+8. **D8 — large certificates.** Add production chunked folds and the PNT+
+   point and sum corpus. Remove every need for a `native_decide` proof path in
+   the selected compatibility files.
+9. **D9 — branch search.** Add arbitrary and function-suggested subdivision,
+   plus the Table 10, Table 12, and tiered FKS2 tests. Compare split variable,
+   point, and node-order strategies rather than coupling them. Local shaving,
+   interval Newton, the complete IMO partition, the full FKS2 run, and small
+   translated RealPaver benchmarks are separately labeled prototype or
+   replacement-acceptance subtargets within this milestone.
+10. **D10 — advanced dependency control.** Compare Bernstein,
+    second-order, affine, and Taylor-model methods, plus gain-adaptive ACID-like
+    contractor scheduling, on the challenge corpus before selecting further
+    defaults. Exercise clean handoff to `hex-rcf` for genuinely univariate
+    real-closed-field residuals; multivariate cases such as Motzkin remain
+    outside that tactic's contract.
 
 Every stage has real executable definitions and tests for its advertised
 surface. Unimplemented methods remain absent rather than returning ceremonial
 wide answers that masquerade as the intended algorithm.
+
+`D1`–`D10` is a dependency order, not ten uniform release gates. The first
+public release target is D1–D8 plus the basic arbitrary/function-suggested
+split path and small per-PR D9 samples. Claiming that the tactic replaces
+LeanCert additionally requires the selected full PNT+ local profile, including
+the complete FKS2 stream and whichever D9 contractor prototypes those cases
+actually need. D10 is comparative follow-on work and does not block either
+claim unless the measured replacement corpus demonstrates that one of its
+methods is necessary.
+
+Verified raster graphing begins only after the `interval_bound` and batch APIs
+are stable; certified ODE integration is a later client of D6/D10 machinery.
+Neither application is a release or replacement gate above.
 
 ## Open design questions
 
@@ -1350,7 +1791,32 @@ the fixed soundness and trust contracts.
 9. Does the dyadic-working and exact-rational-source hybrid beat an exact
    rational working backend with regularization on real tactic workloads?
 10. For the initial rule portfolio, do function-specific subdivision
-    suggestions produce better gain per proof node than backward contractors?
+    suggestions produce better gain per proof node than HC4, box consistency,
+    3B/CID shaving, or interval Newton? Which RealPaver-style improvement
+    thresholds and ACID learning signals remain useful after proof-construction
+    cost is included?
+11. Does `Hex.Interval` internally bundle the cut-consistency proof, or use
+    plain normalized data with Boolean validation at construction and replay
+    boundaries?
+12. Which branch-state representation wins at the observed sizes: array
+    copy-on-write, a persistent paged trie, chunked parent/delta overlays, or
+    depth-first mutation with a rollback trail? Is a hybrid crossover useful?
+13. What is the smallest stable derivation language after the D2 vertical
+    prototype: explicit equality transport and program-extension constructors,
+    or validated tables referenced by fewer generic constructors?
+14. Should bounded expression instantiation be eager, propagation-epoch based,
+    or fully lazy? Which triggers need congruence/E-matching, which should make
+    direct structural proposals, and when should generated nodes be global
+    rather than branch-local?
+15. Which deterministic policy becomes the release default after comparing the
+    staged `balancedV1` prototype, simple fair queues, RealPaver-style
+    gain-adaptive scheduling, and bandit-like scores? The answer may differ by
+    pinned policy name without altering proof validity.
+16. For verified graphs, is the most useful first artifact a certified outer
+    cover, a ternary raster with local hit/miss proofs, or both? Which hit
+    certificates justify the cost of exact binary pixels?
+17. Which interval, affine, or Taylor payload API can later serve validated ODE
+    steps without freezing an ODE trace or complicating the first tactic?
 
 ## File organization
 
@@ -1376,16 +1842,36 @@ the fixed soundness and trust contracts.
 - `conformance/HexInterval/EmitFixtures.lean`: Mathlib-free arithmetic oracle
   fixtures.
 - `conformance/HexIntervalMathlib/Conformance.lean`: tactic, replay, axiom, and
-  migrated downstream regressions.
+  small migrated downstream regressions in the per-PR `core` profile.
+- `conformance/HexIntervalMathlib/CrossCheck.lean`: the measured deterministic
+  medium FKS2 shard, included in the per-PR `HexConformance` target under the
+  repository's standard heavier-check module name.
 - `conformance/HexIntervalMathlib/EmitFixtures.lean`: elementary-function
   fixtures for the external oracle.
+- `conformance-fixtures/HexIntervalMathlib/`: split JSONL inputs and pinned
+  release manifests for the elementary and full-corpus campaigns.
+- `conformance/HexIntervalMathlib/Generated/`: gitignored Lean chunk modules
+  materialized only for a full local run. They belong to the explicit
+  non-default `HexIntervalLocalConformance` Lake target, not the per-PR
+  `HexConformance` globs.
+- `scripts/conformance/run_hex_interval_local.sh`: stream the split JSONL,
+  first regenerate the complete fixed set of chunk modules plus a balanced
+  aggregator under that `Generated/` directory, then run
+  `lake build HexIntervalLocalConformance`, and finally audit every resulting
+  theorem. The target is never invoked without this generation step. The
+  pinned release invocation records fixture hashes, chunk size, config, and
+  toolchain.
 
 Unlike a correspondence-only companion, `hex-interval-mathlib` contains an
 executable reifier, rule registry, and tactic. Its own conformance target tests
 that runtime-facing API while keeping the released Mathlib-free conformance
 target free of Mathlib imports. Small explanatory examples remain in
 `Examples.lean`; the bulk PNT+, nonlinear, and challenge corpus belongs in the
-companion conformance project and is built in CI.
+companion conformance project. Its `core` and measured `ci` profiles are built
+on every PR; complete FKS2 and other full campaigns remain `local` campaigns,
+with pinned invocations used as release gates. The generated local modules are
+proof-bearing inputs to an ordinary Lake build, not a compiled fixture-only
+shortcut, and no additional workflow or CI job is introduced.
 
 ## References
 
@@ -1409,6 +1895,11 @@ companion conformance project and is built in CI.
   [Arb: efficient arbitrary-precision midpoint-radius interval arithmetic](https://arxiv.org/abs/1611.02831).
 - [IBEX contractors](https://ibex-team.github.io/ibex-lib/contractor.html)
   and [IBEX strategies](https://ibex-team.github.io/ibex-lib/strategy.html).
+- Laurent Granvilliers and Frédéric Benhamou,
+  [Algorithm 852: RealPaver](https://hal.science/hal-00480813),
+  together with the
+  [RealPaver 1.1 paper](https://doi.org/10.21105/joss.09331) and
+  [source repository](https://github.com/realpaver/realpaver).
 - [Isabelle verified affine arithmetic](https://isa-afp.org/entries/Affine_Arithmetic.html)
   and [verified Taylor models](https://isa-afp.org/entries/Taylor_Models.html).
 - Lawrence Paulson,

--- a/SPEC/Libraries/hex-interval-mathlib.md
+++ b/SPEC/Libraries/hex-interval-mathlib.md
@@ -1,0 +1,1422 @@
+# hex-interval-mathlib (real semantics, verified propagators, and the `interval` tactic)
+
+`hex-interval-mathlib` gives mathematical meaning to
+[hex-interval](hex-interval.md), proves soundness theorems for interval
+propagators, and provides the `interval` tactic. It depends on Mathlib and
+`hex-interval`. There is no separate proof-only companion beyond this library.
+
+The tactic proves bounds for ordinary Lean expressions over `ℝ`. It reads
+bounds from the local context, reifies shared expressions to a static
+single-assignment program, runs the compiled `hex-interval` search, and turns
+the successful trace into an ordinary Lean proof. Search is untrusted. A rule
+can affect the generated theorem only by supplying a proof through its
+registered soundness theorem or verified certificate checker.
+
+This design is intended to replace LeanCert for interval proofs, not to wrap
+it. The compatibility milestone includes the actual PNT+ workloads and checks
+that generated theorems do not depend on compiler trust. No implementation,
+example, test, or fallback in this library uses `native_decide`.
+
+A later domain registration may give direct interval semantics to `ℚ`. The
+first release handles `ℚ`, `ℤ`, and `ℕ` literals and casts into `ℝ`. Direct
+interval facts for the discrete types need ceil/floor normalization and a
+separate domain contract; the dense dyadic-cut invariant is not reused for
+them. No frontend uses recursive typeclass search to synthesize
+per-expression propagators.
+
+## User contract
+
+The main tactic is best-effort:
+
+```lean
+example (x : ℝ) (hx : x ∈ Set.Icc 0 1) : x * (1 - x) ≤ 1 / 4 := by
+  interval
+
+example (x : ℝ) (hx : x ∈ Set.Ioo 0 1) : x + x < 2 := by
+  interval
+
+example : (3 : ℝ) < Real.pi := by
+  interval
+```
+
+On success, the goal is closed by a kernel-checked proof. On failure, the
+tactic leaves the goal unchanged and reports the best relevant bounds, the
+main source of overestimation, useful untried actions, and the exhausted
+budgets. It never changes a strict goal to a non-strict one and never accepts a
+numerical candidate without checking its enclosure theorem.
+
+Bounds obtained only after assuming the negation of the goal are labeled as
+conditional counterexample-box bounds. They are not offered in a pasteable
+`have` statement. Context-wide bounds come from the original assumption scope
+or a separate `interval_bound` search.
+
+The initial target forms are:
+
+- `s < t`, `s ≤ t`, `s > t`, and `s ≥ t`;
+- `s = t` when both sides reduce to the same singleton enclosure;
+- `s ≠ t` when an enclosure of `s - t` excludes zero;
+- membership in `Set.Icc`, `Set.Ico`, `Set.Ioc`, `Set.Ioo`, `Set.Ici`,
+  `Set.Ioi`, `Set.Iic`, or `Set.Iio`;
+- `False`, when the interval facts in the context are inconsistent;
+- conjunctions whose leaves all have one of these forms.
+
+The tactic does not introduce quantifiers or implications. Users write
+`intro` when needed. It declines unsupported propositions with a message that
+names the first unsupported expression.
+
+## Semantic layer
+
+Finite endpoints use the exact embedding `(d.toRat : ℝ)`, following the Hex
+root libraries without adding a dependency on them. The interval membership
+relation is:
+
+```lean
+namespace Hex
+namespace Interval
+
+def Lower.Holds : Lower → ℝ → Prop
+  | .unbounded, _      => True
+  | .finite a false, x => (a.toRat : ℝ) ≤ x
+  | .finite a true,  x => (a.toRat : ℝ) < x
+
+def Upper.Holds : Upper → ℝ → Prop
+  | .finite b false, x => x ≤ (b.toRat : ℝ)
+  | .finite b true,  x => x < (b.toRat : ℝ)
+  | .unbounded, _      => True
+
+end Interval
+
+def Interval.Mem (I : Interval) (x : ℝ) : Prop :=
+  match I.repr with
+  | .empty        => False
+  | .bounds lo hi => lo.Holds x ∧ hi.Holds x
+
+end Hex
+```
+
+The notation `x ∈ᵢ I` is local to this library. The public conversion lemmas
+identify each normalized shape with the corresponding Mathlib set interval.
+Infinities are endpoint markers, not real values.
+
+The foundational theorems are:
+
+```lean
+theorem mem_intersect : x ∈ᵢ I → x ∈ᵢ J → x ∈ᵢ intersect I J
+theorem mem_hull_left  : x ∈ᵢ I → x ∈ᵢ hull I J
+theorem mem_hull_right : x ∈ᵢ J → x ∈ᵢ hull I J
+theorem split_cover : x ∈ᵢ I → x ∈ᵢ (split I m).1 ∨ x ∈ᵢ (split I m).2
+theorem not_mem_empty : ¬x ∈ᵢ .empty
+```
+
+Each arithmetic operation has an image theorem. Representative shapes are:
+
+```lean
+theorem mem_add : x ∈ᵢ I → y ∈ᵢ J → x + y ∈ᵢ add I J
+theorem mem_mul : x ∈ᵢ I → y ∈ᵢ J → x * y ∈ᵢ mul I J
+theorem mem_invAt : x ∈ᵢ I → x⁻¹ ∈ᵢ invAt p I
+theorem mem_divAt : x ∈ᵢ I → y ∈ᵢ J → x / y ∈ᵢ divAt p I J
+theorem mem_pow : x ∈ᵢ I → x ^ n ∈ᵢ pow I n
+theorem mem_regularize : x ∈ᵢ I → x ∈ᵢ regularize p I
+```
+
+Proofs cover empty and unbounded inputs directly. They do not infer field laws
+from interval operations.
+
+### Total functions and domain conditions
+
+The theorem statement follows Lean's function, including its values outside a
+traditional analytic domain. For example, a reciprocal rule crossing zero
+must account for `0⁻¹ = 0`. A logarithm rule may use a tight monotonic theorem
+only after proving the input interval is positive. Otherwise it uses a theorem
+for Mathlib's total `Real.log`, returns a coarse result, or reports the rule as
+inapplicable.
+
+A rule result records analytic side conditions separately from its interval:
+
+- input lies in the theorem's domain;
+- differentiability or continuity holds where a centered method uses it;
+- a monotonicity sign is proved;
+- a reduction identity is valid for the selected parameters.
+
+This is more useful for proof construction than attaching an IEEE decoration
+to every interval value.
+
+## Trust model
+
+There are three computational layers.
+
+1. The planner and propagator evaluators run as compiled Lean code during
+   elaboration. They may select precision, Taylor order, algebraic form,
+   contractors, and split points. Their answers are untrusted.
+2. Each retained rule application has a small soundness theorem. Expensive
+   rules also have a rule-specific certificate and checker.
+3. The replay elaborator applies those theorems, constructs kernel-checkable
+   evidence for literal certificates, and emits the final proof. The Lean
+   kernel checks that proof in the ordinary way.
+
+The planner is never reduced in the kernel. The compiler does not certify any
+mathematical fact. A compiler error may cause search to fail or propose bad
+data, but bad data cannot satisfy the replay theorem.
+
+Every kernel-facing checker uses structural recursion or an explicit natural
+fuel whose decrease is visible after reduction. A checker must not hide a
+well-founded recursion whose proof terms block ordinary kernel evaluation.
+This applies in particular to logarithm and bit-precision helpers. Compiled
+and kernel evaluation are benchmarked separately before a checker is admitted
+to generated proofs.
+
+A compiled call to a Boolean checker is only a preflight optimization. It is
+never converted into a proof. Every premise such as
+`hcheck : check payload = true`, as well as program and trace validity, is
+supplied by transparent kernel reduction (`rfl` where practical), ordinary
+kernel `decide`, or an explicit theorem chain. If that construction is too
+large or fails to reduce, replay fails. Splitting a certificate into chunks
+does not change this rule; each chunk receives its own kernel-checkable
+equality proof.
+
+### Axiom contract
+
+Every public tactic regression checks its theorem's axioms. CI also enumerates
+every built-in registered soundness theorem and checker theorem and audits its
+transitive axiom set. Before the library is released, those registrations,
+representative proofs, and every PNT+ compatibility fixture must exclude:
+
+- `Lean.ofReduceBool`;
+- `Lean.trustCompiler`;
+- generated declarations matching `*.native_decide.ax_*`;
+- `sorryAx`;
+- every project-local axiom.
+
+The expected dependencies are ordinary mathematical axioms already used by
+Mathlib, such as choice or quotient soundness when the invoked theorem needs
+them. The audit reports the exact set rather than asserting an informal
+"axiom-free" label.
+
+A release source audit rejects declarations of `axiom`, `sorry`, or `admit`,
+uses of `native_decide`, and uses of `Lean.ofReduceBool` anywhere in the
+library family. Import tests ensure that a consumer of the logarithm rules
+does not acquire unrelated unfinished obligations from trigonometric or
+error-function modules. User registrations remain the user's trust choice,
+but the trace and diagnostics identify them and their transitive axiom set can
+be requested by the same audit command.
+
+`native_decide` is banned even for a fallback or a supposedly temporary large
+fixture. Small literal checks may use kernel `decide` when their transparent
+reduction is measured and stable. Proof-producing tactics such as `norm_num`,
+`ring`, and `linarith` are also admissible. Large batches use the certificate
+scheme below rather than one enormous kernel reduction.
+
+## Program semantics and the golden theorem
+
+The reified program is an array of typed instructions whose arguments refer to
+earlier entries. A valuation assigns real values to free-variable nodes. The
+program's `OpKey` table gives each instruction its real meaning; a chosen
+`RuleKey` is only a method for enclosing that meaning.
+
+The natural checker does not interpret arbitrary operation keys from the
+extension registry. It has a fixed, kernel-visible `Natural.Prim` language for
+variables, exact constants, negation, addition, subtraction, multiplication,
+and natural powers. A validated natural region records the translation from
+its program-local `OpId`s to those primitives. Adding a user propagator cannot
+extend this trusted interpreter. Custom functions, alternate forms, and
+adaptive steps replay through explicit theorem applications or
+rule-specific checker theorems.
+
+Natural interval evaluation has one generic theorem for such a validated
+region:
+
+```lean
+theorem Natural.eval_mem
+    (hregion : Natural.Region p region)
+    (hinputs : Inputs.Mem valuation inputBox)
+    (hcert : Natural.check region inputBox output cert = true) :
+    Natural.eval region valuation output.node ∈ᵢ output.interval
+```
+
+The exact API may separate validation, evaluation, and the output lookup. The
+essential point is that one induction over the shared program proves all
+ordinary arithmetic instructions. Repeated subexpressions are evaluated and
+proved once.
+
+Reification also constructs semantic links. For each region boundary or
+custom node, replay retains a proof that its program meaning equals the quoted
+Lean term it represents. In particular, the root has an equality between the
+checked program value and the original goal expression. Goal closure composes
+`Natural.eval_mem` with this root link; it never concludes a theorem merely
+about an internal program. A missing or ill-typed link is a reification
+failure, not an unchecked assumption.
+
+This theorem is the fast path for straight natural evaluation. Adaptive
+derivations use additional theorem nodes for intersection, centered forms,
+rewrites, contractors, and branches. The result is a hybrid proof:
+
+- a reflected checker handles regular runs of simple SSA instructions;
+- explicit theorem applications describe the shallow adaptive structure;
+- rule-specific checkers handle Taylor remainders, range reduction, and other
+  expensive leaves.
+
+This avoids both extremes: a huge tactic-generated tree of low-level
+inequalities, and a single giant Boolean reduction containing the entire
+search.
+
+## Propagator registration
+
+Propagators use an explicit environment extension. They are not typeclass
+instances. The registry can contain several methods for one head symbol and
+can prioritize them without affecting elaboration of unrelated terms.
+
+A registration supplies:
+
+- the fully qualified head declaration and arity;
+- the accepted argument and result domains;
+- a compiled evaluator declaration;
+- an initial cost class and supported effort range;
+- an optional state constructor and cache invalidation rule;
+- a proof recipe that names either a direct theorem or a checker soundness
+  theorem;
+- optional backward contractor, rewrite, local-refinement, and split-suggestion
+  declarations;
+- a stable rule name and natural certificate-schema version, together forming
+  the `RuleKey` used in diagnostics and replay traces.
+
+For a simple rule, the soundness theorem has this form:
+
+```lean
+theorem add_check_sound
+    (hcheck : addCheck I J out payload = true) :
+    x ∈ᵢ I → y ∈ᵢ J → x + y ∈ᵢ out
+```
+
+For a theorem whose output is already a transparent function of its inputs,
+the registration may apply `mem_add` directly and omit `payload`. A Taylor
+rule instead stores its polynomial degree, reduced argument, endpoint values,
+and remainder witness, then uses a checker theorem for those fields.
+
+The registration command validates the theorem's conclusion against the head
+symbol and argument mapping. It also rejects duplicate `RuleKey`s.
+It cannot turn an invalid theorem into a proof. If a compiled evaluator and
+its theorem disagree, replay fails with the rule name and candidate data.
+
+Applicable rules are ordered by declared cost class, explicit priority, and
+versioned stable rule key. Import order and fresh declaration identifiers are not
+tie-breakers. Registrations are scoped through the environment extension, so a
+function module contributes rules only when imported.
+
+### User extensions
+
+A user-defined real function can register one or more forward rules without
+modifying the tactic. A minimal rule needs only an executable enclosure and a
+theorem proving it. Optional methods are independent registrations.
+
+The intended authoring progression is:
+
+1. state a direct range theorem on dyadic input intervals;
+2. implement the executable endpoint calculation;
+3. package any nontrivial arithmetic as a small certificate checker;
+4. register the rule under the function's head declaration;
+5. add typical, boundary, and adversarial conformance cases.
+
+An approximation theorem plus a computable modulus of uniform continuity can
+produce a generic forward rule. The rule partitions the input interval finely
+enough for the modulus, evaluates certified point approximations, and takes an
+outward hull. The modulus may depend on the input interval. This construction
+is a later convenience API, not a requirement imposed on every function.
+
+## Reification
+
+Reification uses `Qq` and `Lean.Meta`. It preserves user sharing and introduces
+additional common-subexpression sharing after normalization.
+
+### Supported initial language
+
+The first arithmetic language contains:
+
+- real variables and exact integer, rational, and decimal constants;
+- negation, addition, subtraction, multiplication, division, inverse, and
+  natural powers;
+- `abs`, `min`, `max`, and `Real.sqrt`;
+- named real constants with registered nullary rules;
+- registered unary and binary functions.
+
+The first elementary-function milestone adds `Real.exp`, `Real.log`,
+`Real.sin`, `Real.cos`, `Real.atan`, and `Real.rpow` on proved positive bases.
+The LeanCert compatibility milestone then audits the rest of the expression
+heads its downstream users need, including hyperbolic functions, `arsinh`,
+`atanh`, `sinc`, and `erf`. A name in the reified language is not considered
+supported until at least one sound propagator covers its stated domain.
+
+### Context facts
+
+The frontend recognizes:
+
+- strict and non-strict comparisons with rational expressions;
+- equality as two closed bounds;
+- all finite and one-sided `Set.Ixx` membership forms;
+- conjunctions of recognized facts;
+- local definitions that are definitionally equal after elaboration.
+
+Facts about arbitrary derived terms are retained. They are not restricted to
+free variables. Unknown hypotheses remain in the context but do not enter the
+interval program.
+
+A propositional hypothesis `h : s = t` does not merge SSA nodes. It becomes a
+source constraint with `SourceId h` and bidirectional bound transfer. This
+avoids cycles such as identifying the node for `x` with its descendant
+`x + 1`, and it lets inconsistent equalities be contracted and reported.
+
+### Certified normalization
+
+Normalization is a portfolio, not one irreversible simplification pass.
+
+- Casts and exact rational literals receive canonical nodes.
+- Syntactic identities such as `sub_eq_add_neg` can share a common primitive
+  form.
+- When two operands have the same `NodeId`, proved identities such as
+  `sub_self` and `add_neg_cancel` create an exact zero alternate. CSE alone
+  would not make interval subtraction dependency-aware; this rule is what
+  closes `x - x` and `10^9*x - 10^9*x + 1` exactly.
+- Polynomial fragments may keep the original form, a Horner form, a centered
+  form, and a normalized polynomial form. Each alternate has a proof of
+  equality to the original node.
+- Repeated finite sums use a fold instruction instead of an expanded chain of
+  additions.
+- Function-specific rewrites such as `exp (-log N / k)` or trigonometric range
+  reduction are registered theorem applications, not unchecked expression
+  mutation.
+
+Blind ring normalization can improve one dependency and destroy another. The
+planner may evaluate several proved forms and intersect their ranges.
+`maxProgramNodes` and `maxFormsPerNode` apply while these alternates are
+materialized. If the original DAG alone exceeds `maxProgramNodes`, reification
+fails safely with a budget diagnostic. If alternate generation reaches either
+limit, the original DAG remains valid, skipped alternates are reported, and
+search continues without them.
+
+## Tactic interface
+
+The planned syntax is:
+
+```lean
+interval
+interval [h₁, h₂]
+interval only [h₁, h₂]
+interval (config := { maxSplits := 8, maxEffort := 80 })
+interval?
+interval_bound e
+```
+
+`interval [h₁, h₂]` adds the named facts to the local facts already recognized.
+`only` restricts hypothesis ingestion to the supplied facts. `interval?` runs
+the same proof search, reports the successful action summary and a pasteable
+configuration, then closes the goal. `interval_bound e` leaves the goal
+unchanged and reports the best enclosure of `e` together with a pasteable
+`have` statement whose proof is `by interval`. If an exact rational source cut
+is stronger than its dyadic working projection, the report retains the exact
+cut.
+
+After subdivision, “best” means the proved hull over every live or pending
+leaf, never the enclosure from one favorable branch. Replay uses the partial
+branch tree to prove that hull even when the original search result is
+`unknown`.
+
+The programmatic frontend exposes a `deriveBound` entry point for other
+tactics. It returns the dyadic search interval, any stronger exact rational
+source cuts, proof expressions for the selected global bounds, and search
+diagnostics.
+This is the future integration seam. This SPEC does not register it with
+`grind`.
+
+### Configuration
+
+The stable configuration fields are:
+
+```lean
+structure Interval.Config where
+  policy         : Name := `balancedV1
+  maxProgramNodes : Nat
+  maxFormsPerNode : Nat
+  maxSteps       : Nat
+  maxRuleCalls   : Nat
+  maxEffort      : Nat
+  maxSplits      : Nat
+  maxDepth       : Nat
+  maxLeaves      : Nat
+  maxLocalPieces : Nat
+  maxEndpointHeight : Nat
+  maxAlignmentShift : Nat
+  maxTraceNodes  : Nat
+  maxProofNodes  : Nat
+  maxPayloadEntries : Nat
+  maxPayloadBytes : Nat
+  maxCheckerSteps : Nat
+  rules          : RuleFilter
+```
+
+The implementation also has an emergency timeout, but test expectations and
+successful replay do not depend on a particular machine reaching it.
+
+Effort is a natural-number precision tier. Rules are encouraged to interpret
+effort `p` as an error target near `2^-p`, but no monotonicity or error law is
+part of the generic interface. The scheduler measures actual gains.
+
+## Built-in enclosure methods
+
+The tactic tries cheap natural evaluation first and then selects from the
+methods below. Every method returns an ordinary interval and a proof. The
+planner may intersect several results.
+
+### Exact arithmetic
+
+The required initial rules are constants, identity, negation, addition,
+subtraction, multiplication, natural powers, `abs`, `min`, and `max`. Inverse
+and division use the precision-indexed outward operations, with sign-specific
+rules and a sound coarse fallback. Square root uses monotonicity on nonnegative
+inputs and accounts for Mathlib's value on negative inputs when the interval
+is not known nonnegative.
+
+Exact arithmetic primitives preserve their tight endpoint-attainment flags.
+An approximate elementary or user rule may deliberately close a cut when that
+is the cheapest proved enclosure. The diagnostic record distinguishes a
+semantic loss of openness from numerical width.
+
+### Centered form and automatic differentiation
+
+For a function of the relevant free variables, the first dependency-reduction
+method is the multivariate mean-value enclosure
+
+```text
+f(X) ⊆ f(c) + sum_i (X_i - c_i) * partial_i f(X).
+```
+
+Here `X` is a bounded box, `c` lies in `X`, and every segment from `c` to a
+point of `X` stays within the certified differentiability domain. Derivative
+intervals enclose each partial derivative on that whole box. An unbounded
+dependency coordinate must first be bounded or omitted by a proved
+independence result. The univariate formula is the one-coordinate special
+case.
+
+Forward automatic differentiation computes value intervals and a sparse
+gradient on the shared program. If one partial derivative interval has
+constant sign, the rule can evaluate the appropriate boundary face instead.
+If a second derivative later has constant sign, convexity can reduce a maximum
+to boundary faces.
+
+Nondifferentiable nodes return an unknown derivative interval and let natural
+evaluation continue. They do not invalidate unrelated parts of the program.
+The planner first applies centered refinement at the requested output and at
+high-influence internal nodes. Applying it at every node is an optional policy
+for comparison.
+
+### Polynomial forms
+
+Polynomial expressions receive several inexpensive alternatives:
+
+- natural evaluation with shared subexpressions;
+- Horner evaluation under several variable orders;
+- centered first-order evaluation;
+- Bernstein coefficients over a bounded box;
+- monotonicity from derivative intervals.
+
+The first release need not implement every item. The registration and policy
+interfaces must permit them without changing the proof trace format.
+Bernstein and centered forms are prioritized before affine arithmetic because
+they require less certificate machinery and address many small nonlinear
+goals.
+
+### Backward contractors
+
+Forward-backward propagation follows the HC4 pattern:
+
+1. evaluate every affected instruction forward;
+2. intersect a constraint node with its required interval;
+3. apply inverse rules to narrow arguments;
+4. re-enqueue only instructions whose input facts changed.
+
+Initial contractors cover addition, subtraction, sign-separated
+multiplication, square, `abs`, and monotone elementary functions. A contractor
+that naturally returns a union either creates two solver branches or uses a
+later two-component interval type. It never drops one alternative.
+
+When the tactic proves a goal by eliminating counterexamples, it adds the
+logical negation of the target comparison and proves that every resulting
+branch is empty. The contractor theorem states that it preserves all possible
+counterexamples. This prevents circular use of the desired conclusion.
+
+### Affine arithmetic and Taylor methods
+
+Affine forms are a later registered abstract domain. They preserve linear
+correlation with noise symbols and convert their final result back to an
+ordinary interval fact. Symbol compaction and nonlinear remainder bounds are
+part of their certificate.
+
+Second-order midpoint Taylor bounds come before full Taylor models. They give
+derivative-sign, monotonicity, and convexity reductions without introducing a
+general multivariate polynomial remainder representation. Full Taylor models
+remain a later challenge milestone. They do not block the initial tactic.
+
+## Elementary functions
+
+Point enclosure and range enclosure are separate APIs.
+
+### Certified point bounds
+
+A point algorithm works only with exact dyadic or rational data:
+
+1. apply a proved argument-reduction identity;
+2. evaluate a convergent series or rational approximation on a small domain;
+3. prove an outward remainder bound;
+4. reconstruct the original function with proved identities;
+5. round the final cut outward to the requested dyadic precision.
+
+The certificate contains the reduction parameters, approximation order,
+endpoint values, and remainder witness. The planner selects them. The checker
+verifies them.
+
+### Sine and cosine
+
+The initial sine rule follows the existing experiment on `[-1,1]`: evaluate a
+rational Taylor polynomial and bound the Lagrange remainder. The implementation
+uses dyadic endpoints in its hot arithmetic and retains the experiment's
+Mathlib proof of the analytic remainder.
+
+Outside that range, two proved methods may coexist:
+
+- recursively apply `sin x = 3 sin (x/3) - 4 sin(x/3)^3` until the argument is
+  small, then propagate the reconstruction polynomial;
+- use certified bounds for `π`, reduce modulo a period, and isolate critical
+  points between certified dyadic guards when needed.
+
+The triple-angle method avoids requiring `π` for the first working rule. The
+periodic method is necessary for tight ranges and large-argument performance.
+If an interval covers a complete period, the range rule returns `[-1,1]`
+without point evaluation. Ambiguous period indices cause a precision increase
+or a dyadic global split. An exact symbolic critical point may be handled
+inside the range theorem, but it is not inserted as an irrational solver cut.
+Very large arguments have an explicit work cap and a sound coarse fallback.
+
+Exact identities such as `sin Real.pi = 0` are rewrite rules. Increasing
+numeric precision is not a substitute for an exact symbolic theorem.
+
+### Exponential and logarithm
+
+`Real.exp` uses monotonic endpoint evaluation plus certified point bounds.
+Range reduction may use repeated halving and squaring, which directly covers
+the PNT+ pattern that was manually rewritten as
+`(exp (C * s / 64)) ^ 64`.
+
+`Real.log` uses monotonicity on a proved positive interval. Rewrites for
+`exp (log x)` and expressions such as `exp (-log N / k)` require explicit
+positivity side conditions and are registered with proofs. Nested logarithms
+are reified normally once each inner interval is positive.
+
+Nullary `π` propagation returns successively tighter dyadic enclosures.
+Square root uses integer square-root bounds after scaling. The same point-rule
+interface later admits `atan`, hyperbolic functions, `sinc`, and `erf`.
+
+Positive-base real powers use the proved identity
+`x ^ y = exp (log x * y)` together with a direct monotonicity rule when the
+signs of `log x` and `y` make it sharper. A dedicated unary rule for `x ^ x`
+retains the correlation that a generic binary `x ^ y` rule loses. This rule is
+required by the IMO 2020 and BKLNW corpora. Inputs containing zero or negative
+bases use the exact Mathlib definition and separate the necessary cases rather
+than importing the partial-domain convention of a numerical library.
+
+### Rule state and local partitions
+
+A higher-effort elementary rule may refine its previous partition and reuse
+certified point evaluations. It can split its input interval locally, prove
+that the pieces cover it, evaluate each piece, and return their hull. This
+does not duplicate the complete solver state.
+
+Function-specific split suggestions include zero, domain boundaries, kinks,
+poles, and dyadic guards enclosing certified trigonometric critical points. A
+theorem-specific local partition may use symbolic landmarks inside its
+payload; a global split suggestion always names a dyadic cut. The scheduler
+decides whether local refinement, more endpoint precision, or a global case
+split has the best predicted gain.
+
+## Efficient replay
+
+Proof efficiency is a correctness-adjacent release requirement. A tactic that
+finds a bound quickly but emits a theorem that takes minutes to elaborate does
+not satisfy this SPEC.
+
+### Sharing
+
+- Every SSA fact is proved at most once per branch.
+- Proofs established before a split are `let`-bound outside both children.
+- The derivation slice removes unused propagations and every failed probe.
+- When equal cuts have several derivations, replay prefers the lower estimated
+  proof cost.
+- Repeated constants, Taylor tables, and fold certificates are shared.
+
+### Batch and fold certificates
+
+Finite sums and arrays are not expanded into thousands of tactic applications.
+The reifier recognizes `Finset` ranges and other supported folds. A batch
+certificate contains the element enclosures and a balanced aggregation tree.
+A generic theorem proves the fold bound.
+
+Large batches are checked in measured chunks and combined by a balanced proof
+tree. The initial chunk ceiling is selected by batch-replay measurements. It is not
+hard-coded by this SPEC. This avoids both a linear-depth proof term and one
+enormous Boolean reduction. Kernel-facing recursive checkers use exposed
+definitions and reduction-stable payload types. They do not rely on opaque
+array equality reduction across module boundaries.
+
+The BKLNW sums with upper limits 29, 37, 63, 145, 289, and 433 are the scaling
+ladder. Their index set is `Icc 3 N`, so they contain `N - 2` summands. The
+13,590-cell FKS2 corpus is the large-batch acceptance test.
+
+### Failure during replay
+
+Replay is normally run only after compiled search finds a derivation. If a
+rule candidate does not check, the tactic reports:
+
+- rule name and version;
+- input and proposed output intervals;
+- certificate field or theorem application that failed;
+- source location of the registration.
+
+It does not try `native_decide`, insert `sorry`, trust the candidate, or hide
+the failure by returning a weaker theorem.
+
+## Evidence and resulting requirements
+
+### Research note and sine experiment
+
+The [interval arithmetic note](https://hackmd.io/ZagrUv95RFSU-7WP9TNxUQ)
+supplies the central model adopted here:
+
+- saturate all shared subexpressions with bounds;
+- associate stateful forward propagators with function symbols;
+- measure the gain from an action and use that sensitivity to choose later
+  work;
+- allow function-specific subdivision suggestions;
+- consider backward propagation without requiring it for the first version;
+- let effort trade work for tighter output without demanding a global law;
+- regularize growing rationals by sound outward compression;
+- permit multiple propagators for one symbol;
+- derive propagators from point approximations and moduli of continuity;
+- keep rule selection out of recursive typeclass search.
+
+The associated
+[sine experiment at commit `f174f318`](https://github.com/kim-em/mathlib4/blob/f174f3188252c99f17be96feee42b242cc465b2d/Mathlib/Analysis/SpecialFunctions/Trigonometric/Intervals.lean)
+demonstrates rational Taylor bounds for sine, unary and binary forward rules,
+an effort parameter, and the need for open and unbounded rule domains. It only
+sketches outward regularization: `Real.rounding.mem` still contains three
+`sorry`s at that commit. This SPEC retains the proved ideas but does not
+inherit those unfinished proofs. It replaces the fixed closed rational
+interval and speculative heterogeneous type list with exact dyadic cuts, SSA
+instructions, and an explicit rule registry.
+
+### Lean Zulip requirements survey
+
+The public Lean Zulip discussion supplies both early requirements and concrete
+failure cases.
+
+- The first
+  [interval arithmetic and Lean thread](https://leanprover.zulipchat.com/#narrow/channel/116395-maths/topic/interval.20arithmetic.20and.20Lean/near/211251141)
+  asks for rational certificates, square root, sparse numerical linear algebra,
+  special-function error bounds, and a two-variable positivity problem split
+  into about 80 regions. It also records immediate numerator and denominator
+  growth with unrestricted exact rationals. This supports outward
+  regularization and a strict separation between fast candidate computation
+  and Lean checking.
+- The
+  [representation and tactic thread](https://leanprover.zulipchat.com/#narrow/channel/239415-metaprogramming-.2F-tactics/topic/Interval.20arithmetic.20--.20what.20approach.3F/near/212077493)
+  argues for abstract real enclosure theorems with rational certificates,
+  notes that infinite endpoints are necessary, and separates interval
+  operations from the witness values they enclose.
+- The
+  [verified software floating-point thread](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/Verified.20software.20floating.20point/near/419936247)
+  describes a fixed-integer closed-interval implementation with arithmetic,
+  powers, `exp`, and `log`. Its nonempty-closed representation and sentinel for
+  the whole interval are too narrow here, but its endpoint monotonicity and
+  empirical tightness measurements are useful comparison points.
+- The
+  [constant real inequality tactic thread](https://leanprover.zulipchat.com/#narrow/channel/239415-metaprogramming-.2F-tactics/topic/An.20interval.20tactic.20for.20constant.20real.20inequalities/near/445456796)
+  includes `exp 1 < 2.7182818284591`, a logarithm product, nested `exp` and
+  `log`, and real powers. It also records ordinary reduction getting stuck on
+  a well-founded `Nat.log2`, then succeeding after a structural or fueled
+  implementation replaced it. This is the reason for the checker recursion
+  rule above.
+- A newer
+  [transcendental `norm_num` discussion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/norm_num.20extension.20for.20Real.2Eexp.2C.20Real.2Elog.2C.20sin.2C.20cos/near/612728678)
+  links the kernel-clean
+  [`lean-interval-bounds` prototype at `1586bcb`](https://github.com/peti12352/lean-interval-bounds/tree/1586bcbc5ea84e5ed0ecdbdc941dbf18d4055d48).
+  It adaptively tries Taylor degrees for rational `exp`, `log`, `sin`, and
+  `cos` bounds, has a standalone extensible handler registry, and checks that
+  representative proofs avoid `native_decide`. Community feedback there
+  independently favors a standalone extensible tactic over making interval
+  search a `norm_num` extension. Its point-focused scope and first-success
+  handler loop remain migration baselines, not the desired propagation
+  architecture.
+- The
+  [`by_approx` discussion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/New.20.60by_approx.60.20tactic.20for.20proving.20real.20inequalities/near/407069390)
+  identifies one global precision, discarded work, unrounded rationals, and
+  repeated `norm_num` construction as failure modes. Local error attribution,
+  memoized facts, and node-specific effort directly address them.
+- The
+  [interval component API discussion](https://leanprover.zulipchat.com/#narrow/channel/345428-mathlib-reviewers/topic/components.20for.20interval.20tactics/near/532547860)
+  asks for user-defined propagators and the regression
+  `x^2 + y^2 = 1 ⊢ x^4 + y^4 ≤ 1`. It also exposed awkward definitional
+  interactions between `WithTop` and `WithBot`. Dedicated lower and upper cut
+  types avoid making those implementation details part of the theorem API.
+- The
+  [sharp inequalities thread](https://leanprover.zulipchat.com/#narrow/channel/239415-metaprogramming-.2F-tactics/topic/Proving.20sharp.20inequalities.20using.20interval.20arithmetic/near/446334247)
+  supplies an entropy inequality with a sharp endpoint and singular derivative,
+  plus the dependency example `10^9*x - 10^9*x + 1`. A good tactic needs
+  analytic boundary lemmas, alternate forms, and a diagnosis of dependency
+  loss rather than endless uniform bisection.
+
+The survey also requires the engine to return its best proved interval even
+when no contradiction or target closes. Interactive proofs, plotting, and
+integral bounds all consume such facts. `interval_bound` is therefore part of
+the first frontend, not a later diagnostic addition.
+
+The complete direct-message history between Kim Morrison and Bhavik Mehta was
+also reviewed for requirements. Because that correspondence is private, this
+SPEC does not quote it or reproduce distinctive unpublished problems. Its
+technical consequences are recorded here: count rational height in policy
+cost, test continued-fraction regularization, compare backward propagation
+against function-directed subdivision empirically, retain a first-class
+best-bound query, include exact-`π` and very-high-precision logarithm stretch
+certificates, and test nonlinear-equality handoffs plus active-subset split
+planning. Public artifacts linked by that discussion are cited in the corpus
+below; the unpublished planner case is represented by a synthetic generator.
+
+The working endpoint choice remains empirical. This SPEC selects arbitrary
+dyadics for propagated facts and preserves exact rational source facts. The
+backend-comparison milestone compares that hybrid against a separate exact
+rational search prototype with deliberate regularization on tactic-scale
+examples. The public search protocol and certificate concepts should not
+prevent a later representation revision if measured proof cost favors the
+rational variant.
+
+### Existing `bound` tactic
+
+Mathlib's `bound` tactic recursively combines monotonicity, positivity, and
+local inequalities through an Aesop rule set. It already proves structural
+goals such as `(exp x)^2 ≤ (exp y)^2` from `x ≤ y`, and it can move between a
+goal like `0 ≤ a*c - b*c` and the simpler facts `b ≤ a` and `0 ≤ c`.
+
+`interval` must be compared against this existing capability rather than
+claiming every structural inequality as new. The division of responsibility
+is:
+
+- `bound` applies local order lemmas to the expression already present;
+- `interval` maintains simultaneous numerical enclosures, attributes error,
+  retries rules at local effort, contracts a shared program, and performs
+  certified case splits;
+- either tactic may use an ordinary theorem produced by the other, but neither
+  tactic's search is trusted.
+
+The common regressions include:
+
+- `x ≤ y ⟹ (exp x)^2 ≤ (exp y)^2`;
+- `0 ≤ x ∧ x ≤ y ⟹ 0 ≤ x*(y-x)`;
+- `a ≤ b ∧ x ≤ y ⟹ a*(y-x)^3 ≤ b*(y-x)^3`.
+
+Measurements compare an explicit worklist policy with Aesop-style
+backtracking. Stable priorities, bounded backtracking, and a traceable
+tie-break are required because tactic outcomes must not depend on fresh
+identifier order.
+
+### LeanCert and PNT+
+
+The inspected LeanCert snapshot is
+[`31579b5`](https://github.com/alerad/leancert/tree/31579b55618d11e4fbe622a6b5e30b0359b2ee6d).
+The inspected PNT+ snapshot is
+[`be5e07e`](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/tree/be5e07e04cde20c5ceabf63759bd097a9c88173f).
+Its
+[lakefile](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/be5e07e04cde20c5ceabf63759bd097a9c88173f/lakefile.toml)
+pins LeanCert `v4.32.1` at commit `87a21d7`. The differences from the inspected
+LeanCert main snapshot do not change the interval representation or trust
+findings below.
+
+The useful LeanCert ideas are a small semantic expression language, a golden
+soundness theorem, exact rational and dyadic evaluators, affine arithmetic,
+derivative-sign pruning, and untrusted discovery followed by checked
+evaluation. The replacement keeps those ideas.
+
+The following limitations become explicit requirements here.
+
+- Practical LeanCert tactics usually close checks with `native_decide`. The
+  pinned audit shows `Lean.ofReduceBool` plus a fresh generated declaration
+  matching `<decl>._native.native_decide.ax_*`; reliance on compiled
+  evaluation is the trust issue, while `Lean.trustCompiler` is not listed as a
+  direct dependency of those audited theorems. This library excludes all of
+  these paths.
+- `IntervalRat` represents only nonempty finite closed intervals. This library
+  represents empty, open, half-open, and unbounded intervals.
+- Backend choice is mostly static. This library measures rule outcomes and can
+  escalate precision, form, rewriting, propagation, or subdivision.
+- Raw-expression reification has bespoke cases and proof-tree growth for large
+  sums. This library uses a shared program and generic fold certificates.
+- Manual rewrites and fixed midpoint depths are common downstream. This
+  library registers proved rewrites and arbitrary split suggestions.
+- Heavy verified facts are sometimes separated from sorry-bearing public
+  interfaces. This library requires the ordinary public theorem to replay its
+  certificate and rejects `sorryAx` in the acceptance audit.
+
+The LeanCert
+[axiom audit](https://github.com/alerad/leancert/blob/31579b55618d11e4fbe622a6b5e30b0359b2ee6d/Tests/AxiomAudit.lean)
+and PNT+ PR [#922](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/pull/922)
+provide regression expectations for the trust boundary.
+
+PNT+ supplies the principal real-world corpus:
+
+At the pinned snapshot it contains about 280 actual `interval_decide`
+invocations across 15 files. Compatibility must therefore be tested by
+maintaining source-pinned copies of representative statements and expression
+definitions with their LeanCert calls replaced. Merely importing an upstream
+declaration whose existing proof already used compiler trust does not test the
+replacement. A few translated README examples are also insufficient.
+
+- [LogTables.lean](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/be5e07e04cde20c5ceabf63759bd097a9c88173f/PrimeNumberTheoremAnd/IEANTN/LogTables.lean)
+  contains hundreds of `exp` and `log` point bounds, nested logs, large
+  arguments, and errors down to about `10^-100`.
+- [BKLNW_a2_bounds.lean](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/be5e07e04cde20c5ceabf63759bd097a9c88173f/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW_a2_bounds.lean)
+  contains finite sums whose certified upper limits reach 433.
+- BKLNW Table 10 contains sums of exponentials with small margins. PNT+ PR
+  [#1510](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/pull/1510)
+  records a false target exposed numerically. Failure diagnostics must report
+  the incompatible enclosure rather than only request more precision.
+- PNT+ PR [#1405](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/pull/1405)
+  records manual treatment of `exp (-log N / k)` and a theorem containing
+  roughly 135 interval checks. It also records four false original boundary
+  rows, at `b = log(5e10)`, `25`, `log(3.2e13)`, and `32`; at least one
+  original row remains an expected-failure regression. These cases motivate
+  certified normalization, batch replay, and useful failure bounds.
+- [Table4ExtCore.lean](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/be5e07e04cde20c5ceabf63759bd097a9c88173f/PrimeNumberTheoremAnd/IEANTN/FKS2Tables/Table4ExtCore.lean)
+  defines the generic cell checker and its transport theorem. The 13,590 cells
+  live in
+  [fourteen `Table4ExtData_*` shards](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/tree/be5e07e04cde20c5ceabf63759bd097a9c88173f/PrimeNumberTheoremAnd/IEANTN/FKS2Tables),
+  thirteen of size 1,000 and one of size 590, and
+  [Table4Ext.lean](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/be5e07e04cde20c5ceabf63759bd097a9c88173f/PrimeNumberTheoremAnd/IEANTN/FKS2Tables/Table4Ext.lean)
+  assembles them. Their manual exponential range-reduction rewrite motivates
+  shared certificates, local effort, arbitrary partitions, and bounded object
+  size. PNT+ PR
+  [#1563](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/pull/1563)
+  records the rewrite and batching rationale.
+- LeanCert's
+  [Li2Verified.lean](https://github.com/alerad/leancert/blob/31579b55618d11e4fbe622a6b5e30b0359b2ee6d/LeanCert/Examples/Li2Verified.lean)
+  uses a cancellation-preserving integrand rewrite, seven main pieces, exactly
+  2,300 middle cells, four 100-cell numerical side intervals, and analytic
+  endpoint pieces. It is a later challenge for removable behavior, open
+  endpoints, adaptive partitions, and verified integration. Integration
+  itself is not part of the first interval tactic release.
+
+### Lessons from other systems
+
+| System or method | Adopted lesson | Deliberate limit |
+| --- | --- | --- |
+| IEEE 1788 | Separate mathematical sets, finite endpoint data, and encoding. Include empty and unbounded cases. | Its set flavor does not represent open endpoints, so it does not determine the Lean type. |
+| CoqInterval | Shared straight-line programs, reflection, automatic differentiation, Taylor bounds, and subdivision are all practical in a proof assistant. | The initial implementation uses a hybrid replay rather than copying one monolithic evaluator. |
+| Gappa and Sollya | Untrusted search can propose rewrites, polynomial bounds, and subdivisions for a small proof checker. Best-bound diagnostics are valuable. | They are optional proposal sources only. Lean replay remains independent. |
+| MPFR and MPFI | Arbitrary precision, directed rounding, and argument reduction guide endpoint algorithms. | Hardware rounding state and foreign results are not trusted. |
+| Arb | Midpoint-radius balls and cached high-precision point evaluation are efficient for narrow inputs. | Balls are an internal candidate representation. Public semantics remain endpoint intervals because balls do not express open or half-infinite sets. |
+| IBEX HC4 | Dependency worklists, forward-backward contractors, contraction thresholds, smear scores, and split policies transfer directly. | Constraint solving heuristics never justify a Lean fact by themselves. |
+| HOL Light nonlinear verification | Monotonicity, convexity, boundary reuse, and certificate DAGs can scale to hard inequalities. | Full Flyspeck-style second-order verification is a later milestone. |
+| Affine arithmetic | Noise symbols retain first-order correlations and are formally verifiable. | Open and unbounded sets stay in the endpoint layer. Affine forms are a later method. |
+| Taylor models | Polynomial plus rigorous remainder is the strongest planned dependency-control method. | Full multivariate Taylor models do not block the first release. |
+| dReal-style interval constraint propagation | Counterexample boxes, contractor scheduling, and influence-based branching are useful search ideas. | The tactic proves exact Lean propositions. It does not use delta weakening. |
+
+## Regression and challenge corpus
+
+Each case records the required feature, expected success or safe failure,
+selected policy, search statistics, replay time, certificate size, and axiom
+set. Exact imported statements are pinned to upstream commits when licensing
+permits copying them into test modules.
+
+### Endpoint semantics
+
+- all four closure combinations at finite ends;
+- both one-sided unbounded shapes and the whole interval;
+- singleton normalization and the three empty equal-endpoint shapes;
+- strict conclusion from one open summand, such as
+  `x ∈ (0,1), y ∈ [0,1] ⟹ x + y < 2`;
+- reciprocal on positive open and half-open intervals, including the outward
+  dyadic enclosure of `{3}⁻¹ = {1/3}` at two precisions;
+- inverse and division across zero, including Lean's value at zero;
+- logarithm at, below, and just above zero;
+- a split whose cut equals a parent endpoint.
+
+### Arithmetic and dependency
+
+```lean
+x - x = 0
+x ∈ [0,1]             ⟹ x * (1 - x) ≤ 1/4
+x ∈ [-1,1]            ⟹ x^2 ≤ 1
+x ∈ (0,+∞)            ⟹ 0 < x / (x + 1)
+x ∈ [0,1], y ∈ [0,1]  ⟹ (x+y)*x + (x+y) ≥ 0
+```
+
+These cases distinguish proved same-node cancellation, centered forms,
+contractors, and subdivision from naive repeated interval evaluation. Sharing
+alone does not prove `x - x = 0`; the exact cancellation alternate does.
+
+Additional coordination and handoff cases are:
+
+- `x^2 + y^2 = 1 ⟹ x^4 + y^4 ≤ 1`, which needs information to move from a
+  nonlinear equality into the forward bounds;
+- `y * 2 - y * Real.sqrt 2 ^ 2 ≤ 0`, using
+  `Real.sq_sqrt zero_le_two` before the linear arithmetic handoff;
+- the four-corner multiplication theorem: from `a ≤ u ≤ b`, `c ≤ v ≤ d`,
+  and a lower bound below all four products `a*c`, `a*d`, `b*c`, `b*d`, prove
+  that it is below `u*v`;
+- `0 ≤ 1 - 3*x^2*y^2 + x^2*y^4 + x^4*y^2` as a handoff case. A polynomial
+  certificate tactic can solve the residual, while plain intervals over
+  unbounded variables should decline it;
+- a deterministic synthetic generator parameterized by variable count,
+  irrelevant linear constraints, and constraints of the form `ν ≤ max a b`.
+  Its known solution uses a small active subset while the number of apparent
+  max branches grows rapidly. It tests split planning without reproducing an
+  unpublished application statement or its identifying dimensions.
+
+### Elementary functions
+
+- the sine experiment's point bounds
+  `-25/48 ≤ sin (-1/2)` and `sin (1/3) ≤ 637/1944`;
+- `|sin x| ≤ 1` on an unbounded input;
+- a narrow sine interval crossing a critical point;
+- a large-argument sine that uses periodic reduction;
+- exact `sin π = 0` through a symbolic rewrite;
+- `exp x ≥ 1 + x` on `[0,+∞)` through derivative monotonicity;
+- `x < 1 + x^3` on `[-1,+∞)`, matching the
+  [pinned CoqInterval example](https://gitlab.inria.fr/coqinterval/interval/-/blob/dcdffc06d31e8e3646829b948c137ff140756b80/README.md#L334);
+- `sin x ≤ 0` on `[3.2,6.2]`;
+- high-precision bounds for `sin 100`, `π`, `log 2`, and `sqrt 2`;
+- `exp (0.117^2) ≤ 1.013879`, `π ≤ 3.15`, and `4 * log 11 < 11`. The last
+  appears in PNT+ issue
+  [#1129](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/issues/1129);
+- compatibility with the `lean-interval-bounds` examples
+  `2718/1000 < exp 1 < 2719/1000`, `log 2 < 694/1000`,
+  `-694/1000 < log (1/2)`, `968/1000 < cos (1/4)`,
+  `exp (3/2) < 5`, and `exp (4 / exp 1) ≤ 7`.
+
+### PNT+ compatibility
+
+The committed compatibility subset includes:
+
+- two-sided `log 2` and `log 3` bounds;
+- the one-sided nested bound `0.633415 < log (log 6.58)` and the two-sided
+  bound `-0.366513 ≤ log (log 2) ≤ -0.366512`;
+- `exp (-1)`, `exp (-1/2)`, and `exp (-2/3)`;
+- `log 11723 ≤ 9.37`, `exp 20 ≤ 485165196`, and
+  `10^9 ≤ exp 22`;
+- representative `10^-20` and `10^-100` tail bounds;
+- BKLNW sums with upper limits 29, 37, 63, 145, 289, and 433;
+- one Table 10 shard and the recorded false target as an expected failure;
+- the approximately 135-case Table 12 batch, plus one of its four false
+  original boundary rows as an expected failure;
+- a small, medium, and complete 13,590-cell FKS2 batch;
+- mutated Taylor, range-reduction, fold, and split certificates, all rejected.
+
+The [PNT+ log-table generator](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/blob/be5e07e04cde20c5ceabf63759bd097a9c88173f/scripts/gen_log_tables.py)
+is a model for optional untrusted candidate generation. The committed tests
+still exercise the native Lean planner and replay path.
+
+### Zulip and downstream challenge sets
+
+The [IMO 2020 Q2 interval thread](https://leanprover.zulipchat.com/#narrow/channel/208328-IMO-grand-challenge/topic/IMO.202020/near/211282511)
+is the main adaptive-subdivision corpus. Early experiments bisected a cube into
+eight children, then found that the boundary behavior of `x^x` prevents a
+pure compactness argument from guaranteeing success. Later runs combined an
+analytic boundary lemma with hundreds of boxes. The attached
+[generated Lean proof](https://leanprover.zulipchat.com/user_uploads/3121/3HBLKR994JFwvm3gxr6XWEAn/imo2020_q2_intervals.lean)
+contains the exact lemma
+`x ∈ [1/4,11/32] ⟹ x^x ≤ 1569/2048`. Extracted tests cover:
+
+- a small box solved after a registered unary `x ↦ x^x` enclosure supplies
+  the leaf bound;
+- a box where recognizing unary `x ↦ x^x` is tighter than a generic `x^y`;
+- a boundary box that must request an analytic lemma instead of subdividing
+  indefinitely;
+- the complete generated partition as a proof-size comparison.
+
+Bhavik Mehta's
+[exponential Ramsey logarithm file](https://github.com/b-mehta/exponential-ramsey/blob/2cdad383b3235eff3a8e039566b8a600c1b8949b/src/necessary_log_estimates.lean#L465)
+contains more than a thousand lines of manual interval propagation. It includes
+high-precision bounds for `1 / log 2`, `log 3`, `log 5`, logarithms of rational
+ratios, entropy expressions, derivatives, and local maxima. Its long chains of
+weakened rational bounds form a regularization and certificate-planning
+benchmark.
+
+Pinned Ramsey fixtures include
+`logb 2 (30991/17356) ∈ [0.8364148,0.8364149]`,
+`g' 0.4339 ∈ [1.99928,1.99929]`, and
+`g'_deriv 0.4339 ∈ [0,10^-6]`. Together they test nested logarithms,
+outward regularization, and certification of a local maximum.
+
+The following specialized computations are stretch tests, not baseline
+requirements for a general rule:
+
+- exact-`π` rational approximations following the
+  [`exact-pi` interface](https://hackage.haskell.org/package/exact-pi-0.5.0.2/docs/Data-ExactPi.html#v:rationalApproximations);
+- `log 2` at 30,000 and one million decimal digits, using binary splitting and
+  an atanh series;
+- the
+  [million-digit kernel-style logarithm certificate](https://github.com/CBirkbeck/LeanBridge/blob/b136733232e200c75fcc0c3e7ba50e35f4f8d204/LeanBridge/Compute/LogSmallBig.lean#L937),
+  which uses kernel `decide` rather than `native_decide`;
+- the spigot, BBP-style, and AGM certificate patterns in
+  [*Distant decimals of π*](https://arxiv.org/abs/1709.01743), including its
+  one-million-decimal and billionth-hexadecimal-digit targets, as a specialized
+  non-`native_decide` certificate benchmark rather than a tactic release gate;
+- cubic convergence to `π` by iterating `x ↦ x + sin x`, with locally
+  increasing Taylor effort.
+
+The [certifying LMFDB polynomial corpus at `1db6458`](https://github.com/xgenereux/certifying-lmfdb-data/tree/1db645848ee80c91632952485f290c9a62508a32/CertifyingLmfdbData/Polynomial)
+provides downstream integration tests for interval outputs used inside
+Newton-Kantorovich certificates. Small cases isolate a root of
+`X^6 + 7*X^5 + X^4 - 1` near `0.641564061943673` to radius `10^-10`, and a root
+of `X^6 - 1` near `1` to radius `10^-30`. The larger case encloses all six
+roots of `X^6 - 5*X^4 - 50*X^2 + 125` to sup-norm radius `10^-57`. The interval
+tactic should discharge the rational norm inequalities in those certificates.
+Root existence and uniqueness remain the responsibility of the root library.
+
+### CoqInterval and Isabelle comparison suites
+
+CoqInterval's MT1 through MT25 comparison changed open or unbounded domains
+into finite closed intervals, normally using `ε = 2^-10`, and sometimes added
+`ε` to create a visible numerical gap. The test data therefore retains two
+suites:
+
+- `mtModified`, matching the finite closed benchmark in the
+  [CoqInterval paper](https://guillaume.melquiond.fr/doc/15-jar.pdf#page=25);
+- `mtOriginal`, restoring the original MetiTarski domains and strictness from
+  the [pinned problem collection](https://bitbucket.org/lcpaulson/metitarski-git/src/0e4da8d3dac39d8fb54554ed5c6a99683e447631/tptp/Problems/).
+
+Representative original statements are:
+
+```text
+-1 < x       ⟹ 2*|x|/(2+x) ≤ |log (1+x)|
+|x| < 1      ⟹ |log (1+x)| ≤ -log (1-|x|)
+0 ≤ x        ⟹ exp (x-x^2) ≤ 1+x
+x < 1        ⟹ exp (-x/(1-x)) ≤ 1-x
+0 < x        ⟹ 1 < (x+1/x) * atan x
+0 < x ≤ π    ⟹ cos x ≤ sin x / x
+0 ≤ x        ⟹ 12 - 14.2*exp (-0.318*x)
+                   + (3.25*cos (1.16*x) - 0.155*sin (1.16*x))*exp (-1.34*x) > 0
+```
+
+These explicitly exercise open cuts, unbounded ends, equality margins,
+division near a boundary, and mixed transcendental expressions. The complete
+25-statement table is fixed below so the later fixture module does not have to
+reconstruct it from benchmark names. Here `ε = 1/1024`.
+
+1. MT1, `-1 < x`: `2*|x|/(2+x) ≤ |log (1+x)|`. The modified domain is
+   `[-1+ε,10]` and its right side is increased by `ε`.
+2. MT2, `|x| < 1`: `|log (1+x)| ≤ -log (1-|x|)`. The modified domain is
+   `[-1+ε,1-ε]` and its right side is increased by `ε`.
+3. MT3, `|x| < 1`: `|x|/(1+|x|) ≤ |log (1+x)|`. The modified domain is
+   `[-1+ε,1]` and its right side is increased by `ε`.
+4. MT4, `|x| < 1`:
+   `|log (1+x)| ≤ |x|*(1+|x|)/|1+x|`. The modified domain is
+   `[-1+ε,1]` and its right side is increased by `ε`.
+5. MT5, `|x| < 1` and `x ≠ 0`: `|x|/4 < |exp x - 1|`. The modified domain is
+   `[-1,-ε] ∪ [ε,1]`.
+6. MT6, `|x| < 1` and `x ≠ 0`: `|exp x - 1| < 7*|x|/4`. The modified domain
+   is `[-1,-ε] ∪ [ε,1]`.
+7. MT7, all real `x`: `|exp x - 1| ≤ exp |x| - 1`. The modified domain is
+   `[-10,-ε]`.
+8. MT8, all real `x`:
+   `|exp x - (1+x)| ≤ |exp |x| - (1+|x|)|`. The modified domain is
+   `[-10,-ε]`.
+9. MT9, all real `x`:
+   `|exp x - (1+x/2)^2| ≤ |exp |x| - (1+|x|/2)^2|`. The modified domain is
+   `[-10,-ε]`.
+10. MT10, `0 ≤ x`: `2*x/(2+x) ≤ log (1+x)`. The modified domain is `[0,10]`
+    and its right side is increased by `ε`.
+11. MT11, `-1 < x ≤ 0`: `x/sqrt (1+x) ≤ log (1+x)`. The modified domain is
+    `[-1/3,0]` and its right side is increased by `ε`.
+12. MT12, `0 < x`:
+    `log (1+1/x) ≤ (12*x^2+12*x+1)/(12*x^3+18*x^2+6*x)`. The modified domain
+    is `[1/3,10]` and rewrites the logarithm as `log ((1+x)/x)`.
+13. MT13, `0 < x`: `log (1+1/x) ≤ 1/sqrt (x^2+x)`. The modified domain is
+    `[1/3,10]` and uses the same logarithm rewrite.
+14. MT14, `0 ≤ x`: `exp (x-x^2) ≤ 1+x`. The modified domain is `[0,1]` and
+    its right side is increased by `ε`.
+15. MT15, `x < 1`: `exp (-x/(1-x)) ≤ 1-x`. The modified domain is
+    `[-10,1/2]` and its right side is increased by `ε`.
+16. MT16, `|x| < 1`: `|sin x| ≤ 6*|x|/5`. The modified domain is `[-1,1]`
+    and its right side is increased by `ε`.
+17. MT17, `0 < x < 1/2`: `1-2*x < cos (π*x)`. The modified domain is
+    `[ε,100/201]`.
+18. MT18, all real `x`: `0 ≤ cos x - 1 + x^2/2`. The modified domain is
+    `[-10,10]` and adds `ε` to the right-hand expression.
+19. MT19, `0 < x`:
+    `8*sqrt 3*x/(3*sqrt 3 + sqrt (75+80*x^2)) < atan x`. The modified domain
+    is `[0,10]`, changes `<` to `≤`, and adds `ε` to `atan x`.
+20. MT20, `0 < x`: `1 < (x+1/x)*atan x`. The modified domain is `[ε,10]`.
+21. MT21, `0 < x`: `3*x/(1+2*sqrt (1+x^2)) < atan x`. The modified domain
+    is `[0,10]`, changes `<` to `≤`, and adds `ε` to `atan x`.
+22. MT22, `0 < x ≤ π`: `cos x ≤ sin x/x`. The modified domain is `[ε,π]`.
+23. MT23, `0 < x < π/2`: `cos x < (sin x/x)^2`. The modified domain is
+    `[ε,π/2]`.
+24. MT24, `x ∈ [π/3,2*π/3]`: `0 < sin x/3 + sin (3*x)/6`. The modified
+    domain is `[π/3,2*π/3-ε]`.
+25. MT25, `0 ≤ x`:
+    `12 - 14.2*exp (-0.318*x)
+      + (3.25*cos (1.16*x) - 0.155*sin (1.16*x))*exp (-1.34*x) > 0`.
+    The modified domain is `[0,2]`.
+
+Each fixture links its original TPTP file and records whether it belongs to
+the original or modified suite. Decimal constants are parsed exactly before
+any outward rounding.
+
+MT19 through MT21 enter only after the `atan` rule milestone. The original
+unbounded versions of MT7 through MT9, MT18, and MT25 require global analytic
+or tail rules; finite subdivision of their modified boxes is not evidence for
+the original statements.
+
+The pinned
+[Isabelle `Approximation_Ex` page](https://isabelle.in.tum.de/website-Isabelle2011/dist/library/HOL/Decision_Procs/Approximation_Ex.html)
+adds the following exact strict enclosures. Decimal literals remain exact
+rationals during reification.
+
+```text
+|log 2 - 544531980202654583340825686620847
+           / 785593587443817081832229725798400| < 1/2^51
+|exp 1.626 - 5.083499996273| < 10^-10
+|sqrt 2 - 1.4142135623730951| < 10^-16
+|π - 3.1415926535897932385| < 10^-18
+|sin 100 + 0.50636564110975879| < 10^-17
+```
+
+It also supplies:
+
+```text
+3.2 ≤ x ≤ 6.2  ⟹ sin x ≤ 0
+0 ≤ x ≤ 1      ⟹ x^2 ≤ x
+0.5 ≤ x ≤ 4.5  ⟹ |atan x - 0.91| < 0.455
+```
+
+The arctangent case is repeated upstream as a decimal conjunction, the same
+decimal bounds expressed by set membership, a tighter decimal box, and a
+dyadic-fraction formulation. Retaining those forms tests exact literal parsing
+and hypothesis reification rather than mathematical strength.
+
+A later `tan` registration also takes the Isabelle fixture with
+`g = 9.80665`, `v = 128.61`, and `d = π/180`:
+
+```text
+g/v * tan (35*d) ∈ [3*d, 3.1*d].
+```
+
+### Later challenge problems
+
+- the LeanCert Li2 proof, which evolved from the symmetric `[0,1]` proposal
+  with target `[1.039,1.06]`: seven pieces, exactly 2,300 middle cells, four
+  100-cell numerical side intervals, and analytic endpoint pieces handling
+  cancellation and removable behavior;
+- the sharp entropy inequality from the Zulip thread, with separate endpoint
+  analysis and an interior partition;
+- interval Newton problems with narrow equation solution sets;
+- sparse matrix and QR consumers that request componentwise enclosures;
+- verified plotting on pixel boxes, where unresolved pixels receive an
+  explicit `unknown` result rather than an invented color classification;
+- selected Flyspeck, Caprasse, magnetism, heart, and Schwefel inequalities;
+- affine and Taylor-model comparisons on the same boxes.
+
+These cases do not enlarge the trusted base. A new method must still finish by
+producing ordinary interval facts and replay the same branch theorem.
+
+## Conformance
+
+The required Lean-only checks include:
+
+- semantic theorems for every interval operation and endpoint shape;
+- one direct and one certificate-backed propagator registration;
+- failure of a deliberately corrupted registration payload;
+- rejection of out-of-range operation, node, fact, and payload identifiers;
+- rejection of a wrong input side or fact version, sibling or non-ancestor
+  dependencies, cyclic or multiply-parented scopes, a mismatched split
+  assumption, and a `Close.goal` whose facts do not imply the target;
+- raw-expression reification for casts, decimals, powers, `abs`, shared terms,
+  and finite folds;
+- goal closure for strict, non-strict, equality, disequality, membership,
+  contradiction, and conjunction targets;
+- safe refusal for an unsupported function and an exhausted budget;
+- a proof axiom audit excluding compiler trust and `sorryAx`;
+- proof sharing across repeated subexpressions and split branches;
+- chunked fold replay at every chunk boundary.
+
+Every malformed-trace case must fail before the tactic assigns the user's
+goal metavariable.
+
+The external oracle profile uses `python-flint` Arb for independently computed
+point and elementary-function enclosures. A fixture fixes an input box and a
+coarse rational target. Lean proves that the function image lies in the target.
+Arb independently encloses the complete closed input ball at higher precision
+and checks that its enclosure also lies in the same target. Separate fixtures
+sample deterministic rational points and exercise known extrema and domain
+boundaries. This is bug-finding evidence, not a proof and not a runtime
+dependency. CoqInterval or MPFI comparison runs may be local informational
+tests.
+
+## Performance acceptance
+
+The test harness records four times separately:
+
+1. compiled planning and propagator execution;
+2. proof expression construction;
+3. elaboration and kernel replay;
+4. incremental rebuild of a file importing the finished theorem.
+
+It also records allocations, program nodes, accepted actions, rule calls,
+splits, leaves, maximum endpoint heights, certificate bytes, proof nodes, and
+object-file size.
+
+Initial targets, to be confirmed on the reference host during performance
+validation, are:
+
+- an exact arithmetic goal with at most 20 SSA nodes and no split: under
+  200 ms end to end;
+- a one-variable elementary goal with at most 50 SSA nodes: under 1 second;
+- a successful proof with at most eight solver leaves: kernel replay no more
+  than the compiled search time by a factor of two;
+- the BKLNW case with upper limit 433 and 431 summands: proof size and replay
+  grow at most linearly in the number of summands, with logarithmic proof
+  depth;
+- batch replay: no linear elaboration-depth growth and no chunk requiring an
+  increased recursion limit;
+- the complete FKS2 corpus: bounded per-cell certificate size, shared static
+  data, and no theorem or object-file blowup proportional to duplicated
+  transcendental tables.
+
+The LeanCert version pinned by PNT+ is a migration baseline. The new tactic is
+not declared a replacement until it proves the selected downstream corpus,
+passes the stricter axiom audit, and improves either total time or artifact
+size on every large tier without a serious regression on the other measure.
+
+## Development order
+
+1. Prove interval semantics, normalization, arithmetic enclosure, rational
+   projection, regularization, and split coverage.
+2. Before freezing checker or trace formats, build a narrow vertical
+   feasibility prototype for one small arithmetic DAG, the BKLNW fold with
+   upper limit 433, and one high-precision `exp` or `log` certificate. For each,
+   record compiled checking, proof construction, kernel replay, transitive
+   axioms, proof and object bytes, and incremental import time. Failure to make
+   ordinary kernel replay practical changes the architecture before wider
+   implementation.
+3. Implement the production shared program, natural evaluator, generic
+   soundness theorem, reifier, and scoped proof slicer for arithmetic over
+   `ℝ`.
+4. Add the explicit rule registry, multiple methods per head, diagnostics, and
+   the `interval` and `interval_bound` frontends.
+5. Port the sine experiment to dyadic endpoints. Add stateful Taylor
+   certificates and the triple-angle rewrite.
+6. Add centered automatic differentiation, derivative-sign monotonicity, and
+   dependency-aware backward propagation.
+7. Add `π`, `exp`, `log`, square root, `atan`, positive-base real powers,
+   certified range reduction, and symbolic special values.
+8. Add production chunked folds and the PNT+ point and sum corpus. Remove every
+   need for a `native_decide` proof path in the selected compatibility files.
+9. Add arbitrary and function-suggested subdivision, then the Table 10, Table
+   12, FKS2, and complete IMO partition tiers.
+10. Compare Bernstein, second-order, affine, and Taylor-model methods on the
+    challenge corpus before selecting further defaults.
+
+Every stage has real executable definitions and tests for its advertised
+surface. Unimplemented methods remain absent rather than returning ceremonial
+wide answers that masquerade as the intended algorithm.
+
+## Open design questions
+
+The following choices require prototypes and measurements. They do not weaken
+the fixed soundness and trust contracts.
+
+1. Which elementary and user-registered approximation rules should spend
+   extra work to prove an open cut, and which should return a sound closed
+   enclosure? Exact arithmetic primitives already preserve tight endpoint
+   attainment.
+2. Is a two-component `IntervalSet` needed for the first contractor release,
+   or are certified splits sufficient?
+3. Which leaf classes are smaller with reflected Boolean checks, and which are
+   smaller as direct theorem applications?
+4. What batch chunk size minimizes combined construction and replay time on
+   the reference host?
+5. Should centered refinement visit only the output and high-influence nodes,
+   or should a measured policy also offer an all-nodes pass?
+6. Which functions beyond `exp`, `log`, `sin`, `cos`, `atan`, `Real.rpow`,
+   square root, and `π` are required before the first public release?
+7. Should optional MPFR, Arb, Sollya, or Gappa planners be supported in the
+   first release, or only after the native planner meets the PNT+ corpus?
+8. Which parts of a successful derivation should be serializable as a stable
+   certificate format for generated tables?
+9. Does the dyadic-working and exact-rational-source hybrid beat an exact
+   rational working backend with regularization on real tactic workloads?
+10. For the initial rule portfolio, do function-specific subdivision
+    suggestions produce better gain per proof node than backward contractors?
+
+## File organization
+
+- `HexIntervalMathlib/Semantics.lean`: real membership and cut/set lemmas.
+- `HexIntervalMathlib/Arithmetic.lean`: soundness of exact interval operations.
+- `HexIntervalMathlib/Program.lean`: real program evaluation and natural
+  evaluator soundness.
+- `HexIntervalMathlib/Rule.lean`: registration environment and theorem-schema
+  validation.
+- `HexIntervalMathlib/Proof.lean`: derivation slicing, certificate checks, and
+  proof construction.
+- `HexIntervalMathlib/Reify.lean`: expressions, hypotheses, targets, and folds.
+- `HexIntervalMathlib/Derivative.lean`: automatic differentiation and centered
+  enclosures.
+- `HexIntervalMathlib/Elementary/{SinCos,ExpLog,Sqrt,Constants}.lean`:
+  elementary point and range rules.
+- `HexIntervalMathlib/Contractor.lean`: backwards propagation theorems.
+- `HexIntervalMathlib/Tactic.lean`: `interval`, `interval?`, and
+  `interval_bound`.
+- `HexIntervalMathlib/Examples.lean`: small user-facing examples.
+- `conformance/HexInterval/Conformance.lean`: Mathlib-free computational
+  checks for `hex-interval` only.
+- `conformance/HexInterval/EmitFixtures.lean`: Mathlib-free arithmetic oracle
+  fixtures.
+- `conformance/HexIntervalMathlib/Conformance.lean`: tactic, replay, axiom, and
+  migrated downstream regressions.
+- `conformance/HexIntervalMathlib/EmitFixtures.lean`: elementary-function
+  fixtures for the external oracle.
+
+Unlike a correspondence-only companion, `hex-interval-mathlib` contains an
+executable reifier, rule registry, and tactic. Its own conformance target tests
+that runtime-facing API while keeping the released Mathlib-free conformance
+target free of Mathlib imports. Small explanatory examples remain in
+`Examples.lean`; the bulk PNT+, nonlinear, and challenge corpus belongs in the
+companion conformance project and is built in CI.
+
+## References
+
+- Kim Morrison, [Interval arithmetic research note](https://hackmd.io/ZagrUv95RFSU-7WP9TNxUQ).
+- Kim Morrison,
+  [interval propagator and sine experiment](https://github.com/kim-em/mathlib4/blob/f174f3188252c99f17be96feee42b242cc465b2d/Mathlib/Analysis/SpecialFunctions/Trigonometric/Intervals.lean).
+- Guillaume Melquiond,
+  [The Coq Interval library](https://guillaume.melquiond.fr/doc/15-jar.pdf).
+- [IEEE Standard for Interval Arithmetic](https://grouper.ieee.org/groups/1788/).
+- [GNU MPFR algorithms](https://www.mpfr.org/algorithms.pdf).
+- [Sollya evaluation and rewriting documentation](https://sollya.org/sollya-2.9/help.php).
+- Alexey Solovyev and Thomas Hales,
+  [Formal verification of nonlinear inequalities with Taylor interval approximations](https://arxiv.org/abs/1301.1702).
+- Florent de Dinechin, Christoph Lauter, and Guillaume Melquiond,
+  [Certifying the floating-point implementation of an elementary function using Gappa](https://arxiv.org/abs/cs/0701186).
+- Russell O'Connor,
+  [Certified exact transcendental real number computation in Coq](https://arxiv.org/abs/0805.2438).
+- Robbert Krebbers and Bas Spitters,
+  [Computer certified efficient exact reals in Coq](https://arxiv.org/abs/1105.2751).
+- Fredrik Johansson,
+  [Arb: efficient arbitrary-precision midpoint-radius interval arithmetic](https://arxiv.org/abs/1611.02831).
+- [IBEX contractors](https://ibex-team.github.io/ibex-lib/contractor.html)
+  and [IBEX strategies](https://ibex-team.github.io/ibex-lib/strategy.html).
+- [Isabelle verified affine arithmetic](https://isa-afp.org/entries/Affine_Arithmetic.html)
+  and [verified Taylor models](https://isa-afp.org/entries/Taylor_Models.html).
+- Lawrence Paulson,
+  [MetiTarski: past and future](https://www.cl.cam.ac.uk/~lp15/papers/Arith/calculemus2008.pdf).
+- Sicun Gao, Jeremy Avigad, and Edmund Clarke,
+  [Delta-complete decision procedures for satisfiability over the reals](https://arxiv.org/abs/1204.3513).
+- [IntervalArithmetic.jl documentation](https://juliaintervals.github.io/IntervalArithmetic.jl/stable/).
+- LeanCert at
+  [`31579b5`](https://github.com/alerad/leancert/tree/31579b55618d11e4fbe622a6b5e30b0359b2ee6d)
+  and PNT+ at
+  [`be5e07e`](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/tree/be5e07e04cde20c5ceabf63759bd097a9c88173f).

--- a/SPEC/Libraries/hex-interval.md
+++ b/SPEC/Libraries/hex-interval.md
@@ -21,8 +21,10 @@ It does not mean the goal is false.
 
 The design must satisfy all of the following.
 
-1. A finite bound is an arbitrary-exponent `Dyadic`. No floating-point value is
-   used as a proved endpoint.
+1. Every proved endpoint is exact. The initial proof-facing format uses Lean
+   core's arbitrary-exponent `Dyadic`; no floating-point value is used as a
+   proved endpoint. Whether search also keeps exact-rational working facts is
+   decided by the feasibility experiments below, not by the trust contract.
 2. The lower and upper ends independently support strict and non-strict bounds.
    Either end may be unbounded. Empty, singleton, and whole intervals have
    canonical representations.
@@ -41,6 +43,22 @@ The design must satisfy all of the following.
    not appear in the generated proof.
 8. No part of the implementation, conformance suite, benchmark, or tactic
    fallback uses `native_decide`.
+
+The fixed contracts are semantic: exact enclosures, independent strictness,
+safe failure, replayable provenance, deterministic resource accounting, and
+the trust boundary in the companion SPEC. The following are deliberately
+empirical until measured: the physical interval representation, dyadic-only
+versus rational working facts, branch-state storage, the exact derivation
+constructors, eager versus lazy expression generation, policy scores and
+stage order, and the preferred enclosure method for each function. A first
+implementation is a hypothesis about these choices, not a reason to close the
+design space.
+
+“Compiled search” means ordinary elaboration-time Lean execution of the
+untrusted planner. It does not authorize `precompileModules := true`; the Lake
+target continues to follow [the repository policy](../design-principles.md#lakefile),
+which reserves precompiled modules for libraries exporting approved externs
+and forbids them for Mathlib-importing libraries.
 
 ## Scope
 
@@ -68,13 +86,23 @@ The following are not initial goals:
 Optional external software may later propose bounds, range-reduction data, or
 split points. Such output is an untrusted candidate. The Mathlib companion must
 check it with the same theorems as a native candidate, and the native Lean rule
-must remain the default and fallback.
+must remain the default and fallback. Any such hook follows the
+untrusted-dispatch contract in
+[SPEC.md's project-wide proof policy](../SPEC.md#project-wide-proof-policy):
+availability is never mentioned by a theorem, rejection falls back to native
+Lean, and only independently checked candidate data crosses the boundary.
+This SPEC presently approves no `@[extern]` planner hook. Adding one requires a
+SPEC revision naming its versioned symbol and candidate schema, shape
+validator, checker soundness theorem, and native absence/rejection fallback.
 
 ## Interval representation
 
-The public shape is intentionally small. The exact constructor names may
-change while the implementation is scaffolded, but the distinctions below are
-part of the contract.
+The semantic shape is intentionally small. The exact constructors and the
+placement of the canonicity invariant remain experimental, but the observable
+distinctions below are part of the contract. `Dyadic` means Lean core's
+`Init.Data.Dyadic` type. The rounding precision used by the initial dyadic
+backend is signed `Int`, as in core; negative values are needed for coarse
+grids at large magnitudes.
 
 ```lean
 namespace Hex
@@ -90,19 +118,32 @@ inductive Upper
   | finite (value : Dyadic) (strict : Bool)
   | unbounded
 
-inductive Repr
+inductive Raw
   | empty
   | bounds (lower : Lower) (upper : Upper)
 
 end Interval
-
-/-- A canonical interval representation. -/
-structure Interval where
-  repr  : Interval.Repr
-  valid : repr.CutConsistent
-
 end Hex
 ```
+
+`Raw` avoids shadowing Lean's `Repr` typeclass. The public `Hex.Interval` is an
+opaque API with a `view : Hex.Interval → Hex.Interval.Raw` eliminator, smart
+constructors, and normalization; consumers do not project its backing store.
+Two internal candidates must be compared during the vertical feasibility
+prototype:
+
+1. a structure bundling `raw : Raw` with a proof of `raw.CutConsistent`;
+2. plain data whose `Bool`-valued consistency and normalization are checked at
+   construction or replay boundaries, without carrying a proof in every hot
+   value.
+
+The comparison measures compiled search, ordinary kernel replay, proof bytes,
+allocation, and whether a proof field obstructs safe `#eval`. The SPEC freezes
+neither candidate before that measurement. All public examples use the fully
+qualified `Hex.Interval`, because Mathlib also has a root `Interval` type; the
+public namespace is itself revisitable before release if qualification proves
+awkward. Unless a block explicitly says otherwise, unqualified API sketches
+below are declarations inside `Hex.Interval`.
 
 The comments describe cuts as viewed from outside the interval. In semantic
 notation, a finite lower cut `(a, false)` means `a ≤ x`, and `(a, true)` means
@@ -123,14 +164,16 @@ This gives all ordinary interval shapes:
 | `(-∞,b]` / `(-∞,b)` | unbounded | finite |
 | `(-∞,+∞)` | unbounded | unbounded |
 
-`Repr.CutConsistent` says that `empty` is the unique inconsistent cut pair and
-that a `bounds` value has ordered cuts. Over a dense ordered domain containing
-the dyadics, such a pair is nonempty. `normalize` returns `empty` when the
-lower value exceeds the upper value, or when equal finite values have at least
-one open cut. It is idempotent. Public smart constructors and operations
-return `Interval` values with this invariant. Infinite ends do not carry
-meaningless closure flags. This invariant deliberately does not claim that,
-for example, `(0,1)` contains an integer.
+`Raw.CutConsistent` says exactly that `empty` is the unique empty shape, and a
+finite `bounds` pair has either `a < b`, or `a = b` with both cuts closed.
+Pairs with an infinite end are consistent. Over a dense ordered domain
+containing the dyadics, every consistent `bounds` value is nonempty.
+`normalize` returns `empty` when the lower value exceeds the upper value, or
+when equal finite values have at least one open cut. It is idempotent. Public
+smart constructors and operations return canonical observable values under
+either internal candidate. Infinite ends do not carry meaningless closure
+flags. This invariant deliberately does not claim that, for example, `(0,1)`
+contains an integer.
 
 The representation differs from IEEE 1788 set-based intervals in one
 important respect. IEEE intervals are closed as sets of finite real numbers,
@@ -154,15 +197,27 @@ structure Fact where
   proofCost     : Nat
 ```
 
+This sketch shows the dyadic candidate. If the backend experiment selects
+exact-rational working facts, `Fact.value` becomes an opaque working-endpoint
+identifier and the retained certificate projects it to an exact dyadic or
+rational cut. That decision is made before the trace format is frozen.
+
 This avoids manufacturing an intersection proof after every update. When a
 new lower fact is stronger, the state changes one pointer. The corresponding
 upper fact is unchanged. If two facts state the same cut, the state retains
 the one with the cheaper estimated proof. Weaker facts may remain available
 when they have much smaller endpoints or lead to a cheaper downstream proof.
+Each scope's fact arena is append-only and immutable: “retains” means updating
+a selection pointer, never overwriting a fact. The version counter belongs to
+the selected `(node, side)` slot and increases whenever its selected fact
+changes. Rule cache keys use those slot versions, while derivations keep the
+stable `FactId` of the immutable input.
 
 Two finite facts are contradictory precisely when the lower value is greater
 than the upper value, or when the values are equal and either fact is strict.
-That check is exact dyadic arithmetic.
+That check uses exact endpoint arithmetic: exact dyadic arithmetic in the
+initial candidate, or the selected exact comparison if the working-endpoint
+experiment adopts rationals.
 
 ### Exact rational source facts
 
@@ -197,6 +252,8 @@ policy.
 The initial operations are:
 
 ```lean
+namespace Hex.Interval
+
 def intersect  : Interval → Interval → Interval
 def hull       : Interval → Interval → Interval
 def neg        : Interval → Interval
@@ -211,7 +268,13 @@ def min        : Interval → Interval → Interval
 def max        : Interval → Interval → Interval
 def split      : Interval → Dyadic → Interval × Interval
 def regularize : Precision → Interval → Interval
+
+end Hex.Interval
 ```
+
+For the initial dyadic backend, `Precision` is an alias for signed `Int` and
+the implementation reuses core `Dyadic.roundDown`, `roundUp`, `invAtPrec`, and
+`divAtPrec` rather than reimplementing directed rounding.
 
 The Mathlib companion proves their set-enclosure theorems. The computational
 tests also check the following exactness rules.
@@ -223,10 +286,11 @@ tests also check the following exactness rules.
 - Negation swaps the ends and preserves their openness.
 - A finite endpoint of a sum is closed exactly when both contributing
   endpoints are closed.
-- Multiplication partitions both inputs by sign, enumerates finite corner and
-  zero candidates, and tracks whether each extremum is attained. Zero is an
-  attained extremum whenever either factor contains zero, not only when a
-  factor is the singleton zero. For example,
+- After the empty-input short circuit, multiplication partitions both inputs
+  by sign, enumerates finite corner and zero candidates, and tracks whether
+  each extremum is attained. Zero is an attained extremum whenever either
+  nonempty factor contains zero, not only when a factor is the singleton zero.
+  For example,
   `[0,1] * (0,1] = [0,1]`, while `(0,1] * (0,1] = (0,1]`.
 - A power distinguishes zero, odd powers, and positive even powers. It does
   not implement powers by repeated interval multiplication when a direct hull
@@ -237,14 +301,22 @@ tests also check the following exactness rules.
   than blindly copying one endpoint flag.
 - `split I m` returns `I ∩ (-∞,m]` and `I ∩ (m,+∞)`. The children are disjoint
   and cover `I`.
+- Empty is canonical. Unary image operations and regularization preserve empty;
+  binary image and intersection operations absorb an empty argument; and
+  `split empty m = (empty, empty)`. Hull instead has empty as a two-sided
+  identity.
+- `pow I 0` is `{1}` for nonempty `I`, including unbounded `I`, and is `empty`
+  for empty `I`. Thus the operation is the direct image of Lean's power
+  function rather than a vacuously sound but noncanonical enclosure.
 
-These named arithmetic operations return tight cuts in their representable
-dyadic result class, including exact endpoint attainment. Conservatively
-closing a cut is permitted for an approximate registered propagator, not for
-these primitives.
+The primitives whose exact images have dyadic endpoints return tight cuts,
+including exact endpoint attainment. Precision-indexed inverse and division
+must first be sound; their grid-tightness has the additional proof obligation
+below. Conservatively closing a cut is permitted for an approximate registered
+propagator, not for an exact primitive once its tightness theorem is present.
 
 The image of reciprocal or division may be disconnected, and even `{3}⁻¹`
-has a nondyadic endpoint. `invAt p` and `divAt p` return the tightest
+has a nondyadic endpoint. `invAt p` and `divAt p` return a sound
 single-interval enclosure on the `2^-p` dyadic grid for the complete image
 under Lean's total inverse, including `0⁻¹ = 0`. Moved grid endpoints use the
 strictness rule above. Thus a positive interval bounded away from zero has the
@@ -254,6 +326,25 @@ whole-interval hull. A rule can request a split at zero before using a tighter
 sign-specific result. A later `IntervalSet` with at most two components is an
 isolated extension, not a reason to complicate every initial operation.
 
+Grid-tightness remains an acceptance target, not an assumed consequence of
+core's API. Core currently proves the one-sided `roundDown_le` and
+`le_roundUp` lemmas but leaves the corresponding optimality characterizations
+as TODOs. The implementation proves the following characterizations locally
+or contributes them upstream:
+
+```lean
+Dyadic.le_roundDown
+  (hy : y.precision ≤ some p) (hyx : y ≤ x) :
+  y ≤ x.roundDown p
+
+Dyadic.roundUp_le
+  (hy : y.precision ≤ some p) (hxy : x ≤ y) :
+  x.roundUp p ≤ y
+```
+
+These lemmas are required before the theorem API claims “tightest”. Enclosure
+soundness does not wait on that optimization proof.
+
 Lean defines functions such as inverse and logarithm on inputs where a
 numerical interval library might call them undefined. The computational
 operation does not choose the mathematical convention. Each companion rule
@@ -262,16 +353,18 @@ using a tighter theorem.
 
 ### Outward regularization
 
-`regularize p I` widens finite endpoints onto a grid with denominator at most
-`2^p`. It rounds a lower endpoint down and an upper endpoint up. It never
+`regularize p I` widens finite endpoints onto the grid `2^-p · ℤ`. It rounds a
+lower endpoint down and an upper endpoint up. It never
 replaces the strongest fact in the solver. Instead, it creates a cheaper view
 that a later rule may use.
 
 If an endpoint moves, the regularized cut is strict: a moved lower endpoint
 is strictly below the old lower endpoint, and a moved upper endpoint is
 strictly above the old upper endpoint. An unchanged endpoint inherits its old
-strictness. This is the strongest sound outward view and makes regularization
-idempotent without throwing away useful strict inequalities.
+strictness. This is the candidate strongest sound outward view and makes
+regularization idempotent without throwing away useful strict inequalities;
+the same rounding-characterization lemmas used for grid-tightness must certify
+both claims.
 
 This distinction matters. Exact dyadic numerators can still grow rapidly.
 Discarding a strong fact to shorten it would make the state order-dependent.
@@ -281,20 +374,25 @@ trade precision against arithmetic cost without losing information.
 The backend-comparison milestone also builds a separate exact-rational search
 prototype. Its regularizer uses continued-fraction convergents or
 semiconvergents to find low-height outward bounds under a denominator budget.
-It is not silently substituted for `Fact.value : Dyadic`: retained proof
-traces are projected to dyadic cuts, and adopting rational working facts would
-require an explicit representation revision. The dyadic backend remains the
-specified default because its bit-height contract and kernel certificates are
-simpler. The comparison records total search, proof construction, and replay
-cost. A small arithmetic microbenchmark alone is not enough to settle the
-public representation.
+It is not silently substituted for the dyadic prototype: retained proof
+traces must identify their endpoint encoding, and adopting rational working
+facts requires an explicit representation revision before formats are frozen.
+The dyadic backend is the first hypothesis because its bit-height contract and
+kernel certificates appear simpler, not because this SPEC assumes the
+experiment's outcome. The comparison records total search, proof construction,
+and replay cost. A small arithmetic microbenchmark alone is not enough to
+settle the public representation.
 
 ## Shared expression program
 
-The frontend reifies terms into a typed static single-assignment program. Each
-instruction refers only to earlier instruction identifiers. Common
+The frontend first reifies terms into a typed single-assignment base program.
+Each instruction refers only to earlier instruction identifiers. Common
 subexpression elimination occurs before search, so the array is also a compact
-encoding of an expression DAG.
+encoding of an expression DAG. The base is immutable after validation. A
+separate, bounded extension mechanism may add proved-relevant expressions as
+search discovers useful shapes; eager pre-materialization, epochal extension,
+and fully append-only extension are candidates to compare rather than a choice
+already frozen here.
 
 Conceptually:
 
@@ -306,8 +404,9 @@ structure Node where
 
 structure Program where
   operations : Array OpKey
-  nodes     : Array Node
-  consumers : Array (Array NodeId)
+  nodes      : Array Node
+  consumers  : Array (Array NodeId)
+  equalities : Array EqEdge
 ```
 
 An `OpKey` identifies the semantic operation at a node, including its domain
@@ -328,6 +427,62 @@ The program is typed by construction in the frontend. The scheduler uses only
 the compact identifiers. This avoids a dependent heterogeneous term language
 inside the hot loop while leaving room for domains other than `ℝ` later.
 
+An `EqEdge` connects two node identifiers that the companion can prove equal.
+It may come from normalization, a local equality hypothesis, or a certified
+instantiation. The Mathlib-free table records endpoints, scope requirements,
+and a proof-recipe key; the validated companion program pairs it with the
+actual equality proof. Equal nodes are not merged, so descendant equalities do
+not introduce cycles.
+
+### Bounded expression instantiation
+
+A rule may match a shape already in the program and propose additional
+expressions whose bounds make another rule applicable. This is analogous to
+`grind` instantiating a theorem, but the products are expression nodes and
+ordinary interval facts. Typical uses include:
+
+- introducing the centered form `1/4 - (x - 1/2)^2` when bounding
+  `x * (1 - x)`;
+- deriving `1 - 2*x^2*y^2` from the source equality `x^2 + y^2 = 1` when
+  bounding `x^4 + y^4`;
+- introducing derivative, range-reduction, or function-specific alternate
+  expressions only after their input range makes them useful;
+- instantiating a monotonicity theorem by adding product or difference nodes
+  that were absent from the original goal.
+
+An instantiation proposal contains a versioned rule key, a canonical
+substitution, new SSA instructions, equality or derived-fact recipes, and an
+untrusted claimed generation. Acceptance validates operation arities and
+domains, topological order, scope visibility, and every referenced input;
+recomputes each node's generation from the trigger provenance and generated
+dependencies, rejecting a mismatch or over-budget descendant; deduplicates
+expressions by the same canonical CSE key as the base program; updates consumer
+and rule indexes; and freezes the proof recipe for replay. Base nodes have
+generation zero, and a generated node is one plus the maximum relevant
+generation in the instance that caused it. The new expression is not trusted
+merely because a trigger matched or labeled itself generation zero.
+
+Generation is explicitly budgeted by new nodes, new equality edges, rule
+applications, depth, and retained payload bytes. A canonical key consisting
+of the rule, substitution, scope, and generated expression prevents duplicate
+instances. Candidate traversal and insertion order are deterministic. If a
+branch-local fact triggers a semantically branch-independent expression, the
+node may be shared globally while the resulting fact and conditional equality
+remain branch-scoped. Whether the first implementation uses that scheme or
+branch-local extensions is an experiment; identifiers and replay must make
+the choice explicit.
+
+The initial feasibility comparison has three arms:
+
+1. eagerly materialize every alternate admitted by the node/form budgets;
+2. run bounded instantiation between propagation epochs, then validate and
+   freeze a new program snapshot;
+3. append nodes lazily during search with incremental dependency updates.
+
+The corpus measures program size, duplicate instances, useful-instance ratio,
+search time, and replay size. Safe budget exhaustion leaves the already
+validated program and facts usable.
+
 ## Rule protocol
 
 Rules are explicit registrations, not typeclass instances. Typeclass search
@@ -335,12 +490,13 @@ must not recursively decide which algorithm computes an expression's bound.
 The registry may contain several rules for one head symbol, and the policy may
 try or combine all of them.
 
-A structural, form-directed rule search similar to `apply_rules` remains a
-benchmark alternative because it has worked well in other proof assistants
-and may compose local order lemmas cheaply. The specified implementation keeps
-an explicit registry and incremental scheduler so it can share facts, retain
-state, and compare multiple methods. The benchmark compares these search
-styles rather than assuming the registry wins every structural goal.
+The explicit registration and validation boundary is fixed. Discovery and
+scheduling above it remain empirical: one arm uses an incremental registry
+worklist to share facts and retain state, while a second traverses the same
+registered rules in a structural, form-directed loop similar to `apply_rules`.
+Neither arm uses recursive typeclass search or bypasses rule validation. The
+benchmark compares these discovery styles rather than preselecting one for
+every structural goal; a hybrid may use the structural loop as one action.
 
 Rule-private caches can have arbitrary Lean types. For that reason the
 Mathlib-free library does not store them in a heterogeneous array. It exposes
@@ -362,6 +518,12 @@ The companion reconstructs every retained fact from the rule's soundness
 theorem. A failed reconstruction identifies a broken registration rather than
 closing the user's goal.
 
+Cost observations used by a deterministic policy are specified logical counts
+such as declared arithmetic work, visited certificate entries, generated
+nodes, or estimated proof nodes. Actual runtime reductions, allocations, and
+wall time are telemetry only: compiler and backend changes can alter them, so
+they cannot influence a reproducible action choice.
+
 ### Action kinds
 
 The protocol distinguishes the following actions.
@@ -371,8 +533,13 @@ The protocol distinguishes the following actions.
   contract an argument interval.
 - `improve`: rerun a rule at greater effort, use a tighter enclosure method, or
   subdivide only the rule's input range and take the hull of the pieces.
-- `rewrite`: activate a proved alternate expression and equality edge that the
-  frontend materialized before search.
+- `shave`: temporarily slice one input, run a bounded contractor on each slice,
+  discard slices proved inconsistent, and return the hull of survivors with a
+  local branch certificate.
+- `instantiate`: propose validated new expression nodes and their proof
+  recipes from a matched shape.
+- `rewrite`: activate a proved alternate expression and equality edge already
+  present in the current validated program snapshot.
 - `regularize`: create bounded-height working views without deleting stronger
   facts.
 - `split`: create proof branches by adding complementary cuts for one node.
@@ -382,22 +549,39 @@ propagator can tighten the range of a function without duplicating the whole
 proof state. A solver split is needed when a dependency between several nodes
 requires different assumptions in different cases.
 
-An `Outcome` may be `noChange`, `inapplicable`, or `failed` without affecting
-soundness. Rules do not promise that greater effort always gives a tighter
-answer. The solver intersects every result with existing facts, measures the
-actual improvement, and learns from that observation.
+`shave` is also distinct from a solver split. It is the proof-producing analogue
+of RealPaver's 3B/CID strong-consistency step: its temporary cases live inside
+one rule payload, and replay proves that every removed edge slice is
+inconsistent before hulling the survivors. A policy may compare cheap HC4-style
+forward/backward contraction, BC-style searches for repeated occurrences,
+targeted shaving, interval Newton, and a global split. Which strength to apply
+is empirical and may depend on occurrence counts, derivative influence,
+observed contraction, and proof cost.
 
-The initial `Program` is static after validation. Generic alternate forms are
-present before search, and `rewrite` only changes which existing form is
-scheduled. Adaptive range reduction or a Taylor polynomial may remain inside
-a rule-specific payload and return a fact about the existing node. It does not
-append unchecked instructions. A later append-only program extension would
-need its own validation, dependency-update, and branch-storage design.
+An `Outcome` may be `noChange`, `inapplicable`, `resourceLimit`, or `failed`
+without affecting soundness. `resourceLimit` names the exhausted budget and is
+not cached as mathematical inapplicability. Rules do not promise that greater
+effort always gives a tighter answer. The solver intersects every result with
+existing facts, measures the actual improvement, and learns from that
+observation.
+
+The base `Program` is static after validation. Generic cheap alternates may be
+present before search, and `rewrite` only changes which form in the current
+validated snapshot is scheduled. Adaptive range reduction or a Taylor
+polynomial may instead remain inside a rule-specific payload and return a fact
+about an existing node. Dynamic instantiation is never unchecked mutation: it
+uses the validation, dependency-update, scope, generation, and replay contract
+above.
 
 ### Stateful rules
 
-A cache key includes the rule, node, input fact versions, and effort. A rule
-may retain:
+A cache is either owned by one branch or explicitly keyed by `ScopeId`. Its
+key also includes the immutable program-snapshot identifier (or equivalent
+canonical expression key), versioned rule, node, exact input `FactId`s and
+slot versions, and effort. A node number and scope-local version counters are
+not a global key: siblings may reuse those numbers for different cuts or
+extensions. Cross-branch reuse is permitted only when all semantic inputs and
+the validated snapshot key agree. A rule may retain:
 
 - Taylor coefficients and remainder data;
 - values at subdivision points;
@@ -461,14 +645,14 @@ structure Policy where
   observe    : State → Action → Observation → State
 ```
 
-The default state uses a versioned priority queue. Changed facts insert or
+The first `balancedV1` prototype uses a versioned priority queue. Changed facts insert or
 invalidate only affected candidates; stale entries are discarded lazily when
 popped. Policies intended for diagnostics may use a simpler complete scan,
 but their complexity is reported honestly.
 
-The initial named policies are:
+The initial prototype policies are:
 
-- `balancedV1`: the deterministic default described below;
+- `balancedV1`: the first deterministic default candidate described below;
 - `propagateV1`: propagation and effort increases, with solver splits disabled;
 - `bisectV1`: a diagnostic midpoint policy after cheap saturation;
 - `replay`: follows an explicitly supplied action plan for regression tests.
@@ -477,9 +661,26 @@ Versioned names let a downstream proof script pin search behavior while the
 default alias can improve. A pinned policy is not a soundness requirement. It
 is only a reproducibility aid.
 
-### The default policy
+### Default-policy contract
 
-`balancedV1` uses four stages.
+The normative requirements on any release default are smaller than one
+particular scoring formula.
+
+- For a fixed validated program, registry contents, configuration, and Lean
+  environment, action choice under a step budget is deterministic.
+- Candidate maps are traversed in canonical sorted order. The final tie-break
+  includes action kind, `NodeId`, versioned `RuleKey`, input fact versions,
+  effort, generation, and split point; hash-table order and freshly allocated
+  identifiers are not tie-breakers.
+- Scores use bounded integer or exact arithmetic with specified saturation,
+  never `Float` or host timing.
+- A fairness mechanism eventually samples every continuously eligible action
+  when the budget is unbounded and only finitely many new actions are added.
+- The policy reports enough observations to replay and compare its decisions;
+  changing it cannot change proof validity.
+
+`balancedV1` is the initial empirical default candidate. Its first prototype
+uses four stages.
 
 1. Drain cheap forward and backward actions whose inputs changed.
 2. Run untried applicable enclosure methods with their initial effort.
@@ -488,7 +689,7 @@ is only a reproducibility aid.
 4. If no candidate has adequate predicted gain, choose a solver split and
    repeat in both children.
 
-The policy computes a goal-directed potential rather than summing raw widths.
+The prototype computes a goal-directed potential rather than summing raw widths.
 Nodes on the backwards dependency slice from the desired comparison or current
 contradiction receive greater weight. A node's uncertainty records:
 
@@ -499,29 +700,26 @@ contradiction receive greater weight. A node's uncertainty records:
 - estimated proof cost;
 - distance in the program from a fact that can close the branch.
 
-The exact coefficients are policy-tuning benchmark data, not mathematical
-constants. They live in `PolicyConfig` and are reported by tracing. Scores use
-bounded integer fixed-point arithmetic with specified saturation, never
-`Float`. `balancedV1` has a
-total tie-break over action stage and kind, `NodeId`, versioned `RuleKey`,
-input fact versions, effort, and dyadic split point. Candidate maps are
-traversed in sorted order, so hash-table iteration and fresh environment
-identifiers cannot affect a step-budgeted result.
+The coefficients, stage boundaries, uncertainty components, and score formula
+are policy-tuning benchmark data, not public contracts. They live in
+`PolicyConfig` and are reported by tracing.
 
-For an action that has run before, its score is the observed reduction in
+The first scoring experiment gives an action that has run before its observed reduction in
 weighted potential divided by declared work plus estimated proof cost. An
 untried action receives an optimism bonus. Repeated `noChange` results decay
 the score unless an input version or effort changes. A fixed quota selects the
 oldest still-valid action in the highest nonempty fairness tier instead of the
-best score. Consequently, with an unbounded step budget and only finitely many
-new insertions, every continuously eligible action is eventually sampled. A
-finite configured budget makes no such promise.
+best score. A competing implementation uses a bandit-style score, and a third
+uses a simpler staged queue. Benchmarks compare solved corpus, proof nodes,
+deterministic work, and robustness under irrelevant actions. A finite
+configured budget makes no completeness promise.
 
 The original sensitivity proposal is recovered as a simple special case: if
 `m` is the global uncertainty measure and an action changes it to `m'`, the
 action's measured sensitivity is a monotone function of `m - m'` or `m / m'`.
-The implementation uses a difference on capped logarithmic widths so
-unbounded values and zero width do not require exceptional arithmetic.
+The first implementation tests a difference on capped logarithmic widths so
+unbounded values and zero width do not require exceptional arithmetic. This is
+replaceable policy data.
 
 ### Precision, propagation, or splitting
 
@@ -547,7 +745,8 @@ branch.
 ### Split candidates
 
 Rules may suggest a node other than one of their direct arguments. Each
-suggestion names a dyadic point and a reason. The default order is:
+suggestion names a dyadic point and a reason. The first `balancedV1` prototype
+orders otherwise comparable suggestions as follows:
 
 1. a pole, total-function boundary, or other semantic landmark;
 2. an `abs`, `min`, or `max` kink;
@@ -572,7 +771,9 @@ arguments.
 
 Every search is finite because the configuration bounds:
 
-- reified program nodes and alternate forms per original node;
+- reified base nodes, dynamically generated nodes and equality edges,
+  instantiation actions and generation depth, and alternate forms per original
+  node;
 - accepted actions;
 - rule invocations and maximum effort;
 - solver split depth and number of leaves;
@@ -585,13 +786,38 @@ Every search is finite because the configuration bounds:
 
 `maxEndpointHeight` is measured after canonical dyadic normalization as the bit
 length of the absolute numerator plus the magnitude of the signed binary
-exponent. A separate alignment-shift limit caps the exponent difference used
-by comparison and arithmetic. This reflects the actual shifted-integer work;
-an exponent of magnitude `2^30` is not treated as a 31-bit endpoint. An
-oversized new candidate is not installed. The rule may instead
-return a separately justified outward-regularized candidate within budget.
-Existing stronger facts are never deleted to satisfy the limit, and an
-oversized result is reported distinctly from `noChange`.
+exponent. This deliberately charges dynamic range linearly: a fact near
+`2^-333` costs at least 333 even when its numerator is tiny. Regularization can
+reduce numerator growth and working precision, but cannot shrink that dynamic
+range; defaults must therefore cover the several-hundred-bit exponents in the
+PNT+ tail corpus. A separate alignment-shift limit caps the exponent difference
+used by comparison and arithmetic. This reflects the actual shifted-integer
+work; an exponent of magnitude `2^30` is not treated as a 31-bit endpoint.
+This is the conservative first accounting policy. Telemetry separately records
+numerator bits, encoded exponent bits, exponent magnitude, and actual shifted
+integer work so experiments can replace the aggregate metric without weakening
+the preflight resource guard.
+
+Every backend in the D2 comparison implements a common exact endpoint-cost and
+preflight interface. The rational candidate at minimum charges normalized
+numerator and denominator bit lengths, predicts cross-multiplication and
+regularization work before allocating the enlarged integers, and returns the
+same distinct `resourceLimit` outcome when its configured bound is exceeded.
+Backend-specific numbers need not be numerically identical to dyadic height,
+but each must prevent an ostensibly small encoded exponent or denominator from
+bypassing the actual arithmetic-work budget and must expose its components in
+telemetry.
+
+For the dyadic candidate, before an exact comparison or arithmetic action the
+engine computes the required alignment shift without performing it. If it
+exceeds the budget, the action returns `resourceLimit` and records the
+exhausted limit; it is never interpreted as “not contradictory” or as a failed
+mathematical comparison. An oversized new candidate is not installed. The rule
+may instead return a separately justified outward-regularized candidate within
+budget when regularization actually helps. Existing stronger facts are never
+deleted to satisfy the limit, and an oversized result is reported distinctly
+from `noChange`. The rational candidate applies the common exact-cost preflight
+above to cross-multiplication and denominator growth instead.
 
 Payload limits are enforced when an accepted recipe is frozen. Deduplicated
 tables are counted once in the immutable arena. A one-node derivation cannot
@@ -615,16 +841,23 @@ as a context-wide fact.
 
 The search log may be large, but the returned derivation is a backwards slice
 from the closing facts. Parent identifiers make that slice linear in the
-facts actually used.
+facts actually used. The constructor set below is a design sketch, not a frozen
+serialization format; the vertical kernel-replay prototype may separate
+validation, evaluation, program-extension, and output lookup differently.
 
 ```lean
 structure FactId where
   scope : ScopeId
   index : Nat
 
+inductive EqualityRef
+  | edge   (edge : EqEdgeId)
+  | source (source : SourceId)
+
 inductive Derivation
   | source     (source : SourceId)
   | rule       (rule : RuleKey) (inputs : Array FactId) (payload : PayloadId)
+  | transportEq (equality : EqualityRef) (input : FactId) (target : NodeId)
   | weaken     (input : FactId) (cut : Cut)
   | splitAssumption (parent : ScopeId) (side : SplitSide)
       (node : NodeId) (cut : Dyadic)
@@ -650,6 +883,15 @@ and neither may refer to the other's facts. The left child receives the closed
 upper cut `node <= cut`; the right child receives the strict lower cut
 `cut < node`. The branch-tree validator checks these relationships, unique
 parentage, acyclicity, and that every leaf has a closing witness.
+
+`transportEq` preserves side, value, and strictness while moving a fact across
+a proved equality. Validation checks that the equality is visible in the
+fact's scope, that its endpoints match the input and target nodes in one of the
+two permitted directions, and that a source equality names an original or
+ancestor hypothesis rather than a sibling fact. The trace is paired with the
+validated equality-edge table and its immutable proof recipes, including edges
+introduced by bounded instantiation. Thus alternate-form intersection and
+contextual equality transfer have an explicit replay step.
 
 The branch tree refers to shared derivations. Facts established before a split
 are stored once in the ancestor scope. Within a branch, repeated uses of one
@@ -703,15 +945,22 @@ states.
 - One worklist update is proportional to the number of rules attached to the
   changed node and its consumers. The scheduler does not scan all `n` nodes
   after every fact.
-- Fact comparison and contradiction checks use exact dyadic comparison. Their
-  integer cost is proportional to effective endpoint height and the permitted
-  exponent-alignment shift.
-- Branch facts use an explicitly persistent paged trie, not Lean `Array`
-  copy-on-write. Creating a child shares the root in `O(1)`; updating a fact
-  copies one trie path and one fixed-size page in `O(log n)` time.
-- Default-policy candidate insertion, invalidation, and heap selection are
-  `O(log q)` amortized, excluding the declared cost of rescoring a stale
-  candidate. A diagnostic policy that scans candidates reports `O(q)`.
+- Fact comparison and contradiction checks use exact endpoint comparison. For
+  the dyadic candidate, integer cost is proportional to effective endpoint
+  height and the permitted exponent-alignment shift; a rational candidate must
+  declare and benchmark its corresponding exact-arithmetic cost.
+- Branch storage must make child creation and isolated updates cheap at the
+  program sizes and leaf counts in the corpus; it must not silently copy all
+  `n` fact slots at every split once that cost dominates. Candidate
+  implementations include Lean `Array` copy-on-write, a persistent paged trie,
+  a chunked vector, and a depth-first mutable trail with rollback. Their actual
+  complexities and constant factors are reported. No one representation is
+  selected before the crossover benchmark.
+- The first priority-queue prototype targets `O(log q)` amortized candidate
+  insertion, invalidation, and selection, excluding the declared cost of
+  rescoring a stale candidate. A diagnostic policy that scans candidates
+  reports `O(q)`; other policy data structures state and measure their own
+  model.
 - Total search is bounded by the configured action, leaf, endpoint-height, and
   payload budgets.
 
@@ -744,11 +993,17 @@ typical, boundary, and adversarial inputs. In particular it includes:
 - all four finite endpoint closure combinations;
 - equal endpoints in all closure combinations;
 - empty, singleton, one-sided unbounded, and whole intervals;
+- table-driven empty laws: every unary operation and `regularize` preserve
+  empty; binary image operations and intersection absorb it; hull has it as an
+  identity; splitting it returns two empty pieces; `pow empty n = empty` even
+  at zero, while `pow I 0 = {1}` for every nonempty `I`;
 - intersection and hull at equal open and closed cuts;
 - split coverage at an endpoint and an interior point;
 - negation and addition closure propagation;
 - multiplication by singleton zero, by a nonsingleton interval containing
   zero, and by unbounded intervals, with exact endpoint-attainment flags;
+- the distinct cases `mul empty whole = empty`, `mul {0} whole = {0}`, and
+  `mul whole {0} = {0}`;
 - `abs`, `min`, and `max` with tied open and closed extrema;
 - precision-indexed reciprocal and division for `{3}`, positive, negative,
   singleton-zero, one-sided-zero, and sign-crossing inputs;
@@ -764,6 +1019,11 @@ typical, boundary, and adversarial inputs. In particular it includes:
 - derivation slicing that removes failed probes and unused facts;
 - branch validation that rejects sibling fact references and mutable or
   dangling payloads;
+- program-extension validation that rejects bad topology, duplicate canonical
+  keys, invisible branch-local nodes, invalid equality endpoints, and an
+  instantiation beyond each generation budget;
+- deterministic deduplication of two triggers proposing the same expression
+  and equality edge in different orders;
 - budget exhaustion returning `unknown` with a nonempty diagnostic record.
 
 The `ci` profile cross-checks finite arithmetic against an independent Python
@@ -786,7 +1046,15 @@ The Mathlib-free benchmark target measures:
   exponent-alignment distance;
 - worklist saturation over synthetic chain, fan-out, and shared-diamond
   programs;
-- persistent paged-trie branch creation and updates over program size;
+- bounded-instantiation saturation over useful, duplicate, and deliberately
+  explosive trigger families, recording generated nodes, equality edges,
+  suppressed instances, and proof-slice retention;
+- HC4-style propagation and local-shaving traces over translated small
+  RealPaver-shaped dependency graphs, without importing their floating-point
+  semantics;
+- branch creation and isolated updates for `Array` copy-on-write, persistent
+  paged-trie, chunked-vector, and trail/rollback candidates, crossing program
+  sizes 20, 50, and 500 with 8, 100, and 1,000 leaves;
 - policy selection over the number of available actions;
 - derivation slicing over total log size and retained proof size.
 

--- a/SPEC/Libraries/hex-interval.md
+++ b/SPEC/Libraries/hex-interval.md
@@ -1,0 +1,813 @@
+# hex-interval (exact interval data and budgeted propagation search, Mathlib-free)
+
+`hex-interval` is the Mathlib-free computational library for interval
+arithmetic. It represents exact dyadic bounds, maintains the bounds of a
+shared expression program, schedules propagation and refinement actions, and
+records the successful search as a compact derivation trace. It does not
+interpret a program as a real-valued function and it does not construct Lean
+proof terms. Those tasks belong to
+[hex-interval-mathlib](hex-interval-mathlib.md).
+
+The library is intended to support a standalone `interval` tactic. Integration
+with `grind` is not part of this development. The scheduler and rule protocol
+should nevertheless be reusable by another frontend later.
+
+The procedure is deliberately incomplete. It tries to prove a requested bound
+or to make a collection of hypotheses inconsistent within explicit budgets.
+Failure means that the selected rules and search policy did not find a proof.
+It does not mean the goal is false.
+
+## Requirements
+
+The design must satisfy all of the following.
+
+1. A finite bound is an arbitrary-exponent `Dyadic`. No floating-point value is
+   used as a proved endpoint.
+2. The lower and upper ends independently support strict and non-strict bounds.
+   Either end may be unbounded. Empty, singleton, and whole intervals have
+   canonical representations.
+3. The program representation shares repeated subexpressions. A bound proved
+   for one occurrence is available to every consumer of that occurrence.
+4. A rule may keep private state, offer several enclosure methods for the same
+   function, improve a previous result at greater effort, suggest a local
+   range split, suggest a proof-level case split, or propagate a result
+   backwards into its arguments.
+5. The search policy is separate from rule correctness. Replacing a heuristic
+   cannot affect soundness.
+6. The default policy is deterministic under a step budget. Wall-clock limits
+   are secondary emergency limits, not the definition of the search.
+7. Search runs as compiled Lean code. The trace contains only successful facts
+   needed by the final derivation. Failed probes and discarded candidates do
+   not appear in the generated proof.
+8. No part of the implementation, conformance suite, benchmark, or tactic
+   fallback uses `native_decide`.
+
+## Scope
+
+The first implementation provides the data and search machinery needed for
+real-valued expressions. The scheduler is independent of real semantics:
+nodes and facts carry small domain and operation identifiers, and the caller
+owns their mathematical meanings. The initial interval fact format is more
+specific. Its cut consistency assumes a dense ordered scalar domain with an
+exact dyadic embedding. The Mathlib companion first instantiates `ℝ`, and a
+later `ℚ` instance is compatible with the same cuts. Direct `ℤ` or `ℕ`
+semantics require domain-specific integer endpoint normalization; until then,
+those types enter only through casts to `ℝ`.
+
+The following are not initial goals:
+
+- a complete decision procedure for nonlinear real arithmetic;
+- cylindrical algebraic decomposition or another multivariate real-closed-field
+  procedure;
+- IEEE 1788 decorations or modal intervals;
+- trusting hardware rounding, `Float`, MPFR, Arb, or an external theorem
+  prover;
+- representing every disconnected image as one value;
+- integration with `grind`.
+
+Optional external software may later propose bounds, range-reduction data, or
+split points. Such output is an untrusted candidate. The Mathlib companion must
+check it with the same theorems as a native candidate, and the native Lean rule
+must remain the default and fallback.
+
+## Interval representation
+
+The public shape is intentionally small. The exact constructor names may
+change while the implementation is scaffolded, but the distinctions below are
+part of the contract.
+
+```lean
+namespace Hex
+namespace Interval
+
+/-- A lower cut. `strict = true` means `value < x`. -/
+inductive Lower
+  | unbounded
+  | finite (value : Dyadic) (strict : Bool)
+
+/-- An upper cut. `strict = true` means `x < value`. -/
+inductive Upper
+  | finite (value : Dyadic) (strict : Bool)
+  | unbounded
+
+inductive Repr
+  | empty
+  | bounds (lower : Lower) (upper : Upper)
+
+end Interval
+
+/-- A canonical interval representation. -/
+structure Interval where
+  repr  : Interval.Repr
+  valid : repr.CutConsistent
+
+end Hex
+```
+
+The comments describe cuts as viewed from outside the interval. In semantic
+notation, a finite lower cut `(a, false)` means `a ≤ x`, and `(a, true)` means
+`a < x`. A finite upper cut `(b, false)` means `x ≤ b`, and `(b, true)` means
+`x < b`.
+
+This gives all ordinary interval shapes:
+
+| Set | Lower | Upper |
+| --- | --- | --- |
+| `∅` | canonical `empty` | canonical `empty` |
+| `{a}` | closed `a` | closed `a` |
+| `[a,b]` | closed `a` | closed `b` |
+| `[a,b)` | closed `a` | open `b` |
+| `(a,b]` | open `a` | closed `b` |
+| `(a,b)` | open `a` | open `b` |
+| `[a,+∞)` / `(a,+∞)` | finite | unbounded |
+| `(-∞,b]` / `(-∞,b)` | unbounded | finite |
+| `(-∞,+∞)` | unbounded | unbounded |
+
+`Repr.CutConsistent` says that `empty` is the unique inconsistent cut pair and
+that a `bounds` value has ordered cuts. Over a dense ordered domain containing
+the dyadics, such a pair is nonempty. `normalize` returns `empty` when the
+lower value exceeds the upper value, or when equal finite values have at least
+one open cut. It is idempotent. Public smart constructors and operations
+return `Interval` values with this invariant. Infinite ends do not carry
+meaningless closure flags. This invariant deliberately does not claim that,
+for example, `(0,1)` contains an integer.
+
+The representation differs from IEEE 1788 set-based intervals in one
+important respect. IEEE intervals are closed as sets of finite real numbers,
+with infinities used as endpoint markers. A proof assistant must also retain
+strict hypotheses and prove strict conclusions. Independent cut openness is
+therefore semantic data here, not a display annotation.
+
+### Endpoint facts
+
+The solver stores the lower and upper facts for a node separately. An
+unbounded end is the absence of a fact. A fact contains:
+
+```lean
+structure Fact where
+  scope         : ScopeId
+  node          : NodeId
+  side          : Side
+  value         : Dyadic
+  strict        : Bool
+  justification : JustificationId
+  proofCost     : Nat
+```
+
+This avoids manufacturing an intersection proof after every update. When a
+new lower fact is stronger, the state changes one pointer. The corresponding
+upper fact is unchanged. If two facts state the same cut, the state retains
+the one with the cheaper estimated proof. Weaker facts may remain available
+when they have much smaller endpoints or lead to a cheaper downstream proof.
+
+Two finite facts are contradictory precisely when the lower value is greater
+than the upper value, or when the values are equal and either fact is strict.
+That check is exact dyadic arithmetic.
+
+### Exact rational source facts
+
+Lean goals often contain rational constants such as `1 / 3`, which are not
+dyadic. The frontend retains each such hypothesis as an exact source fact. At
+working precision `p`, it asks this library for an outward dyadic projection:
+
+- a rational lower bound is rounded down;
+- a rational upper bound is rounded up;
+- an exactly dyadic rational is preserved;
+- strictness is preserved when transitivity proves the projected strict cut.
+
+Increasing effort may request a finer projection from the original rational.
+It never rounds an already rounded endpoint again. This prevents accumulated
+rounding drift and keeps arbitrary rational arithmetic out of the hot
+propagation path.
+
+Projection keeps the strongest strictness justified by order. For a lower
+source cut at `r`, a projected dyadic `q <= r` inherits the source strictness
+when `q = r`; when `q < r`, the projected cut is strict even if the source was
+closed. For an upper source cut, `r <= q` has the dual rule: equality inherits
+strictness and `r < q` makes the projected cut strict. Thus rounding outward
+does not unnecessarily lose a strict goal.
+
+### Arithmetic and closure
+
+`hex-interval` provides named operations rather than ring or field instances.
+Interval addition and multiplication do not satisfy the algebraic laws that a
+consumer expects from instances, and division across zero needs an explicit
+policy.
+
+The initial operations are:
+
+```lean
+def intersect  : Interval → Interval → Interval
+def hull       : Interval → Interval → Interval
+def neg        : Interval → Interval
+def add        : Interval → Interval → Interval
+def sub        : Interval → Interval → Interval
+def mul        : Interval → Interval → Interval
+def invAt      : Precision → Interval → Interval
+def divAt      : Precision → Interval → Interval → Interval
+def pow        : Interval → Nat → Interval
+def abs        : Interval → Interval
+def min        : Interval → Interval → Interval
+def max        : Interval → Interval → Interval
+def split      : Interval → Dyadic → Interval × Interval
+def regularize : Precision → Interval → Interval
+```
+
+The Mathlib companion proves their set-enclosure theorems. The computational
+tests also check the following exactness rules.
+
+- `intersect` chooses the larger lower cut and the smaller upper cut. At equal
+  endpoints it chooses open if either input is open.
+- `hull` chooses the smaller lower cut and the larger upper cut. At equal
+  endpoints it chooses closed if either input contains the endpoint.
+- Negation swaps the ends and preserves their openness.
+- A finite endpoint of a sum is closed exactly when both contributing
+  endpoints are closed.
+- Multiplication partitions both inputs by sign, enumerates finite corner and
+  zero candidates, and tracks whether each extremum is attained. Zero is an
+  attained extremum whenever either factor contains zero, not only when a
+  factor is the singleton zero. For example,
+  `[0,1] * (0,1] = [0,1]`, while `(0,1] * (0,1] = (0,1]`.
+- A power distinguishes zero, odd powers, and positive even powers. It does
+  not implement powers by repeated interval multiplication when a direct hull
+  is tighter.
+- `abs`, `min`, and `max` use the same candidate-and-attainment discipline.
+  In particular, `abs` contains a closed zero exactly when the input contains
+  zero, and tied extrema combine the contributing closure witnesses rather
+  than blindly copying one endpoint flag.
+- `split I m` returns `I ∩ (-∞,m]` and `I ∩ (m,+∞)`. The children are disjoint
+  and cover `I`.
+
+These named arithmetic operations return tight cuts in their representable
+dyadic result class, including exact endpoint attainment. Conservatively
+closing a cut is permitted for an approximate registered propagator, not for
+these primitives.
+
+The image of reciprocal or division may be disconnected, and even `{3}⁻¹`
+has a nondyadic endpoint. `invAt p` and `divAt p` return the tightest
+single-interval enclosure on the `2^-p` dyadic grid for the complete image
+under Lean's total inverse, including `0⁻¹ = 0`. Moved grid endpoints use the
+strictness rule above. Thus a positive interval bounded away from zero has the
+usual reversed reciprocal cuts rounded outward, `[0,1]⁻¹` has hull
+`[0,+∞)`, and an interval containing both negative and positive values has
+whole-interval hull. A rule can request a split at zero before using a tighter
+sign-specific result. A later `IntervalSet` with at most two components is an
+isolated extension, not a reason to complicate every initial operation.
+
+Lean defines functions such as inverse and logarithm on inputs where a
+numerical interval library might call them undefined. The computational
+operation does not choose the mathematical convention. Each companion rule
+must enclose Lean's actual function or require a proved domain cut before
+using a tighter theorem.
+
+### Outward regularization
+
+`regularize p I` widens finite endpoints onto a grid with denominator at most
+`2^p`. It rounds a lower endpoint down and an upper endpoint up. It never
+replaces the strongest fact in the solver. Instead, it creates a cheaper view
+that a later rule may use.
+
+If an endpoint moves, the regularized cut is strict: a moved lower endpoint
+is strictly below the old lower endpoint, and a moved upper endpoint is
+strictly above the old upper endpoint. An unchanged endpoint inherits its old
+strictness. This is the strongest sound outward view and makes regularization
+idempotent without throwing away useful strict inequalities.
+
+This distinction matters. Exact dyadic numerators can still grow rapidly.
+Discarding a strong fact to shorten it would make the state order-dependent.
+Keeping both the strong fact and a regularized working view lets the policy
+trade precision against arithmetic cost without losing information.
+
+The backend-comparison milestone also builds a separate exact-rational search
+prototype. Its regularizer uses continued-fraction convergents or
+semiconvergents to find low-height outward bounds under a denominator budget.
+It is not silently substituted for `Fact.value : Dyadic`: retained proof
+traces are projected to dyadic cuts, and adopting rational working facts would
+require an explicit representation revision. The dyadic backend remains the
+specified default because its bit-height contract and kernel certificates are
+simpler. The comparison records total search, proof construction, and replay
+cost. A small arithmetic microbenchmark alone is not enough to settle the
+public representation.
+
+## Shared expression program
+
+The frontend reifies terms into a typed static single-assignment program. Each
+instruction refers only to earlier instruction identifiers. Common
+subexpression elimination occurs before search, so the array is also a compact
+encoding of an expression DAG.
+
+Conceptually:
+
+```lean
+structure Node where
+  domain : DomainId
+  op     : OpId
+  args   : Array NodeId
+
+structure Program where
+  operations : Array OpKey
+  nodes     : Array Node
+  consumers : Array (Array NodeId)
+```
+
+An `OpKey` identifies the semantic operation at a node, including its domain
+signature and normalization variant. An `OpId` is only a compact index into
+the program's operation table. A `RuleKey` instead identifies one propagation
+method, with a stable name and certificate-schema version. Several
+`RuleKey`s may apply to the same `OpKey`; neither the node nor its mathematical
+meaning changes when the policy selects a different method. This distinction
+also prevents a dynamically registered user rule from being mistaken for an
+instruction understood by the fixed natural-evaluation checker.
+
+The caller supplies nullary nodes for free variables and named constants.
+Unknown free variables begin with the whole interval. Hypotheses add source
+facts. A known constant may instead have one or more nullary propagators, so a
+constant such as `π` can improve its enclosure as effort increases.
+
+The program is typed by construction in the frontend. The scheduler uses only
+the compact identifiers. This avoids a dependent heterogeneous term language
+inside the hot loop while leaving room for domains other than `ℝ` later.
+
+## Rule protocol
+
+Rules are explicit registrations, not typeclass instances. Typeclass search
+must not recursively decide which algorithm computes an expression's bound.
+The registry may contain several rules for one head symbol, and the policy may
+try or combine all of them.
+
+A structural, form-directed rule search similar to `apply_rules` remains a
+benchmark alternative because it has worked well in other proof assistants
+and may compose local order lemmas cheaply. The specified implementation keeps
+an explicit registry and incremental scheduler so it can share facts, retain
+state, and compare multiple methods. The benchmark compares these search
+styles rather than assuming the registry wins every structural goal.
+
+Rule-private caches can have arbitrary Lean types. For that reason the
+Mathlib-free library does not store them in a heterogeneous array. It exposes
+a request-and-reply state machine:
+
+1. The solver produces an `Action` naming a rule, node, input fact versions,
+   effort, and action kind.
+2. The companion registry executes the rule and owns its cache.
+3. The registry returns an `Outcome` containing candidate facts, alternatives,
+   suggestions, cost observations, and an opaque proof recipe identifier.
+4. When a fact is accepted, the registry freezes every value needed for replay
+   into an immutable per-run payload arena. The `PayloadId` in the trace points
+   into this arena, never into a mutable or evictable rule cache.
+5. The solver intersects accepted facts into the state and records their
+   provenance.
+
+An invalid rule outcome may mislead search, but it cannot produce a theorem.
+The companion reconstructs every retained fact from the rule's soundness
+theorem. A failed reconstruction identifies a broken registration rather than
+closing the user's goal.
+
+### Action kinds
+
+The protocol distinguishes the following actions.
+
+- `forward`: compute an enclosure of a node from current argument intervals.
+- `backward`: use the node's current interval and all but one argument to
+  contract an argument interval.
+- `improve`: rerun a rule at greater effort, use a tighter enclosure method, or
+  subdivide only the rule's input range and take the hull of the pieces.
+- `rewrite`: activate a proved alternate expression and equality edge that the
+  frontend materialized before search.
+- `regularize`: create bounded-height working views without deleting stronger
+  facts.
+- `split`: create proof branches by adding complementary cuts for one node.
+
+`improve` and `split` are intentionally distinct. Local subdivision inside one
+propagator can tighten the range of a function without duplicating the whole
+proof state. A solver split is needed when a dependency between several nodes
+requires different assumptions in different cases.
+
+An `Outcome` may be `noChange`, `inapplicable`, or `failed` without affecting
+soundness. Rules do not promise that greater effort always gives a tighter
+answer. The solver intersects every result with existing facts, measures the
+actual improvement, and learns from that observation.
+
+The initial `Program` is static after validation. Generic alternate forms are
+present before search, and `rewrite` only changes which existing form is
+scheduled. Adaptive range reduction or a Taylor polynomial may remain inside
+a rule-specific payload and return a fact about the existing node. It does not
+append unchecked instructions. A later append-only program extension would
+need its own validation, dependency-update, and branch-storage design.
+
+### Stateful rules
+
+A cache key includes the rule, node, input fact versions, and effort. A rule
+may retain:
+
+- Taylor coefficients and remainder data;
+- values at subdivision points;
+- argument-reduction integers;
+- automatic-differentiation intervals;
+- a previous local partition that can be refined;
+- proof payload fragments that remain valid after an input interval shrinks.
+
+Shrinking an input does not require a rule to discard all earlier work. Cache
+reuse is a performance feature only. Every returned fact still receives a new
+or reused sound justification.
+
+## Propagation state
+
+Each live branch contains:
+
+- the strongest and selected cheap lower and upper facts for every node;
+- monotonically increasing fact versions;
+- a dependency worklist;
+- rule effort, cache keys, and the result of the last invocation;
+- policy observations and action ages;
+- the branch assumptions introduced by splits;
+- step, endpoint-height, trace-size, depth, and leaf counters.
+
+A stronger fact enqueues only consumers and reverse rules that depend on the
+changed side. The default implementation does not run repeated whole-program
+passes. A pass remains a useful diagnostic grouping, but the algorithm is an
+incremental worklist.
+
+The initial saturation runs all cheap forward rules once in program order and
+then drains the dependency worklist. It also runs zero-cost contradiction
+checks after every accepted fact. More expensive improvement and split actions
+start only after this cheap fixed point, unless a rule marks a singularity that
+requires an immediate split.
+
+Backward propagation uses the same worklist. A contractor is valid only when
+its soundness theorem says that it preserves every assignment satisfying the
+current constraints. When proving a goal by contradiction, the frontend may
+seed the negation of the goal and contract the possible counterexamples. It
+must never assume the desired conclusion itself.
+
+The negated goal lives in an explicit counterexample scope below the original
+context. Facts derived there are conditional on that assumption. If the scope
+does not close by contradiction, its intervals are reported only as
+counterexample-box diagnostics. A public best-bound theorem is replayed from
+pre-assumption facts or from a separate bound search, never by leaking a
+conditional fact into the parent scope.
+
+## Search policy
+
+The policy affects success and performance, never validity. The library
+exposes a pure interface with private state and incremental candidate events:
+
+```lean
+structure Policy where
+  State      : Type
+  init       : Snapshot → State
+  insert     : State → Action → State
+  invalidate : State → ActionKey → State
+  choose     : State → Snapshot → Option (Action × State)
+  observe    : State → Action → Observation → State
+```
+
+The default state uses a versioned priority queue. Changed facts insert or
+invalidate only affected candidates; stale entries are discarded lazily when
+popped. Policies intended for diagnostics may use a simpler complete scan,
+but their complexity is reported honestly.
+
+The initial named policies are:
+
+- `balancedV1`: the deterministic default described below;
+- `propagateV1`: propagation and effort increases, with solver splits disabled;
+- `bisectV1`: a diagnostic midpoint policy after cheap saturation;
+- `replay`: follows an explicitly supplied action plan for regression tests.
+
+Versioned names let a downstream proof script pin search behavior while the
+default alias can improve. A pinned policy is not a soundness requirement. It
+is only a reproducibility aid.
+
+### The default policy
+
+`balancedV1` uses four stages.
+
+1. Drain cheap forward and backward actions whose inputs changed.
+2. Run untried applicable enclosure methods with their initial effort.
+3. Compare targeted effort increases, rewrites, local range refinement, and
+   contractor probes.
+4. If no candidate has adequate predicted gain, choose a solver split and
+   repeat in both children.
+
+The policy computes a goal-directed potential rather than summing raw widths.
+Nodes on the backwards dependency slice from the desired comparison or current
+contradiction receive greater weight. A node's uncertainty records:
+
+- how many ends remain unbounded;
+- a capped base-2 width for a bounded interval;
+- whether a strict cut would close the goal where a non-strict cut does not;
+- endpoint bit length;
+- estimated proof cost;
+- distance in the program from a fact that can close the branch.
+
+The exact coefficients are policy-tuning benchmark data, not mathematical
+constants. They live in `PolicyConfig` and are reported by tracing. Scores use
+bounded integer fixed-point arithmetic with specified saturation, never
+`Float`. `balancedV1` has a
+total tie-break over action stage and kind, `NodeId`, versioned `RuleKey`,
+input fact versions, effort, and dyadic split point. Candidate maps are
+traversed in sorted order, so hash-table iteration and fresh environment
+identifiers cannot affect a step-budgeted result.
+
+For an action that has run before, its score is the observed reduction in
+weighted potential divided by declared work plus estimated proof cost. An
+untried action receives an optimism bonus. Repeated `noChange` results decay
+the score unless an input version or effort changes. A fixed quota selects the
+oldest still-valid action in the highest nonempty fairness tier instead of the
+best score. Consequently, with an unbounded step budget and only finitely many
+new insertions, every continuously eligible action is eventually sampled. A
+finite configured budget makes no such promise.
+
+The original sensitivity proposal is recovered as a simple special case: if
+`m` is the global uncertainty measure and an action changes it to `m'`, the
+action's measured sensitivity is a monotone function of `m - m'` or `m / m'`.
+The implementation uses a difference on capped logarithmic widths so
+unbounded values and zero width do not require exceptional arithmetic.
+
+### Precision, propagation, or splitting
+
+The policy records why a range is wide.
+
+- If doubling effort materially moves an endpoint, another `improve` action is
+  promising.
+- If endpoint movement is much smaller than the interval width, the loss is
+  probably input uncertainty or dependency. The policy favors a centered
+  form, contractor, rewrite, or split.
+- If a propagation sweep contracts a relevant variable, another sweep is
+  cheap and receives priority.
+- If a virtual split probe predicts two substantially better worst-case
+  children, a solver split is preferred.
+- If a singularity, kink, or certified critical point lies inside an interval,
+  the associated rule suggestion outranks an arbitrary midpoint.
+
+Universal proof search must close every child. Split scoring therefore uses
+the worst predicted child, with total predicted proof size as a tie-breaker.
+An average-only score can repeatedly create one easy branch and one hopeless
+branch.
+
+### Split candidates
+
+Rules may suggest a node other than one of their direct arguments. Each
+suggestion names a dyadic point and a reason. The default order is:
+
+1. a pole, total-function boundary, or other semantic landmark;
+2. an `abs`, `min`, or `max` kink;
+3. a certified derivative zero or trigonometric extremum;
+4. a point proposed by a productive backward contractor;
+5. zero, one, or another small dyadic inside an unbounded interval;
+6. the midpoint of a bounded interval.
+
+A symbolic or irrational landmark cannot be a global cut in this first
+format. Its rule instead proposes a nearby dyadic guard backed by a certified
+enclosure, or handles a symbolic partition entirely inside its local proof
+payload.
+
+A split on term `t` adds `t ≤ m` to the left child and `m < t` to the right
+child. This complementary form preserves strictness, avoids a duplicate
+boundary case, and is justified by linear order. A split need not target a
+free variable. Splitting a derived node is useful when several occurrences
+share that node, though contractors are needed to transfer the cut to its
+arguments.
+
+### Budgets and termination
+
+Every search is finite because the configuration bounds:
+
+- reified program nodes and alternate forms per original node;
+- accepted actions;
+- rule invocations and maximum effort;
+- solver split depth and number of leaves;
+- local range pieces made by one rule;
+- effective endpoint height, alignment shift, and regularized working
+  precision;
+- retained trace nodes, frozen payload entries and bytes, kernel-checker work,
+  and estimated proof nodes;
+- optional wall-clock time.
+
+`maxEndpointHeight` is measured after canonical dyadic normalization as the bit
+length of the absolute numerator plus the magnitude of the signed binary
+exponent. A separate alignment-shift limit caps the exponent difference used
+by comparison and arithmetic. This reflects the actual shifted-integer work;
+an exponent of magnitude `2^30` is not treated as a 31-bit endpoint. An
+oversized new candidate is not installed. The rule may instead
+return a separately justified outward-regularized candidate within budget.
+Existing stronger facts are never deleted to satisfy the limit, and an
+oversized result is reported distinctly from `noChange`.
+
+Payload limits are enforced when an accepted recipe is frozen. Deduplicated
+tables are counted once in the immutable arena. A one-node derivation cannot
+bypass certificate-byte, entry, or checker-work limits by pointing to an
+unbounded payload.
+
+Reaching a budget returns `unknown` with the best state and diagnostics. It
+does not silently lower a target, discard a branch, or turn a failed strict
+bound into a weak one.
+
+After any solver split, a reported bound is global. For each requested node,
+the result takes the hull of its proved interval over every live, completed,
+and pending leaf. An unexplored child contributes at least its inherited
+ancestor facts, never the tighter state of its sibling. The result retains a
+partial `BranchTree` whose leaves close membership in this hull, even if they
+do not close the original goal. `interval_bound` can therefore replay a real
+theorem from an `unknown` search; diagnostics never present a branch-local cut
+as a context-wide fact.
+
+## Derivation trace
+
+The search log may be large, but the returned derivation is a backwards slice
+from the closing facts. Parent identifiers make that slice linear in the
+facts actually used.
+
+```lean
+structure FactId where
+  scope : ScopeId
+  index : Nat
+
+inductive Derivation
+  | source     (source : SourceId)
+  | rule       (rule : RuleKey) (inputs : Array FactId) (payload : PayloadId)
+  | weaken     (input : FactId) (cut : Cut)
+  | splitAssumption (parent : ScopeId) (side : SplitSide)
+      (node : NodeId) (cut : Dyadic)
+
+inductive Close
+  | goal          (facts : Array FactId)
+  | contradiction (lower upper : FactId)
+
+inductive BranchTree
+  | leaf  (scope : ScopeId) (close : Close)
+  | split (scope : ScopeId) (node : NodeId) (cut : Dyadic)
+      (leftScope rightScope : ScopeId) (left right : BranchTree)
+
+inductive ProofPlan
+  | direct (tree : BranchTree)
+  | byContradiction (counterScope : ScopeId) (negatedGoal : SourceId)
+      (tree : BranchTree)
+```
+
+Every fact identifier is scope-qualified. A fact may depend only on facts in
+its own scope or an ancestor scope. The two child scopes of a split are fresh,
+and neither may refer to the other's facts. The left child receives the closed
+upper cut `node <= cut`; the right child receives the strict lower cut
+`cut < node`. The branch-tree validator checks these relationships, unique
+parentage, acyclicity, and that every leaf has a closing witness.
+
+The branch tree refers to shared derivations. Facts established before a split
+are stored once in the ancestor scope. Within a branch, repeated uses of one
+fact refer to one identifier. Backwards slicing starts from every leaf's
+`Close`, retains the necessary ancestor facts and split assumptions, and
+discards all other probes. The Mathlib companion turns this representation
+into nested `let`, `have`, and case bindings so Lean's elaborator and kernel
+also see the sharing.
+
+`ProofPlan.byContradiction` tells replay to introduce the negated target in a
+fresh counterexample scope before replaying its tree. Its `SourceId` cannot be
+resolved as an original local hypothesis, and every leaf in that plan must
+close by contradiction. A direct plan may close the target or use a
+contradiction already derivable from the original context. A partial
+best-bound certificate always uses `direct`, so a failed contradiction attempt
+cannot leak its temporary assumption.
+
+The trace never contains a proof of its own validity. It is untrusted data.
+The companion registration for each `RuleKey` reconstructs the corresponding
+theorem application or checks a rule-specific certificate. A trace is paired
+with its immutable payload arena and operation table. Replay rejects an
+unknown rule version, wrong payload schema, dangling payload identifier, or
+scope violation.
+
+## Diagnostics and observability
+
+On `unknown`, the engine returns enough information for a user or future policy
+to act:
+
+- the best interval for each requested term;
+- the node with the greatest goal-directed uncertainty;
+- the rule and action that last improved each endpoint;
+- which rules were inapplicable and which exhausted effort;
+- whether loss appears dominated by endpoint rounding, dependency, an
+  unbounded input, or branch count;
+- the best split suggestion not taken;
+- all exhausted budgets.
+
+Trace levels are `off`, `summary`, `actions`, and `bounds`. The default failure
+message uses `summary`. Machine-readable observations can be exported for
+offline policy tuning, but reading such telemetry is never required to check
+a proof.
+
+## Complexity contract
+
+Let `n` be the number of program nodes, `e` the number of argument-to-consumer
+edges, `q` the number of queued candidates, and `b` the number of live branch
+states.
+
+- Program validation and initial dependency construction are `O(n + e)`.
+- One worklist update is proportional to the number of rules attached to the
+  changed node and its consumers. The scheduler does not scan all `n` nodes
+  after every fact.
+- Fact comparison and contradiction checks use exact dyadic comparison. Their
+  integer cost is proportional to effective endpoint height and the permitted
+  exponent-alignment shift.
+- Branch facts use an explicitly persistent paged trie, not Lean `Array`
+  copy-on-write. Creating a child shares the root in `O(1)`; updating a fact
+  copies one trie path and one fixed-size page in `O(log n)` time.
+- Default-policy candidate insertion, invalidation, and heap selection are
+  `O(log q)` amortized, excluding the declared cost of rescoring a stale
+  candidate. A diagnostic policy that scans candidates reports `O(q)`.
+- Total search is bounded by the configured action, leaf, endpoint-height, and
+  payload budgets.
+
+Individual propagators declare their own arithmetic complexity and cache
+behavior in the Mathlib companion. The solver does not hide that cost inside
+a scheduler bound.
+
+## File organization
+
+- `HexInterval/Bound.lean`: lower and upper cuts, comparison, normalization.
+- `HexInterval/Interval.lean`: intersection, hull, arithmetic, splitting, and
+  regularization.
+- `HexInterval/Program.lean`: node identifiers, SSA program, dependencies.
+- `HexInterval/Fact.lean`: facts, versions, provenance, contradiction checks.
+- `HexInterval/Action.lean`: requests, outcomes, suggestions, observations.
+- `HexInterval/State.lean`: branch state and incremental worklists.
+- `HexInterval/Policy.lean`: policy interface and `balancedV1`.
+- `HexInterval/Search.lean`: budgeted branch search and derivation slicing.
+- `HexInterval/Trace.lean`: diagnostics and machine-readable telemetry.
+- `conformance/HexInterval/{Conformance,EmitFixtures}.lean`: Lean-only checks
+  and oracle fixtures.
+- `bench/HexInterval/Bench.lean`: Mathlib-free interval and scheduler
+  benchmarks.
+
+## Conformance
+
+The required Lean-only profile covers every interval shape and operation with
+typical, boundary, and adversarial inputs. In particular it includes:
+
+- all four finite endpoint closure combinations;
+- equal endpoints in all closure combinations;
+- empty, singleton, one-sided unbounded, and whole intervals;
+- intersection and hull at equal open and closed cuts;
+- split coverage at an endpoint and an interior point;
+- negation and addition closure propagation;
+- multiplication by singleton zero, by a nonsingleton interval containing
+  zero, and by unbounded intervals, with exact endpoint-attainment flags;
+- `abs`, `min`, and `max` with tied open and closed extrema;
+- precision-indexed reciprocal and division for `{3}`, positive, negative,
+  singleton-zero, one-sided-zero, and sign-crossing inputs;
+- powers on negative, mixed-sign, open-zero, and singleton inputs;
+- rational-to-dyadic projection at exact and inexact values, including the
+  strict cut gained by moving a closed source outward;
+- regularization idempotence, outward containment, moved closed cuts, and
+  exact-grid open cuts;
+- a dependency worklist in which one fact wakes only the affected consumers;
+- multiple rules for one node, including a later effort result that does not
+  improve the interval;
+- deterministic action choice for a fixed `balancedV1` configuration;
+- derivation slicing that removes failed probes and unused facts;
+- branch validation that rejects sibling fact references and mutable or
+  dangling payloads;
+- budget exhaustion returning `unknown` with a nonempty diagnostic record.
+
+The `ci` profile cross-checks finite arithmetic against an independent Python
+implementation using exact `Fraction` corner calculations and explicit
+endpoint-attainment flags. `python-flint` Arb is reserved for the companion's
+elementary-function fixtures. The oracle result is testing evidence only. It
+is never imported by the tactic. Open-cut and unbounded semantics also receive
+direct Lean property checks because ordinary ball types do not represent them
+faithfully.
+
+No conformance assertion uses `native_decide`. Small closed computations may
+use ordinary `#guard` or `by decide`. Larger deterministic campaigns run as
+compiled fixture emitters and compare their serialized results outside Lean.
+
+## Benchmarks
+
+The Mathlib-free benchmark target measures:
+
+- `intersect`, `mul`, and `regularize` over effective endpoint height and
+  exponent-alignment distance;
+- worklist saturation over synthetic chain, fan-out, and shared-diamond
+  programs;
+- persistent paged-trie branch creation and updates over program size;
+- policy selection over the number of available actions;
+- derivation slicing over total log size and retained proof size.
+
+The declared models follow the complexity section above. Scientific runs also
+record accepted actions, endpoint heights, live leaves, retained derivations,
+and cache hits so a faster time cannot conceal a weaker search.
+
+Tactic elaboration and Mathlib theorem replay are measured in the companion's
+local test profile. They do not enter this Mathlib-free benchmark target.
+
+## References
+
+- Kim Morrison, [Interval arithmetic research note](https://hackmd.io/ZagrUv95RFSU-7WP9TNxUQ).
+- IEEE 1788 working group, [IEEE Standard for Interval Arithmetic](https://grouper.ieee.org/groups/1788/).
+- Nathalie Revol and Fabrice Rouillier,
+  [Motivations for an arbitrary precision interval arithmetic library and the MPFI library](https://perso.ens-lyon.fr/nathalie.revol/publis/RR05.pdf).
+- Fredrik Johansson,
+  [Arb: efficient arbitrary-precision midpoint-radius interval arithmetic](https://arxiv.org/abs/1611.02831).
+- Oliver Flatt and Pavel Panchekha,
+  [An interval arithmetic for robust error estimation](https://arxiv.org/abs/2107.05784).
+- [IBEX contractor documentation](https://ibex-team.github.io/ibex-lib/contractor.html)
+  and [strategy documentation](https://ibex-team.github.io/ibex-lib/strategy.html).
+- [IntervalArithmetic.jl construction and exact input guidance](https://juliaintervals.github.io/IntervalArithmetic.jl/stable/manual/construction/).
+- [Boost.Interval policies and representation](https://www.boost.org/doc/libs/latest/libs/numeric/interval/doc/interval.htm).

--- a/SPEC/testing.md
+++ b/SPEC/testing.md
@@ -2,15 +2,16 @@
 
 Conformance testing cross-checks Lean implementations against either
 (a) independently stated algebraic properties, or (b) an external
-oracle (`python-flint`, `fpylll`, `cypari2`, or the committed Frank
-Lübeck Conway cache). The goal is to catch implementation bugs
+oracle (an independent Python `fractions.Fraction` reference,
+`python-flint`, `fpylll`, `cypari2`, or the committed Frank Lübeck Conway
+cache). The goal is to catch implementation bugs
 *before* proof work starts. No point proving theorems about wrong
 implementations.
 
 When conformance fails, the response is the same as when benchmarking
 returns an unexpected complexity verdict ([benchmarking.md](benchmarking.md)):
 file a GitHub issue ([PLAN/Conventions.md §Bench-found and
-conformance-found issues](../PLAN/Conventions.md#bench-found-and-conformance-found-issues))
+conformance-found issues](../PLAN/Conventions.md#bench-found-conformance-found-and-audit-found-issues))
 and roll the affected library's `done_through` backward
 ([PLAN/Conventions.md §Rollback is a normal action](../PLAN/Conventions.md#rollback-is-a-normal-action)).
 Conformance and benchmarking share one bug-finding loop; the choice
@@ -21,12 +22,19 @@ Conformance testing is a tiered system rather than one monolithic
 workflow. The repository supports three profiles:
 
 - `core` — deterministic Lean-only checks with no external dependencies.
-  Runs on every push and every pull request. MUST be green to merge.
-- `ci` — modest randomized cross-checks against external oracles, run
-  only when the oracle is available on the runner. Runs on every push
-  and every pull request; oracle-missing cases are recorded as skipped.
+  Runs on every CI-triggering push to `main` and every pull request. MUST be
+  green to merge.
+- `ci` — bounded heavier per-PR checks: deterministic shards or campaigns that
+  always run, plus randomized cross-check components whose external oracles
+  run according to their individual availability modes. Runs on every
+  CI-triggering push to `main` and every pull request; a missing optional
+  oracle skips only that component.
 - `local` — developer-driven runs with customisable sizes and tools.
   Triggered via `workflow_dispatch` or run by hand; not a merge gate.
+
+A release criterion may require one pinned invocation of the existing `local`
+profile. “Release” is not a fourth profile and does not imply that the full
+campaign runs on every PR.
 
 Every failure must be replayable: record the library, profile, seed,
 fully serialised input, and the oracle (if any) in the failure report.
@@ -41,8 +49,10 @@ is the `core` profile for `HexFoo`. It MUST:
 1. **Open with a docstring** declaring the library-specific
    conformance contract:
 
-   - **Oracle:** which external oracle applies, or `none`.
-   - **Mode:** `always` / `if_available` / `required`.
+   - **Oracle:** which external oracle components apply, or `none`; several may
+     be listed under this existing label.
+   - **Mode:** `always` / `if_available` / `required`, paired with each listed
+     component when their modes differ.
    - **Covered operations:** bulleted list of the public operations
      this module exercises (matches the library's SPEC API surface).
    - **Covered properties:** bulleted list of the algebraic /
@@ -167,8 +177,8 @@ on the repository style guide's banned-vocabulary list.
 
 ## Oracle discipline
 
-Every operation in a library's SPEC API surface that is exercised by
-fixtures via `HexFoo/EmitFixtures.lean` MUST have an external-oracle
+Every operation in a library's SPEC API surface that is exercised by fixtures
+via `conformance/HexFoo/EmitFixtures.lean` MUST have an external-oracle
 cross-check that satisfies all three rules below. A SPEC declaration
 that names an operation but cannot be paired with an oracle satisfying
 these rules is not Phase-3-ready: file the oracle issue first and hold
@@ -199,8 +209,8 @@ the library at `done_through ≤ 2`.
 3. **Explicit non-coverage is a tracking obligation.** An emitted
    operation that has no external oracle (whether deferred or
    genuinely blocked) must be paired with an open `directive`
-   issue, linked from both `EmitFixtures.lean` and the corresponding
-   oracle script's docstring. The library's `Conformance.lean`
+   issue, linked from both `conformance/HexFoo/EmitFixtures.lean` and the
+   corresponding oracle script's docstring. The library's `Conformance.lean`
    docstring must not claim the operation as covered. Self-consistency
    invariants are not a substitute for an external oracle and must
    not be advertised as conformance coverage.
@@ -311,14 +321,16 @@ MUST NOT appear in any `Conformance.lean`:
   theorem is `sorry`, delete the example. The example becomes
   meaningful only when the theorem it relies on has a real proof.
 
-- **`Hex*Mathlib/Conformance.lean` files.** The `Hex*Mathlib`
-  libraries are proof-only — they have no executable runtime to
-  conform to a contract. A `Hex*Mathlib/Conformance.lean` file
-  should not exist. Any `#guard` or `#eval` exercising Hex
-  executable code belongs in the computational sibling's
-  `Hex*/Conformance.lean` (e.g. checks on `Hex.Berlekamp.rabinTest`
-  live in `HexBerlekamp/Conformance.lean`, never in
-  `HexBerlekampMathlib/Conformance.lean`).
+- **Conformance files in correspondence-only `Hex*Mathlib` bridges.** Such
+  libraries are proof-only and have no executable runtime to conform to, so a
+  `HexFooMathlib/Conformance.lean` file should not exist. Any `#guard` or
+  `#eval` exercising the Mathlib-free executable belongs in the computational
+  sibling (for example, checks on `Hex.Berlekamp.rabinTest` live in
+  `HexBerlekamp/Conformance.lean`, never in
+  `HexBerlekampMathlib/Conformance.lean`). A Mathlib-importing library that
+  itself owns an executable reifier, certificate checker, or tactic is not a
+  correspondence-only bridge and may have a dedicated conformance target when
+  its library SPEC defines that runtime contract and CI reachability.
 
 ## `#eval` vs `#eval!`
 
@@ -368,6 +380,12 @@ subsection. Default oracle assignments:
 
 - `hex-arith` — Lean's built-in `Nat` / `Int` big integer semantics;
   property checks (Bézout, `Nat.gcd` agreement) sufficient for `core`.
+- `hex-interval` — an independent Python `fractions.Fraction` implementation,
+  mode `always`, computing finite arithmetic, normalization, and endpoint
+  attainment from the original serialized inputs rather than Lean's output.
+- `hex-interval-mathlib` — `python-flint` Arb, mode `if_available`, recomputing
+  closed-box elementary-function enclosures from original exact inputs at
+  higher precision. Open and unbounded cut laws remain Lean property tests.
 - `hex-mod-arith` — Lean big-integer modular arithmetic as property
   oracle.
 - `hex-poly`, `hex-poly-z`, `hex-poly-fp` — `python-flint` primary
@@ -416,10 +434,10 @@ bounds and seed.
   are floors of coverage, not ceilings. Polynomial degrees up to
   about `8-12`, matrix dimensions up to about `6-8`, finite-field
   extensions up to degree `6`, LLL dimensions up to about `10`.
-- `ci`: modest randomised cases. Integer/finite-field polynomial
-  degrees around `16-32`, coefficient bit-sizes around `8-32`, Hensel
-  lift exponents around `2-5`, and LLL dimensions around `15-25`
-  with small entries.
+- `ci`: bounded heavier deterministic shards plus modest randomized cases.
+  Integer/finite-field polynomial degrees around `16-32`, coefficient
+  bit-sizes around `8-32`, Hensel lift exponents around `2-5`, and LLL
+  dimensions around `15-25` with small entries are the randomized defaults.
 - `local`: larger campaigns. More seeds, larger degrees/dimensions,
   optional high-cost oracles, manually triggered runs that would be
   too expensive for standard CI.
@@ -429,8 +447,9 @@ partial external-tool availability.
 
 ## Execution modes
 
-- `always` — no external tools; must run everywhere. The `core`
-  profile is always `always`.
+- `always` — no optional external tool; must run everywhere using Lean or a
+  runner-guaranteed standard dependency such as Python's standard library. The
+  `core` profile is always `always`.
 - `if_available` — run oracle-backed checks only for tools present on
   the runner; skip (and record the skip) otherwise. The `ci` profile
   is typically `if_available`.
@@ -440,18 +459,21 @@ partial external-tool availability.
 
 ## CI integration
 
-The conformance workflow MUST:
+The conformance portion of the single `build` job in
+`.github/workflows/ci.yml` MUST:
 
 - Run on `push` to `main` and on `pull_request`. Not
   `workflow_dispatch`-only.
 - Always run the `core` profile. Any elaboration error in
   `conformance/HexFoo/Conformance.lean` fails the job.
-- Run the `ci` profile for libraries whose oracle mode is `always`
-  or `if_available`. For `if_available`, a missing oracle counts as
-  skipped, not failed; the job summary records which oracles were
-  skipped.
-- For oracle mode `always`, a missing oracle fails the job.
-- Keep the `local` profile gated behind `workflow_dispatch`.
+- Run every mandatory deterministic component of the `ci` profile. Run each
+  oracle-backed component according to its own mode. For `if_available`, a
+  missing oracle skips that component, not the deterministic shard; the job
+  summary records what was skipped. A missing `always` dependency fails the
+  job.
+- Keep the `local` profile behind the same workflow's
+  `workflow_dispatch` entry point or a documented developer command; it is not
+  part of the ordinary merge gate.
 
 Separately, the CI build's `lake build HexConformance` step MUST
 elaborate every `conformance/HexFoo/Conformance.lean` (and any
@@ -460,26 +482,29 @@ elaborate every `conformance/HexFoo/Conformance.lean` (and any
 `#guard`s.
 
 Landing a new conformance-tree module therefore means adding it to the
-`HexConformance` globs in `lakefile.lean`. When the oracle workflow's
-matrix is hand-listed, the same PR that lands `Conformance.lean` MUST
-also update that matrix.
+`HexConformance` globs in `lakefile.lean`. The same PR updates the sequential
+oracle runner when appropriate. It does not add a job, matrix entry, or
+workflow; see [CI.md § Job-count budget](CI.md#job-count-budget).
 
 ## Infrastructure contract
 
-Lean produces and consumes a simple serialised case/result format —
-JSON or JSONL — for:
+Lean produces and consumes an extensible serialised case/result format — JSON
+or JSONL — including:
 
 - polynomials
 - matrices
 - lattice bases
 - primes / modulus choices
-- expected normalised outputs
+- exact interval endpoints, cut openness, unbounded ends, and requested
+  precision or quality targets
+- expected normalized outputs or the comparison relation to check
 
 Python or shell driver scripts are responsible for:
 
 - detecting which tools are installed
 - invoking external oracles
-- normalising oracle outputs into the shared format
+- normalising oracle outputs into the shared format and applying the declared
+  equality, containment, refinement, or quality relation
 - gracefully skipping checks when an optional tool is unavailable
 
 ### Layout
@@ -488,14 +513,22 @@ The oracle infrastructure is bootstrapped by the `hex-poly`
 python-flint cross-check; subsequent libraries replicate the same
 pattern.
 
-- **JSONL fixture+result stream.** One record per line. Fixture
-  records use kinds `poly` / `matrix` / `lattice` / `prime`; result
+- **JSONL fixture+result stream.** One record per line. Fixture records use
+  versioned kinds such as `poly` / `matrix` / `lattice` / `prime` /
+  `interval`; result
   records carry `kind="result"` plus an `op` string and Lean's
-  computed `value`. Schemas live in `scripts/oracle/common.py`.
+  computed `value`. A non-equality contract also carries its comparison kind,
+  exact original inputs, requested precision/effort, the Lean output cuts, and
+  any width or rounding-slack target. Interval cuts serialize finite endpoints
+  exactly and represent empty, openness, and infinity as data rather than
+  sentinels. Schemas live in `scripts/oracle/common.py`.
 - **Lean-side emission.** `Hex/Conformance/Emit.lean` provides
   `emitPolyFixture`, `emitMatrixFixture`, `emitLatticeFixture`,
-  `emitPrimeFixture`, and `emitResult`. Per-library drivers live
-  under `Hex<X>/EmitFixtures.lean` and define a `main`; lakefile
+  `emitPrimeFixture`, `emitIntervalFixture`, and `emitResult`. The interval
+  helper accepts a versioned exact-cut record including empty, finite strict or
+  closed, and unbounded forms; it does not encode infinity as a large number.
+  Per-library drivers live
+  under `conformance/Hex<X>/EmitFixtures.lean` and define a `main`; lakefile
   exposes them as `lean_exe hex<x>_emit_fixtures`. Output goes to
   `stdout` by default, or to the file named by `HEX_FIXTURE_OUTPUT`.
 - **Committed sample fixtures.** Each library commits a small
@@ -505,8 +538,9 @@ pattern.
   invoking the oracle, so any drift trips the build.
 - **Oracle drivers.** `scripts/oracle/<lib>_<oracle>.py`, e.g.
   `scripts/oracle/poly_flint.py`. Drivers reuse
-  `scripts/oracle/common.py` for `read_fixtures`, `assert_equal`,
-  and `write_failure`. A driver MUST treat a missing oracle import
+  `scripts/oracle/common.py` for `read_fixtures`, the contract-appropriate
+  assertion such as `assert_equal` or `assert_subset`, and `write_failure`. A
+  driver MUST treat a missing oracle import
   as a `SKIP` (exit 0) when the SPEC oracle mode is `if_available`,
   and MUST exit non-zero on any mismatch.
 - **Failure records.** On mismatch, the driver writes a JSON record
@@ -518,18 +552,21 @@ pattern.
 
 ### Adding a new oracle
 
-1. Add a per-library emit driver `Hex<X>/EmitFixtures.lean`
-   following `HexPoly/EmitFixtures.lean`.
+1. Add a per-library emit driver `conformance/Hex<X>/EmitFixtures.lean`
+   following `conformance/HexPoly/EmitFixtures.lean`.
 2. Register it as `lean_exe hex<x>_emit_fixtures` in the lakefile.
 3. Commit a JSONL snapshot at
    `conformance-fixtures/Hex<X>/<topic>.jsonl` produced by running
    the new driver.
 4. Add `scripts/oracle/<lib>_<oracle>.py` mirroring
    `scripts/oracle/poly_flint.py`: it must read the JSONL stream,
-   re-run each `op` through the external oracle, and call
-   `assert_equal` against the Lean `value`.
-5. Wire the new oracle into the **single-ubuntu-job** Conformance
-   workflow at `.github/workflows/conformance.yml`. Concretely:
+   re-run each `op` from the original fixture input through the external
+   oracle, and apply the operation's declared comparison contract against the
+   Lean `value`. Exact operations normally use equality; enclosure operations
+   use the containment and separate quality checks required by their library
+   SPEC.
+5. Wire the new oracle into the **single-ubuntu-job** conformance
+   tail of `.github/workflows/ci.yml`. Concretely:
    - if a new system dependency is needed, append it to the existing
      `apt-get install` step;
    - if a new Python dependency is needed, append it to the existing
@@ -542,7 +579,7 @@ pattern.
 
    **Do NOT** add a new top-level workflow job, do **NOT** add a
    `strategy.matrix`, and do **NOT** add a new workflow file. The
-   Conformance workflow runs as exactly one ubuntu job — see
+   conformance tail stays inside `ci.yml`'s one ubuntu `build` job — see
    [SPEC/CI.md](CI.md). Conformance failure artefacts are uploaded
    by the workflow's existing `if: failure()` artifact step.
 

--- a/progress/20260727T042637Z.md
+++ b/progress/20260727T042637Z.md
@@ -1,0 +1,50 @@
+# Interval arithmetic specifications
+
+**Accomplished**
+
+- Surveyed the public Lean Zulip discussions on interval arithmetic,
+  transcendental bounds, nonlinear inequalities, tactic extension, and
+  downstream consumers. Reviewed the complete Kim Morrison and Bhavik Mehta
+  direct-message history, while keeping private statements out of the SPEC.
+- Inspected the interval research note, the pinned sine experiment, LeanCert,
+  PNT+, the linked root-certification and Ramsey examples, and interval methods
+  from Coq, Isabelle, HOL Light, Gappa, Sollya, MPFR/MPFI, Arb, IBEX, Julia,
+  Boost, affine arithmetic, Taylor models, and dReal.
+- Added `SPEC/Libraries/hex-interval.md`, specifying exact open, closed, empty,
+  and unbounded dyadic intervals, tight endpoint attainment, precision-indexed
+  inverse and division, a shared SSA program, incremental propagation,
+  adaptive effort and subdivision, scoped traces, deterministic policies,
+  explicit budgets, conformance, and benchmarks.
+- Added `SPEC/Libraries/hex-interval-mathlib.md`, specifying real semantics,
+  the trust boundary, kernel-checkable certificate replay, reification, an
+  extensible versioned rule registry, the tactic interface, elementary and
+  nonlinear methods, efficient proof sharing, and a source-pinned regression
+  corpus.
+- Added both planned libraries to `SPEC/Libraries/README.md` with their
+  dependencies and independent library-pair diagram.
+- Incorporated independent requirements, architecture, and corpus reviews.
+  In particular, separated operation and rule identities, made branch facts
+  scope-safe, made best bounds global across leaves, added immutable payload
+  limits, corrected endpoint-attainment and rational-projection rules, and
+  added an early kernel-replay feasibility gate.
+- Verified all cited HTTP links successfully, checked balanced Markdown
+  fences, ran `git diff --check`, and scanned for stale phase names, malformed
+  proposed identifiers, and prohibited vocabulary.
+
+**Current frontier**
+
+- The requested design and research SPECs are written and indexed. This was a
+  documentation-only session; no Lean implementation exists yet and no Lean
+  build was needed.
+- The changes are present in the worktree and have not been committed.
+
+**Next step**
+
+- Begin with the vertical feasibility gate in the companion SPEC: a small
+  arithmetic DAG, the BKLNW fold with upper limit 433, and one high-precision
+  transcendental certificate, measuring ordinary kernel replay and axiom
+  dependencies before freezing trace or checker formats.
+
+**Blockers**
+
+- None.

--- a/progress/20260727T052925Z.md
+++ b/progress/20260727T052925Z.md
@@ -1,0 +1,48 @@
+# Interval SPEC review and extension
+
+**Accomplished**
+
+- Opened draft PR #8895 with the initial interval-engine and tactic SPECs, then
+  obtained an independent Opus review and verified its findings against the
+  repository's proof-boundary, testing, and CI doctrine.
+- Kept representation, working-endpoint, trace, branch-storage, expression-
+  generation, contractor, and scheduling choices explicitly experimental while
+  tightening fixed soundness, resource-limit, cache-scope, and kernel-replay
+  contracts.
+- Added bounded expression instantiation, scoped equality transport, and the
+  public `grind` failure regression that motivates generating expressions not
+  present in the original goal.
+- Studied the supplied interval-arithmetic discussion and the current pinned
+  RealPaver source, papers, strategy code, and benchmark corpus. Added HC4,
+  BC4, 3B, CID, ACID, interval-Newton, split-policy, and translated-corpus
+  design hypotheses without importing RealPaver's floating-point trust model.
+- Added proof-facing application contracts for verified raster graphs and
+  future certified ODE integration, including the distinction between outer
+  graph covers, exact hit/miss pixels, existence tubes, unique flows, and
+  universal reachable enclosures.
+- Strengthened adversarial replay tests, empty-operation laws, exact oracle
+  relations, FKS2 core/CI/local tiering, and the one-job CI documentation. The
+  complete local corpus must elaborate and kernel-replay chunked certificates;
+  serialized data alone is not acceptance evidence.
+- Rechecked 70 unique cited HTTP links, relative paths and anchors, Markdown
+  fence balance, whitespace, namespace collisions, and the project-wide
+  `native_decide` prohibition.
+
+**Current frontier**
+
+- The research-stage design is complete enough to begin experiments, while
+  retaining explicit open questions for choices that should be settled by D2
+  and later corpus measurements.
+- The change remains documentation-only; no interval implementation or Lean
+  build target exists yet.
+
+**Next step**
+
+- Implement the D2 vertical feasibility prototype, including one arithmetic
+  DAG, one generated node plus equality transport, one chunked BKLNW fold, and
+  one high-precision elementary certificate. Measure ordinary kernel replay,
+  proof bytes, object bytes, and import time before freezing representations.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
## Summary

- add the Mathlib-free `hex-interval` engine SPEC and the
  `hex-interval-mathlib` semantics/tactic SPEC
- specify exact open, closed, empty, and independently unbounded cuts; a
  shared expression program; replayable derivations; deterministic budgeted
  search; propagation, improvement, local shaving, and global subdivision
- add bounded expression instantiation and scoped equality transport, so
  shaped rules can introduce useful expressions absent from the original goal
- derive contractor and scheduling experiments from a source-pinned study of
  RealPaver, including HC4/BC4, 3B/CID, ACID, interval Newton, and its benchmark
  corpus
- define downstream contracts for verified raster graphs and later certified
  ODE integration without making either a first-release gate
- add source-pinned LeanCert/PNT+, Zulip, theorem-prover, and interval-library
  regression corpora, with FKS2 split into per-PR and full local tiers
- extend the shared testing doctrine for exact interval fixtures, relational
  Arb checks, executable tactic companions, and the repository's single-job CI

## Design posture

This is intentionally a research-stage SPEC. It fixes semantic soundness,
ordinary-kernel replay, independent endpoint strictness, safe resource-limit
behavior, cache/scope isolation, determinism, and diagnostics. It keeps the
physical interval representation, dyadic versus rational working endpoints,
trace encoding, branch storage, expression-generation timing, contractor
strength, policy scores, and production defaults open until the staged
experiments measure them.

`native_decide` is prohibited throughout, including tests, compatibility
fixtures, and fallback paths. The design does not approve any new extern or
precompiled-module exception.

## Independent review

The PR was opened before requesting an independent Opus review. The revision
incorporates the findings that survived repository-level verification:
contextual equality actions, explicit equality replay, mechanically tested
checker reducibility, opaque/public interval representation, backend-neutral
resource guards, scoped cache keys, adversarial trace tests, realistic corpus
tiering, and stronger oracle relations. Choices that need evidence remain open.
The suggested `precompileModules` change was rejected because it conflicts with
the repository's Lake policy for Mathlib-importing libraries.

## Validation

- `git diff --cached --check`
- all 70 unique cited HTTP links fetched successfully
- all relative paths and relevant anchors resolved
- Markdown fence-balance and stale terminology/namespace scans
- independent architecture, requirements, and corpus audits
- not run: `lake build` (documentation-only change)
