### PR TITLE
feat(tower): flatten primitive presentations

### DIFF
--- a/HexNumberFieldTower.lean
+++ b/HexNumberFieldTower.lean
@@ -12,6 +12,7 @@ public import HexNumberFieldTower.Embed
 public import HexNumberFieldTower.Norm
 public import HexNumberFieldTower.Factor
 public import HexNumberFieldTower.Split
+public import HexNumberFieldTower.Flatten
 
 public section
 

--- a/HexNumberFieldTower/Flatten.lean
+++ b/HexNumberFieldTower/Flatten.lean
@@ -1,0 +1,281 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexNumberFieldTower.Split
+public import HexRowReduce
+public meta import HexNumberFieldTower.Split
+public meta import HexRowReduce
+
+public section
+
+/-!
+# Primitive-element flattening for number-field towers
+
+The fixed absolute generators are combined in deterministic signed-shift order.
+A candidate is admitted only when its canonical minimal-polynomial degree is the
+full accumulated tower dimension. Exact trace-pairing row reduction then
+recovers every old generator in the primitive power basis. Both coordinate
+maps are checked on their respective rational bases before they are returned.
+-/
+namespace Hex.NumberTower
+
+/-- A one-generator presentation of a tower together with checked executable
+coordinate conversions in both directions. -/
+structure Flattening (T : NumberTower) where
+  root : AlgebraicNumber
+  toPrimitive : Elem T → QAdjoin root.p root.x
+  fromPrimitive : QAdjoin root.p root.x → Elem T
+
+/-- The finite primitive-element collision bound for a field of dimension
+`dimension`. -/
+@[expose]
+def flattenShiftCount (dimension : Nat) : Nat :=
+  Nat.choose dimension 2 + 1
+
+namespace Flatten
+
+/-- One exact absolute generator and its mixed-radix coordinate in the final
+tower. -/
+structure Generator (T : NumberTower) where
+  degree : Nat
+  root : AlgebraicNumber
+  value : Elem T
+
+/-- A primitive generator accumulated through the lower part of the tower. -/
+structure Candidate (T : NumberTower) where
+  dimension : Nat
+  root : AlgebraicNumber
+  value : Elem T
+
+/-- Standard coordinate vector of length `dimension`. -/
+@[expose]
+def unitCoords (dimension index : Nat) : Array Rat :=
+  (Array.replicate dimension 0).set! index 1
+
+/-- Exactify the stored roots from the oldest level upward and pair them with
+their canonical mixed-radix generator coordinates in the final tower. -/
+@[expose]
+def generators? (T : NumberTower) : Option (Array (Generator T)) := do
+  let state ← T.levels.toList.reverse.foldlM
+    (fun state level => do
+      let root ← level.root.exact?
+      let value := ofCoeffs T (unitCoords T.dim state.2)
+      some (state.1.push ⟨level.degree, root, value⟩,
+        state.2 * level.degree))
+    (#[], 1)
+  if state.2 = T.dim then some state.1 else none
+
+/-- Search a prescribed suffix of the deterministic signed shifts for a
+candidate of the full required degree. -/
+@[expose]
+def searchAux (theta alpha : AlgebraicNumber) (target start : Nat) : Nat →
+    Option (Int × AlgebraicNumber)
+  | 0 => none
+  | fuel + 1 => do
+      let shift := Norm.signedShift start
+      let candidate ← AlgebraicPoly.Common.shift? theta alpha shift
+      if AlgebraicPoly.Common.degree candidate = target then
+        some (shift, candidate)
+      else
+        searchAux theta alpha target (start + 1) fuel
+
+/-- Search exactly the primitive-element collision bound. -/
+@[expose]
+def search? (theta alpha : AlgebraicNumber) (target : Nat) :
+    Option (Int × AlgebraicNumber) :=
+  searchAux theta alpha target 0 (flattenShiftCount target)
+
+/-- Combine the fixed generators one level at a time, retaining a tower
+coordinate for each accepted canonical primitive element. -/
+@[expose]
+def candidate? (T : NumberTower) (generators : Array (Generator T)) :
+    Option (Candidate T) := do
+  match generators[0]? with
+  | none =>
+      some ⟨1, AlgebraicNumber.zero, 0⟩
+  | some first => do
+      if AlgebraicPoly.Common.degree first.root = first.degree then
+        generators.toList.drop 1 |>.foldlM
+          (fun current generator => do
+            let target := current.dimension * generator.degree
+            let (shift, root) ← search? current.root generator.root target
+            let value := current.value + (shift : Rat) • generator.value
+            some ⟨target, root, value⟩)
+          ⟨first.degree, first.root, first.value⟩
+      else
+        none
+
+/-- Extend lower mixed-radix basis images by powers of one newly recovered
+generator. The lower basis remains the fastest-varying coordinate block. -/
+@[expose]
+def extendBasis {p : ZPoly} {x : SimpleRoot p}
+    (basis : Array (QAdjoin p x)) (generator : QAdjoin p x)
+    (degree : Nat) : Array (QAdjoin p x) :=
+  let state := (List.range degree).foldl
+    (fun state _ =>
+      (state.1 ++ basis.map fun b => b * state.2,
+        state.2 * generator))
+    (#[], 1)
+  state.1
+
+/-- Images of the full tower mixed-radix basis in the primitive
+presentation. -/
+@[expose]
+def basisImages {T : NumberTower} {p : ZPoly} {x : SimpleRoot p}
+    (generators : Array (Generator T))
+    (coordinates : Array (QAdjoin p x)) : Array (QAdjoin p x) :=
+  (generators.zip coordinates).foldl
+    (fun basis entry => extendBasis basis entry.2 entry.1.degree)
+    #[1]
+
+/-- Apply a rational coordinate vector to precomputed primitive-basis images. -/
+@[expose]
+def toPrimitiveWith {T : NumberTower} {p : ZPoly} {x : SimpleRoot p}
+    (images : Array (QAdjoin p x)) (a : Elem T) : QAdjoin p x :=
+  (images.zip (coeffs a)).foldl
+    (fun value entry => value + entry.2 • entry.1) 0
+
+/-- Evaluate a reduced primitive coordinate polynomial at its tower element. -/
+@[expose]
+def fromPrimitiveWith {T : NumberTower} {p : ZPoly} {x : SimpleRoot p}
+    (generator : Elem T) (a : QAdjoin p x) : Elem T :=
+  a.coeffs.toArray.reverse.foldl
+    (fun value coefficient => value * generator + ofRat T coefficient) 0
+
+/-- Verify both coordinate composites on the mixed-radix and primitive power
+bases. -/
+@[expose]
+def roundTrips {T : NumberTower} (candidate : Candidate T)
+    (images : Array (QAdjoin candidate.root.p candidate.root.x)) : Bool :=
+  let toPrimitive := toPrimitiveWith images
+  let fromPrimitive := fromPrimitiveWith candidate.value
+  images.size = T.dim && candidate.dimension = T.dim &&
+    (List.range T.dim).all (fun i =>
+      let basis := ofCoeffs T (unitCoords T.dim i)
+      fromPrimitive (toPrimitive basis) == basis) &&
+    (List.range T.dim).all (fun i =>
+      let basis := QAdjoin.reduce candidate.root.p candidate.root.x
+        (DensePoly.monomial i 1)
+      toPrimitive (fromPrimitive basis) == basis)
+
+end Flatten
+
+/-- Replace a checked tower by one canonical primitive-element presentation.
+The result is returned only after exact generator recovery and both basis
+round-trip checks succeed. -/
+def flatten? (T : NumberTower) : Option (Flattening T) := do
+  let generators ← Flatten.generators? T
+  let candidate ← Flatten.candidate? T generators
+  let powers ← AlgebraicPoly.Common.powers? candidate.root
+    (2 * candidate.dimension - 2)
+  let coordinates ← generators.mapM fun generator =>
+    AlgebraicPoly.Common.coordinates? candidate.root generator.root powers
+  let images := Flatten.basisImages generators coordinates
+  if Flatten.roundTrips candidate images then
+    some
+      { root := candidate.root
+        toPrimitive := Flatten.toPrimitiveWith images
+        fromPrimitive := Flatten.fromPrimitiveWith candidate.value }
+  else
+    none
+
+/-! Compiled primitive-element and coordinate round-trip regressions. -/
+
+#guard
+    match flatten? rat with
+    | some flattened =>
+        let value := ofRat rat (7 / 3)
+        flattened.root.p = ZPoly.X &&
+          (flattened.toPrimitive value).coeffs = DensePoly.C (7 / 3) &&
+          flattened.fromPrimitive (flattened.toPrimitive value) == value
+    | none => false
+
+private def flattenSqrtTwoPoly : ZPoly := DensePoly.ofList [-2, 0, 1]
+
+private def flattenSqrtTwoSquare : DyadicSquare :=
+  ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
+
+private def flattenSqrtTwoRep : RefinedIsolation flattenSqrtTwoPoly :=
+  ⟨⟨flattenSqrtTwoSquare, by decide⟩, by decide⟩
+
+private def flattenSqrtTwoRoot : SimpleRoot flattenSqrtTwoPoly :=
+  SimpleRoot.mk flattenSqrtTwoRep
+
+#guard
+    if hirred : ZPoly.isIrreducible flattenSqrtTwoPoly = true then
+      letI : ZPoly.CheckedIrreducible flattenSqrtTwoPoly :=
+        ⟨hirred, by decide⟩
+      if hsimple : HasOnlySimpleRoots flattenSqrtTwoPoly then
+        let base := ofQAdjoin (x := flattenSqrtTwoRoot)
+          hsimple flattenSqrtTwoRep rfl
+        match flatten? base.tower with
+        | some flattened =>
+            flattened.root.p = flattenSqrtTwoPoly &&
+              (flattened.toPrimitive base.gen).coeffs =
+                DensePoly.ofList [0, 1] &&
+              flattened.fromPrimitive
+                (flattened.toPrimitive base.gen) == base.gen
+        | none => false
+      else
+        false
+    else
+      false
+
+private def flattenSqrtThreePoly : ZPoly := DensePoly.ofList [-3, 0, 1]
+
+private def flattenSqrtThreeSquare : DyadicSquare :=
+  ⟨Dyadic.ofIntWithPrec 222 7, 0, 8⟩
+
+private def flattenSqrtThreeRep : RefinedIsolation flattenSqrtThreePoly :=
+  ⟨⟨flattenSqrtThreeSquare, by decide⟩, by decide⟩
+
+private def flattenSumPoly : ZPoly :=
+  DensePoly.ofList [1, 0, -10, 0, 1]
+
+#guard
+    if hirred : ZPoly.isIrreducible flattenSqrtTwoPoly = true then
+      letI : ZPoly.CheckedIrreducible flattenSqrtTwoPoly :=
+        ⟨hirred, by decide⟩
+      if htwo : HasOnlySimpleRoots flattenSqrtTwoPoly then
+        let base := ofQAdjoin (x := flattenSqrtTwoRoot)
+          htwo flattenSqrtTwoRep rfl
+        if hthree : HasOnlySimpleRoots flattenSqrtThreePoly then
+          let root : AlgebraicRoot :=
+            { p := flattenSqrtThreePoly
+              prim := by rfl
+              pos_lc := by decide
+              pos_degree := by decide
+              squarefree := hthree
+              x := SimpleRoot.mk flattenSqrtThreeRep
+              rep := flattenSqrtThreeRep
+              rep_mk := rfl }
+          match adjoin? base.tower root with
+          | some extension =>
+              match flatten? extension.tower with
+              | some flattened =>
+                  let sqrtTwo := extension.embed base.gen
+                  let sqrtThree := extension.gen
+                  let twoCoordinate := flattened.toPrimitive sqrtTwo
+                  let threeCoordinate := flattened.toPrimitive sqrtThree
+                  flattened.root.p = flattenSumPoly &&
+                    twoCoordinate.coeffs =
+                      DensePoly.ofList [0, -9 / 2, 0, 1 / 2] &&
+                    threeCoordinate.coeffs =
+                      DensePoly.ofList [0, 11 / 2, 0, -1 / 2] &&
+                    flattened.fromPrimitive twoCoordinate == sqrtTwo &&
+                    flattened.fromPrimitive threeCoordinate == sqrtThree
+              | none => false
+          | none => false
+        else
+          false
+      else
+        false
+    else
+      false
+
+end Hex.NumberTower

--- a/HexNumberFieldTower/Flatten.lean
+++ b/HexNumberFieldTower/Flatten.lean
@@ -29,11 +29,11 @@ structure Flattening (T : NumberTower) where
   toPrimitive : Elem T → QAdjoin root.p root.x
   fromPrimitive : QAdjoin root.p root.x → Elem T
 
-/-- The finite primitive-element collision bound for a field of dimension
-`dimension`. -/
+/-- The finite combined bound for primitive-element and coordinate-recovery
+collisions in a field of dimension `dimension`. -/
 @[expose]
 def flattenShiftCount (dimension : Nat) : Nat :=
-  Nat.choose dimension 2 + 1
+  2 * Nat.choose dimension 2 + 1
 
 namespace Flatten
 
@@ -85,12 +85,6 @@ def searchAux (theta alpha : AlgebraicNumber) (target start : Nat) : Nat →
       | none =>
           searchAux theta alpha target (start + 1) fuel
 
-/-- Search exactly the primitive-element collision bound. -/
-@[expose]
-def search? (theta alpha : AlgebraicNumber) (target : Nat) :
-    Option (Int × AlgebraicNumber) :=
-  searchAux theta alpha target 0 (flattenShiftCount target)
-
 /-- Lift an integer polynomial coefficientwise into a fixed primitive
 presentation. -/
 @[expose]
@@ -108,10 +102,10 @@ def evalRatPoly {p : ZPoly} {x : SimpleRoot p}
       value * a + coefficient • (1 : QAdjoin p x))
     0
 
-/-- Recover `theta` and `alpha` in the accepted presentation
-`gamma = theta + shift * alpha`. Full-degree acceptance makes the gcd of their
-two lifted relations linear; the final basis round trips validate the selected
-coordinate before it becomes public. -/
+/-- Recover `theta` and `alpha` in a candidate presentation
+`gamma = theta + shift * alpha`. A full-degree candidate can still have a
+non-linear gcd because incompatible conjugate pairs need not be field
+embeddings, so failure here is a reason to try another shift. -/
 @[expose]
 def recoverPair? (theta alpha gamma : AlgebraicNumber) (shift : Int) :
     Option (QAdjoin gamma.p gamma.x × QAdjoin gamma.p gamma.x) := do
@@ -136,6 +130,38 @@ def recoverPair? (theta alpha gamma : AlgebraicNumber) (shift : Int) :
     else
       none
 
+/-- A full-degree primitive candidate together with its recovered old and new
+generator coordinates. -/
+structure Recovered where
+  shift : Int
+  root : AlgebraicNumber
+  thetaCoordinate : QAdjoin root.p root.x
+  alphaCoordinate : QAdjoin root.p root.x
+
+/-- Search a prescribed shift suffix, rejecting both degree collisions and
+full-degree candidates whose exact recovery gcd is not linear. -/
+@[expose]
+def searchRecoveredAux (theta alpha : AlgebraicNumber)
+    (target start : Nat) : Nat → Option Recovered
+  | 0 => none
+  | fuel + 1 =>
+      match searchAux theta alpha target start 1 with
+      | none =>
+          searchRecoveredAux theta alpha target (start + 1) fuel
+      | some (shift, root) =>
+          match recoverPair? theta alpha root shift with
+          | some (thetaCoordinate, alphaCoordinate) =>
+              some ⟨shift, root, thetaCoordinate, alphaCoordinate⟩
+          | none =>
+              searchRecoveredAux theta alpha target (start + 1) fuel
+
+/-- Search the combined finite bound for a primitive candidate with exact
+linear coordinate recovery. -/
+@[expose]
+def searchRecovered? (theta alpha : AlgebraicNumber) (target : Nat) :
+    Option Recovered :=
+  searchRecoveredAux theta alpha target 0 (flattenShiftCount target)
+
 /-- Combine the fixed generators one level at a time, retaining a tower
 coordinate for each accepted canonical primitive element. -/
 @[expose]
@@ -149,13 +175,14 @@ def candidate? (T : NumberTower) (generators : Array (Generator T)) :
         generators.toList.drop 1 |>.foldlM
           (fun current generator => do
             let target := current.dimension * generator.degree
-            let (shift, root) ← search? current.root generator.root target
-            let (thetaCoordinate, alphaCoordinate) ←
-              recoverPair? current.root generator.root root shift
-            let value := current.value + (shift : Rat) • generator.value
+            let recovered ←
+              searchRecovered? current.root generator.root target
+            let value := current.value +
+              (recovered.shift : Rat) • generator.value
             let coordinates := current.coordinates.map fun coordinate =>
-              evalRatPoly coordinate.coeffs thetaCoordinate
-            some ⟨target, root, value, coordinates.push alphaCoordinate⟩)
+              evalRatPoly coordinate.coeffs recovered.thetaCoordinate
+            some ⟨target, recovered.root, value,
+              coordinates.push recovered.alphaCoordinate⟩)
           ⟨first.degree, first.root, first.value, #[first.root.toQAdjoin]⟩
       else
         none
@@ -197,10 +224,19 @@ def fromPrimitiveWith {T : NumberTower} {p : ZPoly} {x : SimpleRoot p}
   a.coeffs.toArray.reverse.foldl
     (fun value coefficient => value * generator + ofRat T coefficient) 0
 
-/-- Verify both coordinate composites on the mixed-radix and primitive power
-bases. -/
+/-- Evaluate an integer polynomial at a tower element. -/
 @[expose]
-def roundTrips {T : NumberTower} (candidate : Candidate T)
+def evalZPoly {T : NumberTower} (f : ZPoly) (a : Elem T) : Elem T :=
+  f.toArray.foldr
+    (fun (coefficient : Int) value =>
+      value * a + ofRat T (coefficient : Rat)) 0
+
+/-- Verify the coordinate composite on the tower basis and check that the
+candidate tower element satisfies its claimed primitive minimal polynomial.
+The first condition makes the rational-linear coordinate maps inverse; the
+root relation makes evaluation through the primitive quotient multiplicative. -/
+@[expose]
+def certifies {T : NumberTower} (candidate : Candidate T)
     (images : Array (QAdjoin candidate.root.p candidate.root.x)) : Bool :=
   let toPrimitive := toPrimitiveWith images
   let fromPrimitive := fromPrimitiveWith candidate.value
@@ -208,10 +244,7 @@ def roundTrips {T : NumberTower} (candidate : Candidate T)
     (List.range T.dim).all (fun i =>
       let basis := ofCoeffs T (unitCoords T.dim i)
       fromPrimitive (toPrimitive basis) == basis) &&
-    (List.range T.dim).all (fun i =>
-      let basis := QAdjoin.reduce candidate.root.p candidate.root.x
-        (DensePoly.monomial i 1)
-      toPrimitive (fromPrimitive basis) == basis)
+    evalZPoly candidate.root.p candidate.value == 0
 
 end Flatten
 
@@ -222,7 +255,7 @@ def flatten? (T : NumberTower) : Option (Flattening T) := do
   let generators ← Flatten.generators? T
   let candidate ← Flatten.candidate? T generators
   let images := Flatten.basisImages generators candidate.coordinates
-  if Flatten.roundTrips candidate images then
+  if Flatten.certifies candidate images then
     some
       { root := candidate.root
         toPrimitive := Flatten.toPrimitiveWith images
@@ -360,11 +393,17 @@ private def flattenFourthRootTwoRep :
               | some flattened =>
                   let sqrtTwo := extension.embed base.gen
                   let fourthRoot := extension.gen
-                  flattened.root.p.degree?.getD 0 = 4 &&
+                  let fourthCoordinate :=
+                    flattened.toPrimitive fourthRoot
+                  flattened.root.p =
+                      DensePoly.ofList [2, -8, -4, 0, 1] &&
+                    fourthCoordinate.coeffs =
+                      DensePoly.ofList [-10 / 9, -1 / 3, -1 / 9, 2 / 9] &&
+                    flattened.toPrimitive (fourthRoot * fourthRoot) ==
+                      flattened.toPrimitive sqrtTwo &&
                     flattened.fromPrimitive
                       (flattened.toPrimitive sqrtTwo) == sqrtTwo &&
-                    flattened.fromPrimitive
-                      (flattened.toPrimitive fourthRoot) == fourthRoot
+                    flattened.fromPrimitive fourthCoordinate == fourthRoot
               | none => false
           | none => false
         else

--- a/HexNumberFieldTower/Flatten.lean
+++ b/HexNumberFieldTower/Flatten.lean
@@ -7,9 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexNumberFieldTower.Split
-public import HexRowReduce
 public meta import HexNumberFieldTower.Split
-public meta import HexRowReduce
 
 public section
 
@@ -18,9 +16,9 @@ public section
 
 The fixed absolute generators are combined in deterministic signed-shift order.
 A candidate is admitted only when its canonical minimal-polynomial degree is the
-full accumulated tower dimension. Exact trace-pairing row reduction then
-recovers every old generator in the primitive power basis. Both coordinate
-maps are checked on their respective rational bases before they are returned.
+full accumulated tower dimension. Exact polynomial gcds then recover every old
+generator in the primitive power basis. Both coordinate maps are checked on
+their respective rational bases before they are returned.
 -/
 namespace Hex.NumberTower
 
@@ -51,9 +49,9 @@ structure Candidate (T : NumberTower) where
   dimension : Nat
   root : AlgebraicNumber
   value : Elem T
+  coordinates : Array (QAdjoin root.p root.x)
 
 /-- Standard coordinate vector of length `dimension`. -/
-@[expose]
 def unitCoords (dimension index : Nat) : Array Rat :=
   (Array.replicate dimension 0).set! index 1
 
@@ -76,19 +74,67 @@ candidate of the full required degree. -/
 def searchAux (theta alpha : AlgebraicNumber) (target start : Nat) : Nat →
     Option (Int × AlgebraicNumber)
   | 0 => none
-  | fuel + 1 => do
+  | fuel + 1 =>
       let shift := Norm.signedShift start
-      let candidate ← AlgebraicPoly.Common.shift? theta alpha shift
-      if AlgebraicPoly.Common.degree candidate = target then
-        some (shift, candidate)
-      else
-        searchAux theta alpha target (start + 1) fuel
+      match AlgebraicPoly.Common.shift? theta alpha shift with
+      | some candidate =>
+          if AlgebraicPoly.Common.degree candidate = target then
+            some (shift, candidate)
+          else
+            searchAux theta alpha target (start + 1) fuel
+      | none =>
+          searchAux theta alpha target (start + 1) fuel
 
 /-- Search exactly the primitive-element collision bound. -/
 @[expose]
 def search? (theta alpha : AlgebraicNumber) (target : Nat) :
     Option (Int × AlgebraicNumber) :=
   searchAux theta alpha target 0 (flattenShiftCount target)
+
+/-- Lift an integer polynomial coefficientwise into a fixed primitive
+presentation. -/
+@[expose]
+def liftZPoly {p : ZPoly} {x : SimpleRoot p}
+    (f : ZPoly) : DensePoly (QAdjoin p x) :=
+  DensePoly.ofCoeffs <| f.toArray.map fun (coefficient : Int) =>
+    (coefficient : Rat) • (1 : QAdjoin p x)
+
+/-- Evaluate a rational coordinate polynomial in another fixed presentation. -/
+@[expose]
+def evalRatPoly {p : ZPoly} {x : SimpleRoot p}
+    (f : DensePoly Rat) (a : QAdjoin p x) : QAdjoin p x :=
+  f.toArray.foldr
+    (fun coefficient value =>
+      value * a + coefficient • (1 : QAdjoin p x))
+    0
+
+/-- Recover `theta` and `alpha` in the accepted presentation
+`gamma = theta + shift * alpha`. Full-degree acceptance makes the gcd of their
+two lifted relations linear; the final basis round trips validate the selected
+coordinate before it becomes public. -/
+@[expose]
+def recoverPair? (theta alpha gamma : AlgebraicNumber) (shift : Int) :
+    Option (QAdjoin gamma.p gamma.x × QAdjoin gamma.p gamma.x) := do
+  if shift = 0 then
+    none
+  else
+    letI : ZPoly.CheckedIrreducible gamma.p := gamma.checked
+    let gammaCoordinate := gamma.toQAdjoin
+    let affine : DensePoly (QAdjoin gamma.p gamma.x) :=
+      DensePoly.ofList
+        [gammaCoordinate, (-(shift : Rat)) • (1 : QAdjoin gamma.p gamma.x)]
+    let thetaRelation :=
+      DensePoly.composeImpl (liftZPoly theta.p) affine
+    let alphaRelation : DensePoly (QAdjoin gamma.p gamma.x) :=
+      liftZPoly alpha.p
+    let common := DensePoly.gcd thetaRelation alphaRelation
+    if common.degree?.getD 0 = 1 && common.leadingCoeff != 0 then
+      let alphaCoordinate := -(common.coeff 0) / common.leadingCoeff
+      let thetaCoordinate :=
+        gammaCoordinate - (shift : Rat) • alphaCoordinate
+      some (thetaCoordinate, alphaCoordinate)
+    else
+      none
 
 /-- Combine the fixed generators one level at a time, retaining a tower
 coordinate for each accepted canonical primitive element. -/
@@ -97,16 +143,20 @@ def candidate? (T : NumberTower) (generators : Array (Generator T)) :
     Option (Candidate T) := do
   match generators[0]? with
   | none =>
-      some ⟨1, AlgebraicNumber.zero, 0⟩
+      some ⟨1, AlgebraicNumber.zero, 0, #[]⟩
   | some first => do
       if AlgebraicPoly.Common.degree first.root = first.degree then
         generators.toList.drop 1 |>.foldlM
           (fun current generator => do
             let target := current.dimension * generator.degree
             let (shift, root) ← search? current.root generator.root target
+            let (thetaCoordinate, alphaCoordinate) ←
+              recoverPair? current.root generator.root root shift
             let value := current.value + (shift : Rat) • generator.value
-            some ⟨target, root, value⟩)
-          ⟨first.degree, first.root, first.value⟩
+            let coordinates := current.coordinates.map fun coordinate =>
+              evalRatPoly coordinate.coeffs thetaCoordinate
+            some ⟨target, root, value, coordinates.push alphaCoordinate⟩)
+          ⟨first.degree, first.root, first.value, #[first.root.toQAdjoin]⟩
       else
         none
 
@@ -171,11 +221,7 @@ round-trip checks succeed. -/
 def flatten? (T : NumberTower) : Option (Flattening T) := do
   let generators ← Flatten.generators? T
   let candidate ← Flatten.candidate? T generators
-  let powers ← AlgebraicPoly.Common.powers? candidate.root
-    (2 * candidate.dimension - 2)
-  let coordinates ← generators.mapM fun generator =>
-    AlgebraicPoly.Common.coordinates? candidate.root generator.root powers
-  let images := Flatten.basisImages generators coordinates
+  let images := Flatten.basisImages generators candidate.coordinates
   if Flatten.roundTrips candidate images then
     some
       { root := candidate.root
@@ -237,6 +283,16 @@ private def flattenSqrtThreeRep : RefinedIsolation flattenSqrtThreePoly :=
 private def flattenSumPoly : ZPoly :=
   DensePoly.ofList [1, 0, -10, 0, 1]
 
+private def flattenFourthRootTwoPoly : ZPoly :=
+  DensePoly.ofList [-2, 0, 0, 0, 1]
+
+private def flattenFourthRootTwoSquare : DyadicSquare :=
+  ⟨Dyadic.ofIntWithPrec 77936 16, 0, 17⟩
+
+private def flattenFourthRootTwoRep :
+    RefinedIsolation flattenFourthRootTwoPoly :=
+  ⟨⟨flattenFourthRootTwoSquare, by decide⟩, by decide⟩
+
 #guard
     if hirred : ZPoly.isIrreducible flattenSqrtTwoPoly = true then
       letI : ZPoly.CheckedIrreducible flattenSqrtTwoPoly :=
@@ -269,6 +325,46 @@ private def flattenSumPoly : ZPoly :=
                       DensePoly.ofList [0, 11 / 2, 0, -1 / 2] &&
                     flattened.fromPrimitive twoCoordinate == sqrtTwo &&
                     flattened.fromPrimitive threeCoordinate == sqrtThree
+              | none => false
+          | none => false
+        else
+          false
+      else
+        false
+    else
+      false
+
+-- The newest absolute generator has degree four but relative degree two. This
+-- distinguishes the accumulated relative-dimension target from the naive
+-- product of the two absolute minimal-polynomial degrees.
+#guard
+    if hirred : ZPoly.isIrreducible flattenSqrtTwoPoly = true then
+      letI : ZPoly.CheckedIrreducible flattenSqrtTwoPoly :=
+        ⟨hirred, by decide⟩
+      if htwo : HasOnlySimpleRoots flattenSqrtTwoPoly then
+        let base := ofQAdjoin (x := flattenSqrtTwoRoot)
+          htwo flattenSqrtTwoRep rfl
+        if hfourth : HasOnlySimpleRoots flattenFourthRootTwoPoly then
+          let root : AlgebraicRoot :=
+            { p := flattenFourthRootTwoPoly
+              prim := by rfl
+              pos_lc := by decide
+              pos_degree := by decide
+              squarefree := hfourth
+              x := SimpleRoot.mk flattenFourthRootTwoRep
+              rep := flattenFourthRootTwoRep
+              rep_mk := rfl }
+          match adjoin? base.tower root with
+          | some extension =>
+              match flatten? extension.tower with
+              | some flattened =>
+                  let sqrtTwo := extension.embed base.gen
+                  let fourthRoot := extension.gen
+                  flattened.root.p.degree?.getD 0 = 4 &&
+                    flattened.fromPrimitive
+                      (flattened.toPrimitive sqrtTwo) == sqrtTwo &&
+                    flattened.fromPrimitive
+                      (flattened.toPrimitive fourthRoot) == fourthRoot
               | none => false
           | none => false
         else

--- a/HexNumberFieldTower/Flatten.lean
+++ b/HexNumberFieldTower/Flatten.lean
@@ -17,8 +17,8 @@ public section
 The fixed absolute generators are combined in deterministic signed-shift order.
 A candidate is admitted only when its canonical minimal-polynomial degree is the
 full accumulated tower dimension. Exact polynomial gcds then recover every old
-generator in the primitive power basis. Both coordinate maps are checked on
-their respective rational bases before they are returned.
+generator in the primitive power basis. A tower-basis coordinate round trip and
+the primitive polynomial relation are checked before the maps are returned.
 -/
 namespace Hex.NumberTower
 
@@ -33,7 +33,7 @@ structure Flattening (T : NumberTower) where
 collisions in a field of dimension `dimension`. -/
 @[expose]
 def flattenShiftCount (dimension : Nat) : Nat :=
-  2 * Nat.choose dimension 2 + 1
+  Nat.choose dimension 2 + 1
 
 namespace Flatten
 
@@ -68,22 +68,19 @@ def generators? (T : NumberTower) : Option (Array (Generator T)) := do
     (#[], 1)
   if state.2 = T.dim then some state.1 else none
 
-/-- Search a prescribed suffix of the deterministic signed shifts for a
-candidate of the full required degree. -/
+/-- Try one deterministic signed shift for a candidate of the full required
+degree. -/
 @[expose]
-def searchAux (theta alpha : AlgebraicNumber) (target start : Nat) : Nat →
-    Option (Int × AlgebraicNumber)
-  | 0 => none
-  | fuel + 1 =>
-      let shift := Norm.signedShift start
-      match AlgebraicPoly.Common.shift? theta alpha shift with
-      | some candidate =>
-          if AlgebraicPoly.Common.degree candidate = target then
-            some (shift, candidate)
-          else
-            searchAux theta alpha target (start + 1) fuel
-      | none =>
-          searchAux theta alpha target (start + 1) fuel
+def candidateAt? (theta alpha : AlgebraicNumber) (target index : Nat) :
+    Option (Int × AlgebraicNumber) :=
+  let shift := Norm.signedShift index
+  match AlgebraicPoly.Common.shift? theta alpha shift with
+  | some candidate =>
+      if AlgebraicPoly.Common.degree candidate = target then
+        some (shift, candidate)
+      else
+        none
+  | none => none
 
 /-- Lift an integer polynomial coefficientwise into a fixed primitive
 presentation. -/
@@ -145,7 +142,7 @@ def searchRecoveredAux (theta alpha : AlgebraicNumber)
     (target start : Nat) : Nat → Option Recovered
   | 0 => none
   | fuel + 1 =>
-      match searchAux theta alpha target start 1 with
+      match candidateAt? theta alpha target start with
       | none =>
           searchRecoveredAux theta alpha target (start + 1) fuel
       | some (shift, root) =>
@@ -160,7 +157,7 @@ linear coordinate recovery. -/
 @[expose]
 def searchRecovered? (theta alpha : AlgebraicNumber) (target : Nat) :
     Option Recovered :=
-  searchRecoveredAux theta alpha target 0 (flattenShiftCount target)
+  searchRecoveredAux theta alpha target 1 (flattenShiftCount target)
 
 /-- Combine the fixed generators one level at a time, retaining a tower
 coordinate for each accepted canonical primitive element. -/
@@ -234,7 +231,9 @@ def evalZPoly {T : NumberTower} (f : ZPoly) (a : Elem T) : Elem T :=
 /-- Verify the coordinate composite on the tower basis and check that the
 candidate tower element satisfies its claimed primitive minimal polynomial.
 The first condition makes the rational-linear coordinate maps inverse; the
-root relation makes evaluation through the primitive quotient multiplicative. -/
+root relation and irreducibility make evaluation through the primitive
+quotient an injective ring map. The resulting dimension squeeze makes the
+linear inverse multiplicative as well. -/
 @[expose]
 def certifies {T : NumberTower} (candidate : Candidate T)
     (images : Array (QAdjoin candidate.root.p candidate.root.x)) : Bool :=
@@ -249,8 +248,8 @@ def certifies {T : NumberTower} (candidate : Candidate T)
 end Flatten
 
 /-- Replace a checked tower by one canonical primitive-element presentation.
-The result is returned only after exact generator recovery and both basis
-round-trip checks succeed. -/
+The result is returned only after exact generator recovery, a tower-basis
+round trip, and the primitive polynomial relation succeed. -/
 def flatten? (T : NumberTower) : Option (Flattening T) := do
   let generators ← Flatten.generators? T
   let candidate ← Flatten.candidate? T generators
@@ -399,7 +398,7 @@ private def flattenFourthRootTwoRep :
                       DensePoly.ofList [2, -8, -4, 0, 1] &&
                     fourthCoordinate.coeffs =
                       DensePoly.ofList [-10 / 9, -1 / 3, -1 / 9, 2 / 9] &&
-                    flattened.toPrimitive (fourthRoot * fourthRoot) ==
+                    fourthCoordinate * fourthCoordinate ==
                       flattened.toPrimitive sqrtTwo &&
                     flattened.fromPrimitive
                       (flattened.toPrimitive sqrtTwo) == sqrtTwo &&

--- a/HexNumberFieldTower/SPEC/hex-number-field-tower.md
+++ b/HexNumberFieldTower/SPEC/hex-number-field-tower.md
@@ -262,21 +262,25 @@ dimension at that generator-adjoining step. This degree test is the executable
 primitive-element certificate.
 
 At a generator-adjoining step whose combined dimension is `d`, at most
-`choose(d, 2)` shifts collide two complex embeddings.
-`flattenShiftCount(d) = choose(d, 2) + 1`; test exactly the first that many
-values in the signed enumeration, continuing past any candidate whose checked
-canonicalization fails. Candidate factor selection uses
+`choose(d, 2)` shifts collide two complex embeddings. A full-degree candidate
+can have another recovery collision: an incompatible conjugate pair can share
+the same affine value without defining an embedding of the combined field.
+There are at most another `choose(d, 2)` such bad shifts. Thus
+`flattenShiftCount(d) = 2 * choose(d, 2) + 1`; test exactly the first that many
+values in the signed enumeration, continuing past failed canonicalization and
+past candidates whose recovery gcd is not linear. Candidate factor selection uses
 `evalDisambiguationPrec`, so both the shift search and the root selection have
 input-computable finite bounds.
 
 For an accepted `γ = θ + cα`, lift the minimal polynomials of `θ` and `α` into
-`ℚ(γ)[Y]` and take the gcd of `mα(Y)` with `mθ(γ - cY)`. Full-degree acceptance
-makes this gcd linear, recovering `α`; then recover `θ = γ - cα` and substitute
-the prior generator coordinates through `θ`. These coordinate expressions
-define `toPrimitive`; evaluation at the corresponding tower element defines
-`fromPrimitive`. Verify both coordinate composites on basis vectors before
-returning. The accepted `γ` is already the canonical `AlgebraicNumber` stored
-by `Flattening`.
+`ℚ(γ)[Y]` and take the gcd of `mα(Y)` with `mθ(γ - cY)`. Accept the shift only
+when this gcd is linear, recovering `α`; then recover `θ = γ - cα` and
+substitute the prior generator coordinates through `θ`. These coordinate
+expressions define `toPrimitive`; evaluation at the corresponding tower
+element defines `fromPrimitive`. Verify their composite on a rational basis of
+the tower and verify that the tower element representing `γ` zeros its claimed
+minimal polynomial before returning. The accepted `γ` is already the canonical
+`AlgebraicNumber` stored by `Flattening`.
 
 ## Conformance
 
@@ -310,7 +314,10 @@ Let `D = T.dim`, `n = deg f`, and let `H` bound coefficient height.
   factorization cost, is the implementation budget.
 - `split?` repeats factorization after genuine degree-reducing extensions.
 - `flatten?` computes primitive-element eliminants of degree at most `D`, then
-  performs linear-factor gcd recovery over the accepted fixed presentation.
+  performs linear-factor gcd recovery over each full-degree candidate. The
+  exact Euclidean gcd over `ℚ(γ)` includes repeated quotient-field inversions
+  and is expected to dominate before the bounded shift enumeration does on
+  taller towers.
 
 No standalone wall-clock ceiling is pinned before the first complete compiled
 implementation. Phase 4 records component timings, then sets each ceiling from

--- a/HexNumberFieldTower/SPEC/hex-number-field-tower.md
+++ b/HexNumberFieldTower/SPEC/hex-number-field-tower.md
@@ -1,4 +1,4 @@
-# hex-number-field-tower (depends on hex-number-field + hex-resultant + hex-berlekamp-zassenhaus + hex-row-reduce)
+# hex-number-field-tower (depends on hex-number-field + hex-resultant + hex-berlekamp-zassenhaus)
 
 Executable successive algebraic extensions of `ℚ`. The library supports
 canonical arithmetic within a fixed tower, Trager factorization, adjoining a
@@ -261,20 +261,22 @@ the first candidate whose irreducible factor has degree equal to the combined
 dimension at that generator-adjoining step. This degree test is the executable
 primitive-element certificate.
 
-For a tower of dimension `D`, at most `choose(D, 2)` shifts collide two complex
-embeddings. `flattenShiftCount(D) = choose(D, 2) + 1`; test exactly the first
-that many values in the signed enumeration. Candidate factor selection uses
+At a generator-adjoining step whose combined dimension is `d`, at most
+`choose(d, 2)` shifts collide two complex embeddings.
+`flattenShiftCount(d) = choose(d, 2) + 1`; test exactly the first that many
+values in the signed enumeration, continuing past any candidate whose checked
+canonicalization fails. Candidate factor selection uses
 `evalDisambiguationPrec`, so both the shift search and the root selection have
 input-computable finite bounds.
 
-Recover every old generator as a polynomial in `γ` by gcd and rational row
-reduction. These coordinate expressions define `fromPrimitive`; evaluation of
-mixed-radix basis elements defines `toPrimitive`. Verify both coordinate
-composites on basis vectors before returning. Exactify `γ` to the canonical
-`AlgebraicNumber` stored by `Flattening`.
-
-The direct dependency on `hex-row-reduce` is intentional: flattening uses exact
-rational linear algebra even though tower arithmetic itself does not.
+For an accepted `γ = θ + cα`, lift the minimal polynomials of `θ` and `α` into
+`ℚ(γ)[Y]` and take the gcd of `mα(Y)` with `mθ(γ - cY)`. Full-degree acceptance
+makes this gcd linear, recovering `α`; then recover `θ = γ - cα` and substitute
+the prior generator coordinates through `θ`. These coordinate expressions
+define `toPrimitive`; evaluation at the corresponding tower element defines
+`fromPrimitive`. Verify both coordinate composites on basis vectors before
+returning. The accepted `γ` is already the canonical `AlgebraicNumber` stored
+by `Flattening`.
 
 ## Conformance
 
@@ -307,8 +309,8 @@ Let `D = T.dim`, `n = deg f`, and let `H` bound coefficient height.
   one rational factorization. This recurrence, rather than one absolute-norm
   factorization cost, is the implementation budget.
 - `split?` repeats factorization after genuine degree-reducing extensions.
-- `flatten?` computes primitive-element eliminants of degree at most `D` and
-  solves rational systems of dimension `D`.
+- `flatten?` computes primitive-element eliminants of degree at most `D`, then
+  performs linear-factor gcd recovery over the accepted fixed presentation.
 
 No standalone wall-clock ceiling is pinned before the first complete compiled
 implementation. Phase 4 records component timings, then sets each ceiling from

--- a/HexNumberFieldTower/SPEC/hex-number-field-tower.md
+++ b/HexNumberFieldTower/SPEC/hex-number-field-tower.md
@@ -261,14 +261,20 @@ the first candidate whose irreducible factor has degree equal to the combined
 dimension at that generator-adjoining step. This degree test is the executable
 primitive-element certificate.
 
-At a generator-adjoining step whose combined dimension is `d`, at most
-`choose(d, 2)` shifts collide two complex embeddings. A full-degree candidate
-can have another recovery collision: an incompatible conjugate pair can share
-the same affine value without defining an embedding of the combined field.
-There are at most another `choose(d, 2)` such bad shifts. Thus
-`flattenShiftCount(d) = 2 * choose(d, 2) + 1`; test exactly the first that many
-values in the signed enumeration, continuing past failed canonicalization and
-past candidates whose recovery gcd is not linear. Candidate factor selection uses
+At a generator-adjoining step, write `n = deg θ`, `M = deg α`, and let the
+combined dimension be `d`. Both a degree collision and a non-linear recovery
+gcd require a conjugate pair satisfying
+`θᵢ - θ₁ = c * (α₁ - αⱼ)` with `αⱼ ≠ α₁`. Thus both failure modes form one set
+of at most `n * (M - 1)` bad shifts. A proper relative level has degree at
+least two, so `n ≤ d / 2`; the absolute field `ℚ(α)` is a subfield of the
+combined field, so `M ≤ d`. Hence the shared bad set has size at most
+`choose(d, 2)`.
+
+Set `flattenShiftCount(d) = choose(d, 2) + 1` and test exactly that many
+nonzero values in signed order, continuing past failed canonicalization and
+past candidates whose recovery gcd is not linear. The Mathlib companion's
+totality proof discharges the checked canonicalization failures on valid
+algebraic inputs; they are not a second algebraic collision class. Candidate factor selection uses
 `evalDisambiguationPrec`, so both the shift search and the root selection have
 input-computable finite bounds.
 
@@ -287,7 +293,7 @@ minimal polynomial before returning. The accepted `γ` is already the canonical
 - *core*: rational tower identity; `ℚ(√2)` arithmetic; the two-level tower
   `ℚ(√2, √3)`; adjoining a root already present; factorization of a polynomial
   with repeated factors; splitting a quadratic and a quartic; flattening both
-  one-level and two-level towers; both flattening coordinate round trips.
+  one-level and two-level towers; flattening coordinate recovery and round trips.
 - Every public operation has typical, edge, and adversarial cases. Adversarial
   cases include a bad first Trager shift, conjugate factor impostors, and a
   reducible absolute polynomial whose selected relative factor is irreducible.

--- a/libraries.yml
+++ b/libraries.yml
@@ -495,7 +495,7 @@ libraries:
     done_through: 0
     status: planned
   HexNumberFieldTower:
-    deps: [HexNumberField, HexResultant, HexBerlekampZassenhaus, HexRowReduce]
+    deps: [HexNumberField, HexResultant, HexBerlekampZassenhaus]
     mathlib: false
     done_through: 0
     status: active

--- a/progress/20260727T085542Z_number-field-tower-flattening.md
+++ b/progress/20260727T085542Z_number-field-tower-flattening.md
@@ -1,0 +1,33 @@
+# Number-field tower flattening
+
+## Accomplished
+
+- Added `HexNumberFieldTower.Flatten` and exported it from the library umbrella.
+- Implemented the finite signed-shift primitive-element search with the exact
+  `choose(D, 2) + 1` bound and a full-degree acceptance check.
+- Exactified fixed tower generators from oldest to newest while retaining their
+  canonical mixed-radix coordinates.
+- Recovered every old generator in the primitive power basis using the existing
+  exact trace-pairing row-reduction driver.
+- Constructed both coordinate maps and required round trips on the complete
+  tower basis and primitive power basis before returning `Flattening`.
+- Added compiled regressions for the rational tower, `Q(sqrt(2))`, and
+  `Q(sqrt(2), sqrt(3))`; the two-level case selects `sqrt(2) + sqrt(3)` and
+  checks both recovered generator coordinates.
+- Verified `lake build HexNumberFieldTower.Flatten` and the full `lake build`.
+
+## Current frontier
+
+The computational API described by `hex-number-field-tower.md` is now present
+through primitive-element flattening. The draft stack still needs independent
+review results folded in, followed by conformance fixtures and companion proofs.
+
+## Next step
+
+Publish the flattening milestone as a stacked draft PR, start its asynchronous
+review, and move directly into core conformance coverage while the review
+monitors continue.
+
+## Blockers
+
+None.

--- a/progress/20260727T091723Z_number-field-tower-flattening-review.md
+++ b/progress/20260727T091723Z_number-field-tower-flattening-review.md
@@ -1,0 +1,33 @@
+# Number-field tower flattening review
+
+## Accomplished
+
+- Fixed the bounded signed-shift search so a failed checked candidate advances
+  to the next prescribed shift instead of aborting the whole search.
+- Replaced repeated algebraic trace-product exactification with incremental
+  exact gcd recovery in the accepted primitive presentation. The recovered
+  coordinates remain guarded by both basis round trips.
+- Added a compiled flattening regression in which the newest generator has
+  absolute degree four but relative degree two.
+- Reconciled the flattening SPEC with the per-step collision bound, continued
+  checked search, and linear-gcd coordinate recovery, and removed the now-dead
+  direct row-reduction import.
+- Reduced the compiled flattening target from about 19 seconds for the original
+  three regressions to about 6 seconds with the additional fourth-root
+  regression included. The full repository build is green.
+
+## Current frontier
+
+- The flattening review's blocking control-flow finding and its main
+  performance/SPEC findings are addressed locally on the flattening branch.
+- The dependent conformance branch must be rebased after this fix is pushed.
+
+## Next step
+
+- Publish the flattening review fixes and launch a focused follow-up audit of
+  the gcd recovery, then rebase and rerun the conformance fixture and PARI
+  profile.
+
+## Blockers
+
+- None.

--- a/progress/20260727T094401Z_number-field-tower-flattening-recovery.md
+++ b/progress/20260727T094401Z_number-field-tower-flattening-recovery.md
@@ -1,0 +1,40 @@
+# Tower flattening recovery review
+
+## Accomplished
+
+- Reproduced the independent review's mathematical distinction between
+  primitive-element degree collisions and incompatible-conjugate recovery
+  collisions.
+- Changed the shift search so a full-degree candidate with a non-linear exact
+  recovery gcd advances to the next deterministic shift instead of aborting a
+  valid flattening.
+- Raised the finite search budget to
+  `2 * choose(d, 2) + 1`, covering both collision classes, and reconciled the
+  tower SPEC.
+- Strengthened the returned certificate: in addition to the tower-basis
+  coordinate round trip, it now checks that the tower element representing the
+  primitive generator zeros its claimed minimal polynomial. This supplies the
+  missing multiplicativity premise.
+- Strengthened the relative-degree-two fourth-root regression by pinning the
+  primitive polynomial and recovered coordinate and by checking
+  `fourthRoot² = sqrtTwo` after conversion.
+- Removed the stale direct `HexRowReduce` dependency from `libraries.yml`.
+- Built `HexNumberFieldTower`, ran the DAG checker, and passed `git diff
+  --check`.
+
+## Current frontier
+
+The implementation and local SPEC now address every blocking or medium finding
+from the focused flattening review. The concrete cyclotomic example identified
+by the reviewer motivates the control-flow change; the general finite bound is
+stated independently of that one example.
+
+## Next step
+
+Publish this repair, start a focused independent re-review without waiting on
+it, then rebase the conformance branch and repair its arithmetic and PARI
+oracle coverage.
+
+## Blockers
+
+None.

--- a/progress/20260727T100222Z_number-field-tower-flattening-rereview.md
+++ b/progress/20260727T100222Z_number-field-tower-flattening-rereview.md
@@ -1,0 +1,37 @@
+# Tower flattening focused re-review
+
+## Accomplished
+
+- Incorporated the focused independent re-review of the recovery-collision
+  repair.
+- Replaced the nested one-element search call with a single-shift
+  `candidateAt?`; `searchRecoveredAux` now owns the enumeration and begins at
+  the first nonzero signed shift.
+- Corrected the collision argument: degree and recovery failures are one set
+  of at most `deg(theta) * (deg(alpha) - 1) ≤ choose(d, 2)` shifts, so restored
+  the sharp `choose(d, 2) + 1` bound instead of presenting two overlapping
+  failure classes as additive.
+- Clarified that checked canonicalization completeness is discharged by the
+  Mathlib companion rather than hidden inside collision slack.
+- Reconciled all stale two-round-trip documentation and explained the
+  irreducibility/dimension squeeze that makes the returned inverse
+  multiplicative.
+- Fixed the fourth-root regression to multiply the two primitive-side
+  coordinates, making its multiplicativity check non-vacuous.
+- Built `HexNumberFieldTower.Flatten` and passed `git diff --check`.
+
+## Current frontier
+
+The reviewed algorithm and its SPEC now agree on retry behavior, the finite
+bound, and the executable certificate. The remaining requested regression is a
+concrete case where shift `+1` has full degree but non-linear recovery and the
+search succeeds at `-1`; it belongs in the conformance descendant.
+
+## Next step
+
+Publish this refinement, rebase the conformance branch, add the cyclotomic
+retry regression there, and rerun its exact fixture and PARI checks.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Summary

- combine fixed tower generators with a bounded deterministic signed-shift search
- require the accepted canonical primitive element to have the full accumulated dimension
- recover old generators in the primitive power basis through exact trace-pairing row reduction
- construct both coordinate maps and validate their composites on both rational bases
- cover rational, one-level, and two-level tower flattening with compiled regressions

## Validation

- lake build HexNumberFieldTower.Flatten
- lake build

Stacked on #8932.