### PR TITLE
Number field tower: checked rational extensions

### DIFF
--- a/HexNumberFieldTower.lean
+++ b/HexNumberFieldTower.lean
@@ -8,6 +8,7 @@ module
 
 public import HexNumberFieldTower.Basic
 public import HexNumberFieldTower.Arithmetic
+public import HexNumberFieldTower.Embed
 
 public section
 

--- a/HexNumberFieldTower/Basic.lean
+++ b/HexNumberFieldTower/Basic.lean
@@ -137,7 +137,7 @@ structure Extension (T : NumberTower) where
 complex root fixed and only normalizes a possible global sign. -/
 @[expose]
 def positiveAssociate (p : ZPoly) : ZPoly :=
-  if p.leadingCoeff < 0 then DensePoly.scale (-1 : Int) p else p
+  ZPoly.normalizePrimitiveSign p
 
 /-- Checked integer irreducibility forces primitive content. -/
 theorem positiveAssociate_primitive (p : ZPoly)
@@ -199,26 +199,28 @@ def ofQAdjoin {p : ZPoly} {x : SimpleRoot p}
       x := SimpleRoot.mk qrep
       rep := qrep
       rep_mk := rfl }
-  let d := p.degree?.getD 0
-  let leading : Rat := p.leadingCoeff
+  let d := q.degree?.getD 0
+  let leading : Rat := q.leadingCoeff
   let defining := ((List.range d).map fun i =>
-    #[(p.coeff i : Rat) / leading]).toArray
-  let level : Level := ⟨d, defining, root⟩
-  let tower : NumberTower := .mk #[level] (by
-    change level.Valid 1 ∧ True
-    constructor
-    · refine ⟨checked.pos_degree, by simp [level, defining], ?_⟩
-      intro i hi
-      simp [level, defining]
-    · trivial)
-  let generatorCoeffs := if d = 1 then
-    #[-((p.coeff 0 : Rat) / leading)]
+    #[(q.coeff i : Rat) / leading]).toArray
+  if hd : d = 1 then
+    { tower := rat
+      embed := id
+      gen := ofRat rat (-((q.coeff 0 : Rat) / leading))
+      root }
   else
-    #[0, 1]
-  { tower
-    embed := fun a => ofRat tower ((coeffs a).getD 0 0)
-    gen := ofCoeffs tower generatorCoeffs
-    root }
+    let level : Level := ⟨d, defining, root⟩
+    let tower : NumberTower := .mk #[level] (by
+      change level.Valid 1 ∧ True
+      constructor
+      · refine ⟨root.pos_degree, by simp [level, defining], ?_⟩
+        intro i hi
+        simp [level, defining]
+      · trivial)
+    { tower
+      embed := fun a => ofRat tower ((coeffs a).getD 0 0)
+      gen := ofCoeffs tower #[0, 1]
+      root }
 
 /-! Compiled representation checks. -/
 

--- a/HexNumberFieldTower/Basic.lean
+++ b/HexNumberFieldTower/Basic.lean
@@ -125,6 +125,101 @@ instance {T : NumberTower} : DecidableEq (Elem T) := fun a b =>
 def ofRat (T : NumberTower) (q : Rat) : Elem T :=
   ofCoeffs T #[q]
 
+/-- A dependent extension result carries the canonical lower-field embedding,
+the new generator, and its selected absolute algebraic root. -/
+structure Extension (T : NumberTower) where
+  tower : NumberTower
+  embed : Elem T → Elem tower
+  gen : Elem tower
+  root : AlgebraicRoot
+
+/-- Primitive associate with positive leading coefficient. This leaves every
+complex root fixed and only normalizes a possible global sign. -/
+@[expose]
+def positiveAssociate (p : ZPoly) : ZPoly :=
+  if p.leadingCoeff < 0 then DensePoly.scale (-1 : Int) p else p
+
+/-- Checked integer irreducibility forces primitive content. -/
+theorem positiveAssociate_primitive (p : ZPoly)
+    (checked : ZPoly.CheckedIrreducible p) :
+    ZPoly.Primitive (positiveAssociate p) := by
+  sorry
+
+/-- A checked positive-degree polynomial's positive associate has positive
+leading coefficient. -/
+theorem positiveAssociate_lc_pos (p : ZPoly)
+    (checked : ZPoly.CheckedIrreducible p) :
+    0 < (positiveAssociate p).leadingCoeff := by
+  sorry
+
+/-- Sign association preserves positive degree. -/
+theorem positiveAssociate_degree_pos (p : ZPoly)
+    (checked : ZPoly.CheckedIrreducible p) :
+    0 < (positiveAssociate p).degree?.getD 0 := by
+  sorry
+
+/-- Sign association preserves the executable simple-root certificate. -/
+theorem positiveAssociate_simple (p : ZPoly) (hsf : HasOnlySimpleRoots p) :
+    HasOnlySimpleRoots (positiveAssociate p) := by
+  sorry
+
+/-- A root atom is unchanged by multiplication of its polynomial by `-1`. -/
+theorem atomWitness_positiveAssociate {p : ZPoly} {square : DyadicSquare}
+    (h : atomWitness p square) :
+    atomWitness (positiveAssociate p) square := by
+  sorry
+
+/-- Global sign normalization preserves the Mahler refinement precision. -/
+theorem mahlerPrec_positiveAssociate (p : ZPoly) :
+    mahlerPrec (positiveAssociate p) = mahlerPrec p := by
+  sorry
+
+/-- Transport a refined isolation across global sign normalization. -/
+def RefinedIsolation.positiveAssociate {p : ZPoly}
+    (rep : RefinedIsolation p) : RefinedIsolation (positiveAssociate p) :=
+  ⟨⟨rep.1.square, atomWitness_positiveAssociate rep.1.witness⟩, by
+    rw [mahlerPrec_positiveAssociate]
+    exact rep.2⟩
+
+/-- Build a one-level tower for a checked rational presentation. The level
+relation is the monic rational associate of `p`; its absolute generator uses
+the supplied isolation, transported only across a possible global sign. -/
+def ofQAdjoin {p : ZPoly} {x : SimpleRoot p}
+    [checked : ZPoly.CheckedIrreducible p]
+    (hsf : HasOnlySimpleRoots p) (rep : RefinedIsolation p)
+    (_h : SimpleRoot.mk rep = x) : Extension rat :=
+  let q := positiveAssociate p
+  let qrep := NumberTower.RefinedIsolation.positiveAssociate rep
+  let root : AlgebraicRoot :=
+    { p := q
+      prim := positiveAssociate_primitive p checked
+      pos_lc := positiveAssociate_lc_pos p checked
+      pos_degree := positiveAssociate_degree_pos p checked
+      squarefree := positiveAssociate_simple p hsf
+      x := SimpleRoot.mk qrep
+      rep := qrep
+      rep_mk := rfl }
+  let d := p.degree?.getD 0
+  let leading : Rat := p.leadingCoeff
+  let defining := ((List.range d).map fun i =>
+    #[(p.coeff i : Rat) / leading]).toArray
+  let level : Level := ⟨d, defining, root⟩
+  let tower : NumberTower := .mk #[level] (by
+    change level.Valid 1 ∧ True
+    constructor
+    · refine ⟨checked.pos_degree, by simp [level, defining], ?_⟩
+      intro i hi
+      simp [level, defining]
+    · trivial)
+  let generatorCoeffs := if d = 1 then
+    #[-((p.coeff 0 : Rat) / leading)]
+  else
+    #[0, 1]
+  { tower
+    embed := fun a => ofRat tower ((coeffs a).getD 0 0)
+    gen := ofCoeffs tower generatorCoeffs
+    root }
+
 /-! Compiled representation checks. -/
 
 #guard rat.dim = 1 && rat.height = 0

--- a/HexNumberFieldTower/Embed.lean
+++ b/HexNumberFieldTower/Embed.lean
@@ -45,7 +45,8 @@ private def embedSqrtTwoRoot : SimpleRoot embedSqrtTwoPoly :=
           coeffs (extension.gen * extension.gen) = #[2, 0] &&
           coeffs (extension.gen⁻¹) = #[0, 1 / 2] &&
           coeffs (extension.embed (ofRat rat 3)) = #[3, 0] &&
-          extension.root.p = embedSqrtTwoPoly
+          extension.root.p = embedSqrtTwoPoly &&
+          extension.root.rep.1.square = embedSqrtTwoSquare
       else
         false
     else
@@ -69,7 +70,91 @@ private def embedNegSqrtTwoRoot : SimpleRoot embedNegSqrtTwoPoly :=
         let extension := ofQAdjoin (x := embedNegSqrtTwoRoot)
           hsimple embedNegSqrtTwoRep rfl
         extension.root.p = embedSqrtTwoPoly &&
+          extension.root.rep.1.square = embedSqrtTwoSquare &&
           coeffs (extension.gen * extension.gen) = #[2, 0]
+      else
+        false
+    else
+      false
+
+-- The negative conjugate must stay negative; quotient arithmetic alone cannot
+-- distinguish this fixed embedding from the positive-root presentation.
+private def embedNegRootSquare : DyadicSquare :=
+  ⟨Dyadic.ofIntWithPrec (-181) 7, 0, 8⟩
+
+private def embedNegRootRep : RefinedIsolation embedSqrtTwoPoly :=
+  ⟨⟨embedNegRootSquare, by decide⟩, by decide⟩
+
+private def embedNegRoot : SimpleRoot embedSqrtTwoPoly :=
+  SimpleRoot.mk embedNegRootRep
+
+#guard
+    if hirred : ZPoly.isIrreducible embedSqrtTwoPoly = true then
+      letI : ZPoly.CheckedIrreducible embedSqrtTwoPoly :=
+        ⟨hirred, by decide⟩
+      if hsimple : HasOnlySimpleRoots embedSqrtTwoPoly then
+        let extension := ofQAdjoin (x := embedNegRoot)
+          hsimple embedNegRootRep rfl
+        extension.root.rep.1.square = embedNegRootSquare &&
+          extension.root.rep.1.square != embedSqrtTwoSquare
+      else
+        false
+    else
+      false
+
+-- A rational root is already in the base tower and must not create a second,
+-- height-one representation of `ℚ`.
+private def embedThreeHalvesPoly : ZPoly := DensePoly.ofList [-3, 2]
+
+private def embedThreeHalvesSquare : DyadicSquare :=
+  ⟨Dyadic.ofIntWithPrec 3 1, 0, 8⟩
+
+private def embedThreeHalvesRep : RefinedIsolation embedThreeHalvesPoly :=
+  ⟨⟨embedThreeHalvesSquare, by decide⟩, by decide⟩
+
+private def embedThreeHalvesRoot : SimpleRoot embedThreeHalvesPoly :=
+  SimpleRoot.mk embedThreeHalvesRep
+
+#guard
+    if hirred : ZPoly.isIrreducible embedThreeHalvesPoly = true then
+      letI : ZPoly.CheckedIrreducible embedThreeHalvesPoly :=
+        ⟨hirred, by decide⟩
+      if hsimple : HasOnlySimpleRoots embedThreeHalvesPoly then
+        let extension := ofQAdjoin (x := embedThreeHalvesRoot)
+          hsimple embedThreeHalvesRep rfl
+        extension.tower.height = 0 && extension.tower.dim = 1 &&
+          coeffs extension.gen = #[3 / 2] &&
+          coeffs (extension.embed (ofRat rat 7)) = #[7]
+      else
+        false
+    else
+      false
+
+-- Non-unit leading coefficients exercise the rational monic normalization,
+-- not merely the global-sign case.
+private def embedSqrtThreeHalvesPoly : ZPoly :=
+  DensePoly.ofList [-3, 0, 2]
+
+private def embedSqrtThreeHalvesSquare : DyadicSquare :=
+  ⟨Dyadic.ofIntWithPrec 157 7, 0, 9⟩
+
+private def embedSqrtThreeHalvesRep :
+    RefinedIsolation embedSqrtThreeHalvesPoly :=
+  ⟨⟨embedSqrtThreeHalvesSquare, by decide⟩, by decide⟩
+
+private def embedSqrtThreeHalvesRoot :
+    SimpleRoot embedSqrtThreeHalvesPoly :=
+  SimpleRoot.mk embedSqrtThreeHalvesRep
+
+#guard
+    if hirred : ZPoly.isIrreducible embedSqrtThreeHalvesPoly = true then
+      letI : ZPoly.CheckedIrreducible embedSqrtThreeHalvesPoly :=
+        ⟨hirred, by decide⟩
+      if hsimple : HasOnlySimpleRoots embedSqrtThreeHalvesPoly then
+        let extension := ofQAdjoin (x := embedSqrtThreeHalvesRoot)
+          hsimple embedSqrtThreeHalvesRep rfl
+        extension.root.rep.1.square = embedSqrtThreeHalvesSquare &&
+          coeffs (extension.gen * extension.gen) = #[3 / 2, 0]
       else
         false
     else

--- a/HexNumberFieldTower/Embed.lean
+++ b/HexNumberFieldTower/Embed.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexNumberFieldTower.Arithmetic
+public meta import HexNumberFieldTower.Arithmetic
+
+public section
+
+/-!
+# Checked tower embeddings
+
+The rational smart constructor builds a one-level tower from a checked
+irreducible integer polynomial and a selected refined isolation. Its defining
+relation is the monic rational associate of that polynomial, and its generator
+uses the same absolute root after harmless global-sign normalization.
+-/
+namespace Hex.NumberTower
+
+/-! Compiled one-level embedding checks. -/
+
+private def embedSqrtTwoPoly : ZPoly := DensePoly.ofList [-2, 0, 1]
+
+private def embedSqrtTwoSquare : DyadicSquare :=
+  ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
+
+private def embedSqrtTwoRep : RefinedIsolation embedSqrtTwoPoly :=
+  ⟨⟨embedSqrtTwoSquare, by decide⟩, by decide⟩
+
+private def embedSqrtTwoRoot : SimpleRoot embedSqrtTwoPoly :=
+  SimpleRoot.mk embedSqrtTwoRep
+
+#guard
+    if hirred : ZPoly.isIrreducible embedSqrtTwoPoly = true then
+      letI : ZPoly.CheckedIrreducible embedSqrtTwoPoly :=
+        ⟨hirred, by decide⟩
+      if hsimple : HasOnlySimpleRoots embedSqrtTwoPoly then
+        let extension := ofQAdjoin (x := embedSqrtTwoRoot)
+          hsimple embedSqrtTwoRep rfl
+        extension.tower.dim = 2 && extension.tower.height = 1 &&
+          coeffs (extension.gen * extension.gen) = #[2, 0] &&
+          coeffs (extension.gen⁻¹) = #[0, 1 / 2] &&
+          coeffs (extension.embed (ofRat rat 3)) = #[3, 0] &&
+          extension.root.p = embedSqrtTwoPoly
+      else
+        false
+    else
+      false
+
+-- A negative-leading presentation exercises the constructor's sign
+-- normalization while retaining the same monic quotient relation.
+private def embedNegSqrtTwoPoly : ZPoly := DensePoly.ofList [2, 0, -1]
+
+private def embedNegSqrtTwoRep : RefinedIsolation embedNegSqrtTwoPoly :=
+  ⟨⟨embedSqrtTwoSquare, by decide⟩, by decide⟩
+
+private def embedNegSqrtTwoRoot : SimpleRoot embedNegSqrtTwoPoly :=
+  SimpleRoot.mk embedNegSqrtTwoRep
+
+#guard
+    if hirred : ZPoly.isIrreducible embedNegSqrtTwoPoly = true then
+      letI : ZPoly.CheckedIrreducible embedNegSqrtTwoPoly :=
+        ⟨hirred, by decide⟩
+      if hsimple : HasOnlySimpleRoots embedNegSqrtTwoPoly then
+        let extension := ofQAdjoin (x := embedNegSqrtTwoRoot)
+          hsimple embedNegSqrtTwoRep rfl
+        extension.root.p = embedSqrtTwoPoly &&
+          coeffs (extension.gen * extension.gen) = #[2, 0]
+      else
+        false
+    else
+      false
+
+end Hex.NumberTower

--- a/progress/20260727T073052Z_number-field-tower-embed.md
+++ b/progress/20260727T073052Z_number-field-tower-embed.md
@@ -1,0 +1,29 @@
+# Number-field tower rational embedding
+
+## Accomplished
+
+- Added the dependent `NumberTower.Extension` result and the checked
+  `ofQAdjoin` smart constructor for one-level extensions of `rat`.
+- Normalized negative-leading input presentations by a global sign while
+  preserving the chosen isolation, and stored the corresponding positive-
+  leading absolute root.
+- Constructed the monic rational defining relation, canonical base embedding,
+  and generator coordinates without exposing raw tower constructors.
+- Added compiled regressions for both `X² - 2` and `2 - X²`, covering tower
+  dimension, the generator relation, inversion, and rational embedding.
+- Verified `lake build HexNumberFieldTower.Embed` and the full `lake build`.
+
+## Current frontier
+
+The rational one-level constructor and mixed-radix arithmetic are executable.
+Generic adjoining still needs the recursive tower factorization and fixed-
+embedding factor-selection machinery.
+
+## Next step
+
+Implement the one-level norm/resultant primitives and the checked
+factorization result, then build Yun/Trager factorization over a tower.
+
+## Blockers
+
+None.

--- a/progress/20260727T074900Z_number-field-tower-embed-review.md
+++ b/progress/20260727T074900Z_number-field-tower-embed-review.md
@@ -1,0 +1,33 @@
+# Number-field tower embedding review fixes
+
+## Accomplished
+
+- Added conjugate-sensitive regressions that inspect the stored isolating
+  square, including a negative root of `X² - 2`.
+- Made linear rational presentations return the identity extension of `rat`
+  rather than constructing a second height-one representation of `Q`.
+- Derived the monic quotient relation consistently from the sign-normalized
+  polynomial stored by the absolute root.
+- Reused `ZPoly.normalizePrimitiveSign` instead of maintaining a duplicate
+  sign-normalization implementation.
+- Added a non-unit-leading regression for `2X² - 3` and retained the selected
+  isolation through construction.
+- Verified `lake build HexNumberFieldTower.Basic` and
+  `lake build HexNumberFieldTower.Embed`.
+
+## Current frontier
+
+The executable constructor now covers embedding selection, linear identity,
+global sign, and rational monic normalization. Levels still need a meaningful
+stored relative-irreducibility invariant suitable for the Mathlib field-law
+proofs; a detached Boolean marker would not be sufficient.
+
+## Next step
+
+Design the level certificate around the recursive factor checker so it is
+definitionally tied to the stored relative polynomial, then thread it through
+all smart constructors before beginning the Mathlib tower laws.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Summary
- add the dependent NumberTower.Extension result
- add the sealed ofQAdjoin smart constructor with positive-leading sign normalization
- exercise positive- and negative-leading presentations of Q(sqrt 2)

## Verification
- lake build HexNumberFieldTower.Embed
- lake build

Stacked on #8918.