### PR TITLE
RCF foundation: certify literal generalized Sturm chains

### DIFF
--- a/HexRealRootsMathlib.lean
+++ b/HexRealRootsMathlib.lean
@@ -12,6 +12,9 @@ public import HexRealRootsMathlib.Hadamard
 public import HexRealRootsMathlib.Discr
 public import HexRealRootsMathlib.Separation
 public import HexRealRootsMathlib.ChainCorrespond
+public import HexRealRootsMathlib.LiteralChain
+public import HexRealRootsMathlib.LiteralIsolations
+public import HexRealRootsMathlib.LiteralChainTests
 public import HexRealRootsMathlib.SquareFreeCore
 public import HexRealRootsMathlib.Isolations
 public import HexRealRootsMathlib.IsolateRoots
@@ -40,10 +43,12 @@ free of any `HexRealRoots` dependence, so it can be contributed to Mathlib
 
 The executable-correspondence and consequence files build on it:
 `ChainCorrespond` connects `Hex.sturmChain`, `Hex.sturmCount`, and `Hex.rootCount`
-to the abstract development; `Separation` supplies the Mahler separation bound,
-using `HexPolyZMathlib.MahlerSeparation` and the analysis re-exported by the
-`Discr`/`Hadamard` compatibility modules; `Isolations` and `Drivers` prove
-isolation soundness, run
+to the abstract development; `LiteralChain` proves the corresponding theorem
+for a supplied positive-scaled recurrence, and `LiteralIsolations` states
+isolation semantics for its supplied counts; `Separation` supplies the Mahler
+separation bound, using `HexPolyZMathlib.MahlerSeparation` and the analysis
+re-exported by the `Discr`/`Hadamard` compatibility modules; `Isolations` and
+`Drivers` prove isolation soundness, run
 completeness, driver completeness, and refinement; `SimpleRealRoot` proves the
 root-identity theorems (overlap classes are the real roots); and `TwoCircle`
 proves Descartes-engine termination (`isolateDescartes?_isSome`) behind its

--- a/HexRealRootsMathlib/ChainCorrespond.lean
+++ b/HexRealRootsMathlib/ChainCorrespond.lean
@@ -409,6 +409,12 @@ theorem toPolyℝ_neg (p : Hex.ZPoly) : toPolyℝ (-p) = -(toPolyℝ p) := by
   show (HexPolyMathlib.toPolynomial (-p)).map (Int.castRingHom ℝ) = _
   rw [HexPolyMathlib.toPolynomial_neg, Polynomial.map_neg]
 
+/-- The real cast is multiplicative. -/
+theorem toPolyℝ_mul (p q : Hex.ZPoly) :
+    toPolyℝ (p * q) = toPolyℝ p * toPolyℝ q := by
+  show (HexPolyZMathlib.toPolynomial (p * q)).map (Int.castRingHom ℝ) = _
+  rw [HexPolyZMathlib.toPolynomial_mul, Polynomial.map_mul]
+
 /-- The real cast of the zero polynomial. -/
 @[simp] theorem toPolyℝ_zero : toPolyℝ 0 = 0 := by
   show (HexPolyMathlib.toPolynomial 0).map (Int.castRingHom ℝ) = _
@@ -954,7 +960,7 @@ private theorem chainList_last_unit :
 `C c₀ · a = Q · b − C k · c'` (with `k ≠ 0`) transports `IsCoprime b c'` *back* to
 `IsCoprime a b`: solving the relation for `c'` and substituting into a Bezout
 combination for `(b, c')` yields one for `(a, b)`. -/
-private theorem coprime_step_rev {a b c' : Polynomial ℝ} {c₀ k : ℝ} {Q : Polynomial ℝ}
+theorem coprime_step_rev {a b c' : Polynomial ℝ} {c₀ k : ℝ} {Q : Polynomial ℝ}
     (hk : k ≠ 0)
     (hrel : Polynomial.C c₀ * a = Q * b - Polynomial.C k * c')
     (h : IsCoprime b c') : IsCoprime a b := by
@@ -1075,7 +1081,7 @@ private theorem eventually_flank_of_deriv_pos {f : Polynomial ℝ} {r : ℝ}
 `s₀' = C γ · s₁` with `γ > 0` (the executable seeds: the primitive parts of
 `p` and `p'`), then `s₀ · s₁` is negative just left of `r` and positive just
 right: its derivative at `r` is `γ · s₁(r)² > 0`. -/
-private theorem flank_of_key {s₀ s₁ : Polynomial ℝ} {γ : ℝ} (hγ : 0 < γ)
+theorem flank_of_key {s₀ s₁ : Polynomial ℝ} {γ : ℝ} (hγ : 0 < γ)
     (hkey : Polynomial.derivative s₀ = Polynomial.C γ * s₁)
     {r : ℝ} (h0 : s₀.eval r = 0) (h1 : s₁.eval r ≠ 0) :
     (∀ᶠ x in nhdsWithin r (Set.Iio r), (s₀ * s₁).eval x < 0) ∧
@@ -1090,7 +1096,7 @@ private theorem flank_of_key {s₀ s₁ : Polynomial ℝ} {γ : ℝ} (hγ : 0 < 
 /-! ### Assembly: the executable chain is a Sturm chain -/
 
 /-- Coprime polynomials never vanish together. -/
-private theorem eval_ne_zero_of_isCoprime {a b : Polynomial ℝ} (h : IsCoprime a b)
+theorem eval_ne_zero_of_isCoprime {a b : Polynomial ℝ} (h : IsCoprime a b)
     {x : ℝ} (ha : a.eval x = 0) : b.eval x ≠ 0 := by
   obtain ⟨u, v, huv⟩ := h
   intro hb
@@ -1365,9 +1371,16 @@ private theorem squarefree_toPolyℝ_primitivePart (p : Hex.ZPoly) (hp0 : p ≠ 
       by rw [toPolyℝ_eq_C_content_mul_primitivePart p]; ring⟩ hsep.squarefree
 
 /-- Dyadic order transfers to the real values. -/
-private theorem toReal_lt_toReal {a b : Dyadic} (h : a < b) :
+theorem toReal_lt_toReal {a b : Dyadic} (h : a < b) :
     Dyadic.toReal a < Dyadic.toReal b := by
   have h2 : a.toRat < b.toRat := Dyadic.toRat_lt_toRat_iff.mpr h
+  unfold Dyadic.toReal
+  exact_mod_cast h2
+
+/-- Nonstrict dyadic order transfers to the real values. -/
+theorem toReal_le_toReal {a b : Dyadic} (h : a ≤ b) :
+    Dyadic.toReal a ≤ Dyadic.toReal b := by
+  have h2 : a.toRat ≤ b.toRat := Dyadic.toRat_le_toRat_iff.mpr h
   unfold Dyadic.toReal
   exact_mod_cast h2
 
@@ -1408,7 +1421,7 @@ private theorem sign_intCast_sign (n : Int) :
 
 /-- The executable `+∞` variation count matches the abstract one: both read
 the signs of the leading coefficients. -/
-private theorem sturmVarPosInf_eq (chain : Array Hex.ZPoly) :
+theorem sturmVarPosInf_eq (chain : Array Hex.ZPoly) :
     Hex.sturmVarPosInf chain = Sturm.sturmVarPosInf (chain.toList.map toPolyℝ) := by
   rw [Hex.sturmVarPosInf, signVar_eq, Sturm.sturmVarPosInf]
   apply Sturm.signVariations_congr
@@ -1421,7 +1434,7 @@ private theorem sturmVarPosInf_eq (chain : Array Hex.ZPoly) :
 
 /-- The executable `−∞` variation count matches the abstract one: both read
 `sign(lc) · (−1)^degree`. -/
-private theorem sturmVarNegInf_eq (chain : Array Hex.ZPoly) :
+theorem sturmVarNegInf_eq (chain : Array Hex.ZPoly) :
     Hex.sturmVarNegInf chain = Sturm.sturmVarNegInf (chain.toList.map toPolyℝ) := by
   rw [Hex.sturmVarNegInf, signVar_eq, Sturm.sturmVarNegInf]
   apply Sturm.signVariations_congr

--- a/HexRealRootsMathlib/Drivers.lean
+++ b/HexRealRootsMathlib/Drivers.lean
@@ -76,12 +76,6 @@ private theorem dlt_trans {a b c : Dyadic} (h1 : a < b) (h2 : b < c) : a < c := 
   rw [← Dyadic.toRat_lt_toRat_iff] at h1 h2 ⊢
   exact lt_trans h1 h2
 
-/-- Dyadic `≤` transfers to the real values. -/
-private theorem toReal_le_toReal {a b : Dyadic} (h : a ≤ b) :
-    Dyadic.toReal a ≤ Dyadic.toReal b := by
-  have h2 : a.toRat ≤ b.toRat := Dyadic.toRat_le_toRat_iff.mpr h
-  unfold Dyadic.toReal; exact_mod_cast h2
-
 /-- A right shift by one bit halves the real value. -/
 private theorem toReal_shiftRight_one (x : Dyadic) :
     Dyadic.toReal (x >>> (1 : Int)) = Dyadic.toReal x / 2 := by

--- a/HexRealRootsMathlib/Isolations.lean
+++ b/HexRealRootsMathlib/Isolations.lean
@@ -88,13 +88,6 @@ theorem degree?_ne_none (hp0 : p ≠ 0) : p.degree? ≠ none := by
   rw [Hex.DensePoly.coeff_zero]
   exact Hex.DensePoly.coeff_eq_zero_of_size_le p (by omega)
 
-/-- Dyadic order transfers to the real values. -/
-private theorem toReal_le_toReal {a b : Dyadic} (h : a ≤ b) :
-    Dyadic.toReal a ≤ Dyadic.toReal b := by
-  have h2 : a.toRat ≤ b.toRat := Dyadic.toRat_le_toRat_iff.mpr h
-  unfold Dyadic.toReal
-  exact_mod_cast h2
-
 /-- **Isolation soundness.** A certified isolation of `p` names exactly one real
 root of `toPolyℝ p` in its half-open interval `(lower, upper]`. -/
 theorem RealRootIsolation.exists_unique_root (hp : Hex.ZPoly.SquareFreeRat p)

--- a/HexRealRootsMathlib/LiteralChain.lean
+++ b/HexRealRootsMathlib/LiteralChain.lean
@@ -1,0 +1,364 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRealRootsMathlib.ChainCorrespond
+
+public section
+
+/-!
+# Literal generalized Sturm chains
+
+This file packages the algebra used by multiplication-only certificate replayers.
+Unlike `Hex.ZPoly.sturmChain`, a literal chain is supplied by the caller. Its
+three-term identities and terminal unit prove coprimality backwards through the
+chain; a positive derivative identity then supplies the head flanks required by
+`Sturm.IsSturmChain`.
+-/
+
+open Polynomial
+
+namespace Sturm
+
+/-- A positive three-term Sturm recurrence
+`C left * a = quotient * b - C right * c`. -/
+@[expose] def ReplayStep (a b c : Polynomial ℝ) : Prop :=
+  ∃ (left : ℝ) (quotient : Polynomial ℝ) (right : ℝ),
+    0 < left ∧ 0 < right ∧
+      Polynomial.C left * a = quotient * b - Polynomial.C right * c
+
+/-- Recurrences for a chain of length at least two, ending in a unit.
+
+The recursive shape is convenient both for a compiled array checker to build and
+for the soundness proof to consume: each constructor adds exactly one supplied
+three-term identity. -/
+inductive Replay : Polynomial ℝ → Polynomial ℝ → List (Polynomial ℝ) → Prop where
+  | pair {a b : Polynomial ℝ} (last : IsUnit b) : Replay a b []
+  | cons {a b c : Polynomial ℝ} {rest : List (Polynomial ℝ)}
+      (step : ReplayStep a b c) (tail : Replay b c rest) :
+      Replay a b (c :: rest)
+
+namespace Replay
+
+/-- The first two entries of a replay are coprime. -/
+theorem first_coprime {a b : Polynomial ℝ} {rest : List (Polynomial ℝ)}
+    (h : Replay a b rest) : IsCoprime a b := by
+  induction h with
+  | pair hunit =>
+      obtain ⟨u, rfl⟩ := hunit
+      exact ⟨0, ↑u⁻¹, by simp⟩
+  | cons step tail ih =>
+      obtain ⟨left, quotient, right, hleft, hright, hrel⟩ := step
+      exact HexRealRootsMathlib.coprime_step_rev
+        (ne_of_gt hright) hrel ih
+
+/-- Every consecutive pair in a replay is coprime. -/
+theorem pair_coprime {x y : Polynomial ℝ} {rest : List (Polynomial ℝ)}
+    (h : Replay x y rest) : ∀ (i : ℕ) (a b : Polynomial ℝ),
+      (x :: y :: rest)[i]? = some a → (x :: y :: rest)[i + 1]? = some b →
+      IsCoprime a b := by
+  induction h with
+  | pair hunit =>
+      intro i a b ha hb
+      cases i with
+      | zero =>
+          simp only [List.getElem?_cons_zero, Option.some.injEq] at ha
+          subst a
+          simp only [Nat.zero_add, List.getElem?_cons_succ, List.getElem?_cons_zero,
+            Option.some.injEq] at hb
+          subst b
+          exact (Replay.pair hunit).first_coprime
+      | succ i =>
+          simp only [List.getElem?_cons_succ] at ha hb
+          cases i <;> simp_all
+  | cons step tail ih =>
+      intro i a b ha hb
+      cases i with
+      | zero =>
+          simp only [List.getElem?_cons_zero, Option.some.injEq] at ha
+          subst a
+          simp only [Nat.zero_add, List.getElem?_cons_succ, List.getElem?_cons_zero,
+            Option.some.injEq] at hb
+          subst b
+          exact (Replay.cons step tail).first_coprime
+      | succ i =>
+          simp only [List.getElem?_cons_succ] at ha hb
+          simpa [Nat.succ_add] using ih i a b ha hb
+
+/-- Every consecutive triple in a replay has its supplied positive recurrence. -/
+theorem triple {x y : Polynomial ℝ} {rest : List (Polynomial ℝ)}
+    (h : Replay x y rest) : ∀ (i : ℕ) (a b c : Polynomial ℝ),
+      (x :: y :: rest)[i]? = some a → (x :: y :: rest)[i + 1]? = some b →
+      (x :: y :: rest)[i + 2]? = some c → ReplayStep a b c := by
+  induction h with
+  | pair hunit =>
+      intro i a b c ha hb hc
+      cases i <;> simp_all
+  | cons step tail ih =>
+      intro i a b c ha hb hc
+      cases i with
+      | zero =>
+          simp only [List.getElem?_cons_zero, Option.some.injEq] at ha
+          subst a
+          simp only [Nat.zero_add, List.getElem?_cons_succ, List.getElem?_cons_zero,
+            Option.some.injEq] at hb
+          subst b
+          simp only [List.getElem?_cons_succ, List.getElem?_cons_zero,
+            Option.some.injEq] at hc
+          subst c
+          exact step
+      | succ i =>
+          simp only [List.getElem?_cons_succ] at ha hb hc
+          simpa [Nat.succ_add] using ih i a b c ha hb hc
+
+/-- The last entry of a replay is a unit. -/
+theorem last_unit {x y : Polynomial ℝ} {rest : List (Polynomial ℝ)}
+    (h : Replay x y rest) : ∀ q, (x :: y :: rest).getLast? = some q → IsUnit q := by
+  induction h with
+  | pair hunit =>
+      intro q hq
+      simp only [List.getLast?_cons_cons, List.getLast?_singleton, Option.some.injEq] at hq
+      subst q
+      exact hunit
+  | cons step tail ih =>
+      intro q hq
+      apply ih q
+      simpa using hq
+
+end Replay
+
+/-- A literal positive recurrence replay gives all generalized Sturm-chain
+axioms. Nonvanishing is kept explicit because a unit terminal and recurrence
+identities alone permit a zero entry immediately before a unit. -/
+theorem isChain_of_replay {f s₁ : Polynomial ℝ} {rest : List (Polynomial ℝ)}
+    (hrep : Replay f s₁ rest)
+    (hnz : ∀ q ∈ f :: s₁ :: rest, q ≠ 0)
+    (δ : ℝ) (hδ : 0 < δ)
+    (hderiv : Polynomial.derivative f = Polynomial.C δ * s₁) :
+    IsSturmChain f (f :: s₁ :: rest) := by
+  have hcop : IsCoprime f s₁ := hrep.first_coprime
+  refine { nonempty := by simp, head := rfl, root_flank := ?_, nonzero_mem := hnz,
+           consec_coprime := ?_, interior_alternates := ?_, last_no_root := ?_ }
+  · intro r hr
+    have hs₁r : s₁.eval r ≠ 0 :=
+      HexRealRootsMathlib.eval_ne_zero_of_isCoprime hcop hr
+    obtain ⟨hleft, hright⟩ :=
+      HexRealRootsMathlib.flank_of_key hδ hderiv hr hs₁r
+    exact ⟨s₁, rfl, hs₁r, hleft, hright⟩
+  · intro i x a b ha hb hax
+    exact HexRealRootsMathlib.eval_ne_zero_of_isCoprime
+      (hrep.pair_coprime i a b ha hb) hax
+  · intro i x a b c ha hb hc hbx
+    obtain ⟨left, quotient, right, hleft, hright, hrel⟩ :=
+      hrep.triple i a b c ha hb hc
+    have hcop_ab := hrep.pair_coprime i a b ha hb
+    have heval := congrArg (Polynomial.eval x) hrel
+    rw [Polynomial.eval_mul, Polynomial.eval_sub, Polynomial.eval_mul,
+      Polynomial.eval_mul, Polynomial.eval_C, Polynomial.eval_C, hbx, mul_zero,
+      zero_sub] at heval
+    have hax : a.eval x ≠ 0 :=
+      HexRealRootsMathlib.eval_ne_zero_of_isCoprime hcop_ab.symm hbx
+    have hcx : c.eval x ≠ 0 := by
+      intro hcx
+      rw [hcx, mul_zero, neg_zero, mul_eq_zero] at heval
+      rcases heval with hzero | hzero
+      · exact (ne_of_gt hleft) hzero
+      · exact hax hzero
+    refine ⟨hax, hcx, ?_⟩
+    have hsign : left * (a.eval x * c.eval x) =
+        -(right * (c.eval x * c.eval x)) := by
+      linear_combination c.eval x * heval
+    nlinarith [hsign, hleft, hright, mul_self_pos.mpr hcx]
+  · intro q hq x
+    have hunit := hrep.last_unit q hq
+    obtain ⟨u, hu, hCu⟩ := Polynomial.isUnit_iff.mp hunit
+    rw [← hCu, Polynomial.eval_C]
+    exact hu.ne_zero
+
+/-- A literal positive recurrence replay proves squarefreeness by genuine
+polynomial coprimality of the head and its derivative. -/
+theorem squarefree_of_replay {f s₁ : Polynomial ℝ} {rest : List (Polynomial ℝ)}
+    (hrep : Replay f s₁ rest)
+    (δ : ℝ) (hδ : 0 < δ)
+    (hderiv : Polynomial.derivative f = Polynomial.C δ * s₁) :
+    Squarefree f := by
+  have hcop : IsCoprime f s₁ := hrep.first_coprime
+  have hsep : f.Separable := by
+    rw [Polynomial.separable_def, hderiv]
+    obtain ⟨u, v, huv⟩ := hcop
+    refine ⟨u, v * Polynomial.C δ⁻¹, ?_⟩
+    have hC : Polynomial.C δ⁻¹ * Polynomial.C δ = (1 : Polynomial ℝ) := by
+      rw [← Polynomial.C_mul, inv_mul_cancel₀ (ne_of_gt hδ), Polynomial.C_1]
+    calc
+      u * f + (v * Polynomial.C δ⁻¹) * (Polynomial.C δ * s₁) =
+          u * f + v * (Polynomial.C δ⁻¹ * Polynomial.C δ) * s₁ := by ring
+      _ = u * f + v * s₁ := by rw [hC]; simp
+      _ = 1 := huv
+  exact hsep.squarefree
+
+end Sturm
+
+namespace HexRealRootsMathlib
+
+/-- An integer-polynomial instance of a positive three-term recurrence. -/
+@[expose] def ZReplayStep (a b c : Hex.ZPoly) : Prop :=
+  ∃ (left : Int) (quotient : Hex.ZPoly) (right : Int),
+    0 < left ∧ 0 < right ∧
+      Hex.DensePoly.scale left a = quotient * b - Hex.DensePoly.scale right c
+
+/-- A literal integer-polynomial recurrence chain ending in a nonzero
+constant. -/
+inductive ZReplay : Hex.ZPoly → Hex.ZPoly → List Hex.ZPoly → Prop where
+  | pair {a b : Hex.ZPoly} (last : b.size = 1) : ZReplay a b []
+  | cons {a b c : Hex.ZPoly} {rest : List Hex.ZPoly}
+      (step : ZReplayStep a b c) (tail : ZReplay b c rest) :
+      ZReplay a b (c :: rest)
+
+namespace ZReplay
+
+/-- A normalized size-one dense polynomial is a nonzero constant, hence a unit
+after casting. The dense-polynomial no-trailing-zero invariant rules out the
+otherwise problematic coefficient array `#[0]`. -/
+private theorem cast_unit {p : Hex.ZPoly} (hsize : p.size = 1) :
+    IsUnit (toPolyℝ p) := by
+  have hp0 : p ≠ 0 := by
+    intro hp
+    subst p
+    simp at hsize
+  have hcast0 : toPolyℝ p ≠ 0 := fun h => hp0 (toPolyℝ_eq_zero_iff.mp h)
+  have hdegree : (toPolyℝ p).natDegree = 0 := by
+    rw [natDegree_toPolyℝ,
+      Hex.DensePoly.degree?_eq_some_of_pos_size p (by omega), hsize]
+    rfl
+  rw [Polynomial.isUnit_iff_degree_eq_zero,
+    Polynomial.degree_eq_natDegree hcast0, hdegree]
+  rfl
+
+/-- Cast a literal integer replay to the abstract real-polynomial replay. -/
+theorem toReplay {a b : Hex.ZPoly} {rest : List Hex.ZPoly}
+    (h : ZReplay a b rest) :
+    Sturm.Replay (toPolyℝ a) (toPolyℝ b) (rest.map toPolyℝ) := by
+  induction h with
+  | pair hlast =>
+      exact Sturm.Replay.pair (cast_unit hlast)
+  | cons step tail ih =>
+      apply Sturm.Replay.cons
+      · obtain ⟨left, quotient, right, hleft, hright, hrel⟩ := step
+        refine ⟨(left : ℝ), toPolyℝ quotient, (right : ℝ), ?_, ?_, ?_⟩
+        · exact_mod_cast hleft
+        · exact_mod_cast hright
+        · have hcast := congrArg toPolyℝ hrel
+          simpa [toPolyℝ_scale, toPolyℝ_sub, toPolyℝ_mul] using hcast
+      · exact ih
+
+end ZReplay
+
+/-- Checked literal integer identities imply a generalized Sturm chain for the
+real cast. -/
+theorem ZReplay.isChain {f s₁ : Hex.ZPoly} {rest : List Hex.ZPoly}
+    (hrep : ZReplay f s₁ rest)
+    (hnz : ∀ q ∈ f :: s₁ :: rest, q ≠ 0)
+    (δ : Int) (hδ : 0 < δ)
+    (hderiv : Hex.DensePoly.derivative f = Hex.DensePoly.scale δ s₁) :
+    Sturm.IsSturmChain (toPolyℝ f) ((f :: s₁ :: rest).map toPolyℝ) := by
+  have hnz' : ∀ q ∈ (f :: s₁ :: rest).map toPolyℝ, q ≠ 0 := by
+    intro q hq
+    rw [List.mem_map] at hq
+    obtain ⟨z, hz, rfl⟩ := hq
+    exact fun h => hnz z hz (toPolyℝ_eq_zero_iff.mp h)
+  have hderiv' : Polynomial.derivative (toPolyℝ f) =
+      Polynomial.C (δ : ℝ) * toPolyℝ s₁ := by
+    have hcast := congrArg toPolyℝ hderiv
+    simpa [toPolyℝ_derivative, toPolyℝ_scale] using hcast
+  simpa using Sturm.isChain_of_replay hrep.toReplay hnz' (δ : ℝ)
+    (by exact_mod_cast hδ) hderiv'
+
+/-- Checked literal integer identities prove squarefreeness of the real cast. -/
+theorem ZReplay.squarefree {f s₁ : Hex.ZPoly} {rest : List Hex.ZPoly}
+    (hrep : ZReplay f s₁ rest)
+    (δ : Int) (hδ : 0 < δ)
+    (hderiv : Hex.DensePoly.derivative f = Hex.DensePoly.scale δ s₁) :
+    Squarefree (toPolyℝ f) := by
+  have hderiv' : Polynomial.derivative (toPolyℝ f) =
+      Polynomial.C (δ : ℝ) * toPolyℝ s₁ := by
+    have hcast := congrArg toPolyℝ hderiv
+    simpa [toPolyℝ_derivative, toPolyℝ_scale] using hcast
+  exact Sturm.squarefree_of_replay hrep.toReplay (δ : ℝ)
+    (by exact_mod_cast hδ) hderiv'
+
+namespace Literal
+
+/-- Membership in the real half-open interval represented by `I`. -/
+@[expose] def InInterval (I : Hex.DyadicInterval) (x : ℝ) : Prop :=
+  Dyadic.toReal I.lower < x ∧ x ≤ Dyadic.toReal I.upper
+
+/-- The multiset of real roots of `f` in a half-open dyadic interval. -/
+@[expose] noncomputable def rootsIn
+    (f : Polynomial ℝ) (I : Hex.DyadicInterval) : Multiset ℝ := by
+  classical
+  exact f.roots.filter (InInterval I)
+
+end Literal
+
+/-- A literal chain's finite variation drop is the exact number of roots in a
+half-open dyadic interval. This reads the supplied chain directly and never
+calls the executable chain builder. -/
+theorem literalCount_eq_card_roots (p : Hex.ZPoly) (chain : Array Hex.ZPoly)
+    (hp : toPolyℝ p ≠ 0) (hsf : Squarefree (toPolyℝ p))
+    (hchain : Sturm.IsSturmChain (toPolyℝ p) (chain.toList.map toPolyℝ))
+    (I : Hex.DyadicInterval) :
+    (Hex.sturmVarAt chain I.lower : Int) - Hex.sturmVarAt chain I.upper =
+      (Literal.rootsIn (toPolyℝ p) I).card := by
+  rw [sturmVarAt_eq, sturmVarAt_eq]
+  simpa only [Literal.rootsIn, Literal.InInterval] using
+    Sturm.sturm_half_open hp hsf hchain (toReal_lt_toReal I.lt)
+
+/-- A literal chain's variation drop at infinity is the exact total number of
+real roots. -/
+theorem literalRootCount_eq_card_roots (p : Hex.ZPoly) (chain : Array Hex.ZPoly)
+    (hp : toPolyℝ p ≠ 0) (hsf : Squarefree (toPolyℝ p))
+    (hchain : Sturm.IsSturmChain (toPolyℝ p) (chain.toList.map toPolyℝ)) :
+    (Hex.sturmVarNegInf chain : Int) - Hex.sturmVarPosInf chain =
+      (toPolyℝ p).roots.card := by
+  rw [sturmVarNegInf_eq, sturmVarPosInf_eq]
+  exact Sturm.sturm_line hp hsf hchain
+
+/-- A checked integer replay gives the exact literal count on an interval.
+
+The array consumed by the executable variation reader is the array conversion
+of the replay list, so no separate list/array alignment proof is required. -/
+theorem ZReplay.count_eq_card_roots {f s₁ : Hex.ZPoly} {rest : List Hex.ZPoly}
+    (hrep : ZReplay f s₁ rest)
+    (hnz : ∀ q ∈ f :: s₁ :: rest, q ≠ 0)
+    (δ : Int) (hδ : 0 < δ)
+    (hderiv : Hex.DensePoly.derivative f = Hex.DensePoly.scale δ s₁)
+    (I : Hex.DyadicInterval) :
+    (Hex.sturmVarAt (f :: s₁ :: rest).toArray I.lower : Int) -
+        Hex.sturmVarAt (f :: s₁ :: rest).toArray I.upper =
+      (Literal.rootsIn (toPolyℝ f) I).card := by
+  apply literalCount_eq_card_roots f (f :: s₁ :: rest).toArray
+  · intro hf
+    exact hnz f (by simp) (toPolyℝ_eq_zero_iff.mp hf)
+  · exact hrep.squarefree δ hδ hderiv
+  · simpa using hrep.isChain hnz δ hδ hderiv
+
+/-- A checked integer replay gives the exact total literal root count. -/
+theorem ZReplay.total_eq_card_roots {f s₁ : Hex.ZPoly} {rest : List Hex.ZPoly}
+    (hrep : ZReplay f s₁ rest)
+    (hnz : ∀ q ∈ f :: s₁ :: rest, q ≠ 0)
+    (δ : Int) (hδ : 0 < δ)
+    (hderiv : Hex.DensePoly.derivative f = Hex.DensePoly.scale δ s₁) :
+    (Hex.sturmVarNegInf (f :: s₁ :: rest).toArray : Int) -
+        Hex.sturmVarPosInf (f :: s₁ :: rest).toArray =
+      (toPolyℝ f).roots.card := by
+  apply literalRootCount_eq_card_roots f (f :: s₁ :: rest).toArray
+  · intro hf
+    exact hnz f (by simp) (toPolyℝ_eq_zero_iff.mp hf)
+  · exact hrep.squarefree δ hδ hderiv
+  · simpa using hrep.isChain hnz δ hδ hderiv
+
+end HexRealRootsMathlib

--- a/HexRealRootsMathlib/LiteralChainTests.lean
+++ b/HexRealRootsMathlib/LiteralChainTests.lean
@@ -43,6 +43,14 @@ example : Squarefree quad := by
   apply Sturm.squarefree_of_replay replay 2 (by norm_num)
   simp [quad, Polynomial.derivative_pow]
 
+/-- A zero middle entry cannot satisfy a positive recurrence between `X` and
+the terminal constant. This guards the sign convention of malformed triples. -/
+example : ¬ Sturm.ReplayStep X 0 1 := by
+  rintro ⟨left, quotient, right, hleft, hright, hrel⟩
+  have heval := congrArg (Polynomial.eval (0 : ℝ)) hrel
+  have : (0 : ℝ) = -right := by simpa using heval
+  nlinarith
+
 /-! The integer replay below has four entries, so it exercises both supplied
 triple identities as well as the list-to-array count bridge. -/
 

--- a/HexRealRootsMathlib/LiteralChainTests.lean
+++ b/HexRealRootsMathlib/LiteralChainTests.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRealRootsMathlib.LiteralIsolations
+
+public section
+
+/-! Small proof-level regression tests for literal-chain replay. -/
+
+open Polynomial
+
+namespace HexRealRootsMathlib.LiteralChainTests
+
+private noncomputable def quad : Polynomial ℝ := X ^ 2 - 1
+
+private theorem replay : Sturm.Replay quad X [1] := by
+  apply Sturm.Replay.cons
+  · change ∃ left quotient right, 0 < left ∧ 0 < right ∧ _
+    refine ⟨1, X, 1, by norm_num, by norm_num, ?_⟩
+    simp [quad, pow_two]
+  · exact Sturm.Replay.pair isUnit_one
+
+private theorem nonzero : ∀ q ∈ [quad, X, 1], q ≠ 0 := by
+  intro q hq
+  simp only [List.mem_cons, List.not_mem_nil, or_false] at hq
+  rcases hq with rfl | rfl | rfl
+  · intro h
+    have heval := congrArg (Polynomial.eval (0 : ℝ)) h
+    norm_num [quad] at heval
+  · exact Polynomial.X_ne_zero
+  · exact one_ne_zero
+
+example : Sturm.IsSturmChain quad [quad, X, 1] := by
+  apply Sturm.isChain_of_replay replay nonzero 2 (by norm_num)
+  simp [quad, Polynomial.derivative_pow]
+
+example : Squarefree quad := by
+  apply Sturm.squarefree_of_replay replay 2 (by norm_num)
+  simp [quad, Polynomial.derivative_pow]
+
+/-! The integer replay below has four entries, so it exercises both supplied
+triple identities as well as the list-to-array count bridge. -/
+
+private def zf : Hex.ZPoly :=
+  Hex.DensePoly.ofCoeffs #[(0 : Int), -1, 0, 1]
+
+private def zs₁ : Hex.ZPoly :=
+  Hex.DensePoly.ofCoeffs #[(-1 : Int), 0, 3]
+
+private def zs₂ : Hex.ZPoly :=
+  Hex.DensePoly.ofCoeffs #[(0 : Int), 1]
+
+private def zs₃ : Hex.ZPoly :=
+  Hex.DensePoly.ofCoeffs #[(1 : Int)]
+
+private theorem zreplay : ZReplay zf zs₁ [zs₂, zs₃] := by
+  apply ZReplay.cons
+  · change ∃ left quotient right, 0 < left ∧ 0 < right ∧ _
+    refine ⟨3, Hex.DensePoly.ofCoeffs #[(0 : Int), 1], 2,
+      by decide, by decide, by decide⟩
+  · apply ZReplay.cons
+    · change ∃ left quotient right, 0 < left ∧ 0 < right ∧ _
+      refine ⟨1, Hex.DensePoly.ofCoeffs #[(0 : Int), 3], 1,
+        by decide, by decide, by decide⟩
+    · exact ZReplay.pair (by decide)
+
+private theorem znonzero : ∀ q ∈ [zf, zs₁, zs₂, zs₃], q ≠ 0 := by
+  intro q hq
+  simp only [List.mem_cons, List.not_mem_nil, or_false] at hq
+  rcases hq with rfl | rfl | rfl | rfl <;> decide
+
+private theorem zderiv :
+    Hex.DensePoly.derivative zf = Hex.DensePoly.scale 1 zs₁ := by
+  decide
+
+private def zinterval₁ : Hex.DyadicInterval :=
+  Hex.DyadicInterval.mk (Dyadic.ofInt (-2)) (Dyadic.ofInt (-1)) (by decide)
+
+private def zinterval₂ : Hex.DyadicInterval :=
+  Hex.DyadicInterval.mk (Dyadic.ofInt (-1)) (Dyadic.ofInt 0) (by decide)
+
+private def zinterval₃ : Hex.DyadicInterval :=
+  Hex.DyadicInterval.mk (Dyadic.ofInt 0) (Dyadic.ofInt 2) (by decide)
+
+private def zcount (I : Hex.DyadicInterval) : Int :=
+  (Hex.sturmVarAt [zf, zs₁, zs₂, zs₃].toArray I.lower : Int) -
+    Hex.sturmVarAt [zf, zs₁, zs₂, zs₃].toArray I.upper
+
+private def ztotal : Int :=
+  (Hex.sturmVarNegInf [zf, zs₁, zs₂, zs₃].toArray : Int) -
+    Hex.sturmVarPosInf [zf, zs₁, zs₂, zs₃].toArray
+
+private def zisolations : LiteralIsolations zcount ztotal where
+  isolations := #[⟨zinterval₁, by decide⟩, ⟨zinterval₂, by decide⟩,
+    ⟨zinterval₃, by decide⟩]
+  ordered := by decide
+  complete := by decide
+
+private theorem zcount_exact (i : Fin zisolations.isolations.size) :
+    zcount zisolations.isolations[i].interval =
+      (Literal.rootsIn (toPolyℝ zf) zisolations.isolations[i].interval).card := by
+  simpa only [zcount] using
+    zreplay.count_eq_card_roots znonzero 1 (by decide) zderiv
+      zisolations.isolations[i].interval
+
+private theorem ztotal_exact :
+    ztotal = ((toPolyℝ zf).roots.card : Int) := by
+  simpa only [ztotal] using
+    zreplay.total_eq_card_roots znonzero 1 (by decide) zderiv
+
+example : ∀ r : ℝ, (toPolyℝ zf).IsRoot r →
+    ∃! i : Fin zisolations.isolations.size,
+      Literal.InInterval zisolations.isolations[i].interval r := by
+  apply LiteralIsolations.isolates (p := zf) (by decide)
+    (zreplay.squarefree 1 (by decide) zderiv) zisolations
+    zcount_exact ztotal_exact
+
+end HexRealRootsMathlib.LiteralChainTests

--- a/HexRealRootsMathlib/LiteralIsolations.lean
+++ b/HexRealRootsMathlib/LiteralIsolations.lean
@@ -1,0 +1,160 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRealRootsMathlib.LiteralChain
+
+public section
+
+/-!
+# Isolation semantics for literal root counts
+
+This module separates real-root isolation semantics from the executable
+`Hex.sturmCount` and `Hex.rootCount` functions. A `LiteralIsolation` stores an
+interval whose supplied count is one; a `LiteralIsolations` stores an ordered
+array of those intervals whose size is a supplied total count. Semantic
+exactness of the two supplied counts is an explicit hypothesis of the
+theorems below.
+
+This is the interface used by certificate checkers that replay a literal
+Sturm chain: the checker may define its counts from that chain without first
+identifying it with `Hex.ZPoly.sturmChain`.
+-/
+
+namespace HexRealRootsMathlib
+
+open Polynomial
+
+noncomputable section
+
+/-- One interval certified by an externally supplied integer root count. -/
+structure LiteralIsolation (count : Hex.DyadicInterval → Int) where
+  /-- The half-open interval `(lower, upper]`. -/
+  interval : Hex.DyadicInterval
+  /-- The supplied count says that the interval contains one root. -/
+  count_one : count interval = 1
+
+/-- An ordered, complete array of intervals certified by externally supplied
+interval and total root counts. -/
+structure LiteralIsolations (count : Hex.DyadicInterval → Int) (total : Int) where
+  /-- The count-one intervals. -/
+  isolations : Array (LiteralIsolation count)
+  /-- Earlier half-open intervals end no later than later intervals begin. -/
+  ordered : ∀ i j : Fin isolations.size, i < j →
+    isolations[i].interval.upper ≤ isolations[j].interval.lower
+  /-- The supplied total count agrees with the number of intervals. -/
+  complete : total = isolations.size
+
+/-- A literal count of one denotes exactly one real root in the interval.
+
+No squarefreeness hypothesis is needed locally: the exact multiset count of
+the interval is already one. Nonzeroness is needed to pass between `IsRoot`
+and membership in `Polynomial.roots`. -/
+theorem LiteralIsolation.exists_unique_root {p : Hex.ZPoly}
+    {count : Hex.DyadicInterval → Int} (hp : p ≠ 0)
+    (iso : LiteralIsolation count)
+    (hcount : count iso.interval = (Literal.rootsIn (toPolyℝ p) iso.interval).card) :
+    ∃! r : ℝ, (toPolyℝ p).IsRoot r ∧ Literal.InInterval iso.interval r := by
+  classical
+  have hP : toPolyℝ p ≠ 0 := fun h => hp (toPolyℝ_eq_zero_iff.mp h)
+  have hcardZ : ((Literal.rootsIn (toPolyℝ p) iso.interval).card : Int) = 1 := by
+    rw [← hcount]
+    exact iso.count_one
+  have hcard : (Literal.rootsIn (toPolyℝ p) iso.interval).card = 1 := by
+    exact_mod_cast hcardZ
+  obtain ⟨r, hr⟩ := Multiset.card_eq_one.mp hcard
+  have hrmem : r ∈ Literal.rootsIn (toPolyℝ p) iso.interval := by
+    rw [hr]
+    exact Multiset.mem_singleton_self r
+  simp only [Literal.rootsIn, Multiset.mem_filter] at hrmem
+  refine ⟨r, ⟨(Polynomial.mem_roots'.mp hrmem.1).2, hrmem.2⟩, ?_⟩
+  rintro y ⟨hyroot, hyI⟩
+  have hymem : y ∈ Literal.rootsIn (toPolyℝ p) iso.interval := by
+    simp only [Literal.rootsIn, Multiset.mem_filter]
+    exact ⟨Polynomial.mem_roots'.mpr ⟨hP, hyroot⟩, hyI⟩
+  rw [hr, Multiset.mem_singleton] at hymem
+  exact hymem
+
+/-- An ordered complete array of literal count-one intervals captures every
+real root at exactly one array index.
+
+Squarefreeness is used only to show that the root multiset has no duplicate
+elements, so equality of the supplied total count with `roots.card` measures
+the number of distinct roots. -/
+theorem LiteralIsolations.isolates {p : Hex.ZPoly}
+    {count : Hex.DyadicInterval → Int} {total : Int} (hp : p ≠ 0)
+    (hsf : Squarefree (toPolyℝ p)) (out : LiteralIsolations count total)
+    (hcount : ∀ i : Fin out.isolations.size,
+      count out.isolations[i].interval =
+        (Literal.rootsIn (toPolyℝ p) out.isolations[i].interval).card)
+    (htotal : total = ((toPolyℝ p).roots.card : Int)) :
+    ∀ r : ℝ, (toPolyℝ p).IsRoot r →
+      ∃! i : Fin out.isolations.size,
+        Literal.InInterval out.isolations[i].interval r := by
+  classical
+  have hP : toPolyℝ p ≠ 0 := fun h => hp (toPolyℝ_eq_zero_iff.mp h)
+  have hsep : (toPolyℝ p).Separable :=
+    PerfectField.separable_iff_squarefree.mpr hsf
+  have hnodup : (toPolyℝ p).roots.Nodup := nodup_roots hsep
+  have H : ∀ i : Fin out.isolations.size, ∃ y : ℝ,
+      ((toPolyℝ p).IsRoot y ∧ Literal.InInterval out.isolations[i].interval y) ∧
+        ∀ z, ((toPolyℝ p).IsRoot z ∧
+          Literal.InInterval out.isolations[i].interval z) → z = y :=
+    fun i => LiteralIsolation.exists_unique_root hp out.isolations[i]
+      (hcount i)
+  choose theRoot hroot huniq using H
+  have hmono : ∀ i j : Fin out.isolations.size, i < j → theRoot i < theRoot j := by
+    intro i j hij
+    have hord := out.ordered i j hij
+    have hi : Dyadic.toReal out.isolations[i].interval.lower < theRoot i ∧
+        theRoot i ≤ Dyadic.toReal out.isolations[i].interval.upper := by
+      simpa only [Literal.InInterval] using (hroot i).2
+    have hj : Dyadic.toReal out.isolations[j].interval.lower < theRoot j ∧
+        theRoot j ≤ Dyadic.toReal out.isolations[j].interval.upper := by
+      simpa only [Literal.InInterval] using (hroot j).2
+    calc
+      theRoot i ≤ Dyadic.toReal out.isolations[i].interval.upper := hi.2
+      _ ≤ Dyadic.toReal out.isolations[j].interval.lower := toReal_le_toReal hord
+      _ < theRoot j := hj.1
+  have hinj : Function.Injective theRoot := by
+    intro i j hij
+    rcases lt_trichotomy i j with hlt | heq | hgt
+    · exact absurd hij (ne_of_lt (hmono i j hlt))
+    · exact heq
+    · exact absurd hij.symm (ne_of_lt (hmono j i hgt))
+  let rootSet := (toPolyℝ p).roots.toFinset
+  have hmem : ∀ i, theRoot i ∈ rootSet := fun i =>
+    Multiset.mem_toFinset.mpr (Polynomial.mem_roots'.mpr ⟨hP, (hroot i).1⟩)
+  have hcardZ : (rootSet.card : Int) = out.isolations.size := by
+    rw [show rootSet.card = (toPolyℝ p).roots.card by
+      exact Multiset.toFinset_card_of_nodup hnodup]
+    exact htotal.symm.trans out.complete
+  have hcard : rootSet.card = out.isolations.size := by
+    exact_mod_cast hcardZ
+  have himage : Finset.image theRoot Finset.univ = rootSet := by
+    refine Finset.eq_of_subset_of_card_le ?_ ?_
+    · intro x hx
+      simp only [Finset.mem_image, Finset.mem_univ, true_and] at hx
+      obtain ⟨i, rfl⟩ := hx
+      exact hmem i
+    · rw [Finset.card_image_of_injective _ hinj, Finset.card_univ,
+        Fintype.card_fin, hcard]
+  intro r hr
+  have hrmem : r ∈ rootSet :=
+    Multiset.mem_toFinset.mpr (Polynomial.mem_roots'.mpr ⟨hP, hr⟩)
+  rw [← himage, Finset.mem_image] at hrmem
+  obtain ⟨i, -, hir⟩ := hrmem
+  have hri : Literal.InInterval out.isolations[i].interval r := hir ▸ (hroot i).2
+  refine ⟨i, hri, ?_⟩
+  intro j hrj
+  have hrj' : r = theRoot j := huniq j r ⟨hr, hrj⟩
+  apply hinj
+  rw [← hrj', hir]
+
+end
+
+end HexRealRootsMathlib

--- a/HexRealRootsMathlib/SimpleRealRoot.lean
+++ b/HexRealRootsMathlib/SimpleRealRoot.lean
@@ -67,12 +67,6 @@ variable {p : Hex.ZPoly}
 
 /-! ### Dyadic-order helpers (real values) -/
 
-/-- Dyadic `≤` transfers to the real values. -/
-private theorem toReal_le_toReal {a b : Dyadic} (h : a ≤ b) :
-    Dyadic.toReal a ≤ Dyadic.toReal b := by
-  have h2 : a.toRat ≤ b.toRat := Dyadic.toRat_le_toRat_iff.mpr h
-  unfold Dyadic.toReal; exact_mod_cast h2
-
 /-- Failing dyadic `≤` gives the reverse inequality on the real values (the
 core `Dyadic` order need not be a `LinearOrder`, so this routes through the
 total order on `ℚ` via `toRat`). -/

--- a/HexRealRootsMathlib/SquareFreeCore.lean
+++ b/HexRealRootsMathlib/SquareFreeCore.lean
@@ -87,12 +87,6 @@ theorem aeval_eq_eval_toPolyℝ (q : Hex.ZPoly) (x : ℝ) :
     aeval x (toPolynomial q) = (toPolyℝ q).eval x := by
   rw [aeval_def, eval₂_eq_eval_map, algebraMap_int_eq]
 
-/-- The real cast is multiplicative. -/
-theorem toPolyℝ_mul (p q : Hex.ZPoly) :
-    toPolyℝ (p * q) = toPolyℝ p * toPolyℝ q := by
-  show (HexPolyZMathlib.toPolynomial (p * q)).map (Int.castRingHom ℝ) = _
-  rw [HexPolyZMathlib.toPolynomial_mul, Polynomial.map_mul]
-
 /-- The real cast is the composition of the rational cast with `ℚ → ℝ`. -/
 theorem toPolyℝ_eq_map_toPolyℚ (q : Hex.ZPoly) :
     toPolyℝ q = (toPolyℚ q).map (algebraMap ℚ ℝ) := by

--- a/SPEC/Libraries/hex-real-roots-mathlib.md
+++ b/SPEC/Libraries/hex-real-roots-mathlib.md
@@ -141,28 +141,32 @@ multiplication identities without identifying it with the executable
 `sturmChain`. The companion therefore exposes a second bridge from
 literal integer-polynomial chains to the same abstract theorem.
 
-The reusable proof is an induction over an abstract nonempty list
+The reusable proof is an induction over an abstract list of at least two entries
 `[f, s₁, ..., sₙ]` with these hypotheses:
 
-- every entry is nonzero, degrees strictly descend, and `sₙ` is a
-  nonzero constant;
+- every entry is nonzero and `sₙ` is a nonzero constant;
 - `derivative f = scale δ s₁` for a positive integer `δ`;
 - every consecutive triple satisfies
   `scale α sᵢ = q * sᵢ₊₁ - scale β sᵢ₊₂` for positive integers
   `α`, `β` and a supplied `q`.
 
 It concludes that the cast list is an `IsSturmChain (toPolyℝ f)` and
-that `toPolyℝ f` is squarefree. The induction is independent of
-`chainList`; the existing executable correspondence instantiates it,
-as does RCF's Boolean literal-chain checker. The generic supporting
-lemmas for reverse coprimality, derivative flanks, and exclusion of a
-common zero are public short APIs, not duplicated consumer proofs.
+that `toPolyℝ f` is squarefree. Degree descent is useful for bounding and
+validating a compiled replay certificate, but is not an axiom of
+`IsSturmChain` and is therefore not a hypothesis of this proof. The induction
+is independent of `chainList` and serves RCF's Boolean literal-chain checker;
+the older executable correspondence remains a separate proof for the chain it
+constructs. Both use the public supporting lemmas for reverse coprimality,
+derivative flanks, and exclusion of a common zero.
 
 The finite-point bridge `sturmVarAt_eq` and the infinity bridges
 `sturmVarNegInf_eq` / `sturmVarPosInf_eq` are public for an arbitrary
 literal `Array ZPoly`. Together with `Sturm.sturm_half_open` and
 `Sturm.sturm_line`, they turn literal executable variation reads into
-root counts without calling `sturmCount` or `rootCount`.
+root counts without calling `sturmCount` or `rootCount`. The
+`ZReplay.count_eq_card_roots` and `ZReplay.total_eq_card_roots` corollaries
+perform the list-to-array alignment and compose replay, squarefreeness, and
+counting in the form consumed by a checker.
 
 The same layer supplies generalized isolation semantics parameterized
 by those literal counts: count-one gives a unique root in `(lower,
@@ -170,7 +174,10 @@ upper]`, while an ordered complete array captures every root exactly
 once. These statements consume `Squarefree (toPolyℝ f)` and `f ≠ 0`,
 not the executable `SquareFreeRat f` predicate, and do not reuse the
 current `RealRootIsolation` fields that are definitionally tied to
-`sturmCount`.
+`sturmCount`. The existing executable isolation theorem remains separate for
+API compatibility: the generic statement intentionally mirrors its finite
+cardinality argument rather than coupling the literal layer back to the
+executable structures it is meant to abstract over.
 
 ### Consequences for the executable counts
 
@@ -544,16 +551,20 @@ Status and boundaries:
 HexRealRootsMathlib/
   SturmChainDefs.lean  -- IsSturmChain, sturmVar over Polynomial ℝ
   SturmTheorem.lean    -- the counting theorem and the line form
-  ChainCorrespond.lean -- executable-chain correspondence plus the abstract
-                          literal-recurrence bridge and finite/infinity
-                          variation casts; sturmCount_eq_card_roots;
+  ChainCorrespond.lean -- executable-chain correspondence and the shared
+                          recurrence/cast helpers; sturmCount_eq_card_roots;
                           compatibility aliases for HexPolyZMathlib.Squarefree
+  LiteralChain.lean    -- abstract and integer literal recurrences,
+                          IsSturmChain/squarefree consequences, literal counts
+  LiteralChainTests.lean -- proof-level literal-replay regressions
+  LiteralIsolations.lean -- unique-root and full-coverage semantics for
+                            supplied interval and total counts
   Discr.lean            -- compatibility import of the shared discriminant API
   Hadamard.lean         -- compatibility import of the shared determinant bound
   Separation.lean      -- sepPrec_separates, rootBound_bounds_roots;
                           specializes shared Mahler/Vandermonde analysis
-  Isolations.lean      -- executable and literal-count forms of
-                          exists_unique_root and isolates
+  Isolations.lean      -- executable-count forms of exists_unique_root,
+                          isolates
   IsolateRoots.lean    -- IsolatedRealRoots, its constructors, the
                           bridge tactic, and the isolate_roots
                           term elaborator

--- a/progress/20260727T050821Z_rcf-literal-sturm.md
+++ b/progress/20260727T050821Z_rcf-literal-sturm.md
@@ -1,0 +1,42 @@
+# RCF literal-Sturm foundation milestone
+
+## Accomplished
+
+- Added abstract positive-scaled `Sturm.Replay` recurrences and proved they
+  give consecutive coprimality, all generalized Sturm-chain axioms, and
+  squarefreeness.
+- Added integer `ZReplay` witnesses, exact integer-to-real replay transport,
+  and composed finite-interval and whole-line root-count theorems over the
+  literal replay array.
+- Added generic literal isolation structures and proved count-one uniqueness
+  plus ordered complete coverage of every real root.
+- Added proof regressions for an abstract quadratic and for the four-entry
+  integer chain of `x³ - x`; the latter composes replay, squarefreeness,
+  literal counts, and three nontrivially ordered isolations end to end.
+- Promoted and deduplicated the small recurrence, cast, variation, and dyadic
+  order lemmas needed by literal consumers, and updated the companion SPEC.
+- Incorporated two independent Claude Opus reviews. The first confirmed the
+  mathematics but found four integration/documentation blockers; the second
+  verified all four were closed and returned a merge-ready verdict.
+- Passed `lake build HexRealRootsMathlib HexRCF` (8,784 jobs) and the
+  copyright, line-count, DAG, phase-4, Mathlib-free bench, conformance-target,
+  diff, and forbidden-proof-token checks.
+
+## Current frontier
+
+Issue #8891 is ready to publish. The shared Mathlib theorem layer now accepts
+literal generalized Sturm recurrences without identifying them with
+`Hex.ZPoly.sturmChain`, which removes the main trust-boundary dependency for
+the RCF checker.
+
+## Next step
+
+Implement the executable RCF replay certificate and Boolean checker. Instrument
+the existing `spemAux` loop to emit exact positive left/right scales and
+quotients, starting from the literal polynomial head rather than its primitive
+part, then prove successful checking produces `ZReplay` and the two composed
+count theorems.
+
+## Blockers
+
+None.

--- a/progress/20260727T050821Z_rcf-literal-sturm.md
+++ b/progress/20260727T050821Z_rcf-literal-sturm.md
@@ -10,9 +10,10 @@
   literal replay array.
 - Added generic literal isolation structures and proved count-one uniqueness
   plus ordered complete coverage of every real root.
-- Added proof regressions for an abstract quadratic and for the four-entry
-  integer chain of `x³ - x`; the latter composes replay, squarefreeness,
-  literal counts, and three nontrivially ordered isolations end to end.
+- Added positive and malformed proof regressions for an abstract recurrence,
+  plus the four-entry integer chain of `x³ - x`; the latter composes replay,
+  squarefreeness, literal counts, and three nontrivially ordered isolations end
+  to end.
 - Promoted and deduplicated the small recurrence, cast, variation, and dyadic
   order lemmas needed by literal consumers, and updated the companion SPEC.
 - Incorporated two independent Claude Opus reviews. The first confirmed the


### PR DESCRIPTION
Closes #8891

## Summary

- prove abstract positive-scaled literal recurrences form generalized Sturm chains and imply squarefreeness
- transport integer `ZReplay` certificates to real polynomials and compose them with literal finite/total root counts
- add generic literal isolation semantics independent of executable `sturmChain` records
- add abstract positive/malformed regressions and a four-entry integer replay with three ordered isolations end to end
- document the public replay contract and deduplicate shared cast/dyadic helpers

## Validation

- `lake build HexRealRootsMathlib HexRCF` (8,784 jobs)
- `git diff --check`
- copyright and file-line-count checks
- DAG and phase-4 checks
- Mathlib-free bench import check
- conformance target registration check
- no `sorry`, `axiom`, or `native_decide` in new modules

## Independent review

Two fresh Claude Opus reviews were run. The first found no mathematical unsoundness but identified four integration/specification blockers. The patch was repaired to share one literal interval predicate, provide composed list-to-array replay count corollaries, exercise the integer/isolation consumer path, and correct the SPEC. A fresh follow-up verified all blockers closed and returned a merge-ready verdict with no blockers.