### PR TITLE
feat(number-field): add algebraic polynomial boundary

### DIFF
--- a/HexNumberField.lean
+++ b/HexNumberField.lean
@@ -12,6 +12,7 @@ public import HexNumberField.QAdjoin
 public import HexNumberField.Convert
 public import HexNumberField.Lazy
 public import HexNumberField.Disambiguate
+public import HexNumberField.AlgebraicPoly
 
 public section
 

--- a/HexNumberField/AlgebraicPoly.lean
+++ b/HexNumberField/AlgebraicPoly.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexNumberField.Disambiguate
+public meta import HexNumberField.Disambiguate
+
+public section
+
+/-!
+Polynomials with canonical algebraic coefficients.
+
+This representation owns semantic trailing-zero normalization. In particular,
+the Mathlib-free layer never instantiates `DensePoly AlgebraicNumber`: its
+normalizer would require a kernel `DecidableEq`, while canonical algebraic
+equality is intentionally exposed here only through checked Boolean equality.
+-/
+namespace Hex
+
+/-- A semantically normalized polynomial with canonical algebraic
+coefficients. Construction is sealed so every stored array has had its
+trailing semantic zeros removed. -/
+structure AlgebraicPoly where
+  private mk ::
+  data : Array AlgebraicNumber
+
+namespace AlgebraicPoly
+
+/-- Construct a polynomial and remove all trailing coefficients whose
+canonical minimal polynomial is `X`. -/
+def ofArray (coeffs : Array AlgebraicNumber) : AlgebraicPoly :=
+  .mk (coeffs.popWhile fun a => a.isZero)
+
+/-- The normalized coefficient array, in increasing degree order. -/
+@[expose]
+def coeffs (f : AlgebraicPoly) : Array AlgebraicNumber :=
+  f.data
+
+/-- Number of stored coefficients. -/
+@[expose]
+def size (f : AlgebraicPoly) : Nat :=
+  f.data.size
+
+/-- Coefficient at degree `n`, defaulting to canonical zero. -/
+@[expose]
+def coeff (f : AlgebraicPoly) (n : Nat) : AlgebraicNumber :=
+  f.data.getD n 0
+
+/-- Semantic zero test. -/
+@[expose]
+def isZero (f : AlgebraicPoly) : Bool :=
+  f.data.isEmpty
+
+/-- Degree of a nonzero polynomial. -/
+@[expose]
+def degree? (f : AlgebraicPoly) : Option Nat :=
+  if f.isZero then none else some (f.size - 1)
+
+/-- Canonical coefficientwise Boolean equality. -/
+@[expose]
+def beq (f g : AlgebraicPoly) : Bool :=
+  f.data == g.data
+
+instance : BEq AlgebraicPoly := ⟨beq⟩
+
+/-! Compiled semantic-normalization checks. -/
+
+#guard
+    let z := AlgebraicNumber.zero
+    let f := ofArray #[z, z, z]
+    f.isZero && f.coeffs.isEmpty && f.degree? = none
+
+#guard
+    let z := AlgebraicNumber.zero
+    let f := ofArray #[]
+    let g := ofArray #[z]
+    f == g && (f.coeff 17).isZero
+
+end AlgebraicPoly
+end Hex

--- a/HexNumberField/AlgebraicPoly.lean
+++ b/HexNumberField/AlgebraicPoly.lean
@@ -21,19 +21,43 @@ equality is intentionally exposed here only through checked Boolean equality.
 -/
 namespace Hex
 
+/-- A coefficient array has no trailing semantic zero. This erased invariant
+is carried by `AlgebraicPoly` so downstream correctness theorems may quantify
+over every value, rather than only values visibly built by `ofArray`. -/
+@[expose]
+def AlgebraicPolyNormalized (coeffs : Array AlgebraicNumber) : Prop :=
+  match coeffs.toList.reverse.head? with
+  | some a => a.isZero = false
+  | none => True
+
 /-- A semantically normalized polynomial with canonical algebraic
 coefficients. Construction is sealed so every stored array has had its
 trailing semantic zeros removed. -/
 structure AlgebraicPoly where
   private mk ::
   data : Array AlgebraicNumber
+  normalized : AlgebraicPolyNormalized data
 
 namespace AlgebraicPoly
+
+private theorem normalized_popWhile (coeffs : Array AlgebraicNumber) :
+    AlgebraicPolyNormalized (coeffs.popWhile fun a => a.isZero) := by
+  change
+    match
+        (coeffs.popWhile fun a => a.isZero).toList.reverse.head? with
+    | some a => a.isZero = false
+    | none => True
+  rw [← Array.toArray_toList (xs := coeffs)]
+  simp only [List.popWhile_toArray, List.toList_toArray,
+    List.reverse_reverse]
+  have h := List.head?_dropWhile_not
+    (fun a : AlgebraicNumber => a.isZero) coeffs.toList.reverse
+  split at * <;> simp_all
 
 /-- Construct a polynomial and remove all trailing coefficients whose
 canonical minimal polynomial is `X`. -/
 def ofArray (coeffs : Array AlgebraicNumber) : AlgebraicPoly :=
-  .mk (coeffs.popWhile fun a => a.isZero)
+  .mk (coeffs.popWhile fun a => a.isZero) (normalized_popWhile coeffs)
 
 /-- The normalized coefficient array, in increasing degree order. -/
 @[expose]

--- a/progress/20260727T064155Z_numberfield-algebraic-poly.md
+++ b/progress/20260727T064155Z_numberfield-algebraic-poly.md
@@ -1,0 +1,28 @@
+# HexNumberField algebraic-polynomial representation
+
+## Accomplished
+
+- Added the constructor-sealed `AlgebraicPoly` representation for arrays of
+  canonical algebraic coefficients.
+- Made `ofArray` remove semantic trailing zeros through
+  `AlgebraicNumber.isZero`, without requiring a kernel `DecidableEq` instance.
+- Added normalized coefficient access, size, degree, zero, and Boolean equality
+  operations together with compiled zero-normalization checks.
+- Exported the new module from the `HexNumberField` umbrella and rebuilt both
+  targets successfully.
+
+## Current frontier
+
+The Mathlib-free algebraic-coefficient polynomial boundary is complete. The
+next implementation layer is fixed-field root computation: squarefree
+decomposition, norm eliminants, isolation, and bounded embedding
+disambiguation.
+
+## Next step
+
+Implement the fixed-field polynomial/root primitives and then expose
+`QAdjoin.roots?` and its total wrapper.
+
+## Blockers
+
+None.

--- a/progress/20260727T070937Z_numberfield-algebraic-poly-review.md
+++ b/progress/20260727T070937Z_numberfield-algebraic-poly-review.md
@@ -1,0 +1,27 @@
+# HexNumberField AlgebraicPoly review repair
+
+## Accomplished
+
+- Verified the independent review's representation-level counterexample:
+  constructor privacy alone did not make trailing-zero normalization available
+  to theorems quantified over every `AlgebraicPoly`.
+- Added the erased `AlgebraicPolyNormalized` invariant to the private
+  representation and proved that semantic `Array.popWhile` establishes it.
+- Retained the private constructor boundary; downstream companion proofs can
+  use the public `normalized` projection without unfolding the smart
+  constructor.
+- Rebuilt `HexNumberField.AlgebraicPoly` successfully.
+
+## Current frontier
+
+The central companion obligation `AlgebraicPoly.isZero_iff` is no longer
+refutable by a malformed trailing-zero inhabitant.
+
+## Next step
+
+Push the repair, rebase the fixed-field and common-field root milestones over
+it, and continue with the tower layer while outstanding reviews run.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Adds the Mathlib-free polynomial representation for canonical algebraic coefficients.

- seals construction behind semantic trailing-zero normalization
- exposes coefficient, size, degree, zero, and canonical Boolean equality operations
- adds compiled normalization checks and umbrella export

Stacked on #8908.

Verification: `lake build HexNumberField.AlgebraicPoly HexNumberField`