### PR TITLE
RCF replay: build and check multiplication-only Sturm certificates

### DIFF
--- a/HexRCF.lean
+++ b/HexRCF.lean
@@ -8,6 +8,9 @@ module
 
 public import HexRCF.Language
 public import HexRCF.LanguageTests
+public import HexRCF.SturmReplay
+public import HexRCF.SturmBuilder
+public import HexRCF.SturmBuilderTests
 
 public section
 
@@ -18,5 +21,7 @@ sentences.
 
 The reflected language supports Boolean combinations of integer-polynomial
 comparisons under one universal or existential quantifier, either over the real
-line or over a half-open dyadic interval.
+line or over a half-open dyadic interval. Multiplication-only generalized Sturm
+replays provide the certified literal root counts used by the decision
+pipeline.
 -/

--- a/HexRCF/SturmBuilder.lean
+++ b/HexRCF/SturmBuilder.lean
@@ -1,0 +1,131 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.SturmReplay
+public import HexRealRoots.Chain
+public import HexPolyZ.Core
+
+public section
+
+/-!
+# Builder for multiplication-only Sturm replays
+
+This is compiled preparation code, outside the proof trust boundary. It
+instruments the existing sign-managed pseudo-remainder loop with an accumulated
+integer scale and quotient, then retains a candidate only when the small
+`SturmReplay.check` verifier accepts it.
+
+The literal chain starts with the supplied polynomial itself, rather than its
+primitive part. This matters for nonprimitive carrier polynomials.
+-/
+
+namespace Hex.RCF
+
+/-- Accumulated identity for one pseudo-remainder computation. Intended
+semantics: `scale leftScale dividend = quotient * divisor + remainder`. -/
+private structure SpemWitness where
+  leftScale : Int
+  quotient : ZPoly
+  remainder : ZPoly
+
+/-- Instrument `ZPoly.spemAux` while accumulating its exact scale and
+quotient. Each reduction step multiplies the previous identity by the positive
+absolute leading coefficient of `g` and adds the cancelled leading monomial to
+the quotient. Unlike `ZPoly.spemAux`, the zero-fuel case accepts only a state
+that has already reached a genuine stopping condition. -/
+private def buildSpemAux (g : ZPoly) : Nat → SpemWitness → Option SpemWitness
+  | 0, state =>
+      if state.remainder.isZero then some state
+      else if (DensePoly.degree? state.remainder).getD 0 <
+          (DensePoly.degree? g).getD 0 then some state
+      else none
+  | fuel + 1, state =>
+      if state.remainder.isZero then some state
+      else if (DensePoly.degree? state.remainder).getD 0 <
+          (DensePoly.degree? g).getD 0 then some state
+      else
+        let cg := DensePoly.leadingCoeff g
+        let lr := DensePoly.leadingCoeff state.remainder
+        let a := if cg < 0 then -cg else cg
+        let b := if cg < 0 then -lr else lr
+        let k := (DensePoly.degree? state.remainder).getD 0 -
+          (DensePoly.degree? g).getD 0
+        buildSpemAux g fuel {
+          leftScale := a * state.leftScale
+          quotient := DensePoly.scale a state.quotient + DensePoly.monomial k b
+          remainder := ZPoly.spemStep g state.remainder }
+
+/-- Compute one pseudo-remainder together with its exact multiplication
+witness. The dividend size is the same structural fuel used by `ZPoly.spem`. -/
+private def buildSpem (dividend divisor : ZPoly) : Option SpemWitness :=
+  buildSpemAux divisor dividend.size {
+    leftScale := 1
+    quotient := 0
+    remainder := dividend }
+
+/-- Extend a replay until its current entry is a nonzero constant. A zero
+remainder before that point detects a nonsquarefree input; fuel exhaustion is
+rejected directly. -/
+private def buildReplayAux (derivScale : Int) :
+    Nat → ZPoly → ZPoly → Array ZPoly → Array SturmStep → Option SturmReplay
+  | 0, _, _, _, _ => none
+  | fuel + 1, prev, cur, chain, steps =>
+      if cur.size = 1 then
+        some { chain, derivScale, steps }
+      else if cur.isZero then none
+      else
+        match buildSpem prev cur with
+        | none => none
+        | some witness =>
+            if witness.remainder.isZero then none
+            else
+              let rightScale := ZPoly.content witness.remainder
+              if rightScale ≤ 0 then none
+              else
+                let next := -(ZPoly.primitivePart witness.remainder)
+                let step : SturmStep := {
+                  leftScale := witness.leftScale
+                  quotient := witness.quotient
+                  rightScale }
+                buildReplayAux derivScale fuel cur next
+                  (chain.push next) (steps.push step)
+
+/-- Build an unchecked replay candidate for a positive-degree polynomial. -/
+private def buildSturmReplayRaw? (f : ZPoly) : Option SturmReplay :=
+  match f.degree? with
+  | some (_ + 1) =>
+      let deriv := DensePoly.derivative f
+      if deriv.isZero then none
+      else
+        let derivScale := ZPoly.content deriv
+        let s₁ := ZPoly.primitivePart deriv
+        buildReplayAux derivScale f.size f s₁ #[f, s₁] #[]
+  | _ => none
+
+/-- Build and verify a multiplication-only generalized Sturm replay.
+
+The compiled builder may use pseudo-remainders and primitive parts, but a
+candidate crosses the boundary only after the multiplication-only checker
+accepts it. -/
+def buildSturmReplay? (f : ZPoly) : Option SturmReplay :=
+  match buildSturmReplayRaw? f with
+  | none => none
+  | some replay => if replay.check f then some replay else none
+
+/-- Every certificate returned by the builder has passed the kernel-facing
+Boolean checker. -/
+theorem check_of_build_eq_some {f : ZPoly} {replay : SturmReplay}
+    (h : buildSturmReplay? f = some replay) : replay.check f = true := by
+  unfold buildSturmReplay? at h
+  split at h
+  · contradiction
+  · split at h
+    · simp_all
+    · contradiction
+
+end Hex.RCF

--- a/HexRCF/SturmBuilderTests.lean
+++ b/HexRCF/SturmBuilderTests.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.SturmBuilder
+import all HexRCF.SturmBuilder
+
+public section
+
+/-! Regression tests for multiplication-only Sturm replay and its builder. -/
+
+namespace Hex.RCF.SturmBuilderTests
+
+private def quad : ZPoly :=
+  DensePoly.ofCoeffs #[(-1 : Int), 0, 1]
+
+private def x : ZPoly :=
+  DensePoly.ofCoeffs #[(0 : Int), 1]
+
+private def one : ZPoly :=
+  DensePoly.ofCoeffs #[(1 : Int)]
+
+private def quadReplay : SturmReplay where
+  chain := #[quad, x, one]
+  derivScale := 2
+  steps := #[{ leftScale := 1, quotient := x, rightScale := 1 }]
+
+example : quadReplay.check quad = true := by decide
+
+example : Squarefree (HexRealRootsMathlib.toPolyℝ quad) :=
+  SturmReplay.squarefree_of_check (cert := quadReplay) (by decide)
+
+private def badScale : SturmReplay :=
+  { quadReplay with
+    steps := #[{ leftScale := 0, quotient := x, rightScale := 1 }] }
+
+private def badQuotient : SturmReplay :=
+  { quadReplay with
+    steps := #[{ leftScale := 1, quotient := 0, rightScale := 1 }] }
+
+private def badRightScale : SturmReplay :=
+  { quadReplay with
+    steps := #[{ leftScale := 1, quotient := x, rightScale := 0 }] }
+
+private def badLength : SturmReplay :=
+  { quadReplay with steps := #[] }
+
+private def badDerivative : SturmReplay :=
+  { quadReplay with derivScale := 3 }
+
+private def badDerivativeSign : SturmReplay :=
+  { quadReplay with derivScale := 0 }
+
+private def twiceQuad : ZPoly :=
+  DensePoly.ofCoeffs #[(-2 : Int), 0, 2]
+
+private def twiceX : ZPoly :=
+  DensePoly.ofCoeffs #[(0 : Int), 2]
+
+private def badHead : SturmReplay where
+  chain := #[twiceQuad, x, one]
+  derivScale := 2
+  steps := #[{ leftScale := 1, quotient := twiceX, rightScale := 2 }]
+
+private def xPlusOne : ZPoly :=
+  DensePoly.ofCoeffs #[(1 : Int), 1]
+
+private def badDegree : SturmReplay where
+  chain := #[quad, x, one, one]
+  derivScale := 2
+  steps := #[{ leftScale := 1, quotient := x, rightScale := 1 },
+    { leftScale := 1, quotient := xPlusOne, rightScale := 1 }]
+
+private def badTerminal : SturmReplay where
+  chain := #[quad, x]
+  derivScale := 2
+  steps := #[]
+
+example : badScale.check quad = false := by decide
+example : badQuotient.check quad = false := by decide
+example : badRightScale.check quad = false := by decide
+example : badLength.check quad = false := by decide
+example : badDerivative.check quad = false := by decide
+example : badDerivativeSign.check quad = false := by decide
+example : badHead.check quad = false := by decide
+example : badDegree.check quad = false := by decide
+example : badTerminal.check quad = false := by decide
+
+private def wide : DyadicInterval :=
+  DyadicInterval.mk (Dyadic.ofInt (-2)) (Dyadic.ofInt 2) (by decide)
+
+private def rightRoot : DyadicInterval :=
+  DyadicInterval.mk (Dyadic.ofInt 0) (Dyadic.ofInt 1) (by decide)
+
+private def excludedLeftRoot : DyadicInterval :=
+  DyadicInterval.mk (Dyadic.ofInt (-1)) (Dyadic.ofInt 0) (by decide)
+
+example : quadReplay.count wide = 2 := by decide
+example : quadReplay.count rightRoot = 1 := by decide
+example : quadReplay.count excludedLeftRoot = 0 := by decide
+example : quadReplay.total = 2 := by decide
+
+example : (HexRealRootsMathlib.Literal.rootsIn
+    (HexRealRootsMathlib.toPolyℝ quad) wide).card = 2 := by
+  have h := SturmReplay.count_eq_card_roots
+    (f := quad) (cert := quadReplay) (by decide) wide
+  have hcount : quadReplay.count wide = 2 := by decide
+  exact_mod_cast (hcount ▸ h).symm
+
+/-- The compiled builder emits and rechecks the expected squarefree cases. -/
+example : (buildSturmReplay? quad).map (fun cert => cert.check quad) = some true := by
+  decide
+
+private def linear : ZPoly :=
+  DensePoly.ofCoeffs #[(3 : Int), 2]
+
+example : (buildSturmReplay? linear).map
+    (fun cert => decide (cert.steps.size = 0) && cert.check linear) = some true := by
+  decide
+
+private def cubic : ZPoly :=
+  DensePoly.ofCoeffs #[(0 : Int), -1, 0, 1]
+
+example : (buildSturmReplay? cubic).map (fun cert => cert.check cubic) = some true := by
+  decide
+
+/-- This chain reaches a negative-leading-coefficient divisor, exercising the
+sign correction in the accumulated quotient. -/
+private def cubicPlus : ZPoly :=
+  DensePoly.ofCoeffs #[(0 : Int), 1, 0, 1]
+
+example : (buildSturmReplay? cubicPlus).map
+    (fun cert => cert.check cubicPlus) = some true := by
+  decide
+
+/-- The first division takes two pseudo-remainder reductions, pinning both the
+accumulated left scale and the scaled previous quotient. -/
+private def accumulated : ZPoly :=
+  DensePoly.ofCoeffs #[(-1 : Int), 0, 1, 1]
+
+private def accumulatedQuotient : ZPoly :=
+  DensePoly.ofCoeffs #[(1 : Int), 3]
+
+example : (buildSturmReplay? accumulated).map (fun cert =>
+    match cert.steps.toList.head? with
+    | some step => decide (step.leftScale = 9) &&
+        DensePoly.beqCoeffs step.quotient accumulatedQuotient
+    | none => false) = some true := by
+  decide
+
+example : (buildSturmReplay? accumulated).map
+    (fun cert => cert.check accumulated) = some true := by
+  decide
+
+/-- The literal head is retained for a nonprimitive polynomial. -/
+private def nonprimitive : ZPoly :=
+  DensePoly.ofCoeffs #[(-6 : Int), 0, 6]
+
+example : (buildSturmReplay? nonprimitive).map
+    (fun cert => match cert.chain.toList.head? with
+      | some head => DensePoly.beqCoeffs head nonprimitive
+      | none => false) = some true := by
+  decide
+
+example : (buildSturmReplay? nonprimitive).map
+    (fun cert => cert.check nonprimitive) = some true := by
+  decide
+
+example : (buildSturmReplay? nonprimitive).map
+    (fun cert => decide (cert.derivScale = 12)) = some true := by
+  decide
+
+private def repeated : ZPoly :=
+  DensePoly.ofCoeffs #[(1 : Int), -2, 1]
+
+example : (buildSturmReplay? repeated).isNone = true := by decide
+example : (buildSturmReplay? one).isNone = true := by decide
+example : (buildSturmReplay? (0 : ZPoly)).isNone = true := by decide
+
+end Hex.RCF.SturmBuilderTests

--- a/HexRCF/SturmReplay.lean
+++ b/HexRCF/SturmReplay.lean
@@ -1,0 +1,260 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRealRootsMathlib.LiteralChain
+
+public section
+
+/-!
+# Multiplication-only Sturm replay certificates
+
+An RCF certificate supplies a literal integer-polynomial chain together with
+positive three-term recurrence scales. The executable checker in this file
+uses only coefficient equality, integer arithmetic, and linear walks over the
+literal arrays. Its soundness theorem packages the accepted data as
+`HexRealRootsMathlib.ZReplay`, ready for the literal Sturm count theorems.
+-/
+
+namespace Hex.RCF
+
+/-- One positive three-term recurrence in a generalized Sturm replay. -/
+structure SturmStep where
+  /-- Positive scale on the polynomial two positions before the new term. -/
+  leftScale : Int
+  /-- Quotient multiplying the preceding polynomial. -/
+  quotient : ZPoly
+  /-- Positive scale on the new polynomial. -/
+  rightScale : Int
+
+/-- A literal generalized Sturm chain and its multiplication-only replay. -/
+structure SturmReplay where
+  /-- The chain `[f, s₁, …, sₙ]`. -/
+  chain : Array ZPoly
+  /-- Positive integer `δ` satisfying `f' = δ s₁`. -/
+  derivScale : Int
+  /-- The three-term identities for consecutive chain triples. -/
+  steps : Array SturmStep
+
+namespace SturmReplay
+
+/-- Boolean validation of a supplied positive three-term identity. -/
+@[expose]
+def checkStep (a b c : ZPoly) (step : SturmStep) : Bool :=
+  decide (0 < step.leftScale) &&
+  decide (0 < step.rightScale) &&
+  DensePoly.beqCoeffs (DensePoly.scale step.leftScale a)
+    (step.quotient * b - DensePoly.scale step.rightScale c)
+
+/-- Validate recurrence steps and the terminal nonzero constant. Its recursive
+shape matches `HexRealRootsMathlib.ZReplay`. -/
+@[expose]
+def checkSteps : ZPoly → ZPoly → List ZPoly → List SturmStep → Bool
+  | _, b, [], [] => decide (b.size = 1)
+  | a, b, c :: rest, step :: steps =>
+      checkStep a b c step && checkSteps b c rest steps
+  | _, _, _, _ => false
+
+/-- Every literal polynomial in a chain is nonzero. -/
+@[expose]
+def checkNonzero : List ZPoly → Bool
+  | [] => true
+  | p :: rest => !p.isZero && checkNonzero rest
+
+/-- Consecutive literal chain degrees strictly decrease. -/
+@[expose]
+def checkDegrees : List ZPoly → Bool
+  | a :: b :: rest =>
+      decide (b.degree?.getD 0 < a.degree?.getD 0) && checkDegrees (b :: rest)
+  | _ => true
+
+/-- Executable generalized Sturm replay checker.
+
+All polynomial comparisons use `DensePoly.beqCoeffs`, avoiding structural
+array equality during kernel reduction. Nonzero checking before strict degree
+descent makes `degree?.getD 0` unambiguous and implies that an accepted head
+has positive degree. Degree descent is retained as an explicit certificate
+invariant even though the abstract `IsSturmChain` consequence does not need
+it. -/
+@[expose]
+def check (f : ZPoly) (cert : SturmReplay) : Bool :=
+  match cert.chain.toList with
+  | a :: s₁ :: rest =>
+      decide (2 ≤ cert.chain.size) &&
+      DensePoly.beqCoeffs a f &&
+      checkNonzero (a :: s₁ :: rest) &&
+      checkDegrees (a :: s₁ :: rest) &&
+      decide (cert.steps.size + 2 = cert.chain.size) &&
+      decide (0 < cert.derivScale) &&
+      DensePoly.beqCoeffs (DensePoly.derivative f)
+        (DensePoly.scale cert.derivScale s₁) &&
+      checkSteps a s₁ rest cert.steps.toList
+  | _ => false
+
+/-- Literal Sturm variation drop across the dyadic interval
+`(I.lower, I.upper]`. -/
+@[expose]
+def count (cert : SturmReplay) (I : DyadicInterval) : Int :=
+  (Hex.sturmVarAt cert.chain I.lower : Int) - Hex.sturmVarAt cert.chain I.upper
+
+/-- Literal Sturm variation drop from negative to positive infinity. -/
+@[expose]
+def total (cert : SturmReplay) : Int :=
+  (Hex.sturmVarNegInf cert.chain : Int) - Hex.sturmVarPosInf cert.chain
+
+/-- Proposition-level adjacent degree descent mirrored by `checkDegrees`. -/
+@[expose]
+def DegreesDescend : List ZPoly → Prop
+  | a :: b :: rest =>
+      b.degree?.getD 0 < a.degree?.getD 0 ∧ DegreesDescend (b :: rest)
+  | _ => True
+
+/-- Kernel-facing consequences of an accepted generalized Sturm replay. The
+existential form keeps this a proposition while exposing the literal list
+decomposition needed by downstream count proofs. -/
+@[expose]
+def Valid (f : ZPoly) (cert : SturmReplay) : Prop :=
+  ∃ (s₁ : ZPoly) (rest : List ZPoly),
+    cert.chain.toList = f :: s₁ :: rest ∧
+      HexRealRootsMathlib.ZReplay f s₁ rest ∧
+        (∀ q ∈ f :: s₁ :: rest, q ≠ 0) ∧
+          DegreesDescend (f :: s₁ :: rest) ∧
+            0 < cert.derivScale ∧
+              DensePoly.derivative f = DensePoly.scale cert.derivScale s₁ ∧
+                cert.steps.size + 2 = cert.chain.size
+
+/-- A successful nonzero walk proves every chain entry nonzero. -/
+theorem checkNonzero_sound {chain : List ZPoly}
+    (h : checkNonzero chain = true) : ∀ q ∈ chain, q ≠ 0 := by
+  induction chain with
+  | nil => simp
+  | cons p rest ih =>
+      simp only [checkNonzero, Bool.and_eq_true, Bool.not_eq_true'] at h
+      obtain ⟨hp, hrest⟩ := h
+      have hp0 : p ≠ 0 := by
+        have hpos := (DensePoly.isZero_eq_false_iff p).mp hp
+        intro hzero
+        subst p
+        simp at hpos
+      intro q hq
+      simp only [List.mem_cons] at hq
+      rcases hq with rfl | hq
+      · exact hp0
+      · exact ih hrest q hq
+
+/-- A successful degree walk proves proposition-level adjacent descent. -/
+theorem checkDegrees_sound {chain : List ZPoly}
+    (h : checkDegrees chain = true) : DegreesDescend chain := by
+  induction chain with
+  | nil => trivial
+  | cons a rest ih =>
+      cases rest with
+      | nil => trivial
+      | cons b rest =>
+          simp only [checkDegrees, Bool.and_eq_true, decide_eq_true_eq] at h
+          exact ⟨h.1, ih h.2⟩
+
+/-- A successful identity check supplies the existential recurrence expected
+by `HexRealRootsMathlib.ZReplay`. -/
+theorem checkStep_sound {a b c : ZPoly} {step : SturmStep}
+    (h : checkStep a b c step = true) :
+    HexRealRootsMathlib.ZReplayStep a b c := by
+  simp only [checkStep, Bool.and_eq_true, decide_eq_true_eq] at h
+  exact ⟨step.leftScale, step.quotient, step.rightScale,
+    h.1.1, h.1.2, DensePoly.eq_of_beqCoeffs h.2⟩
+
+/-- A successful recurrence walk constructs an abstract integer replay. -/
+theorem checkSteps_sound {a b : ZPoly} {rest : List ZPoly}
+    {steps : List SturmStep} (h : checkSteps a b rest steps = true) :
+    HexRealRootsMathlib.ZReplay a b rest := by
+  induction rest generalizing a b steps with
+  | nil =>
+      cases steps with
+      | nil =>
+          simp only [checkSteps, decide_eq_true_eq] at h
+          exact .pair h
+      | cons _ _ => simp [checkSteps] at h
+  | cons c rest ih =>
+      cases steps with
+      | nil => simp [checkSteps] at h
+      | cons step steps =>
+          simp only [checkSteps, Bool.and_eq_true] at h
+          exact .cons (checkStep_sound h.1) (ih h.2)
+
+/-- Soundness of the executable generalized Sturm replay checker. -/
+theorem check_sound {f : ZPoly} {cert : SturmReplay}
+    (h : cert.check f = true) : cert.Valid f := by
+  unfold check at h
+  match hm : cert.chain.toList with
+  | [] => rw [hm] at h; simp at h
+  | [_] => rw [hm] at h; simp at h
+  | a :: s₁ :: rest =>
+      rw [hm] at h
+      simp only [Bool.and_eq_true, decide_eq_true_eq] at h
+      obtain ⟨⟨⟨⟨⟨⟨⟨hsize, hhead⟩, hnz⟩, hdegrees⟩, hcount⟩,
+        hderivPos⟩, hderiv⟩, hsteps⟩ := h
+      have ha : a = f := DensePoly.eq_of_beqCoeffs hhead
+      subst a
+      refine ⟨s₁, rest, hm, checkSteps_sound hsteps, ?_, ?_, hderivPos, ?_, hcount⟩
+      · exact checkNonzero_sound hnz
+      · exact checkDegrees_sound hdegrees
+      · exact DensePoly.eq_of_beqCoeffs hderiv
+
+/-- An accepted replay is a Sturm chain after casting its literal entries to
+real polynomials. -/
+theorem isChain_of_check {f : ZPoly} {cert : SturmReplay}
+    (h : cert.check f = true) :
+    Sturm.IsSturmChain (HexRealRootsMathlib.toPolyℝ f)
+      (cert.chain.toList.map HexRealRootsMathlib.toPolyℝ) := by
+  obtain ⟨s₁, rest, hchain, hrep, hnz, _hdegrees, hpos, hderiv, _hcount⟩ :=
+    check_sound h
+  rw [hchain]
+  exact hrep.isChain hnz cert.derivScale hpos hderiv
+
+/-- An accepted replay proves that the real cast of its head is squarefree. -/
+theorem squarefree_of_check {f : ZPoly} {cert : SturmReplay}
+    (h : cert.check f = true) :
+    Squarefree (HexRealRootsMathlib.toPolyℝ f) := by
+  obtain ⟨_s₁, _rest, _hchain, hrep, _hnz, _hdegrees, hpos, hderiv, _hcount⟩ :=
+    check_sound h
+  exact hrep.squarefree cert.derivScale hpos hderiv
+
+/-- The literal variation drop of an accepted replay counts exactly the real
+roots in the supplied half-open interval. This acts directly on the
+certificate array, avoiding a list-to-array round trip. -/
+theorem count_eq_card_roots {f : ZPoly} {cert : SturmReplay}
+    (h : cert.check f = true) (I : DyadicInterval) :
+    cert.count I =
+      (HexRealRootsMathlib.Literal.rootsIn
+        (HexRealRootsMathlib.toPolyℝ f) I).card := by
+  obtain ⟨s₁, rest, _hchain, _hrep, hnz, _hdegrees, _hpos, _hderiv, _hcount⟩ :=
+    check_sound h
+  unfold count
+  apply HexRealRootsMathlib.literalCount_eq_card_roots f cert.chain
+  · intro hf
+    exact hnz f (by simp) (HexRealRootsMathlib.toPolyℝ_eq_zero_iff.mp hf)
+  · exact squarefree_of_check h
+  · exact isChain_of_check h
+
+/-- The literal infinite-endpoint variation drop of an accepted replay counts
+exactly all real roots of its head. This acts directly on the certificate
+array. -/
+theorem total_eq_card_roots {f : ZPoly} {cert : SturmReplay}
+    (h : cert.check f = true) :
+    cert.total = (HexRealRootsMathlib.toPolyℝ f).roots.card := by
+  obtain ⟨s₁, rest, _hchain, _hrep, hnz, _hdegrees, _hpos, _hderiv, _hcount⟩ :=
+    check_sound h
+  unfold total
+  apply HexRealRootsMathlib.literalRootCount_eq_card_roots f cert.chain
+  · intro hf
+    exact hnz f (by simp) (HexRealRootsMathlib.toPolyℝ_eq_zero_iff.mp hf)
+  · exact squarefree_of_check h
+  · exact isChain_of_check h
+
+end SturmReplay
+
+end Hex.RCF

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -348,6 +348,25 @@ is the corresponding `−∞/+∞` difference. The proof factors through
 separately because the interval-count theorem requires positive
 degree.
 
+The compiled builder obtains the witnesses by instrumenting the existing
+sign-managed pseudo-remainder loop. During division of `prev` by `cur` it
+maintains
+
+```text
+scale A prev = Q * cur + r.
+```
+
+One `spemStep` with positive multiplier `a`, cancelled leading monomial
+`monomial k b`, and new remainder `r'` updates
+`A := a*A`, `Q := scale a Q + monomial k b`, and `r := r'`. At a nonzero
+stopping remainder it emits `next := -primitivePart r` and
+`rightScale := content r`, turning the invariant into exactly the checked
+subtractive recurrence. The builder starts the chain at the literal input
+`f`; only its derivative is primitive-normalized, with `derivScale` equal to
+the derivative content. Fuel exhaustion and a zero remainder before a
+constant terminal entry are rejected, and the public builder retains a raw
+candidate only after `SturmReplay.check` accepts it.
+
 Three existing private lemmas in
 `HexRealRootsMathlib/ChainCorrespond.lean` transfer directly and should
 be exported: `coprime_step_rev`, `flank_of_key`, and
@@ -479,6 +498,10 @@ free to change.
   `HexRCF/LanguageTests.lean`: executable language-semantics tests.
 - `HexRCF/SturmReplay.lean`: generalized multiplication-only chain
   replay and literal root counts.
+- `HexRCF/SturmBuilder.lean`: compiled pseudo-remainder instrumentation that
+  emits replay witnesses and retains only checker-approved candidates;
+  `HexRCF/SturmBuilderTests.lean`: valid, malformed, nonprimitive, and
+  nonsquarefree regressions.
 - `HexRCF/Certificate.lean`: `Certificate`, `check`, `decide`.
 - `HexRCF/Cells.lean`: separation refinement, cell construction,
   endpoint classification for bounded sentences.

--- a/progress/20260727T055405Z_rcf-sturm-replay.md
+++ b/progress/20260727T055405Z_rcf-sturm-replay.md
@@ -1,0 +1,44 @@
+# RCF executable Sturm-replay milestone
+
+## Accomplished
+
+- Added the `Hex.RCF.SturmStep` and `SturmReplay` certificate records and a
+  multiplication-only Boolean checker for head, nonzero, degree, terminal,
+  derivative, step-count, scale, quotient, and recurrence invariants.
+- Proved checker success constructs `HexRealRootsMathlib.ZReplay` and implies
+  real Sturm-chain validity, squarefreeness, exact interval counts, and the
+  exact total real-root count.
+- Added a compiled builder that instruments the existing pseudo-remainder loop
+  with the invariant `scale A prev = Q * cur + r`, retains the literal input as
+  chain head, rejects exhausted/nonsquarefree traces, and returns only
+  checker-approved candidates.
+- Added valid and malformed checker regressions, zero-step and multi-step
+  builder paths, a negative-leading divisor, a nonprimitive input, endpoint-
+  sensitive literal counts, and rejected constant/zero/repeated-root inputs.
+- Updated the RCF SPEC with the exact builder invariant and file organization,
+  and activated the modules through the `HexRCF` umbrella.
+- Incorporated a Sol builder-invariant audit and two fresh Claude Opus reviews.
+  The first found no soundness defect but required broader branch coverage; the
+  follow-up verified those gaps closed and returned a merge-ready verdict.
+- Passed `lake build HexRCF HexRealRootsMathlib` (8,787 jobs) and the copyright,
+  line-count, DAG, phase-4, Mathlib-free bench, conformance-target, diff, and
+  forbidden-proof-token checks.
+
+## Current frontier
+
+Issue #8899 is ready to publish. The RCF trust boundary can now consume a
+literal polynomial and replay certificate without evaluating pseudo-division,
+gcd, primitive-part normalization, square-free-core computation, or root
+search in the checker.
+
+## Next step
+
+Define the top-level certificate carrier package and generalized literal
+isolation records. Recompute atom polynomials and their product from the
+sentence, check the two carrier factor/derivative identities, connect carrier
+roots to the atom-root union, and use the accepted `SturmReplay.count` and
+`total` values for isolation soundness.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #8899

## Summary

- add exact generalized `SturmStep` / `SturmReplay` certificate records and a multiplication-only Boolean checker
- prove checker success yields `ZReplay`, real Sturm-chain validity, squarefreeness, and exact literal interval/total root counts
- instrument the compiled pseudo-remainder loop to emit accumulated scale/quotient witnesses while retaining the literal input head
- gate every raw builder candidate through the small checker before returning it
- cover valid, malformed, zero-step, multi-step, negative-divisor, nonprimitive, repeated-root, constant, zero, and endpoint-sensitive count cases
- document the exact builder invariant and activate the modules through `HexRCF`

## Validation

- `lake build HexRCF HexRealRootsMathlib` (8,787 jobs, including after rebase)
- `git diff --check`
- copyright and file-line-count checks
- DAG and phase-4 checks
- Mathlib-free bench import check
- conformance target registration check
- no `sorry`, `axiom`, or `native_decide` in the new modules

## Independent review

A Sol audit independently re-derived the pseudo-remainder accumulator and found its signs/content/literal-head handling correct. An initial fresh Claude Opus review found no soundness defect but required coverage of the multi-step accumulator and delicate rejection/count paths. After those tests were added, a fresh follow-up returned **merge-ready, no blockers**.