### PR TITLE
perf(hex-matrix): BDPZ two-buffer storage schedule for mulStrassen

### DIFF
--- a/HexMatrix.lean
+++ b/HexMatrix.lean
@@ -16,6 +16,7 @@ public import HexMatrix.Winograd
 public import HexMatrix.Elementary
 public import HexMatrix.Submatrix
 public import HexMatrix.Pad
+public import HexMatrix.Region
 public import HexMatrix.Strassen
 public import HexMatrix.Gram
 

--- a/HexMatrix/Basic.lean
+++ b/HexMatrix/Basic.lean
@@ -361,7 +361,7 @@ list-induction-over-`finRange` scheme as `Vector.getElem_finFoldl_modify`. -/
 
 /-- A left fold of per-index `set`s leaves untouched every position not among
 the written indices. -/
-private theorem foldl_set_ne {N : Nat} (idx : Fin m → Nat) (val : Fin m → R)
+theorem foldl_set_ne {N : Nat} (idx : Fin m → Nat) (val : Fin m → R)
     (bd : ∀ t, idx t < N) {p : Nat} (hp : p < N) :
     ∀ (xs : List (Fin m)) (d0 : Vector R N), (∀ t ∈ xs, idx t ≠ p) →
       (xs.foldl (fun d t => d.set (idx t) (val t) (bd t)) d0)[p]'hp = d0[p]'hp := by
@@ -375,7 +375,7 @@ private theorem foldl_set_ne {N : Nat} (idx : Fin m → Nat) (val : Fin m → R)
 
 /-- A left fold of per-index `set`s at injectively-indexed positions over a
 `Nodup` list writes `val r` at position `idx r` for every member `r`. -/
-private theorem foldl_set_mem {N : Nat} (idx : Fin m → Nat) (val : Fin m → R)
+theorem foldl_set_mem {N : Nat} (idx : Fin m → Nat) (val : Fin m → R)
     (bd : ∀ t, idx t < N) (hinj : ∀ a b : Fin m, idx a = idx b → a = b) :
     ∀ (xs : List (Fin m)), xs.Nodup → ∀ (d0 : Vector R N) (r : Fin m), r ∈ xs →
       (xs.foldl (fun d t => d.set (idx t) (val t) (bd t)) d0)[idx r]'(bd r) = val r := by
@@ -393,7 +393,7 @@ private theorem foldl_set_mem {N : Nat} (idx : Fin m → Nat) (val : Fin m → R
 
 /-- `List.finRange k` has no repeated indices (core-only proof; the Batteries
 `nodup_finRange` is outside this Mathlib-free module's import closure). -/
-private theorem nodup_finRange (k : Nat) : (List.finRange k).Nodup := by
+theorem nodup_finRange (k : Nat) : (List.finRange k).Nodup := by
   induction k with
   | zero => simp
   | succ j ih =>

--- a/HexMatrix/Region.lean
+++ b/HexMatrix/Region.lean
@@ -52,15 +52,33 @@ def row (D : Region N M rows cols) (i : Fin rows) : Fin N :=
 def col (D : Region N M rows cols) (j : Fin cols) : Fin M :=
   ⟨D.c0 + j.val, by have := D.cols_le; omega⟩
 
-/-- Flat destination index corresponding to local region coordinates. -/
+/-- First flat destination index in a local region row. -/
+@[inline]
+def rowStart (D : Region N M rows cols) (i : Fin rows) : Nat :=
+  (D.r0 + i.val) * M + D.c0
+
+/-- Flat destination index corresponding to local region coordinates.  The
+row-invariant multiplication is kept in `rowStart`, outside column loops. -/
 @[inline]
 def index (D : Region N M rows cols) (i : Fin rows) (j : Fin cols) : Fin (N * M) :=
-  ⟨(row D i).val * M + (col D j).val, flatIdx_lt (row D i).isLt (col D j).isLt⟩
+  ⟨rowStart D i + j.val, by
+    have h := flatIdx_lt (row D i).isLt (col D j).isLt
+    simpa only [rowStart, row, col, Nat.add_assoc] using h⟩
 
 /-- Read a matrix entry through a region descriptor. -/
 @[inline]
 def get (D : Region N M rows cols) (A : Matrix R N M) (i : Fin rows) (j : Fin cols) : R :=
   A[(row D i, col D j)]
+
+/-- A region read is a read at its flat `index`. -/
+theorem get_eq_data (D : Region N M rows cols) (A : Matrix R N M)
+    (i : Fin rows) (j : Fin cols) :
+    get D A i j = A.data[(index D i j).val]'(index D i j).isLt := by
+  change A.data.get ⟨(D.r0 + i.val) * M + (D.c0 + j.val), _⟩ =
+    A.data.get (index D i j)
+  congr 1
+  apply Fin.ext
+  simp only [index, rowStart, Nat.add_assoc]
 
 /-- Materialize the entries described by a region.  This is a proof-facing
 operation; the storage-scheduled implementation writes through descriptors
@@ -251,7 +269,8 @@ private theorem index_ne_of_disjoint (D : Region N M rows cols)
     (index D i j).val ≠ (index E i' j').val := by
   intro heq
   have hd : (row D i).val * M + (col D j).val =
-      (row E i').val * M + (col E j').val := heq
+      (row E i').val * M + (col E j').val := by
+    simpa only [index, rowStart, row, col, Nat.add_assoc] using heq
   have hrowD : ((row D i).val * M + (col D j).val) / M = (row D i).val :=
     flatIdx_div (col D j).isLt
   have hrowE : ((row E i').val * M + (col E j').val) / M = (row E i').val :=
@@ -268,33 +287,45 @@ private theorem index_ne_of_disjoint (D : Region N M rows cols)
   unfold Disjoint at h
   rcases h with h | h | h | h <;> omega
 
-/-- Overwrite one row segment of a flat matrix buffer.  The buffer is consumed,
-so `Vector.set` reuses it when it is uniquely referenced. -/
+/-- Overwrite one row segment directly from an entry function.  `rowStart` is
+computed once, and the consumed array is not retained by a temporary row. -/
 @[inline]
-def writeRow (D : Region N M rows cols) (d : Vector R (N * M))
-    (i : Fin rows) (v : Vector R cols) : Vector R (N * M) :=
-  Fin.foldl cols (fun d j => d.set (index D i j).val (v.get j) (index D i j).isLt) d
+private def setRowWith (D : Region N M rows cols) (d : Vector R (N * M))
+    (i : Fin rows) (f : Fin cols → R) : Vector R (N * M) :=
+  let base := rowStart D i
+  Fin.foldl cols (fun d j => d.set (base + j.val) (f j) (index D i j).isLt) d
+
+/-- Update one row segment entrywise.  Each old value is read before
+`Vector.set` consumes the array, avoiding both a temporary row and
+`Vector.modify`'s clear-then-set implementation. -/
+@[inline]
+private def modifyRowWith (D : Region N M rows cols) (d : Vector R (N * M))
+    (i : Fin rows) (g : Fin cols → R → R) : Vector R (N * M) :=
+  let base := rowStart D i
+  Fin.foldl cols (fun d j =>
+    let p := base + j.val
+    let x := d[p]'(index D i j).isLt
+    d.set p (g j x) (index D i j).isLt) d
 
 /-- Flat indices inside a region are injective in their local coordinates. -/
 private theorem index_inj (D : Region N M rows cols) (i i' : Fin rows) (j j' : Fin cols)
     (h : (index D i j).val = (index D i' j').val) : i = i' ∧ j = j' := by
+  have hd : (row D i).val * M + (col D j).val =
+      (row D i').val * M + (col D j').val := by
+    simpa only [index, rowStart, row, col, Nat.add_assoc] using h
   have hr : (row D i).val = (row D i').val := by
     have hi : ((row D i).val * M + (col D j).val) / M = (row D i).val :=
       flatIdx_div (col D j).isLt
     have hi' : ((row D i').val * M + (col D j').val) / M = (row D i').val :=
       flatIdx_div (col D j').isLt
-    change (row D i).val * M + (col D j).val =
-      (row D i').val * M + (col D j').val at h
-    have hdiv := congrArg (fun x => x / M) h
+    have hdiv := congrArg (fun x => x / M) hd
     omega
   have hc : (col D j).val = (col D j').val := by
     have hj : ((row D i).val * M + (col D j).val) % M = (col D j).val :=
       flatIdx_mod (col D j).isLt
     have hj' : ((row D i').val * M + (col D j').val) % M = (col D j').val :=
       flatIdx_mod (col D j').isLt
-    change (row D i).val * M + (col D j).val =
-      (row D i').val * M + (col D j').val at h
-    have hmod := congrArg (fun x => x % M) h
+    have hmod := congrArg (fun x => x % M) hd
     omega
   constructor
   · apply Fin.ext
@@ -304,65 +335,25 @@ private theorem index_inj (D : Region N M rows cols) (i i' : Fin rows) (j j' : F
     simp only [col] at hc
     omega
 
-/-- `List.finRange k` has no repeated indices. -/
-private theorem nodup_finRange (k : Nat) : (List.finRange k).Nodup := by
-  induction k with
-  | zero => simp
-  | succ j ih =>
-    rw [List.finRange_succ, List.nodup_cons]
-    exact ⟨by simp [Fin.ext_iff],
-      List.Pairwise.map _ (fun _ _ hab h => hab (Fin.succ_inj.mp h)) ih⟩
-
-/-- A fold of single-index writes preserves an index that is never targeted. -/
-private theorem foldl_set_ne {count size : Nat} (idx : Fin count → Nat)
-    (val : Fin count → R) (bd : ∀ t, idx t < size) {p : Nat} (hp : p < size) :
-    ∀ (xs : List (Fin count)) (d : Vector R size), (∀ t ∈ xs, idx t ≠ p) →
-      (xs.foldl (fun d t => d.set (idx t) (val t) (bd t)) d)[p]'hp = d[p]'hp := by
-  intro xs
-  induction xs with
-  | nil => intro d _; rfl
-  | cons x xs ih =>
-    intro d hne
-    rw [List.foldl_cons, ih _ (fun t ht => hne t (List.mem_cons_of_mem _ ht)),
-      Vector.getElem_set_ne (bd x) hp (hne x List.mem_cons_self)]
-
-/-- A fold of injectively indexed writes stores the requested member's value. -/
-private theorem foldl_set_mem {count size : Nat} (idx : Fin count → Nat)
-    (val : Fin count → R) (bd : ∀ t, idx t < size)
-    (hinj : ∀ a b : Fin count, idx a = idx b → a = b) :
-    ∀ (xs : List (Fin count)), xs.Nodup → ∀ (d : Vector R size) (r : Fin count), r ∈ xs →
-      (xs.foldl (fun d t => d.set (idx t) (val t) (bd t)) d)[idx r]'(bd r) = val r := by
-  intro xs
-  induction xs with
-  | nil => intro _ _ r hr; simp at hr
-  | cons x xs ih =>
-    intro hnd d r hr
-    rw [List.foldl_cons]
-    rcases List.mem_cons.mp hr with rfl | hr'
-    · rw [foldl_set_ne idx val bd (bd r) xs _ (fun t ht heq =>
-        (List.nodup_cons.mp hnd).1 ((hinj t r heq) ▸ ht))]
-      exact Vector.getElem_set_self (bd r)
-    · rw [ih (List.nodup_cons.mp hnd).2 _ r hr']
-
 /-- Reading the row segment just written returns the supplied value. -/
-private theorem get_writeRow (D : Region N M rows cols) (d : Vector R (N * M))
-    (i : Fin rows) (v : Vector R cols) (j : Fin cols) :
-    (writeRow D d i v)[(index D i j).val]'(index D i j).isLt = v.get j := by
-  unfold writeRow
+private theorem get_setRowWith (D : Region N M rows cols) (d : Vector R (N * M))
+    (i : Fin rows) (f : Fin cols → R) (j : Fin cols) :
+    (setRowWith D d i f)[(index D i j).val]'(index D i j).isLt = f j := by
+  unfold setRowWith
   rw [Fin.foldl_eq_finRange_foldl]
-  exact foldl_set_mem (fun t : Fin cols => (index D i t).val) (fun t => v.get t)
+  exact Matrix.foldl_set_mem (fun t : Fin cols => (index D i t).val) f
     (fun t => (index D i t).isLt)
     (fun a b h => (index_inj D i i a b h).2)
-    (List.finRange cols) (nodup_finRange cols) d j (List.mem_finRange _)
+    (List.finRange cols) (Matrix.nodup_finRange cols) d j (List.mem_finRange _)
 
 /-- Writing a row segment preserves every flat index outside that segment. -/
-private theorem get_writeRow_ne (D : Region N M rows cols) (d : Vector R (N * M))
-    (i : Fin rows) (v : Vector R cols) (p : Nat) (hp : p < N * M)
+private theorem get_setRowWith_ne (D : Region N M rows cols) (d : Vector R (N * M))
+    (i : Fin rows) (f : Fin cols → R) (p : Nat) (hp : p < N * M)
     (hne : ∀ j : Fin cols, (index D i j).val ≠ p) :
-    (writeRow D d i v)[p]'hp = d[p]'hp := by
-  unfold writeRow
+    (setRowWith D d i f)[p]'hp = d[p]'hp := by
+  unfold setRowWith
   rw [Fin.foldl_eq_finRange_foldl]
-  exact foldl_set_ne (fun j : Fin cols => (index D i j).val) (fun j => v.get j)
+  exact Matrix.foldl_set_ne (fun j : Fin cols => (index D i j).val) f
     (fun j => (index D i j).isLt) hp (List.finRange cols) d
     (fun j _ => hne j)
 
@@ -401,38 +392,37 @@ private theorem foldl_rows_mem {count size : Nat}
           (List.nodup_cons.mp hnd).1 (h ▸ ht))), hself]
     · rw [ih (List.nodup_cons.mp hnd).2 _ r hr']
 
-/-- Fill a destination region from an entry function.  The destination matrix
-is threaded linearly; only one temporary row is materialized at a time. -/
+/-- Fill a destination region from an entry function, threading the destination
+array directly through its writes. -/
 @[inline]
 def overwrite (D : Region N M rows cols) (A : Matrix R N M)
     (f : Fin rows → Fin cols → R) : Matrix R N M :=
   match A with
   | ⟨d⟩ =>
-    ⟨Fin.foldl rows (fun d i => writeRow D d i (Vector.ofFn (f i))) d⟩
+    ⟨Fin.foldl rows (fun d i => setRowWith D d i (f i)) d⟩
 
 /-- Reading inside an overwritten region returns the supplied entry. -/
 @[grind =] theorem get_overwrite (D : Region N M rows cols) (A : Matrix R N M)
     (f : Fin rows → Fin cols → R) (i : Fin rows) (j : Fin cols) :
     get D (overwrite D A f) i j = f i j := by
   obtain ⟨d⟩ := A
+  rw [get_eq_data]
   change ((overwrite D ⟨d⟩ f).data[(index D i j).val]'(index D i j).isLt) = f i j
   simp only [overwrite]
   have hfold :
-      Fin.foldl rows (fun d i => writeRow D d i (Vector.ofFn (f i))) d =
+      Fin.foldl rows (fun d i => setRowWith D d i (f i)) d =
         (List.finRange rows).foldl
-          (fun d i => writeRow D d i (Vector.ofFn (f i))) d :=
-    Fin.foldl_eq_finRange_foldl (fun d i => writeRow D d i (Vector.ofFn (f i))) d
+          (fun d i => setRowWith D d i (f i)) d :=
+    Fin.foldl_eq_finRange_foldl (fun d i => setRowWith D d i (f i)) d
   have hmem := foldl_rows_mem
-    (fun d i => writeRow D d i (Vector.ofFn (f i)))
+    (fun d i => setRowWith D d i (f i))
     (fun i => (index D i j).val) (fun i => (index D i j).isLt) (fun i => f i j)
     (fun d i => by
-      rw [get_writeRow]
-      change (Vector.ofFn (f i))[j.val]'j.isLt = f i j
-      rw [Vector.getElem_ofFn])
-    (fun d a i hai => get_writeRow_ne D d a (Vector.ofFn (f a))
+      rw [get_setRowWith])
+    (fun d a i hai => get_setRowWith_ne D d a (f a)
       (index D i j).val (index D i j).isLt (fun t heq =>
         hai (index_inj D a i t j heq).1))
-    (List.finRange rows) (nodup_finRange rows) d i (List.mem_finRange _)
+    (List.finRange rows) (Matrix.nodup_finRange rows) d i (List.mem_finRange _)
   exact (congrArg (fun v : Vector R (N * M) => v.get (index D i j)) hfold).trans hmem
 
 /-- Overwriting one region preserves every disjoint region. -/
@@ -441,44 +431,42 @@ theorem get_overwrite_disjoint (D : Region N M rows cols)
     (f : Fin rows → Fin cols → R) (i : Fin rows') (j : Fin cols') :
     get E (overwrite D A f) i j = get E A i j := by
   obtain ⟨d⟩ := A
+  rw [get_eq_data, get_eq_data]
   change ((overwrite D ⟨d⟩ f).data[(index E i j).val]'(index E i j).isLt) =
     d[(index E i j).val]'(index E i j).isLt
   simp only [overwrite]
   have hfold :
-      Fin.foldl rows (fun d i => writeRow D d i (Vector.ofFn (f i))) d =
+      Fin.foldl rows (fun d i => setRowWith D d i (f i)) d =
         (List.finRange rows).foldl
-          (fun d i => writeRow D d i (Vector.ofFn (f i))) d :=
-    Fin.foldl_eq_finRange_foldl (fun d i => writeRow D d i (Vector.ofFn (f i))) d
+          (fun d i => setRowWith D d i (f i)) d :=
+    Fin.foldl_eq_finRange_foldl (fun d i => setRowWith D d i (f i)) d
   have hpres := foldl_rows_ne
-    (fun d i => writeRow D d i (Vector.ofFn (f i)))
+    (fun d i => setRowWith D d i (f i))
     (index E i j).val (index E i j).isLt (List.finRange rows)
-    (fun d a _ => get_writeRow_ne D d a (Vector.ofFn (f a))
+    (fun d a _ => get_setRowWith_ne D d a (f a)
       (index E i j).val (index E i j).isLt
       (fun b => index_ne_of_disjoint D E h a b i j)) d
   exact (congrArg (fun v : Vector R (N * M) => v.get (index E i j)) hfold).trans hpres
 
-/-- Combine a destination region with entries supplied by a read-only function.
-Each row is fully materialized before its writes begin. -/
+/-- Combine a destination region with entries supplied by a read-only function,
+modifying each destination entry directly. -/
 @[inline]
 def accumulateWith (D : Region N M rows cols) (A : Matrix R N M)
     (f : Fin rows → Fin cols → R) (op : R → R → R) : Matrix R N M :=
   match A with
   | ⟨d⟩ =>
     ⟨Fin.foldl rows (fun d i =>
-      let v := Vector.ofFn fun j => op (d.get (index D i j)) (f i j)
-      writeRow D d i v) d⟩
+      modifyRowWith D d i (fun j x => op x (f i j))) d⟩
 
-/-- Combine a destination region entrywise with a separate matrix.  A row is
-computed before its destination writes begin, so the owned destination backing
-continues to be threaded linearly. -/
+/-- Combine a destination region entrywise with a separate matrix, modifying
+each destination entry directly. -/
 @[inline]
 def accumulateExternal (D : Region N M rows cols) (A : Matrix R N M)
     (B : Matrix R rows cols) (op : R → R → R) : Matrix R N M :=
   match A with
   | ⟨d⟩ =>
     ⟨Fin.foldl rows (fun d i =>
-      let v := Vector.ofFn fun j => op (d.get (index D i j)) B[(i, j)]
-      writeRow D d i v) d⟩
+      modifyRowWith D d i (fun j x => op x B[(i, j)])) d⟩
 
 /-- A row fold whose own row update depends on the previous value stores the
 requested row's transformed value. -/
@@ -501,6 +489,43 @@ private theorem foldl_rows_modify {count size : Nat}
     · rw [ih (List.nodup_cons.mp hnd).2 _ r hr', hne d x r (fun h =>
         (List.nodup_cons.mp hnd).1 (h ▸ hr'))]
 
+/-- Reading an updated row returns the entrywise transformation. -/
+private theorem get_modifyRowWith (D : Region N M rows cols) (d : Vector R (N * M))
+    (i : Fin rows) (g : Fin cols → R → R) (j : Fin cols) :
+    (modifyRowWith D d i g)[(index D i j).val]'(index D i j).isLt =
+      g j (d[(index D i j).val]'(index D i j).isLt) := by
+  unfold modifyRowWith
+  rw [Fin.foldl_eq_finRange_foldl]
+  let step := fun (d : Vector R (N * M)) (j : Fin cols) =>
+    let p := (index D i j).val
+    let x := d[p]'(index D i j).isLt
+    d.set p (g j x) (index D i j).isLt
+  exact foldl_rows_modify step (fun j => (index D i j).val)
+    (fun j => (index D i j).isLt) g
+    (fun d j => by
+      dsimp only [step]
+      rw [Vector.getElem_set_self])
+    (fun d a j haj => by
+      dsimp only [step]
+      exact Vector.getElem_set_ne (index D i a).isLt (index D i j).isLt
+        (fun heq => haj (index_inj D i i a j heq).2))
+    (List.finRange cols) (Matrix.nodup_finRange cols) d j (List.mem_finRange _)
+
+/-- Updating a row preserves every flat index outside that row segment. -/
+private theorem get_modifyRowWith_ne (D : Region N M rows cols) (d : Vector R (N * M))
+    (i : Fin rows) (g : Fin cols → R → R) (p : Nat) (hp : p < N * M)
+    (hne : ∀ j : Fin cols, (index D i j).val ≠ p) :
+    (modifyRowWith D d i g)[p]'hp = d[p]'hp := by
+  unfold modifyRowWith
+  rw [Fin.foldl_eq_finRange_foldl]
+  let step := fun (d : Vector R (N * M)) (j : Fin cols) =>
+    let q := (index D i j).val
+    let x := d[q]'(index D i j).isLt
+    d.set q (g j x) (index D i j).isLt
+  exact foldl_rows_ne step p hp (List.finRange cols) (fun d j _ => by
+    dsimp only [step]
+    exact Vector.getElem_set_ne (index D i j).isLt hp (hne j)) d
+
 /-- Reading a region after accumulation with a function returns the entrywise
 combination. -/
 @[grind =] theorem get_accumulateWith (D : Region N M rows cols) (A : Matrix R N M)
@@ -508,11 +533,12 @@ combination. -/
     (i : Fin rows) (j : Fin cols) :
     get D (accumulateWith D A f op) i j = op (get D A i j) (f i j) := by
   obtain ⟨d⟩ := A
+  rw [get_eq_data, get_eq_data]
   change ((accumulateWith D ⟨d⟩ f op).data[(index D i j).val]'
     (index D i j).isLt) = op (d[(index D i j).val]'(index D i j).isLt) (f i j)
   simp only [accumulateWith]
   let step := fun d (i : Fin rows) =>
-    writeRow D d i (Vector.ofFn fun j => op (d.get (index D i j)) (f i j))
+    modifyRowWith D d i (fun j x => op x (f i j))
   have hfold : Fin.foldl rows step d = (List.finRange rows).foldl step d :=
     Fin.foldl_eq_finRange_foldl step d
   have hmem := foldl_rows_modify step
@@ -520,15 +546,12 @@ combination. -/
     (fun i x => op x (f i j))
     (fun d i => by
       dsimp only [step]
-      rw [get_writeRow]
-      change (Vector.ofFn (fun j => op (d.get (index D i j)) (f i j)))[j.val]'j.isLt = _
-      rw [Vector.getElem_ofFn]
-      rfl)
+      rw [get_modifyRowWith])
     (fun d a i hai => by
       dsimp only [step]
-      exact get_writeRow_ne D d a _ (index D i j).val (index D i j).isLt
+      exact get_modifyRowWith_ne D d a _ (index D i j).val (index D i j).isLt
         (fun t heq => hai (index_inj D a i t j heq).1))
-    (List.finRange rows) (nodup_finRange rows) d i (List.mem_finRange _)
+    (List.finRange rows) (Matrix.nodup_finRange rows) d i (List.mem_finRange _)
   exact (congrArg (fun v : Vector R (N * M) => v.get (index D i j)) hfold).trans hmem
 
 /-- Accumulation with a read-only function preserves every disjoint region. -/
@@ -538,17 +561,18 @@ theorem get_accumulateWith_disjoint (D : Region N M rows cols)
     (i : Fin rows') (j : Fin cols') :
     get E (accumulateWith D A f op) i j = get E A i j := by
   obtain ⟨d⟩ := A
+  rw [get_eq_data, get_eq_data]
   change ((accumulateWith D ⟨d⟩ f op).data[(index E i j).val]'
     (index E i j).isLt) = d[(index E i j).val]'(index E i j).isLt
   simp only [accumulateWith]
   let step := fun d (a : Fin rows) =>
-    writeRow D d a (Vector.ofFn fun b => op (d.get (index D a b)) (f a b))
+    modifyRowWith D d a (fun b x => op x (f a b))
   have hfold : Fin.foldl rows step d = (List.finRange rows).foldl step d :=
     Fin.foldl_eq_finRange_foldl step d
   have hpres := foldl_rows_ne step (index E i j).val (index E i j).isLt
     (List.finRange rows) (fun d a _ => by
       dsimp only [step]
-      exact get_writeRow_ne D d a _ (index E i j).val (index E i j).isLt
+      exact get_modifyRowWith_ne D d a _ (index E i j).val (index E i j).isLt
         (fun b => index_ne_of_disjoint D E h a b i j)) d
   exact (congrArg (fun v : Vector R (N * M) => v.get (index E i j)) hfold).trans hpres
 
@@ -559,12 +583,13 @@ combination. -/
     (i : Fin rows) (j : Fin cols) :
     get D (accumulateExternal D A B op) i j = op (get D A i j) B[(i, j)] := by
   obtain ⟨d⟩ := A
+  rw [get_eq_data, get_eq_data]
   change ((accumulateExternal D ⟨d⟩ B op).data[(index D i j).val]'
     (index D i j).isLt) =
       op (d[(index D i j).val]'(index D i j).isLt) B[(i, j)]
   simp only [accumulateExternal]
   let step := fun d (i : Fin rows) =>
-    writeRow D d i (Vector.ofFn fun j => op (d.get (index D i j)) B[(i, j)])
+    modifyRowWith D d i (fun j x => op x B[(i, j)])
   have hfold : Fin.foldl rows step d = (List.finRange rows).foldl step d :=
     Fin.foldl_eq_finRange_foldl step d
   have hmem := foldl_rows_modify step
@@ -572,15 +597,12 @@ combination. -/
     (fun i x => op x B[(i, j)])
     (fun d i => by
       dsimp only [step]
-      rw [get_writeRow]
-      change (Vector.ofFn (fun j => op (d.get (index D i j)) B[(i, j)]))[j.val]'j.isLt = _
-      rw [Vector.getElem_ofFn]
-      rfl)
+      rw [get_modifyRowWith])
     (fun d a i hai => by
       dsimp only [step]
-      exact get_writeRow_ne D d a _ (index D i j).val (index D i j).isLt
+      exact get_modifyRowWith_ne D d a _ (index D i j).val (index D i j).isLt
         (fun t heq => hai (index_inj D a i t j heq).1))
-    (List.finRange rows) (nodup_finRange rows) d i (List.mem_finRange _)
+    (List.finRange rows) (Matrix.nodup_finRange rows) d i (List.mem_finRange _)
   exact (congrArg (fun v : Vector R (N * M) => v.get (index D i j)) hfold).trans hmem
 
 /-- Accumulating into one region preserves every disjoint region. -/
@@ -589,34 +611,45 @@ theorem get_accumulateExternal_disjoint (D : Region N M rows cols)
     (B : Matrix R rows cols) (op : R → R → R) (i : Fin rows') (j : Fin cols') :
     get E (accumulateExternal D A B op) i j = get E A i j := by
   obtain ⟨d⟩ := A
+  rw [get_eq_data, get_eq_data]
   change ((accumulateExternal D ⟨d⟩ B op).data[(index E i j).val]'
     (index E i j).isLt) = d[(index E i j).val]'(index E i j).isLt
   simp only [accumulateExternal]
   let step := fun d (a : Fin rows) =>
-    writeRow D d a (Vector.ofFn fun b => op (d.get (index D a b)) B[(a, b)])
+    modifyRowWith D d a (fun b x => op x B[(a, b)])
   have hfold : Fin.foldl rows step d = (List.finRange rows).foldl step d :=
     Fin.foldl_eq_finRange_foldl step d
   have hpres := foldl_rows_ne step (index E i j).val (index E i j).isLt
     (List.finRange rows) (fun d a _ => by
       dsimp only [step]
-      exact get_writeRow_ne D d a _ (index E i j).val (index E i j).isLt
+      exact get_modifyRowWith_ne D d a _ (index E i j).val (index E i j).isLt
         (fun b => index_ne_of_disjoint D E h a b i j)) d
   exact (congrArg (fun v : Vector R (N * M) => v.get (index E i j)) hfold).trans hpres
 
-/-- Combine two disjoint regions of the owned output matrix, writing the first.
-The entire source/destination row is read before that row's writes begin. -/
+/-- Combine one row of two disjoint regions directly into the destination.  The
+two entries are read before `Vector.set` consumes the array, so the array is not
+retained by a temporary or modifying closure. -/
+@[inline]
+private def combineRowWith (D S : Region N M rows cols) (d : Vector R (N * M))
+    (i : Fin rows) (op : R → R → R) : Vector R (N * M) :=
+  let base := rowStart D i
+  Fin.foldl cols (fun d j =>
+    let p := base + j.val
+    let x := d[p]'(index D i j).isLt
+    let y := d.get (index S i j)
+    d.set p (op x y) (index D i j).isLt) d
+
+/-- Combine two disjoint regions of the owned output matrix, writing the first
+and threading the backing array directly through every entry update. -/
 @[inline]
 def accumulate (D S : Region N M rows cols) (_h : Disjoint D S)
     (A : Matrix R N M) (op : R → R → R) : Matrix R N M :=
   match A with
-  | ⟨d⟩ =>
-    ⟨Fin.foldl rows (fun d i =>
-      let v := Vector.ofFn fun j => op (d.get (index D i j)) (d.get (index S i j))
-      writeRow D d i v) d⟩
+  | ⟨d⟩ => ⟨Fin.foldl rows (fun d i => combineRowWith D S d i op) d⟩
 
 /-- A row fold can transform one index from both its old value and an invariant
 source index. -/
-private theorem foldl_rows_modify₂ {count size : Nat}
+private theorem foldl_modify₂ {count size : Nat}
     (step : Vector R size → Fin count → Vector R size)
     (dst src : Fin count → Nat) (bdDst : ∀ i, dst i < size) (bdSrc : ∀ i, src i < size)
     (g : Fin count → R → R → R)
@@ -640,41 +673,81 @@ private theorem foldl_rows_modify₂ {count size : Nat}
     · rw [ih (List.nodup_cons.mp hnd).2 _ r hr',
         hneDst d x r (fun h => (List.nodup_cons.mp hnd).1 (h ▸ hr')), hneSrc d x r]
 
+/-- Reading a directly combined row returns the entrywise combination. -/
+private theorem get_combineRowWith (D S : Region N M rows cols) (h : Disjoint D S)
+    (d : Vector R (N * M)) (i : Fin rows) (op : R → R → R) (j : Fin cols) :
+    (combineRowWith D S d i op)[(index D i j).val]'(index D i j).isLt =
+      op (d[(index D i j).val]'(index D i j).isLt)
+        (d[(index S i j).val]'(index S i j).isLt) := by
+  unfold combineRowWith
+  rw [Fin.foldl_eq_finRange_foldl]
+  let step := fun (d : Vector R (N * M)) (j : Fin cols) =>
+    let p := (index D i j).val
+    let x := d[p]'(index D i j).isLt
+    let y := d.get (index S i j)
+    d.set p (op x y) (index D i j).isLt
+  exact foldl_modify₂ step (fun j => (index D i j).val) (fun j => (index S i j).val)
+    (fun j => (index D i j).isLt) (fun j => (index S i j).isLt) (fun _ x y => op x y)
+    (fun d j => by
+      dsimp only [step]
+      rw [Vector.getElem_set_self]
+      rfl)
+    (fun d a j haj => by
+      dsimp only [step]
+      exact Vector.getElem_set_ne (index D i a).isLt (index D i j).isLt
+        (fun heq => haj (index_inj D i i a j heq).2))
+    (fun d a j => by
+      dsimp only [step]
+      exact Vector.getElem_set_ne (index D i a).isLt (index S i j).isLt
+        (index_ne_of_disjoint D S h i a i j))
+    (List.finRange cols) (Matrix.nodup_finRange cols) d j (List.mem_finRange _)
+
+/-- Combining one row preserves every flat index outside its destination. -/
+private theorem get_combineRowWith_ne (D S : Region N M rows cols)
+    (d : Vector R (N * M)) (i : Fin rows) (op : R → R → R)
+    (p : Nat) (hp : p < N * M) (hne : ∀ j : Fin cols, (index D i j).val ≠ p) :
+    (combineRowWith D S d i op)[p]'hp = d[p]'hp := by
+  unfold combineRowWith
+  rw [Fin.foldl_eq_finRange_foldl]
+  let step := fun (d : Vector R (N * M)) (j : Fin cols) =>
+    let q := (index D i j).val
+    let x := d[q]'(index D i j).isLt
+    let y := d.get (index S i j)
+    d.set q (op x y) (index D i j).isLt
+  exact foldl_rows_ne step p hp (List.finRange cols) (fun d j _ => by
+    dsimp only [step]
+    exact Vector.getElem_set_ne (index D i j).isLt hp (hne j)) d
+
 /-- Reading the destination of an in-buffer accumulation returns the requested
 entrywise combination. -/
 @[grind =] theorem get_accumulate (D S : Region N M rows cols) (h : Disjoint D S)
     (A : Matrix R N M) (op : R → R → R) (i : Fin rows) (j : Fin cols) :
     get D (accumulate D S h A op) i j = op (get D A i j) (get S A i j) := by
   obtain ⟨d⟩ := A
+  rw [get_eq_data, get_eq_data, get_eq_data]
   change ((accumulate D S h ⟨d⟩ op).data[(index D i j).val]'
     (index D i j).isLt) = op (d[(index D i j).val]'(index D i j).isLt)
       (d[(index S i j).val]'(index S i j).isLt)
   simp only [accumulate]
-  let step := fun d (i : Fin rows) =>
-    writeRow D d i (Vector.ofFn fun j =>
-      op (d.get (index D i j)) (d.get (index S i j)))
+  let step := fun d (i : Fin rows) => combineRowWith D S d i op
   have hfold : Fin.foldl rows step d = (List.finRange rows).foldl step d :=
     Fin.foldl_eq_finRange_foldl step d
-  have hmem := foldl_rows_modify₂ step
+  have hmem := foldl_modify₂ step
     (fun i => (index D i j).val) (fun i => (index S i j).val)
     (fun i => (index D i j).isLt) (fun i => (index S i j).isLt)
     (fun _ x y => op x y)
     (fun d i => by
       dsimp only [step]
-      rw [get_writeRow]
-      change (Vector.ofFn (fun j =>
-        op (d.get (index D i j)) (d.get (index S i j))))[j.val]'j.isLt = _
-      rw [Vector.getElem_ofFn]
-      rfl)
+      exact get_combineRowWith D S h d i op j)
     (fun d a i hai => by
       dsimp only [step]
-      exact get_writeRow_ne D d a _ (index D i j).val (index D i j).isLt
+      exact get_combineRowWith_ne D S d a op (index D i j).val (index D i j).isLt
         (fun t heq => hai (index_inj D a i t j heq).1))
     (fun d a i => by
       dsimp only [step]
-      exact get_writeRow_ne D d a _ (index S i j).val (index S i j).isLt
+      exact get_combineRowWith_ne D S d a op (index S i j).val (index S i j).isLt
         (fun t => index_ne_of_disjoint D S h a t i j))
-    (List.finRange rows) (nodup_finRange rows) d i (List.mem_finRange _)
+    (List.finRange rows) (Matrix.nodup_finRange rows) d i (List.mem_finRange _)
   exact (congrArg (fun v : Vector R (N * M) => v.get (index D i j)) hfold).trans hmem
 
 /-- In-buffer accumulation writes only its destination region. -/
@@ -683,18 +756,17 @@ theorem get_accumulate_disjoint (D S : Region N M rows cols) (hDS : Disjoint D S
     (op : R → R → R) (i : Fin rows') (j : Fin cols') :
     get E (accumulate D S hDS A op) i j = get E A i j := by
   obtain ⟨d⟩ := A
+  rw [get_eq_data, get_eq_data]
   change ((accumulate D S hDS ⟨d⟩ op).data[(index E i j).val]'
     (index E i j).isLt) = d[(index E i j).val]'(index E i j).isLt
   simp only [accumulate]
-  let step := fun d (a : Fin rows) =>
-    writeRow D d a (Vector.ofFn fun b =>
-      op (d.get (index D a b)) (d.get (index S a b)))
+  let step := fun d (a : Fin rows) => combineRowWith D S d a op
   have hfold : Fin.foldl rows step d = (List.finRange rows).foldl step d :=
     Fin.foldl_eq_finRange_foldl step d
   have hpres := foldl_rows_ne step (index E i j).val (index E i j).isLt
     (List.finRange rows) (fun d a _ => by
       dsimp only [step]
-      exact get_writeRow_ne D d a _ (index E i j).val (index E i j).isLt
+      exact get_combineRowWith_ne D S d a op (index E i j).val (index E i j).isLt
         (fun b => index_ne_of_disjoint D E hDE a b i j)) d
   exact (congrArg (fun v : Vector R (N * M) => v.get (index E i j)) hfold).trans hpres
 

--- a/HexMatrix/Region.lean
+++ b/HexMatrix/Region.lean
@@ -1,0 +1,741 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMatrix.Submatrix
+public import HexMatrix.Block
+
+public section
+
+/-!
+Backing-free output regions for storage-scheduled matrix algorithms.
+
+Unlike `Submatrix`, a `Region` deliberately carries no matrix.  It is only an
+offset and bounds proof into an output matrix that is passed separately and
+linearly through every write.  Consequently four quadrant descriptors do not
+create four aliases of the output backing buffer.
+-/
+
+namespace Hex
+
+universe u
+
+namespace Matrix
+
+/-- A backing-free descriptor for a `rows × cols` rectangle inside an
+`N × M` matrix. -/
+structure Region (N M rows cols : Nat) where
+  /-- Row offset in the destination matrix. -/
+  r0 : Nat
+  /-- Column offset in the destination matrix. -/
+  c0 : Nat
+  /-- The described rows lie in the destination. -/
+  rows_le : r0 + rows ≤ N
+  /-- The described columns lie in the destination. -/
+  cols_le : c0 + cols ≤ M
+
+namespace Region
+
+variable {R : Type u} {N M rows cols : Nat}
+
+/-- Destination row corresponding to a local region row. -/
+@[inline]
+def row (D : Region N M rows cols) (i : Fin rows) : Fin N :=
+  ⟨D.r0 + i.val, by have := D.rows_le; omega⟩
+
+/-- Destination column corresponding to a local region column. -/
+@[inline]
+def col (D : Region N M rows cols) (j : Fin cols) : Fin M :=
+  ⟨D.c0 + j.val, by have := D.cols_le; omega⟩
+
+/-- Flat destination index corresponding to local region coordinates. -/
+@[inline]
+def index (D : Region N M rows cols) (i : Fin rows) (j : Fin cols) : Fin (N * M) :=
+  ⟨(row D i).val * M + (col D j).val, flatIdx_lt (row D i).isLt (col D j).isLt⟩
+
+/-- Read a matrix entry through a region descriptor. -/
+@[inline]
+def get (D : Region N M rows cols) (A : Matrix R N M) (i : Fin rows) (j : Fin cols) : R :=
+  A[(row D i, col D j)]
+
+/-- Materialize the entries described by a region.  This is a proof-facing
+operation; the storage-scheduled implementation writes through descriptors
+without calling it. -/
+@[expose]
+def toMatrix (D : Region N M rows cols) (A : Matrix R N M) : Matrix R rows cols :=
+  Matrix.ofFn fun i j => get D A i j
+
+/-- Entry formula for a materialized region. -/
+@[simp, grind =] theorem getElem_toMatrix (D : Region N M rows cols) (A : Matrix R N M)
+    (i : Fin rows) (j : Fin cols) : (toMatrix D A)[i][j] = get D A i j := by
+  rw [toMatrix, Matrix.getElem_ofFn]
+
+/-- Extract an entry equality from equality of a materialized region and a matrix. -/
+theorem get_of_toMatrix_eq (D : Region N M rows cols) (A : Matrix R N M)
+    (B : Matrix R rows cols) (h : toMatrix D A = B) (i : Fin rows) (j : Fin cols) :
+    get D A i j = B[(i, j)] := by
+  have e := congrArg (fun X => X[i][j]) h
+  simpa only [getElem_toMatrix, getElem_pair_eq_nested] using e
+
+/-- Equal materialized regions have equal entries. -/
+theorem get_eq_of_toMatrix_eq (D : Region N M rows cols) (A B : Matrix R N M)
+    (h : toMatrix D A = toMatrix D B) (i : Fin rows) (j : Fin cols) :
+    get D A i j = get D B i j := by
+  have e := congrArg (fun X => X[i][j]) h
+  simpa only [getElem_toMatrix] using e
+
+/-- The descriptor for a whole matrix. -/
+@[inline]
+def full (N M : Nat) : Region N M N M where
+  r0 := 0
+  c0 := 0
+  rows_le := by omega
+  cols_le := by omega
+
+/-- Reading through a whole-matrix descriptor is ordinary matrix access. -/
+@[simp, grind =] theorem get_full (A : Matrix R N M) (i : Fin N) (j : Fin M) :
+    get (full N M) A i j = A[(i, j)] := by
+  simp only [get, full, row, col, Nat.zero_add, getElem_pair_eq_nested]
+
+/-- Materializing a whole-matrix descriptor returns the matrix. -/
+@[simp] theorem toMatrix_full (A : Matrix R N M) :
+    toMatrix (full N M) A = A := by
+  apply Matrix.ext_getElem
+  intro i j
+  rw [getElem_toMatrix, get_full, getElem_pair_eq_nested]
+
+/-- Top-left quadrant of an evenly split region. -/
+@[inline]
+def toBlocks₁₁ (D : Region N M (h + h) (w + w)) : Region N M h w where
+  r0 := D.r0
+  c0 := D.c0
+  rows_le := by have := D.rows_le; omega
+  cols_le := by have := D.cols_le; omega
+
+/-- Top-right quadrant of an evenly split region. -/
+@[inline]
+def toBlocks₁₂ (D : Region N M (h + h) (w + w)) : Region N M h w where
+  r0 := D.r0
+  c0 := D.c0 + w
+  rows_le := by have := D.rows_le; omega
+  cols_le := by have := D.cols_le; omega
+
+/-- Bottom-left quadrant of an evenly split region. -/
+@[inline]
+def toBlocks₂₁ (D : Region N M (h + h) (w + w)) : Region N M h w where
+  r0 := D.r0 + h
+  c0 := D.c0
+  rows_le := by have := D.rows_le; omega
+  cols_le := by have := D.cols_le; omega
+
+/-- Bottom-right quadrant of an evenly split region. -/
+@[inline]
+def toBlocks₂₂ (D : Region N M (h + h) (w + w)) : Region N M h w where
+  r0 := D.r0 + h
+  c0 := D.c0 + w
+  rows_le := by have := D.rows_le; omega
+  cols_le := by have := D.cols_le; omega
+
+/-- Two region descriptors have disjoint rectangles. -/
+@[expose]
+def Disjoint (D : Region N M rows cols) (E : Region N M rows' cols') : Prop :=
+  D.r0 + rows ≤ E.r0 ∨ E.r0 + rows' ≤ D.r0 ∨
+  D.c0 + cols ≤ E.c0 ∨ E.c0 + cols' ≤ D.c0
+
+/-- The left and right quadrants in the top row are disjoint. -/
+theorem disjoint₁₁₁₂ (D : Region N M (h + h) (w + w)) :
+    Disjoint D.toBlocks₁₁ D.toBlocks₁₂ := by
+  simp only [Disjoint, toBlocks₁₁, toBlocks₁₂]
+  omega
+
+/-- The top-left and bottom-left quadrants are disjoint. -/
+theorem disjoint₁₁₂₁ (D : Region N M (h + h) (w + w)) :
+    Disjoint D.toBlocks₁₁ D.toBlocks₂₁ := by
+  simp only [Disjoint, toBlocks₁₁, toBlocks₂₁]
+  omega
+
+/-- The top-left and bottom-right quadrants are disjoint. -/
+theorem disjoint₁₁₂₂ (D : Region N M (h + h) (w + w)) :
+    Disjoint D.toBlocks₁₁ D.toBlocks₂₂ := by
+  simp only [Disjoint, toBlocks₁₁, toBlocks₂₂]
+  omega
+
+/-- The top-right and bottom-left quadrants are disjoint. -/
+theorem disjoint₁₂₂₁ (D : Region N M (h + h) (w + w)) :
+    Disjoint D.toBlocks₁₂ D.toBlocks₂₁ := by
+  simp only [Disjoint, toBlocks₁₂, toBlocks₂₁]
+  omega
+
+/-- The top-right and bottom-right quadrants are disjoint. -/
+theorem disjoint₁₂₂₂ (D : Region N M (h + h) (w + w)) :
+    Disjoint D.toBlocks₁₂ D.toBlocks₂₂ := by
+  simp only [Disjoint, toBlocks₁₂, toBlocks₂₂]
+  omega
+
+/-- The left and right quadrants in the bottom row are disjoint. -/
+theorem disjoint₂₁₂₂ (D : Region N M (h + h) (w + w)) :
+    Disjoint D.toBlocks₂₁ D.toBlocks₂₂ := by
+  simp only [Disjoint, toBlocks₂₁, toBlocks₂₂]
+  omega
+
+/-- A region disjoint from a parent is disjoint from its top-left quadrant. -/
+theorem disjoint_toBlocks₁₁ (D : Region N M (h + h) (w + w))
+    (E : Region N M rows cols) (hDE : Disjoint D E) : Disjoint D.toBlocks₁₁ E := by
+  simp only [Disjoint, toBlocks₁₁] at hDE ⊢
+  omega
+
+/-- A region disjoint from a parent is disjoint from its top-right quadrant. -/
+theorem disjoint_toBlocks₁₂ (D : Region N M (h + h) (w + w))
+    (E : Region N M rows cols) (hDE : Disjoint D E) : Disjoint D.toBlocks₁₂ E := by
+  simp only [Disjoint, toBlocks₁₂] at hDE ⊢
+  omega
+
+/-- A region disjoint from a parent is disjoint from its bottom-left quadrant. -/
+theorem disjoint_toBlocks₂₁ (D : Region N M (h + h) (w + w))
+    (E : Region N M rows cols) (hDE : Disjoint D E) : Disjoint D.toBlocks₂₁ E := by
+  simp only [Disjoint, toBlocks₂₁] at hDE ⊢
+  omega
+
+/-- A region disjoint from a parent is disjoint from its bottom-right quadrant. -/
+theorem disjoint_toBlocks₂₂ (D : Region N M (h + h) (w + w))
+    (E : Region N M rows cols) (hDE : Disjoint D E) : Disjoint D.toBlocks₂₂ E := by
+  simp only [Disjoint, toBlocks₂₂] at hDE ⊢
+  omega
+
+/-- Materializing a descriptor's top-left quadrant is matrix block extraction. -/
+theorem toMatrix_toBlocks₁₁ (D : Region N M (h + h) (w + w)) (A : Matrix R N M) :
+    toMatrix D.toBlocks₁₁ A = Matrix.toBlocks₁₁ (toMatrix D A) := by
+  apply Matrix.ext_getElem
+  intro i j
+  simp only [getElem_toMatrix, Matrix.getElem_toBlocks₁₁, get, row, col, toBlocks₁₁,
+    Fin.val_castAdd]
+
+/-- Materializing a descriptor's top-right quadrant is matrix block extraction. -/
+theorem toMatrix_toBlocks₁₂ (D : Region N M (h + h) (w + w)) (A : Matrix R N M) :
+    toMatrix D.toBlocks₁₂ A = Matrix.toBlocks₁₂ (toMatrix D A) := by
+  apply Matrix.ext_getElem
+  intro i j
+  simp only [getElem_toMatrix, Matrix.getElem_toBlocks₁₂, get, row, col, toBlocks₁₂,
+    Fin.val_castAdd, Fin.val_natAdd, Nat.add_assoc]
+
+/-- Materializing a descriptor's bottom-left quadrant is matrix block extraction. -/
+theorem toMatrix_toBlocks₂₁ (D : Region N M (h + h) (w + w)) (A : Matrix R N M) :
+    toMatrix D.toBlocks₂₁ A = Matrix.toBlocks₂₁ (toMatrix D A) := by
+  apply Matrix.ext_getElem
+  intro i j
+  simp only [getElem_toMatrix, Matrix.getElem_toBlocks₂₁, get, row, col, toBlocks₂₁,
+    Fin.val_castAdd, Fin.val_natAdd, Nat.add_assoc]
+
+/-- Materializing a descriptor's bottom-right quadrant is matrix block extraction. -/
+theorem toMatrix_toBlocks₂₂ (D : Region N M (h + h) (w + w)) (A : Matrix R N M) :
+    toMatrix D.toBlocks₂₂ A = Matrix.toBlocks₂₂ (toMatrix D A) := by
+  apply Matrix.ext_getElem
+  intro i j
+  simp only [getElem_toMatrix, Matrix.getElem_toBlocks₂₂, get, row, col, toBlocks₂₂,
+    Fin.val_natAdd, Nat.add_assoc]
+
+/-- Disjointness of region descriptors is symmetric. -/
+theorem disjoint_comm {D : Region N M rows cols} {E : Region N M rows' cols'} :
+    Disjoint D E ↔ Disjoint E D := by
+  simp only [Disjoint]
+  omega
+
+/-- Disjoint rectangles have distinct flat indices. -/
+private theorem index_ne_of_disjoint (D : Region N M rows cols)
+    (E : Region N M rows' cols') (h : Disjoint D E)
+    (i : Fin rows) (j : Fin cols) (i' : Fin rows') (j' : Fin cols') :
+    (index D i j).val ≠ (index E i' j').val := by
+  intro heq
+  have hd : (row D i).val * M + (col D j).val =
+      (row E i').val * M + (col E j').val := heq
+  have hrowD : ((row D i).val * M + (col D j).val) / M = (row D i).val :=
+    flatIdx_div (col D j).isLt
+  have hrowE : ((row E i').val * M + (col E j').val) / M = (row E i').val :=
+    flatIdx_div (col E j').isLt
+  have hcolD : ((row D i).val * M + (col D j).val) % M = (col D j).val :=
+    flatIdx_mod (col D j).isLt
+  have hcolE : ((row E i').val * M + (col E j').val) % M = (col E j').val :=
+    flatIdx_mod (col E j').isLt
+  have hr : (row D i).val = (row E i').val := by
+    rw [← hrowD, hd, hrowE]
+  have hc : (col D j).val = (col E j').val := by
+    rw [← hcolD, hd, hcolE]
+  simp only [row, col] at hr hc
+  unfold Disjoint at h
+  rcases h with h | h | h | h <;> omega
+
+/-- Overwrite one row segment of a flat matrix buffer.  The buffer is consumed,
+so `Vector.set` reuses it when it is uniquely referenced. -/
+@[inline]
+def writeRow (D : Region N M rows cols) (d : Vector R (N * M))
+    (i : Fin rows) (v : Vector R cols) : Vector R (N * M) :=
+  Fin.foldl cols (fun d j => d.set (index D i j).val (v.get j) (index D i j).isLt) d
+
+/-- Flat indices inside a region are injective in their local coordinates. -/
+private theorem index_inj (D : Region N M rows cols) (i i' : Fin rows) (j j' : Fin cols)
+    (h : (index D i j).val = (index D i' j').val) : i = i' ∧ j = j' := by
+  have hr : (row D i).val = (row D i').val := by
+    have hi : ((row D i).val * M + (col D j).val) / M = (row D i).val :=
+      flatIdx_div (col D j).isLt
+    have hi' : ((row D i').val * M + (col D j').val) / M = (row D i').val :=
+      flatIdx_div (col D j').isLt
+    change (row D i).val * M + (col D j).val =
+      (row D i').val * M + (col D j').val at h
+    have hdiv := congrArg (fun x => x / M) h
+    omega
+  have hc : (col D j).val = (col D j').val := by
+    have hj : ((row D i).val * M + (col D j).val) % M = (col D j).val :=
+      flatIdx_mod (col D j).isLt
+    have hj' : ((row D i').val * M + (col D j').val) % M = (col D j').val :=
+      flatIdx_mod (col D j').isLt
+    change (row D i).val * M + (col D j).val =
+      (row D i').val * M + (col D j').val at h
+    have hmod := congrArg (fun x => x % M) h
+    omega
+  constructor
+  · apply Fin.ext
+    simp only [row] at hr
+    omega
+  · apply Fin.ext
+    simp only [col] at hc
+    omega
+
+/-- `List.finRange k` has no repeated indices. -/
+private theorem nodup_finRange (k : Nat) : (List.finRange k).Nodup := by
+  induction k with
+  | zero => simp
+  | succ j ih =>
+    rw [List.finRange_succ, List.nodup_cons]
+    exact ⟨by simp [Fin.ext_iff],
+      List.Pairwise.map _ (fun _ _ hab h => hab (Fin.succ_inj.mp h)) ih⟩
+
+/-- A fold of single-index writes preserves an index that is never targeted. -/
+private theorem foldl_set_ne {count size : Nat} (idx : Fin count → Nat)
+    (val : Fin count → R) (bd : ∀ t, idx t < size) {p : Nat} (hp : p < size) :
+    ∀ (xs : List (Fin count)) (d : Vector R size), (∀ t ∈ xs, idx t ≠ p) →
+      (xs.foldl (fun d t => d.set (idx t) (val t) (bd t)) d)[p]'hp = d[p]'hp := by
+  intro xs
+  induction xs with
+  | nil => intro d _; rfl
+  | cons x xs ih =>
+    intro d hne
+    rw [List.foldl_cons, ih _ (fun t ht => hne t (List.mem_cons_of_mem _ ht)),
+      Vector.getElem_set_ne (bd x) hp (hne x List.mem_cons_self)]
+
+/-- A fold of injectively indexed writes stores the requested member's value. -/
+private theorem foldl_set_mem {count size : Nat} (idx : Fin count → Nat)
+    (val : Fin count → R) (bd : ∀ t, idx t < size)
+    (hinj : ∀ a b : Fin count, idx a = idx b → a = b) :
+    ∀ (xs : List (Fin count)), xs.Nodup → ∀ (d : Vector R size) (r : Fin count), r ∈ xs →
+      (xs.foldl (fun d t => d.set (idx t) (val t) (bd t)) d)[idx r]'(bd r) = val r := by
+  intro xs
+  induction xs with
+  | nil => intro _ _ r hr; simp at hr
+  | cons x xs ih =>
+    intro hnd d r hr
+    rw [List.foldl_cons]
+    rcases List.mem_cons.mp hr with rfl | hr'
+    · rw [foldl_set_ne idx val bd (bd r) xs _ (fun t ht heq =>
+        (List.nodup_cons.mp hnd).1 ((hinj t r heq) ▸ ht))]
+      exact Vector.getElem_set_self (bd r)
+    · rw [ih (List.nodup_cons.mp hnd).2 _ r hr']
+
+/-- Reading the row segment just written returns the supplied value. -/
+private theorem get_writeRow (D : Region N M rows cols) (d : Vector R (N * M))
+    (i : Fin rows) (v : Vector R cols) (j : Fin cols) :
+    (writeRow D d i v)[(index D i j).val]'(index D i j).isLt = v.get j := by
+  unfold writeRow
+  rw [Fin.foldl_eq_finRange_foldl]
+  exact foldl_set_mem (fun t : Fin cols => (index D i t).val) (fun t => v.get t)
+    (fun t => (index D i t).isLt)
+    (fun a b h => (index_inj D i i a b h).2)
+    (List.finRange cols) (nodup_finRange cols) d j (List.mem_finRange _)
+
+/-- Writing a row segment preserves every flat index outside that segment. -/
+private theorem get_writeRow_ne (D : Region N M rows cols) (d : Vector R (N * M))
+    (i : Fin rows) (v : Vector R cols) (p : Nat) (hp : p < N * M)
+    (hne : ∀ j : Fin cols, (index D i j).val ≠ p) :
+    (writeRow D d i v)[p]'hp = d[p]'hp := by
+  unfold writeRow
+  rw [Fin.foldl_eq_finRange_foldl]
+  exact foldl_set_ne (fun j : Fin cols => (index D i j).val) (fun j => v.get j)
+    (fun j => (index D i j).isLt) hp (List.finRange cols) d
+    (fun j _ => hne j)
+
+/-- A fold of row transforms preserves a flat index when every row transform
+preserves it. -/
+private theorem foldl_rows_ne {count size : Nat}
+    (step : Vector R size → Fin count → Vector R size) (p : Nat) (hp : p < size)
+    (xs : List (Fin count))
+    (hstep : ∀ d i, i ∈ xs → (step d i)[p]'hp = d[p]'hp) :
+    ∀ (d : Vector R size),
+      (xs.foldl step d)[p]'hp = d[p]'hp := by
+  induction xs with
+  | nil => intro d; rfl
+  | cons x xs ih =>
+    intro d
+    rw [List.foldl_cons, ih (fun d i hi => hstep d i (List.mem_cons_of_mem _ hi)),
+      hstep d x List.mem_cons_self]
+
+/-- A fold of distinct row transforms stores the requested row's value when
+each transform writes its own row and preserves every other row. -/
+private theorem foldl_rows_mem {count size : Nat}
+    (step : Vector R size → Fin count → Vector R size)
+    (idx : Fin count → Nat) (bd : ∀ i, idx i < size) (val : Fin count → R)
+    (hself : ∀ d i, (step d i)[idx i]'(bd i) = val i)
+    (hne : ∀ d i r, i ≠ r → (step d i)[idx r]'(bd r) = d[idx r]'(bd r)) :
+    ∀ (xs : List (Fin count)), xs.Nodup → ∀ (d : Vector R size) (r : Fin count), r ∈ xs →
+      (xs.foldl step d)[idx r]'(bd r) = val r := by
+  intro xs
+  induction xs with
+  | nil => intro _ _ r hr; simp at hr
+  | cons x xs ih =>
+    intro hnd d r hr
+    rw [List.foldl_cons]
+    rcases List.mem_cons.mp hr with rfl | hr'
+    · rw [foldl_rows_ne step (idx r) (bd r) xs (fun d t ht => hne d t r (fun h =>
+          (List.nodup_cons.mp hnd).1 (h ▸ ht))), hself]
+    · rw [ih (List.nodup_cons.mp hnd).2 _ r hr']
+
+/-- Fill a destination region from an entry function.  The destination matrix
+is threaded linearly; only one temporary row is materialized at a time. -/
+@[inline]
+def overwrite (D : Region N M rows cols) (A : Matrix R N M)
+    (f : Fin rows → Fin cols → R) : Matrix R N M :=
+  match A with
+  | ⟨d⟩ =>
+    ⟨Fin.foldl rows (fun d i => writeRow D d i (Vector.ofFn (f i))) d⟩
+
+/-- Reading inside an overwritten region returns the supplied entry. -/
+@[grind =] theorem get_overwrite (D : Region N M rows cols) (A : Matrix R N M)
+    (f : Fin rows → Fin cols → R) (i : Fin rows) (j : Fin cols) :
+    get D (overwrite D A f) i j = f i j := by
+  obtain ⟨d⟩ := A
+  change ((overwrite D ⟨d⟩ f).data[(index D i j).val]'(index D i j).isLt) = f i j
+  simp only [overwrite]
+  have hfold :
+      Fin.foldl rows (fun d i => writeRow D d i (Vector.ofFn (f i))) d =
+        (List.finRange rows).foldl
+          (fun d i => writeRow D d i (Vector.ofFn (f i))) d :=
+    Fin.foldl_eq_finRange_foldl (fun d i => writeRow D d i (Vector.ofFn (f i))) d
+  have hmem := foldl_rows_mem
+    (fun d i => writeRow D d i (Vector.ofFn (f i)))
+    (fun i => (index D i j).val) (fun i => (index D i j).isLt) (fun i => f i j)
+    (fun d i => by
+      rw [get_writeRow]
+      change (Vector.ofFn (f i))[j.val]'j.isLt = f i j
+      rw [Vector.getElem_ofFn])
+    (fun d a i hai => get_writeRow_ne D d a (Vector.ofFn (f a))
+      (index D i j).val (index D i j).isLt (fun t heq =>
+        hai (index_inj D a i t j heq).1))
+    (List.finRange rows) (nodup_finRange rows) d i (List.mem_finRange _)
+  exact (congrArg (fun v : Vector R (N * M) => v.get (index D i j)) hfold).trans hmem
+
+/-- Overwriting one region preserves every disjoint region. -/
+theorem get_overwrite_disjoint (D : Region N M rows cols)
+    (E : Region N M rows' cols') (h : Disjoint D E) (A : Matrix R N M)
+    (f : Fin rows → Fin cols → R) (i : Fin rows') (j : Fin cols') :
+    get E (overwrite D A f) i j = get E A i j := by
+  obtain ⟨d⟩ := A
+  change ((overwrite D ⟨d⟩ f).data[(index E i j).val]'(index E i j).isLt) =
+    d[(index E i j).val]'(index E i j).isLt
+  simp only [overwrite]
+  have hfold :
+      Fin.foldl rows (fun d i => writeRow D d i (Vector.ofFn (f i))) d =
+        (List.finRange rows).foldl
+          (fun d i => writeRow D d i (Vector.ofFn (f i))) d :=
+    Fin.foldl_eq_finRange_foldl (fun d i => writeRow D d i (Vector.ofFn (f i))) d
+  have hpres := foldl_rows_ne
+    (fun d i => writeRow D d i (Vector.ofFn (f i)))
+    (index E i j).val (index E i j).isLt (List.finRange rows)
+    (fun d a _ => get_writeRow_ne D d a (Vector.ofFn (f a))
+      (index E i j).val (index E i j).isLt
+      (fun b => index_ne_of_disjoint D E h a b i j)) d
+  exact (congrArg (fun v : Vector R (N * M) => v.get (index E i j)) hfold).trans hpres
+
+/-- Combine a destination region with entries supplied by a read-only function.
+Each row is fully materialized before its writes begin. -/
+@[inline]
+def accumulateWith (D : Region N M rows cols) (A : Matrix R N M)
+    (f : Fin rows → Fin cols → R) (op : R → R → R) : Matrix R N M :=
+  match A with
+  | ⟨d⟩ =>
+    ⟨Fin.foldl rows (fun d i =>
+      let v := Vector.ofFn fun j => op (d.get (index D i j)) (f i j)
+      writeRow D d i v) d⟩
+
+/-- Combine a destination region entrywise with a separate matrix.  A row is
+computed before its destination writes begin, so the owned destination backing
+continues to be threaded linearly. -/
+@[inline]
+def accumulateExternal (D : Region N M rows cols) (A : Matrix R N M)
+    (B : Matrix R rows cols) (op : R → R → R) : Matrix R N M :=
+  match A with
+  | ⟨d⟩ =>
+    ⟨Fin.foldl rows (fun d i =>
+      let v := Vector.ofFn fun j => op (d.get (index D i j)) B[(i, j)]
+      writeRow D d i v) d⟩
+
+/-- A row fold whose own row update depends on the previous value stores the
+requested row's transformed value. -/
+private theorem foldl_rows_modify {count size : Nat}
+    (step : Vector R size → Fin count → Vector R size)
+    (idx : Fin count → Nat) (bd : ∀ i, idx i < size) (g : Fin count → R → R)
+    (hself : ∀ d i, (step d i)[idx i]'(bd i) = g i (d[idx i]'(bd i)))
+    (hne : ∀ d i r, i ≠ r → (step d i)[idx r]'(bd r) = d[idx r]'(bd r)) :
+    ∀ (xs : List (Fin count)), xs.Nodup → ∀ (d : Vector R size) (r : Fin count), r ∈ xs →
+      (xs.foldl step d)[idx r]'(bd r) = g r (d[idx r]'(bd r)) := by
+  intro xs
+  induction xs with
+  | nil => intro _ _ r hr; simp at hr
+  | cons x xs ih =>
+    intro hnd d r hr
+    rw [List.foldl_cons]
+    rcases List.mem_cons.mp hr with rfl | hr'
+    · rw [foldl_rows_ne step (idx r) (bd r) xs (fun d t ht => hne d t r (fun h =>
+          (List.nodup_cons.mp hnd).1 (h ▸ ht))), hself]
+    · rw [ih (List.nodup_cons.mp hnd).2 _ r hr', hne d x r (fun h =>
+        (List.nodup_cons.mp hnd).1 (h ▸ hr'))]
+
+/-- Reading a region after accumulation with a function returns the entrywise
+combination. -/
+@[grind =] theorem get_accumulateWith (D : Region N M rows cols) (A : Matrix R N M)
+    (f : Fin rows → Fin cols → R) (op : R → R → R)
+    (i : Fin rows) (j : Fin cols) :
+    get D (accumulateWith D A f op) i j = op (get D A i j) (f i j) := by
+  obtain ⟨d⟩ := A
+  change ((accumulateWith D ⟨d⟩ f op).data[(index D i j).val]'
+    (index D i j).isLt) = op (d[(index D i j).val]'(index D i j).isLt) (f i j)
+  simp only [accumulateWith]
+  let step := fun d (i : Fin rows) =>
+    writeRow D d i (Vector.ofFn fun j => op (d.get (index D i j)) (f i j))
+  have hfold : Fin.foldl rows step d = (List.finRange rows).foldl step d :=
+    Fin.foldl_eq_finRange_foldl step d
+  have hmem := foldl_rows_modify step
+    (fun i => (index D i j).val) (fun i => (index D i j).isLt)
+    (fun i x => op x (f i j))
+    (fun d i => by
+      dsimp only [step]
+      rw [get_writeRow]
+      change (Vector.ofFn (fun j => op (d.get (index D i j)) (f i j)))[j.val]'j.isLt = _
+      rw [Vector.getElem_ofFn]
+      rfl)
+    (fun d a i hai => by
+      dsimp only [step]
+      exact get_writeRow_ne D d a _ (index D i j).val (index D i j).isLt
+        (fun t heq => hai (index_inj D a i t j heq).1))
+    (List.finRange rows) (nodup_finRange rows) d i (List.mem_finRange _)
+  exact (congrArg (fun v : Vector R (N * M) => v.get (index D i j)) hfold).trans hmem
+
+/-- Accumulation with a read-only function preserves every disjoint region. -/
+theorem get_accumulateWith_disjoint (D : Region N M rows cols)
+    (E : Region N M rows' cols') (h : Disjoint D E) (A : Matrix R N M)
+    (f : Fin rows → Fin cols → R) (op : R → R → R)
+    (i : Fin rows') (j : Fin cols') :
+    get E (accumulateWith D A f op) i j = get E A i j := by
+  obtain ⟨d⟩ := A
+  change ((accumulateWith D ⟨d⟩ f op).data[(index E i j).val]'
+    (index E i j).isLt) = d[(index E i j).val]'(index E i j).isLt
+  simp only [accumulateWith]
+  let step := fun d (a : Fin rows) =>
+    writeRow D d a (Vector.ofFn fun b => op (d.get (index D a b)) (f a b))
+  have hfold : Fin.foldl rows step d = (List.finRange rows).foldl step d :=
+    Fin.foldl_eq_finRange_foldl step d
+  have hpres := foldl_rows_ne step (index E i j).val (index E i j).isLt
+    (List.finRange rows) (fun d a _ => by
+      dsimp only [step]
+      exact get_writeRow_ne D d a _ (index E i j).val (index E i j).isLt
+        (fun b => index_ne_of_disjoint D E h a b i j)) d
+  exact (congrArg (fun v : Vector R (N * M) => v.get (index E i j)) hfold).trans hpres
+
+/-- Reading a region after an external accumulation returns the entrywise
+combination. -/
+@[grind =] theorem get_accumulateExternal (D : Region N M rows cols)
+    (A : Matrix R N M) (B : Matrix R rows cols) (op : R → R → R)
+    (i : Fin rows) (j : Fin cols) :
+    get D (accumulateExternal D A B op) i j = op (get D A i j) B[(i, j)] := by
+  obtain ⟨d⟩ := A
+  change ((accumulateExternal D ⟨d⟩ B op).data[(index D i j).val]'
+    (index D i j).isLt) =
+      op (d[(index D i j).val]'(index D i j).isLt) B[(i, j)]
+  simp only [accumulateExternal]
+  let step := fun d (i : Fin rows) =>
+    writeRow D d i (Vector.ofFn fun j => op (d.get (index D i j)) B[(i, j)])
+  have hfold : Fin.foldl rows step d = (List.finRange rows).foldl step d :=
+    Fin.foldl_eq_finRange_foldl step d
+  have hmem := foldl_rows_modify step
+    (fun i => (index D i j).val) (fun i => (index D i j).isLt)
+    (fun i x => op x B[(i, j)])
+    (fun d i => by
+      dsimp only [step]
+      rw [get_writeRow]
+      change (Vector.ofFn (fun j => op (d.get (index D i j)) B[(i, j)]))[j.val]'j.isLt = _
+      rw [Vector.getElem_ofFn]
+      rfl)
+    (fun d a i hai => by
+      dsimp only [step]
+      exact get_writeRow_ne D d a _ (index D i j).val (index D i j).isLt
+        (fun t heq => hai (index_inj D a i t j heq).1))
+    (List.finRange rows) (nodup_finRange rows) d i (List.mem_finRange _)
+  exact (congrArg (fun v : Vector R (N * M) => v.get (index D i j)) hfold).trans hmem
+
+/-- Accumulating into one region preserves every disjoint region. -/
+theorem get_accumulateExternal_disjoint (D : Region N M rows cols)
+    (E : Region N M rows' cols') (h : Disjoint D E) (A : Matrix R N M)
+    (B : Matrix R rows cols) (op : R → R → R) (i : Fin rows') (j : Fin cols') :
+    get E (accumulateExternal D A B op) i j = get E A i j := by
+  obtain ⟨d⟩ := A
+  change ((accumulateExternal D ⟨d⟩ B op).data[(index E i j).val]'
+    (index E i j).isLt) = d[(index E i j).val]'(index E i j).isLt
+  simp only [accumulateExternal]
+  let step := fun d (a : Fin rows) =>
+    writeRow D d a (Vector.ofFn fun b => op (d.get (index D a b)) B[(a, b)])
+  have hfold : Fin.foldl rows step d = (List.finRange rows).foldl step d :=
+    Fin.foldl_eq_finRange_foldl step d
+  have hpres := foldl_rows_ne step (index E i j).val (index E i j).isLt
+    (List.finRange rows) (fun d a _ => by
+      dsimp only [step]
+      exact get_writeRow_ne D d a _ (index E i j).val (index E i j).isLt
+        (fun b => index_ne_of_disjoint D E h a b i j)) d
+  exact (congrArg (fun v : Vector R (N * M) => v.get (index E i j)) hfold).trans hpres
+
+/-- Combine two disjoint regions of the owned output matrix, writing the first.
+The entire source/destination row is read before that row's writes begin. -/
+@[inline]
+def accumulate (D S : Region N M rows cols) (_h : Disjoint D S)
+    (A : Matrix R N M) (op : R → R → R) : Matrix R N M :=
+  match A with
+  | ⟨d⟩ =>
+    ⟨Fin.foldl rows (fun d i =>
+      let v := Vector.ofFn fun j => op (d.get (index D i j)) (d.get (index S i j))
+      writeRow D d i v) d⟩
+
+/-- A row fold can transform one index from both its old value and an invariant
+source index. -/
+private theorem foldl_rows_modify₂ {count size : Nat}
+    (step : Vector R size → Fin count → Vector R size)
+    (dst src : Fin count → Nat) (bdDst : ∀ i, dst i < size) (bdSrc : ∀ i, src i < size)
+    (g : Fin count → R → R → R)
+    (hself : ∀ d i,
+      (step d i)[dst i]'(bdDst i) = g i (d[dst i]'(bdDst i)) (d[src i]'(bdSrc i)))
+    (hneDst : ∀ d i r, i ≠ r →
+      (step d i)[dst r]'(bdDst r) = d[dst r]'(bdDst r))
+    (hneSrc : ∀ d i r, (step d i)[src r]'(bdSrc r) = d[src r]'(bdSrc r)) :
+    ∀ (xs : List (Fin count)), xs.Nodup → ∀ (d : Vector R size) (r : Fin count), r ∈ xs →
+      (xs.foldl step d)[dst r]'(bdDst r) =
+        g r (d[dst r]'(bdDst r)) (d[src r]'(bdSrc r)) := by
+  intro xs
+  induction xs with
+  | nil => intro _ _ r hr; simp at hr
+  | cons x xs ih =>
+    intro hnd d r hr
+    rw [List.foldl_cons]
+    rcases List.mem_cons.mp hr with rfl | hr'
+    · rw [foldl_rows_ne step (dst r) (bdDst r) xs (fun d t ht =>
+          hneDst d t r (fun h => (List.nodup_cons.mp hnd).1 (h ▸ ht))), hself]
+    · rw [ih (List.nodup_cons.mp hnd).2 _ r hr',
+        hneDst d x r (fun h => (List.nodup_cons.mp hnd).1 (h ▸ hr')), hneSrc d x r]
+
+/-- Reading the destination of an in-buffer accumulation returns the requested
+entrywise combination. -/
+@[grind =] theorem get_accumulate (D S : Region N M rows cols) (h : Disjoint D S)
+    (A : Matrix R N M) (op : R → R → R) (i : Fin rows) (j : Fin cols) :
+    get D (accumulate D S h A op) i j = op (get D A i j) (get S A i j) := by
+  obtain ⟨d⟩ := A
+  change ((accumulate D S h ⟨d⟩ op).data[(index D i j).val]'
+    (index D i j).isLt) = op (d[(index D i j).val]'(index D i j).isLt)
+      (d[(index S i j).val]'(index S i j).isLt)
+  simp only [accumulate]
+  let step := fun d (i : Fin rows) =>
+    writeRow D d i (Vector.ofFn fun j =>
+      op (d.get (index D i j)) (d.get (index S i j)))
+  have hfold : Fin.foldl rows step d = (List.finRange rows).foldl step d :=
+    Fin.foldl_eq_finRange_foldl step d
+  have hmem := foldl_rows_modify₂ step
+    (fun i => (index D i j).val) (fun i => (index S i j).val)
+    (fun i => (index D i j).isLt) (fun i => (index S i j).isLt)
+    (fun _ x y => op x y)
+    (fun d i => by
+      dsimp only [step]
+      rw [get_writeRow]
+      change (Vector.ofFn (fun j =>
+        op (d.get (index D i j)) (d.get (index S i j))))[j.val]'j.isLt = _
+      rw [Vector.getElem_ofFn]
+      rfl)
+    (fun d a i hai => by
+      dsimp only [step]
+      exact get_writeRow_ne D d a _ (index D i j).val (index D i j).isLt
+        (fun t heq => hai (index_inj D a i t j heq).1))
+    (fun d a i => by
+      dsimp only [step]
+      exact get_writeRow_ne D d a _ (index S i j).val (index S i j).isLt
+        (fun t => index_ne_of_disjoint D S h a t i j))
+    (List.finRange rows) (nodup_finRange rows) d i (List.mem_finRange _)
+  exact (congrArg (fun v : Vector R (N * M) => v.get (index D i j)) hfold).trans hmem
+
+/-- In-buffer accumulation writes only its destination region. -/
+theorem get_accumulate_disjoint (D S : Region N M rows cols) (hDS : Disjoint D S)
+    (E : Region N M rows' cols') (hDE : Disjoint D E) (A : Matrix R N M)
+    (op : R → R → R) (i : Fin rows') (j : Fin cols') :
+    get E (accumulate D S hDS A op) i j = get E A i j := by
+  obtain ⟨d⟩ := A
+  change ((accumulate D S hDS ⟨d⟩ op).data[(index E i j).val]'
+    (index E i j).isLt) = d[(index E i j).val]'(index E i j).isLt
+  simp only [accumulate]
+  let step := fun d (a : Fin rows) =>
+    writeRow D d a (Vector.ofFn fun b =>
+      op (d.get (index D a b)) (d.get (index S a b)))
+  have hfold : Fin.foldl rows step d = (List.finRange rows).foldl step d :=
+    Fin.foldl_eq_finRange_foldl step d
+  have hpres := foldl_rows_ne step (index E i j).val (index E i j).isLt
+    (List.finRange rows) (fun d a _ => by
+      dsimp only [step]
+      exact get_writeRow_ne D d a _ (index E i j).val (index E i j).isLt
+        (fun b => index_ne_of_disjoint D E hDE a b i j)) d
+  exact (congrArg (fun v : Vector R (N * M) => v.get (index E i j)) hfold).trans hpres
+
+/-- Matrix-level form of `get_overwrite_disjoint`. -/
+theorem toMatrix_overwrite_disjoint (D : Region N M rows cols)
+    (E : Region N M rows' cols') (h : Disjoint D E) (A : Matrix R N M)
+    (f : Fin rows → Fin cols → R) :
+    toMatrix E (overwrite D A f) = toMatrix E A := by
+  apply Matrix.ext_getElem
+  intro i j
+  rw [getElem_toMatrix, getElem_toMatrix, get_overwrite_disjoint D E h]
+
+/-- Matrix-level form of `get_accumulateWith_disjoint`. -/
+theorem toMatrix_accumulateWith_disjoint (D : Region N M rows cols)
+    (E : Region N M rows' cols') (h : Disjoint D E) (A : Matrix R N M)
+    (f : Fin rows → Fin cols → R) (op : R → R → R) :
+    toMatrix E (accumulateWith D A f op) = toMatrix E A := by
+  apply Matrix.ext_getElem
+  intro i j
+  rw [getElem_toMatrix, getElem_toMatrix, get_accumulateWith_disjoint D E h]
+
+/-- Matrix-level form of `get_accumulateExternal_disjoint`. -/
+theorem toMatrix_accumulateExternal_disjoint (D : Region N M rows cols)
+    (E : Region N M rows' cols') (h : Disjoint D E) (A : Matrix R N M)
+    (B : Matrix R rows cols) (op : R → R → R) :
+    toMatrix E (accumulateExternal D A B op) = toMatrix E A := by
+  apply Matrix.ext_getElem
+  intro i j
+  rw [getElem_toMatrix, getElem_toMatrix, get_accumulateExternal_disjoint D E h]
+
+/-- Matrix-level form of `get_accumulate_disjoint`. -/
+theorem toMatrix_accumulate_disjoint (D S : Region N M rows cols)
+    (hDS : Disjoint D S) (E : Region N M rows' cols') (hDE : Disjoint D E)
+    (A : Matrix R N M) (op : R → R → R) :
+    toMatrix E (accumulate D S hDS A op) = toMatrix E A := by
+  apply Matrix.ext_getElem
+  intro i j
+  rw [getElem_toMatrix, getElem_toMatrix, get_accumulate_disjoint D S hDS E hDE]
+
+end Region
+
+end Matrix
+
+end Hex

--- a/HexMatrix/SPEC/hex-matrix.md
+++ b/HexMatrix/SPEC/hex-matrix.md
@@ -276,15 +276,20 @@ at square, even recursion nodes. It reuses two auxiliary `(n/2)²` matrices
 `X` and `Y`, writes each recursive product directly into one of the four
 output quadrants, and accumulates the `Uᵢ` values there without a
 `fromBlocks` copy. Rectangular top-level inputs and odd square recursion nodes
-retain `mulStrassenView` as the shape-safe fallback.
+retain `mulStrassenView` as the shape-safe fallback; reaching an odd node
+reverts that node's entire subtree, so a dimension such as 1000 uses the
+schedule for `1000 → 500 → 250` and the reference below 125.
 
 Writes use `Region`, a backing-free rectangle descriptor containing offsets
 and bounds proofs but no matrix. One owned output `Matrix` is threaded through
 every write and recursive call; quadrant descriptors therefore cannot create
-four aliases of its backing. Each update materializes one source/destination
-row before calling `Vector.set`, so the generated C passes the consumed array
-through `lean_array_fset` and can reuse it when uniquely referenced. The
-writer's proof has a stronger frame property: it returns exactly the reference
+four aliases of its backing. Each update operates directly on the owned
+region. Row-start arithmetic is hoisted outside the column loop; overwrite
+and accumulation both read the needed entries and then thread the consumed
+array through one `lean_array_fset`, without a copy-out/copy-back row. The
+generated C can therefore reuse the array when uniquely referenced. The
+writer's proof has a stronger
+frame property: it returns exactly the reference
 result in its destination and preserves every disjoint region. This proves the
 complete BDPZ accumulation order without introducing ring assumptions into
 the equality transfer.

--- a/HexMatrix/SPEC/hex-matrix.md
+++ b/HexMatrix/SPEC/hex-matrix.md
@@ -135,15 +135,12 @@ available to every ring-typed caller.
 Making Strassen "the default at runtime" therefore has a concrete, stated
 mechanism, not an implicit one:
 
-1. `mulStrassen` is the ring-level entry point: a computable recursive `def`
-   whose compiled body runs at runtime. The naive `mul` stays the semantic
-   reference it is proved equal to (`mulStrassen_eq_mul`). Unlike `mul`,
-   `mulStrassen` needs no `@[csimp]` twin, because it is already the fast body
-   rather than a kernel-facing specification with a slow reference form. If a
-   later `decide` cross-check needs `mulStrassen` to reduce cheaply in the
-   kernel, add a `mulStrassenImpl` twin with a proved
-   `@[csimp] mulStrassen_eq_impl`, mirroring `mul` / `mulImpl` /
-   `mul_eq_mulImpl`, never `@[implemented_by]`.
+1. `mulStrassen` remains the ring-level reference entry point and the theorem
+   `mulStrassen_eq_mul` continues to state its equality to naive `mul`.
+   Compiled calls are transferred to the storage-scheduled
+   `mulStrassenImpl` by the proved function equality
+   `@[csimp] mulStrassen_eq_impl : @mulStrassen = @mulStrassenImpl`, mirroring
+   `mul` / `mulImpl` / `mul_eq_mulImpl`, never `@[implemented_by]`.
 2. Ring-typed callers with genuine matrix-matrix products opt in by calling
    `mulStrassen` at their own call sites. A survey of the tree found no such
    caller: the dense consumers (`hex-determinant`, `hex-bareiss`,
@@ -273,14 +270,24 @@ which is why the public `baseMul` keeps the clean
 a materialized `Matrix` at each leaf.
 
 The `Sᵢ` and `Tᵢ` operand sums are genuinely new values, so the *logical*
-schedule names fifteen sums. The *storage* schedule is separate: Boyer-Dumas-
-Pernet-Zhou show the product needs only two auxiliary `(n/2)²` buffers beyond
-the recursion, reusing them across the `Sᵢ`/`Tᵢ`/`Pᵢ` steps and adding the `Uᵢ`
-results directly into the `C` quadrant views so the output assembles in place
-with no quadrant copy-back. The first correct implementation may use the naive
-storage (one buffer per sum) and the storage schedule is a later refinement; the
-logical schedule and the correctness proof do not depend on which storage
-schedule is used.
+schedule names fifteen sums. The *storage* schedule is separate:
+`mulStrassenImpl` implements the Boyer-Dumas-Pernet-Zhou two-buffer schedule
+at square, even recursion nodes. It reuses two auxiliary `(n/2)²` matrices
+`X` and `Y`, writes each recursive product directly into one of the four
+output quadrants, and accumulates the `Uᵢ` values there without a
+`fromBlocks` copy. Rectangular top-level inputs and odd square recursion nodes
+retain `mulStrassenView` as the shape-safe fallback.
+
+Writes use `Region`, a backing-free rectangle descriptor containing offsets
+and bounds proofs but no matrix. One owned output `Matrix` is threaded through
+every write and recursive call; quadrant descriptors therefore cannot create
+four aliases of its backing. Each update materializes one source/destination
+row before calling `Vector.set`, so the generated C passes the consumed array
+through `lean_array_fset` and can reuse it when uniquely referenced. The
+writer's proof has a stronger frame property: it returns exactly the reference
+result in its destination and preserves every disjoint region. This proves the
+complete BDPZ accumulation order without introducing ring assumptions into
+the equality transfer.
 
 The **flat row-major backing** (see "Backing representation" above) is what
 makes such views cheap: stride-and-cache locality across a whole block, cheap
@@ -290,10 +297,11 @@ that is pure offset-and-stride arithmetic into one shared buffer
 one-field structure (design principle 10) precisely so that representation
 switch stayed invisible to consumers when it landed. The recursion runs over
 the `Submatrix` view type (backing matrix plus row/column offsets plus block
-dimensions plus real-data extent), so the only allocations are the fifteen
-`Sᵢ`/`Tᵢ`/`Uᵢ` operand sums, the seven recursive products, the top-level
-full-matrix view of each operand, and the leaf materialization for `cfg.baseMul`
-— the per-level quadrant and pad copies are gone. Correctness reduces to the
+dimensions plus real-data extent). The reference recursion still exposes the
+logical `Sᵢ`/`Tᵢ`/`Uᵢ`, product, assembly, and crop allocations; the compiled
+square/even path replaces that node-local storage with `X`, `Y`, and the
+already-owned output, while leaf materialization remains for `cfg.baseMul`.
+Correctness reduces to the
 same three lemmas: a view-to-matrix abstraction lemma (`toMatrix` of a quadrant
 view equals `toBlocks` of the materialized parent, and `toMatrix` of a widened
 view equals `Matrix.pad` of the materialized source) carries the view recursion

--- a/HexMatrix/Strassen.lean
+++ b/HexMatrix/Strassen.lean
@@ -225,19 +225,20 @@ def mulStrassenView {R : Type u} [Mul R] [Add R] [Sub R] [OfNat R 0]
 /-! ### Two-buffer square schedule -/
 
 /-- Transport both matrix dimensions along equalities. -/
+@[expose]
 def castDims {R : Type u} {n m n' m' : Nat} (hn : n = n') (hm : m = m')
     (A : Matrix R n m) : Matrix R n' m' :=
   hn ▸ hm ▸ A
 
-/-- Transporting the same two matrices is injective. -/
-theorem castDims_inj {R : Type u} {n m n' m' : Nat} (hn : n = n') (hm : m = m')
+/-- `castDims hn hm` is injective. -/
+private theorem castDims_inj {R : Type u} {n m n' m' : Nat} (hn : n = n') (hm : m = m')
     {A B : Matrix R n m} (h : castDims hn hm A = castDims hn hm B) : A = B := by
   subst n'
   subst m'
   exact h
 
 /-- Transporting a materialized region changes only its index types. -/
-theorem castDims_toMatrix {R : Type u} {n m n' m' N M : Nat}
+private theorem castDims_toMatrix {R : Type u} {n m n' m' N M : Nat}
     (hn : n = n') (hm : m = m') (D : Region N M n m) (D' : Region N M n' m')
     (hr : D.r0 = D'.r0) (hc : D.c0 = D'.c0) (A : Matrix R N M) :
     castDims hn hm (D.toMatrix A) = D'.toMatrix A := by
@@ -257,7 +258,7 @@ theorem castDims_toMatrix {R : Type u} {n m n' m' N M : Nat}
 
 /-- Cropping a matrix to its full dimensions and transporting the result is the
 original matrix. -/
-theorem castDims_crop {R : Type u} {n h : Nat} (hn : n = h + h)
+private theorem castDims_crop {R : Type u} {n h : Nat} (hn : n = h + h)
     (A : Matrix R (h + h) (h + h)) :
     castDims hn hn
       (takeCols (takeRows A n (by omega)) n (by omega)) = A := by
@@ -275,6 +276,8 @@ reference view recursion as a shape-safe fallback. -/
 def mulStrassenInto {R : Type u} [Mul R] [Add R] [Sub R] [OfNat R 0]
     (cfg : StrassenConfig R) {n N M : Nat} (A B : Submatrix R n n)
     (C : Matrix R N M) (D : Region N M n n) : Matrix R N M :=
+  -- Keep the six repeated disjuncts: this is syntactically `mulStrassenView`'s
+  -- `n = m = k` guard, which makes the equality proof reduce without algebra.
   if n ≤ 1 ∨ n ≤ 1 ∨ n ≤ 1 ∨ n < cfg.cutoff ∨ n < cfg.cutoff ∨ n < cfg.cutoff then
     let P := cfg.baseMul A.toMatrix B.toMatrix
     D.overwrite C fun i j => P[(i, j)]
@@ -659,16 +662,19 @@ def mulStrassenImpl {R : Type u} [Mul R] [Add R] [Sub R] [OfNat R 0]
     Matrix R n k :=
   if hnm : n = m then
     if hmk : m = k then
-      let A' : Matrix R n n := castDims rfl hnm.symm A
-      let B' : Matrix R n n := castDims hnm.symm (hmk.symm.trans hnm.symm) B
-      let C : Matrix R n n := Matrix.ofFn fun _ _ => 0
-      castDims rfl (hnm.trans hmk)
-        (mulStrassenInto cfg (Submatrix.ofMatrix A') (Submatrix.ofMatrix B') C
-          (Region.full n n))
+      if n ≤ 1 ∨ n < cfg.cutoff then
+        mulStrassenView cfg (Submatrix.ofMatrix A) (Submatrix.ofMatrix B)
+      else
+        let A' : Matrix R n n := castDims rfl hnm.symm A
+        let B' : Matrix R n n := castDims hnm.symm (hmk.symm.trans hnm.symm) B
+        let C : Matrix R n n := Matrix.ofFn fun _ _ => 0
+        castDims rfl (hnm.trans hmk)
+          (mulStrassenInto cfg (Submatrix.ofMatrix A') (Submatrix.ofMatrix B') C
+            (Region.full n n))
     else
-      mulStrassen cfg A B
+      mulStrassenView cfg (Submatrix.ofMatrix A) (Submatrix.ofMatrix B)
   else
-    mulStrassen cfg A B
+    mulStrassenView cfg (Submatrix.ofMatrix A) (Submatrix.ofMatrix B)
 
 /-- The storage-scheduled implementation is extensionally equal to the reference
 entry point.  This transfers the implementation without changing
@@ -682,10 +688,12 @@ entry point.  This transfers the implementation without changing
     · rename_i hmk
       subst m
       subst k
-      simp only [castDims, mulStrassen]
-      simpa only [Region.toMatrix_full] using
-        (mulStrassenInto_spec cfg (Submatrix.ofMatrix A) (Submatrix.ofMatrix B)
-          (Matrix.ofFn fun _ _ => 0) (Region.full n n)).1.symm
+      split
+      · rfl
+      · simp only [castDims, mulStrassen]
+        simpa only [Region.toMatrix_full] using
+          (mulStrassenInto_spec cfg (Submatrix.ofMatrix A) (Submatrix.ofMatrix B)
+            (Matrix.ofFn fun _ _ => 0) (Region.full n n)).1.symm
     · rfl
   · rfl
 

--- a/HexMatrix/Strassen.lean
+++ b/HexMatrix/Strassen.lean
@@ -8,6 +8,7 @@ module
 
 public import HexMatrix.Block
 public import HexMatrix.Pad
+public import HexMatrix.Region
 public import HexMatrix.Winograd
 
 public section
@@ -221,6 +222,424 @@ def mulStrassenView {R : Type u} [Mul R] [Add R] [Sub R] [OfNat R 0]
   termination_by n + m + k
   decreasing_by all_goals (simp_wf; omega)
 
+/-! ### Two-buffer square schedule -/
+
+/-- Transport both matrix dimensions along equalities. -/
+def castDims {R : Type u} {n m n' m' : Nat} (hn : n = n') (hm : m = m')
+    (A : Matrix R n m) : Matrix R n' m' :=
+  hn ▸ hm ▸ A
+
+/-- Transporting the same two matrices is injective. -/
+theorem castDims_inj {R : Type u} {n m n' m' : Nat} (hn : n = n') (hm : m = m')
+    {A B : Matrix R n m} (h : castDims hn hm A = castDims hn hm B) : A = B := by
+  subst n'
+  subst m'
+  exact h
+
+/-- Transporting a materialized region changes only its index types. -/
+theorem castDims_toMatrix {R : Type u} {n m n' m' N M : Nat}
+    (hn : n = n') (hm : m = m') (D : Region N M n m) (D' : Region N M n' m')
+    (hr : D.r0 = D'.r0) (hc : D.c0 = D'.c0) (A : Matrix R N M) :
+    castDims hn hm (D.toMatrix A) = D'.toMatrix A := by
+  subst n'
+  subst m'
+  have hD : D = D' := by
+    cases D with
+    | mk dr dc drl dcl =>
+      cases D' with
+      | mk er ec erl ecl =>
+        simp only at hr hc
+        subst er
+        subst ec
+        rfl
+  subst D'
+  rfl
+
+/-- Cropping a matrix to its full dimensions and transporting the result is the
+original matrix. -/
+theorem castDims_crop {R : Type u} {n h : Nat} (hn : n = h + h)
+    (A : Matrix R (h + h) (h + h)) :
+    castDims hn hn
+      (takeCols (takeRows A n (by omega)) n (by omega)) = A := by
+  subst n
+  apply Matrix.ext_getElem
+  intro i j
+  simp only [castDims, getElem_takeCols, getElem_takeRows]
+
+/-- Write a square Strassen result into a backing-free region of one owned output
+matrix.  Even recursive nodes use the Boyer–Dumas–Pernet–Zhou schedule: `X` and
+`Y` are the only half-size matrix buffers, while products and `Uᵢ` values are
+written directly into the four output quadrants.  Base and odd nodes retain the
+reference view recursion as a shape-safe fallback. -/
+@[expose]
+def mulStrassenInto {R : Type u} [Mul R] [Add R] [Sub R] [OfNat R 0]
+    (cfg : StrassenConfig R) {n N M : Nat} (A B : Submatrix R n n)
+    (C : Matrix R N M) (D : Region N M n n) : Matrix R N M :=
+  if n ≤ 1 ∨ n ≤ 1 ∨ n ≤ 1 ∨ n < cfg.cutoff ∨ n < cfg.cutoff ∨ n < cfg.cutoff then
+    let P := cfg.baseMul A.toMatrix B.toMatrix
+    D.overwrite C fun i j => P[(i, j)]
+  else
+    let h := (n + 1) / 2
+    if heven : n = h + h then
+      let Ap := A.pad (h + h) (h + h) (by omega) (by omega)
+      let Bp := B.pad (h + h) (h + h) (by omega) (by omega)
+      let A₁₁ := Ap.toBlocks₁₁
+      let A₁₂ := Ap.toBlocks₁₂
+      let A₂₁ := Ap.toBlocks₂₁
+      let A₂₂ := Ap.toBlocks₂₂
+      let B₁₁ := Bp.toBlocks₁₁
+      let B₁₂ := Bp.toBlocks₁₂
+      let B₂₁ := Bp.toBlocks₂₁
+      let B₂₂ := Bp.toBlocks₂₂
+      let Dp : Region N M (h + h) (h + h) :=
+        { r0 := D.r0, c0 := D.c0
+          rows_le := by have := D.rows_le; omega
+          cols_le := by have := D.cols_le; omega }
+      let C₁₁ := Dp.toBlocks₁₁
+      let C₁₂ := Dp.toBlocks₁₂
+      let C₂₁ := Dp.toBlocks₂₁
+      let C₂₂ := Dp.toBlocks₂₂
+      have h₁₁₁₂ : Region.Disjoint C₁₁ C₁₂ := Region.disjoint₁₁₁₂ Dp
+      have h₁₁₂₁ : Region.Disjoint C₁₁ C₂₁ := Region.disjoint₁₁₂₁ Dp
+      have h₁₁₂₂ : Region.Disjoint C₁₁ C₂₂ := Region.disjoint₁₁₂₂ Dp
+      have h₁₂₂₁ : Region.Disjoint C₁₂ C₂₁ := Region.disjoint₁₂₂₁ Dp
+      have h₁₂₂₂ : Region.Disjoint C₁₂ C₂₂ := Region.disjoint₁₂₂₂ Dp
+      have h₂₁₂₂ : Region.Disjoint C₂₁ C₂₂ := Region.disjoint₂₁₂₂ Dp
+      -- Table 1 of BDPZ (ISSAC 2009), with products accumulated in `C`.
+      let X : Matrix R h h := Matrix.ofFn fun i j => A₁₁.entry i j - A₂₁.entry i j
+      let Y : Matrix R h h := Matrix.ofFn fun i j => B₂₂.entry i j - B₁₂.entry i j
+      let C := mulStrassenInto cfg (Submatrix.ofMatrix X) (Submatrix.ofMatrix Y) C C₂₁
+      let X := Matrix.ofFn fun i j => A₂₁.entry i j + A₂₂.entry i j
+      let Y := Matrix.ofFn fun i j => B₁₂.entry i j - B₁₁.entry i j
+      let C := mulStrassenInto cfg (Submatrix.ofMatrix X) (Submatrix.ofMatrix Y) C C₂₂
+      let X := (Region.full h h).accumulateWith X (fun i j => A₁₁.entry i j)
+        (fun x a => x - a)
+      let Y := (Region.full h h).accumulateWith Y (fun i j => B₂₂.entry i j)
+        (fun y b => b - y)
+      let C := mulStrassenInto cfg (Submatrix.ofMatrix X) (Submatrix.ofMatrix Y) C C₁₂
+      let X := (Region.full h h).accumulateWith X (fun i j => A₁₂.entry i j)
+        (fun x a => a - x)
+      let C := mulStrassenInto cfg (Submatrix.ofMatrix X) B₂₂ C C₁₁
+      let X := mulStrassenInto cfg A₁₁ B₁₁ X (Region.full h h)
+      let C := C₁₂.accumulateExternal C X (fun p₆ p₁ => p₁ + p₆)
+      let C := C₂₁.accumulate C₁₂ (Region.disjoint_comm.mp h₁₂₂₁) C
+        (fun p₇ u₂ => u₂ + p₇)
+      let C := C₁₂.accumulate C₂₂ h₁₂₂₂ C (fun u₂ p₅ => u₂ + p₅)
+      let C := C₂₂.accumulate C₂₁ (Region.disjoint_comm.mp h₂₁₂₂) C
+        (fun p₅ u₃ => u₃ + p₅)
+      let C := C₁₂.accumulate C₁₁ (Region.disjoint_comm.mp h₁₁₁₂) C
+        (fun u₄ p₃ => u₄ + p₃)
+      let Y := (Region.full h h).accumulateWith Y (fun i j => B₂₁.entry i j)
+        (fun y b => y - b)
+      let C := mulStrassenInto cfg A₂₂ (Submatrix.ofMatrix Y) C C₁₁
+      let C := C₂₁.accumulate C₁₁ (Region.disjoint_comm.mp h₁₁₂₁) C
+        (fun u₃ p₄ => u₃ - p₄)
+      let C := mulStrassenInto cfg A₁₂ B₂₁ C C₁₁
+      C₁₁.accumulateExternal C X (fun p₂ p₁ => p₁ + p₂)
+    else
+      let P := mulStrassenView cfg A B
+      D.overwrite C fun i j => P[(i, j)]
+  termination_by n
+  decreasing_by all_goals (simp_wf; omega)
+
+set_option maxHeartbeats 1000000 in
+/-- The region writer returns the reference result in its destination and
+preserves every disjoint region. -/
+theorem mulStrassenInto_spec {R : Type u} [Mul R] [Add R] [Sub R] [OfNat R 0]
+    (cfg : StrassenConfig R) {n N M : Nat} (A B : Submatrix R n n)
+    (C : Matrix R N M) (D : Region N M n n) :
+    Region.toMatrix D (mulStrassenInto cfg A B C D) = mulStrassenView cfg A B ∧
+      ∀ {rows cols} (E : Region N M rows cols), Region.Disjoint D E →
+        Region.toMatrix E (mulStrassenInto cfg A B C D) = Region.toMatrix E C := by
+  fun_induction mulStrassenInto cfg A B C D with
+  | case1 n N M A B C D hbase P =>
+    constructor
+    · apply Matrix.ext_getElem
+      intro i j
+      rw [Region.getElem_toMatrix, Region.get_overwrite]
+      rw [mulStrassenView]
+      simp only [hbase, ↓reduceIte]
+      rw [getElem_pair_eq_nested]
+    · intro rows cols E hDE
+      apply Matrix.ext_getElem
+      intro i j
+      rw [Region.getElem_toMatrix, Region.getElem_toMatrix,
+        Region.get_overwrite_disjoint D E hDE]
+  | case2 n N M A B C0 D hbase h heven Ap Bp
+      A₁₁ A₁₂ A₂₁ A₂₂ B₁₁ B₁₂ B₂₁ B₂₂ Dp C₁₁ C₁₂ C₂₁ C₂₂
+      h₁₁₁₂ h₁₁₂₁ h₁₁₂₂ h₁₂₂₁ h₁₂₂₂ h₂₁₂₂
+      X4 Y3 C11 X3 Y2 C10 X2 Y1 C9 X1 C8 X C7 C6 C5 C4 C3 Y C2 C1 C
+      hP7 _ hP5 _ hP6 _ hP3 hP1 _ _ hP4 _ hP2 =>
+    have eS2 : Submatrix.ofMatrix X2 = (A₂₁.add A₂₂).sub A₁₁ := by
+      rw [Submatrix.sub]
+      congr 1
+      apply Matrix.ext_getElem
+      intro i j
+      rw [← getElem_pair_eq_nested]
+      rw [← Region.get_full X2 i j]
+      rw [Region.get_accumulateWith, Region.get_full, Matrix.getElem_ofFn]
+      simp only [X3, Matrix.getElem_ofFn, Submatrix.entry_ofMatrix, Submatrix.add]
+      rw [getElem_pair_eq_nested, Matrix.getElem_ofFn]
+    have eT2 : Submatrix.ofMatrix Y1 = B₂₂.sub (B₁₂.sub B₁₁) := by
+      rw [Submatrix.sub]
+      congr 1
+      apply Matrix.ext_getElem
+      intro i j
+      rw [← getElem_pair_eq_nested]
+      rw [← Region.get_full Y1 i j]
+      rw [Region.get_accumulateWith, Region.get_full, Matrix.getElem_ofFn]
+      simp only [Y2, Matrix.getElem_ofFn, Submatrix.entry_ofMatrix, Submatrix.sub]
+      rw [getElem_pair_eq_nested, Matrix.getElem_ofFn]
+    have eS4 : Submatrix.ofMatrix X1 = A₁₂.sub ((A₂₁.add A₂₂).sub A₁₁) := by
+      rw [Submatrix.sub]
+      congr 1
+      apply Matrix.ext_getElem
+      intro i j
+      rw [← getElem_pair_eq_nested]
+      rw [← Region.get_full X1 i j]
+      rw [Region.get_accumulateWith, Matrix.getElem_ofFn]
+      rw [Region.get_of_toMatrix_eq (Region.full h h) X2
+        (Matrix.ofFn fun i j => (A₂₁.entry i j + A₂₂.entry i j) - A₁₁.entry i j)]
+      · simp only [Matrix.getElem_ofFn, Submatrix.entry_ofMatrix, Submatrix.sub,
+          Submatrix.add]
+        rw [getElem_pair_eq_nested, Matrix.getElem_ofFn]
+      · apply Matrix.ext_getElem
+        intro i j
+        rw [Region.getElem_toMatrix, Region.get_accumulateWith, Region.get_full]
+        simp only [X3]
+        rw [getElem_pair_eq_nested, Matrix.getElem_ofFn]
+        rw [Matrix.getElem_ofFn]
+    have eT4 : Submatrix.ofMatrix Y =
+        (B₂₂.sub (B₁₂.sub B₁₁)).sub B₂₁ := by
+      rw [Submatrix.sub]
+      congr 1
+      apply Matrix.ext_getElem
+      intro i j
+      rw [← getElem_pair_eq_nested]
+      rw [← Region.get_full Y i j]
+      rw [Region.get_accumulateWith, Matrix.getElem_ofFn]
+      rw [Region.get_of_toMatrix_eq (Region.full h h) Y1
+        (Matrix.ofFn fun i j => B₂₂.entry i j -
+          (B₁₂.entry i j - B₁₁.entry i j))]
+      · simp only [Matrix.getElem_ofFn, Submatrix.entry_ofMatrix, Submatrix.sub]
+        rw [getElem_pair_eq_nested, Matrix.getElem_ofFn]
+      · apply Matrix.ext_getElem
+        intro i j
+        rw [Region.getElem_toMatrix, Region.get_accumulateWith, Region.get_full]
+        simp only [Y2]
+        rw [getElem_pair_eq_nested, Matrix.getElem_ofFn]
+        rw [Matrix.getElem_ofFn]
+    have eS3 : Submatrix.ofMatrix X4 = A₁₁.sub A₂₁ := by rfl
+    have eT3 : Submatrix.ofMatrix Y3 = B₂₂.sub B₁₂ := by rfl
+    have eS1 : Submatrix.ofMatrix X3 = A₂₁.add A₂₂ := by rfl
+    have eT1 : Submatrix.ofMatrix Y2 = B₁₂.sub B₁₁ := by rfl
+    let P1 := mulStrassenView cfg A₁₁ B₁₁
+    let P2 := mulStrassenView cfg A₁₂ B₂₁
+    let P3 := mulStrassenView cfg (A₁₂.sub ((A₂₁.add A₂₂).sub A₁₁)) B₂₂
+    let P4 := mulStrassenView cfg A₂₂
+      ((B₂₂.sub (B₁₂.sub B₁₁)).sub B₂₁)
+    let P5 := mulStrassenView cfg (A₂₁.add A₂₂) (B₁₂.sub B₁₁)
+    let P6 := mulStrassenView cfg ((A₂₁.add A₂₂).sub A₁₁)
+      (B₂₂.sub (B₁₂.sub B₁₁))
+    let P7 := mulStrassenView cfg (A₁₁.sub A₂₁) (B₂₂.sub B₁₂)
+    have gP7 (i j : Fin h) : C₂₁.get C11 i j = P7[(i, j)] :=
+      Region.get_of_toMatrix_eq C₂₁ C11 _ (by simpa only [eS3, eT3, C11] using hP7.1) i j
+    have gP5 (i j : Fin h) : C₂₂.get C10 i j = P5[(i, j)] :=
+      Region.get_of_toMatrix_eq C₂₂ C10 _ (by simpa only [eS1, eT1, C10] using hP5.1) i j
+    have gP6 (i j : Fin h) : C₁₂.get C9 i j = P6[(i, j)] :=
+      Region.get_of_toMatrix_eq C₁₂ C9 _ (by simpa only [eS2, eT2, C9] using hP6.1) i j
+    have gP3 (i j : Fin h) : C₁₁.get C8 i j = P3[(i, j)] :=
+      Region.get_of_toMatrix_eq C₁₁ C8 _ (by simpa only [eS4, C8] using hP3.1) i j
+    have gP1 (i j : Fin h) : X[(i, j)] = P1[(i, j)] := by
+      rw [← Region.get_full X i j]
+      exact Region.get_of_toMatrix_eq (Region.full h h) X _ hP1.1 i j
+    have gP4 (i j : Fin h) : C₁₁.get C2 i j = P4[(i, j)] :=
+      Region.get_of_toMatrix_eq C₁₁ C2 _ (by simpa only [eT4, C2] using hP4.1) i j
+    have gP2 (i j : Fin h) : C₁₁.get C i j = P2[(i, j)] :=
+      Region.get_of_toMatrix_eq C₁₁ C _ (by simpa only [C] using hP2.1) i j
+    have gU2 (i j : Fin h) : C₁₂.get C7 i j = P1[(i, j)] + P6[(i, j)] := by
+      rw [Region.get_accumulateExternal, gP1]
+      rw [Region.get_eq_of_toMatrix_eq C₁₂ C8 C9
+        (by simpa only [C8] using hP3.2 C₁₂ h₁₁₁₂)]
+      rw [gP6]
+    have gP7C7 (i j : Fin h) : C₂₁.get C7 i j = P7[(i, j)] := by
+      rw [Region.get_accumulateExternal_disjoint C₁₂ C₂₁ h₁₂₂₁]
+      rw [Region.get_eq_of_toMatrix_eq C₂₁ C8 C9
+        (by simpa only [C8] using hP3.2 C₂₁ h₁₁₂₁)]
+      rw [Region.get_eq_of_toMatrix_eq C₂₁ C9 C10
+        (by simpa only [C9] using hP6.2 C₂₁ h₁₂₂₁)]
+      rw [Region.get_eq_of_toMatrix_eq C₂₁ C10 C11
+        (by simpa only [C10] using hP5.2 C₂₁ (Region.disjoint_comm.mp h₂₁₂₂))]
+      exact gP7 i j
+    have gU3 (i j : Fin h) : C₂₁.get C6 i j =
+        (P1[(i, j)] + P6[(i, j)]) + P7[(i, j)] := by
+      rw [Region.get_accumulate, gU2, gP7C7]
+    have gP5C6 (i j : Fin h) : C₂₂.get C6 i j = P5[(i, j)] := by
+      rw [Region.get_accumulate_disjoint C₂₁ C₁₂ _ C₂₂ h₂₁₂₂]
+      rw [Region.get_accumulateExternal_disjoint C₁₂ C₂₂ h₁₂₂₂]
+      rw [Region.get_eq_of_toMatrix_eq C₂₂ C8 C9
+        (by simpa only [C8] using hP3.2 C₂₂ h₁₁₂₂)]
+      rw [Region.get_eq_of_toMatrix_eq C₂₂ C9 C10
+        (by simpa only [C9] using hP6.2 C₂₂ h₁₂₂₂)]
+      exact gP5 i j
+    have gU4 (i j : Fin h) : C₁₂.get C5 i j =
+        (P1[(i, j)] + P6[(i, j)]) + P5[(i, j)] := by
+      rw [Region.get_accumulate]
+      rw [Region.get_accumulate_disjoint C₂₁ C₁₂ _ C₁₂
+        (Region.disjoint_comm.mp h₁₂₂₁), gU2, gP5C6]
+    have gU7 (i j : Fin h) : C₂₂.get C4 i j =
+        ((P1[(i, j)] + P6[(i, j)]) + P7[(i, j)]) + P5[(i, j)] := by
+      rw [Region.get_accumulate]
+      rw [Region.get_accumulate_disjoint C₁₂ C₂₂ _ C₂₂ h₁₂₂₂,
+        gP5C6]
+      rw [Region.get_accumulate_disjoint C₁₂ C₂₂ _ C₂₁ h₁₂₂₁,
+        gU3]
+    have gP3C4 (i j : Fin h) : C₁₁.get C4 i j = P3[(i, j)] := by
+      rw [Region.get_accumulate_disjoint C₂₂ C₂₁ _ C₁₁
+        (Region.disjoint_comm.mp h₁₁₂₂)]
+      rw [Region.get_accumulate_disjoint C₁₂ C₂₂ _ C₁₁
+        (Region.disjoint_comm.mp h₁₁₁₂)]
+      rw [Region.get_accumulate_disjoint C₂₁ C₁₂ _ C₁₁
+        (Region.disjoint_comm.mp h₁₁₂₁)]
+      rw [Region.get_accumulateExternal_disjoint C₁₂ C₁₁
+        (Region.disjoint_comm.mp h₁₁₁₂)]
+      exact gP3 i j
+    have gU5 (i j : Fin h) : C₁₂.get C3 i j =
+        ((P1[(i, j)] + P6[(i, j)]) + P5[(i, j)]) + P3[(i, j)] := by
+      rw [Region.get_accumulate, gP3C4]
+      rw [Region.get_accumulate_disjoint C₂₂ C₂₁ _ C₁₂
+        (Region.disjoint_comm.mp h₁₂₂₂), gU4]
+    have e11 : C₁₁.toMatrix (C₁₁.accumulateExternal C X fun p2 p1 => p1 + p2) =
+        P1 + P2 := by
+      apply Matrix.ext_getElem
+      intro i j
+      rw [Region.getElem_toMatrix, Region.get_accumulateExternal, Matrix.getElem_add,
+        gP1, gP2]
+      simp only [getElem_pair_eq_nested]
+    have e21 : C₂₁.toMatrix (C₁₁.accumulateExternal C X fun p2 p1 => p1 + p2) =
+        (P1 + P6 + P7) - P4 := by
+      apply Matrix.ext_getElem
+      intro i j
+      rw [Region.getElem_toMatrix, Matrix.getElem_sub, Matrix.getElem_add, Matrix.getElem_add]
+      rw [Region.get_accumulateExternal_disjoint C₁₁ C₂₁ h₁₁₂₁]
+      rw [Region.get_eq_of_toMatrix_eq C₂₁ C C1
+        (by simpa only [C] using hP2.2 C₂₁ h₁₁₂₁)]
+      rw [Region.get_accumulate, gP4]
+      rw [Region.get_eq_of_toMatrix_eq C₂₁ C2 C3
+        (by simpa only [C2] using hP4.2 C₂₁ h₁₁₂₁)]
+      rw [Region.get_accumulate_disjoint C₁₂ C₁₁ _ C₂₁ h₁₂₂₁]
+      rw [Region.get_accumulate_disjoint C₂₂ C₂₁ _ C₂₁
+        (Region.disjoint_comm.mp h₂₁₂₂)]
+      rw [Region.get_accumulate_disjoint C₁₂ C₂₂ _ C₂₁ h₁₂₂₁]
+      rw [gU3]
+      simp only [getElem_pair_eq_nested]
+    have e12 : C₁₂.toMatrix (C₁₁.accumulateExternal C X fun p2 p1 => p1 + p2) =
+        (P1 + P6 + P5) + P3 := by
+      apply Matrix.ext_getElem
+      intro i j
+      rw [Region.getElem_toMatrix, Matrix.getElem_add, Matrix.getElem_add, Matrix.getElem_add]
+      rw [Region.get_accumulateExternal_disjoint C₁₁ C₁₂ h₁₁₁₂]
+      rw [Region.get_eq_of_toMatrix_eq C₁₂ C C1
+        (by simpa only [C] using hP2.2 C₁₂ h₁₁₁₂)]
+      rw [Region.get_accumulate_disjoint C₂₁ C₁₁ _ C₁₂
+        (Region.disjoint_comm.mp h₁₂₂₁)]
+      rw [Region.get_eq_of_toMatrix_eq C₁₂ C2 C3
+        (by simpa only [C2] using hP4.2 C₁₂ h₁₁₁₂)]
+      rw [gU5]
+      simp only [getElem_pair_eq_nested]
+    have e22 : C₂₂.toMatrix (C₁₁.accumulateExternal C X fun p2 p1 => p1 + p2) =
+        (P1 + P6 + P7) + P5 := by
+      apply Matrix.ext_getElem
+      intro i j
+      rw [Region.getElem_toMatrix, Matrix.getElem_add, Matrix.getElem_add, Matrix.getElem_add]
+      rw [Region.get_accumulateExternal_disjoint C₁₁ C₂₂ h₁₁₂₂]
+      rw [Region.get_eq_of_toMatrix_eq C₂₂ C C1
+        (by simpa only [C] using hP2.2 C₂₂ h₁₁₂₂)]
+      rw [Region.get_accumulate_disjoint C₂₁ C₁₁ _ C₂₂ h₂₁₂₂]
+      rw [Region.get_eq_of_toMatrix_eq C₂₂ C2 C3
+        (by simpa only [C2] using hP4.2 C₂₂ h₁₁₂₂)]
+      rw [Region.get_accumulate_disjoint C₁₂ C₁₁ _ C₂₂ h₁₂₂₂]
+      rw [gU7]
+      simp only [getElem_pair_eq_nested]
+    let Cout := C₁₁.accumulateExternal C X fun p2 p1 => p1 + p2
+    have assembled : Dp.toMatrix Cout =
+        fromBlocks (P1 + P2) ((P1 + P6 + P5) + P3)
+          ((P1 + P6 + P7) - P4) ((P1 + P6 + P7) + P5) := by
+      rw [← Matrix.fromBlocks_toBlocks (Dp.toMatrix Cout)]
+      rw [← Region.toMatrix_toBlocks₁₁ Dp Cout,
+        ← Region.toMatrix_toBlocks₁₂ Dp Cout,
+        ← Region.toMatrix_toBlocks₂₁ Dp Cout,
+        ← Region.toMatrix_toBlocks₂₂ Dp Cout]
+      simp only [Cout]
+      rw [e11, e12, e21, e22]
+    have reference : castDims heven heven (mulStrassenView cfg A B) =
+        fromBlocks (P1 + P2) ((P1 + P6 + P5) + P3)
+          ((P1 + P6 + P7) - P4) ((P1 + P6 + P7) + P5) := by
+      rw [mulStrassenView]
+      simp only [hbase, ↓reduceIte]
+      rw [castDims_crop]
+    constructor
+    · apply castDims_inj heven heven
+      rw [castDims_toMatrix heven heven D Dp rfl rfl, assembled, reference]
+    · intro rows cols E hDE
+      have hDpE : Region.Disjoint Dp E := by
+        simp only [Region.Disjoint, Dp] at hDE ⊢
+        omega
+      have h11E : Region.Disjoint C₁₁ E := by
+        simpa only [C₁₁] using Region.disjoint_toBlocks₁₁ Dp E hDpE
+      have h12E : Region.Disjoint C₁₂ E := by
+        simpa only [C₁₂] using Region.disjoint_toBlocks₁₂ Dp E hDpE
+      have h21E : Region.Disjoint C₂₁ E := by
+        simpa only [C₂₁] using Region.disjoint_toBlocks₂₁ Dp E hDpE
+      have h22E : Region.Disjoint C₂₂ E := by
+        simpa only [C₂₂] using Region.disjoint_toBlocks₂₂ Dp E hDpE
+      calc
+        E.toMatrix Cout = E.toMatrix C := by
+          simpa only [Cout] using
+            Region.toMatrix_accumulateExternal_disjoint C₁₁ E h11E C X
+              (fun p2 p1 => p1 + p2)
+        _ = E.toMatrix C1 := by simpa only [C] using hP2.2 E h11E
+        _ = E.toMatrix C2 := by
+          simpa only [C1] using
+            Region.toMatrix_accumulate_disjoint C₂₁ C₁₁
+              (Region.disjoint_comm.mp h₁₁₂₁) E h21E C2 (fun u3 p4 => u3 - p4)
+        _ = E.toMatrix C3 := by simpa only [C2] using hP4.2 E h11E
+        _ = E.toMatrix C4 := by
+          simpa only [C3] using
+            Region.toMatrix_accumulate_disjoint C₁₂ C₁₁
+              (Region.disjoint_comm.mp h₁₁₁₂) E h12E C4 (fun u4 p3 => u4 + p3)
+        _ = E.toMatrix C5 := by
+          simpa only [C4] using
+            Region.toMatrix_accumulate_disjoint C₂₂ C₂₁
+              (Region.disjoint_comm.mp h₂₁₂₂) E h22E C5 (fun p5 u3 => u3 + p5)
+        _ = E.toMatrix C6 := by
+          simpa only [C5] using
+            Region.toMatrix_accumulate_disjoint C₁₂ C₂₂ h₁₂₂₂ E h12E C6
+              (fun u2 p5 => u2 + p5)
+        _ = E.toMatrix C7 := by
+          simpa only [C6] using
+            Region.toMatrix_accumulate_disjoint C₂₁ C₁₂
+              (Region.disjoint_comm.mp h₁₂₂₁) E h21E C7 (fun p7 u2 => u2 + p7)
+        _ = E.toMatrix C8 := by
+          simpa only [C7] using
+            Region.toMatrix_accumulateExternal_disjoint C₁₂ E h12E C8 X
+              (fun p6 p1 => p1 + p6)
+        _ = E.toMatrix C9 := by simpa only [C8] using hP3.2 E h11E
+        _ = E.toMatrix C10 := by simpa only [C9] using hP6.2 E h12E
+        _ = E.toMatrix C11 := by simpa only [C10] using hP5.2 E h22E
+        _ = E.toMatrix C0 := by simpa only [C11] using hP7.2 E h21E
+  | case3 n N M A B C D hbase h hOdd P =>
+    constructor
+    · apply Matrix.ext_getElem
+      intro i j
+      rw [Region.getElem_toMatrix, Region.get_overwrite]
+      rw [getElem_pair_eq_nested]
+    · intro rows cols E hDE
+      apply Matrix.ext_getElem
+      intro i j
+      rw [Region.getElem_toMatrix, Region.getElem_toMatrix,
+        Region.get_overwrite_disjoint D E hDE]
+
 /-- **Strassen-Winograd multiplication.** The public entry point wraps the operands
 as full-matrix `Submatrix` views and runs the view recursion `mulStrassenView`;
 the quadrant splitting inside never materializes or copies a quadrant buffer —
@@ -231,6 +650,44 @@ def mulStrassen {R : Type u} [Mul R] [Add R] [Sub R] [OfNat R 0]
     (cfg : StrassenConfig R) {n m k : Nat} (M : Matrix R n m) (N : Matrix R m k) :
     Matrix R n k :=
   mulStrassenView cfg (Submatrix.ofMatrix M) (Submatrix.ofMatrix N)
+
+/-- Storage-scheduled implementation of `mulStrassen`.  Square inputs run the
+two-buffer writer; all other shapes retain the reference view recursion. -/
+@[expose]
+def mulStrassenImpl {R : Type u} [Mul R] [Add R] [Sub R] [OfNat R 0]
+    (cfg : StrassenConfig R) {n m k : Nat} (A : Matrix R n m) (B : Matrix R m k) :
+    Matrix R n k :=
+  if hnm : n = m then
+    if hmk : m = k then
+      let A' : Matrix R n n := castDims rfl hnm.symm A
+      let B' : Matrix R n n := castDims hnm.symm (hmk.symm.trans hnm.symm) B
+      let C : Matrix R n n := Matrix.ofFn fun _ _ => 0
+      castDims rfl (hnm.trans hmk)
+        (mulStrassenInto cfg (Submatrix.ofMatrix A') (Submatrix.ofMatrix B') C
+          (Region.full n n))
+    else
+      mulStrassen cfg A B
+  else
+    mulStrassen cfg A B
+
+/-- The storage-scheduled implementation is extensionally equal to the reference
+entry point.  This transfers the implementation without changing
+`mulStrassen`'s statement or its ring-level correctness theorem. -/
+@[csimp] theorem mulStrassen_eq_impl : @mulStrassen = @mulStrassenImpl := by
+  funext R _ _ _ _ cfg n m k A B
+  simp only [mulStrassenImpl]
+  split
+  · rename_i hnm
+    split
+    · rename_i hmk
+      subst m
+      subst k
+      simp only [castDims, mulStrassen]
+      simpa only [Region.toMatrix_full] using
+        (mulStrassenInto_spec cfg (Submatrix.ofMatrix A) (Submatrix.ofMatrix B)
+          (Matrix.ofFn fun _ _ => 0) (Region.full n n)).1.symm
+    · rfl
+  · rfl
 
 /-- The view recursion computes the same matrix as the reference `mul` of the
 materialized operands, for every valid configuration. Proved by functional

--- a/conformance/HexMatrix/Conformance.lean
+++ b/conformance/HexMatrix/Conformance.lean
@@ -197,6 +197,8 @@ private def cfgDeep : StrassenConfig Int := { cutoff := 0, baseMul := naiveKerne
 -- Even, odd, and prime square dimensions under both custom configs.
 #guard let A := genInt 0 8 8; let B := genInt 1 8 8; mulStrassen cfgNaive A B = A * B
 #guard let A := genInt 0 8 8; let B := genInt 1 8 8; mulStrassen cfgDeep A B = A * B
+#guard let A := genInt 0 6 6; let B := genInt 1 6 6; mulStrassen cfgDeep A B = A * B
+#guard let A := genInt 0 12 12; let B := genInt 1 12 12; mulStrassen cfgDeep A B = A * B
 #guard let A := genInt 0 9 9; let B := genInt 1 9 9; mulStrassen cfgNaive A B = A * B
 #guard let A := genInt 0 9 9; let B := genInt 1 9 9; mulStrassen cfgDeep A B = A * B
 #guard let A := genInt 0 5 5; let B := genInt 1 5 5; mulStrassen cfgNaive A B = A * B

--- a/progress/20260727T072942Z_issue-8851.md
+++ b/progress/20260727T072942Z_issue-8851.md
@@ -1,0 +1,33 @@
+# Issue 8851 — BDPZ two-buffer Strassen schedule
+
+## Accomplished
+
+- Claimed GitHub issue #8851 and validated its measurement gate with cold-child
+  baseline runs at dimensions 512 and 1024 plus heaptrack and generated-C
+  inspection.
+- Added backing-free `Matrix.Region` descriptors and proved their overwrite and
+  accumulation operations update the destination while preserving disjoint
+  regions.
+- Implemented the square/even BDPZ schedule in `mulStrassenInto`, with two
+  half-size scratch matrices and direct accumulation into the owned output.
+- Proved the writer equals the reference view recursion and added the required
+  `@[csimp] mulStrassen_eq_impl : @mulStrassen = @mulStrassenImpl` transfer.
+- Recorded five-process before/after wall-time and peak-RSS samples, heaptrack
+  evidence, generated-C evidence, and updated the SPEC and performance report.
+- Completed `lake build` (9462 jobs) and the Strassen benchmark verification;
+  no new warnings or Mathlib boundary violations were observed.
+
+## Current frontier
+
+The implementation and local validation are complete. The branch still needs
+the requested independent Claude Opus review, followed by PR creation and the
+merge-conflict/CI loop.
+
+## Next step
+
+Commit this checkpoint, run the `second-opinion` skill against the committed
+diff, address verified findings, then open and shepherd the PR to green merge.
+
+## Blockers
+
+None.

--- a/progress/20260727T081156Z_issue-8851.md
+++ b/progress/20260727T081156Z_issue-8851.md
@@ -1,0 +1,23 @@
+# Issue 8851 two-buffer Strassen schedule
+
+## Accomplished
+
+- Claimed issue #8851 and implemented the exact Boyer-Dumas-Pernet-Zhou two-buffer schedule at square, even recursion nodes, retaining the reference view recursion for rectangular and odd nodes.
+- Added backing-free `Region` descriptors and proved destination correctness plus disjoint-region frame preservation while threading one owned output matrix through every recursive call and write.
+- Kept `mulStrassen` and `mulStrassen_eq_mul` unchanged, added the same-signature `mulStrassenImpl`, and proved `@[csimp] mulStrassen_eq_impl : @mulStrassen = @mulStrassenImpl` without `sorry`, `axiom`, or `native_decide`.
+- Measured the required cold-child baseline before implementation. The projected 10.6% peak-RSS saving at dimension 1024 cleared the 5% gate.
+- Measured the final implementation: median wall time changed by -4.4% at 512 and -5.1% at 1024; median peak RSS changed by -8.1% and -10.9%, respectively. Heaptrack's tracked peak heap fell from 4.06 MiB to 2.92 MiB while GMP-dominated allocation counts remained unchanged.
+- Asked Claude Opus for the required independent review. Addressed its actionable concerns by removing temporary rows, hoisting row-start arithmetic, sharing the existing flat-write lemmas, bypassing zero-filled scheduled output below cutoff, making fallback calls explicit, documenting the odd-subtree behavior, and adding 6x6 and 12x12 even-to-odd recursion tests. Generated C showed that the suggested `Vector.modify` would clear and set; the final direct update instead performs one read and one `lean_array_fset` per destination entry.
+- Updated the HexMatrix SPEC, performance report, and raw benchmark JSON. The complete `lake build` passed all 9,462 jobs, and the benchmark checksum verification passed.
+
+## Current frontier
+
+The implementation and evidence are complete and ready to rebase and publish as a pull request.
+
+## Next step
+
+Rebase on the current `origin/main`, open the pull request, monitor individual Actions jobs, address any review or CI failures, and enable squash auto-merge once green.
+
+## Blockers
+
+None.

--- a/reports/bench-results/hex-matrix-strassen-two-buffer-chungus2.json
+++ b/reports/bench-results/hex-matrix-strassen-two-buffer-chungus2.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": 1,
+  "benchmark": "Hex.MatrixBench.runSquareMulStrassenChecksum",
+  "issue": 8851,
+  "method": "single-call cold child, five independent processes per dimension",
+  "command": ".lake/build/bin/hexmatrix_bench profile Hex.MatrixBench.runSquareMulStrassenChecksum --param N --cache-mode cold --profiler '/run/current-system/sw/bin/time -v'",
+  "environment": {
+    "hostname": "chungus2",
+    "cpu": "AMD EPYC 9455 48-Core Processor",
+    "lean_toolchain": "leanprover/lean4:4.32.0-rc1",
+    "baseline_commit": "ce3ff80879fc473265f46a885543c441e5512c35"
+  },
+  "results": [
+    {
+      "dimension": 512,
+      "result_hash": "0x3ff9d8390625168",
+      "baseline": {
+        "per_call_nanos": [4991310555, 4924036450, 4940249884, 4948861355, 4954106583],
+        "peak_rss_kb": [106028, 105052, 111352, 112484, 111140],
+        "median_per_call_nanos": 4948861355,
+        "median_peak_rss_kb": 111140
+      },
+      "two_buffer": {
+        "per_call_nanos": [5029670204, 4833392870, 4973013786, 4941400584, 5531543194],
+        "peak_rss_kb": [86480, 92216, 93300, 91488, 92876],
+        "median_per_call_nanos": 4973013786,
+        "median_peak_rss_kb": 92216
+      },
+      "median_wall_time_change_percent": 0.488,
+      "median_peak_rss_change_percent": -17.027
+    },
+    {
+      "dimension": 1024,
+      "result_hash": "0x1ffbbcd11f386b8e",
+      "baseline": {
+        "per_call_nanos": [42617436656, 41997417698, 40767385316, 41935462353, 43621837006],
+        "peak_rss_kb": [218088, 225728, 232328, 224088, 225608],
+        "median_per_call_nanos": 41997417698,
+        "median_peak_rss_kb": 225608
+      },
+      "two_buffer": {
+        "per_call_nanos": [41033430136, 41210378181, 41472000235, 40337998571, 41003355467],
+        "peak_rss_kb": [189828, 201216, 196064, 191916, 200400],
+        "median_per_call_nanos": 41033430136,
+        "median_peak_rss_kb": 196064
+      },
+      "median_wall_time_change_percent": -2.295,
+      "median_peak_rss_change_percent": -13.095
+    }
+  ],
+  "gate": {
+    "projected_pointer_storage": {
+      "reference_slots_in_n_squared": "14/3",
+      "two_buffer_output_slots_in_n_squared": "5/3",
+      "projected_saving_mib_at_1024": 24.0,
+      "projected_fraction_of_baseline_peak_rss_percent": 10.6
+    },
+    "threshold_percent": 5.0,
+    "decision": "proceed: projected and measured peak-RSS savings clear the gate"
+  },
+  "heaptrack_512": {
+    "command": "heaptrack -o TRACE hexmatrix_bench _child --bench Hex.MatrixBench.runSquareMulStrassenChecksum --param 512 --target-nanos 500000000 --cache-mode cold",
+    "baseline": {
+      "allocations": 398980177,
+      "temporary_allocations": 88150227,
+      "peak_heap_mb": 4.06,
+      "peak_rss_with_heaptrack_mb": 111.76
+    },
+    "two_buffer": {
+      "allocations": 398980177,
+      "temporary_allocations": 88150226,
+      "peak_heap_mb": 2.92,
+      "peak_rss_with_heaptrack_mb": 102.26
+    },
+    "interpretation": "GMP call counts are unchanged because arithmetic is unchanged; peak tracked heap falls 28.1%. Lean-managed array traffic is evidenced by generated C and the cold-child RSS measurements."
+  },
+  "generated_c": {
+    "file": ".lake/build/ir/HexMatrix/Region.c",
+    "evidence": "Region.writeRow compiles to lean_array_fset on the consumed array; accumulate variants construct a complete row before threading that array through writeRow."
+  },
+  "dimension_2048": "not run: one uninstrumented sample was projected near five minutes, making a five-process before/after set unsuitable for this host session"
+}

--- a/reports/bench-results/hex-matrix-strassen-two-buffer-chungus2.json
+++ b/reports/bench-results/hex-matrix-strassen-two-buffer-chungus2.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "benchmark": "Hex.MatrixBench.runSquareMulStrassenChecksum",
   "issue": 8851,
-  "method": "single-call cold child, five independent processes per dimension",
+  "method": "single-call cold child; five baseline processes per dimension, seven final processes at 512 and five at 1024",
   "command": ".lake/build/bin/hexmatrix_bench profile Hex.MatrixBench.runSquareMulStrassenChecksum --param N --cache-mode cold --profiler '/run/current-system/sw/bin/time -v'",
   "environment": {
     "hostname": "chungus2",
@@ -21,13 +21,15 @@
         "median_peak_rss_kb": 111140
       },
       "two_buffer": {
-        "per_call_nanos": [5029670204, 4833392870, 4973013786, 4941400584, 5531543194],
-        "peak_rss_kb": [86480, 92216, 93300, 91488, 92876],
-        "median_per_call_nanos": 4973013786,
-        "median_peak_rss_kb": 92216
+        "per_call_nanos": [6156732425, 4900753501, 4656543446, 4703423338, 4730082246, 4786657621, 4686091991],
+        "peak_rss_kb": [91492, 103212, 96524, 102884, 103180, 92344, 102132],
+        "median_per_call_nanos": 4730082246,
+        "median_peak_rss_kb": 102132,
+        "per_call_range_nanos": [4656543446, 6156732425],
+        "peak_rss_range_kb": [91492, 103212]
       },
-      "median_wall_time_change_percent": 0.488,
-      "median_peak_rss_change_percent": -17.027
+      "median_wall_time_change_percent": -4.421,
+      "median_peak_rss_change_percent": -8.105
     },
     {
       "dimension": 1024,
@@ -39,13 +41,15 @@
         "median_peak_rss_kb": 225608
       },
       "two_buffer": {
-        "per_call_nanos": [41033430136, 41210378181, 41472000235, 40337998571, 41003355467],
-        "peak_rss_kb": [189828, 201216, 196064, 191916, 200400],
-        "median_per_call_nanos": 41033430136,
-        "median_peak_rss_kb": 196064
+        "per_call_nanos": [39864652303, 39765779571, 39296088685, 40044913482, 39848566413],
+        "peak_rss_kb": [200996, 201476, 200936, 200900, 194104],
+        "median_per_call_nanos": 39848566413,
+        "median_peak_rss_kb": 200936,
+        "per_call_range_nanos": [39296088685, 40044913482],
+        "peak_rss_range_kb": [194104, 201476]
       },
-      "median_wall_time_change_percent": -2.295,
-      "median_peak_rss_change_percent": -13.095
+      "median_wall_time_change_percent": -5.117,
+      "median_peak_rss_change_percent": -10.936
     }
   ],
   "gate": {
@@ -70,13 +74,13 @@
       "allocations": 398980177,
       "temporary_allocations": 88150226,
       "peak_heap_mb": 2.92,
-      "peak_rss_with_heaptrack_mb": 102.26
+      "peak_rss_with_heaptrack_mb": 114.91
     },
     "interpretation": "GMP call counts are unchanged because arithmetic is unchanged; peak tracked heap falls 28.1%. Lean-managed array traffic is evidenced by generated C and the cold-child RSS measurements."
   },
   "generated_c": {
     "file": ".lake/build/ir/HexMatrix/Region.c",
-    "evidence": "Region.writeRow compiles to lean_array_fset on the consumed array; accumulate variants construct a complete row before threading that array through writeRow."
+    "evidence": "The write helpers compute rowStart once per row; overwrite and accumulation read their needed entries and then call lean_array_fset once per destination entry, with no temporary row or Vector.modify clear-then-set sequence."
   },
   "dimension_2048": "not run: one uninstrumented sample was projected near five minutes, making a five-process before/after set unsuitable for this host session"
 }

--- a/reports/hex-matrix-performance.md
+++ b/reports/hex-matrix-performance.md
@@ -135,6 +135,33 @@ Profile captured on `carica` through the bench-timed-region filtering wrapper
 The dominant inclusive costs all map to registered `HexMatrix.Bench`
 targets. No unattributed dominant cost was observed.
 
+## Strassen two-buffer storage schedule
+
+The BDPZ schedule was gated and measured on `chungus2` with the same toolchain
+as above. Each wall/RSS observation is one cold child and one multiplication;
+five independent processes were used per dimension. Raw observations and
+commands are committed in
+`reports/bench-results/hex-matrix-strassen-two-buffer-chungus2.json`.
+
+| dimension | reference wall median | two-buffer wall median | change | reference RSS median | two-buffer RSS median | change |
+|---:|---:|---:|---:|---:|---:|---:|
+| 512 | 4.949 s | 4.973 s | +0.5% | 111,140 KiB | 92,216 KiB | −17.0% |
+| 1024 | 41.997 s | 41.033 s | −2.3% | 225,608 KiB | 196,064 KiB | −13.1% |
+
+All trials produced the pre-change hashes (`0x3ff9d8390625168` at 512 and
+`0x1ffbbcd11f386b8e` at 1024). The wall-time result is neutral to modestly
+positive; peak RSS clears the 5% gate at both sizes. Dimension 2048 was not
+run because a single sample was projected near five minutes on this host.
+
+A cold heaptrack run at 512 reported unchanged GMP-dominated allocation-call
+counts (398,980,177 total, 291,803,993 through `__gmp_default_allocate`) and a
+tracked peak-heap reduction from 4.06 MiB to 2.92 MiB (−28.1%). This is
+consistent with unchanged arithmetic and lower live matrix storage; heaptrack
+does not account for Lean-managed arrays as ordinary allocation calls.
+Generated C supplies that evidence: `Region.writeRow` threads its consumed
+array through `lean_array_fset`, and each accumulation builds the complete
+source/destination row before the write fold begins.
+
 ## Concerns
 
 None for the dense base surface.

--- a/reports/hex-matrix-performance.md
+++ b/reports/hex-matrix-performance.md
@@ -139,28 +139,32 @@ targets. No unattributed dominant cost was observed.
 
 The BDPZ schedule was gated and measured on `chungus2` with the same toolchain
 as above. Each wall/RSS observation is one cold child and one multiplication;
-five independent processes were used per dimension. Raw observations and
-commands are committed in
+the final implementation has seven processes at 512 and five at 1024. Raw
+observations and commands are committed in
 `reports/bench-results/hex-matrix-strassen-two-buffer-chungus2.json`.
 
 | dimension | reference wall median | two-buffer wall median | change | reference RSS median | two-buffer RSS median | change |
 |---:|---:|---:|---:|---:|---:|---:|
-| 512 | 4.949 s | 4.973 s | +0.5% | 111,140 KiB | 92,216 KiB | −17.0% |
-| 1024 | 41.997 s | 41.033 s | −2.3% | 225,608 KiB | 196,064 KiB | −13.1% |
+| 512 | 4.949 s | 4.730 s | −4.4% | 111,140 KiB | 102,132 KiB | −8.1% |
+| 1024 | 41.997 s | 39.849 s | −5.1% | 225,608 KiB | 200,936 KiB | −10.9% |
 
 All trials produced the pre-change hashes (`0x3ff9d8390625168` at 512 and
-`0x1ffbbcd11f386b8e` at 1024). The wall-time result is neutral to modestly
-positive; peak RSS clears the 5% gate at both sizes. Dimension 2048 was not
-run because a single sample was projected near five minutes on this host.
+`0x1ffbbcd11f386b8e` at 1024). The 512 wall range (`4.66–6.16 s`) includes one
+high-contention outlier, so its 4.4% median improvement is directional; the
+1024 range (`39.30–40.04 s`) supports the 5.1% wall improvement. Peak RSS
+clears the 5% gate at both sizes. Dimension 2048 was not run because a single
+sample was projected near five minutes on this host.
 
 A cold heaptrack run at 512 reported unchanged GMP-dominated allocation-call
 counts (398,980,177 total, 291,803,993 through `__gmp_default_allocate`) and a
 tracked peak-heap reduction from 4.06 MiB to 2.92 MiB (−28.1%). This is
 consistent with unchanged arithmetic and lower live matrix storage; heaptrack
 does not account for Lean-managed arrays as ordinary allocation calls.
-Generated C supplies that evidence: `Region.writeRow` threads its consumed
-array through `lean_array_fset`, and each accumulation builds the complete
-source/destination row before the write fold begins.
+Generated C supplies that evidence: the region helpers thread their consumed
+array through `lean_array_fset`. After independent review, the write primitives
+were tightened further: row-start multiplication is hoisted out of column
+loops, and each accumulation reads its operands before one `lean_array_fset`,
+without a temporary row or `Vector.modify`'s clear-then-set sequence.
 
 ## Concerns
 


### PR DESCRIPTION
Closes #8851.

## Gate

The required cold-child baseline was measured before implementation at dimensions 512 and 1024. The reference recursion's live per-level pointer storage projected a reachable peak-RSS reduction of about 24 MiB at 1024, or 10.6% of the measured 225,608 KiB baseline, so the estimate cleared the issue's 5% gate.

## What shipped

- Adds backing-free `Region` descriptors. A descriptor stores only offsets and bounds proofs; it never owns or aliases the matrix backing.
- Threads one owned output matrix through every write and recursive call. Destination quadrants are descriptors, so uniqueness-based `lean_array_fset` reuse is preserved.
- Implements the exact Boyer-Dumas-Pernet-Zhou Table 1 two-buffer schedule at square, even recursion nodes. The two half-size scratch matrices are reused while products and `U_i` combinations accumulate directly into output quadrants.
- Retains the existing `mulStrassenView` recursion for rectangular inputs and odd square nodes. Reaching an odd node reverts that node's entire subtree.
- Keeps the public `mulStrassen` definition and `mulStrassen_eq_mul` theorem untouched. The same-signature `mulStrassenImpl` is transferred by `@[csimp] mulStrassen_eq_impl : @mulStrassen = @mulStrassenImpl`.
- Proves both destination correctness and a disjoint-region frame property for the output-threading recursion, with no `sorry`, `axiom`, or `native_decide`.
- Adds even-to-odd subtree conformance coverage at dimensions 6 and 12, and updates the HexMatrix SPEC and performance evidence.

## Measurements

Each observation is a single multiplication in a cold child. Baseline has five processes per dimension; final has seven at 512 and five at 1024.

| dimension | reference wall median | two-buffer wall median | change | reference RSS median | two-buffer RSS median | change |
|---:|---:|---:|---:|---:|---:|---:|
| 512 | 4.949 s | 4.730 s | -4.4% | 111,140 KiB | 102,132 KiB | -8.1% |
| 1024 | 41.997 s | 39.849 s | -5.1% | 225,608 KiB | 200,936 KiB | -10.9% |

The 512 wall range (4.66-6.16 s) includes one high-contention outlier, so its wall result is directional. The tighter 1024 range (39.30-40.04 s) supports the 5.1% wall improvement. All trials produced the pre-change checksum.

A cold heaptrack run at 512 left the GMP-dominated allocation count unchanged, as expected from unchanged arithmetic, while tracked peak heap fell from 4.06 MiB to 2.92 MiB (-28.1%). Generated C computes the row start once and, for each accumulation, reads the operands before exactly one `lean_array_fset`; it creates no temporary row and does not use `Vector.modify`'s clear-then-set sequence. Raw observations and commands are in `reports/bench-results/hex-matrix-strassen-two-buffer-chungus2.json`.

Dimension 2048 was not run: one sample was projected near five minutes on this host, making a meaningful before/after process set unsuitable for the session.

## Independent review

Claude Opus independently checked the schedule algebra, aliasing design, frame proof, equality transfer, and `csimp` shape and found them sound. I agreed with and addressed its concerns about temporary rows, repeated index arithmetic, duplicated flat-write proof infrastructure, unnecessary zero-filled output below cutoff, fallback clarity, odd-subtree documentation, and even-to-odd tests.

I did not take its literal suggestion to replace the update with `Vector.modify`: generated C showed that primitive clearing and then setting the entry. I instead implemented a direct old-value read followed by one `Vector.set`, which emits one `lean_array_fset` and preserves the intended uniqueness path.

## Validation

- `lake build` (9,462 jobs)
- `lake build HexMatrix.Strassen HexMatrix.Conformance` after rebasing onto current `origin/main`
- `.lake/build/bin/hexmatrix_bench verify Hex.MatrixBench.runSquareMulStrassenChecksum`
- JSON validation, `git diff --check`, and forbidden-proof scan
