### PR TITLE
feat(number-field): bound candidate disambiguation

### DIFF
--- a/HexNumberField.lean
+++ b/HexNumberField.lean
@@ -11,6 +11,7 @@ public import HexNumberField.Approx
 public import HexNumberField.QAdjoin
 public import HexNumberField.Convert
 public import HexNumberField.Lazy
+public import HexNumberField.Disambiguate
 
 public section
 

--- a/HexNumberField/Disambiguate.lean
+++ b/HexNumberField/Disambiguate.lean
@@ -38,6 +38,27 @@ def evalLowerDenom (q : ZPoly) : Nat :=
 
 end ZPoly
 
+namespace Disambiguation
+
+/-- Error-amplification majorant for Horner evaluation at a root of `q`,
+parameterized by an integer magnitude bound on coefficients so tower elements
+can reuse the same recurrence. Candidate-root square balls may have radius up
+to twice the nominal common input error because of their circumscribed-disc
+conversion. -/
+@[expose]
+def evalMajorant {A : Type} [Zero A] [DecidableEq A]
+    (f : DensePoly A) (valueBound : A → Nat) (q : ZPoly) : Nat :=
+  let rootBound := 2 ^ cauchyExp q + 1
+  let state := f.toArray.foldr
+    (fun coeff state =>
+      let value := state.1 * rootBound + valueBound coeff
+      let error := 2 * state.1 + rootBound * state.2 + 2 * state.2 + 1
+      (value, error))
+    (0, 0)
+  Nat.max 1 state.2
+
+end Disambiguation
+
 namespace QAdjoin
 
 /-- Ceiling of the absolute value of a rational, computed with integer
@@ -57,20 +78,14 @@ def valueMajorant {p : ZPoly} {x : SimpleRoot p} (a : QAdjoin p x) : Nat :=
 /-- Error-amplification majorant for Horner evaluation at a root of `q`.
 
 The state tracks a value bound `V` and a coefficient of the common input
-error `E`. For `(acc * y) + c`, with input errors at most one, the update
-`E' = V + B*E + E + 1` covers root error, propagated accumulator error, their
-product, and coefficient error. -/
+error `E`. For `(acc * y) + c`, coefficient errors are at most one nominal
+unit while the circumscribed root ball is at most two. The update
+`E' = 2*V + B*E + 2*E + 1` covers root error, propagated accumulator error,
+their product, and coefficient error. -/
 @[expose]
 def evalMajorant {p : ZPoly} {x : SimpleRoot p}
     (f : DensePoly (QAdjoin p x)) (q : ZPoly) : Nat :=
-  let rootBound := 2 ^ cauchyExp q + 1
-  let state := f.toArray.foldr
-    (fun coeff state =>
-      let value := state.1 * rootBound + valueMajorant coeff
-      let error := state.1 + rootBound * state.2 + state.2 + 1
-      (value, error))
-    (0, 0)
-  Nat.max 1 state.2
+  Disambiguation.evalMajorant f valueMajorant q
 
 end QAdjoin
 
@@ -81,11 +96,13 @@ the displayed ceiling is already exact. -/
 def evalDisambiguationLimit (q : ZPoly) (majorant : Nat) : Nat :=
   ceilLog2 (2 * q.evalLowerDenom * Nat.max 1 majorant) + 2
 
-/-- The evaluation radius is strictly below half the reciprocal-Cauchy lower
-bound, written without division as `2 * D * radius < 1`. -/
+/-- The evaluation radius is below one third of the reciprocal-Cauchy lower
+bound, written without division as `3 * D * radius < 1`. The factor three is
+needed because `excludesZero` uses the centre's maximum coordinate, which can
+be a factor `sqrt 2` below its Euclidean norm. -/
 @[expose]
 def evalRadiusSmall (q : ZPoly) (radius : Dyadic) : Bool :=
-  decide (((2 * q.evalLowerDenom : Nat) : Dyadic) * radius < 1)
+  decide (((3 * q.evalLowerDenom : Nat) : Dyadic) * radius < 1)
 
 /-- Least precision in the finite prescribed range whose certified Horner
 ball has sufficiently small radius. A failed ball construction is skipped;
@@ -120,6 +137,11 @@ def retainZero? (q : ZPoly) (majorant : Nat)
 
 #guard
     let q : ZPoly := DensePoly.ofList [-1, 1]
+    let f : DensePoly Nat := DensePoly.ofList [1, 2]
+    Disambiguation.evalMajorant f id q = 10
+
+#guard
+    let q : ZPoly := DensePoly.ofList [-1, 1]
     let evalAt := fun prec : Nat =>
       some ({ re := 0, im := 0, radius := Dyadic.ofIntWithPrec 1 prec } :
         DyadicComplexBall)
@@ -130,5 +152,12 @@ def retainZero? (q : ZPoly) (majorant : Nat)
 #guard
     let zeroEval : ZPoly := 0
     retainZero? zeroEval 1 (fun _ => none) = some true
+
+#guard
+    let q : ZPoly := DensePoly.ofList [-1, 1]
+    let evalAt := fun prec : Nat =>
+      some ({ re := 1, im := 0, radius := Dyadic.ofIntWithPrec 1 prec } :
+        DyadicComplexBall)
+    retainZero? q 8 evalAt = some false
 
 end Hex

--- a/HexNumberField/Disambiguate.lean
+++ b/HexNumberField/Disambiguate.lean
@@ -42,9 +42,10 @@ namespace Disambiguation
 
 /-- Error-amplification majorant for Horner evaluation at a root of `q`,
 parameterized by an integer magnitude bound on coefficients so tower elements
-can reuse the same recurrence. Candidate-root square balls may have radius up
-to twice the nominal common input error because of their circumscribed-disc
-conversion. -/
+can reuse the same recurrence. The factor two on the root bound covers the
+`|re| + |im|` centre magnitude used by complex-ball multiplication; the three
+extra propagated-error units cover centre-radius conversion and the bilinear
+radius term. -/
 @[expose]
 def evalMajorant {A : Type} [Zero A] [DecidableEq A]
     (f : DensePoly A) (valueBound : A → Nat) (q : ZPoly) : Nat :=
@@ -52,7 +53,8 @@ def evalMajorant {A : Type} [Zero A] [DecidableEq A]
   let state := f.toArray.foldr
     (fun coeff state =>
       let value := state.1 * rootBound + valueBound coeff
-      let error := 2 * state.1 + rootBound * state.2 + 2 * state.2 + 1
+      let error :=
+        2 * state.1 + 2 * rootBound * state.2 + 3 * state.2 + 1
       (value, error))
     (0, 0)
   Nat.max 1 state.2
@@ -79,9 +81,9 @@ def valueMajorant {p : ZPoly} {x : SimpleRoot p} (a : QAdjoin p x) : Nat :=
 
 The state tracks a value bound `V` and a coefficient of the common input
 error `E`. For `(acc * y) + c`, coefficient errors are at most one nominal
-unit while the circumscribed root ball is at most two. The update
-`E' = 2*V + B*E + 2*E + 1` covers root error, propagated accumulator error,
-their product, and coefficient error. -/
+unit. The update `E' = 2*V + 2*B*E + 3*E + 1` covers root error, the
+`|re| + |im|` inflation in propagated accumulator error, their product, and
+coefficient error. -/
 @[expose]
 def evalMajorant {p : ZPoly} {x : SimpleRoot p}
     (f : DensePoly (QAdjoin p x)) (q : ZPoly) : Nat :=
@@ -138,7 +140,7 @@ def retainZero? (q : ZPoly) (majorant : Nat)
 #guard
     let q : ZPoly := DensePoly.ofList [-1, 1]
     let f : DensePoly Nat := DensePoly.ofList [1, 2]
-    Disambiguation.evalMajorant f id q = 10
+    Disambiguation.evalMajorant f id q = 14
 
 #guard
     let q : ZPoly := DensePoly.ofList [-1, 1]

--- a/HexNumberField/Disambiguate.lean
+++ b/HexNumberField/Disambiguate.lean
@@ -1,0 +1,134 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexNumberField.Lazy
+public meta import HexNumberField.Lazy
+
+public section
+
+/-!
+Finite-precision disambiguation of candidate algebraic roots.
+
+An evaluation eliminant supplies a reciprocal-Cauchy lower bound for every
+nonzero value. A conservative Horner majorant turns that lower bound into an
+input-computable endpoint, and the search below chooses the first precision at
+which the certified evaluation ball is small enough to distinguish zero from
+nonzero. No caller performs unbounded refinement.
+-/
+namespace Hex
+
+namespace ZPoly
+
+/-- Remove zero roots and content from a candidate-evaluation eliminant. -/
+@[expose]
+def normalizeEval (q : ZPoly) : ZPoly :=
+  primitivePart q.removeX
+
+/-- Denominator in the reciprocal-Cauchy lower bound
+`|z| ≥ 1 / (1 + height q)` for a nonzero root `z` of the normalized
+evaluation eliminant. -/
+@[expose]
+def evalLowerDenom (q : ZPoly) : Nat :=
+  1 + coeffAbsMax q.normalizeEval
+
+end ZPoly
+
+namespace QAdjoin
+
+/-- Ceiling of the absolute value of a rational, computed with integer
+arithmetic. -/
+@[expose]
+def ratAbsCeil (q : Rat) : Nat :=
+  (q.num.natAbs + q.den - 1) / q.den
+
+/-- Integer magnitude majorant for a fixed-field coordinate evaluated at any
+root of its defining polynomial. -/
+@[expose]
+def valueMajorant {p : ZPoly} {x : SimpleRoot p} (a : QAdjoin p x) : Nat :=
+  let rootBound := 2 ^ cauchyExp p + 1
+  a.coeffs.toArray.foldr
+    (fun coeff acc => acc * rootBound + ratAbsCeil coeff) 0
+
+/-- Error-amplification majorant for Horner evaluation at a root of `q`.
+
+The state tracks a value bound `V` and a coefficient of the common input
+error `E`. For `(acc * y) + c`, with input errors at most one, the update
+`E' = V + B*E + E + 1` covers root error, propagated accumulator error, their
+product, and coefficient error. -/
+@[expose]
+def evalMajorant {p : ZPoly} {x : SimpleRoot p}
+    (f : DensePoly (QAdjoin p x)) (q : ZPoly) : Nat :=
+  let rootBound := 2 ^ cauchyExp q + 1
+  let state := f.toArray.foldr
+    (fun coeff state =>
+      let value := state.1 * rootBound + valueMajorant coeff
+      let error := state.1 + rootBound * state.2 + state.2 + 1
+      (value, error))
+    (0, 0)
+  Nat.max 1 state.2
+
+end QAdjoin
+
+/-- The specified finite search endpoint
+`ceilLog2(ceil(2 * (1 + height(q)) * C)) + 2`. All inputs are integral, so
+the displayed ceiling is already exact. -/
+@[expose]
+def evalDisambiguationLimit (q : ZPoly) (majorant : Nat) : Nat :=
+  ceilLog2 (2 * q.evalLowerDenom * Nat.max 1 majorant) + 2
+
+/-- The evaluation radius is strictly below half the reciprocal-Cauchy lower
+bound, written without division as `2 * D * radius < 1`. -/
+@[expose]
+def evalRadiusSmall (q : ZPoly) (radius : Dyadic) : Bool :=
+  decide (((2 * q.evalLowerDenom : Nat) : Dyadic) * radius < 1)
+
+/-- Least precision in the finite prescribed range whose certified Horner
+ball has sufficiently small radius. A failed ball construction is skipped;
+the companion proves that the endpoint succeeds for the shipped evaluators. -/
+@[expose]
+def evalDisambiguationPrec (q : ZPoly) (majorant : Nat)
+    (evalAt : Nat → Option DyadicComplexBall) : Option Nat :=
+  let limit := evalDisambiguationLimit q majorant
+  (List.range (limit + 1)).findSome? fun prec => do
+    let ball ← evalAt prec
+    if evalRadiusSmall q ball.radius then some prec else none
+
+/-- Decide whether a candidate evaluation can be zero. A zero eliminant is
+retained immediately. Otherwise evaluate at the first sufficiently small
+precision and retain exactly when the certified ball does not exclude zero. -/
+@[expose]
+def retainZero? (q : ZPoly) (majorant : Nat)
+    (evalAt : Nat → Option DyadicComplexBall) : Option Bool :=
+  if q.normalizeEval.isZero then
+    some true
+  else do
+    let prec ← evalDisambiguationPrec q majorant evalAt
+    let ball ← evalAt prec
+    some (!ball.excludesZero)
+
+/-! Compiled bound and bounded-search checks. -/
+
+#guard
+    let q : ZPoly := DensePoly.ofList [0, 0, -6, 12]
+    q.normalizeEval = DensePoly.ofList [-1, 2] &&
+      q.evalLowerDenom = 3
+
+#guard
+    let q : ZPoly := DensePoly.ofList [-1, 1]
+    let evalAt := fun prec : Nat =>
+      some ({ re := 0, im := 0, radius := Dyadic.ofIntWithPrec 1 prec } :
+        DyadicComplexBall)
+    evalDisambiguationLimit q 8 = 7 &&
+      evalDisambiguationPrec q 8 evalAt = some 3 &&
+      retainZero? q 8 evalAt = some true
+
+#guard
+    let zeroEval : ZPoly := 0
+    retainZero? zeroEval 1 (fun _ => none) = some true
+
+end Hex

--- a/HexNumberField/SPEC/hex-number-field.md
+++ b/HexNumberField/SPEC/hex-number-field.md
@@ -321,7 +321,10 @@ Define `evalDisambiguationPrec` as the least precision in the finite range
 0 .. ceilLog2(ceil(2 * (1 + height(q)) * C)) + 2
 ```
 
-whose Horner enclosure radius is below `1 / (2 * (1 + height(q)))`.
+whose Horner enclosure radius is below `1 / (3 * (1 + height(q)))`.
+The factor `3` accounts for the shipped zero-exclusion test using the maximum
+absolute centre coordinate, which may be a factor `sqrt 2` below the Euclidean
+centre norm. The displayed search endpoint still has sufficient slack.
 The displayed endpoint proves that the bounded search succeeds. The same
 construction, with the eliminant for each generator/factor evaluation, is used
 by tower adjoining. No API performs unbounded refinement.

--- a/progress/20260727T063220Z_numberfield-disambiguate.md
+++ b/progress/20260727T063220Z_numberfield-disambiguate.md
@@ -1,0 +1,30 @@
+# HexNumberField bounded disambiguation
+
+## Accomplished
+
+- Added evaluation-eliminant normalization by maximal `X`-factor removal and
+  primitive-part normalization.
+- Added the reciprocal-Cauchy lower-bound denominator and conservative
+  fixed-field coordinate/Horner error majorants.
+- Implemented the SPEC's finite disambiguation endpoint and least-precision
+  search using exact dyadic radius comparisons.
+- Added a checked candidate decision that retains zero eliminants immediately
+  and otherwise excludes candidates only with a certified nonzero ball.
+- Added compiled normalization, endpoint, least-precision, and zero-eliminant
+  regressions and rebuilt the umbrella `HexNumberField` target.
+
+## Current frontier
+
+The bounded candidate-selection substrate shared by fixed-field roots and
+tower adjoining is executable. The later root driver must construct each
+candidate evaluation eliminant and supply its certified ball evaluator.
+
+## Next step
+
+Publish this milestone, start its review monitor, then repair the completed
+minimal-polynomial review findings and propagate the stacked branches before
+starting `AlgebraicPoly` and the root driver.
+
+## Blockers
+
+None.

--- a/progress/20260727T065537Z_numberfield-disambiguation-review-fixes.md
+++ b/progress/20260727T065537Z_numberfield-disambiguation-review-fixes.md
@@ -1,0 +1,30 @@
+# HexNumberField disambiguation review fixes
+
+## Accomplished
+
+- Tightened the radius threshold from `2 * D * r < 1` to the sufficient
+  `3 * D * r < 1`, accounting for the infinity-norm centre used by the shipped
+  zero-exclusion test.
+- Corrected the internally inconsistent SPEC threshold while retaining its
+  finite search endpoint, whose extra two bits still cover the stronger test.
+- Strengthened the Horner error recurrence for circumscribed root balls, whose
+  radius can be up to two nominal input-error units.
+- Generalized the recurrence over a coefficient magnitude callback so the
+  number-field tower can reuse it without copying the proof-sensitive logic.
+- Added compiled recurrence and nonzero-refutation checks and rebuilt the
+  disambiguation and umbrella targets successfully.
+
+## Current frontier
+
+The independent review's two numeric completeness failures are addressed. The
+fixed-field roots caller additionally requests one extra candidate-square bit,
+so it lies inside the generalized two-unit contract with margin.
+
+## Next step
+
+Push the repaired disambiguation branch, rebase all descendants, and rerun the
+fixed-field root regressions before returning to the common-field API.
+
+## Blockers
+
+None.

--- a/progress/20260727T071809Z_numberfield-bounds-rereview.md
+++ b/progress/20260727T071809Z_numberfield-bounds-rereview.md
@@ -1,0 +1,27 @@
+# HexNumberField bounds re-review repair
+
+## Accomplished
+
+- Verified the completed bounds review against `DyadicComplexBall.mul`: the
+  prior recurrence did not charge the `|re| + |im|` inflation on propagated
+  accumulator error.
+- Strengthened the reusable Horner recurrence to
+  `E' = 2V + 2BE + 3E + 1`, covering the centre norm conversion, root input
+  error, bilinear radius product, and coefficient error with integer slack.
+- Updated the compiled recurrence regression and rebuilt the disambiguation
+  target successfully.
+
+## Current frontier
+
+The two correctness-critical root-disambiguation findings are now repaired:
+the zero-exclusion threshold is `3Dr < 1`, and the finite endpoint uses a
+majorant compatible with the shipped complex-ball multiplication primitive.
+
+## Next step
+
+Push the repair and rebase the algebraic-polynomial, roots, common-field, and
+tower scaffold milestones before continuing mixed-radix arithmetic.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Summary

- normalize candidate-evaluation eliminants for reciprocal-Cauchy bounds
- compute fixed-field coordinate and Horner error majorants
- implement the finite least-precision search from the number-field SPEC
- retain candidates only when a sufficiently small certified ball cannot exclude zero

## Verification

- `lake build HexNumberField.Disambiguate HexNumberField`
- compiled normalization, endpoint, least-precision, and zero-eliminant checks

Stacked on #8907.