### PR TITLE
Number field tower: one-level Trager norms

### DIFF
--- a/HexNumberFieldTower.lean
+++ b/HexNumberFieldTower.lean
@@ -9,6 +9,7 @@ module
 public import HexNumberFieldTower.Basic
 public import HexNumberFieldTower.Arithmetic
 public import HexNumberFieldTower.Embed
+public import HexNumberFieldTower.Norm
 
 public section
 

--- a/HexNumberFieldTower/Arithmetic.lean
+++ b/HexNumberFieldTower/Arithmetic.lean
@@ -95,37 +95,39 @@ def mulCoords : (levels : List Level) → Array Rat → Array Rat → Array Rat
           convolved
         flattenBlocks d lowerDim (reduced.take d)
 
-/-- Internal dynamically indexed lower-tower coefficient used only to invoke
-the generic dense-polynomial Euclidean algorithms. -/
-private structure RawElem (levels : List Level) where
+/-- Dynamically indexed tower coefficient used internally when an algorithm
+recurses through runtime level data rather than a dependent `NumberTower`.
+The `raw` helper normalizes to the represented mixed-radix dimension. -/
+structure RawElem (levels : List Level) where
   data : Array Rat
 
-private def raw (levels : List Level) (data : Array Rat) : RawElem levels :=
-  ⟨fixedCoeffs (levelsDim levels) data⟩
+@[expose]
+def raw (levels : List Level) (data : Array Rat) : RawElem levels :=
+  .mk (fixedCoeffs (levelsDim levels) data)
 
-private instance (levels : List Level) : DecidableEq (RawElem levels) :=
+instance (levels : List Level) : DecidableEq (RawElem levels) :=
   fun a b =>
     match decEq a.data.toList b.data.toList with
     | isTrue h => isTrue (by cases a; cases b; simpa using h)
     | isFalse h => isFalse fun hab => h (by simp [hab])
 
-private instance (levels : List Level) : Zero (RawElem levels) :=
+instance (levels : List Level) : Zero (RawElem levels) :=
   ⟨raw levels #[]⟩
 
-private instance (levels : List Level) : One (RawElem levels) :=
+instance (levels : List Level) : One (RawElem levels) :=
   ⟨raw levels #[1]⟩
 
-private instance (levels : List Level) : Add (RawElem levels) :=
-  ⟨fun a b => ⟨addCoords (levelsDim levels) a.data b.data⟩⟩
+instance (levels : List Level) : Add (RawElem levels) :=
+  ⟨fun a b => .mk (addCoords (levelsDim levels) a.data b.data)⟩
 
-private instance (levels : List Level) : Sub (RawElem levels) :=
-  ⟨fun a b => ⟨subCoords (levelsDim levels) a.data b.data⟩⟩
+instance (levels : List Level) : Sub (RawElem levels) :=
+  ⟨fun a b => .mk (subCoords (levelsDim levels) a.data b.data)⟩
 
-private instance (levels : List Level) : Neg (RawElem levels) :=
-  ⟨fun a => ⟨negCoords (levelsDim levels) a.data⟩⟩
+instance (levels : List Level) : Neg (RawElem levels) :=
+  ⟨fun a => .mk (negCoords (levelsDim levels) a.data)⟩
 
-private instance (levels : List Level) : Mul (RawElem levels) :=
-  ⟨fun a b => ⟨mulCoords levels a.data b.data⟩⟩
+instance (levels : List Level) : Mul (RawElem levels) :=
+  ⟨fun a b => .mk (mulCoords levels a.data b.data)⟩
 
 /-- Recursive inverse coordinates. The zero convention is inherited at every
 level; defensive nonconstant/zero gcd branches are unreachable for a tower
@@ -160,6 +162,12 @@ def invCoords : (levels : List Level) → Array Rat → Array Rat
         else
           Hex.panicWith (Array.replicate (d * lowerDim) 0)
             "NumberTower.inv: nonconstant gcd"
+
+instance (levels : List Level) : Inv (RawElem levels) :=
+  ⟨fun a => raw levels (invCoords levels a.data)⟩
+
+instance (levels : List Level) : Div (RawElem levels) :=
+  ⟨fun a b => a * b⁻¹⟩
 
 private def sqrtTwoLevel : Level where
   degree := 2

--- a/HexNumberFieldTower/Norm.lean
+++ b/HexNumberFieldTower/Norm.lean
@@ -42,8 +42,9 @@ with coefficients regarded as constant polynomials in `X`. -/
 @[expose]
 def definingOuter (level : Level) (lower : List Level) :
     DensePoly (DensePoly (RawElem lower)) :=
-  DensePoly.ofCoeffs <| (level.defining.map fun a =>
-    DensePoly.C (raw lower a)).push (DensePoly.C 1)
+  DensePoly.ofCoeffs <| (((List.range level.degree).map fun i =>
+    DensePoly.C (raw lower (level.defining.getD i #[]))).toArray).push
+      (DensePoly.C 1)
 
 /-- Substitute `X - cY` into a polynomial over the current tower, presenting
 the result as a polynomial in `Y` over `lower[X]`. -/
@@ -127,6 +128,11 @@ private def normSqrtThreeLevel : Level where
   defining := #[#[-3, 0], #[0, 0]]
   root := AlgebraicNumber.zero.toRoot
 
+private def normCubeRootTwoLevel : Level where
+  degree := 3
+  defining := #[#[-2], #[0], #[0]]
+  root := AlgebraicNumber.zero.toRoot
+
 #guard
     let xSubSqrtTwo : Array (Array Rat) := #[#[0, -1], #[1, 0]]
     oneLevel normSqrtTwoLevel [] xSubSqrtTwo 0 =
@@ -155,11 +161,30 @@ private def normSqrtThreeLevel : Level where
       #[#[2, 0], #[0, -2], #[1, 0]]
 
 #guard
+    let repeatedOverLower : Array (Array Rat) :=
+      #[#[2, 0], #[0, -2], #[1, 0]]
+    !isSquarefree [normSqrtTwoLevel] repeatedOverLower
+
+-- This cubic elimination reaches Brown's nonunit polynomial exact-division
+-- branch and exercises cascading reduction in a degree-three level.
+#guard
+    let g : Array (Array Rat) := #[#[1, 0, 0], #[0, 0, 1]]
+    oneLevel normCubeRootTwoLevel [] g 1 =
+      #[#[-1], #[0], #[0], #[4]]
+
+#guard
     let xSubSqrtTwo : Array (Array Rat) := #[#[0, -1], #[1, 0]]
     let found := findSquarefreeShift normSqrtTwoLevel [] xSubSqrtTwo
     tragerShiftCount 2 3 = 16 &&
       (List.range 5).map signedShift = [0, 1, -1, 2, -2] &&
       found = some (0, #[#[-2], #[0], #[1]])
+
+-- The first norm is repeated, so the search must advance to shift one.
+#guard
+    let rationalQuadratic : Array (Array Rat) :=
+      #[#[-3, 0], #[0, 0], #[1, 0]]
+    findSquarefreeShift normSqrtTwoLevel [] rationalQuadratic =
+      some (1, #[#[1], #[0], #[-10], #[0], #[1]])
 
 end Norm
 

--- a/HexNumberFieldTower/Norm.lean
+++ b/HexNumberFieldTower/Norm.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexNumberFieldTower.Embed
+public import HexResultant
+public meta import HexNumberFieldTower.Embed
+public meta import HexResultant
+
+public section
+
+/-!
+# One-level tower norms
+
+Trager factorization eliminates only the newest generator at each recursive
+step. This module forms `Res_Y(m(Y), g(X - cY))` directly over the lower-tower
+coefficient ring, so it neither materializes a determinant nor collapses the
+whole tower into one absolute norm.
+-/
+namespace Hex.NumberTower
+
+namespace Norm
+
+open Arithmetic
+
+/-- Interpret flattened current-tower coordinates as a polynomial in the top
+generator, with coefficients that are constant polynomials in `X` over the
+lower tower. -/
+@[expose]
+def liftCoefficient (level : Level) (lower : List Level)
+    (a : Array Rat) : DensePoly (DensePoly (RawElem lower)) :=
+  let lowerDim := levelsDim lower
+  DensePoly.ofCoeffs <| ((List.range level.degree).map fun j =>
+    DensePoly.C (raw lower (block a j lowerDim))).toArray
+
+/-- The newest level's monic defining polynomial in the elimination variable,
+with coefficients regarded as constant polynomials in `X`. -/
+@[expose]
+def definingOuter (level : Level) (lower : List Level) :
+    DensePoly (DensePoly (RawElem lower)) :=
+  DensePoly.ofCoeffs <| (level.defining.map fun a =>
+    DensePoly.C (raw lower a)).push (DensePoly.C 1)
+
+/-- Substitute `X - cY` into a polynomial over the current tower, presenting
+the result as a polynomial in `Y` over `lower[X]`. -/
+@[expose]
+def shiftedOuter (level : Level) (lower : List Level)
+    (f : Array (Array Rat)) (c : Int) :
+    DensePoly (DensePoly (RawElem lower)) :=
+  let x : DensePoly (RawElem lower) := DensePoly.monomial 1 1
+  let negShift : RawElem lower := raw lower #[(-(c : Rat))]
+  let xSubCY : DensePoly (DensePoly (RawElem lower)) :=
+    DensePoly.ofCoeffs #[x, DensePoly.C negShift]
+  let start : DensePoly (DensePoly (RawElem lower)) ×
+      DensePoly (DensePoly (RawElem lower)) := (0, 1)
+  (f.foldl (fun state coefficient =>
+    (state.1 + liftCoefficient level lower coefficient * state.2,
+      state.2 * xSubCY)) start).1
+
+/-- One Trager norm step. Input coefficients are flattened over
+`level :: lower`; output coefficients are flattened over `lower`. -/
+@[expose]
+def oneLevel (level : Level) (lower : List Level)
+    (f : Array (Array Rat)) (c : Int) : Array (Array Rat) :=
+  (DensePoly.resultant (definingOuter level lower)
+    (shiftedOuter level lower f c)).toArray.map RawElem.data
+
+/-- Formal derivative over a runtime-indexed lower tower. -/
+@[expose]
+def derivative (lower : List Level) (f : DensePoly (RawElem lower)) :
+    DensePoly (RawElem lower) :=
+  DensePoly.ofCoeffs <| ((List.range (f.size - 1)).map fun i =>
+    raw lower <| (f.coeff (i + 1)).data.map fun q =>
+      ((i + 1 : Nat) : Rat) * q).toArray
+
+/-- Monic normalization over the runtime-indexed lower tower. -/
+@[expose]
+def monic (f : DensePoly (RawElem lower)) : DensePoly (RawElem lower) :=
+  if f.isZero then 0 else DensePoly.scale f.leadingCoeff⁻¹ f
+
+/-- Executable squarefreeness test over a checked lower tower. -/
+@[expose]
+def isSquarefree (lower : List Level) (f : Array (Array Rat)) : Bool :=
+  let p : DensePoly (RawElem lower) :=
+    DensePoly.ofCoeffs (f.map (raw lower))
+  !p.isZero && (DensePoly.gcd p (derivative lower p)).size ≤ 1
+
+/-- Number of deterministic Trager shifts required for a top degree `d` and
+component degree `m`. -/
+@[expose]
+def tragerShiftCount (d m : Nat) : Nat :=
+  Nat.choose (d * m) 2 + 1
+
+/-- Deterministic signed enumeration `0, 1, -1, 2, -2, ...`. -/
+@[expose]
+def signedShift (i : Nat) : Int :=
+  if i = 0 then
+    0
+  else if i % 2 = 1 then
+    Int.ofNat ((i + 1) / 2)
+  else
+    -Int.ofNat (i / 2)
+
+/-- Search exactly the finite Trager collision bound and return the first
+shift whose one-level norm is squarefree over the lower tower. -/
+@[expose]
+def findSquarefreeShift (level : Level) (lower : List Level)
+    (f : Array (Array Rat)) : Option (Int × Array (Array Rat)) :=
+  (List.range (tragerShiftCount level.degree (f.size - 1))).findSome? fun i =>
+    let c := signedShift i
+    let norm := oneLevel level lower f c
+    if isSquarefree lower norm then some (c, norm) else none
+
+/-! Compiled one-level norm regressions over `ℚ(√2)`. -/
+
+private def normSqrtTwoLevel : Level where
+  degree := 2
+  defining := #[#[-2], #[0]]
+  root := AlgebraicNumber.zero.toRoot
+
+private def normSqrtThreeLevel : Level where
+  degree := 2
+  defining := #[#[-3, 0], #[0, 0]]
+  root := AlgebraicNumber.zero.toRoot
+
+#guard
+    let xSubSqrtTwo : Array (Array Rat) := #[#[0, -1], #[1, 0]]
+    oneLevel normSqrtTwoLevel [] xSubSqrtTwo 0 =
+      #[#[-2], #[0], #[1]] &&
+    oneLevel normSqrtTwoLevel [] xSubSqrtTwo 1 =
+      #[#[-8], #[0], #[1]]
+
+#guard
+    let rationalQuadratic : Array (Array Rat) :=
+      #[#[-3, 0], #[0, 0], #[1, 0]]
+    let norm := oneLevel normSqrtTwoLevel [] rationalQuadratic 0
+    norm = #[#[9], #[0], #[-6], #[0], #[1]] &&
+      !isSquarefree [] norm
+
+-- The resultant coefficient ring is itself the recursively represented lower
+-- tower: eliminating sqrt(3) from a polynomial already over Q(sqrt(2)) uses
+-- lower-tower multiplication and exact division.
+#guard
+    let xSubSqrtThree : Array (Array Rat) :=
+      #[#[0, 0, -1, 0], #[1, 0, 0, 0]]
+    let xSubSqrtTwo : Array (Array Rat) :=
+      #[#[0, -1, 0, 0], #[1, 0, 0, 0]]
+    oneLevel normSqrtThreeLevel [normSqrtTwoLevel] xSubSqrtThree 0 =
+      #[#[-3, 0], #[0, 0], #[1, 0]] &&
+    oneLevel normSqrtThreeLevel [normSqrtTwoLevel] xSubSqrtTwo 0 =
+      #[#[2, 0], #[0, -2], #[1, 0]]
+
+#guard
+    let xSubSqrtTwo : Array (Array Rat) := #[#[0, -1], #[1, 0]]
+    let found := findSquarefreeShift normSqrtTwoLevel [] xSubSqrtTwo
+    tragerShiftCount 2 3 = 16 &&
+      (List.range 5).map signedShift = [0, 1, -1, 2, -2] &&
+      found = some (0, #[#[-2], #[0], #[1]])
+
+end Norm
+
+end Hex.NumberTower

--- a/progress/20260727T073727Z_number-field-tower-norm.md
+++ b/progress/20260727T073727Z_number-field-tower-norm.md
@@ -1,0 +1,31 @@
+# Number-field tower one-level norms
+
+## Accomplished
+
+- Added a runtime-indexed lower-tower coefficient carrier with recursive field
+  operations for generic polynomial gcd and resultant algorithms.
+- Implemented direct one-level Trager elimination
+  `Res_Y(m(Y), g(X - cY))` over the immediately lower tower.
+- Added derivative, monic normalization, and executable squarefreeness checks
+  for runtime-indexed tower polynomials.
+- Implemented the exact `choose(d*m, 2) + 1` shift budget, the deterministic
+  signed shift enumeration, and first-squarefree-norm search.
+- Added compiled norms over `Q(sqrt(2))` and over
+  `Q(sqrt(2), sqrt(3))`, including repeated-norm detection.
+- Verified `lake build HexNumberFieldTower.Norm` and the full `lake build`.
+
+## Current frontier
+
+The finite Trager shift step now produces squarefree norms over the lower tower.
+Recursive factorization and gcd recovery of lifted lower factors remain to be
+connected.
+
+## Next step
+
+Add checked factorization result types and reconstruction, implement Yun
+decomposition on runtime tower polynomials, then recurse through Trager norms
+and recover factors by shifted gcd.
+
+## Blockers
+
+None.

--- a/progress/20260727T075304Z_number-field-tower-norm-review.md
+++ b/progress/20260727T075304Z_number-field-tower-norm-review.md
@@ -1,0 +1,17 @@
+# Accomplished
+
+- Tightened `Norm.definingOuter` to use exactly the declared level degree.
+- Added recursive squarefreeness, nonunit Brown exact-division, cascading cubic reduction, and bad-first-shift regressions requested by the independent review.
+- Rebuilt `HexNumberFieldTower.Norm` successfully.
+
+# Current frontier
+
+The norm implementation now has direct coverage for the delicate elimination and shift-search branches. Raw-element encapsulation and allocation-heavy arithmetic remain broader representation concerns rather than local norm correctness defects.
+
+# Next step
+
+Land these corrections through the dependent PR stack, then tighten the Yun decomposition and its checker before refactoring the raw/certified tower boundary.
+
+# Blockers
+
+None.


### PR DESCRIPTION
## Summary
- add runtime-indexed lower-tower coefficients for recursive polynomial algorithms
- compute one-level Brown resultants for Trager shifts
- add squarefreeness checks, the exact collision bound, and deterministic signed search
- cover one- and two-level norm calculations with compiled regressions

## Verification
- lake build HexNumberFieldTower.Norm
- lake build

Stacked on #8919.