### PR TITLE
Number field tower: Trager factorization

### DIFF
--- a/HexNumberFieldTower/Factor.lean
+++ b/HexNumberFieldTower/Factor.lean
@@ -181,6 +181,155 @@ def factorRat? (input : DensePoly Rat) :
     else
       none
 
+/-- The newest generator as a runtime-indexed element. A linear level already
+lies in the lower field, so its generator is the negative constant term of its
+monic relation. -/
+@[expose]
+def topGenerator (level : Level) (lower : List Level) :
+    RawElem (level :: lower) :=
+  if level.degree = 1 then
+    -raw (level :: lower) (level.defining.getD 0 #[])
+  else
+    raw (level :: lower) ((Array.replicate (levelsDim lower) 0).push 1)
+
+/-- Substitute `X - c*alpha` in a current-level polynomial. -/
+@[expose]
+def shiftTop (level : Level) (lower : List Level)
+    (f : Array (Array Rat)) (c : Int) : Array (Array Rat) :=
+  let levels := level :: lower
+  let delta := raw levels #[(c : Rat)] * topGenerator level lower
+  let substitution : DensePoly (RawElem levels) :=
+    DensePoly.ofCoeffs #[-delta, 1]
+  polyCoords (DensePoly.compose (rawPoly levels f) substitution)
+
+/-- Embed a lower-tail polynomial into the current level. Mixed-radix order
+places lower coordinates in the first top-generator block. -/
+@[expose]
+def embedLower (level : Level) (lower : List Level)
+    (f : Array (Array Rat)) : Array (Array Rat) :=
+  let levels := level :: lower
+  polyCoords <| DensePoly.ofCoeffs <| f.map fun coefficient =>
+    raw levels coefficient
+
+/-- Recover current-level factors from irreducible lower factors of a
+squarefree Trager norm, then undo the selected generator shift. -/
+@[expose]
+def recover (level : Level) (lower : List Level)
+    (shift : Int) (component : Array (Array Rat))
+    (lowerFactors : Array (Array (Array Rat))) :
+    Array (Array (Array Rat)) :=
+  let levels := level :: lower
+  let shifted := rawPoly levels (shiftTop level lower component shift)
+  lowerFactors.foldl (fun out lowerFactor =>
+    let lifted := rawPoly levels (embedLower level lower lowerFactor)
+    let common := Norm.monic (DensePoly.gcd shifted lifted)
+    if 0 < common.degree?.getD 0 then
+      let unshifted := shiftTop level lower (polyCoords common) (-shift)
+      out.push (polyCoords (Norm.monic (rawPoly levels unshifted)))
+    else
+      out) #[]
+
+/-- Recursive Trager factorization of one monic squarefree component. The
+recursion is structural in the tower height; every proper level performs one
+bounded one-level norm search and recurses only on the lower tail. -/
+@[expose]
+def factorSquarefree? : (levels : List Level) → Array (Array Rat) →
+    Option (Array (Array (Array Rat)))
+  | [], f => factorRat? (toRatPoly f)
+  | level :: lower, f => do
+      let (shift, norm) ← Norm.findSquarefreeShift level lower f
+      let lowerFactors ← factorSquarefree? lower norm
+      let factors := recover level lower shift f lowerFactors
+      let p := Norm.monic (rawPoly (level :: lower) f)
+      let product := factors.foldl
+        (fun product factor => product * rawPoly (level :: lower) factor)
+        1
+      if factors.all (fun factor =>
+          0 < (rawPoly (level :: lower) factor).degree?.getD 0) &&
+          product = p then
+        some factors
+      else
+        none
+
+/-- Runtime factorization payload before re-indexing coefficients by a public
+`NumberTower`. -/
+structure RawFactorization where
+  scalar : Array Rat
+  factors : Array (Array (Array Rat) × Nat)
+deriving DecidableEq
+
+/-- Lexicographic order on rational lists. -/
+@[expose]
+def ratListLess : List Rat → List Rat → Bool
+  | [], [] => false
+  | [], _ :: _ => true
+  | _ :: _, [] => false
+  | a :: as, b :: bs =>
+      if a < b then true else if b < a then false else ratListLess as bs
+
+/-- Flatten polynomial coefficient coordinates for canonical sorting. -/
+@[expose]
+def flattenPoly (f : Array (Array Rat)) : List Rat :=
+  f.toList.flatMap Array.toList
+
+/-- Canonical lexicographic factor order. -/
+@[expose]
+def factorLess (a b : Array (Array Rat)) : Bool :=
+  ratListLess (flattenPoly a) (flattenPoly b)
+
+/-- Check that adjacent factors are in canonical nondecreasing order. -/
+@[expose]
+def factorsSorted (factors : Array (Array (Array Rat) × Nat)) : Bool :=
+  (List.range (factors.size - 1)).all fun i =>
+    !factorLess factors[i + 1]!.1 factors[i]!.1
+
+/-- Multiply a scalar and powered raw factor list. -/
+@[expose]
+def factorProduct (levels : List Level) (scalar : Array Rat)
+    (factors : Array (Array (Array Rat) × Nat)) : Array (Array Rat) :=
+  polyCoords <| factors.foldl
+    (fun product factor =>
+      product * polyPow (rawPoly levels factor.1) factor.2)
+    (DensePoly.C (raw levels scalar))
+
+/-- Executable recursive irreducibility checker for a monic squarefree raw
+tower polynomial. It reruns Trager factorization and accepts exactly a
+singleton reconstruction. -/
+@[expose]
+def isIrreducible (levels : List Level) (f : Array (Array Rat)) : Bool :=
+  let p := rawPoly levels f
+  0 < p.degree?.getD 0 && p.leadingCoeff = 1 &&
+    Norm.isSquarefree levels f &&
+    match factorSquarefree? levels f with
+    | some factors => factors = #[polyCoords p]
+    | none => false
+
+/-- Full executable raw factorization certificate check. -/
+@[expose]
+def check (levels : List Level) (f : Array (Array Rat)) (scalar : Array Rat)
+    (factors : Array (Array (Array Rat) × Nat)) : Bool :=
+  factors.all (fun factor => 0 < factor.2 && isIrreducible levels factor.1) &&
+    factorsSorted factors && factorProduct levels scalar factors = f
+
+/-- Complete factorization with Yun multiplicities and recursive Trager
+recovery. Every candidate is sorted and replayed through the full executable
+certificate check before it is returned. -/
+@[expose]
+def factorRaw? (levels : List Level) (f : Array (Array Rat)) :
+    Option RawFactorization := do
+  let p := rawPoly levels f
+  let scalar := p.leadingCoeff.data
+  let components := yunRaw levels f
+  let factors ← components.foldlM (fun out component => do
+    let irreducibles ← factorSquarefree? levels component.1
+    pure <| irreducibles.foldl
+      (fun out factor => out.push (factor, component.2)) out) #[]
+  let factors := factors.qsort fun a b => factorLess a.1 b.1
+  if check levels f scalar factors then
+    some ⟨scalar, factors⟩
+  else
+    none
+
 /-! Compiled Yun regressions. -/
 
 private def yunSqrtTwoLevel : Level where
@@ -242,6 +391,109 @@ private def yunSqrtTwoLevel : Level where
 #guard
     let xSubOne : DensePoly Rat := DensePoly.ofList [-1, 1]
     (factorRat? (xSubOne * xSubOne)).isNone
+
+-- Trager's first two shifts collide conjugate sums for `X²-2`; the bounded
+-- search reaches shift `2`, recovers both linear factors, and undoes the shift.
+#guard
+    let levels := [yunSqrtTwoLevel]
+    let xSqSubTwo : Array (Array Rat) :=
+      #[#[-2, 0], #[0, 0], #[1, 0]]
+    match Norm.findSquarefreeShift yunSqrtTwoLevel [] xSqSubTwo,
+        factorSquarefree? levels xSqSubTwo with
+    | some (shift, _), some factors =>
+        let product := factors.foldl
+          (fun product factor => product * rawPoly levels factor) 1
+        shift = 2 && factors.size = 2 &&
+          product = rawPoly levels xSqSubTwo
+    | _, _ => false
+
+#guard
+    let levels := [yunSqrtTwoLevel]
+    let xSqSubThree : Array (Array Rat) :=
+      #[#[-3, 0], #[0, 0], #[1, 0]]
+    match factorSquarefree? levels xSqSubThree with
+    | some factors =>
+        factors = #[xSqSubThree]
+    | none => false
+
+#guard
+    let levels := [yunSqrtTwoLevel]
+    let xSqSubTwo : DensePoly (RawElem levels) :=
+      rawPoly levels #[#[-2, 0], #[0, 0], #[1, 0]]
+    let xSubOne : DensePoly (RawElem levels) :=
+      rawPoly levels #[#[-1, 0], #[1, 0]]
+    let f := polyPow xSqSubTwo 2 * polyPow xSubOne 3
+    match factorRaw? levels (polyCoords f) with
+    | some result =>
+        result.factors.size = 3 &&
+          result.factors.all (fun factor => 0 < factor.2) &&
+          check levels (polyCoords f) result.scalar result.factors
+    | none => false
+
 end Factor
+
+/-- Reconstruct and recursively certify a proposed public factorization. -/
+@[expose]
+def checkFactorization {T : NumberTower} (f : Poly T) (scalar : Elem T)
+    (factors : Array (Poly T × Nat)) : Bool :=
+  Factor.check T.levels.toList
+    (f.toArray.map coeffs) (coeffs scalar)
+    (factors.map fun factor =>
+      (factor.1.toArray.map coeffs, factor.2))
+
+/-- A checked complete factorization in a fixed tower. -/
+structure Factorization (T : NumberTower) (f : Poly T) where
+  scalar : Elem T
+  factors : Array (Poly T × Nat)
+  checked : checkFactorization f scalar factors = true
+
+/-- Complete irreducible factorization with multiplicity. -/
+def factor? (T : NumberTower) (f : Poly T) : Option (Factorization T f) := do
+  let raw ← Factor.factorRaw? T.levels.toList (f.toArray.map coeffs)
+  let scalar := ofCoeffs T raw.scalar
+  let factors := raw.factors.map fun factor =>
+    (DensePoly.ofCoeffs (factor.1.map (ofCoeffs T)), factor.2)
+  if h : checkFactorization f scalar factors then
+    some ⟨scalar, factors, h⟩
+  else
+    none
+
+/-! Compiled public dependent-result regression. -/
+
+private def factorSqrtTwoPoly : ZPoly := DensePoly.ofList [-2, 0, 1]
+
+private def factorSqrtTwoSquare : DyadicSquare :=
+  ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
+
+private def factorSqrtTwoRep : RefinedIsolation factorSqrtTwoPoly :=
+  ⟨⟨factorSqrtTwoSquare, by decide⟩, by decide⟩
+
+private def factorSqrtTwoRoot : SimpleRoot factorSqrtTwoPoly :=
+  SimpleRoot.mk factorSqrtTwoRep
+
+#guard
+    if hirred : ZPoly.isIrreducible factorSqrtTwoPoly = true then
+      letI : ZPoly.CheckedIrreducible factorSqrtTwoPoly :=
+        ⟨hirred, by decide⟩
+      if hsimple : HasOnlySimpleRoots factorSqrtTwoPoly then
+        let extension := ofQAdjoin (x := factorSqrtTwoRoot)
+          hsimple factorSqrtTwoRep rfl
+        let f : Poly extension.tower := DensePoly.ofCoeffs
+          #[ofRat extension.tower (-2), 0, 1]
+        match factor? extension.tower f,
+            factor? extension.tower 0,
+            factor? extension.tower (DensePoly.C (ofRat extension.tower 5)) with
+        | some result, some zeroResult, some constantResult =>
+            result.factors.size = 2 &&
+              coeffs result.scalar = #[1, 0] &&
+              zeroResult.factors.isEmpty &&
+              isZero zeroResult.scalar &&
+              constantResult.factors.isEmpty &&
+              coeffs constantResult.scalar = #[5, 0]
+        | _, _, _ => false
+      else
+        false
+    else
+      false
 
 end Hex.NumberTower

--- a/HexNumberFieldTower/Factor.lean
+++ b/HexNumberFieldTower/Factor.lean
@@ -82,12 +82,19 @@ def yunRaw (levels : List Level) (f : Array (Array Rat)) :
     let d := c - Norm.derivative levels b
     yunAux levels b d 1 (p.size + 1) #[]
 
-/-- Polynomial power used by reconstruction checks. -/
+/-- Polynomial power used by reconstruction checks, computed by repeated
+squaring so high multiplicities do not induce a linear multiplication chain. -/
 @[expose]
-def polyPow {levels : List Level} (f : DensePoly (RawElem levels)) : Nat →
-    DensePoly (RawElem levels)
-  | 0 => 1
-  | n + 1 => polyPow f n * f
+def polyPow {levels : List Level} (f : DensePoly (RawElem levels)) (n : Nat) :
+    DensePoly (RawElem levels) :=
+  if n = 0 then
+    1
+  else
+    let half := polyPow f (n / 2)
+    let square := half * half
+    if n % 2 = 0 then square else square * f
+termination_by n
+decreasing_by omega
 
 /-- Reconstruct a monic polynomial from raw Yun components. -/
 @[expose]
@@ -104,7 +111,8 @@ def yunProduct (levels : List Level)
 def yunMultiplicitiesIncrease
     (components : Array (Array (Array Rat) × Nat)) : Bool :=
   (List.range (components.size - 1)).all fun i =>
-    components[i]!.2 < components[i + 1]!.2
+    (components.getD i (#[], 0)).2 <
+      (components.getD (i + 1) (#[], 0)).2
 
 /-- Check that distinct Yun components are pairwise coprime. -/
 @[expose]
@@ -112,8 +120,8 @@ def yunPairwiseCoprime (levels : List Level)
     (components : Array (Array (Array Rat) × Nat)) : Bool :=
   (List.range components.size).all fun i =>
     (List.range i).all fun j =>
-      (DensePoly.gcd (rawPoly levels components[i]!.1)
-        (rawPoly levels components[j]!.1)).size ≤ 1
+      (DensePoly.gcd (rawPoly levels (components.getD i (#[], 0)).1)
+        (rawPoly levels (components.getD j (#[], 0)).1)).size ≤ 1
 
 /-- Self-check a Yun decomposition: multiplicities are positive and strictly
 increasing, the monic squarefree components are pairwise coprime, and their
@@ -237,17 +245,20 @@ def factorSquarefree? : (levels : List Level) → Array (Array Rat) →
     Option (Array (Array (Array Rat)))
   | [], f => factorRat? (toRatPoly f)
   | level :: lower, f => do
-      let (shift, norm) ← Norm.findSquarefreeShift level lower f
-      let lowerFactors ← factorSquarefree? lower norm
-      let factors := recover level lower shift f lowerFactors
-      let p := Norm.monic (rawPoly (level :: lower) f)
-      let product := factors.foldl
-        (fun product factor => product * rawPoly (level :: lower) factor)
-        1
-      if factors.all (fun factor =>
-          0 < (rawPoly (level :: lower) factor).degree?.getD 0) &&
-          product = p then
-        some factors
+      if Norm.isSquarefree (level :: lower) f then
+        let (shift, norm) ← Norm.findSquarefreeShift level lower f
+        let lowerFactors ← factorSquarefree? lower norm
+        let factors := recover level lower shift f lowerFactors
+        let p := Norm.monic (rawPoly (level :: lower) f)
+        let product := factors.foldl
+          (fun product factor => product * rawPoly (level :: lower) factor)
+          1
+        if factors.all (fun factor =>
+            0 < (rawPoly (level :: lower) factor).degree?.getD 0) &&
+            product = p then
+          some factors
+        else
+          none
       else
         none
 
@@ -256,7 +267,6 @@ def factorSquarefree? : (levels : List Level) → Array (Array Rat) →
 structure RawFactorization where
   scalar : Array Rat
   factors : Array (Array (Array Rat) × Nat)
-deriving DecidableEq
 
 /-- Lexicographic order on rational lists. -/
 @[expose]
@@ -283,7 +293,8 @@ paired natural number. -/
 @[expose]
 def factorsSorted (factors : Array (Array (Array Rat) × Nat)) : Bool :=
   (List.range (factors.size - 1)).all fun i =>
-    factorLess factors[i]!.1 factors[i + 1]!.1
+    factorLess (factors.getD i (#[], 0)).1
+      (factors.getD (i + 1) (#[], 0)).1
 
 /-- Multiply a scalar and powered raw factor list. -/
 @[expose]
@@ -295,27 +306,33 @@ def factorProduct (levels : List Level) (scalar : Array Rat)
     (DensePoly.C (raw levels scalar))
 
 /-- Executable recursive irreducibility checker for a monic squarefree raw
-tower polynomial. It reruns Trager factorization and accepts exactly a
-singleton reconstruction. -/
+tower polynomial. The rational base uses the independent integer-polynomial
+checker; proper towers accept exactly a singleton Trager reconstruction. -/
 @[expose]
 def isIrreducible (levels : List Level) (f : Array (Array Rat)) : Bool :=
   let p := rawPoly levels f
   0 < p.degree?.getD 0 && p.leadingCoeff = 1 &&
     Norm.isSquarefree levels f &&
-    match factorSquarefree? levels f with
-    | some factors => factors = #[polyCoords p]
-    | none => false
+    match levels with
+    | [] => ZPoly.isIrreducible (ZPoly.ratPolyPrimitivePart (toRatPoly f))
+    | _ :: _ =>
+        match factorSquarefree? levels f with
+        | some factors => factors = #[polyCoords p]
+        | none => false
 
-/-- Full executable raw factorization certificate check. -/
+/-- Full executable raw factorization certificate check. At proper tower
+levels, “irreducible” means a piece the recursive Trager checker cannot split;
+the Mathlib companion supplies the semantic irreducibility theorem. Cheap
+reconstruction and canonical-order checks precede recursive replay. -/
 @[expose]
 def check (levels : List Level) (f : Array (Array Rat)) (scalar : Array Rat)
     (factors : Array (Array (Array Rat) × Nat)) : Bool :=
-  factors.all (fun factor => 0 < factor.2 && isIrreducible levels factor.1) &&
-    factorsSorted factors && factorProduct levels scalar factors = f
+  factorProduct levels scalar factors = f && factorsSorted factors &&
+    factors.all (fun factor => 0 < factor.2 && isIrreducible levels factor.1)
 
-/-- Complete factorization with Yun multiplicities and recursive Trager
-recovery. Every candidate is sorted and replayed through the full executable
-certificate check before it is returned. -/
+/-- Produce a canonical factorization candidate with checked Yun
+multiplicities and recursive Trager recovery. The public dependent constructor
+performs the one full executable certificate replay. -/
 @[expose]
 def factorRaw? (levels : List Level) (f : Array (Array Rat)) :
     Option RawFactorization := do
@@ -327,11 +344,10 @@ def factorRaw? (levels : List Level) (f : Array (Array Rat)) :
       let irreducibles ← factorSquarefree? levels component.1
       pure <| irreducibles.foldl
         (fun out factor => out.push (factor, component.2)) out) #[]
-    let factors := factors.qsort fun a b => factorLess a.1 b.1
-    if check levels f scalar factors then
-      some ⟨scalar, factors⟩
-    else
-      none
+    let keyed := factors.map fun factor => (flattenPoly factor.1, factor)
+    let factors :=
+      (keyed.qsort fun a b => ratListLess a.1 b.1).map fun entry => entry.2
+    some ⟨scalar, factors⟩
   else
     none
 
@@ -340,6 +356,11 @@ def factorRaw? (levels : List Level) (f : Array (Array Rat)) :
 private def yunSqrtTwoLevel : Level where
   degree := 2
   defining := #[#[-2], #[0]]
+  root := AlgebraicNumber.zero.toRoot
+
+private def factorSqrtThreeLevel : Level where
+  degree := 2
+  defining := #[#[-3, 0], #[0, 0]]
   root := AlgebraicNumber.zero.toRoot
 
 #guard
@@ -397,7 +418,7 @@ private def yunSqrtTwoLevel : Level where
     let xSubOne : DensePoly Rat := DensePoly.ofList [-1, 1]
     (factorRat? (xSubOne * xSubOne)).isNone
 
--- Trager's first two shifts collide conjugate sums for `X²-2`; the bounded
+-- Trager's first three shifts collide conjugate sums for `X²-2`; the bounded
 -- search reaches shift `2`, recovers both linear factors, and undoes the shift.
 #guard
     let levels := [yunSqrtTwoLevel]
@@ -420,6 +441,27 @@ private def yunSqrtTwoLevel : Level where
     | some factors =>
         factors = #[xSqSubThree]
     | none => false
+
+-- Recursive one-level Trager must retain the intermediate field. Over
+-- Q(sqrt(2), sqrt(3)), `X² - 3` splits at the top level even though an
+-- absolute norm would obscure that structure with repeated powers.
+#guard
+    let levels := [factorSqrtThreeLevel, yunSqrtTwoLevel]
+    let xSqSubThree : Array (Array Rat) :=
+      #[#[-3, 0, 0, 0], #[0, 0, 0, 0], #[1, 0, 0, 0]]
+    match factorRaw? levels xSqSubThree with
+    | some result =>
+        result.factors.size = 2 &&
+          check levels xSqSubThree result.scalar result.factors
+    | none => false
+
+-- The squarefree entry guard rejects invalid recursive calls before spending
+-- the full collision-bound search on resultants.
+#guard
+    let levels := [yunSqrtTwoLevel]
+    let xSubOne : DensePoly (RawElem levels) :=
+      rawPoly levels #[#[-1, 0], #[1, 0]]
+    (factorSquarefree? levels (polyCoords (polyPow xSubOne 2))).isNone
 
 #guard
     let levels := [yunSqrtTwoLevel]

--- a/HexNumberFieldTower/Factor.lean
+++ b/HexNumberFieldTower/Factor.lean
@@ -277,11 +277,13 @@ def flattenPoly (f : Array (Array Rat)) : List Rat :=
 def factorLess (a b : Array (Array Rat)) : Bool :=
   ratListLess (flattenPoly a) (flattenPoly b)
 
-/-- Check that adjacent factors are in canonical nondecreasing order. -/
+/-- Check that adjacent factors are in strict canonical order. Strictness
+ensures each irreducible occurs once, with its multiplicity stored in the
+paired natural number. -/
 @[expose]
 def factorsSorted (factors : Array (Array (Array Rat) × Nat)) : Bool :=
   (List.range (factors.size - 1)).all fun i =>
-    !factorLess factors[i + 1]!.1 factors[i]!.1
+    factorLess factors[i]!.1 factors[i + 1]!.1
 
 /-- Multiply a scalar and powered raw factor list. -/
 @[expose]
@@ -320,13 +322,16 @@ def factorRaw? (levels : List Level) (f : Array (Array Rat)) :
   let p := rawPoly levels f
   let scalar := p.leadingCoeff.data
   let components := yunRaw levels f
-  let factors ← components.foldlM (fun out component => do
-    let irreducibles ← factorSquarefree? levels component.1
-    pure <| irreducibles.foldl
-      (fun out factor => out.push (factor, component.2)) out) #[]
-  let factors := factors.qsort fun a b => factorLess a.1 b.1
-  if check levels f scalar factors then
-    some ⟨scalar, factors⟩
+  if checkYun levels f components then
+    let factors ← components.foldlM (fun out component => do
+      let irreducibles ← factorSquarefree? levels component.1
+      pure <| irreducibles.foldl
+        (fun out factor => out.push (factor, component.2)) out) #[]
+    let factors := factors.qsort fun a b => factorLess a.1 b.1
+    if check levels f scalar factors then
+      some ⟨scalar, factors⟩
+    else
+      none
   else
     none
 
@@ -429,6 +434,13 @@ private def yunSqrtTwoLevel : Level where
           result.factors.all (fun factor => 0 < factor.2) &&
           check levels (polyCoords f) result.scalar result.factors
     | none => false
+
+-- A factor may appear only once in the canonical certificate; its complete
+-- multiplicity belongs in the paired natural number.
+#guard
+    let xSubOne : Array (Array Rat) := #[#[-1], #[1]]
+    let f := polyCoords <| polyPow (rawPoly [] xSubOne) 3
+    !check [] f #[1] #[(xSubOne, 1), (xSubOne, 2)]
 
 end Factor
 

--- a/HexNumberFieldTower/Factor.lean
+++ b/HexNumberFieldTower/Factor.lean
@@ -134,13 +134,14 @@ def checkYun (levels : List Level) (f : Array (Array Rat))
   if p.isZero then
     components.isEmpty
   else
-    components.all (fun component =>
+    yunMultiplicitiesIncrease components &&
+      components.all (fun component =>
         0 < component.2 &&
           let factor := rawPoly levels component.1
-          !factor.isZero && factor.leadingCoeff = 1 &&
-            Norm.isSquarefree levels component.1) &&
-      yunMultiplicitiesIncrease components &&
+          0 < factor.degree?.getD 0 && factor.leadingCoeff = 1) &&
       yunPairwiseCoprime levels components &&
+      components.all (fun component =>
+        Norm.isSquarefree levels component.1) &&
       yunProduct levels components = polyCoords (Norm.monic p)
 
 /-- Checked Yun decomposition in a fixed tower. -/
@@ -306,8 +307,9 @@ def factorProduct (levels : List Level) (scalar : Array Rat)
     (DensePoly.C (raw levels scalar))
 
 /-- Executable recursive irreducibility checker for a monic squarefree raw
-tower polynomial. The rational base uses the independent integer-polynomial
-checker; proper towers accept exactly a singleton Trager reconstruction. -/
+tower polynomial. The rational base delegates to the integer-polynomial checker
+shared by rational factorization; proper towers accept exactly a singleton
+Trager reconstruction. -/
 @[expose]
 def isIrreducible (levels : List Level) (f : Array (Array Rat)) : Bool :=
   let p := rawPoly levels f
@@ -327,8 +329,11 @@ reconstruction and canonical-order checks precede recursive replay. -/
 @[expose]
 def check (levels : List Level) (f : Array (Array Rat)) (scalar : Array Rat)
     (factors : Array (Array (Array Rat) × Nat)) : Bool :=
-  factorProduct levels scalar factors = f && factorsSorted factors &&
-    factors.all (fun factor => 0 < factor.2 && isIrreducible levels factor.1)
+  factors.all (fun factor =>
+      polyCoords (rawPoly levels factor.1) = factor.1) &&
+    factorProduct levels scalar factors = f && factorsSorted factors &&
+      factors.all (fun factor =>
+        0 < factor.2 && isIrreducible levels factor.1)
 
 /-- Produce a canonical factorization candidate with checked Yun
 multiplicities and recursive Trager recovery. The public dependent constructor
@@ -400,6 +405,12 @@ private def factorSqrtThreeLevel : Level where
     let f := polyPow xSubOne 3
     !checkYun [] (polyCoords f)
       #[(polyCoords xSubOne, 1), (polyCoords xSubOne, 2)]
+
+-- Positive multiplicity is not enough: Yun components must have positive
+-- polynomial degree, so the constant unit is never a component.
+#guard
+    let one : DensePoly (RawElem []) := 1
+    !checkYun [] (polyCoords one) #[(polyCoords one, 1)]
 
 #guard
     let xSqSubTwo : DensePoly Rat := DensePoly.ofList [-2, 0, 1]
@@ -483,6 +494,14 @@ private def factorSqrtThreeLevel : Level where
     let xSubOne : Array (Array Rat) := #[#[-1], #[1]]
     let f := polyCoords <| polyPow (rawPoly [] xSubOne) 3
     !check [] f #[1] #[(xSubOne, 1), (xSubOne, 2)]
+
+-- Coordinate padding cannot disguise a duplicate factor from the strict
+-- canonical-order check.
+#guard
+    let xSubOne : Array (Array Rat) := #[#[-1], #[1]]
+    let padded : Array (Array Rat) := #[#[-1, 0, 0], #[1]]
+    let f := polyCoords <| polyPow (rawPoly [] xSubOne) 3
+    !check [] f #[1] #[(padded, 2), (xSubOne, 1)]
 
 end Factor
 

--- a/HexNumberFieldTower/Norm.lean
+++ b/HexNumberFieldTower/Norm.lean
@@ -106,15 +106,27 @@ def signedShift (i : Nat) : Int :=
   else
     -Int.ofNat (i / 2)
 
+/-- Search successive signed shifts without materializing the remaining range. -/
+@[expose]
+def findSquarefreeShiftAux (level : Level) (lower : List Level)
+    (f : Array (Array Rat)) (i : Nat) : Nat →
+    Option (Int × Array (Array Rat))
+  | 0 => none
+  | fuel + 1 =>
+    let c := signedShift i
+    let norm := oneLevel level lower f c
+    if isSquarefree lower norm then
+      some (c, norm)
+    else
+      findSquarefreeShiftAux level lower f (i + 1) fuel
+
 /-- Search exactly the finite Trager collision bound and return the first
 shift whose one-level norm is squarefree over the lower tower. -/
 @[expose]
 def findSquarefreeShift (level : Level) (lower : List Level)
     (f : Array (Array Rat)) : Option (Int × Array (Array Rat)) :=
-  (List.range (tragerShiftCount level.degree (f.size - 1))).findSome? fun i =>
-    let c := signedShift i
-    let norm := oneLevel level lower f c
-    if isSquarefree lower norm then some (c, norm) else none
+  findSquarefreeShiftAux level lower f 0
+    (tragerShiftCount level.degree (f.size - 1))
 
 /-! Compiled one-level norm regressions over `ℚ(√2)`. -/
 

--- a/progress/20260727T074955Z_number-field-tower-trager.md
+++ b/progress/20260727T074955Z_number-field-tower-trager.md
@@ -1,0 +1,32 @@
+# Number-field tower Trager factorization
+
+## Accomplished
+
+- Implemented generator shifts, lower-polynomial embedding, shifted gcd
+  recovery, and inverse shifting for one Trager recursion level.
+- Added structurally recursive squarefree factorization through lower tower
+  tails, with exact reconstruction before returning recovered factors.
+- Added the full Yun-plus-Trager driver with scalar extraction, explicit
+  multiplicities, canonical lexicographic sorting, and recursive executable
+  irreducibility replay.
+- Added the public `checkFactorization`, dependent `Factorization`, and
+  `factor?` APIs from the tower SPEC.
+- Added compiled regressions for a collision search that first succeeds at
+  shift 2, an irreducible component, repeated factors, zero/constants, and the
+  public dependent result over `Q(sqrt(2))`.
+- Verified `lake build HexNumberFieldTower.Factor` and the full `lake build`.
+
+## Current frontier
+
+Complete factorization is executable and self-checking. The checker is not yet
+stored as an invariant of each constructed level, so the representation must
+be refactored before the Mathlib field-law proofs rely on tower validity.
+
+## Next step
+
+Tie level construction definitionally to the relative irreducibility checker,
+then implement fixed-embedding factor selection for `adjoin?`.
+
+## Blockers
+
+None.

--- a/progress/20260727T080047Z_number-field-tower-factor-check.md
+++ b/progress/20260727T080047Z_number-field-tower-factor-check.md
@@ -1,0 +1,18 @@
+# Accomplished
+
+- Required the full factorization driver to validate Yun output before recursive Trager factorization.
+- Made canonical factor ordering strict so duplicate irreducibles cannot be split across multiple multiplicity entries.
+- Added a reconstruction-preserving duplicate-factor negative regression.
+- Rebuilt `HexNumberFieldTower.Factor` successfully after rebasing the corrected Yun implementation.
+
+# Current frontier
+
+The local and final factorization certificates now agree on unique multiplicity representation. The independent Trager review is still running asynchronously.
+
+# Next step
+
+Propagate this checker hardening, then establish a validated raw/certified tower boundary so only checked levels can reach public arithmetic and factorization APIs.
+
+# Blockers
+
+None.

--- a/progress/20260727T080840Z_number-field-tower-trager-review.md
+++ b/progress/20260727T080840Z_number-field-tower-trager-review.md
@@ -1,0 +1,19 @@
+# Accomplished
+
+- Incorporated the completed independent Trager review after verifying its findings against the current stack.
+- Removed the duplicate successful full-certificate replay, reordered the remaining checker from cheap to expensive checks, and added an independent `ZPoly.isIrreducible` base leg.
+- Added a recursive squarefree entry guard, keyed canonical sorting, logarithmic polynomial powering, panic-free checker indexing, and a lazy collision-bound shift search.
+- Added the specified height-two `X² - 3` regression over `Q(sqrt(2), sqrt(3))` and a nonsquarefree-entry regression.
+- Rebuilt `HexNumberFieldTower.Norm`, `HexNumberFieldTower.Factor`, and the full repository successfully.
+
+# Current frontier
+
+All merge-relevant Trager review findings are addressed. The review confirmed the shift direction, resultant orientation, collision bound, mixed-radix layout, and termination; lower-priority allocation cleanup in recovery remains optional.
+
+# Next step
+
+Push the reviewed Trager milestone, rebase the adjoining-roots branch, and implement fixed-embedding factor selection together with a validated tower-construction boundary.
+
+# Blockers
+
+None.

--- a/progress/20260727T082756Z_number-field-tower-trager-review-round2.md
+++ b/progress/20260727T082756Z_number-field-tower-trager-review-round2.md
@@ -1,0 +1,19 @@
+# Accomplished
+
+- Processed the completed independent Trager review, which confirmed the Yun recurrence, shift and resultant orientation, mixed-radix layout, collision bound, and earlier hardening changes.
+- Closed the review's canonicalization hole by requiring every raw factor coordinate array to equal its normalized representation before ordering or certification.
+- Reordered Yun checks so multiplicity and monic positive-degree shape checks precede gcd work, and explicitly rejected constant Yun components.
+- Clarified that rational irreducibility checking shares the integer factorization implementation rather than claiming an independent oracle.
+- Added regressions for disguised duplicate factors and constant Yun components; rebuilt `HexNumberFieldTower.Factor` successfully.
+
+# Current frontier
+
+The remaining review suggestion is witness-cached Trager replay, a performance redesign rather than a correctness issue. The current finite checker deliberately recomputes candidates and remains within the Phase 1 scope.
+
+# Next step
+
+Carry this focused review fix through the stacked root-selection and validated-adjoin branches, then continue the splitting-field implementation.
+
+# Blockers
+
+None.


### PR DESCRIPTION
## Summary
- implement bounded recursive Trager factorization over tower tails
- recover shifted factors by gcd, undo shifts, and verify reconstruction
- add canonical sorting and recursive executable irreducibility replay
- expose checked Factorization and factor? dependent APIs
- cover collisions, irreducible components, multiplicities, zero, and constants

## Verification
- lake build HexNumberFieldTower.Factor
- lake build

Stacked on #8921.