### PR TITLE
feat(number-field): exactify lazy roots

### DIFF
--- a/HexNumberField.lean
+++ b/HexNumberField.lean
@@ -9,6 +9,7 @@ module
 public import HexNumberField.Basic
 public import HexNumberField.Approx
 public import HexNumberField.QAdjoin
+public import HexNumberField.Convert
 
 public section
 

--- a/HexNumberField/Convert.lean
+++ b/HexNumberField/Convert.lean
@@ -47,29 +47,32 @@ end AlgebraicNumber
 
 namespace AlgebraicRoot
 
-/-- Try one normalized factor of an enclosing polynomial. Every proof stored
-in the resulting canonical number comes from a freshly executed Boolean or
-decidable check on this factor. -/
-def exactFactor? (a : AlgebraicRoot) (q : ZPoly) : Option AlgebraicNumber :=
-  if hprim : ZPoly.content q = 1 then
-    if hpos : 0 < q.leadingCoeff then
-      if hdegree : 0 < q.degree?.getD 0 then
-        if hirred : ZPoly.isIrreducible q = true then
-          if hsquarefree : HasOnlySimpleRoots q then do
-            let isolations ← isolate q hsquarefree (separationDepth q : Int)
-            let refined ← isolations.mapM DyadicRootIsolation.toRefined?
-            -- `a.rep` has the separation precision for `a.p`.  A factor can
-            -- have a weaker intrinsic separation bound, so refine its roots
-            -- to the enclosing polynomial's precision before comparing
-            -- discs.  Then two meeting discs cannot represent distinct roots
-            -- of `a.p`.
-            let comparable ← refined.mapM fun r => do
-              let r' ← r.refineTo? (mahlerPrec a.p : Int)
-              some r'.1
-            let matching ← comparable.toList.find? fun r =>
-              r.1.square.discsMeet a.rep.1.square
-            AlgebraicNumber.ofNormalized? q hprim hpos hdegree
-              ⟨hirred, hdegree⟩ hsquarefree matching
+/-- Factor a lazy root's enclosing polynomial and select the normalized
+irreducible factor containing its chosen root. -/
+@[expose]
+def exact? (a : AlgebraicRoot) : Option AlgebraicNumber :=
+  let tryFactor := fun q =>
+    if hprim : ZPoly.content q = 1 then
+      if hpos : 0 < q.leadingCoeff then
+        if hdegree : 0 < q.degree?.getD 0 then
+          if hirred : ZPoly.isIrreducible q = true then
+            if hsquarefree : HasOnlySimpleRoots q then do
+              let isolations ← isolate q hsquarefree (separationDepth q : Int)
+              let refined ← isolations.mapM DyadicRootIsolation.toRefined?
+              -- `a.rep` has the separation precision for `a.p`. A factor can
+              -- have a weaker intrinsic bound, so refine its roots to the
+              -- enclosing polynomial's precision before comparing discs.
+              let comparable ← refined.mapM fun r => do
+                let r' ← r.refineTo? (mahlerPrec a.p : Int)
+                some r'.1
+              -- Separation for `a.p` makes a match unique across all of its
+              -- factors, so selecting the first matching isolation is sound.
+              let matching ← comparable.toList.find? fun r =>
+                r.1.square.discsMeet a.rep.1.square
+              AlgebraicNumber.ofNormalized? q hprim hpos hdegree
+                ⟨hirred, hdegree⟩ hsquarefree matching
+            else
+              none
           else
             none
         else
@@ -78,18 +81,11 @@ def exactFactor? (a : AlgebraicRoot) (q : ZPoly) : Option AlgebraicNumber :=
         none
     else
       none
-  else
-    none
-
-/-- Factor a lazy root's enclosing polynomial and select the normalized
-irreducible factor containing its chosen root. -/
-@[expose]
-def exact? (a : AlgebraicRoot) : Option AlgebraicNumber :=
   (ZPoly.factorize a.p).factors.foldl
     (fun found entry =>
       match found with
       | some b => some b
-      | none => exactFactor? a entry.1)
+      | none => tryFactor entry.1)
     none
 
 /-- Canonicalize a lazy root. Failure is a checked implementation branch whose
@@ -148,6 +144,34 @@ private def reducibleRoot (hsquarefree : HasOnlySimpleRoots enclosingPoly) :
 #guard
     if hsquarefree : HasOnlySimpleRoots enclosingPoly then
       match (reducibleRoot hsquarefree).exact? with
+      | some b => b.p = sqrtTwoPoly
+      | none => false
+    else
+      false
+
+-- A nearby rational root lies inside the linear factor's own coarse
+-- separation disc. Cross-factor matching must nevertheless retain `X² - 2`
+-- by refining candidates to the enclosing polynomial's precision.
+private def nearEnclosingPoly : ZPoly :=
+  sqrtTwoPoly * DensePoly.ofList [-99, 70]
+
+private def nearEnclosingRep : RefinedIsolation nearEnclosingPoly :=
+  ⟨⟨enclosingSquare, by decide⟩, by decide⟩
+
+private def nearReducibleRoot
+    (hsquarefree : HasOnlySimpleRoots nearEnclosingPoly) : AlgebraicRoot where
+  p := nearEnclosingPoly
+  prim := by rfl
+  pos_lc := by decide
+  pos_degree := by decide
+  squarefree := hsquarefree
+  x := SimpleRoot.mk nearEnclosingRep
+  rep := nearEnclosingRep
+  rep_mk := rfl
+
+#guard
+    if hsquarefree : HasOnlySimpleRoots nearEnclosingPoly then
+      match (nearReducibleRoot hsquarefree).exact? with
       | some b => b.p = sqrtTwoPoly
       | none => false
     else

--- a/HexNumberField/Convert.lean
+++ b/HexNumberField/Convert.lean
@@ -1,0 +1,153 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexNumberField.QAdjoin
+public meta import HexNumberField.QAdjoin
+
+public section
+
+/-!
+Canonical fixed-presentation conversion and exactification of lazy roots.
+
+Exactification factors the enclosing squarefree polynomial, rechecks each
+factor's executable normalization certificates, isolates its roots, and keeps
+the unique factor isolation whose disc meets the input representative. The
+selected factor is finally passed through `AlgebraicNumber.ofNormalized?`, so
+the stored representative follows the library's deterministic canonical
+isolation strategy.
+-/
+namespace Hex
+
+namespace AlgebraicNumber
+
+/-- The canonical algebraic number as the fixed-field generator in its own
+minimal-polynomial presentation. -/
+@[expose]
+def toQAdjoin (a : AlgebraicNumber) : QAdjoin a.p a.x :=
+  QAdjoin.reduce a.p a.x (DensePoly.ofList ([0, 1] : List Rat))
+
+/-- Forget minimality while retaining every checked root certificate. -/
+@[expose]
+def toRoot (a : AlgebraicNumber) : AlgebraicRoot where
+  p := a.p
+  prim := a.prim
+  pos_lc := a.pos_lc
+  pos_degree := a.pos_degree
+  squarefree := a.squarefree
+  x := a.x
+  rep := a.rep
+  rep_mk := a.rep_mk
+
+end AlgebraicNumber
+
+namespace AlgebraicRoot
+
+/-- Try one normalized factor of an enclosing polynomial. Every proof stored
+in the resulting canonical number comes from a freshly executed Boolean or
+decidable check on this factor. -/
+def exactFactor? (a : AlgebraicRoot) (q : ZPoly) : Option AlgebraicNumber :=
+  if hprim : ZPoly.content q = 1 then
+    if hpos : 0 < q.leadingCoeff then
+      if hdegree : 0 < q.degree?.getD 0 then
+        if hirred : ZPoly.isIrreducible q = true then
+          if hsquarefree : HasOnlySimpleRoots q then do
+            let isolations ← isolate q hsquarefree (separationDepth q : Int)
+            let refined ← isolations.mapM DyadicRootIsolation.toRefined?
+            let matching ← refined.toList.find? fun r =>
+              r.1.square.discsMeet a.rep.1.square
+            AlgebraicNumber.ofNormalized? q hprim hpos hdegree
+              ⟨hirred, hdegree⟩ hsquarefree matching
+          else
+            none
+        else
+          none
+      else
+        none
+    else
+      none
+  else
+    none
+
+/-- Factor a lazy root's enclosing polynomial and select the normalized
+irreducible factor containing its chosen root. -/
+@[expose]
+def exact? (a : AlgebraicRoot) : Option AlgebraicNumber :=
+  (ZPoly.factorize a.p).factors.foldl
+    (fun found entry =>
+      match found with
+      | some b => some b
+      | none => exactFactor? a entry.1)
+    none
+
+/-- Canonicalize a lazy root. Failure is a checked implementation branch whose
+unreachability is proved by the Mathlib companion. -/
+@[expose]
+def exact (a : AlgebraicRoot) : AlgebraicNumber :=
+  a.exact?.getD (Hex.panicWith 0 "AlgebraicRoot.exact: certification failed")
+
+/-! Compiled canonicalization regressions. -/
+
+private def sqrtTwoPoly : ZPoly := DensePoly.ofList [-2, 0, 1]
+
+private def sqrtTwoSquare : DyadicSquare :=
+  ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
+
+private def sqrtTwoRep : RefinedIsolation sqrtTwoPoly :=
+  ⟨⟨sqrtTwoSquare, by decide⟩, by decide⟩
+
+private def sqrtTwoRoot (hsquarefree : HasOnlySimpleRoots sqrtTwoPoly) : AlgebraicRoot where
+  p := sqrtTwoPoly
+  prim := by rfl
+  pos_lc := by decide
+  pos_degree := by decide
+  squarefree := hsquarefree
+  x := SimpleRoot.mk sqrtTwoRep
+  rep := sqrtTwoRep
+  rep_mk := rfl
+
+#guard
+    if hsquarefree : HasOnlySimpleRoots sqrtTwoPoly then
+      (sqrtTwoRoot hsquarefree).exact?.isSome
+    else
+      false
+
+private def enclosingPoly : ZPoly :=
+  sqrtTwoPoly * DensePoly.ofList [-3, 1]
+
+private def enclosingSquare : DyadicSquare :=
+  ⟨Dyadic.ofIntWithPrec 6074001000 32, 0, 32⟩
+
+private def enclosingRep : RefinedIsolation enclosingPoly :=
+  ⟨⟨enclosingSquare, by decide⟩, by decide⟩
+
+private def reducibleRoot (hsquarefree : HasOnlySimpleRoots enclosingPoly) :
+    AlgebraicRoot where
+  p := enclosingPoly
+  prim := by rfl
+  pos_lc := by decide
+  pos_degree := by decide
+  squarefree := hsquarefree
+  x := SimpleRoot.mk enclosingRep
+  rep := enclosingRep
+  rep_mk := rfl
+
+-- Exactification discards the irrelevant linear factor and returns `X² - 2`.
+#guard
+    if hsquarefree : HasOnlySimpleRoots enclosingPoly then
+      match (reducibleRoot hsquarefree).exact? with
+      | some b => b.p = sqrtTwoPoly
+      | none => false
+    else
+      false
+
+#guard
+    let q := AlgebraicNumber.zero.toQAdjoin
+    q.coeffs = 0 && AlgebraicNumber.zero.toRoot.isZero
+
+end AlgebraicRoot
+end Hex

--- a/HexNumberField/Convert.lean
+++ b/HexNumberField/Convert.lean
@@ -58,7 +58,15 @@ def exactFactor? (a : AlgebraicRoot) (q : ZPoly) : Option AlgebraicNumber :=
           if hsquarefree : HasOnlySimpleRoots q then do
             let isolations ← isolate q hsquarefree (separationDepth q : Int)
             let refined ← isolations.mapM DyadicRootIsolation.toRefined?
-            let matching ← refined.toList.find? fun r =>
+            -- `a.rep` has the separation precision for `a.p`.  A factor can
+            -- have a weaker intrinsic separation bound, so refine its roots
+            -- to the enclosing polynomial's precision before comparing
+            -- discs.  Then two meeting discs cannot represent distinct roots
+            -- of `a.p`.
+            let comparable ← refined.mapM fun r => do
+              let r' ← r.refineTo? (mahlerPrec a.p : Int)
+              some r'.1
+            let matching ← comparable.toList.find? fun r =>
               r.1.square.discsMeet a.rep.1.square
             AlgebraicNumber.ofNormalized? q hprim hpos hdegree
               ⟨hirred, hdegree⟩ hsquarefree matching

--- a/progress/20260727T054057Z_numberfield-convert.md
+++ b/progress/20260727T054057Z_numberfield-convert.md
@@ -1,0 +1,32 @@
+# HexNumberField root exactification
+
+## Accomplished
+
+- Added canonical conversion from `AlgebraicNumber` to its fixed-field
+  generator coordinates and to the factorization-lazy `AlgebraicRoot` view.
+- Implemented checked lazy-root exactification by factoring the enclosing
+  polynomial, rechecking primitive/sign/degree/irreducibility/squarefreeness
+  certificates, isolating each candidate factor, and selecting the one whose
+  root disc meets the input representative.
+- Routed the selected factor through `AlgebraicNumber.ofNormalized?` so the
+  returned canonical number uses the deterministic stored representative.
+- Added the total `AlgebraicRoot.exact` wrapper with the specified loud
+  fallback.
+- Added compiled regressions for irreducible exactification, removal of an
+  irrelevant factor from `(X² - 2)(X - 3)`, and canonical zero conversion.
+- Added `Convert.lean` to the public umbrella and rebuilt `HexNumberField`.
+
+## Current frontier
+
+Lazy-root exactification is executable and tested. Fixed-field element
+canonicalization still needs the multiplication-operator minimal-polynomial
+path required by `QAdjoin.toAlgebraicNumber?`.
+
+## Next step
+
+Publish this focused milestone, obtain its asynchronous review, then implement
+the fixed-field multiplication-matrix/minimal-polynomial stage.
+
+## Blockers
+
+None.

--- a/progress/20260727T054845Z_numberfield-convert-refresh.md
+++ b/progress/20260727T054845Z_numberfield-convert-refresh.md
@@ -1,0 +1,24 @@
+# HexNumberField conversion refresh
+
+## Accomplished
+
+- Rebased the conversion milestone onto the reviewed fixed-field arithmetic and
+  threaded-approximation follow-ups.
+- Refined factor-root candidates to the enclosing polynomial's Mahler
+  separation precision before cross-polynomial disc matching.
+- Rebuilt `HexNumberField` successfully.
+
+## Current frontier
+
+The conversion milestone is ready to republish on its existing stacked PR.
+The next implementation stage is the fixed-field multiplication operator and
+minimal-polynomial conversion back to a canonical algebraic number.
+
+## Next step
+
+Force-push the refreshed conversion branch, then implement the multiplication
+operator and row-reduction minimal-polynomial path on a new stacked branch.
+
+## Blockers
+
+None.

--- a/progress/20260727T060933Z_numberfield-convert-review.md
+++ b/progress/20260727T060933Z_numberfield-convert-review.md
@@ -1,0 +1,30 @@
+# HexNumberField conversion review follow-up
+
+## Accomplished
+
+- Confirmed the independent conversion review reproduced the cross-factor
+  precision issue already fixed on the refreshed branch.
+- Inlined the factor-selection worker into public `AlgebraicRoot.exact?`, so
+  callers cannot invoke it with a polynomial unrelated to the enclosing
+  factorization.
+- Documented the uniqueness argument supplied by enclosing-polynomial Mahler
+  precision.
+- Added a near-collision regression for `(X² - 2)(70X - 99)`, whose rational
+  root lies inside the linear factor's old coarse disc around `sqrt 2`.
+- Rebuilt `HexNumberField.Convert` successfully.
+
+## Current frontier
+
+The conversion review's blocking and API-soundness findings are addressed.
+The remaining certificate sorries in `Basic` are Phase 1 propositional
+obligations; earlier attempts confirmed that the compiled guards do not yet
+reduce through the deeper gcd/isolation kernel paths under `by decide`.
+
+## Next step
+
+Push this conversion follow-up and begin the fixed-field multiplication
+operator/minimal-polynomial implementation on a new stacked branch.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Summary
- convert canonical algebraic numbers to their fixed-field and lazy-root views
- factor and re-certify enclosing polynomials to exactify a selected lazy root
- select the matching irreducible factor geometrically and canonicalize its representative
- cover irreducible and irrelevant-factor exactification in compiled regressions

## Validation
- `lake build HexNumberField`

This is the next stacked HexNumberField milestone after #8896.