### PR TITLE
RCF: certify cached common-root packages

### DIFF
--- a/HexRCF.lean
+++ b/HexRCF.lean
@@ -19,6 +19,8 @@ public import HexRCF.Separation
 public import HexRCF.SeparationTests
 public import HexRCF.Cells
 public import HexRCF.CellsTests
+public import HexRCF.CommonRoot
+public import HexRCF.CommonRootTests
 
 public section
 
@@ -37,4 +39,6 @@ strictly separated intervals, and exact replay counts classify their roots
 against bounded-domain endpoints. The checked roots induce an alternating,
 size-indexed partition into root and open cells with exact dyadic samples and
 exact guarded intersection tests for half-open bounded domains.
+Checked common-root packages cache one multiplication-only gcd witness and
+generalized replay per distinct nonconstant atom, with exact root-cell queries.
 -/

--- a/HexRCF/Carrier.lean
+++ b/HexRCF/Carrier.lean
@@ -135,6 +135,11 @@ theorem check_sound {s : Sentence} {cert : CarrierCert}
   · exact DensePoly.eq_of_beqCoeffs hfactor
   · exact DensePoly.eq_of_beqCoeffs hderiv
 
+/-- The carrier replay component recovered from the combined checker. -/
+theorem replay_of_check {s : Sentence} {cert : CarrierCert}
+    (h : cert.check s = true) : cert.replay.check cert.carrier = true :=
+  (check_sound h).2.2.2.2.2.2.2
+
 /-- An accepted carrier certificate has a nonzero carrier polynomial. -/
 theorem carrier_ne_zero {s : Sentence} {cert : CarrierCert}
     (h : cert.check s = true) : cert.carrier ≠ 0 := by

--- a/HexRCF/CommonRoot.lean
+++ b/HexRCF/CommonRoot.lean
@@ -1,0 +1,300 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.Cells
+
+public section
+
+/-!
+# Certified common roots for RCF sign matrices
+
+A common-root package is checked once for each distinct nonconstant atom
+polynomial.  Its multiplication identities prove that a supplied polynomial
+has exactly the common real roots of the atom and the square-free carrier.  A
+nonconstant common-root polynomial also carries one generalized Sturm replay,
+which is then shared by every carrier root cell.
+-/
+
+namespace Hex.RCF
+
+open HexRealRootsMathlib Polynomial
+
+/-- Multiplication-checkable witnesses for the common roots of an atom and a
+carrier polynomial.  The atom and carrier themselves are external checker
+inputs, so certificate data cannot silently substitute different polynomials.
+-/
+structure CommonRootCert where
+  /-- Proposed common-root polynomial. -/
+  gcd : ZPoly
+  /-- Quotient witnessing that the common-root polynomial divides the atom. -/
+  atomFactor : ZPoly
+  /-- Quotient witnessing that the common-root polynomial divides the carrier. -/
+  carrierFactor : ZPoly
+  /-- Atom coefficient in the scaled Bezout identity. -/
+  atomCoeff : ZPoly
+  /-- Carrier coefficient in the scaled Bezout identity. -/
+  carrierCoeff : ZPoly
+  /-- Nonzero integer scale in the Bezout identity. -/
+  scale : Int
+  /-- Cached replay for a nonconstant common-root polynomial.  A nonzero
+  constant common-root polynomial uses `none`. -/
+  replay : Option SturmReplay
+
+namespace CommonRootCert
+
+/-- Validate the constant/nonconstant replay branch. -/
+@[expose]
+def checkReplay (cert : CommonRootCert) : Bool :=
+  match cert.replay with
+  | none => decide (cert.gcd.size = 1)
+  | some replay =>
+      -- The replay checker already implies this degree bound.  Keeping the
+      -- guard makes the constant/nonconstant trust boundary explicit.
+      decide (0 < cert.gcd.degree?.getD 0) && replay.check cert.gcd
+
+/-- Proposition-level replay facts recovered from `checkReplay`. -/
+@[expose]
+def ReplayValid (cert : CommonRootCert) : Prop :=
+  match cert.replay with
+  | none => cert.gcd.size = 1
+  | some replay =>
+      0 < cert.gcd.degree?.getD 0 ∧ replay.check cert.gcd = true
+
+/-- Check the divisibility and scaled Bezout identities against the external
+atom and carrier polynomials. -/
+@[expose]
+def check (atom carrier : ZPoly) (cert : CommonRootCert) : Bool :=
+  decide (cert.scale ≠ 0) &&
+  DensePoly.beqCoeffs atom (cert.gcd * cert.atomFactor) &&
+  DensePoly.beqCoeffs carrier (cert.gcd * cert.carrierFactor) &&
+  DensePoly.beqCoeffs
+    (cert.atomCoeff * atom + cert.carrierCoeff * carrier)
+    (DensePoly.scale cert.scale cert.gcd) &&
+  cert.checkReplay
+
+/-- Proposition-level facts recovered from the common-root checker. -/
+@[expose]
+def Valid (atom carrier : ZPoly) (cert : CommonRootCert) : Prop :=
+  cert.scale ≠ 0 ∧
+  atom = cert.gcd * cert.atomFactor ∧
+  carrier = cert.gcd * cert.carrierFactor ∧
+  cert.atomCoeff * atom + cert.carrierCoeff * carrier =
+    DensePoly.scale cert.scale cert.gcd ∧
+  cert.ReplayValid
+
+/-- Soundness of the constant/nonconstant replay branch. -/
+theorem checkReplay_sound {cert : CommonRootCert}
+    (h : cert.checkReplay = true) : cert.ReplayValid := by
+  cases hreplay : cert.replay with
+  | none => simpa [checkReplay, ReplayValid, hreplay] using h
+  | some replay => simpa [checkReplay, ReplayValid, hreplay] using h
+
+/-- Soundness of the executable common-root checker. -/
+theorem check_sound {atom carrier : ZPoly} {cert : CommonRootCert}
+    (h : cert.check atom carrier = true) : cert.Valid atom carrier := by
+  simp only [check, Bool.and_eq_true, decide_eq_true_eq] at h
+  obtain ⟨⟨⟨⟨hscale, hatom⟩, hcarrier⟩, hbezout⟩, hreplay⟩ := h
+  exact ⟨hscale, DensePoly.eq_of_beqCoeffs hatom,
+    DensePoly.eq_of_beqCoeffs hcarrier,
+    DensePoly.eq_of_beqCoeffs hbezout, checkReplay_sound hreplay⟩
+
+/-- A checked common-root polynomial is nonzero in both certificate branches. -/
+theorem gcd_ne_zero {atom carrier : ZPoly} {cert : CommonRootCert}
+    (h : cert.check atom carrier = true) : cert.gcd ≠ 0 := by
+  have hvalid := (check_sound h).2.2.2.2
+  cases hreplay : cert.replay with
+  | none =>
+      simp only [ReplayValid, hreplay] at hvalid
+      intro hzero
+      rw [hzero] at hvalid
+      simp at hvalid
+  | some replay =>
+      simp only [ReplayValid, hreplay] at hvalid
+      exact SturmReplay.head_ne_zero hvalid.2
+
+/-- Recover the checked replay in the nonconstant certificate branch. -/
+theorem replay_of_check {atom carrier : ZPoly} {cert : CommonRootCert}
+    {replay : SturmReplay} (h : cert.check atom carrier = true)
+    (hreplay : cert.replay = some replay) : replay.check cert.gcd = true := by
+  have hvalid := (check_sound h).2.2.2.2
+  simp only [ReplayValid, hreplay] at hvalid
+  exact hvalid.2
+
+/-- A checked common-root polynomial has exactly the common real roots of the
+atom and carrier. -/
+theorem isRoot_iff {atom carrier : ZPoly} {cert : CommonRootCert}
+    (h : cert.check atom carrier = true) (x : ℝ) :
+    (toPolyℝ cert.gcd).IsRoot x ↔
+      (toPolyℝ atom).IsRoot x ∧ (toPolyℝ carrier).IsRoot x := by
+  obtain ⟨hscale, hatom, hcarrier, hbezout, _hreplay⟩ := check_sound h
+  have hscaleℝ : ((cert.scale : Int) : ℝ) ≠ 0 := by exact_mod_cast hscale
+  have hatomℝ := congrArg toPolyℝ hatom
+  have hcarrierℝ := congrArg toPolyℝ hcarrier
+  have hbezoutℝ := congrArg toPolyℝ hbezout
+  rw [toPolyℝ_mul] at hatomℝ hcarrierℝ
+  rw [toPolyℝ_add, toPolyℝ_mul, toPolyℝ_mul, toPolyℝ_scale] at hbezoutℝ
+  constructor
+  · intro hgcd
+    constructor
+    · rw [Polynomial.IsRoot, hatomℝ, Polynomial.eval_mul]
+      rw [show (toPolyℝ cert.gcd).eval x = 0 from hgcd, zero_mul]
+    · rw [Polynomial.IsRoot, hcarrierℝ, Polynomial.eval_mul]
+      rw [show (toPolyℝ cert.gcd).eval x = 0 from hgcd, zero_mul]
+  · rintro ⟨hatomRoot, hcarrierRoot⟩
+    simp only [Polynomial.IsRoot] at hatomRoot hcarrierRoot ⊢
+    have heval := congrArg (Polynomial.eval x) hbezoutℝ
+    simp only [Polynomial.eval_add, Polynomial.eval_mul, Polynomial.eval_C] at heval
+    simp only [hatomRoot, hcarrierRoot, mul_zero, zero_add] at heval
+    exact (mul_eq_zero.mp heval.symm).resolve_left hscaleℝ
+
+/-- A checked constant common-root branch has no real roots. -/
+theorem noRoot_of_constant {atom carrier : ZPoly} {cert : CommonRootCert}
+    (h : cert.check atom carrier = true) (hreplay : cert.replay = none)
+    (x : ℝ) : ¬(toPolyℝ cert.gcd).IsRoot x := by
+  have hvalid := (check_sound h).2.2.2.2
+  simp only [ReplayValid, hreplay] at hvalid
+  have hg0 : cert.gcd ≠ 0 := gcd_ne_zero h
+  have hcast0 : toPolyℝ cert.gcd ≠ 0 :=
+    fun hzero => hg0 (toPolyℝ_eq_zero_iff.mp hzero)
+  have hdegree : (toPolyℝ cert.gcd).natDegree = 0 := by
+    rw [natDegree_toPolyℝ,
+      DensePoly.degree?_eq_some_of_pos_size cert.gcd (by omega), hvalid]
+    rfl
+  have hunit : IsUnit (toPolyℝ cert.gcd) := by
+    rw [Polynomial.isUnit_iff_degree_eq_zero,
+      Polynomial.degree_eq_natDegree hcast0, hdegree]
+    rfl
+  intro hroot
+  obtain ⟨u, hu, hunitEq⟩ := Polynomial.isUnit_iff.mp hunit
+  rw [← hunitEq, Polynomial.IsRoot, Polynomial.eval_C] at hroot
+  exact hu.ne_zero hroot
+
+/-- Decide whether the cached common-root polynomial has a root in an
+interval.  The constant branch is root-free; the nonconstant branch reads its
+shared generalized Sturm replay.  Its semantic guarantee applies when the
+interval comes from a checked carrier isolation. -/
+@[expose]
+def hasRoot (cert : CommonRootCert) (I : DyadicInterval) : Bool :=
+  match cert.replay with
+  | none => false
+  | some replay => decide (replay.count I = 1)
+
+/-- A cached nonconstant replay counts one common root in a carrier isolation
+exactly when the atom vanishes at its supplied carrier root. -/
+theorem count_eq_one_iff {carrier : ZPoly} {carrierReplay : SturmReplay}
+    (hcarrier : carrierReplay.check carrier = true)
+    {isolations : IsolationCert} (hcert : isolations.check carrierReplay = true)
+    {atom : ZPoly} {common : CommonRootCert} {gcdReplay : SturmReplay}
+    (hcommon : common.check atom carrier = true)
+    (hgcdReplay : common.replay = some gcdReplay)
+    (i : Fin isolations.intervals.size) {root : ℝ}
+    (hroot : (toPolyℝ carrier).IsRoot root)
+    (hmem : Literal.InInterval isolations.intervals[i] root) :
+    gcdReplay.count isolations.intervals[i] = 1 ↔
+      (toPolyℝ atom).IsRoot root := by
+  classical
+  let I := isolations.intervals[i]
+  have hgReplay : gcdReplay.check common.gcd = true :=
+    common.replay_of_check hcommon hgcdReplay
+  have hP0 : toPolyℝ carrier ≠ 0 := by
+    intro hzero
+    exact SturmReplay.head_ne_zero hcarrier (toPolyℝ_eq_zero_iff.mp hzero)
+  have hgDiv : toPolyℝ common.gcd ∣ toPolyℝ carrier := by
+    obtain ⟨_scale, _atom, hfactor, _bezout, _replay⟩ := check_sound hcommon
+    refine ⟨toPolyℝ common.carrierFactor, ?_⟩
+    simpa only [toPolyℝ_mul] using congrArg toPolyℝ hfactor
+  have hrootsLe :
+      Literal.rootsIn (toPolyℝ common.gcd) I ≤
+        Literal.rootsIn (toPolyℝ carrier) I := by
+    exact Multiset.filter_le_filter _
+      (Polynomial.roots.le_of_dvd hP0 hgDiv)
+  have hcarrierCard :
+      (Literal.rootsIn (toPolyℝ carrier) I).card = 1 := by
+    have hcount := IsolationCert.count_one_of_check
+      (IsolationCert.counts_of_check hcert) i
+    have hcard := SturmReplay.count_eq_card_roots hcarrier I
+    rw [hcount] at hcard
+    exact_mod_cast hcard.symm
+  constructor
+  · intro hcount
+    have hcard : (Literal.rootsIn (toPolyℝ common.gcd) I).card = 1 := by
+      have hcard := SturmReplay.count_eq_card_roots hgReplay I
+      rw [hcount] at hcard
+      exact_mod_cast hcard.symm
+    have hpos : 0 < (Literal.rootsIn (toPolyℝ common.gcd) I).card := by
+      omega
+    obtain ⟨y, hrootMem⟩ := Multiset.card_pos_iff_exists_mem.mp hpos
+    simp only [Literal.rootsIn, Multiset.mem_filter] at hrootMem
+    have hgRoot : (toPolyℝ common.gcd).IsRoot y :=
+      (Polynomial.mem_roots'.mp hrootMem.1).2
+    have hboth := (common.isRoot_iff hcommon y).mp hgRoot
+    have hrootEq : y = root :=
+      (IsolationCert.exists_unique_root_of_check hcarrier hcert i).unique
+        ⟨hboth.2, hrootMem.2⟩ ⟨hroot, hmem⟩
+    simpa only [hrootEq] using hboth.1
+  · intro hatomRoot
+    have hgRoot : (toPolyℝ common.gcd).IsRoot root :=
+      (common.isRoot_iff hcommon _).mpr ⟨hatomRoot, hroot⟩
+    have hg0 : toPolyℝ common.gcd ≠ 0 := by
+      intro hzero
+      exact SturmReplay.head_ne_zero hgReplay (toPolyℝ_eq_zero_iff.mp hzero)
+    have hgMem : root ∈ Literal.rootsIn (toPolyℝ common.gcd) I := by
+      simp only [Literal.rootsIn, Multiset.mem_filter]
+      exact ⟨Polynomial.mem_roots'.mpr ⟨hg0, hgRoot⟩, hmem⟩
+    have hpos : 0 < (Literal.rootsIn (toPolyℝ common.gcd) I).card :=
+      Multiset.card_pos_iff_exists_mem.mpr ⟨_, hgMem⟩
+    have hle : (Literal.rootsIn (toPolyℝ common.gcd) I).card ≤ 1 := by
+      rw [← hcarrierCard]
+      exact Multiset.card_le_card hrootsLe
+    have hcard : (Literal.rootsIn (toPolyℝ common.gcd) I).card = 1 := by omega
+    have hcount := SturmReplay.count_eq_card_roots hgReplay I
+    simpa only [hcard, Nat.cast_one] using hcount
+
+/-- The executable cached-root query is exact at a supplied carrier root in a
+checked isolation, including the constant-gcd branch. -/
+theorem hasRoot_iff {carrier : ZPoly} {carrierReplay : SturmReplay}
+    (hcarrier : carrierReplay.check carrier = true)
+    {isolations : IsolationCert}
+    (hcert : isolations.check carrierReplay = true)
+    {atom : ZPoly} {common : CommonRootCert}
+    (hcommon : common.check atom carrier = true)
+    (i : Fin isolations.intervals.size) {root : ℝ}
+    (hroot : (toPolyℝ carrier).IsRoot root)
+    (hmem : Literal.InInterval isolations.intervals[i] root) :
+    common.hasRoot isolations.intervals[i] = true ↔
+      (toPolyℝ atom).IsRoot root := by
+  cases hreplay : common.replay with
+  | none =>
+      constructor
+      · simp [hasRoot, hreplay]
+      · intro hatom
+        have hgcd := (common.isRoot_iff hcommon _).mpr ⟨hatom, hroot⟩
+        exact (common.noRoot_of_constant hcommon hreplay _ hgcd).elim
+  | some replay =>
+      simp only [hasRoot, hreplay, decide_eq_true_eq]
+      exact common.count_eq_one_iff hcarrier hcert hcommon hreplay i hroot hmem
+
+/-- Specialize `hasRoot_iff` to the canonical root model of a strict
+isolation certificate. -/
+theorem hasRoot_model_iff {carrier : ZPoly} {carrierReplay : SturmReplay}
+    (hcarrier : carrierReplay.check carrier = true)
+    {isolations : IsolationCert}
+    (hstrict : isolations.checkStrict carrierReplay = true)
+    {atom : ZPoly} {common : CommonRootCert}
+    (hcommon : common.check atom carrier = true)
+    (i : Fin isolations.intervals.size) :
+    common.hasRoot isolations.intervals[i] = true ↔
+      (toPolyℝ atom).IsRoot
+        ((isolations.rootModel hcarrier hstrict).root i) :=
+  common.hasRoot_iff hcarrier (IsolationCert.check_of_checkStrict hstrict)
+    hcommon i ((isolations.rootModel hcarrier hstrict).isRoot i)
+    ((isolations.rootModel hcarrier hstrict).inInterval i)
+
+end CommonRootCert
+
+end Hex.RCF

--- a/HexRCF/CommonRootTests.lean
+++ b/HexRCF/CommonRootTests.lean
@@ -1,0 +1,196 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.Carrier
+public import HexRCF.CommonRoot
+import all HexRCF.CommonRoot
+
+public section
+
+/-! Regression tests for cached common-root certificates. -/
+
+namespace Hex.RCF.CommonRootTests
+
+open HexRealRootsMathlib
+
+private def quad : ZPoly := DensePoly.ofCoeffs #[(-1 : Int), 0, 1]
+private def x : ZPoly := DensePoly.ofCoeffs #[(0 : Int), 1]
+private def one : ZPoly := DensePoly.ofCoeffs #[(1 : Int)]
+private def minusOne : ZPoly := DensePoly.ofCoeffs #[(-1 : Int)]
+private def minusTwo : ZPoly := DensePoly.ofCoeffs #[(-2 : Int)]
+private def twiceX : ZPoly := DensePoly.ofCoeffs #[(0 : Int), 2]
+private def xMinusOne : ZPoly := DensePoly.ofCoeffs #[(-1 : Int), 1]
+private def xPlusOne : ZPoly := DensePoly.ofCoeffs #[(1 : Int), 1]
+
+private def quadReplay : SturmReplay where
+  chain := #[quad, x, one]
+  derivScale := 2
+  steps := #[{ leftScale := 1, quotient := x, rightScale := 1 }]
+
+private def minusReplay : SturmReplay where
+  chain := #[xMinusOne, one]
+  derivScale := 1
+  steps := #[]
+
+private def sentence : Sentence := .forallReal (.atom ⟨quad, .ge⟩)
+
+private def carrier : CarrierCert where
+  carrier := quad
+  repeated := one
+  derivPart := twiceX
+  factorScale := 1
+  derivScale := 1
+  replay := quadReplay
+
+private def negHalf : Dyadic := Dyadic.ofInt (-1) >>> (1 : Int)
+private def half : Dyadic := Dyadic.ofInt 1 >>> (1 : Int)
+
+private def isolations : IsolationCert := ⟨#[
+  DyadicInterval.mk (Dyadic.ofInt (-2)) negHalf (by decide),
+  DyadicInterval.mk half (Dyadic.ofInt 2) (by decide)]⟩
+
+private theorem carrier_ok : carrier.check sentence = true := by decide
+private theorem strict_ok : isolations.checkStrict carrier.replay = true := by decide
+
+/-! The shared-factor case has the right carrier root and not the left one. -/
+
+private def shared : CommonRootCert where
+  gcd := xMinusOne
+  atomFactor := one
+  carrierFactor := xPlusOne
+  atomCoeff := one
+  carrierCoeff := 0
+  scale := 1
+  replay := some minusReplay
+
+private theorem shared_ok : shared.check xMinusOne quad = true := by decide
+
+example : shared.hasRoot isolations.intervals[0] = false := by decide
+example : shared.hasRoot isolations.intervals[1] = true := by decide
+
+example (i : Fin isolations.intervals.size) :
+    shared.hasRoot isolations.intervals[i] = true ↔
+      (toPolyℝ xMinusOne).IsRoot
+        ((isolations.rootModel (CarrierCert.replay_of_check carrier_ok) strict_ok).root i) :=
+  shared.hasRoot_model_iff
+    (CarrierCert.replay_of_check carrier_ok) strict_ok shared_ok i
+
+/-! A constant gcd certifies a coprime atom/carrier pair without a replay. -/
+
+private def coprime : CommonRootCert where
+  gcd := one
+  atomFactor := x
+  carrierFactor := quad
+  atomCoeff := x
+  carrierCoeff := minusOne
+  scale := 1
+  replay := none
+
+private theorem coprime_ok : coprime.check x quad = true := by decide
+
+example : coprime.hasRoot isolations.intervals[0] = false := by decide
+example : coprime.hasRoot isolations.intervals[1] = false := by decide
+
+example (i : Fin isolations.intervals.size) :
+    coprime.hasRoot isolations.intervals[i] = true ↔
+      (toPolyℝ x).IsRoot
+        ((isolations.rootModel (CarrierCert.replay_of_check carrier_ok) strict_ok).root i) :=
+  coprime.hasRoot_model_iff
+    (CarrierCert.replay_of_check carrier_ok) strict_ok coprime_ok i
+
+/-! Equal atom and carrier polynomials share every carrier root. -/
+
+private def equal : CommonRootCert where
+  gcd := quad
+  atomFactor := one
+  carrierFactor := one
+  atomCoeff := one
+  carrierCoeff := 0
+  scale := 1
+  replay := some quadReplay
+
+private theorem equal_ok : equal.check quad quad = true := by decide
+
+example : equal.hasRoot isolations.intervals[0] = true := by decide
+example : equal.hasRoot isolations.intervals[1] = true := by decide
+
+example (z : ℝ) :
+    (toPolyℝ equal.gcd).IsRoot z ↔
+      (toPolyℝ quad).IsRoot z ∧ (toPolyℝ quad).IsRoot z :=
+  equal.isRoot_iff equal_ok z
+
+/-! Every independently checked identity and replay branch rejects tampering. -/
+
+private def badAtomFactor : CommonRootCert :=
+  { shared with atomFactor := x }
+
+private def badCarrierFactor : CommonRootCert :=
+  { shared with carrierFactor := one }
+
+private def badBezout : CommonRootCert :=
+  { shared with atomCoeff := 0 }
+
+private def badScale : CommonRootCert :=
+  { shared with scale := 0 }
+
+private def missingReplay : CommonRootCert :=
+  { shared with replay := none }
+
+private def extraReplay : CommonRootCert :=
+  { coprime with replay := some quadReplay }
+
+private def malformedReplay : CommonRootCert :=
+  { shared with replay := some { minusReplay with derivScale := 2 } }
+
+private def wrongReplayHead : CommonRootCert :=
+  { shared with replay := some quadReplay }
+
+private def zeroGcd : CommonRootCert :=
+  { coprime with gcd := 0 }
+
+/-- Both factor identities accept this proper divisor of the actual gcd; only
+the scaled Bezout identity rules it out. -/
+private def shrunkGcd : CommonRootCert where
+  gcd := xMinusOne
+  atomFactor := xPlusOne
+  carrierFactor := xPlusOne
+  atomCoeff := one
+  carrierCoeff := 0
+  scale := 1
+  replay := some minusReplay
+
+/-- A genuine denominator-clearing scale exercises a nonunit Bezout scale in
+the constant-gcd branch. -/
+private def scaled : CommonRootCert where
+  gcd := one
+  atomFactor := twiceX
+  carrierFactor := quad
+  atomCoeff := x
+  carrierCoeff := minusTwo
+  scale := 2
+  replay := none
+
+example : badAtomFactor.check xMinusOne quad = false := by decide
+example : badCarrierFactor.check xMinusOne quad = false := by decide
+example : badBezout.check xMinusOne quad = false := by decide
+example : badScale.check xMinusOne quad = false := by decide
+example : missingReplay.check xMinusOne quad = false := by decide
+example : extraReplay.check x quad = false := by decide
+example : malformedReplay.check xMinusOne quad = false := by decide
+example : wrongReplayHead.check xMinusOne quad = false := by decide
+example : zeroGcd.check x quad = false := by decide
+example : shrunkGcd.check quad quad = false := by decide
+example : shrunkGcd.checkReplay = true := by decide
+example : DensePoly.beqCoeffs quad (shrunkGcd.gcd * shrunkGcd.atomFactor) = true := by
+  decide
+example : DensePoly.beqCoeffs quad (shrunkGcd.gcd * shrunkGcd.carrierFactor) = true := by
+  decide
+example : scaled.check twiceX quad = true := by decide
+example : ({ scaled with scale := 3 }).check twiceX quad = false := by decide
+
+end Hex.RCF.CommonRootTests

--- a/HexRealRootsMathlib/ChainCorrespond.lean
+++ b/HexRealRootsMathlib/ChainCorrespond.lean
@@ -321,6 +321,12 @@ theorem toPolyℝ_scale (c : Int) (p : Hex.ZPoly) :
     Polynomial.coeff_C_mul, coeff_toPolyℝ]
   push_cast; ring
 
+/-- The real cast is additive. -/
+theorem toPolyℝ_add (p q : Hex.ZPoly) :
+    toPolyℝ (p + q) = toPolyℝ p + toPolyℝ q := by
+  show (HexPolyMathlib.toPolynomial (p + q)).map (Int.castRingHom ℝ) = _
+  rw [HexPolyMathlib.toPolynomial_add, Polynomial.map_add]
+
 /-- The real cast of an `x^k` shift. -/
 theorem toPolyℝ_shift (k : Nat) (p : Hex.ZPoly) :
     toPolyℝ (Hex.DensePoly.shift k p) = Polynomial.X ^ k * toPolyℝ p := by

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -255,20 +255,37 @@ proved equivalences.
 
 7. **Prepare common-root packages.** Do the expensive work once per
    distinct nonconstant atom, not once per root cell. For each `pⱼ`,
-   the builder computes a rational gcd representative `gⱼ` and emits
-   `aⱼ`, `bⱼ`, `uⱼ`, `vⱼ` and a nonzero integer `cⱼ` satisfying
+   the builder computes a rational gcd representative `gⱼ` and emits a
+   `CommonRootCert` containing `gcd`, `atomFactor`, `carrierFactor`,
+   `atomCoeff`, `carrierCoeff`, a nonzero integer `scale`, and an optional
+   generalized replay. Its checker receives `pⱼ` and `P` externally and
+   verifies
 
    ```text
-   pⱼ = gⱼ * aⱼ
-   P  = gⱼ * bⱼ
-   uⱼ * pⱼ + vⱼ * P = scale cⱼ gⱼ.
+   pⱼ = gcd * atomFactor
+   P  = gcd * carrierFactor
+   atomCoeff * pⱼ + carrierCoeff * P = scale scale gcd.
    ```
 
-   These multiplication-checkable identities prove that the real
-   roots of `gⱼ` are exactly the common real roots of `pⱼ` and `P`.
-   No executable `gcdZ` API is assumed. A nonzero constant `gⱼ` has
-   count zero; each distinct nonconstant `gⱼ` carries one cached
-   generalized Sturm replay used for all carrier roots.
+   These multiplication-checkable identities prove `CommonRootCert.isRoot_iff`:
+   the real roots of `gⱼ` are exactly the common real roots of `pⱼ` and
+   `P`. No executable `gcdZ` API is assumed. The `none` replay branch is
+   accepted exactly when `gⱼ` has dense size one, so it is a nonzero
+   constant and has no roots. The `some replay` branch requires positive
+   degree and checks the replay against `gⱼ`.
+
+   `CommonRootCert.hasRoot` returns `false` for the constant branch and tests
+   whether the cached replay count is one otherwise. Under the independently
+   checked carrier, strict isolations, and common-root package,
+   `CommonRootCert.hasRoot_iff` proves that this Boolean is true exactly when
+   `pⱼ` vanishes at any supplied carrier root in the checked isolation;
+   `hasRoot_model_iff` specializes it to the canonical `RootModel` root. The
+   underlying `count_eq_one_iff` uses divisibility to bound the `gⱼ` roots in
+   a carrier isolation by its single `P` root. Thus one replay is shared by all
+   carrier root cells for that distinct atom polynomial. Deduplication and alignment
+   of these packages with the recomputed distinct atom-polynomial order are
+   responsibilities of the step-8 sign-matrix checker, not trusted fields of
+   an individual package.
 
 8. **Sign matrix.** For each cell and each atom polynomial `pⱼ`:
    - Open cells: exact Horner evaluation at the cell's dyadic test
@@ -541,6 +558,10 @@ free to change.
   `Ioc` intersection; `HexRCF/CellsTests.lean`: enumeration,
   zero/singleton/multiple-root samples, endpoint equality/order guards,
   relevance tables, and malformed lower/upper claim regressions.
+- `HexRCF/CommonRoot.lean`: multiplication-checkable common-root packages,
+  constant/nonconstant replay branches, exact common-root semantics, and
+  cached root-cell queries; `HexRCF/CommonRootTests.lean`: shared-factor,
+  coprime, equal-polynomial, and tampered-evidence regressions.
 - `HexRCF/SignMatrix.lean`: test-point evaluation, the `gⱼ` root-cell
   computation, Boolean folding.
 - `HexRCF/Soundness.lean`: `check_sound` and its four factors.

--- a/progress/20260727T102339Z_rcf-common-root.md
+++ b/progress/20260727T102339Z_rcf-common-root.md
@@ -1,0 +1,38 @@
+# RCF cached common-root packages
+
+## Accomplished
+
+- Added `CommonRootCert` with externally supplied atom/carrier inputs,
+  multiplication-checked factor identities, a scaled Bezout identity, and
+  exact constant/nonconstant replay validation.
+- Proved that every accepted gcd candidate is nonzero and has exactly the
+  common real roots of the atom and carrier.
+- Added the cached `hasRoot` query, a generic count-one equivalence for any
+  certified carrier root in an isolation, and a strict-`RootModel` corollary.
+- Proved the interval bound with multiplicity-aware root-multiset divisibility,
+  so a cached gcd replay reports one precisely when the atom vanishes at the
+  corresponding carrier root.
+- Added a carrier replay accessor and a reusable additive real-cast lemma.
+- Added shared-factor, coprime constant-gcd, equal-polynomial, nonunit-scale,
+  proper-divisor, wrong-replay-head, zero-scale, and malformed identity/replay
+  regressions.
+- Updated the umbrella and SPEC to document the actual package API and defer
+  deduplication/alignment explicitly to the sign-matrix checker.
+- Addressed two fresh Claude reviews; both reported no blockers after tracing
+  the trust boundary and count proof.
+- Completed a green full `lake build` at the final commit point (9472 jobs).
+
+## Current frontier
+
+Issue #8936 is implemented and locally verified. The branch is ready for its
+commit, rebase, PR, hosted CI, and merge gates.
+
+## Next step
+
+Publish and merge the common-root milestone, then implement open-cell sign
+constancy, root-cell sign transfer, executable sign reflection, distinct-atom
+package alignment, and formula folding.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #8936.

This milestone implements SPEC step 7:

- adds multiplication-checkable common-root packages with external atom/carrier inputs;
- proves exact gcd-root iff atom-root and carrier-root semantics;
- validates nonzero-constant and checked nonconstant replay branches;
- proves cached interval count-one and Boolean root queries exact at certified carrier roots;
- adds shared-factor, coprime, equal-polynomial, proper-divisor, nonunit-scale, wrong-head, and malformed-evidence regressions;
- updates the umbrella, SPEC, reusable cast/replay accessors, and progress record.

Verification:

- focused HexRCF and CommonRoot test builds passed;
- full lake build passed at the final commit point (9472 jobs);
- two fresh independent Claude reviews reported no blockers, and their API/test recommendations were incorporated;
- an independent Sol proof spike validated the multiplicity-aware divisibility/count argument against the repository APIs.
