### PR TITLE
feat(number-field): canonicalize fixed-field values

### DIFF
--- a/HexNumberField/Convert.lean
+++ b/HexNumberField/Convert.lean
@@ -9,6 +9,7 @@ module
 public import HexNumberField.QAdjoin
 public import HexRowReduce
 public meta import HexNumberField.QAdjoin
+public meta import HexRowReduce
 
 public section
 
@@ -195,9 +196,11 @@ variable {p : ZPoly} {x : SimpleRoot p}
 @[expose]
 def mulMatrix (a : QAdjoin p x) :
     Matrix Rat (p.degree?.getD 0) (p.degree?.getD 0) :=
+  let n := p.degree?.getD 0
+  let products : Vector (QAdjoin p x) n := Vector.ofFn fun j =>
+    a * reduce p x (DensePoly.monomial j.val 1)
   Matrix.ofFn fun i j =>
-    let basis := reduce p x (DensePoly.monomial j.val 1)
-    (a * basis).coeffs.coeff i.val
+    products[j].coeffs.coeff i.val
 
 /-- First monic relation in the Krylov orbit of the multiplication operator,
 normalized as a primitive positive-leading integer polynomial. -/
@@ -208,11 +211,11 @@ def minpoly? [ZPoly.CheckedIrreducible p]
   let M := a.mulMatrix
   let one : Vector Rat n := Vector.unit Rat ⟨0, ZPoly.CheckedIrreducible.pos_degree⟩
   let orbit := (List.range n).foldl
-    (fun vs _ => vs.push (M * vs.getD (vs.size - 1) 0)) #[one]
+    (fun vs _ => vs.push (M * vs[vs.size - 1]!)) #[one]
   let relation := fun (k : Nat) => do
     let previous : Matrix Rat k n := Matrix.ofFn fun i j =>
-      (orbit.getD i.val 0)[j]
-    let target : Vector Rat n := orbit.getD k 0
+      orbit[i.val]![j]
+    let target : Vector Rat n := orbit[k]!
     let coeffs ← Matrix.spanCoeffs previous target
     let rational := DensePoly.ofCoeffs ((coeffs.toArray.map fun c => -c).push 1)
     some (ZPoly.ratPolyPrimitivePart rational)
@@ -235,8 +238,17 @@ def toAlgebraicNumber? [ZPoly.CheckedIrreducible p]
             let refined ← isolations.mapM DyadicRootIsolation.toRefined?
             let requested : Int := mahlerPrec q
             let target := requested + (approxGuardBits rep.1.square a.coeffs : Int)
+            -- This checked bind is deliberate: `QAdjoin.approx` has a sound
+            -- but potentially coarse fallback when refinement fails, while
+            -- root selection must fail rather than compare that wide ball.
             let threaded ← rep.refineTo? target
             let valueBall := evalRatBall a.coeffs threaded.1.1.square target
+            -- Candidate discs have radius below `sep(q)/4`; the guarded value
+            -- ball requested at `mahlerPrec q` has radius below
+            -- `sep(q)/(4*sqrt 2)`. Hence two candidates meeting it would put
+            -- distinct roots less than `2r + 2R < sep(q)` apart. The first
+            -- match is therefore unique. The precision here must follow `q`,
+            -- not the defining polynomial `p`.
             let matching ← refined.toList.find? fun r =>
               r.1.square.meetsBall valueBall
             AlgebraicNumber.ofNormalized? q hprim hpos hdegree
@@ -280,15 +292,28 @@ private def sqrtTwo : QAdjoin sqrtTwoPoly sqrtTwoRoot :=
 private def oneAddSqrtTwo : QAdjoin sqrtTwoPoly sqrtTwoRoot :=
   1 + sqrtTwo
 
+private def three : QAdjoin sqrtTwoPoly sqrtTwoRoot :=
+  reduce sqrtTwoPoly sqrtTwoRoot (DensePoly.C 3)
+
 #guard
     if hirred : ZPoly.isIrreducible sqrtTwoPoly = true then
       letI : ZPoly.CheckedIrreducible sqrtTwoPoly := ⟨hirred, by decide⟩
+      let shiftedPoly : ZPoly := DensePoly.ofList [-1, -2, 1]
+      let sqrtTwoTotal := sqrtTwo.toAlgebraicNumber sqrtTwoRep rfl
       sqrtTwo.minpoly? = some sqrtTwoPoly &&
+        three.minpoly? = some (DensePoly.ofList [-3, 1]) &&
+        oneAddSqrtTwo.minpoly? = some shiftedPoly &&
+        sqrtTwoTotal.p = sqrtTwoPoly &&
+        sqrtTwoTotal.rep.1.square.discsMeet sqrtTwoSquare &&
         (match sqrtTwo.toAlgebraicNumber? sqrtTwoRep rfl with
-        | some a => a.p = sqrtTwoPoly
+        | some a => a.p = sqrtTwoPoly && a.rep.1.square.discsMeet sqrtTwoSquare
         | none => false) &&
-        oneAddSqrtTwo.minpoly? =
-          some (DensePoly.ofList ([-1, -2, 1] : List Int))
+        (match (-sqrtTwo).toAlgebraicNumber? sqrtTwoRep rfl with
+        | some a => a.p = sqrtTwoPoly && !a.rep.1.square.discsMeet sqrtTwoSquare
+        | none => false) &&
+        (match oneAddSqrtTwo.toAlgebraicNumber? sqrtTwoRep rfl with
+        | some a => a.p = shiftedPoly && decide (0 < a.rep.1.square.re)
+        | none => false)
     else
       false
 

--- a/HexNumberField/Convert.lean
+++ b/HexNumberField/Convert.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexNumberField.QAdjoin
+public import HexRowReduce
 public meta import HexNumberField.QAdjoin
 
 public section
@@ -182,4 +183,114 @@ private def nearReducibleRoot
     q.coeffs = 0 && AlgebraicNumber.zero.toRoot.isZero
 
 end AlgebraicRoot
+
+namespace QAdjoin
+
+variable {p : ZPoly} {x : SimpleRoot p}
+
+/-! ## Fixed-presentation minimal polynomials -/
+
+/-- Matrix of multiplication by `a` in the power basis
+`1, X, ..., X^(degree p - 1)`. -/
+@[expose]
+def mulMatrix (a : QAdjoin p x) :
+    Matrix Rat (p.degree?.getD 0) (p.degree?.getD 0) :=
+  Matrix.ofFn fun i j =>
+    let basis := reduce p x (DensePoly.monomial j.val 1)
+    (a * basis).coeffs.coeff i.val
+
+/-- First monic relation in the Krylov orbit of the multiplication operator,
+normalized as a primitive positive-leading integer polynomial. -/
+@[expose]
+def minpoly? [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) : Option ZPoly :=
+  let n := p.degree?.getD 0
+  let M := a.mulMatrix
+  let one : Vector Rat n := Vector.unit Rat ⟨0, ZPoly.CheckedIrreducible.pos_degree⟩
+  let orbit := (List.range n).foldl
+    (fun vs _ => vs.push (M * vs.getD (vs.size - 1) 0)) #[one]
+  let relation := fun (k : Nat) => do
+    let previous : Matrix Rat k n := Matrix.ofFn fun i j =>
+      (orbit.getD i.val 0)[j]
+    let target : Vector Rat n := orbit.getD k 0
+    let coeffs ← Matrix.spanCoeffs previous target
+    let rational := DensePoly.ofCoeffs ((coeffs.toArray.map fun c => -c).push 1)
+    some (ZPoly.ratPolyPrimitivePart rational)
+  (List.range n).findSome? fun i => relation (i + 1)
+
+/-- Convert a fixed-presentation value to its canonical irreducible
+representation. Every stored certificate and every precision-sensitive step
+is checked before construction. -/
+@[expose]
+def toAlgebraicNumber? [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) (rep : RefinedIsolation p)
+    (_h : SimpleRoot.mk rep = x) : Option AlgebraicNumber := do
+  let q ← a.minpoly?
+  if hprim : ZPoly.content q = 1 then
+    if hpos : 0 < q.leadingCoeff then
+      if hdegree : 0 < q.degree?.getD 0 then
+        if hirred : ZPoly.isIrreducible q = true then
+          if hsquarefree : HasOnlySimpleRoots q then do
+            let isolations ← isolate q hsquarefree (separationDepth q : Int)
+            let refined ← isolations.mapM DyadicRootIsolation.toRefined?
+            let requested : Int := mahlerPrec q
+            let target := requested + (approxGuardBits rep.1.square a.coeffs : Int)
+            let threaded ← rep.refineTo? target
+            let valueBall := evalRatBall a.coeffs threaded.1.1.square target
+            let matching ← refined.toList.find? fun r =>
+              r.1.square.meetsBall valueBall
+            AlgebraicNumber.ofNormalized? q hprim hpos hdegree
+              ⟨hirred, hdegree⟩ hsquarefree matching
+          else
+            none
+        else
+          none
+      else
+        none
+    else
+      none
+  else
+    none
+
+/-- Total fixed-presentation conversion. The checked failure branch is proved
+unreachable by the Mathlib companion. -/
+@[expose]
+def toAlgebraicNumber [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) : AlgebraicNumber :=
+  (a.toAlgebraicNumber? rep h).getD
+    (Hex.panicWith 0 "QAdjoin.toAlgebraicNumber: certification failed")
+
+/-! Compiled fixed-field conversion regressions. -/
+
+private def sqrtTwoPoly : ZPoly := DensePoly.ofList [-2, 0, 1]
+
+private def sqrtTwoSquare : DyadicSquare :=
+  ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
+
+private def sqrtTwoRep : RefinedIsolation sqrtTwoPoly :=
+  ⟨⟨sqrtTwoSquare, by decide⟩, by decide⟩
+
+private def sqrtTwoRoot : SimpleRoot sqrtTwoPoly :=
+  SimpleRoot.mk sqrtTwoRep
+
+private def sqrtTwo : QAdjoin sqrtTwoPoly sqrtTwoRoot :=
+  reduce sqrtTwoPoly sqrtTwoRoot (DensePoly.ofList [0, 1])
+
+private def oneAddSqrtTwo : QAdjoin sqrtTwoPoly sqrtTwoRoot :=
+  1 + sqrtTwo
+
+#guard
+    if hirred : ZPoly.isIrreducible sqrtTwoPoly = true then
+      letI : ZPoly.CheckedIrreducible sqrtTwoPoly := ⟨hirred, by decide⟩
+      sqrtTwo.minpoly? = some sqrtTwoPoly &&
+        (match sqrtTwo.toAlgebraicNumber? sqrtTwoRep rfl with
+        | some a => a.p = sqrtTwoPoly
+        | none => false) &&
+        oneAddSqrtTwo.minpoly? =
+          some (DensePoly.ofList ([-1, -2, 1] : List Int))
+    else
+      false
+
+end QAdjoin
 end Hex

--- a/progress/20260727T061628Z_numberfield-minpoly.md
+++ b/progress/20260727T061628Z_numberfield-minpoly.md
@@ -1,0 +1,31 @@
+# HexNumberField fixed-presentation minimal polynomials
+
+## Accomplished
+
+- Added the multiplication-by-element matrix in the defining polynomial's
+  power basis.
+- Implemented exact Krylov-orbit row reduction to recover the first monic
+  rational relation, then clear denominators and normalize its primitive
+  integer part.
+- Implemented checked and total `QAdjoin` conversion to canonical
+  `AlgebraicNumber`, including executable normalization checks, root isolation,
+  guarded ball evaluation, and certified root matching.
+- Kept the new API in `Convert.lean`, matching the SPEC file organization.
+- Added compiled regressions for `sqrt 2` and `1 + sqrt 2` and rebuilt both
+  `HexNumberField.Convert` and the umbrella `HexNumberField` target.
+
+## Current frontier
+
+The complete executable fixed-presentation canonicalization path is present.
+The Mathlib companion still needs the semantic Krylov/minimal-polynomial proof,
+root-selection uniqueness, and `_isSome` theorem that retire the total
+wrapper's checked fallback.
+
+## Next step
+
+Publish this milestone as a stacked PR, launch its independent review monitor,
+and begin the lazy arithmetic/eliminant stage without waiting for that review.
+
+## Blockers
+
+None.

--- a/progress/20260727T063444Z_numberfield-minpoly-review-fixes.md
+++ b/progress/20260727T063444Z_numberfield-minpoly-review-fixes.md
@@ -1,0 +1,33 @@
+# HexNumberField minimal-polynomial review fixes
+
+## Accomplished
+
+- Strengthened conversion regressions to distinguish the positive and negative
+  conjugates, rather than checking only their shared polynomial.
+- Added a degree-one early Krylov exit for a rational fixed-field element and
+  converted `1 + sqrt 2` through a minimal polynomial unrelated to the defining
+  polynomial.
+- Exercised the primary total conversion wrapper directly.
+- Documented the separation-margin argument and why checked refinement cannot
+  be replaced by the fallback-bearing approximation wrapper.
+- Materialized multiplication columns once before filling the matrix and made
+  impossible Krylov indexing failures loud instead of silently inserting zero
+  vectors.
+- Added the explicit meta import for the row-reduction dependency and rebuilt
+  `HexNumberField.Convert` and `HexNumberField`.
+
+## Current frontier
+
+The independent review found no incorrect public data or valid-input fallback.
+Its correctness and regression findings are addressed. Incremental row
+reduction and reusing an already computed isolation array remain optional
+performance improvements, not correctness blockers.
+
+## Next step
+
+Push the review fix and rebase/push the lazy-arithmetic and disambiguation PRs
+so the entire active stack contains it.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Summary

- represent multiplication by a fixed-field element in the power basis
- derive the first monic Krylov relation using exact row reduction
- normalize the relation and identify its certified complex root
- expose checked and total QAdjoin-to-AlgebraicNumber conversion

## Verification

- `lake build HexNumberField.Convert HexNumberField`
- compiled regressions for `sqrt 2` and `1 + sqrt 2`

Stacked on #8902.