### PR TITLE
perf(modarith): compute ZMod64 inverse in word arithmetic

### DIFF
--- a/HexModArith/Basic.lean
+++ b/HexModArith/Basic.lean
@@ -454,9 +454,11 @@ Compute a modular inverse candidate via the integer extended-GCD helper from
 
 When `a` is coprime to `p`, this is the canonical inverse mod `p`; otherwise it
 still exposes the executable Bezout-derived residue needed by later algebraic
-layers.
+layers. The trusted runtime contract is `lean_hex_zmod64_inv`, which runs the
+same Euclidean remainder and cofactor recurrence directly in bounded word
+arithmetic and returns the cofactor modulo `p`.
 -/
-@[expose]
+@[expose, extern "lean_hex_zmod64_inv"]
 def inv (a : ZMod64 p) : ZMod64 p :=
   let (_, s, _) := HexArith.Int.extGcd (Int.ofNat a.toNat) (Int.ofNat p)
   ofNat p (Int.toNat (s % Int.ofNat p))

--- a/HexModArith/SPEC/hex-mod-arith.md
+++ b/HexModArith/SPEC/hex-mod-arith.md
@@ -45,20 +45,16 @@ Mathlib dependency.
 ## Default operations
 
 Operations are stated as semantic contracts on the canonical
-representative. `mul` and `pow` carry mandatory `@[extern]` runtime
+representative. `mul`, `pow`, and `inv` carry mandatory `@[extern]` runtime
 paths; `add`/`sub` are one-line `ofNat` specifications, with the
 division-free branchy `UInt64` bodies in `addImpl`/`subImpl` behind
-proved `@[csimp]` equalities (design principle 11), and `inv` routes
-through the
-`@[extern "lean_hex_mpz_gcdext"]`-bearing `extGcd` declared in
-`HexArith.Int` (see "Extern contract: `mpz_gcdext`" in
-`SPEC/Libraries/hex-arith.md`). **`inv` must NOT call
-`Hex.pureIntExtGcd` directly** — that's the pure-Lean reference
-body the extern falls through to as a portable fallback, and is
-intended for proofs only. Calling it bypasses GMP and runs the
-recursive `Nat` reference at runtime, which allocates a fresh `Nat`
-blob per recursive step (the same regression class as omitting
-`@[extern]` on `mulHi`).
+proved `@[csimp]` equalities (design principle 11). `inv` retains the
+`HexArith.Int.extGcd`-based logical body used by proofs, while its
+`lean_hex_zmod64_inv` extern runs the same Euclidean remainder/cofactor
+recurrence directly in bounded word arithmetic. **`inv` must NOT call
+`Hex.pureIntExtGcd` directly at runtime** — that is the recursive proof
+reference and allocates a fresh `Nat` blob per step (the same regression class
+as omitting `@[extern]` on `mulHi`).
 
 ```lean
 @[extern "lean_hex_zmod64_mul"]
@@ -67,7 +63,8 @@ def ZMod64.add (a b : ZMod64 p) : ZMod64 p          -- spec: ofNat; runtime: add
 def ZMod64.sub (a b : ZMod64 p) : ZMod64 p          -- spec: ofNat; runtime: subImpl (@[csimp])
 def ZMod64.zero : ZMod64 p
 def ZMod64.one  : ZMod64 p                          -- equals zero when p = 1
-def ZMod64.inv  (a : ZMod64 p) : ZMod64 p           -- via Hex.Int.extGcd
+@[extern "lean_hex_zmod64_inv"]
+def ZMod64.inv  (a : ZMod64 p) : ZMod64 p           -- spec: Int.extGcd; runtime: words
 @[extern "lean_hex_zmod64_pow"]
 def ZMod64.pow  (a : ZMod64 p) (n : Nat) : ZMod64 p
 ```
@@ -136,6 +133,30 @@ precision `Nat` by two. The runtime result must agree with the
 logical body for every bounded modulus, including the degenerate
 modulus `1`.
 
+### `ZMod64.inv` runtime contract
+
+The transparent logical definition of `HexArith.Int.extGcd` reduces to
+`Hex.pureIntExtGcd`. The `inv` body selects that reference algorithm's first
+Bézout cofactor `s` and returns `s % p`; this pins the result even when the
+inputs are not coprime. The runtime implementation is `lean_hex_zmod64_inv` in
+`HexModArith/ffi/zmod64_mul.c`. For the nonnegative inputs `a < p`, it follows
+the same Euclidean quotient/remainder sequence as the logical reference, but
+tracks the first cofactor modulo `p`:
+
+```text
+(old_r, r) := (a, p)       (old_s, s) := (1, 0)
+q := old_r / r
+(old_r, r) := (r, old_r % r)
+(old_s, s) := (s, old_s - q*s mod p)
+```
+
+Reducing each cofactor update modulo `p` preserves the final cofactor residue,
+so this agrees with the logical body for every input, including composite
+moduli and non-coprime residues. This is not Fermat inversion. Under
+`p < 2^31`, every remainder and reduced cofactor is below `p`, every quotient
+is at most `p`, and `q*s < 2^62`; the complete runtime path therefore stays in
+`uint64_t` arithmetic and never constructs a Lean `Int` or calls GMP.
+
 ## Hot-loop optimization (opt-in)
 
 Sustained modular multiplication (polynomial arithmetic,
@@ -181,9 +202,9 @@ for `ZMod64`, not for `MontResidue`.
 runtime model is a `Nat` paired with a proof — every operation
 routes through GMP arbitrary-precision arithmetic. `ZMod64 p`
 exists to put the value in a `UInt64` and route every operation
-through native machine arithmetic, with `mul` going through the
-mandatory C extern above and the rest compiling to native UInt64
-ops in pure Lean.
+through native machine arithmetic, with `mul`, `pow`, and `inv` going through
+the mandatory C externs above and the remaining operations compiling to native
+`UInt64` ops in pure Lean.
 
 ## External comparators
 
@@ -191,8 +212,8 @@ No external comparator is required.
 
 **Justification:** `implementation-is-extern` per
 `SPEC/benchmarking.md §"Comparator naming"`. HexModArith's modular
-operations route through GMP (for `Nat`/`Int` residue arithmetic)
-or through the dedicated `UInt64`-modular C extern (for `ZMod64`).
+operations route through GMP (for general `Nat`/`Int` arithmetic)
+or through dedicated word-arithmetic C externs (for `ZMod64`).
 The Phase-4 surface is GMP / native arithmetic; there is no
 algorithmically distinct reference implementation to compare
 against externally.

--- a/HexModArith/ffi/zmod64_mul.c
+++ b/HexModArith/ffi/zmod64_mul.c
@@ -30,6 +30,45 @@ LEAN_EXPORT uint64_t lean_hex_zmod64_mul(b_lean_obj_arg p, uint64_t a, uint64_t 
     return product % modulus;
 }
 
+/* Return the exact residue selected by the logical `ZMod64.inv` body without
+   constructing Lean Ints or entering GMP.  For the positive inputs here,
+   `Hex.pureIntExtGcd` starts with remainder rows `(a, p)` and cofactor rows
+   `(1, 0)`, then repeatedly applies
+
+       quotient := old_r / r
+       (old_r, r) := (r, old_r % r)
+       (old_s, s) := (s, old_s - quotient * s).
+
+   We need only `old_s % p`, so the cofactor recurrence can run modulo `p`.
+   This remains exact for composite moduli and non-coprime inputs: reducing
+   after every linear update preserves the final cofactor's residue.  Under
+   `ZMod64.Bounds`, `p < 2^31`; all remainders and reduced cofactors are below
+   `p`, every quotient is at most `p`, and `quotient * s < 2^62`, so every
+   operation fits in uint64_t. */
+LEAN_EXPORT uint64_t lean_hex_zmod64_inv(b_lean_obj_arg p, uint64_t a) {
+    uint64_t modulus = lean_uint64_of_nat(p);
+    uint64_t old_r = a;
+    uint64_t r = modulus;
+    uint64_t old_s = 1 % modulus;
+    uint64_t s = 0;
+
+    while (r != 0) {
+        uint64_t quotient = old_r / r;
+        uint64_t next_r = old_r % r;
+        uint64_t quotient_s = (quotient * s) % modulus;
+        uint64_t next_s = old_s >= quotient_s
+            ? old_s - quotient_s
+            : old_s + (modulus - quotient_s);
+
+        old_r = r;
+        r = next_r;
+        old_s = s;
+        s = next_s;
+    }
+
+    return old_s;
+}
+
 static uint64_t lean_hex_mul_mod_word(uint64_t a, uint64_t b, uint64_t modulus) {
     __uint128_t product = (__uint128_t)a * (__uint128_t)b;
     return (uint64_t)(product % modulus);

--- a/conformance/HexModArith/Conformance.lean
+++ b/conformance/HexModArith/Conformance.lean
@@ -35,6 +35,7 @@ Covered properties:
 Covered edge cases:
 - modulus `1`
 - small prime modulus `7`
+- composite modulus `15`, including the exact non-coprime inverse convention
 - power-of-two modulus `16`
 - small Barrett-friendly moduli `2`, `7`, and `65535`
 - odd Montgomery-friendly moduli `3`, `7`, and `65537`
@@ -54,6 +55,7 @@ private instance conformanceBoundsOne : Bounds 1 := ⟨by decide, by decide⟩
 private instance conformanceBoundsTwo : Bounds 2 := ⟨by decide, by decide⟩
 private instance conformanceBoundsThree : Bounds 3 := ⟨by decide, by decide⟩
 private instance conformanceBoundsSeven : Bounds 7 := ⟨by decide, by decide⟩
+private instance conformanceBoundsFifteen : Bounds 15 := ⟨by decide, by decide⟩
 private instance conformanceBoundsSixteen : Bounds 16 := ⟨by decide, by decide⟩
 private instance conformanceBoundsBarrettWide : Bounds BarrettWideMod := ⟨by decide, by decide⟩
 private instance conformanceBoundsMontWide : Bounds MontWideMod := ⟨by decide, by decide⟩
@@ -122,6 +124,7 @@ private def a3 : ZMod64 3 := ofNat 3 2
 private def b3 : ZMod64 3 := ofNat 3 2
 private def a7 : ZMod64 7 := ofNat 7 3
 private def b7 : ZMod64 7 := ofNat 7 5
+private def nonCoprime15 : ZMod64 15 := ofNat 15 6
 private def c16 : ZMod64 16 := ofNat 16 15
 private def d16 : ZMod64 16 := ofNat 16 9
 private def barrettWideA : ZMod64 BarrettWideMod := ofNat BarrettWideMod 65534
@@ -205,7 +208,15 @@ private def montCtxWide : Hex.MontCtx MontWideMod :=
 
 #guard (inv a7 * a7).toNat = 1 % 7
 #guard (inv oneOnly * oneOnly).toNat = 1 % 1
+#guard (inv nonCoprime15).toNat = 13
+#guard (List.range 15).all fun n =>
+  let a : ZMod64 15 := ofNat 15 n
+  (inv a * a).toNat == Nat.gcd n 15 % 15
 #guard (inv wideA * wideA).toNat = 1 % LargeMod
+
+/-- The logical reference separately pins the non-coprime cofactor convention. -/
+example : (HexArith.Int.extGcd 6 15).2.1 % 15 = 13 := by
+  simp [HexArith.Int.extGcd, Hex.pureIntExtGcd, Hex.pureIntExtGcd.go.eq_def]
 
 #guard (-a7).toNat = (7 - a7.toNat) % 7
 #guard (-oneOnly).toNat = (1 - oneOnly.toNat) % 1

--- a/conformance/HexModArith/FastCheck.lean
+++ b/conformance/HexModArith/FastCheck.lean
@@ -12,21 +12,23 @@ public import HexModArith.Basic
 public section
 
 /-!
-Executable `#guard` / `#eval` checks for the default `ZMod64` multiplication path.
+Executable `#guard` / `#eval` checks for the default `ZMod64` extern paths.
 
-Because `Hex.ZMod64.mul` is extern-backed, these checks live in a separate
-module so `#eval` runs against the compiled native implementation from
-`HexModArith.Basic`.
+Because `Hex.ZMod64.mul`, `pow`, and `inv` are extern-backed, these checks live
+in a separate module so `#eval` runs against the compiled native
+implementations from `HexModArith.Basic`.
 -/
 namespace Hex
 namespace ZMod64
 
 instance : Bounds (2 ^ 31 - 1) := ⟨by decide, by decide⟩
 instance : Bounds 7 := ⟨by decide, by decide⟩
+instance : Bounds 15 := ⟨by decide, by decide⟩
 
 private def mersenneA : ZMod64 (2 ^ 31 - 1) := ofNat _ (2 ^ 31 - 2)
 private def mersenneB : ZMod64 (2 ^ 31 - 1) := ofNat _ (2 ^ 31 - 3)
 private def smallA : ZMod64 7 := ofNat _ 3
+private def nonCoprimeA : ZMod64 15 := ofNat _ 6
 
 /-- info: 2 -/
 #guard_msgs in #eval (mul mersenneA mersenneB).toNat
@@ -40,10 +42,14 @@ private def smallA : ZMod64 7 := ofNat _ 3
 /-- info: 1 -/
 #guard_msgs in #eval (mul (inv smallA) smallA).toNat
 
+/-- info: 13 -/
+#guard_msgs in #eval (inv nonCoprimeA).toNat
+
 #guard (mul mersenneA mersenneB).toNat = 2
 #guard (pow smallA 5).toNat = 5
 #guard (inv smallA).toNat = 5
 #guard (mul (inv smallA) smallA).toNat = 1
+#guard (inv nonCoprimeA).toNat = 13
 
 end ZMod64
 end Hex

--- a/progress/20260727T054841Z_issue-8635.md
+++ b/progress/20260727T054841Z_issue-8635.md
@@ -1,0 +1,34 @@
+# Issue #8635: word-arithmetic `ZMod64.inv`
+
+## Accomplished
+
+- Replaced the compiled `ZMod64.inv` route through `Int.extGcd`/GMP with a
+  direct `UInt64` Euclidean/cofactor-residue extern while preserving the
+  transparent `pureIntExtGcd` logical body.
+- Added native and logical convention pins for composite, non-coprime inputs,
+  including an exhaustive Bézout-property check modulo 15.
+- Updated the HexModArith SPEC with the exact all-input runtime contract.
+- Verified exact agreement against GMP on 1,999,000 exhaustive small pairs and
+  2,000,000 deterministic high-bound random pairs; the C source is warning-free
+  under `-Wall -Wextra -Werror`.
+- Confirmed fresh HexPolyFp, Berlekamp, Berlekamp-Zassenhaus, and row-reduction
+  fixtures are byte-identical and pass their FLINT oracles.
+- Completed the full 9,460-job `lake build`, the HexModArith benchmark registry,
+  and DAG/style checks; strengthened the logical/runtime test split and contract
+  wording during the final audit.
+- Measured `runInvChecksum` at 32,768 inversions: 3.360 ms before and 1.430 ms
+  after (about 2.35x faster on `chungus2`).
+
+## Current frontier
+
+The implementation and local verification are complete. The branch needs to be
+rebased over the latest `origin/main`, published as a PR, and run through CI.
+
+## Next step
+
+Rebase, rerun the full build on the rebased commit, open the PR, resolve any
+conflicts or CI failures, and squash-auto-merge without deleting the branch.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Summary

- add a direct `lean_hex_zmod64_inv` extern that runs the Euclidean remainder/cofactor recurrence entirely in `uint64_t` arithmetic
- preserve the transparent `pureIntExtGcd` logical definition and its exact residue convention for composite and non-coprime inputs
- add separate native and logical convention checks, including all residues modulo 15
- document the all-input runtime contract

## Verification

- `lake build` (9,463 jobs on rebased `origin/main`)
- HexPolyFp, Berlekamp, Berlekamp-Zassenhaus, and row-reduction fixtures byte-identical and FLINT-clean (35 + 57 + 101 + 27 cases)
- 1,999,000 exhaustive small and 2,000,000 deterministic high-bound randomized comparisons against GMP
- `hexmodarith_bench verify` (13/13)
- `runInvChecksum`, n=32768: 3.360 ms before, 1.430 ms after (~2.35x)
- `scripts/check_dag.py`; Mathlib-free bench check; C `-Wall -Wextra -Werror`

Closes #8635
