### PR TITLE
perf(roots): reuse Taylor shifts in certification

### DIFF
--- a/HexRoots/Bisection.lean
+++ b/HexRoots/Bisection.lean
@@ -96,6 +96,13 @@ the fallback is unreachable in the current implementation. -/
 
 namespace Component
 
+/-- A Taylor shift cached at a component's enclosing-square centre. The
+    equality field prevents coefficient-level certification kernels from being
+    called with a shift from another centre. -/
+structure PelletShift (p : ZPoly) (c : Component) where
+  coeffs : Array GaussDyadic
+  valid : coeffs = taylor p (encSquare c.squares).center
+
 /-- One subdivision round: split every square into four children one bit
     finer, discard children whose disc certifiably contains no root (the
     `T₀` test; a child whose `T₀` test fails to certify is kept, which is
@@ -121,20 +128,28 @@ lineages. -/
       (fun s => !rootFree p s)
   (glueCovered survivors).map fun ss => { squares := ss, candidateK := 1 }
 
-/-- Attempt Pellet certification for one positive candidate count, including
-the same-count speculative Newton jump and its disc-containment guard. -/
-@[expose] def certifyPelletAt? (p : ZPoly) (c : Component)
+/-- Attempt Pellet certification for one positive candidate count from the
+    cached Taylor shift at the component's enclosing-square centre. The proof
+    argument ties the cache to that centre; it is erased from compiled code. -/
+@[expose] def certifyPelletAtShift? (p : ZPoly) (c : Component)
+    (shift : PelletShift p c)
     (k : Nat) : Option (Certified p) :=
   let enc := encSquare c.squares
   if hk : 0 < k then
-    if hw : witnessCheck p enc k = true then
-      let cluster : DyadicRootCluster p := ⟨c.squares, k, hk, hw⟩
+    if hw : Taylor.witnessCheck shift.coeffs enc k = true then
+      have hw₀ : witnessCheck p enc k = true := by
+        simpa [witnessCheck, shift.valid] using hw
+      let cluster : DyadicRootCluster p := ⟨c.squares, k, hk, hw₀⟩
       let base : Certified p :=
         if hk1 : k = 1 then .atom (cluster.atomize hk1) else .cluster cluster
-      let s' := newtonSquare p enc k
+      let s' := Taylor.newtonSquare shift.coeffs enc k
       if _hins : (encSquare #[s']).discInside enc = true then
-        if hw' : witnessCheck p (encSquare #[s']) k = true then
-          let cluster' : DyadicRootCluster p := ⟨#[s'], k, hk, hw'⟩
+        let cand := encSquare #[s']
+        let cs' := taylor p cand.center
+        if hw' : Taylor.witnessCheck cs' cand k = true then
+          have hw₀' : witnessCheck p cand k = true := by
+            simpa [witnessCheck] using hw'
+          let cluster' : DyadicRootCluster p := ⟨#[s'], k, hk, hw₀'⟩
           if hk1 : k = 1 then some (.atom (cluster'.atomize hk1))
           else some (.cluster cluster')
         else some base
@@ -142,12 +157,29 @@ the same-count speculative Newton jump and its disc-containment guard. -/
     else none
   else none
 
-/-- First successful Pellet certificate in a candidate-count list. -/
-@[expose] def certifyPelletList? (p : ZPoly) (c : Component)
+/-- Public one-count Pellet attempt. It computes the enclosing-centre Taylor
+    shift once and passes it to the cached implementation. -/
+@[expose] def certifyPelletAt? (p : ZPoly) (c : Component)
+    (k : Nat) : Option (Certified p) :=
+  let shift : PelletShift p c := ⟨taylor p (encSquare c.squares).center, rfl⟩
+  certifyPelletAtShift? p c shift k
+
+/-- First successful Pellet certificate in a candidate-count list, reusing
+    one enclosing-centre Taylor shift for every failed count. -/
+@[expose] def certifyPelletListShift? (p : ZPoly) (c : Component)
+    (shift : PelletShift p c)
     : List Nat → Option (Certified p)
   | [] => none
-  | k :: ks => (certifyPelletAt? p c k).orElse
-      fun _ => certifyPelletList? p c ks
+  | k :: ks => (certifyPelletAtShift? p c shift k).orElse
+      fun _ => certifyPelletListShift? p c shift ks
+
+/-- Public candidate-count search. The exact Taylor shift is shared by every
+    attempt; only a successful count's speculative candidate needs a new
+    shift for its witness recheck. -/
+@[expose] def certifyPelletList? (p : ZPoly) (c : Component)
+    (ks : List Nat) : Option (Certified p) :=
+  let shift : PelletShift p c := ⟨taylor p (encSquare c.squares).center, rfl⟩
+  certifyPelletListShift? p c shift ks
 
 /-- The Pellet half of component certification, factored from `certify?` so
 its base and speculative same-count branches have a narrow correspondence
@@ -173,15 +205,21 @@ theorem in the Mathlib companion. -/
   match strategy with
   | .nk | .nkThenPellet =>
     let base := enc.doubled
-    if h : nkWitnessCheck p base = true then
+    let cs := taylor p base.center
+    if h : Taylor.nkWitnessCheck cs base = true then
+      have h₀ : nkWitnessCheck p base = true := by
+        simpa [nkWitnessCheck] using h
       -- `base` certifies; try to sharpen with a speculative Newton jump,
       -- accepted only when the recentred square stays inside `base` and
       -- certifies in the same (NK) form.
-      let cand := (newtonSquare p base 1).doubled
+      let cand := (Taylor.newtonSquare cs base 1).doubled
       if cand.squareInside base = true then
-        if h' : nkWitnessCheck p cand = true then
-          return some (.atom ⟨cand, Or.inl h'⟩)
-      return some (.atom ⟨base, Or.inl h⟩)
+        let cs' := taylor p cand.center
+        if h' : Taylor.nkWitnessCheck cs' cand = true then
+          have h₀' : nkWitnessCheck p cand = true := by
+            simpa [nkWitnessCheck] using h'
+          return some (.atom ⟨cand, Or.inl h₀'⟩)
+      return some (.atom ⟨base, Or.inl h₀⟩)
   | .pellet => pure ()
   -- Pellet attempt, on a quadrupled enclosing square. The original component
   -- lies in its central quarter, giving the converse theorem a uniform

--- a/HexRoots/Bisection.lean
+++ b/HexRoots/Bisection.lean
@@ -96,13 +96,6 @@ the fallback is unreachable in the current implementation. -/
 
 namespace Component
 
-/-- A Taylor shift cached at a component's enclosing-square centre. The
-    equality field prevents coefficient-level certification kernels from being
-    called with a shift from another centre. -/
-structure PelletShift (p : ZPoly) (c : Component) where
-  coeffs : Array GaussDyadic
-  valid : coeffs = taylor p (encSquare c.squares).center
-
 /-- One subdivision round: split every square into four children one bit
     finer, discard children whose disc certifiably contains no root (the
     `T₀` test; a child whose `T₀` test fails to certify is kept, which is
@@ -132,23 +125,23 @@ lineages. -/
     cached Taylor shift at the component's enclosing-square centre. The proof
     argument ties the cache to that centre; it is erased from compiled code. -/
 @[expose] def certifyPelletAtShift? (p : ZPoly) (c : Component)
-    (shift : PelletShift p c)
+    (shift : TaylorShift p (encSquare c.squares).center)
     (k : Nat) : Option (Certified p) :=
   let enc := encSquare c.squares
   if hk : 0 < k then
-    if hw : Taylor.witnessCheck shift.coeffs enc k = true then
+    if hw : TaylorShift.witnessCheck enc shift k = true then
       have hw₀ : witnessCheck p enc k = true := by
-        simpa [witnessCheck, shift.valid] using hw
+        simpa using hw
       let cluster : DyadicRootCluster p := ⟨c.squares, k, hk, hw₀⟩
       let base : Certified p :=
         if hk1 : k = 1 then .atom (cluster.atomize hk1) else .cluster cluster
-      let s' := Taylor.newtonSquare shift.coeffs enc k
+      let s' := TaylorShift.newtonSquare enc shift k
       if _hins : (encSquare #[s']).discInside enc = true then
         let cand := encSquare #[s']
-        let cs' := taylor p cand.center
-        if hw' : Taylor.witnessCheck cs' cand k = true then
+        let shift' := TaylorShift.compute p cand.center
+        if hw' : TaylorShift.witnessCheck cand shift' k = true then
           have hw₀' : witnessCheck p cand k = true := by
-            simpa [witnessCheck] using hw'
+            simpa using hw'
           let cluster' : DyadicRootCluster p := ⟨#[s'], k, hk, hw₀'⟩
           if hk1 : k = 1 then some (.atom (cluster'.atomize hk1))
           else some (.cluster cluster')
@@ -161,13 +154,13 @@ lineages. -/
     shift once and passes it to the cached implementation. -/
 @[expose] def certifyPelletAt? (p : ZPoly) (c : Component)
     (k : Nat) : Option (Certified p) :=
-  let shift : PelletShift p c := ⟨taylor p (encSquare c.squares).center, rfl⟩
+  let shift := TaylorShift.compute p (encSquare c.squares).center
   certifyPelletAtShift? p c shift k
 
 /-- First successful Pellet certificate in a candidate-count list, reusing
     one enclosing-centre Taylor shift for every failed count. -/
 @[expose] def certifyPelletListShift? (p : ZPoly) (c : Component)
-    (shift : PelletShift p c)
+    (shift : TaylorShift p (encSquare c.squares).center)
     : List Nat → Option (Certified p)
   | [] => none
   | k :: ks => (certifyPelletAtShift? p c shift k).orElse
@@ -178,16 +171,22 @@ lineages. -/
     shift for its witness recheck. -/
 @[expose] def certifyPelletList? (p : ZPoly) (c : Component)
     (ks : List Nat) : Option (Certified p) :=
-  let shift : PelletShift p c := ⟨taylor p (encSquare c.squares).center, rfl⟩
+  let shift := TaylorShift.compute p (encSquare c.squares).center
   certifyPelletListShift? p c shift ks
 
-/-- The Pellet half of component certification, factored from `certify?` so
-its base and speculative same-count branches have a narrow correspondence
-theorem in the Mathlib companion. -/
-@[expose] def certifyPellet? (p : ZPoly) (c : Component) : Option (Certified p) :=
+/-- The Pellet half of component certification using a supplied shift. -/
+@[expose] def certifyPelletShift? (p : ZPoly) (c : Component)
+    (shift : TaylorShift p (encSquare c.squares).center) : Option (Certified p) :=
   let deg := p.degree?.getD 0
   let ks := #[c.candidateK] ++ ((Array.range (deg + 1)).filter (· != c.candidateK))
-  certifyPelletList? p c ks.toList
+  certifyPelletListShift? p c shift ks.toList
+
+/-- The public Pellet half of component certification. This proof-facing
+    compatibility surface computes its own shift; `certify?` supplies the
+    already-cached shift to `certifyPelletShift?`. -/
+@[expose] def certifyPellet? (p : ZPoly) (c : Component) : Option (Certified p) :=
+  let shift := TaylorShift.compute p (encSquare c.squares).center
+  certifyPelletShift? p c shift
 
 /-- Try to certify the component. Per `strategy`, first the
     Newton-Kantorovich atom witness on the doubled enclosing square (with a
@@ -201,23 +200,23 @@ theorem in the Mathlib companion. -/
 @[expose] def certify? (p : ZPoly) (strategy : AtomStrategy := .nkThenPellet)
     (c : Component) : Option (Certified p) := Id.run do
   let enc := encSquare c.squares
+  let shift := TaylorShift.compute p enc.center
   -- Newton-Kantorovich attempt, on the doubled enclosing square.
   match strategy with
   | .nk | .nkThenPellet =>
     let base := enc.doubled
-    let cs := taylor p base.center
-    if h : Taylor.nkWitnessCheck cs base = true then
+    if h : TaylorShift.nkWitnessCheck base shift = true then
       have h₀ : nkWitnessCheck p base = true := by
-        simpa [nkWitnessCheck] using h
+        simpa using h
       -- `base` certifies; try to sharpen with a speculative Newton jump,
       -- accepted only when the recentred square stays inside `base` and
       -- certifies in the same (NK) form.
-      let cand := (Taylor.newtonSquare cs base 1).doubled
+      let cand := (TaylorShift.newtonSquare base shift 1).doubled
       if cand.squareInside base = true then
-        let cs' := taylor p cand.center
-        if h' : Taylor.nkWitnessCheck cs' cand = true then
+        let shift' := TaylorShift.compute p cand.center
+        if h' : TaylorShift.nkWitnessCheck cand shift' = true then
           have h₀' : nkWitnessCheck p cand = true := by
-            simpa [nkWitnessCheck] using h'
+            simpa using h'
           return some (.atom ⟨cand, Or.inl h₀'⟩)
       return some (.atom ⟨base, Or.inl h₀⟩)
   | .pellet => pure ()
@@ -228,7 +227,11 @@ theorem in the Mathlib companion. -/
   | .pellet | .nkThenPellet =>
     let wide : Component :=
       { squares := #[enc.doubled.doubled], candidateK := c.candidateK }
-    return certifyPellet? p wide
+    let wideCenter := (encSquare wide.squares).center
+    let wideShift : TaylorShift p wideCenter :=
+      if hcenter : enc.center = wideCenter then shift.cast hcenter
+      else TaylorShift.compute p wideCenter
+    return certifyPelletShift? p wide wideShift
   | .nk => pure ()
   return none
 

--- a/HexRoots/Kantorovich.lean
+++ b/HexRoots/Kantorovich.lean
@@ -195,9 +195,11 @@ theorem Dyadic.invFloor_eq_invAtPrec_of_pos {x : Dyadic} (hx : 0 < x) (q : Int) 
       rw [← hpows] at hltmul
       grind
 
-/-- The Newton-Kantorovich contraction check on the closed square `s` itself
-    (sup norm), with `r = 2^{−s.prec}` the half-width. Writing
-    `cs = taylor p s.center` for the exact Taylor coefficients and requiring
+namespace Taylor
+
+/-- The Newton-Kantorovich contraction check from an already-computed Taylor
+    shift on the closed square `s` itself (sup norm), with `r = 2^{−s.prec}`
+    the half-width. Requiring
     `2 ≤ cs.size` with `0 < normSq c₁`, it builds the exact reciprocal
     `w = conj(c₁)·invFloor (normSq c₁) q` (pinned precision
     `q = 8 + max 0 (ceilLog2 (normSq c₁))`), the residuals `dₖ = w·cₖ`, and the
@@ -206,8 +208,7 @@ theorem Dyadic.invFloor_eq_invAtPrec_of_pos {x : Dyadic} (hx : 0 < x) (q : Int) 
     It then returns the conjunction of the three strict exact-dyadic
     comparisons `0 < normSq c₁`, `y + z₁·r + z₂·r²/2 < r`, and
     `z₁ + z₂·r < 1`. -/
-@[expose] def nkWitnessCheck (p : ZPoly) (s : DyadicSquare) : Bool :=
-  let cs := taylor p s.center
+@[expose] def nkWitnessCheck (cs : Array GaussDyadic) (s : DyadicSquare) : Bool :=
   if 2 ≤ cs.size then
     let c₁ := cs.getD 1 (0, 0)
     let nsq := GaussDyadic.normSq c₁
@@ -236,6 +237,13 @@ theorem Dyadic.invFloor_eq_invAtPrec_of_pos {x : Dyadic} (hx : 0 < x) (q : Int) 
       && decide (z₁ + z₂ * r < 1)
   else
     false
+
+end Taylor
+
+/-- The Newton-Kantorovich contraction check on the closed square `s` itself,
+    using the exact Taylor shift of `p` at `s.center`. -/
+@[expose] def nkWitnessCheck (p : ZPoly) (s : DyadicSquare) : Bool :=
+  Taylor.nkWitnessCheck (taylor p s.center) s
 
 /-- Newton-Kantorovich contraction witness on the closed square `s` itself
     (sup norm), with `r = 2^{−s.prec}` the half-width and `y, z₁, z₂` the exact

--- a/HexRoots/Kantorovich.lean
+++ b/HexRoots/Kantorovich.lean
@@ -195,7 +195,7 @@ theorem Dyadic.invFloor_eq_invAtPrec_of_pos {x : Dyadic} (hx : 0 < x) (q : Int) 
       rw [← hpows] at hltmul
       grind
 
-namespace Taylor
+namespace TaylorShift
 
 /-- The Newton-Kantorovich contraction check from an already-computed Taylor
     shift on the closed square `s` itself (sup norm), with `r = 2^{−s.prec}`
@@ -208,7 +208,9 @@ namespace Taylor
     It then returns the conjunction of the three strict exact-dyadic
     comparisons `0 < normSq c₁`, `y + z₁·r + z₂·r²/2 < r`, and
     `z₁ + z₂·r < 1`. -/
-@[expose] def nkWitnessCheck (cs : Array GaussDyadic) (s : DyadicSquare) : Bool :=
+@[expose] def nkWitnessCheck {p : ZPoly} (s : DyadicSquare)
+    (shift : TaylorShift p s.center) : Bool :=
+  let cs := shift.coeffs
   if 2 ≤ cs.size then
     let c₁ := cs.getD 1 (0, 0)
     let nsq := GaussDyadic.normSq c₁
@@ -238,12 +240,20 @@ namespace Taylor
   else
     false
 
-end Taylor
+end TaylorShift
 
 /-- The Newton-Kantorovich contraction check on the closed square `s` itself,
     using the exact Taylor shift of `p` at `s.center`. -/
 @[expose] def nkWitnessCheck (p : ZPoly) (s : DyadicSquare) : Bool :=
-  Taylor.nkWitnessCheck (taylor p s.center) s
+  TaylorShift.nkWitnessCheck s (TaylorShift.compute p s.center)
+
+/-- The centre-indexed coefficient kernel is exactly the public polynomial
+    Newton–Kantorovich check. -/
+@[simp] theorem TaylorShift.nkWitnessCheck_eq {p : ZPoly} (s : DyadicSquare)
+    (shift : TaylorShift p s.center) :
+    TaylorShift.nkWitnessCheck s shift = _root_.Hex.nkWitnessCheck p s := by
+  rw [TaylorShift.nkWitnessCheck, _root_.Hex.nkWitnessCheck, shift.valid]
+  rfl
 
 /-- Newton-Kantorovich contraction witness on the closed square `s` itself
     (sup norm), with `r = 2^{−s.prec}` the half-width and `y, z₁, z₂` the exact

--- a/HexRoots/Newton.lean
+++ b/HexRoots/Newton.lean
@@ -32,16 +32,13 @@ precision choices here, only the success rate does.
 -/
 namespace Hex
 
-/-- Speculative Newton step `x' = x − k·c₀/c₁` from the centre of `s`,
-    returning the recentred, much smaller square at
-    `prec' = max (s.prec + 2) (2·s.prec)`. `k = 1` is the atom form; general
-    `k` is the `k`-order cluster step (BSSY §5). Purely speculative: the
-    caller must re-certify and apply the coverage guard. Degree `< 1`
-    (`cs.size < 2`) returns `s` unchanged; `c₁ = 0` gives `1/|c₁|² = 0`, so
-    the centre is returned unchanged (`x' = x`) at the finer `prec'`. Either
-    way the degenerate result is rejected by the re-check. -/
-@[expose] def newtonSquare (p : ZPoly) (s : DyadicSquare) (k : Nat) : DyadicSquare :=
-  let cs := taylor p s.center
+namespace Taylor
+
+/-- Speculative Newton step from already-computed Taylor coefficients. The
+    caller is responsible for supplying the shift at `s.center`; this kernel
+    exists so certification can reuse the shift that established its base
+    witness. -/
+@[expose] def newtonSquare (cs : Array GaussDyadic) (s : DyadicSquare) (k : Nat) : DyadicSquare :=
   if cs.size < 2 then s else
   let c0 := cs.getD 0 (0, 0)
   let c1 := cs.getD 1 (0, 0)
@@ -75,6 +72,19 @@ namespace Hex
   { re := (s.re - t.1 * inv).roundDown (prec' + 3),
     im := (s.im - t.2 * inv).roundDown (prec' + 3),
     prec := prec' }
+
+end Taylor
+
+/-- Speculative Newton step `x' = x − k·c₀/c₁` from the centre of `s`,
+    returning the recentred, much smaller square at
+    `prec' = max (s.prec + 2) (2·s.prec)`. `k = 1` is the atom form; general
+    `k` is the `k`-order cluster step (BSSY §5). Purely speculative: the
+    caller must re-certify and apply the coverage guard. Degree `< 1`
+    (`cs.size < 2`) returns `s` unchanged; `c₁ = 0` gives `1/|c₁|² = 0`, so
+    the centre is returned unchanged (`x' = x`) at the finer `prec'`. Either
+    way the degenerate result is rejected by the re-check. -/
+@[expose] def newtonSquare (p : ZPoly) (s : DyadicSquare) (k : Nat) : DyadicSquare :=
+  Taylor.newtonSquare (taylor p s.center) s k
 
 /-- The square concentric with `s`, one level coarser (half-width doubled).
     The Newton-Kantorovich certification convention tests and stores this. -/

--- a/HexRoots/Newton.lean
+++ b/HexRoots/Newton.lean
@@ -32,13 +32,15 @@ precision choices here, only the success rate does.
 -/
 namespace Hex
 
-namespace Taylor
+namespace TaylorShift
 
 /-- Speculative Newton step from already-computed Taylor coefficients. The
     caller is responsible for supplying the shift at `s.center`; this kernel
     exists so certification can reuse the shift that established its base
     witness. -/
-@[expose] def newtonSquare (cs : Array GaussDyadic) (s : DyadicSquare) (k : Nat) : DyadicSquare :=
+@[expose] def newtonSquare {p : ZPoly} (s : DyadicSquare)
+    (shift : TaylorShift p s.center) (k : Nat) : DyadicSquare :=
+  let cs := shift.coeffs
   if cs.size < 2 then s else
   let c0 := cs.getD 0 (0, 0)
   let c1 := cs.getD 1 (0, 0)
@@ -73,7 +75,7 @@ namespace Taylor
     im := (s.im - t.2 * inv).roundDown (prec' + 3),
     prec := prec' }
 
-end Taylor
+end TaylorShift
 
 /-- Speculative Newton step `x' = x − k·c₀/c₁` from the centre of `s`,
     returning the recentred, much smaller square at
@@ -84,7 +86,15 @@ end Taylor
     the centre is returned unchanged (`x' = x`) at the finer `prec'`. Either
     way the degenerate result is rejected by the re-check. -/
 @[expose] def newtonSquare (p : ZPoly) (s : DyadicSquare) (k : Nat) : DyadicSquare :=
-  Taylor.newtonSquare (taylor p s.center) s k
+  TaylorShift.newtonSquare s (TaylorShift.compute p s.center) k
+
+/-- The centre-indexed coefficient kernel is exactly the public polynomial
+    Newton step. -/
+@[simp] theorem TaylorShift.newtonSquare_eq {p : ZPoly} (s : DyadicSquare)
+    (shift : TaylorShift p s.center) (k : Nat) :
+    TaylorShift.newtonSquare s shift k = _root_.Hex.newtonSquare p s k := by
+  rw [TaylorShift.newtonSquare, _root_.Hex.newtonSquare, shift.valid]
+  rfl
 
 /-- The square concentric with `s`, one level coarser (half-width doubled).
     The Newton-Kantorovich certification convention tests and stores this. -/

--- a/HexRoots/Pellet.lean
+++ b/HexRoots/Pellet.lean
@@ -92,18 +92,19 @@ theorem two_lt_sqrt2Hi_sq : 2 < sqrt2Hi * sqrt2Hi := by decide
   else
     false
 
-namespace Taylor
+namespace TaylorShift
 
 /-- Three-radius strong Pellet check from an already-computed Taylor shift.
     Keeping this coefficient-level kernel separate lets a certifier test every
     candidate root count at one centre without repeating the quadratic Taylor
     shift. -/
-@[expose] def witnessCheck (cs : Array GaussDyadic) (s : DyadicSquare) (k : Nat) : Bool :=
-  pelletAt cs k s.radiusLo s.radiusHi
-    && pelletAt cs k (s.radiusLo <<< (1 : Int)) (s.radiusHi <<< (1 : Int))
-    && pelletAt cs k (s.radiusLo <<< (2 : Int)) (s.radiusHi <<< (2 : Int))
+@[expose] def witnessCheck {p : ZPoly} (s : DyadicSquare)
+    (shift : TaylorShift p s.center) (k : Nat) : Bool :=
+  pelletAt shift.coeffs k s.radiusLo s.radiusHi
+    && pelletAt shift.coeffs k (s.radiusLo <<< (1 : Int)) (s.radiusHi <<< (1 : Int))
+    && pelletAt shift.coeffs k (s.radiusLo <<< (2 : Int)) (s.radiusHi <<< (2 : Int))
 
-end Taylor
+end TaylorShift
 
 /-- Three-radius strong Pellet check for `k` roots (with multiplicity) in
     the circumscribed disc of `s`: the exact Taylor coefficients of `p` at
@@ -111,7 +112,15 @@ end Taylor
     4× the base radius (the radius bounds shifted left by 1 and 2). This is
     BSSY's Newton-readiness condition. -/
 @[expose] def witnessCheck (p : ZPoly) (s : DyadicSquare) (k : Nat) : Bool :=
-  Taylor.witnessCheck (taylor p s.center) s k
+  TaylorShift.witnessCheck s (TaylorShift.compute p s.center) k
+
+/-- The centre-indexed coefficient kernel is exactly the public polynomial
+    witness check. -/
+@[simp] theorem TaylorShift.witnessCheck_eq {p : ZPoly} (s : DyadicSquare)
+    (shift : TaylorShift p s.center) (k : Nat) :
+    TaylorShift.witnessCheck s shift k = _root_.Hex.witnessCheck p s k := by
+  rw [TaylorShift.witnessCheck, _root_.Hex.witnessCheck, shift.valid]
+  rfl
 
 /-- Strong Pellet witness: with `(c₀, …, c_n)` the exact Taylor
     coefficients of `p` at the centre of `s`, and `ρlo, ρhi` the dyadic
@@ -129,7 +138,10 @@ instance {p : ZPoly} {s : DyadicSquare} {k : Nat} : Decidable (witness p s k) :=
 
 /-- Single-radius `T_0` exclusion: the circumscribed disc of `s`
     certifiably contains no root of `p`, i.e. `lo(c₀) > Σ_{i ≥ 1} hi(c_i)·ρhi^i`
-    (the `rlo^0 = 1` power makes the base radius bound `rlo` unused). -/
+    (the `rlo^0 = 1` power makes the base radius bound `rlo` unused). This
+    fires more often than the three-radius `witness _ _ 0`; discarding a
+    square during refinement needs certification while keeping one is always
+    sound, so refinement uses this. -/
 @[expose] def rootFree (p : ZPoly) (s : DyadicSquare) : Bool :=
   pelletAt (taylor p s.center) 0 s.radiusLo s.radiusHi
 

--- a/HexRoots/Pellet.lean
+++ b/HexRoots/Pellet.lean
@@ -92,16 +92,26 @@ theorem two_lt_sqrt2Hi_sq : 2 < sqrt2Hi * sqrt2Hi := by decide
   else
     false
 
+namespace Taylor
+
+/-- Three-radius strong Pellet check from an already-computed Taylor shift.
+    Keeping this coefficient-level kernel separate lets a certifier test every
+    candidate root count at one centre without repeating the quadratic Taylor
+    shift. -/
+@[expose] def witnessCheck (cs : Array GaussDyadic) (s : DyadicSquare) (k : Nat) : Bool :=
+  pelletAt cs k s.radiusLo s.radiusHi
+    && pelletAt cs k (s.radiusLo <<< (1 : Int)) (s.radiusHi <<< (1 : Int))
+    && pelletAt cs k (s.radiusLo <<< (2 : Int)) (s.radiusHi <<< (2 : Int))
+
+end Taylor
+
 /-- Three-radius strong Pellet check for `k` roots (with multiplicity) in
     the circumscribed disc of `s`: the exact Taylor coefficients of `p` at
     `s.center`, tested by `pelletAt` at the base radius bounds and at 2× and
     4× the base radius (the radius bounds shifted left by 1 and 2). This is
     BSSY's Newton-readiness condition. -/
 @[expose] def witnessCheck (p : ZPoly) (s : DyadicSquare) (k : Nat) : Bool :=
-  let cs := taylor p s.center
-  pelletAt cs k s.radiusLo s.radiusHi
-    && pelletAt cs k (s.radiusLo <<< (1 : Int)) (s.radiusHi <<< (1 : Int))
-    && pelletAt cs k (s.radiusLo <<< (2 : Int)) (s.radiusHi <<< (2 : Int))
+  Taylor.witnessCheck (taylor p s.center) s k
 
 /-- Strong Pellet witness: with `(c₀, …, c_n)` the exact Taylor
     coefficients of `p` at the centre of `s`, and `ρlo, ρhi` the dyadic
@@ -119,10 +129,7 @@ instance {p : ZPoly} {s : DyadicSquare} {k : Nat} : Decidable (witness p s k) :=
 
 /-- Single-radius `T_0` exclusion: the circumscribed disc of `s`
     certifiably contains no root of `p`, i.e. `lo(c₀) > Σ_{i ≥ 1} hi(c_i)·ρhi^i`
-    (the `rlo^0 = 1` power makes the base radius bound `rlo` unused). This
-    fires more often than the three-radius `witness _ _ 0`; discarding a
-    square during refinement needs certification while keeping one is always
-    sound, so refinement uses this. -/
+    (the `rlo^0 = 1` power makes the base radius bound `rlo` unused). -/
 @[expose] def rootFree (p : ZPoly) (s : DyadicSquare) : Bool :=
   pelletAt (taylor p s.center) 0 s.radiusLo s.radiusHi
 

--- a/HexRoots/SPEC/hex-roots.md
+++ b/HexRoots/SPEC/hex-roots.md
@@ -360,6 +360,16 @@ def isolate (p : ZPoly) (h : Hex.HasOnlySimpleRoots p) (atom_prec : Int)
     Option (Array (DyadicRootIsolation p))
 ```
 
+`certify?` computes the exact Taylor shift once at each base square and passes
+the same coefficient array to the witness and Newton kernels. The Pellet
+candidate-count search also shares that base shift across every failed `k`;
+only a speculative recentred candidate that reaches its witness re-check needs
+a new shift. A proof field ties each cached array to the base centre, so the
+coefficient-level kernels cannot be used by certification with coefficients
+from another square. The Newton-Kantorovich route follows the same rule: its
+base witness and Newton step share one shift, and an accepted candidate gets
+one new shift for re-certification.
+
 The speculative Newton step computes `x' = x − k · c₀/c₁` (with
 `k = 1` for atoms; the k-order step for clusters is BSSY §5), places a
 much smaller square at `x'`, and re-runs the witness. If the witness
@@ -794,7 +804,11 @@ bit-length at precision `prec`.
   same shape and cost, plus one `Dyadic.invAtPrec` call, and tests
   one radius where the Pellet form tests three.
 - One Newton step costs the same order as one witness check, plus a
-  single `Dyadic.invAtPrec` call.
+  single `Dyadic.invAtPrec` call. Within `certify?`, the witness and
+  Newton kernels share one Taylor shift; the Pellet candidate-count
+  search likewise pays one base shift rather than one per attempted
+  count. This does not change the asymptotic bound, but removes the
+  repeated dominant `O(n²)` shift from those paths.
 - `isolate` for degree `n`, well-separated roots, target precision
   `prec`: heuristically `O(n³ · B²)` bit operations. Tight root
   clusters add subdivision depth up to `O(mahlerPrec p)`.
@@ -807,10 +821,10 @@ degree-100 rows are measured with `isolateAll?` at the stated
 precision, since `isolate`'s target carries a `separationDepth` floor
 that exceeds these precisions from degree 50 up):
 
-- Degree 10, prec 32: under 1 second (measured 0.14 s).
-- Degree 20, prec 32: under 30 seconds (measured about 15 s). This is
+- Degree 10, prec 32: under 0.6 seconds (measured 0.266 s).
+- Degree 20, prec 32: under 10 seconds (measured 4.85 s). This is
   the scale `hex-number-field` consumes.
-- Degree 50, prec 64: under 15 minutes (measured 8.3 minutes).
+- Degree 50, prec 64: under 14 minutes (measured 6.90 minutes).
 - Degree 100, prec 128: no budget pinned. The measured run did not
   complete within 19 minutes and the extrapolated cost is hours; a
   budget is set once the optimisation work below makes the scale

--- a/HexRoots/SPEC/hex-roots.md
+++ b/HexRoots/SPEC/hex-roots.md
@@ -360,15 +360,17 @@ def isolate (p : ZPoly) (h : Hex.HasOnlySimpleRoots p) (atom_prec : Int)
     Option (Array (DyadicRootIsolation p))
 ```
 
-`certify?` computes the exact Taylor shift once at each base square and passes
-the same coefficient array to the witness and Newton kernels. The Pellet
-candidate-count search also shares that base shift across every failed `k`;
+`certify?` computes an exact Taylor shift once at its enclosing-square centre
+and passes the same coefficient array to the witness and Newton kernels. The
+Pellet candidate-count search also shares one shift across every failed `k`;
 only a speculative recentred candidate that reaches its witness re-check needs
-a new shift. A proof field ties each cached array to the base centre, so the
-coefficient-level kernels cannot be used by certification with coefficients
-from another square. The Newton-Kantorovich route follows the same rule: its
-base witness and Newton step share one shift, and an accepted candidate gets
-one new shift for re-certification.
+a new shift. In the default Newton-then-Pellet route, the widened Pellet square
+is concentric with the Newton enclosure, so an exact centre-equality guard
+reuses the same shift across the fallback as well (and recomputes if that
+equality ever fails). A proof field indexes each cached array by its polynomial
+and centre, so none of the coefficient-level Pellet, Newton, or
+Newton-Kantorovich kernels can be called by certification with coefficients
+from another centre.
 
 The speculative Newton step computes `x' = x − k · c₀/c₁` (with
 `k = 1` for atoms; the k-order step for clusters is BSSY §5), places a
@@ -807,24 +809,29 @@ bit-length at precision `prec`.
   single `Dyadic.invAtPrec` call. Within `certify?`, the witness and
   Newton kernels share one Taylor shift; the Pellet candidate-count
   search likewise pays one base shift rather than one per attempted
-  count. This does not change the asymptotic bound, but removes the
-  repeated dominant `O(n²)` shift from those paths.
+  count, and the default Newton-to-Pellet fallback reuses it because
+  the two base squares are concentric. This does not change the
+  asymptotic bound, but removes the repeated dominant `O(n²)` shift
+  from those paths.
 - `isolate` for degree `n`, well-separated roots, target precision
   `prec`: heuristically `O(n³ · B²)` bit operations. Tight root
   clusters add subdivision depth up to `O(mahlerPrec p)`.
 
 ## Time budgets (Phase 4 validation)
 
-Regression ceilings anchored to measured reality (chungus2, AMD EPYC
-9455, Lean 4.32.0-rc1, single compiled call; the degree-50 and
-degree-100 rows are measured with `isolateAll?` at the stated
-precision, since `isolate`'s target carries a `separationDepth` floor
-that exceeds these precisions from degree 50 up):
+Regression ceilings anchored to measured reality (quiet `chungus2`, AMD EPYC
+9455, Lean 4.32.0-rc1). Every pinned row runs the compiled expression
+`isolateAll? (seededPoly degree) target #[Component.cauchy ...]`; this avoids
+`isolate`'s higher `separationDepth` target and makes the stated precision the
+actual driver target. Degree 10 and 20 use five measured cold calls with no
+discarded warmup; the expensive degree-50 row uses one cold call:
 
-- Degree 10, prec 32: under 0.6 seconds (measured 0.266 s).
-- Degree 20, prec 32: under 10 seconds (measured 4.85 s). This is
-  the scale `hex-number-field` consumes.
-- Degree 50, prec 64: under 14 minutes (measured 6.90 minutes).
+- Degree 10, prec 32: under 0.7 seconds (median 0.324 s, range
+  0.285–0.343 s).
+- Degree 20, prec 32: under 12 seconds (median 5.830 s, range
+  5.426–7.098 s). This is the scale `hex-number-field` consumes.
+- Degree 50, prec 64: under 14 minutes (measured 482.979 s,
+  8.05 minutes).
 - Degree 100, prec 128: no budget pinned. The measured run did not
   complete within 19 minutes and the extrapolated cost is hours; a
   budget is set once the optimisation work below makes the scale

--- a/HexRoots/Taylor.lean
+++ b/HexRoots/Taylor.lean
@@ -504,6 +504,37 @@ private theorem coeffStage_final (p : ZPoly) (z : GaussDyadic) (k : Nat) :
   -- empty (`Nat` subtraction gives `0`), a no-op.
   (List.range n).foldl (init := a₀) (Taylor.pass n z)
 
+/-- Exact Taylor coefficients indexed by the polynomial and centre they
+    represent. The equality is proof-only; compiled values contain just the
+    coefficient array. -/
+structure TaylorShift (p : ZPoly) (center : GaussDyadic) where
+  coeffs : Array GaussDyadic
+  valid : coeffs = taylor p center
+
+namespace TaylorShift
+
+/-- At fixed polynomial and centre the coefficient equality determines the
+    cached shift uniquely. -/
+instance {p : ZPoly} {center : GaussDyadic} : Subsingleton (TaylorShift p center) where
+  allEq a b := by
+    rcases a with ⟨coeffs, hcoeffs⟩
+    rcases b with ⟨coeffs', hcoeffs'⟩
+    subst coeffs
+    subst coeffs'
+    rfl
+
+/-- Compute the exact Taylor shift at `center`. -/
+@[expose] def compute (p : ZPoly) (center : GaussDyadic) : TaylorShift p center :=
+  ⟨taylor p center, rfl⟩
+
+/-- Re-index a cached shift along an exact centre equality. This changes only
+    proof indices; the compiled coefficient array is reused. -/
+@[expose] def cast {p : ZPoly} {center center' : GaussDyadic}
+    (shift : TaylorShift p center) (h : center = center') : TaylorShift p center' :=
+  h ▸ shift
+
+end TaylorShift
+
 /-- A `List.foldl` whose step function preserves array size preserves the
     size of the accumulator. Used to see through the synthetic-division loop
     in `taylor`, whose only mutation is `Array.setIfInBounds`. -/

--- a/HexRootsMathlib/Certificate.lean
+++ b/HexRootsMathlib/Certificate.lean
@@ -276,20 +276,18 @@ private theorem basePellet_mem {p : Hex.ZPoly} {c : Hex.Component} {k : Nat}
   · exact DyadicSquare.closedSquare_subset_closedDisc _ hzsquare
 
 private theorem candidatePellet_mem {p : Hex.ZPoly} {c : Hex.Component} {k : Nat}
+    {cand : Hex.DyadicSquare}
     (hk : 0 < k) (hw : Hex.witness p (Hex.encSquare c.squares) k)
-    (hins : (Hex.encSquare #[Hex.newtonSquare p (Hex.encSquare c.squares) k]).discInside
-      (Hex.encSquare c.squares) = true)
-    (hw' : Hex.witness p
-      (Hex.encSquare #[Hex.newtonSquare p (Hex.encSquare c.squares) k]) k)
+    (hins : (Hex.encSquare #[cand]).discInside (Hex.encSquare c.squares) = true)
+    (hw' : Hex.witness p (Hex.encSquare #[cand]) k)
     {z : ℂ} (hzroot : (toPolyℂ p).eval z = 0)
     (hzbase : z ∈ DyadicSquare.closedDisc (Hex.encSquare c.squares)) :
     let cl : Hex.DyadicRootCluster p :=
-      ⟨#[Hex.newtonSquare p (Hex.encSquare c.squares) k], k, hk, hw'⟩
+      ⟨#[cand], k, hk, hw'⟩
     z ∈ Certified.region
       (if hk1 : k = 1 then .atom (cl.atomize hk1) else .cluster cl) := by
   dsimp only
-  have hzcand : z ∈ DyadicSquare.closedDisc
-      (Hex.encSquare #[Hex.newtonSquare p (Hex.encSquare c.squares) k]) :=
+  have hzcand : z ∈ DyadicSquare.closedDisc (Hex.encSquare #[cand]) :=
     root_mem_nestedPellet hk hw' hw
       (DyadicSquare.closedDisc_subset_of_discInside hins) hzroot hzbase
   split <;> rename_i hk1
@@ -297,10 +295,12 @@ private theorem candidatePellet_mem {p : Hex.ZPoly} {c : Hex.Component} {k : Nat
     exact pelletAtom_mem_region hw' hzroot hzcand
   · exact hzcand
 
-/-- Each individual executable Pellet attempt preserves every polynomial
-root covered by the input component. -/
-theorem certifyPelletAt_preserves {p : Hex.ZPoly} {c : Hex.Component} {k : Nat}
-    {r : Hex.Certified p} (hcert : Hex.Component.certifyPelletAt? p c k = some r)
+/-- Each cached-shift Pellet attempt preserves every polynomial root covered
+    by the input component. -/
+theorem certifyPelletAtShift_preserves {p : Hex.ZPoly} {c : Hex.Component}
+    {shift : Hex.Component.PelletShift p c} {k : Nat}
+    {r : Hex.Certified p}
+    (hcert : Hex.Component.certifyPelletAtShift? p c shift k = some r)
     {z : ℂ} (hzroot : (toPolyℂ p).eval z = 0)
     (hz : z ∈ Component.region c) : z ∈ Certified.region r := by
   let enc := Hex.encSquare c.squares
@@ -308,49 +308,62 @@ theorem certifyPelletAt_preserves {p : Hex.ZPoly} {c : Hex.Component} {k : Nat}
     Component.region_subset_encSquare c hz
   have hzbase : z ∈ DyadicSquare.closedDisc enc :=
     DyadicSquare.closedSquare_subset_closedDisc enc hzsquare
-  unfold Hex.Component.certifyPelletAt? at hcert
+  unfold Hex.Component.certifyPelletAtShift? at hcert
   dsimp only at hcert
   split at hcert <;> rename_i hk
   · split at hcert <;> rename_i hw
-    · let cl : Hex.DyadicRootCluster p := ⟨c.squares, k, hk, hw⟩
+    · have hw₀ : Hex.witness p enc k := by
+        simpa [Hex.witness, Hex.witnessCheck, shift.valid] using hw
+      let cl : Hex.DyadicRootCluster p := ⟨c.squares, k, hk, hw₀⟩
       let base : Hex.Certified p :=
         if hk1 : k = 1 then .atom (cl.atomize hk1) else .cluster cl
-      let cand := Hex.newtonSquare p enc k
+      let cand := Hex.Taylor.newtonSquare shift.coeffs enc k
       split at hcert <;> rename_i hins
       · split at hcert <;> rename_i hw'
-        · let cl' : Hex.DyadicRootCluster p := ⟨#[cand], k, hk, hw'⟩
+        · have hw₀' : Hex.witness p (Hex.encSquare #[cand]) k := by
+            simpa [Hex.witness, Hex.witnessCheck] using hw'
+          let cl' : Hex.DyadicRootCluster p := ⟨#[cand], k, hk, hw₀'⟩
           split at hcert <;> rename_i hk1
           · have hr : r = .atom (cl'.atomize hk1) :=
               (Option.some.inj hcert).symm
             subst r
             simpa only [dif_pos hk1] using
-              candidatePellet_mem hk hw hins hw' hzroot hzbase
+              candidatePellet_mem hk hw₀ hins hw₀' hzroot hzbase
           · have hr : r = .cluster cl' := (Option.some.inj hcert).symm
             subst r
             simpa only [dif_neg hk1] using
-              candidatePellet_mem hk hw hins hw' hzroot hzbase
+              candidatePellet_mem hk hw₀ hins hw₀' hzroot hzbase
         · have hr : r = base := (Option.some.inj hcert).symm
           subst r
-          exact basePellet_mem hk hw hzroot hzsquare
+          exact basePellet_mem hk hw₀ hzroot hzsquare
       · have hr : r = base := (Option.some.inj hcert).symm
         subst r
-        exact basePellet_mem hk hw hzroot hzsquare
+        exact basePellet_mem hk hw₀ hzroot hzsquare
     · simp at hcert
   · simp at hcert
 
-/-- Searching a list of candidate Pellet counts preserves every polynomial
-root covered by the input component, regardless of which candidate succeeds
-first. -/
-theorem certifyPelletList_preserves {p : Hex.ZPoly} {c : Hex.Component}
+/-- The public one-count wrapper has the cached attempt's preservation
+    property. -/
+theorem certifyPelletAt_preserves {p : Hex.ZPoly} {c : Hex.Component} {k : Nat}
+    {r : Hex.Certified p} (hcert : Hex.Component.certifyPelletAt? p c k = some r)
+    {z : ℂ} (hzroot : (toPolyℂ p).eval z = 0)
+    (hz : z ∈ Component.region c) : z ∈ Certified.region r := by
+  unfold Hex.Component.certifyPelletAt? at hcert
+  exact certifyPelletAtShift_preserves hcert hzroot hz
+
+/-- Searching a list with one cached shift preserves every polynomial root
+    covered by the input component, regardless of which candidate succeeds. -/
+theorem certifyPelletListShift_preserves {p : Hex.ZPoly} {c : Hex.Component}
+    {shift : Hex.Component.PelletShift p c}
     (ks : List Nat) {r : Hex.Certified p}
-    (hcert : Hex.Component.certifyPelletList? p c ks = some r)
+    (hcert : Hex.Component.certifyPelletListShift? p c shift ks = some r)
     {z : ℂ} (hzroot : (toPolyℂ p).eval z = 0)
     (hz : z ∈ Component.region c) : z ∈ Certified.region r := by
   induction ks with
-  | nil => simp [Hex.Component.certifyPelletList?] at hcert
+  | nil => simp [Hex.Component.certifyPelletListShift?] at hcert
   | cons k ks ih =>
-      rw [Hex.Component.certifyPelletList?] at hcert
-      cases hat : Hex.Component.certifyPelletAt? p c k with
+      rw [Hex.Component.certifyPelletListShift?] at hcert
+      cases hat : Hex.Component.certifyPelletAtShift? p c shift k with
       | none =>
           simp only [hat, Option.orElse_none] at hcert
           exact ih hcert
@@ -358,7 +371,17 @@ theorem certifyPelletList_preserves {p : Hex.ZPoly} {c : Hex.Component}
           simp only [hat, Option.orElse_some] at hcert
           have hr : r' = r := Option.some.inj hcert
           subst r'
-          exact certifyPelletAt_preserves hat hzroot hz
+          exact certifyPelletAtShift_preserves hat hzroot hz
+
+/-- The public candidate-count search inherits the cached implementation's
+    preservation property. -/
+theorem certifyPelletList_preserves {p : Hex.ZPoly} {c : Hex.Component}
+    (ks : List Nat) {r : Hex.Certified p}
+    (hcert : Hex.Component.certifyPelletList? p c ks = some r)
+    {z : ℂ} (hzroot : (toPolyℂ p).eval z = 0)
+    (hz : z ∈ Component.region c) : z ∈ Certified.region r := by
+  unfold Hex.Component.certifyPelletList? at hcert
+  exact certifyPelletListShift_preserves ks hcert hzroot hz
 
 /-- The input component lies in the central quarter of the widened Pellet
 component used by `certify?`. -/

--- a/HexRootsMathlib/Certificate.lean
+++ b/HexRootsMathlib/Certificate.lean
@@ -298,7 +298,7 @@ private theorem candidatePellet_mem {p : Hex.ZPoly} {c : Hex.Component} {k : Nat
 /-- Each cached-shift Pellet attempt preserves every polynomial root covered
     by the input component. -/
 theorem certifyPelletAtShift_preserves {p : Hex.ZPoly} {c : Hex.Component}
-    {shift : Hex.Component.PelletShift p c} {k : Nat}
+    {shift : Hex.TaylorShift p (Hex.encSquare c.squares).center} {k : Nat}
     {r : Hex.Certified p}
     (hcert : Hex.Component.certifyPelletAtShift? p c shift k = some r)
     {z : ℂ} (hzroot : (toPolyℂ p).eval z = 0)
@@ -313,15 +313,15 @@ theorem certifyPelletAtShift_preserves {p : Hex.ZPoly} {c : Hex.Component}
   split at hcert <;> rename_i hk
   · split at hcert <;> rename_i hw
     · have hw₀ : Hex.witness p enc k := by
-        simpa [Hex.witness, Hex.witnessCheck, shift.valid] using hw
+        simpa [Hex.witness] using hw
       let cl : Hex.DyadicRootCluster p := ⟨c.squares, k, hk, hw₀⟩
       let base : Hex.Certified p :=
         if hk1 : k = 1 then .atom (cl.atomize hk1) else .cluster cl
-      let cand := Hex.Taylor.newtonSquare shift.coeffs enc k
+      let cand := Hex.TaylorShift.newtonSquare enc shift k
       split at hcert <;> rename_i hins
       · split at hcert <;> rename_i hw'
         · have hw₀' : Hex.witness p (Hex.encSquare #[cand]) k := by
-            simpa [Hex.witness, Hex.witnessCheck] using hw'
+            simpa [Hex.witness, cand] using hw'
           let cl' : Hex.DyadicRootCluster p := ⟨#[cand], k, hk, hw₀'⟩
           split at hcert <;> rename_i hk1
           · have hr : r = .atom (cl'.atomize hk1) :=
@@ -354,7 +354,7 @@ theorem certifyPelletAt_preserves {p : Hex.ZPoly} {c : Hex.Component} {k : Nat}
 /-- Searching a list with one cached shift preserves every polynomial root
     covered by the input component, regardless of which candidate succeeds. -/
 theorem certifyPelletListShift_preserves {p : Hex.ZPoly} {c : Hex.Component}
-    {shift : Hex.Component.PelletShift p c}
+    {shift : Hex.TaylorShift p (Hex.encSquare c.squares).center}
     (ks : List Nat) {r : Hex.Certified p}
     (hcert : Hex.Component.certifyPelletListShift? p c shift ks = some r)
     {z : ℂ} (hzroot : (toPolyℂ p).eval z = 0)
@@ -383,6 +383,27 @@ theorem certifyPelletList_preserves {p : Hex.ZPoly} {c : Hex.Component}
   unfold Hex.Component.certifyPelletList? at hcert
   exact certifyPelletListShift_preserves ks hcert hzroot hz
 
+/-- Pellet candidate search with a caller-supplied shift preserves every root
+    covered by the input component. -/
+theorem certifyPelletShift_preserves {p : Hex.ZPoly} {c : Hex.Component}
+    {shift : Hex.TaylorShift p (Hex.encSquare c.squares).center}
+    {r : Hex.Certified p}
+    (hcert : Hex.Component.certifyPelletShift? p c shift = some r)
+    {z : ℂ} (hzroot : (toPolyℂ p).eval z = 0)
+    (hz : z ∈ Component.region c) : z ∈ Certified.region r := by
+  unfold Hex.Component.certifyPelletShift? at hcert
+  exact certifyPelletListShift_preserves _ hcert hzroot hz
+
+/-- The public Pellet search inherits the caller-supplied shift
+    implementation's preservation property. -/
+theorem certifyPellet_preserves {p : Hex.ZPoly} {c : Hex.Component}
+    {r : Hex.Certified p}
+    (hcert : Hex.Component.certifyPellet? p c = some r)
+    {z : ℂ} (hzroot : (toPolyℂ p).eval z = 0)
+    (hz : z ∈ Component.region c) : z ∈ Certified.region r := by
+  unfold Hex.Component.certifyPellet? at hcert
+  exact certifyPelletShift_preserves hcert hzroot hz
+
 /-- The input component lies in the central quarter of the widened Pellet
 component used by `certify?`. -/
 private theorem mem_widePellet {c : Hex.Component} {z : ℂ}
@@ -400,8 +421,7 @@ theorem certifier_preserves_pellet (p : Hex.ZPoly) :
     Certifier.Preserves p .pellet := by
   intro c r hcert z hzroot hz
   simp only [Hex.Component.certify?] at hcert
-  unfold Hex.Component.certifyPellet? at hcert
-  exact certifyPelletList_preserves _ hcert hzroot (mem_widePellet hz)
+  exact certifyPelletShift_preserves hcert hzroot (mem_widePellet hz)
 
 /-- A combined-strategy result is an NK result from the common leading
 branch, or the result of falling through to the Pellet search. -/
@@ -415,9 +435,11 @@ theorem certify_nkThenPellet_cases {p : Hex.ZPoly} {c : Hex.Component}
         r = .atom ⟨cand, Or.inl hcand⟩) ∨
       (∃ hbase : Hex.nkWitness p base,
         r = .atom ⟨base, Or.inl hbase⟩) ∨
-      Hex.Component.certifyPellet? p
-        ⟨#[(Hex.encSquare c.squares).doubled.doubled], c.candidateK⟩ = some r := by
-  simp only [Hex.Component.certify?, Hex.nkWitness] at hcert ⊢
+      ∃ shift,
+        Hex.Component.certifyPelletShift? p
+          ⟨#[(Hex.encSquare c.squares).doubled.doubled], c.candidateK⟩ shift = some r := by
+  simp only [Hex.Component.certify?, Hex.nkWitness,
+    Hex.TaylorShift.nkWitnessCheck_eq, Hex.TaylorShift.newtonSquare_eq] at hcert ⊢
   split at hcert <;> rename_i hbase
   · split at hcert <;> rename_i hinside
     · split at hcert <;> rename_i hcand
@@ -428,7 +450,7 @@ theorem certify_nkThenPellet_cases {p : Hex.ZPoly} {c : Hex.Component}
     · right; left
       exact ⟨hbase, Option.some.inj hcert.symm⟩
   · right; right
-    exact hcert
+    exact ⟨_, hcert⟩
 
 /-- The default combined strategy preserves every input-component root in
 both its NK prefix and its Pellet fallback. -/
@@ -444,8 +466,8 @@ theorem certifier_preserves_nkThenPellet (p : Hex.ZPoly) :
   · obtain ⟨hbase, rfl⟩ := h
     rw [nkAtom_region hbase]
     exact Component.region_subset_doubledEnc c hz
-  · unfold Hex.Component.certifyPellet? at h
-    exact certifyPelletList_preserves _ h hzroot (mem_widePellet hz)
+  · obtain ⟨shift, h⟩ := h
+    exact certifyPelletShift_preserves h hzroot (mem_widePellet hz)
 
 /-- Every component certification strategy preserves each covered root. -/
 theorem certifier_preserves (p : Hex.ZPoly) (strategy : Hex.AtomStrategy) :

--- a/HexRootsMathlib/Completeness/DriverCompleteness.lean
+++ b/HexRootsMathlib/Completeness/DriverCompleteness.lean
@@ -88,12 +88,10 @@ private theorem certifyPelletAt_one {p : Hex.ZPoly} {c : Hex.Component}
       Hex.Component.certifyPelletAt? p c 1 = some (.atom iso) ∧
         (Hex.encSquare c.squares).prec ≤ iso.square.prec := by
   simp only [Hex.witness] at hbase
-  have hbase' : Hex.Taylor.witnessCheck
-      (Hex.taylor p (Hex.encSquare c.squares).center) (Hex.encSquare c.squares) 1 = true := by
-    simpa [Hex.witnessCheck] using hbase
   unfold Hex.Component.certifyPelletAt?
   unfold Hex.Component.certifyPelletAtShift?
-  simp only [Nat.zero_lt_one, ↓reduceDIte, hbase']
+  simp only [Nat.zero_lt_one, ↓reduceDIte,
+    Hex.TaylorShift.witnessCheck_eq, hbase]
   split <;> rename_i hins
   · split <;> rename_i hcand
     · refine ⟨_, rfl, ?_⟩
@@ -104,8 +102,8 @@ private theorem certifyPelletAt_one {p : Hex.ZPoly} {c : Hex.Component}
 private theorem newtonCandidate_prec {p : Hex.ZPoly} {s : Hex.DyadicSquare}
     (hsize : 1 < p.size) :
     s.prec ≤ (Hex.newtonSquare p s 1).doubled.prec := by
-  simp [Hex.newtonSquare, Hex.Taylor.newtonSquare, Hex.taylor_size,
-    show ¬p.size < 2 by omega]
+  simp [Hex.newtonSquare, Hex.TaylorShift.newtonSquare,
+    Hex.TaylorShift.compute, Hex.taylor_size, show ¬p.size < 2 by omega]
 
 /-- A checked NK base makes the NK-only prefix return an atom without losing
 stored precision. -/
@@ -499,23 +497,37 @@ theorem certify_pellet_of_glueCovered {p : Hex.ZPoly}
   have hwitness' : Hex.witness p (Hex.encSquare wc.squares) 1 := by
     simpa [wc] using hwitness
   obtain ⟨iso, hat, hisoPrec⟩ := certifyPelletAt_one hwitness'
-  have hsearch : Hex.Component.certifyPellet? p wc = some (.atom iso) := by
+  have hsearch : Hex.Component.certifyPelletShift? p wc
+      (Hex.TaylorShift.compute p (Hex.encSquare wc.squares).center) =
+        some (.atom iso) := by
     have hat' : Hex.Component.certifyPelletAtShift? p wc
-        ⟨Hex.taylor p (Hex.encSquare wc.squares).center, rfl⟩ 1 = some (.atom iso) := by
+        (Hex.TaylorShift.compute p (Hex.encSquare wc.squares).center) 1 = some (.atom iso) := by
       simpa [Hex.Component.certifyPelletAt?] using hat
     have hlist (ks : List Nat) :
-        Hex.Component.certifyPelletList? p wc (1 :: ks) = some (.atom iso) := by
-      unfold Hex.Component.certifyPelletList?
+        Hex.Component.certifyPelletListShift? p wc
+            (Hex.TaylorShift.compute p (Hex.encSquare wc.squares).center) (1 :: ks) =
+          some (.atom iso) := by
       rw [Hex.Component.certifyPelletListShift?.eq_def]
       simp only
       rw [hat']
       rfl
-    unfold Hex.Component.certifyPellet?
+    unfold Hex.Component.certifyPelletShift?
     simpa using hlist
       (((Array.range (p.degree?.getD 0 + 1)).filter (· != wc.candidateK)).toList)
   have hcert : Hex.Component.certify? p .pellet ⟨component, 1⟩ =
       some (.atom iso) := by
-    simpa [Hex.Component.certify?, enc, wide, wc] using hsearch
+    let shift := Hex.TaylorShift.compute p enc.center
+    let wideCenter := (Hex.encSquare wc.squares).center
+    let wideShift : Hex.TaylorShift p wideCenter :=
+      if hcenter : enc.center = wideCenter then shift.cast hcenter
+      else Hex.TaylorShift.compute p wideCenter
+    have hwideShift : wideShift =
+        Hex.TaylorShift.compute p (Hex.encSquare wc.squares).center :=
+      Subsingleton.elim _ _
+    have hsearch' : Hex.Component.certifyPelletShift? p wc wideShift =
+        some (.atom iso) := by simpa [hwideShift] using hsearch
+    simpa [Hex.Component.certify?, enc, wide, wc, shift, wideCenter, wideShift]
+      using hsearch'
   have hleaf : (Hex.separationDepth p : Int) ≤ prec := by omega
   have henc := encSquare_prec_of_glueCovered hp hsize hsep hleaf hprec hkeep hc
   have hwideTarget : target ≤ wide.prec := by

--- a/HexRootsMathlib/Completeness/DriverCompleteness.lean
+++ b/HexRootsMathlib/Completeness/DriverCompleteness.lean
@@ -88,7 +88,12 @@ private theorem certifyPelletAt_one {p : Hex.ZPoly} {c : Hex.Component}
       Hex.Component.certifyPelletAt? p c 1 = some (.atom iso) ∧
         (Hex.encSquare c.squares).prec ≤ iso.square.prec := by
   simp only [Hex.witness] at hbase
-  simp only [Hex.Component.certifyPelletAt?, Nat.zero_lt_one, ↓reduceDIte, hbase]
+  have hbase' : Hex.Taylor.witnessCheck
+      (Hex.taylor p (Hex.encSquare c.squares).center) (Hex.encSquare c.squares) 1 = true := by
+    simpa [Hex.witnessCheck] using hbase
+  unfold Hex.Component.certifyPelletAt?
+  unfold Hex.Component.certifyPelletAtShift?
+  simp only [Nat.zero_lt_one, ↓reduceDIte, hbase']
   split <;> rename_i hins
   · split <;> rename_i hcand
     · refine ⟨_, rfl, ?_⟩
@@ -99,7 +104,8 @@ private theorem certifyPelletAt_one {p : Hex.ZPoly} {c : Hex.Component}
 private theorem newtonCandidate_prec {p : Hex.ZPoly} {s : Hex.DyadicSquare}
     (hsize : 1 < p.size) :
     s.prec ≤ (Hex.newtonSquare p s 1).doubled.prec := by
-  simp [Hex.newtonSquare, Hex.taylor_size, show ¬p.size < 2 by omega]
+  simp [Hex.newtonSquare, Hex.Taylor.newtonSquare, Hex.taylor_size,
+    show ¬p.size < 2 by omega]
 
 /-- A checked NK base makes the NK-only prefix return an atom without losing
 stored precision. -/
@@ -494,8 +500,19 @@ theorem certify_pellet_of_glueCovered {p : Hex.ZPoly}
     simpa [wc] using hwitness
   obtain ⟨iso, hat, hisoPrec⟩ := certifyPelletAt_one hwitness'
   have hsearch : Hex.Component.certifyPellet? p wc = some (.atom iso) := by
+    have hat' : Hex.Component.certifyPelletAtShift? p wc
+        ⟨Hex.taylor p (Hex.encSquare wc.squares).center, rfl⟩ 1 = some (.atom iso) := by
+      simpa [Hex.Component.certifyPelletAt?] using hat
+    have hlist (ks : List Nat) :
+        Hex.Component.certifyPelletList? p wc (1 :: ks) = some (.atom iso) := by
+      unfold Hex.Component.certifyPelletList?
+      rw [Hex.Component.certifyPelletListShift?.eq_def]
+      simp only
+      rw [hat']
+      rfl
     unfold Hex.Component.certifyPellet?
-    simp [wc, Hex.Component.certifyPelletList?, hat]
+    simpa using hlist
+      (((Array.range (p.degree?.getD 0 + 1)).filter (· != wc.candidateK)).toList)
   have hcert : Hex.Component.certify? p .pellet ⟨component, 1⟩ =
       some (.atom iso) := by
     simpa [Hex.Component.certify?, enc, wide, wc] using hsearch

--- a/HexRootsMathlib/Completeness/PelletDyadic.lean
+++ b/HexRootsMathlib/Completeness/PelletDyadic.lean
@@ -370,7 +370,7 @@ theorem witness_one_of_roots {p : Hex.ZPoly} {sq : Hex.DyadicSquare}
   have hcheck0 :
       Hex.pelletAt (Hex.taylor p sq.center) 1 sq.radiusLo sq.radiusHi = true := by
     simpa only [Int.ofNat_zero, shift_zero] using hcheck 0 (by omega)
-  unfold Hex.witness Hex.witnessCheck
+  unfold Hex.witness Hex.witnessCheck Hex.Taylor.witnessCheck
   simpa [Bool.and_eq_true] using
     ⟨⟨hcheck0, hcheck 1 (by omega)⟩, hcheck 2 (by omega)⟩
 

--- a/HexRootsMathlib/Completeness/PelletDyadic.lean
+++ b/HexRootsMathlib/Completeness/PelletDyadic.lean
@@ -370,7 +370,8 @@ theorem witness_one_of_roots {p : Hex.ZPoly} {sq : Hex.DyadicSquare}
   have hcheck0 :
       Hex.pelletAt (Hex.taylor p sq.center) 1 sq.radiusLo sq.radiusHi = true := by
     simpa only [Int.ofNat_zero, shift_zero] using hcheck 0 (by omega)
-  unfold Hex.witness Hex.witnessCheck Hex.Taylor.witnessCheck
+  unfold Hex.witness Hex.witnessCheck Hex.TaylorShift.witnessCheck
+    Hex.TaylorShift.compute
   simpa [Bool.and_eq_true] using
     ⟨⟨hcheck0, hcheck 1 (by omega)⟩, hcheck 2 (by omega)⟩
 

--- a/HexRootsMathlib/NKCertify.lean
+++ b/HexRootsMathlib/NKCertify.lean
@@ -33,7 +33,8 @@ theorem certify_nk_cases {p : Hex.ZPoly} {c : Hex.Component}
         r = .atom ⟨cand, Or.inl hcand⟩) ∨
       ∃ hbase : Hex.nkWitness p base,
         r = .atom ⟨base, Or.inl hbase⟩ := by
-  simp only [Hex.Component.certify?, Hex.nkWitness] at hcert ⊢
+  simp only [Hex.Component.certify?, Hex.nkWitness,
+    Hex.TaylorShift.nkWitnessCheck_eq, Hex.TaylorShift.newtonSquare_eq] at hcert ⊢
   split at hcert <;> rename_i hbase
   · split at hcert <;> rename_i hinside
     · split at hcert <;> rename_i hcand

--- a/HexRootsMathlib/NKWitness.lean
+++ b/HexRootsMathlib/NKWitness.lean
@@ -94,9 +94,9 @@ theorem witness_iff (p : Hex.ZPoly) (s : Hex.DyadicSquare) :
       0 < normSq p s ∧
       y p s + z1 p s * radius s + z2 p s * halfRadiusSq s < radius s ∧
       z1 p s + z2 p s * radius s < 1 := by
-  simp only [Hex.nkWitness, Hex.nkWitnessCheck, Hex.Taylor.nkWitnessCheck,
-    coeffs, c1, normSq, invPrec, inverse, residual, y, z1, z2Sum, z2, radius,
-    halfRadiusSq]
+  simp only [Hex.nkWitness, Hex.nkWitnessCheck, Hex.TaylorShift.nkWitnessCheck,
+    Hex.TaylorShift.compute, coeffs, c1, normSq, invPrec, inverse, residual, y,
+    z1, z2Sum, z2, radius, halfRadiusSq]
   split <;> rename_i hsize
   · simp only [Bool.and_eq_true, decide_eq_true_eq]
     constructor

--- a/HexRootsMathlib/NKWitness.lean
+++ b/HexRootsMathlib/NKWitness.lean
@@ -94,8 +94,9 @@ theorem witness_iff (p : Hex.ZPoly) (s : Hex.DyadicSquare) :
       0 < normSq p s ∧
       y p s + z1 p s * radius s + z2 p s * halfRadiusSq s < radius s ∧
       z1 p s + z2 p s * radius s < 1 := by
-  simp only [Hex.nkWitness, Hex.nkWitnessCheck, coeffs, c1, normSq, invPrec,
-    inverse, residual, y, z1, z2Sum, z2, radius, halfRadiusSq]
+  simp only [Hex.nkWitness, Hex.nkWitnessCheck, Hex.Taylor.nkWitnessCheck,
+    coeffs, c1, normSq, invPrec, inverse, residual, y, z1, z2Sum, z2, radius,
+    halfRadiusSq]
   split <;> rename_i hsize
   · simp only [Bool.and_eq_true, decide_eq_true_eq]
     constructor

--- a/HexRootsMathlib/Pellet.lean
+++ b/HexRootsMathlib/Pellet.lean
@@ -311,7 +311,7 @@ theorem checks {p : Hex.ZPoly} {s : Hex.DyadicSquare} {k : ℕ}
         (s.radiusLo <<< (1 : Int)) (s.radiusHi <<< (1 : Int)) = true) ∧
       Hex.pelletAt (Hex.taylor p s.center) k
         (s.radiusLo <<< (2 : Int)) (s.radiusHi <<< (2 : Int)) = true := by
-  unfold Hex.witness Hex.witnessCheck at h
+  unfold Hex.witness Hex.witnessCheck Hex.Taylor.witnessCheck at h
   simpa only [Bool.and_eq_true] using h
 
 private theorem radiusLo_nonneg (s : Hex.DyadicSquare) :

--- a/HexRootsMathlib/Pellet.lean
+++ b/HexRootsMathlib/Pellet.lean
@@ -311,7 +311,8 @@ theorem checks {p : Hex.ZPoly} {s : Hex.DyadicSquare} {k : ℕ}
         (s.radiusLo <<< (1 : Int)) (s.radiusHi <<< (1 : Int)) = true) ∧
       Hex.pelletAt (Hex.taylor p s.center) k
         (s.radiusLo <<< (2 : Int)) (s.radiusHi <<< (2 : Int)) = true := by
-  unfold Hex.witness Hex.witnessCheck Hex.Taylor.witnessCheck at h
+  unfold Hex.witness Hex.witnessCheck Hex.TaylorShift.witnessCheck
+    Hex.TaylorShift.compute at h
   simpa only [Bool.and_eq_true] using h
 
 private theorem radiusLo_nonneg (s : Hex.DyadicSquare) :

--- a/progress/20260727T072018Z.md
+++ b/progress/20260727T072018Z.md
@@ -1,0 +1,33 @@
+# Accomplished
+
+- Claimed GitHub issue #8751 and rebased `issue-8751` onto current `origin/main`.
+- Added coefficient-level Pellet, Newton, and Newton–Kantorovich kernels so
+  `Component.certify?` reuses one exact Taylor shift at each base centre.
+- Added a centre-indexed cache invariant and adapted the Mathlib preservation
+  and completeness proofs without changing the public certificate semantics.
+- Rejected a linear T₀ prefilter after measurement showed it regressed the
+  canonical whole isolator; none of that experiment remains in the tree.
+- Measured the focused certification median at 4.419 ms versus 6.655 ms before
+  the change, with the result hash unchanged.
+- Remeasured the SPEC budget rows on chungus2: 0.266 s at degree 10 / precision
+  32, 4.851 s at degree 20 / precision 32, and 413.846 s at degree 50 /
+  precision 64. Ratcheted the ceilings to 0.6 s, 10 s, and 14 minutes.
+- Passed `lake build`, `lake build HexConformance hexroots_emit_fixtures`, and
+  all 14 `hexroots_bench verify` registrations. Fresh emitted fixtures are
+  byte-for-byte identical to the committed HexRoots fixture file.
+
+# Current frontier
+
+The implementation, proofs, SPEC ratchet, and performance report are ready for
+the required independent second-opinion review before a pull request is opened.
+
+# Next step
+
+Run the Claude Opus review, address any validated findings, open the PR, then
+monitor accurate Actions job state through merge and enable squash auto-merge.
+
+# Blockers
+
+`python-flint` is not installed locally, so the external roots oracle could not
+run here. The emitter itself succeeds and reproduces the committed fixtures;
+CI installs python-flint and will run the oracle.

--- a/progress/20260727T080755Z.md
+++ b/progress/20260727T080755Z.md
@@ -1,0 +1,41 @@
+# HexRoots Taylor-shift reuse review and validation
+
+## Accomplished
+
+- Reworked the certification cache into `TaylorShift p center`, whose proof
+  field ties the exact coefficient array to both its polynomial and centre.
+- Shared one shift across Pellet candidate counts, the NK base witness/Newton
+  step, and the concentric NK-to-Pellet fallback; recentred candidates compute
+  a fresh indexed shift.
+- Added explicit coefficient-kernel/public-wrapper bridge lemmas and carried
+  the cached implementations through the Mathlib preservation and completeness
+  proofs without changing the public certificate definitions.
+- Addressed the Claude Opus second-opinion findings: removed the duplicate
+  default-fallback shift, used a centre-indexed cache and accurate namespace,
+  restored the `rootFree` rationale, documented the proof-facing wrappers,
+  and replaced single-call budget evidence with cold repeat ranges where
+  practical.
+- Remeasured the seeded `isolateAll?` budget rows on chungus2: degree 10 /
+  precision 32 median 0.324 s (five calls), degree 20 / precision 32 median
+  5.830 s (five calls), and degree 50 / precision 64 at 482.979 s (one call).
+  Ratcheted the ceilings to 0.7 s, 12 s, and 14 min respectively.
+- Passed `lake build` (9463 jobs), the HexRoots conformance/emitter build,
+  byte-identical 28-line fixture emission, and all 14 HexRoots benchmark
+  verification targets. No `sorry`, `axiom`, or `native_decide` was added.
+
+## Current frontier
+
+The Taylor-shift reuse slice of issue #8751 is implemented and locally green.
+The branch is ready to rebase onto the three newer `origin/main` commits and
+submit for merge-facing CI.
+
+## Next step
+
+Rebase, open the PR, resolve any integration or CI failures, and merge it. Keep
+#8751 open for the larger Graeffe-iteration and soft-Pellet optimizations.
+
+## Blockers
+
+The optional python-flint external oracle is unavailable in this worktree
+(`ModuleNotFoundError: No module named 'flint'`); Lean conformance and fixture
+identity checks passed independently.

--- a/reports/hex-roots-performance.md
+++ b/reports/hex-roots-performance.md
@@ -14,6 +14,37 @@ two runnable processes), Lean `4.32.0-rc1`, lean-bench `0.1.0`. The export's
 `git_dirty: true` records the staged benchmark/report update; its branch point
 is commit `ed0086001407`.
 
+## Taylor-shift reuse ratchet
+
+Component certification now computes one exact Taylor shift at its base centre
+and shares it between the witness and Newton kernels. The Pellet candidate
+search shares that shift across all attempted root counts; the NK route shares
+it between its base witness and speculative Newton step. A recentred candidate
+still gets its own shift for re-certification. The cache carries an equality to
+the centre it represents, so this changes evaluation work without weakening
+the certificate interface.
+
+On the canonical degree-128 pinned-NK `runCertify` case, five-repeat medians on
+`chungus2` fell from **6.655 ms** to **4.419 ms** (**33.6%**), with the result
+hash unchanged at `0x1698ec123da6112f`. The canonical degree-12
+`runIsolateAll` case changed from 9.172 s to 8.994 s; its deeper subdivision
+work dominates the saved certification shifts.
+
+The SPEC budget table was remeasured with compiled `isolateAll?` calls on the
+seeded bounded-coefficient family and ratcheted to roughly twice each observed
+runtime:
+
+| degree | target precision | measured | regression ceiling |
+|---:|---:|---:|---:|
+| 10 | 32 | 0.266 s | 0.6 s |
+| 20 | 32 | 4.851 s | 10 s |
+| 50 | 64 | 413.846 s (6.90 min) | 14 min |
+
+Degree 100 / precision 128 remains unpinned: Taylor reuse removes redundant
+quadratic shifts but does not remove the deep-subdivision and large-witness
+costs that make that scale impractical. Graeffe iteration and soft-Pellet
+filtering therefore remain the next optimization steps tracked by issue #8751.
+
 ## Bench Targets
 
 Parametric registrations:

--- a/reports/hex-roots-performance.md
+++ b/reports/hex-roots-performance.md
@@ -19,26 +19,40 @@ is commit `ed0086001407`.
 Component certification now computes one exact Taylor shift at its base centre
 and shares it between the witness and Newton kernels. The Pellet candidate
 search shares that shift across all attempted root counts; the NK route shares
-it between its base witness and speculative Newton step. A recentred candidate
-still gets its own shift for re-certification. The cache carries an equality to
-the centre it represents, so this changes evaluation work without weakening
-the certificate interface.
+it between its base witness and speculative Newton step. Because the widened
+Pellet fallback is concentric with the NK enclosure, the default combined
+route also reuses that same shift across the strategy boundary under an exact
+centre-equality guard. A recentred candidate still gets its own shift for
+re-certification. The cache is indexed by its polynomial and centre and carries
+the coefficient equality as a proof field, so this changes evaluation work
+without weakening the certificate interface.
 
 On the canonical degree-128 pinned-NK `runCertify` case, five-repeat medians on
-`chungus2` fell from **6.655 ms** to **4.419 ms** (**33.6%**), with the result
+`chungus2` fell from **6.655 ms** to **4.434 ms** (**33.4%**), with the result
 hash unchanged at `0x1698ec123da6112f`. The canonical degree-12
-`runIsolateAll` case changed from 9.172 s to 8.994 s; its deeper subdivision
-work dominates the saved certification shifts.
+`runIsolateAll` case changed from 9.172 s to 8.916 s; its deeper subdivision
+work dominates the saved certification shifts. The final five-repeat ranges
+were 4.400–4.443 ms and 8.888–9.039 s respectively.
 
-The SPEC budget table was remeasured with compiled `isolateAll?` calls on the
-seeded bounded-coefficient family and ratcheted to roughly twice each observed
-runtime:
+The SPEC budget table was remeasured with the compiled expression
+`isolateAll? (seededPoly degree) target #[Component.cauchy ...]`. The degree-10
+and degree-20 rows used five cold measured calls (`warmup := false`); the
+degree-50 row used one cold call because each invocation takes several minutes.
+All runs used `Hex.RootsBench.runIsolateAll` with temporary fixture-only
+degree/target substitutions, `--ignore-expected-hash`, and JSON export. Those
+fixture substitutions were restored after measurement. Machine-readable
+developer-local artefacts are `/tmp/hexroots-8751-d10.json`,
+`/tmp/hexroots-8751-d20.json`, and `/tmp/hexroots-8751-d50.json`.
+
+These are current-tree regression measurements, not claimed controlled
+before/after speedups: the older issue numbers were single calls from earlier
+trees. The ceilings are ratcheted to roughly twice the current measurement:
 
 | degree | target precision | measured | regression ceiling |
 |---:|---:|---:|---:|
-| 10 | 32 | 0.266 s | 0.6 s |
-| 20 | 32 | 4.851 s | 10 s |
-| 50 | 64 | 413.846 s (6.90 min) | 14 min |
+| 10 | 32 | 0.324 s median (0.285–0.343 s, 5 calls) | 0.7 s |
+| 20 | 32 | 5.830 s median (5.426–7.098 s, 5 calls) | 12 s |
+| 50 | 64 | 482.979 s (8.05 min, 1 call) | 14 min |
 
 Degree 100 / precision 128 remains unpinned: Taylor reuse removes redundant
 quadratic shifts but does not remove the deep-subdivision and large-witness


### PR DESCRIPTION
Part of #8751.

This lands the Taylor-shift-reuse slice of the tightening programme; Graeffe iteration and soft-Pellet filtering remain on the issue.

## Summary

- introduce a proof-indexed `TaylorShift p center` cache and coefficient kernels with explicit public-wrapper equivalence lemmas
- reuse one exact shift across Pellet candidate counts, NK witness/Newton work, and the concentric NK-to-Pellet fallback
- preserve fresh shifts for genuinely recentred candidates and carry the cached path through all Mathlib preservation/completeness proofs
- ratchet the SPEC ceilings from 1 s / 30 s / 15 min to 0.7 s / 12 s / 14 min with reproducible cold-run methodology

## Measurements (chungus2, Lean 4.32.0-rc1)

- canonical degree-128 `runCertify`: 6.655 ms → 4.434 ms median (33.4% faster), unchanged hash
- seeded degree 10 / precision 32: 0.324 s median over 5 cold calls (0.285–0.343 s)
- seeded degree 20 / precision 32: 5.830 s median over 5 cold calls (5.426–7.098 s)
- seeded degree 50 / precision 64: 482.979 s for one cold call

## Second opinion

Claude Opus found no soundness gap, but identified duplicate shifting across the default fallback, weak cache indexing, implicit wrapper equivalence, and under-specified benchmark evidence. This revision addresses those findings with center-indexed caches, fallback sharing under exact center equality, explicit bridge lemmas, restored/documented compatibility surfaces, and repeat ranges. Low-priority pre-existing `encSquare` recomputation inside successful candidate handling remains outside this slice.

## Verification

- `lake build` (9463 jobs), again after rebasing onto current `origin/main`
- `lake build HexConformance hexroots_emit_fixtures`
- emitted 28-line HexRoots fixture is byte-identical to `conformance-fixtures/HexRoots/roots.jsonl`
- `lake exe hexroots_bench verify` (all 14 targets)
- changed-line scan adds no `sorry`, `axiom`, or `native_decide`
- python-flint oracle unavailable locally (`ModuleNotFoundError`); Lean conformance and fixture identity checks passed