### PR TITLE
HexNumberField M3: add threaded fixed-field approximation

### DIFF
--- a/HexNumberField.lean
+++ b/HexNumberField.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexNumberField.Basic
+public import HexNumberField.Approx
 public import HexNumberField.QAdjoin
 
 public section

--- a/HexNumberField/Approx.lean
+++ b/HexNumberField/Approx.lean
@@ -33,9 +33,9 @@ def evalRatBall (f : DensePoly Rat) (s : DyadicSquare)
   match cs.back? with
   | none => DyadicComplexBall.zero
   | some top =>
-      cs.pop.foldr
+      cs.foldr
         (fun c acc => (DyadicComplexBall.ofRat c coeffPrec).add (z.mul acc))
-        (DyadicComplexBall.ofRat top coeffPrec)
+        (DyadicComplexBall.ofRat top coeffPrec) (start := cs.size - 1)
 
 /-- Bit-length upper bound for the magnitudes of rational coefficients. Since
 every rational denominator is positive, the numerator magnitude alone is a

--- a/HexNumberField/Approx.lean
+++ b/HexNumberField/Approx.lean
@@ -17,42 +17,9 @@ Threaded dyadic-ball approximation for fixed-field elements.
 Rational coefficients are rounded downward to dyadics with an explicit
 one-ulp radius, then Horner evaluation propagates complex-ball errors. An
 input-derived guard-bit budget accounts for coefficient height, degree, and
-the defining polynomial's Cauchy root bound before refining the root once.
+the selected root's certified magnitude bound before refining the root once.
 -/
 namespace Hex
-
-namespace DyadicComplexBall
-
-/-- The exact zero complex ball. -/
-@[expose]
-def zero : DyadicComplexBall := ⟨0, 0, 0⟩
-
-/-- Minkowski sum of two closed dyadic complex balls. -/
-@[expose]
-def add (a b : DyadicComplexBall) : DyadicComplexBall :=
-  ⟨a.re + b.re, a.im + b.im, a.radius + b.radius⟩
-
-/-- Product enclosure for two closed dyadic complex balls. -/
-@[expose]
-def mul (a b : DyadicComplexBall) : DyadicComplexBall :=
-  let ac : GaussDyadic := (a.re, a.im)
-  let bc : GaussDyadic := (b.re, b.im)
-  let center := GaussDyadic.mul ac bc
-  let radius :=
-    GaussDyadic.hi ac * b.radius + GaussDyadic.hi bc * a.radius +
-      a.radius * b.radius
-  ⟨center.1, center.2, radius⟩
-
-/-- Enclose a rational number by a real-centred dyadic complex ball. Exact
-dyadic rationals receive radius zero; otherwise one ulp encloses the downward
-rounding error. -/
-@[expose]
-def ofRat (q : Rat) (prec : Int) : DyadicComplexBall :=
-  let lo := q.toDyadic prec
-  let radius := if lo.toRat = q then 0 else Dyadic.ofIntWithPrec 1 prec
-  ⟨lo, 0, radius⟩
-
-end DyadicComplexBall
 
 namespace QAdjoin
 
@@ -62,24 +29,35 @@ dyadic square. -/
 def evalRatBall (f : DensePoly Rat) (s : DyadicSquare)
     (coeffPrec : Int) : DyadicComplexBall :=
   let z := s.toBall
-  f.toArray.toList.foldr
-    (fun c acc => (DyadicComplexBall.ofRat c coeffPrec).add (z.mul acc))
-    DyadicComplexBall.zero
+  let cs := f.toArray
+  match cs.back? with
+  | none => DyadicComplexBall.zero
+  | some top =>
+      cs.pop.foldr
+        (fun c acc => (DyadicComplexBall.ofRat c coeffPrec).add (z.mul acc))
+        (DyadicComplexBall.ofRat top coeffPrec)
 
 /-- Bit-length upper bound for the magnitudes of rational coefficients. Since
 every rational denominator is positive, the numerator magnitude alone is a
 valid upper bound. -/
 @[expose]
 def coeffBits (f : DensePoly Rat) : Nat :=
-  f.toArray.toList.foldl
+  f.toArray.foldl
     (fun bits q => Nat.max bits (Hex.ceilLog2 (q.num.natAbs + 1))) 0
 
-/-- Guard bits sufficient for coefficient rounding and Horner amplification
-over the defining polynomial's Cauchy root bound. -/
+/-- Bit-length upper bound for the magnitude of every point in a square's
+circumscribed disc. The bound is clamped at zero when the disc lies inside the
+unit circle. -/
 @[expose]
-def approxGuardBits (p : ZPoly) (f : DensePoly Rat) : Nat :=
+def rootBits (s : DyadicSquare) : Nat :=
+  (max 0 (Hex.Dyadic.ceilLog2 (GaussDyadic.hi s.center + s.radiusHi))).toNat
+
+/-- Guard bits sufficient for coefficient rounding and Horner amplification
+over the selected root's certified circumscribed disc. -/
+@[expose]
+def approxGuardBits (s : DyadicSquare) (f : DensePoly Rat) : Nat :=
   8 + Hex.ceilLog2 (f.size + 1) + coeffBits f +
-    f.size * (cauchyExp p + 3)
+    f.size * (rootBits s + 3)
 
 /-! Compiled ball-arithmetic regressions. -/
 
@@ -95,6 +73,19 @@ def approxGuardBits (p : ZPoly) (f : DensePoly Rat) : Nat :=
     let b := DyadicComplexBall.ofRat (1 / 3 : Rat) 4
     b.re = Dyadic.ofIntWithPrec 5 4 && b.im = 0 &&
       b.radius = Dyadic.ofIntWithPrec 1 4
+
+#guard
+    let b := DyadicComplexBall.ofRat (-1 / 3 : Rat) 4
+    b.re = Dyadic.ofIntWithPrec (-6) 4 && b.im = 0 &&
+      b.radius = Dyadic.ofIntWithPrec 1 4
+
+#guard
+    let a : DyadicComplexBall :=
+      ⟨1, 2, Dyadic.ofIntWithPrec 1 3⟩
+    let b : DyadicComplexBall :=
+      ⟨3, -1, Dyadic.ofIntWithPrec 1 4⟩
+    let m := a.mul b
+    m.re = 5 && m.im = 5 && m.radius = Dyadic.ofIntWithPrec 89 7
 
 #guard
     let f := DensePoly.ofList ([1, 1] : List Rat)

--- a/HexNumberField/Approx.lean
+++ b/HexNumberField/Approx.lean
@@ -1,0 +1,106 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexNumberField.Basic
+public meta import HexNumberField.Basic
+
+public section
+
+/-!
+Threaded dyadic-ball approximation for fixed-field elements.
+
+Rational coefficients are rounded downward to dyadics with an explicit
+one-ulp radius, then Horner evaluation propagates complex-ball errors. An
+input-derived guard-bit budget accounts for coefficient height, degree, and
+the defining polynomial's Cauchy root bound before refining the root once.
+-/
+namespace Hex
+
+namespace DyadicComplexBall
+
+/-- The exact zero complex ball. -/
+@[expose]
+def zero : DyadicComplexBall := ⟨0, 0, 0⟩
+
+/-- Minkowski sum of two closed dyadic complex balls. -/
+@[expose]
+def add (a b : DyadicComplexBall) : DyadicComplexBall :=
+  ⟨a.re + b.re, a.im + b.im, a.radius + b.radius⟩
+
+/-- Product enclosure for two closed dyadic complex balls. -/
+@[expose]
+def mul (a b : DyadicComplexBall) : DyadicComplexBall :=
+  let ac : GaussDyadic := (a.re, a.im)
+  let bc : GaussDyadic := (b.re, b.im)
+  let center := GaussDyadic.mul ac bc
+  let radius :=
+    GaussDyadic.hi ac * b.radius + GaussDyadic.hi bc * a.radius +
+      a.radius * b.radius
+  ⟨center.1, center.2, radius⟩
+
+/-- Enclose a rational number by a real-centred dyadic complex ball. Exact
+dyadic rationals receive radius zero; otherwise one ulp encloses the downward
+rounding error. -/
+@[expose]
+def ofRat (q : Rat) (prec : Int) : DyadicComplexBall :=
+  let lo := q.toDyadic prec
+  let radius := if lo.toRat = q then 0 else Dyadic.ofIntWithPrec 1 prec
+  ⟨lo, 0, radius⟩
+
+end DyadicComplexBall
+
+namespace QAdjoin
+
+/-- Horner evaluation of a rational polynomial on the circumscribed disc of a
+dyadic square. -/
+@[expose]
+def evalRatBall (f : DensePoly Rat) (s : DyadicSquare)
+    (coeffPrec : Int) : DyadicComplexBall :=
+  let z := s.toBall
+  f.toArray.toList.foldr
+    (fun c acc => (DyadicComplexBall.ofRat c coeffPrec).add (z.mul acc))
+    DyadicComplexBall.zero
+
+/-- Bit-length upper bound for the magnitudes of rational coefficients. Since
+every rational denominator is positive, the numerator magnitude alone is a
+valid upper bound. -/
+@[expose]
+def coeffBits (f : DensePoly Rat) : Nat :=
+  f.toArray.toList.foldl
+    (fun bits q => Nat.max bits (Hex.ceilLog2 (q.num.natAbs + 1))) 0
+
+/-- Guard bits sufficient for coefficient rounding and Horner amplification
+over the defining polynomial's Cauchy root bound. -/
+@[expose]
+def approxGuardBits (p : ZPoly) (f : DensePoly Rat) : Nat :=
+  8 + Hex.ceilLog2 (f.size + 1) + coeffBits f +
+    f.size * (cauchyExp p + 3)
+
+/-! Compiled ball-arithmetic regressions. -/
+
+#guard
+    let a : DyadicComplexBall := ⟨1, 1, 0⟩
+    let b : DyadicComplexBall := ⟨1, -1, 0⟩
+    let m := a.mul b
+    let s := a.add b
+    m.re = 2 && m.im = 0 && m.radius = 0 &&
+      s.re = 2 && s.im = 0 && s.radius = 0
+
+#guard
+    let b := DyadicComplexBall.ofRat (1 / 3 : Rat) 4
+    b.re = Dyadic.ofIntWithPrec 5 4 && b.im = 0 &&
+      b.radius = Dyadic.ofIntWithPrec 1 4
+
+#guard
+    let f := DensePoly.ofList ([1, 1] : List Rat)
+    let s : DyadicSquare := ⟨2, 0, 10⟩
+    let b := evalRatBall f s 16
+    b.re = 3 && b.im = 0 && b.radius = s.radiusHi
+
+end QAdjoin
+end Hex

--- a/HexNumberField/QAdjoin.lean
+++ b/HexNumberField/QAdjoin.lean
@@ -6,8 +6,8 @@ Authors: Kim Morrison
 
 module
 
-public import HexNumberField.Basic
-public meta import HexNumberField.Basic
+public import HexNumberField.Approx
+public meta import HexNumberField.Approx
 
 public section
 
@@ -132,6 +132,18 @@ def div [ZPoly.CheckedIrreducible p] (a b : QAdjoin p x) : QAdjoin p x :=
   a * b⁻¹
 
 instance [ZPoly.CheckedIrreducible p] : Div (QAdjoin p x) := ⟨div⟩
+
+/-- Refine a fixed-field generator representative once and evaluate canonical
+coordinates on its disc. The checked driver's `none` fallback retains the
+original representative and therefore still returns a sound ball; the
+companion proves that branch unreachable and proves the requested radius. -/
+@[expose]
+def approx (a : QAdjoin p x) (rep : RefinedIsolation p)
+    (_h : SimpleRoot.mk rep = x) (prec : Int) :
+    RefinedIsolation p × DyadicComplexBall :=
+  let target := prec + (approxGuardBits p a.coeffs : Int)
+  let threaded := (rep.refineTo? target).getD ⟨rep, rfl⟩
+  (threaded.1, evalRatBall a.coeffs threaded.1.1.square target)
 
 /-! Compiled arithmetic regressions in `ℚ[X]/(X²-2)`. -/
 

--- a/HexNumberField/QAdjoin.lean
+++ b/HexNumberField/QAdjoin.lean
@@ -211,6 +211,16 @@ example : LawfulBEq (QAdjoin sqrtTwoPoly sqrtTwoRoot) := inferInstance
     let out := x.approx sqrtTwoRep rfl 64
     out.2.radius ≤ Dyadic.ofIntWithPrec 1 64
 
+-- A genuinely inexact coordinate evaluation, threaded into a second request.
+#guard
+    let coeffs := DensePoly.ofList ([1 / 3, 2 / 5] : List Rat)
+    let a : QAdjoin sqrtTwoPoly sqrtTwoRoot :=
+      reduce sqrtTwoPoly sqrtTwoRoot coeffs
+    let first := a.approx sqrtTwoRep rfl 32
+    let second := a.approx first.1 (approx_root a sqrtTwoRep rfl 32) 64
+    first.2.radius ≤ Dyadic.ofIntWithPrec 1 32 &&
+      second.2.radius ≤ Dyadic.ofIntWithPrec 1 64
+
 private def nonmonicQuadratic : ZPoly := DensePoly.ofList [-1, 0, 2]
 
 #guard

--- a/HexNumberField/QAdjoin.lean
+++ b/HexNumberField/QAdjoin.lean
@@ -139,11 +139,25 @@ original representative and therefore still returns a sound ball; the
 companion proves that branch unreachable and proves the requested radius. -/
 @[expose]
 def approx (a : QAdjoin p x) (rep : RefinedIsolation p)
-    (_h : SimpleRoot.mk rep = x) (prec : Int) :
+    (h : SimpleRoot.mk rep = x) (prec : Int) :
     RefinedIsolation p × DyadicComplexBall :=
-  let target := prec + (approxGuardBits p a.coeffs : Int)
-  let threaded := (rep.refineTo? target).getD ⟨rep, rfl⟩
+  let target := prec + (approxGuardBits rep.1.square a.coeffs : Int)
+  let threaded : {r' : RefinedIsolation p // SimpleRoot.mk r' = x} :=
+    match rep.refineTo? target with
+    | some r' => ⟨r'.1, r'.2.trans h⟩
+    | none => ⟨rep, h⟩
   (threaded.1, evalRatBall a.coeffs threaded.1.1.square target)
+
+/-- The representative returned by `approx` denotes the input root, so callers
+can pass it directly to their next approximation request. -/
+theorem approx_root (a : QAdjoin p x) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) (prec : Int) :
+    SimpleRoot.mk (a.approx rep h prec).1 = x := by
+  unfold approx
+  dsimp only
+  split
+  · exact ‹{r' : RefinedIsolation p // SimpleRoot.mk r' = SimpleRoot.mk rep}›.2.trans h
+  · exact h
 
 /-! Compiled arithmetic regressions in `ℚ[X]/(X²-2)`. -/
 
@@ -190,6 +204,12 @@ example : LawfulBEq (QAdjoin sqrtTwoPoly sqrtTwoRoot) := inferInstance
         (0 : QAdjoin sqrtTwoPoly sqrtTwoRoot)⁻¹ = 0
     else
       false
+
+#guard
+    let xPoly := DensePoly.ofList ([0, 1] : List Rat)
+    let x : QAdjoin sqrtTwoPoly sqrtTwoRoot := reduce sqrtTwoPoly sqrtTwoRoot xPoly
+    let out := x.approx sqrtTwoRep rfl 64
+    out.2.radius ≤ Dyadic.ofIntWithPrec 1 64
 
 private def nonmonicQuadratic : ZPoly := DensePoly.ofList [-1, 0, 2]
 

--- a/HexNumberField/SPEC/hex-number-field.md
+++ b/HexNumberField/SPEC/hex-number-field.md
@@ -170,6 +170,19 @@ Approximation refines once, returns the refined representative for threading,
 and always returns a sound ball. The requested radius is guaranteed by the
 companion's refinement-completeness theorem.
 
+For `n := a.coeffs.size`, evaluation uses target precision
+
+```text
+prec + 8 + ceilLog2(n + 1) + coeffBits(a.coeffs)
+  + n * (rootBits(rep.square) + 3).
+```
+
+`coeffBits` bounds rational coefficient magnitudes by numerator bit length;
+`rootBits` bounds the selected root using the current square's centre and
+circumscribed-disc radius. The per-Horner-step `+3` covers both movement within
+the certified refinement region and the dyadic `hi`/circumscribed-disc
+overestimates. It is part of the soundness budget, not optional slack.
+
 ## Canonicalization and exactification
 
 ```lean

--- a/HexNumberField/SPEC/hex-number-field.md
+++ b/HexNumberField/SPEC/hex-number-field.md
@@ -160,6 +160,10 @@ irreducibility.
 def QAdjoin.approx (a : QAdjoin p x) (rep : RefinedIsolation p)
     (h : SimpleRoot.mk rep = x) (prec : Int) :
     RefinedIsolation p × DyadicComplexBall
+
+theorem QAdjoin.approx_root (a : QAdjoin p x)
+    (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) (prec : Int) :
+    SimpleRoot.mk (a.approx rep h prec).1 = x
 ```
 
 Approximation refines once, returns the refined representative for threading,
@@ -326,7 +330,8 @@ total root wrappers; their `_isSome` theorems make it unreachable.
 ```text
 HexNumberField/
   Basic.lean          : core types, equality, zero, panicWith
-  QAdjoin.lean        : fixed-field operations and approximation
+  Approx.lean         : dyadic-ball evaluation and precision budgets
+  QAdjoin.lean        : fixed-field operations and threaded approximation
   Convert.lean        : canonicalization and exactification
   Lazy.lean           : eliminants and lazy arithmetic
   Disambiguate.lean   : candidate bounds and certified selection

--- a/HexRoots/Pellet.lean
+++ b/HexRoots/Pellet.lean
@@ -140,6 +140,45 @@ never re-derive the `√2` bookkeeping. -/
 @[expose] def DyadicSquare.toBall (s : DyadicSquare) : DyadicComplexBall :=
   ⟨s.re, s.im, s.radiusHi⟩
 
+namespace DyadicComplexBall
+
+/-- The exact zero complex ball. -/
+@[expose]
+def zero : DyadicComplexBall := ⟨0, 0, 0⟩
+
+/-- Minkowski sum of two closed dyadic complex balls. -/
+@[expose]
+def add (a b : DyadicComplexBall) : DyadicComplexBall :=
+  ⟨a.re + b.re, a.im + b.im, a.radius + b.radius⟩
+
+/-- Product enclosure for two closed dyadic complex balls. -/
+@[expose]
+def mul (a b : DyadicComplexBall) : DyadicComplexBall :=
+  let ac : GaussDyadic := (a.re, a.im)
+  let bc : GaussDyadic := (b.re, b.im)
+  let center := GaussDyadic.mul ac bc
+  let radius :=
+    GaussDyadic.hi ac * b.radius + GaussDyadic.hi bc * a.radius +
+      a.radius * b.radius
+  ⟨center.1, center.2, radius⟩
+
+/-- Enclose a rational number by a real-centred dyadic complex ball. Exact
+dyadic rationals receive radius zero; otherwise one ulp encloses the downward
+rounding error. At nonnegative precision the denominator test avoids
+materializing and normalizing a large intermediate rational. -/
+@[expose]
+def ofRat (q : Rat) (prec : Int) : DyadicComplexBall :=
+  let lo := q.toDyadic prec
+  let exact :=
+    if 0 ≤ prec then
+      decide (q.den.isPowerOfTwo ∧ q.den.log2 ≤ prec.toNat)
+    else
+      lo.toRat = q
+  let radius := if exact then 0 else Dyadic.ofIntWithPrec 1 prec
+  ⟨lo, 0, radius⟩
+
+end DyadicComplexBall
+
 /-- A ball containing `p(z)` for every `z` in the circumscribed disc of
     `s`: centred at the exact value `p(centre) = c₀`, with radius
     `Σ_{i ≥ 1} hi(cᵢ)·radiusHi^i ≥ |p(z) − p(centre)|` by the triangle

--- a/HexRoots/SPEC/hex-roots.md
+++ b/HexRoots/SPEC/hex-roots.md
@@ -297,6 +297,11 @@ structure DyadicComplexBall where
   im     : Dyadic
   radius : Dyadic
 
+def DyadicComplexBall.zero : DyadicComplexBall
+def DyadicComplexBall.add (a b : DyadicComplexBall) : DyadicComplexBall
+def DyadicComplexBall.mul (a b : DyadicComplexBall) : DyadicComplexBall
+def DyadicComplexBall.ofRat (q : Rat) (prec : Int) : DyadicComplexBall
+
 /-- `p` has only simple complex roots. Decided by casting `p` and `p'`
     to `DensePoly Rat` and testing whether HexPoly's Euclidean gcd is
     constant. The Mathlib companion proves equivalence with
@@ -306,6 +311,13 @@ instance : Decidable (HasOnlySimpleRoots p) := …
 ```
 
 ## Operations
+
+The generic ball algebra is owned here for reuse by numerical consumers.
+`add` is the Minkowski sum. For centres `aₜ`, `bₜ` and radii `rₐ`, `rᵇ`,
+`mul` uses the exact centre product and radius
+`hi(aₜ) * rᵇ + hi(bₜ) * rₐ + rₐ * rᵇ`. `ofRat q prec` rounds downward
+to `q.toDyadic prec`, with radius zero when that dyadic is exact and otherwise
+one ulp `2^(-prec)`.
 
 ```lean
 namespace Component
@@ -713,8 +725,9 @@ inherit the precision.
   `√2` constants with their `decide`-checked defining inequalities,
   the `witness` predicate and its `Decidable` instance,
   `DyadicRootCluster` (whose field mentions `witness`), and the ball
-  view: `DyadicSquare.toBall`, the sound enclosure `evalBall`, and the
-  ball tests `excludesZero`/`meets`/`meetsBall` that consumers
+  view: `DyadicSquare.toBall`, the generic exact ball algebra, rational
+  enclosure, the sound polynomial enclosure `evalBall`, and the ball tests
+  `excludesZero`/`meets`/`meetsBall` that consumers
   (hex-number-field's disambiguation loops) use instead of re-deriving
   the `√2` radius bookkeeping.
 - `HexRoots/Kantorovich.lean`: `nkWitness` with its `Decidable`

--- a/progress/20260727T043834Z_numberfield-approx.md
+++ b/progress/20260727T043834Z_numberfield-approx.md
@@ -1,0 +1,33 @@
+# HexNumberField fixed-field approximation
+
+## Accomplished
+
+- Added explicit dyadic complex-ball zero, addition, multiplication, and
+  rational enclosure operations.
+- Added Horner evaluation of rational coordinate polynomials on a dyadic root
+  square, together with input-derived coefficient and Cauchy guard-bit bounds.
+- Implemented `QAdjoin.approx` as a single threaded refinement followed by
+  canonical-coordinate ball evaluation, with a sound checked fallback.
+- Added compiled guards for exact complex-ball arithmetic, non-dyadic rational
+  rounding, and linear Horner evaluation.
+- Rebuilt `HexNumberField` and reran DAG, source, phase, bench-import,
+  conformance-matrix, forbidden-form, and whitespace checks successfully.
+
+## Current frontier
+
+The fixed-field representation, canonical reduced arithmetic, inversion, and
+threaded approximation layers are implemented.  The companion proof that the
+approximation radius reaches the requested precision remains a later Mathlib
+obligation.
+
+## Next step
+
+Publish the stacked approximation PR and launch its independent review, then
+repair the already-returned resultant and number-field scaffold review findings
+while that review and CI continue asynchronously.
+
+## Blockers
+
+The repository phase scheduler still blocks HexNumberField Phase 1 on
+HexBerlekampZassenhaus reaching Phase 1, although the dependency APIs used here
+are present and compile.

--- a/progress/20260727T051707Z_numberfield-approx-review.md
+++ b/progress/20260727T051707Z_numberfield-approx-review.md
@@ -1,0 +1,32 @@
+# HexNumberField approximation review repair
+
+## Accomplished
+
+- Preserved and exposed the refined representative's `SimpleRoot` equality so
+  callers can actually thread the result into the next approximation.
+- Replaced the global Cauchy guard-bit multiplier with a certified magnitude
+  bound from the selected root's current isolation square.
+- Moved generic complex-ball zero, addition, multiplication, and rational
+  enclosure operations into their owning HexRoots layer.
+- Removed intermediate-list allocation and the redundant top-coefficient
+  multiplication from rational Horner evaluation.
+- Added compiled negative-rounding, nonzero-radius complex-product, and
+  end-to-end 64-bit square-root approximation regressions.
+- Made the approximation module explicit in the umbrella and corrected the
+  fixed-field file organization and threading contract in the SPEC.
+- Rebuilt `HexRoots` and `HexNumberField` successfully.
+
+## Current frontier
+
+The approximation milestone now addresses every correctness, performance,
+coverage, and layering issue raised by its independent review. Its only
+remaining review item is asynchronous verification of the repaired diff.
+
+## Next step
+
+Push the repair, launch its re-review without waiting, and repair/rebase the
+Resultant PRS milestone onto the merged resultant contract.
+
+## Blockers
+
+None.

--- a/progress/20260727T053612Z_numberfield-approx-verification.md
+++ b/progress/20260727T053612Z_numberfield-approx-verification.md
@@ -1,0 +1,29 @@
+# HexNumberField approximation verification follow-up
+
+## Accomplished
+
+- Removed the last coefficient-array copy from Horner evaluation by folding
+  the original array below its separately seeded leading coefficient.
+- Added a compiled two-stage approximation of `1/3 + (2/5)·√2`, exercising
+  coefficient rounding, the requested radius at two precisions, the returned
+  representative, and its kernel-proved threading equality.
+- Documented the approximation target formula and the soundness role of its
+  per-step margin in the HexNumberField SPEC.
+- Documented the generic ball algebra and rational enclosure in the owning
+  HexRoots SPEC and corrected Pellet's file-organization entry.
+- Rebuilt `HexRoots` and `HexNumberField` successfully.
+
+## Current frontier
+
+All actionable findings scoped to the approximation milestone have been
+addressed. The reviewer also noted the three pre-existing core propositional
+Phase 1 obligations; they remain isolated from executable data production.
+
+## Next step
+
+Push the final approximation repair and continue with the next HexNumberField
+milestone while the PRS and fixed-field verification reviewers finish.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #8894

Implements conservative dyadic complex-ball arithmetic, rational Horner evaluation with an input-derived guard budget, and the threaded `QAdjoin.approx` API. The checked refinement fallback preserves soundness; the companion will discharge its unreachability and requested-radius obligations.

Verification:
- `lake build HexNumberField`
- compiled ball/evaluation guards
- DAG, copyright, line-count, phase, bench-import, conformance-matrix, forbidden-form, and whitespace checks