### PR TITLE
RCF: certify atom carriers and generalized isolations

### DIFF
--- a/HexRCF.lean
+++ b/HexRCF.lean
@@ -11,6 +11,10 @@ public import HexRCF.LanguageTests
 public import HexRCF.SturmReplay
 public import HexRCF.SturmBuilder
 public import HexRCF.SturmBuilderTests
+public import HexRCF.Carrier
+public import HexRCF.CarrierTests
+public import HexRCF.Isolations
+public import HexRCF.IsolationsTests
 
 public section
 
@@ -23,5 +27,7 @@ The reflected language supports Boolean combinations of integer-polynomial
 comparisons under one universal or existential quantifier, either over the real
 line or over a half-open dyadic interval. Multiplication-only generalized Sturm
 replays provide the certified literal root counts used by the decision
-pipeline.
+pipeline. Multiplication-checkable carrier identities connect those counts to
+the sentence's atom roots, and raw generalized isolation certificates package
+the roots as ordered, complete dyadic intervals.
 -/

--- a/HexRCF/Carrier.lean
+++ b/HexRCF/Carrier.lean
@@ -1,0 +1,240 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.Language
+public import HexRCF.SturmReplay
+public import HexRealRootsMathlib.SquareFreeCore
+
+public section
+
+/-!
+# Certified square-free carriers for reflected RCF sentences
+
+The carrier checker recomputes the nonconstant atom polynomials and their
+product from the reflected sentence.  A certificate supplies a proposed
+square-free carrier, two factor witnesses, two nonzero integer scales, and a
+multiplication-only Sturm replay for the carrier.  Checking uses only exact
+polynomial arithmetic, differentiation, coefficient equality, and the replay
+checker.
+-/
+
+namespace Hex.RCF
+
+open HexRealRootsMathlib Polynomial
+
+/-- All atom polynomials in a formula, in deterministic left-to-right order. -/
+@[expose]
+def Formula.polys : Formula → List ZPoly
+  | .atom a => [a.p]
+  | .tt | .ff => []
+  | .not φ => φ.polys
+  | .and φ ψ | .or φ ψ | .imp φ ψ => φ.polys ++ ψ.polys
+
+/-- The body of a one-quantifier sentence. -/
+@[expose]
+def Sentence.formula : Sentence → Formula
+  | .forallReal φ | .existsReal φ | .forallIoc _ _ φ | .existsIoc _ _ φ => φ
+
+/-- The positive-degree atom polynomials used by the carrier decomposition.
+Constant atoms remain in the reflected formula but, after their truth values
+are evaluated, do not contribute carrier boundaries. -/
+@[expose]
+def Sentence.polys (s : Sentence) : List ZPoly :=
+  s.formula.polys.filter fun p => decide (0 < p.degree?.getD 0)
+
+/-- The product of all nonconstant atom polynomials. -/
+@[expose]
+def Sentence.product (s : Sentence) : ZPoly := s.polys.prod
+
+/-- Check that every polynomial in a literal list has positive degree. -/
+@[expose]
+def checkPosDegrees : List ZPoly → Bool
+  | [] => true
+  | p :: ps => decide (0 < p.degree?.getD 0) && checkPosDegrees ps
+
+/-- Multiplication-checkable witnesses that a polynomial is a square-free
+carrier for the atom product of a sentence. -/
+structure CarrierCert where
+  /-- Proposed square-free carrier `P`. -/
+  carrier : ZPoly
+  /-- Repeated-factor witness `R`. -/
+  repeated : ZPoly
+  /-- Derivative quotient witness `S`. -/
+  derivPart : ZPoly
+  /-- Nonzero scale `k` in `Q = scale k (P * R)`. -/
+  factorScale : Int
+  /-- Nonzero scale `d` in `scale d Q' = R * S`. -/
+  derivScale : Int
+  /-- Generalized Sturm replay proving the carrier squarefree. -/
+  replay : SturmReplay
+
+namespace CarrierCert
+
+/-- Executable carrier validation.  The atom product is recomputed from the
+sentence and is never supplied by the certificate. -/
+@[expose]
+def check (s : Sentence) (cert : CarrierCert) : Bool :=
+  let q := s.product
+  -- `Sentence.polys` filters by this predicate; retaining the explicit walk
+  -- makes the certificate contract visible at its trust boundary.
+  checkPosDegrees s.polys &&
+  decide (0 < q.degree?.getD 0) &&
+  !cert.repeated.isZero &&
+  decide (cert.factorScale ≠ 0) &&
+  decide (cert.derivScale ≠ 0) &&
+  DensePoly.beqCoeffs q
+    (DensePoly.scale cert.factorScale (cert.carrier * cert.repeated)) &&
+  DensePoly.beqCoeffs (DensePoly.scale cert.derivScale (DensePoly.derivative q))
+    (cert.repeated * cert.derivPart) &&
+  cert.replay.check cert.carrier
+
+/-- Proposition-level facts recovered from the Boolean carrier checker. -/
+@[expose]
+def Valid (s : Sentence) (cert : CarrierCert) : Prop :=
+  let q := s.product
+  (∀ p ∈ s.polys, 0 < p.degree?.getD 0) ∧
+  0 < q.degree?.getD 0 ∧
+  cert.repeated ≠ 0 ∧
+  cert.factorScale ≠ 0 ∧
+  cert.derivScale ≠ 0 ∧
+  q = DensePoly.scale cert.factorScale (cert.carrier * cert.repeated) ∧
+  DensePoly.scale cert.derivScale (DensePoly.derivative q) =
+    cert.repeated * cert.derivPart ∧
+  cert.replay.check cert.carrier = true
+
+/-- A successful positive-degree walk proves its proposition-level form. -/
+theorem checkPosDegrees_sound {ps : List ZPoly} (h : checkPosDegrees ps = true) :
+    ∀ p ∈ ps, 0 < p.degree?.getD 0 := by
+  induction ps with
+  | nil => simp
+  | cons p ps ih =>
+      simp only [checkPosDegrees, Bool.and_eq_true, decide_eq_true_eq] at h
+      intro q hq
+      simp only [List.mem_cons] at hq
+      rcases hq with rfl | hq
+      · exact h.1
+      · exact ih h.2 q hq
+
+/-- Soundness of the executable carrier checker. -/
+theorem check_sound {s : Sentence} {cert : CarrierCert}
+    (h : cert.check s = true) : cert.Valid s := by
+  simp only [check, Bool.and_eq_true, decide_eq_true_eq] at h
+  obtain ⟨⟨⟨⟨⟨⟨⟨hdegrees, hqdeg⟩, hr0⟩, hk0⟩, hd0⟩, hfactor⟩,
+    hderiv⟩, hreplay⟩ := h
+  refine ⟨checkPosDegrees_sound hdegrees, hqdeg, ?_, hk0, hd0, ?_, ?_, hreplay⟩
+  · simp only [Bool.not_eq_true'] at hr0
+    have hr := (DensePoly.isZero_eq_false_iff cert.repeated).mp hr0
+    intro hzero
+    rw [hzero] at hr
+    simp at hr
+  · exact DensePoly.eq_of_beqCoeffs hfactor
+  · exact DensePoly.eq_of_beqCoeffs hderiv
+
+/-- An accepted carrier certificate has a nonzero carrier polynomial. -/
+theorem carrier_ne_zero {s : Sentence} {cert : CarrierCert}
+    (h : cert.check s = true) : cert.carrier ≠ 0 := by
+  obtain ⟨_hdegrees, _hqdeg, _hr0, _hk0, _hd0, _hfactor, _hderiv, hreplay⟩ :=
+    check_sound h
+  exact SturmReplay.head_ne_zero hreplay
+
+/-- An accepted carrier is squarefree after casting to real coefficients. -/
+theorem squarefree {s : Sentence} {cert : CarrierCert}
+    (h : cert.check s = true) : Squarefree (toPolyℝ cert.carrier) :=
+  by
+    obtain ⟨_hdegrees, _hqdeg, _hr0, _hk0, _hd0, _hfactor, _hderiv, hreplay⟩ :=
+      check_sound h
+    exact SturmReplay.squarefree_of_check hreplay
+
+/-- A positive literal degree implies a nonzero executable polynomial. -/
+private theorem ne_zero_of_degree_pos {p : ZPoly} (h : 0 < p.degree?.getD 0) : p ≠ 0 := by
+  intro hp
+  subst p
+  simp [DensePoly.degree?] at h
+
+/-- The recomputed atom product is nonzero for an accepted certificate. -/
+theorem product_ne_zero {s : Sentence} {cert : CarrierCert}
+    (h : cert.check s = true) : s.product ≠ 0 :=
+  ne_zero_of_degree_pos (check_sound h).2.1
+
+/-- Exact scalar-and-factor identities imply that the proposed factor and the
+original polynomial have the same real roots. -/
+theorem isRoot_factor_iff {q p r t : ZPoly} {k d : Int}
+    (hq0 : q ≠ 0) (hk0 : k ≠ 0) (hd0 : d ≠ 0)
+    (hfactorZ : q = DensePoly.scale k (p * r))
+    (hderivZ : DensePoly.scale d (DensePoly.derivative q) = r * t) (x : ℝ) :
+    (toPolyℝ p).IsRoot x ↔ (toPolyℝ q).IsRoot x := by
+  have hq0ℝ : toPolyℝ q ≠ 0 := fun hzero => hq0 (toPolyℝ_eq_zero_iff.mp hzero)
+  have hk : ((k : Int) : ℝ) ≠ 0 := by exact_mod_cast hk0
+  have hd : ((d : Int) : ℝ) ≠ 0 := by exact_mod_cast hd0
+  have hfactor := congrArg toPolyℝ hfactorZ
+  rw [toPolyℝ_scale, toPolyℝ_mul] at hfactor
+  have hderiv := congrArg toPolyℝ hderivZ
+  rw [toPolyℝ_scale, toPolyℝ_derivative, toPolyℝ_mul] at hderiv
+  have hqcr : toPolyℝ q =
+      (Polynomial.C (k : ℝ) * toPolyℝ p) * toPolyℝ r := by
+    rw [hfactor]
+    ring
+  have hrd : toPolyℝ r ∣ derivative (toPolyℝ q) := by
+    refine ⟨Polynomial.C ((d : ℝ)⁻¹) * toPolyℝ t, ?_⟩
+    have hcancel : Polynomial.C ((d : ℝ)⁻¹) *
+        Polynomial.C (d : ℝ) = (1 : ℝ[X]) := by
+      rw [← Polynomial.C_mul]
+      simp [hd]
+    calc
+      derivative (toPolyℝ q) =
+          (Polynomial.C ((d : ℝ)⁻¹) * Polynomial.C (d : ℝ)) *
+            derivative (toPolyℝ q) := by rw [hcancel, one_mul]
+      _ = Polynomial.C ((d : ℝ)⁻¹) *
+          (Polynomial.C (d : ℝ) * derivative (toPolyℝ q)) := by ring
+      _ = Polynomial.C ((d : ℝ)⁻¹) * (toPolyℝ r * toPolyℝ t) := by rw [hderiv]
+      _ = toPolyℝ r * (Polynomial.C ((d : ℝ)⁻¹) * toPolyℝ t) := by ring
+  have hgen := HexRealRootsMathlib.isRoot_left_iff_of_mul_of_dvd_derivative
+    hq0ℝ hqcr hrd x
+  have hscale :
+      (Polynomial.C (k : ℝ) * toPolyℝ p).IsRoot x ↔ (toPolyℝ p).IsRoot x := by
+    simp only [Polynomial.IsRoot, Polynomial.eval_mul, Polynomial.eval_C, mul_eq_zero]
+    simp [hk]
+  exact hscale.symm.trans hgen
+
+/-- Exact identities accepted by the checker imply that the carrier and
+recomputed atom product have the same real roots. -/
+theorem isRoot_carrier_iff_product {s : Sentence} {cert : CarrierCert}
+    (h : cert.check s = true) (x : ℝ) :
+    (toPolyℝ cert.carrier).IsRoot x ↔ (toPolyℝ s.product).IsRoot x := by
+  obtain ⟨_hdegrees, _hqdeg, _hr0, hk0, hd0, hfactor, hderiv, _hreplay⟩ :=
+    check_sound h
+  exact isRoot_factor_iff (product_ne_zero h) hk0 hd0 hfactor hderiv x
+
+end CarrierCert
+
+/-- A real root of a product of literal integer polynomials is exactly a root
+of one list member. -/
+theorem isRoot_prod_iff {ps : List ZPoly} (x : ℝ) :
+    (toPolyℝ ps.prod).IsRoot x ↔ ∃ p ∈ ps, (toPolyℝ p).IsRoot x := by
+  induction ps with
+  | nil => simp [Polynomial.IsRoot, toPolyℝ]
+  | cons p ps ih =>
+      rw [List.prod_cons, toPolyℝ_mul]
+      simp only [Polynomial.IsRoot, Polynomial.eval_mul, mul_eq_zero]
+      have ih' : (toPolyℝ ps.prod).eval x = 0 ↔
+          ∃ q ∈ ps, (toPolyℝ q).eval x = 0 := by
+        simpa only [Polynomial.IsRoot] using ih
+      rw [ih']
+      aesop
+
+/-- The accepted carrier roots are exactly the union of the roots of the
+nonconstant atom polynomials recomputed from the sentence. -/
+theorem CarrierCert.isRoot_iff_atom {s : Sentence} {cert : CarrierCert}
+    (h : cert.check s = true) (x : ℝ) :
+    (toPolyℝ cert.carrier).IsRoot x ↔
+      ∃ p ∈ s.polys, (toPolyℝ p).IsRoot x := by
+  rw [cert.isRoot_carrier_iff_product h x]
+  unfold Sentence.product
+  exact isRoot_prod_iff x
+
+end Hex.RCF

--- a/HexRCF/CarrierTests.lean
+++ b/HexRCF/CarrierTests.lean
@@ -1,0 +1,134 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.Carrier
+import all HexRCF.Carrier
+
+public section
+
+/-! Regression tests for atom collection and square-free carrier checking. -/
+
+namespace Hex.RCF.CarrierTests
+
+private def quad : ZPoly := DensePoly.ofCoeffs #[(-1 : Int), 0, 1]
+private def x : ZPoly := DensePoly.ofCoeffs #[(0 : Int), 1]
+private def one : ZPoly := DensePoly.ofCoeffs #[(1 : Int)]
+private def twiceX : ZPoly := DensePoly.ofCoeffs #[(0 : Int), 2]
+
+private def replay : SturmReplay where
+  chain := #[quad, x, one]
+  derivScale := 2
+  steps := #[{ leftScale := 1, quotient := x, rightScale := 1 }]
+
+private def formula : Formula :=
+  .and (.atom ⟨0, .eq⟩) (.or (.atom ⟨quad, .ge⟩) (.atom ⟨one, .ne⟩))
+
+private def sentence : Sentence := .forallReal formula
+
+private def cert : CarrierCert where
+  carrier := quad
+  repeated := one
+  derivPart := twiceX
+  factorScale := 1
+  derivScale := 1
+  replay := replay
+
+/-- Constant atoms are retained in the formula but omitted from the carrier. -/
+example : sentence.polys.length = 1 := by decide
+example : cert.check sentence = true := by decide
+
+example (r : ℝ) :
+    (HexRealRootsMathlib.toPolyℝ cert.carrier).IsRoot r ↔
+      ∃ p ∈ sentence.polys, (HexRealRootsMathlib.toPolyℝ p).IsRoot r :=
+  cert.isRoot_iff_atom (by decide) r
+
+private def extraSentence : Sentence :=
+  .forallReal (.and formula (.atom ⟨x, .eq⟩))
+
+private def badRepeated : CarrierCert := { cert with repeated := 0 }
+private def badFactorScale : CarrierCert := { cert with factorScale := 0 }
+private def badDerivScale : CarrierCert := { cert with derivScale := 0 }
+private def badFactor : CarrierCert := { cert with repeated := x }
+private def badDerivative : CarrierCert := { cert with derivPart := x }
+private def badReplay : CarrierCert :=
+  { cert with replay := { replay with derivScale := 3 } }
+
+/-- Changing the reflected sentence changes the recomputed product. -/
+example : cert.check extraSentence = false := by decide
+example : badRepeated.check sentence = false := by decide
+example : badFactorScale.check sentence = false := by decide
+example : badDerivScale.check sentence = false := by decide
+example : badFactor.check sentence = false := by decide
+example : badDerivative.check sentence = false := by decide
+example : badReplay.check sentence = false := by decide
+
+/-- A genuine repeated-factor carrier: `Q = x²`, `P = x`, `R = x`, and
+`Q' = x * 2`. -/
+private def repeatedSentence : Sentence :=
+  .forallReal (.and (.atom ⟨x, .ge⟩) (.atom ⟨x, .le⟩))
+
+private def linearReplay : SturmReplay where
+  chain := #[x, one]
+  derivScale := 1
+  steps := #[]
+
+private def repeatedCert : CarrierCert where
+  carrier := x
+  repeated := x
+  derivPart := DensePoly.ofCoeffs #[(2 : Int)]
+  factorScale := 1
+  derivScale := 1
+  replay := linearReplay
+
+example : linearReplay.check x = true := by decide
+example : repeatedCert.check repeatedSentence = true := by decide
+
+/-- The factor identity alone cannot justify dropping a root: for
+`Q = (x-1)(x+1)`, the derivative identity rejects `P = x-1`. -/
+private def xMinusOne : ZPoly := DensePoly.ofCoeffs #[(-1 : Int), 1]
+private def xPlusOne : ZPoly := DensePoly.ofCoeffs #[(1 : Int), 1]
+
+private def minusReplay : SturmReplay where
+  chain := #[xMinusOne, one]
+  derivScale := 1
+  steps := #[]
+
+private def droppedRoot : CarrierCert where
+  carrier := xMinusOne
+  repeated := xPlusOne
+  derivPart := DensePoly.ofCoeffs #[(2 : Int)]
+  factorScale := 1
+  derivScale := 1
+  replay := minusReplay
+
+example : minusReplay.check xMinusOne = true := by decide
+example : DensePoly.beqCoeffs sentence.product
+    (DensePoly.scale droppedRoot.factorScale
+      (droppedRoot.carrier * droppedRoot.repeated)) = true := by decide
+example : DensePoly.beqCoeffs
+    (DensePoly.scale droppedRoot.derivScale (DensePoly.derivative sentence.product))
+    (droppedRoot.repeated * droppedRoot.derivPart) = false := by decide
+example : droppedRoot.check sentence = false := by decide
+
+/-- The no-carrier branch is mandatory for constant-only formulas. -/
+private def constantSentence : Sentence := .existsReal (.atom ⟨one, .gt⟩)
+example : constantSentence.polys.isEmpty = true := by decide
+example : cert.check constantSentence = false := by decide
+
+/-- Collection covers implication/negation and bounded sentence constructors. -/
+private def bounded : Sentence :=
+  .forallIoc (Dyadic.ofInt (-2)) (Dyadic.ofInt 2)
+    (.imp (.not (.atom ⟨0, .eq⟩)) (.atom ⟨quad, .gt⟩))
+
+private def boundedExists : Sentence :=
+  .existsIoc (Dyadic.ofInt (-2)) (Dyadic.ofInt 2) (.atom ⟨quad, .eq⟩)
+
+example : bounded.polys.length = 1 := by decide
+example : boundedExists.polys.length = 1 := by decide
+
+end Hex.RCF.CarrierTests

--- a/HexRCF/Isolations.lean
+++ b/HexRCF/Isolations.lean
@@ -1,0 +1,213 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.SturmReplay
+public import HexRealRootsMathlib.LiteralIsolations
+
+public section
+
+/-!
+# Generalized literal isolations for RCF replay certificates
+
+An isolation certificate stores only raw dyadic intervals.  Its Boolean
+checker reads root counts from an independently validated `SturmReplay`, checks
+one root per interval, adjacent ordering, and completeness.  Soundness packages
+the raw intervals into `LiteralIsolations` and applies the generic semantic
+isolation theorem; it never identifies the replay with the executable
+pseudo-remainder chain.
+-/
+
+namespace Hex.RCF
+
+open HexRealRootsMathlib
+
+/-- Raw intervals proposed as an ordered, complete isolation of the roots of
+the head polynomial of a generalized Sturm replay. -/
+structure IsolationCert where
+  /-- Proposed half-open root intervals in ascending order. -/
+  intervals : Array DyadicInterval
+
+namespace IsolationCert
+
+/-- Check that every supplied interval has literal replay count one. -/
+@[expose]
+def checkCounts (replay : SturmReplay) (cert : IsolationCert) : Bool :=
+  (List.range cert.intervals.size).all fun i =>
+    if h : i < cert.intervals.size then
+      decide (replay.count (cert.intervals[i]'h) = 1)
+    else false
+
+/-- Check the emitted order in linear time using only adjacent pairs.  This is
+intentionally non-strict for half-open isolations; strict gaps are checked by
+the later cell-separation certificate. -/
+@[expose]
+def checkOrder (cert : IsolationCert) : Bool :=
+  (List.range (cert.intervals.size - 1)).all fun i =>
+    if h : i + 1 < cert.intervals.size then
+      decide ((cert.intervals[i]'(by omega)).upper ≤
+        (cert.intervals[i + 1]'h).lower)
+    else false
+
+/-- Validate literal interval counts, ordering, and total completeness.  Replay
+validation is a separate premise so an outer checker need not reduce it twice. -/
+@[expose]
+def check (replay : SturmReplay) (cert : IsolationCert) : Bool :=
+  cert.checkCounts replay && cert.checkOrder &&
+    decide (replay.total = (cert.intervals.size : Int))
+
+/-- Every interval accepted by the count walk has literal count one. -/
+theorem count_one_of_check {replay : SturmReplay} {cert : IsolationCert}
+    (h : cert.checkCounts replay = true) (i : Fin cert.intervals.size) :
+    replay.count cert.intervals[i] = 1 := by
+  have hmem : i.val ∈ List.range cert.intervals.size := List.mem_range.mpr i.isLt
+  have hcount := (List.all_eq_true.mp h) i.val hmem
+  simp only [i.isLt, dif_pos] at hcount
+  exact of_decide_eq_true hcount
+
+/-- Each adjacent interval pair accepted by the order walk is separated in the
+non-strict half-open sense. -/
+theorem adjacent_of_check {cert : IsolationCert} (h : cert.checkOrder = true)
+    (i : Nat) (hi : i + 1 < cert.intervals.size) :
+    (cert.intervals[i]'(by omega)).upper ≤
+      (cert.intervals[i + 1]'hi).lower := by
+  have hmem : i ∈ List.range (cert.intervals.size - 1) := List.mem_range.mpr (by omega)
+  have hstep := (List.all_eq_true.mp h) i hmem
+  simp only [hi, dif_pos] at hstep
+  exact of_decide_eq_true hstep
+
+/-- `Dyadic` version of `le_of_lt`, derived from the core total order API. -/
+private theorem dyadic_le_of_lt {a b : Dyadic} (h : a < b) : a ≤ b := by
+  rcases Dyadic.le_total a b with hle | hle
+  · exact hle
+  · exact absurd h (Dyadic.not_le.mpr hle)
+
+/-- Adjacent ordering implies the all-pairs ordering used by
+`LiteralIsolations`. -/
+theorem ordered_of_check {cert : IsolationCert} (h : cert.checkOrder = true) :
+    ∀ i j : Fin cert.intervals.size, i < j →
+      cert.intervals[i].upper ≤ cert.intervals[j].lower := by
+  have aux : ∀ (j : Nat) (hj : j < cert.intervals.size) (i : Nat) (_hij : i < j),
+      (cert.intervals[i]'(by omega)).upper ≤ (cert.intervals[j]'hj).lower := by
+    intro j
+    induction j with
+    | zero => intro _ i hij; omega
+    | succ j ih =>
+        intro hj i hij
+        rcases Nat.lt_or_ge i j with hlt | hge
+        · have hjlt : j < cert.intervals.size := by omega
+          have step1 := ih hjlt i hlt
+          have step2 : (cert.intervals[j]'hjlt).lower ≤
+              (cert.intervals[j]'hjlt).upper :=
+            dyadic_le_of_lt (cert.intervals[j]'hjlt).lt
+          have step3 := adjacent_of_check h j (by omega)
+          exact Dyadic.le_trans step1 (Dyadic.le_trans step2 step3)
+        · have hij' : i = j := by omega
+          subst hij'
+          exact adjacent_of_check h i (by omega)
+  intro i j hij
+  exact aux j.val j.isLt i.val hij
+
+/-- The completeness equality recovered from the Boolean isolation checker. -/
+theorem complete_of_check {replay : SturmReplay} {cert : IsolationCert}
+    (h : cert.check replay = true) :
+    replay.total = (cert.intervals.size : Int) := by
+  simp only [check, Bool.and_eq_true, decide_eq_true_eq] at h
+  exact h.2
+
+/-- The count component recovered from the combined checker. -/
+theorem counts_of_check {replay : SturmReplay} {cert : IsolationCert}
+    (h : cert.check replay = true) : cert.checkCounts replay = true := by
+  simp only [check, Bool.and_eq_true] at h
+  exact h.1.1
+
+/-- The order component recovered from the combined checker. -/
+theorem order_of_check {replay : SturmReplay} {cert : IsolationCert}
+    (h : cert.check replay = true) : cert.checkOrder = true := by
+  simp only [check, Bool.and_eq_true] at h
+  exact h.1.2
+
+/-- Package an accepted raw certificate into the generic literal-isolation
+interface. -/
+def toLiteral (replay : SturmReplay) (cert : IsolationCert)
+    (h : cert.check replay = true) :
+    LiteralIsolations replay.count replay.total where
+  isolations := cert.intervals.mapFinIdx fun i _ hi =>
+    { interval := cert.intervals[i]'hi
+      count_one := count_one_of_check (counts_of_check h) ⟨i, hi⟩ }
+  ordered := by
+    intro i j hij
+    let i' : Fin cert.intervals.size := ⟨i.val, by simpa using i.isLt⟩
+    let j' : Fin cert.intervals.size := ⟨j.val, by simpa using j.isLt⟩
+    have hij' : i' < j' := by simpa [i', j'] using hij
+    have hord := ordered_of_check (order_of_check h) i' j' hij'
+    simpa [i', j'] using hord
+  complete := by
+    simpa using complete_of_check h
+
+@[simp] theorem size_toLiteral (replay : SturmReplay) (cert : IsolationCert)
+    (h : cert.check replay = true) :
+    (cert.toLiteral replay h).isolations.size = cert.intervals.size := by
+  simp [toLiteral]
+
+theorem interval_toLiteral (replay : SturmReplay) (cert : IsolationCert)
+    (h : cert.check replay = true)
+    (i : Nat) (hi : i < (cert.toLiteral replay h).isolations.size) :
+    ((cert.toLiteral replay h).isolations[i]'hi).interval =
+      cert.intervals[i]'(by simpa using hi) := by
+  simp [toLiteral]
+
+/-- Every accepted interval contains exactly one real root of the replay head. -/
+theorem exists_unique_root_of_check {f : ZPoly} {replay : SturmReplay}
+    {cert : IsolationCert} (hreplay : replay.check f = true)
+    (hcert : cert.check replay = true) (i : Fin cert.intervals.size) :
+    ∃! r : ℝ, (toPolyℝ f).IsRoot r ∧
+      Literal.InInterval cert.intervals[i] r := by
+  let iso : LiteralIsolation replay.count :=
+    { interval := cert.intervals[i]
+      count_one := count_one_of_check (counts_of_check hcert) i }
+  exact iso.exists_unique_root (SturmReplay.head_ne_zero hreplay)
+    (SturmReplay.count_eq_card_roots hreplay iso.interval)
+
+/-- Accepted raw intervals isolate every real root of the replay head at a
+unique original array index. -/
+theorem isolates_of_check {f : ZPoly} {replay : SturmReplay} {cert : IsolationCert}
+    (hreplay : replay.check f = true) (hcert : cert.check replay = true) :
+    ∀ r : ℝ, (toPolyℝ f).IsRoot r →
+      ∃! i : Fin cert.intervals.size,
+        Literal.InInterval cert.intervals[i] r := by
+  let out := cert.toLiteral replay hcert
+  have hout := out.isolates (SturmReplay.head_ne_zero hreplay)
+    (SturmReplay.squarefree_of_check hreplay)
+    (fun i => SturmReplay.count_eq_card_roots hreplay out.isolations[i].interval)
+    (SturmReplay.total_eq_card_roots hreplay)
+  intro r hr
+  obtain ⟨i, hi, huniq⟩ := hout r hr
+  have hiBound : i.val < cert.intervals.size := by
+    simpa only [out, size_toLiteral] using i.isLt
+  let i' : Fin cert.intervals.size := ⟨i.val, hiBound⟩
+  refine ⟨i', ?_, ?_⟩
+  · rw [show out.isolations[i].interval = cert.intervals[i'] by
+      simpa only [out, i', Fin.getElem_fin] using
+        interval_toLiteral replay cert hcert i.val i.isLt] at hi
+    exact hi
+  · intro j hj
+    have hjBound : j.val < out.isolations.size := by
+      simpa only [out, size_toLiteral] using j.isLt
+    let j' : Fin out.isolations.size := ⟨j.val, hjBound⟩
+    have hj' : Literal.InInterval out.isolations[j'].interval r := by
+      rw [show out.isolations[j'].interval = cert.intervals[j] by
+        simpa only [out, j', Fin.getElem_fin] using
+          interval_toLiteral replay cert hcert j'.val j'.isLt]
+      exact hj
+    have hji : j' = i := huniq j' hj'
+    apply Fin.ext
+    simpa only [j', i'] using congrArg Fin.val hji
+
+end IsolationCert
+
+end Hex.RCF

--- a/HexRCF/IsolationsTests.lean
+++ b/HexRCF/IsolationsTests.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.Isolations
+public import HexRCF.SturmBuilder
+import all HexRCF.Isolations
+import all HexRCF.SturmBuilder
+
+public section
+
+/-! Regression tests for raw generalized literal isolation certificates. -/
+
+namespace Hex.RCF.IsolationsTests
+
+private def quad : ZPoly := DensePoly.ofCoeffs #[(-1 : Int), 0, 1]
+private def x : ZPoly := DensePoly.ofCoeffs #[(0 : Int), 1]
+private def one : ZPoly := DensePoly.ofCoeffs #[(1 : Int)]
+
+private def replay : SturmReplay where
+  chain := #[quad, x, one]
+  derivScale := 2
+  steps := #[{ leftScale := 1, quotient := x, rightScale := 1 }]
+
+private def left : DyadicInterval :=
+  DyadicInterval.mk (Dyadic.ofInt (-2)) (Dyadic.ofInt 0) (by decide)
+
+private def right : DyadicInterval :=
+  DyadicInterval.mk (Dyadic.ofInt 0) (Dyadic.ofInt 2) (by decide)
+
+private def wide : DyadicInterval :=
+  DyadicInterval.mk (Dyadic.ofInt (-2)) (Dyadic.ofInt 2) (by decide)
+
+private def outside : DyadicInterval :=
+  DyadicInterval.mk (Dyadic.ofInt 2) (Dyadic.ofInt 3) (by decide)
+
+private def overlap : DyadicInterval :=
+  DyadicInterval.mk ((Dyadic.ofInt (-1)) >>> (1 : Int))
+    (Dyadic.ofInt 2) (by decide)
+
+private def valid : IsolationCert := ⟨#[left, right]⟩
+private def wrongCount : IsolationCert := ⟨#[left, outside]⟩
+private def doubleCount : IsolationCert := ⟨#[wide, right]⟩
+private def wrongOrder : IsolationCert := ⟨#[left, overlap]⟩
+private def incomplete : IsolationCert := ⟨#[left]⟩
+private def duplicate : IsolationCert := ⟨#[left, left]⟩
+private def reversed : IsolationCert := ⟨#[right, left]⟩
+private def empty : IsolationCert := ⟨#[]⟩
+
+/-- Touching endpoints are valid for ordered half-open isolations. -/
+example : valid.check replay = true := by decide
+example : wrongCount.check replay = false := by decide
+example : doubleCount.check replay = false := by decide
+example : wrongOrder.check replay = false := by decide
+example : incomplete.check replay = false := by decide
+example : duplicate.check replay = false := by decide
+example : reversed.check replay = false := by decide
+example : empty.check replay = false := by decide
+
+example : ∃! r : ℝ, (HexRealRootsMathlib.toPolyℝ quad).IsRoot r ∧
+    HexRealRootsMathlib.Literal.InInterval (valid.intervals[0]'(by decide)) r :=
+  IsolationCert.exists_unique_root_of_check
+    (f := quad) (replay := replay) (cert := valid) (by decide) (by decide)
+      ⟨0, by decide⟩
+
+example : ∀ r : ℝ, (HexRealRootsMathlib.toPolyℝ quad).IsRoot r →
+    ∃! i : Fin valid.intervals.size,
+      HexRealRootsMathlib.Literal.InInterval valid.intervals[i] r :=
+  IsolationCert.isolates_of_check (f := quad) (replay := replay) (cert := valid)
+    (by decide) (by decide)
+
+/-- An empty isolation array is valid for a squarefree polynomial with no real
+roots, while replay validity remains an independent outer obligation. -/
+private def noRoots : ZPoly := DensePoly.ofCoeffs #[(1 : Int), 0, 1]
+
+example : (buildSturmReplay? noRoots).map
+    (fun r => r.check noRoots && empty.check r) = some true := by
+  decide
+
+example : replay.check noRoots = false := by decide
+
+end Hex.RCF.IsolationsTests

--- a/HexRCF/SturmReplay.lean
+++ b/HexRCF/SturmReplay.lean
@@ -204,6 +204,13 @@ theorem check_sound {f : ZPoly} {cert : SturmReplay}
       · exact checkDegrees_sound hdegrees
       · exact DensePoly.eq_of_beqCoeffs hderiv
 
+/-- The head of an accepted replay is nonzero. -/
+theorem head_ne_zero {f : ZPoly} {cert : SturmReplay}
+    (h : cert.check f = true) : f ≠ 0 := by
+  obtain ⟨s₁, rest, _hchain, _hrep, hnz, _hdegrees, _hpos, _hderiv, _hcount⟩ :=
+    check_sound h
+  exact hnz f (by simp)
+
 /-- An accepted replay is a Sturm chain after casting its literal entries to
 real polynomials. -/
 theorem isChain_of_check {f : ZPoly} {cert : SturmReplay}

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -503,6 +503,13 @@ free to change.
   emits replay witnesses and retains only checker-approved candidates;
   `HexRCF/SturmBuilderTests.lean`: valid, malformed, nonprimitive, and
   nonsquarefree regressions.
+- `HexRCF/Carrier.lean`: deterministic nonconstant-atom collection, the
+  multiplication-checkable carrier certificate, and root-set soundness;
+  `HexRCF/CarrierTests.lean`: constant filtering, genuine repeated-factor,
+  dropped-root, and other tampered-carrier regressions.
+- `HexRCF/Isolations.lean`: the raw generalized isolation checker and its
+  bridge to literal isolation semantics; `HexRCF/IsolationsTests.lean`:
+  count, order, completeness, and no-real-root regressions.
 - `HexRCF/Certificate.lean`: `Certificate`, `check`, `decide`.
 - `HexRCF/Cells.lean`: separation refinement, cell construction,
   endpoint classification for bounded sentences.

--- a/progress/20260727T063743Z_rcf-carrier-isolations.md
+++ b/progress/20260727T063743Z_rcf-carrier-isolations.md
@@ -1,0 +1,37 @@
+# RCF carrier and generalized isolations
+
+## Accomplished
+
+- Added deterministic collection of nonconstant atom polynomials and their
+  recomputed product from arbitrary reflected sentences.
+- Added a multiplication-only carrier certificate checker for the factor and
+  derivative identities, with soundness proving carrier/product root equality,
+  squarefreeness, and the atom-root union.
+- Added raw generalized isolation certificates whose checker validates literal
+  replay counts, adjacent dyadic ordering, and total completeness.
+- Bridged accepted raw intervals to the existing literal-isolation semantics,
+  exposing both one-root-per-interval and every-root-isolated theorems.
+- Added positive and adversarial tests, including a genuine repeated factor,
+  a factor-valid carrier that drops a root and fails the derivative identity,
+  constant atoms, malformed scales/factors/replays, touching intervals,
+  overlaps, duplicates, reversed order, incompleteness, and an empty valid
+  isolation set for a polynomial with no real roots.
+- Updated the RCF umbrella and SPEC file-organization notes. Full `HexRCF` and
+  `HexRealRootsMathlib` builds and repository policy checks pass.
+
+## Current frontier
+
+The kernel checker now has a certified square-free carrier whose roots are
+exactly the nonconstant atom roots, plus ordered complete literal isolations of
+that carrier. The strict separation, endpoint classification, and cell
+partition layers have not yet been implemented.
+
+## Next step
+
+Implement the structurally fuel-bounded separation pass and a strict-gap
+certificate checker, then define root/open cells and prove their partition and
+bounded-endpoint classification facts.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #8905.

## Summary

- recompute nonconstant atom polynomials and their product from reflected sentences
- validate multiplication-only carrier factor and derivative identities plus a generalized Sturm replay
- prove accepted carrier roots equal the recomputed product roots and the union of atom roots
- validate raw generalized isolations by replay count, adjacent order, and total completeness
- bridge accepted intervals to one-root and complete-isolation semantics
- add positive and adversarial regressions, including repeated factors and a factor-valid dropped-root candidate rejected by the derivative identity

## Validation

- lake build HexRCF HexRealRootsMathlib
- copyright, line-count, DAG, phase-4, and Mathlib-free bench policy checks
- no sorry, axiom, or native_decide in changed Lean files

## Independent review

Two fresh Claude Opus reviews audited the algebra, dependent array transport, trust boundary, and tests. The first found no soundness blockers and requested the repeated-factor and dropped-root regressions. After those additions, the second returned merge-ready with no blockers.