### PR TITLE
docs(number-field): add resultant and number-field manual chapters

### DIFF
--- a/HexManual.lean
+++ b/HexManual.lean
@@ -52,10 +52,10 @@ authors := ["The hex project"]
 shortTitle := "hex"
 %%%
 
-`hex` is executable, verified computer algebra for Lean 4: finite and number
-fields, polynomial factorization, root isolation, and lattice reduction. The
-computational core is Mathlib-free; each chapter documents one library
-and, where there is one, its correspondence with Mathlib.
+`hex` is executable computer algebra for Lean 4: finite and number fields,
+polynomial factorization, root isolation, and lattice reduction. The
+computational core is Mathlib-free; Mathlib companions state correspondence
+contracts and, for mature libraries, supply their proofs.
 
 {include 0 HexManual.Chapters.HexMatrix}
 

--- a/HexManual.lean
+++ b/HexManual.lean
@@ -18,6 +18,7 @@ import HexManual.Chapters.HexArith
 import HexManual.Chapters.HexModArith
 import HexManual.Chapters.HexPoly
 import HexManual.Chapters.HexPolyZ
+import HexManual.Chapters.HexResultant
 import HexManual.Chapters.HexPolyFp
 import HexManual.Chapters.HexGF2
 import HexManual.Chapters.HexHensel
@@ -28,6 +29,8 @@ import HexManual.Chapters.HexGFq
 import HexManual.Chapters.HexRealRoots
 import HexManual.Chapters.FactorTactics
 import HexManual.Chapters.HexRoots
+import HexManual.Chapters.HexNumberField
+import HexManual.Chapters.HexNumberFieldTower
 -- Tutorials (application-first capstone pages, see SPEC/tutorials.md).
 import HexManual.Tutorials.Coppersmith
 
@@ -49,8 +52,8 @@ authors := ["The hex project"]
 shortTitle := "hex"
 %%%
 
-`hex` is executable, verified computer algebra for Lean 4: finite
-fields, polynomial factorization, and lattice reduction. The
+`hex` is executable, verified computer algebra for Lean 4: finite and number
+fields, polynomial factorization, root isolation, and lattice reduction. The
 computational core is Mathlib-free; each chapter documents one library
 and, where there is one, its correspondence with Mathlib.
 
@@ -97,6 +100,8 @@ here to keep the reference chapters above focused on the released libraries.
 
 {include 2 HexManual.Chapters.HexPolyZ}
 
+{include 2 HexManual.Chapters.HexResultant}
+
 {include 2 HexManual.Chapters.HexPolyFp}
 
 {include 2 HexManual.Chapters.HexGF2}
@@ -117,3 +122,6 @@ here to keep the reference chapters above focused on the released libraries.
 
 {include 2 HexManual.Chapters.HexRoots}
 
+{include 2 HexManual.Chapters.HexNumberField}
+
+{include 2 HexManual.Chapters.HexNumberFieldTower}

--- a/HexManual/Chapters/HexNumberField.lean
+++ b/HexManual/Chapters/HexNumberField.lean
@@ -18,6 +18,15 @@ set_option pp.rawOnError true
 tag := "hex-number-field"
 %%%
 
+# Introduction
+%%%
+tag := "hex-number-field-intro"
+%%%
+
+`HexNumberField` provides executable exact arithmetic for selected complex
+algebraic roots, both in a fixed rational presentation and in a canonical
+minimal-polynomial form.
+
 # Three representations
 %%%
 tag := "hex-number-field-representations"
@@ -48,12 +57,49 @@ convention `0⁻¹ = 0`.
 
 {docstring Hex.QAdjoin.inv}
 
-Approximation refines the stored root representative and evaluates the reduced
-coordinate polynomial with dyadic complex-ball Horner arithmetic. The returned
-representative can be threaded into the next request so earlier work is not
-repeated.
+Approximation takes a root representative, refines it, and evaluates the
+reduced coordinate polynomial with dyadic complex-ball Horner arithmetic. The
+returned representative can be threaded into the next request so earlier work
+is not repeated.
 
 {docstring Hex.QAdjoin.approx}
+
+Here is fixed-field multiplication and inversion in `ℚ(√2)`:
+
+```lean
+open Hex
+
+namespace HexNumberFieldChapter
+
+private def sqrtTwoPoly : ZPoly :=
+  DensePoly.ofList [-2, 0, 1]
+
+private def sqrtTwoSquare : DyadicSquare :=
+  ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
+
+private def sqrtTwoRep : RefinedIsolation sqrtTwoPoly :=
+  ⟨⟨sqrtTwoSquare, by decide⟩, by decide⟩
+
+private def sqrtTwoRoot : SimpleRoot sqrtTwoPoly :=
+  SimpleRoot.mk sqrtTwoRep
+
+#guard
+  if hirred : ZPoly.isIrreducible sqrtTwoPoly = true then
+    letI : ZPoly.CheckedIrreducible sqrtTwoPoly :=
+      ⟨hirred, by decide⟩
+    let xPoly :=
+      DensePoly.ofList ([0, 1] : List Rat)
+    let x : QAdjoin sqrtTwoPoly sqrtTwoRoot :=
+      QAdjoin.reduce sqrtTwoPoly sqrtTwoRoot xPoly
+    let two : QAdjoin sqrtTwoPoly sqrtTwoRoot :=
+      QAdjoin.reduce sqrtTwoPoly sqrtTwoRoot
+        (DensePoly.C 2)
+    x * x = two && x * x⁻¹ = 1
+  else
+    false
+
+end HexNumberFieldChapter
+```
 
 # Lazy arithmetic and exactification
 %%%
@@ -61,8 +107,8 @@ tag := "hex-number-field-lazy"
 %%%
 
 Every certificate-producing operation has an `Option` form. The total form is
-the primary algebraic API; its loud fallback is proved unreachable in
-`HexNumberFieldMathlib`.
+the primary algebraic API; its loud fallback is paired with a companion
+completeness contract.
 
 {docstring Hex.AlgebraicRoot.add?}
 
@@ -107,15 +153,16 @@ finite root array carrying positive multiplicities.
 
 {docstring Hex.AlgebraicPoly.roots?}
 
-# What the companion proves
+# Companion contracts
 %%%
 tag := "hex-number-field-correspondence"
 %%%
 
-`HexNumberFieldMathlib` interprets every selected root in `ℂ`, proves the fixed
-coordinate laws and approximation enclosure, proves exactification and lazy
-arithmetic complete, and identifies the root arrays with Mathlib polynomial
-roots and multiplicities.
+`HexNumberFieldMathlib` currently exposes Phase-1 contract declarations; their
+proof bodies are not yet complete. Once discharged, they interpret selected
+roots in `ℂ`, establish the fixed-coordinate laws and approximation
+enclosure, make exactification and lazy arithmetic complete, and identify the
+returned arrays with Mathlib polynomial roots and multiplicities.
 
 {docstring Hex.AlgebraicRoot.toComplex}
 
@@ -130,9 +177,12 @@ roots and multiplicities.
 tag := "hex-number-field-cross-references"
 %%%
 
+* {ref "hex-poly-z"}[HexPolyZ] supplies the integer-polynomial presentation.
 * {ref "hex-roots"}[HexRoots] supplies certified complex-root isolation and
-  the root-identity quotient.
+  {name}`Hex.SimpleRoot`.
 * {ref "hex-resultant"}[HexResultant] supplies the eliminants used by lazy
   arithmetic and fixed-field norm candidates.
+* {ref "hex-matrix"}[HexMatrix] and {ref "hex-row-reduce"}[HexRowReduce]
+  supply exact span coordinates for fixed-field minimal polynomials.
 * {ref "hex-number-field-tower"}[HexNumberFieldTower] builds successive
   extensions when one primitive presentation is not convenient.

--- a/HexManual/Chapters/HexNumberField.lean
+++ b/HexManual/Chapters/HexNumberField.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import VersoManual
+
+import HexNumberFieldMathlib
+
+open Verso.Genre Manual
+open Verso.Genre.Manual.InlineLean
+
+set_option pp.rawOnError true
+
+#doc (Manual) "HexNumberField: exact algebraic numbers" =>
+%%%
+tag := "hex-number-field"
+%%%
+
+# Three representations
+%%%
+tag := "hex-number-field-representations"
+%%%
+
+`HexNumberField` provides three complementary exact representations.
+{name}`Hex.QAdjoin` stores rational power-basis coordinates in one fixed
+irreducible presentation. {name}`Hex.AlgebraicRoot` stores a certified selected
+root of a squarefree integer polynomial without requiring that polynomial to
+be minimal. {name}`Hex.AlgebraicNumber` is the canonical form: a selected root
+of its normalized irreducible minimal polynomial.
+
+The distinction makes routine arithmetic cheaper. Addition and multiplication
+first build a resultant eliminant and isolate the intended result; factoring
+to a minimal polynomial is postponed until a caller requests
+{name}`Hex.AlgebraicRoot.exact`.
+
+# Fixed-field arithmetic and approximation
+%%%
+tag := "hex-number-field-fixed"
+%%%
+
+Fixed-presentation coordinates are always reduced modulo the defining integer
+polynomial. Inversion uses polynomial extended gcd and follows the total field
+convention `0⁻¹ = 0`.
+
+{docstring Hex.QAdjoin.reduce}
+
+{docstring Hex.QAdjoin.inv}
+
+Approximation refines the stored root representative and evaluates the reduced
+coordinate polynomial with dyadic complex-ball Horner arithmetic. The returned
+representative can be threaded into the next request so earlier work is not
+repeated.
+
+{docstring Hex.QAdjoin.approx}
+
+# Lazy arithmetic and exactification
+%%%
+tag := "hex-number-field-lazy"
+%%%
+
+Every certificate-producing operation has an `Option` form. The total form is
+the primary algebraic API; its loud fallback is proved unreachable in
+`HexNumberFieldMathlib`.
+
+{docstring Hex.AlgebraicRoot.add?}
+
+{docstring Hex.AlgebraicRoot.mul?}
+
+{docstring Hex.AlgebraicRoot.inv?}
+
+{docstring Hex.AlgebraicRoot.exact?}
+
+{docstring Hex.AlgebraicRoot.exact}
+
+Canonical algebraic numbers reuse these lazy operations and exactify the
+answer. Their Boolean equality compares represented values rather than record
+layout. Lazy roots deliberately have no `BEq`; the root driver uses checked
+{name}`Hex.QAdjoin.Roots.sameValue?` instead.
+
+# Polynomials and roots
+%%%
+tag := "hex-number-field-roots"
+%%%
+
+An {name}`Hex.AlgebraicPoly` owns semantic trailing-zero normalization. This is
+separate from `DensePoly AlgebraicNumber`, whose normalizer would require a
+structural equality decision that is not the intended algebraic equality.
+
+{docstring Hex.AlgebraicPoly.ofArray}
+
+```lean
+open Hex
+
+-- Trailing canonical zeros are removed semantically.
+#guard
+  let f := AlgebraicPoly.ofArray
+    #[AlgebraicNumber.zero, AlgebraicNumber.zero]
+  f.isZero && f.coeffs.isEmpty
+```
+
+Root APIs distinguish the zero polynomial, whose root set is universal, from a
+finite root array carrying positive multiplicities.
+
+{docstring Hex.QAdjoin.roots?}
+
+{docstring Hex.AlgebraicPoly.roots?}
+
+# What the companion proves
+%%%
+tag := "hex-number-field-correspondence"
+%%%
+
+`HexNumberFieldMathlib` interprets every selected root in `ℂ`, proves the fixed
+coordinate laws and approximation enclosure, proves exactification and lazy
+arithmetic complete, and identifies the root arrays with Mathlib polynomial
+roots and multiplicities.
+
+{docstring Hex.AlgebraicRoot.toComplex}
+
+{docstring Hex.QAdjoin.toComplex}
+
+{docstring Hex.AlgebraicRoot.exact_toComplex}
+
+{docstring Hex.AlgebraicPoly.contains_roots_iff}
+
+# Cross-references
+%%%
+tag := "hex-number-field-cross-references"
+%%%
+
+* {ref "hex-roots"}[HexRoots] supplies certified complex-root isolation and
+  the root-identity quotient.
+* {ref "hex-resultant"}[HexResultant] supplies the eliminants used by lazy
+  arithmetic and fixed-field norm candidates.
+* {ref "hex-number-field-tower"}[HexNumberFieldTower] builds successive
+  extensions when one primitive presentation is not convenient.

--- a/HexManual/Chapters/HexNumberFieldTower.lean
+++ b/HexManual/Chapters/HexNumberFieldTower.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import VersoManual
+
+import HexNumberFieldTowerMathlib
+
+open Verso.Genre Manual
+open Verso.Genre.Manual.InlineLean
+
+set_option pp.rawOnError true
+
+#doc (Manual) "HexNumberFieldTower: successive algebraic extensions" =>
+%%%
+tag := "hex-number-field-tower"
+%%%
+
+# Validated towers and coordinates
+%%%
+tag := "hex-number-field-tower-data"
+%%%
+
+`HexNumberFieldTower` represents a fixed embedding of a successive extension
+`ℚ(α₁,…,αₙ)`. Levels are stored newest first; element coordinates use the
+mixed-radix order in which the oldest generator varies fastest. Constructors
+validate coefficient widths, relative irreducibility, and vanishing at the
+chosen absolute root before a level enters a public tower.
+
+{docstring Hex.NumberTower.ofQAdjoin}
+
+The rational base tower is useful on its own and illustrates the coordinate
+normalization and total arithmetic conventions:
+
+```lean
+open Hex Hex.NumberTower
+
+#guard rat.dim = 1
+#guard coeffs (ofRat rat 7 / ofRat rat 3) = #[7 / 3]
+#guard coeffs ((0 : Elem rat)⁻¹) = #[0]
+```
+
+# Factorization by relative norms
+%%%
+tag := "hex-number-field-tower-factor"
+%%%
+
+{name}`Hex.NumberTower.factor?` performs Yun decomposition and then recursively
+applies Trager's algorithm one level at a time. At `K(α)/K`, it searches a
+deterministic finite list of integer shifts for a squarefree relative norm,
+factors that norm over `K`, and recovers the factors over `K(α)` by gcd. It does
+not replace this step with an absolute norm, which would duplicate factors
+defined over an intermediate subfield.
+
+{docstring Hex.NumberTower.Norm.oneLevel}
+
+{docstring Hex.NumberTower.factor?}
+
+The returned payload keeps the scalar separate and records each distinct
+factor once with a positive multiplicity.
+
+# Adjoining and splitting
+%%%
+tag := "hex-number-field-tower-split"
+%%%
+
+Adjoining selects the unique relative factor that contains the requested
+absolute algebraic root under the tower's fixed embedding. If that factor is
+linear, the root was already present and the result is an identity extension.
+
+{docstring Hex.NumberTower.adjoin?}
+
+Splitting alternates factorization and genuine adjoining steps until every
+factor is linear. The zero polynomial uses `.all`; a nonzero constant returns
+an empty finite root array.
+
+{docstring Hex.NumberTower.split?}
+
+# Flattening to one primitive element
+%%%
+tag := "hex-number-field-tower-flatten"
+%%%
+
+{name}`Hex.NumberTower.flatten?` replaces a tower by one canonical
+`QAdjoin` presentation. It combines the fixed generators in deterministic
+signed-shift order, retries both degree and coordinate-recovery collisions,
+recovers old generators by exact gcd and row reduction, and checks a tower
+basis round trip plus the primitive polynomial relation before returning maps.
+
+{docstring Hex.NumberTower.flatten?}
+
+# What the companion proves
+%%%
+tag := "hex-number-field-tower-correspondence"
+%%%
+
+`HexNumberFieldTowerMathlib` interprets mixed-radix coordinates in the stored
+complex embedding. It proves arithmetic correspondence, relative-resultant
+agreement, factorization and adjoining completeness, splitting reconstruction
+and generation, and both flattening round trips.
+
+{docstring Hex.NumberTower.toComplex}
+
+{docstring Hex.NumberTower.factor?_sound}
+
+{docstring Hex.NumberTower.adjoin?_sound}
+
+{docstring Hex.NumberTower.split?_sound}
+
+{docstring Hex.NumberTower.flatten?_sound}
+
+# Cross-references
+%%%
+tag := "hex-number-field-tower-cross-references"
+%%%
+
+* {ref "hex-number-field"}[HexNumberField] supplies selected algebraic roots,
+  canonical exactification, and the one-generator target of flattening.
+* {ref "hex-resultant"}[HexResultant] supplies one-level relative elimination.
+* {ref "hex-row-reduce"}[HexRowReduce] supplies exact coordinate recovery for
+  primitive elements.

--- a/HexManual/Chapters/HexNumberFieldTower.lean
+++ b/HexManual/Chapters/HexNumberFieldTower.lean
@@ -18,6 +18,14 @@ set_option pp.rawOnError true
 tag := "hex-number-field-tower"
 %%%
 
+# Introduction
+%%%
+tag := "hex-number-field-tower-intro"
+%%%
+
+`HexNumberFieldTower` performs exact arithmetic, factorization, adjoining, and
+splitting in a sequence of relative algebraic extensions.
+
 # Validated towers and coordinates
 %%%
 tag := "hex-number-field-tower-data"
@@ -52,7 +60,8 @@ applies Trager's algorithm one level at a time. At `K(α)/K`, it searches a
 deterministic finite list of integer shifts for a squarefree relative norm,
 factors that norm over `K`, and recovers the factors over `K(α)` by gcd. It does
 not replace this step with an absolute norm, which would duplicate factors
-defined over an intermediate subfield.
+defined over an intermediate subfield. The rational base case delegates to
+the `HexBerlekampZassenhaus` integer factorizer.
 
 {docstring Hex.NumberTower.Norm.oneLevel}
 
@@ -60,6 +69,50 @@ defined over an intermediate subfield.
 
 The returned payload keeps the scalar separate and records each distinct
 factor once with a positive multiplicity.
+
+The following example constructs `ℚ(√2)` and factors `X² - 2` there; the
+two linear factors correspond to the already-present roots `±√2`.
+
+```lean
+open Hex Hex.NumberTower
+
+namespace HexNumberFieldTowerChapter
+
+private def sqrtTwoPoly : ZPoly :=
+  DensePoly.ofList [-2, 0, 1]
+
+private def sqrtTwoSquare : DyadicSquare :=
+  ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
+
+private def sqrtTwoRep : RefinedIsolation sqrtTwoPoly :=
+  ⟨⟨sqrtTwoSquare, by decide⟩, by decide⟩
+
+private def sqrtTwoRoot : SimpleRoot sqrtTwoPoly :=
+  SimpleRoot.mk sqrtTwoRep
+
+#guard
+  if hirred : ZPoly.isIrreducible sqrtTwoPoly = true then
+    letI : ZPoly.CheckedIrreducible sqrtTwoPoly :=
+      ⟨hirred, by decide⟩
+    if hsimple : HasOnlySimpleRoots sqrtTwoPoly then
+      let extension := ofQAdjoin (x := sqrtTwoRoot)
+        hsimple sqrtTwoRep rfl
+      let f : Poly extension.tower :=
+        DensePoly.ofCoeffs
+          #[ofRat extension.tower (-2), 0, 1]
+      match factor? extension.tower f with
+      | some result =>
+          result.factors.size = 2 &&
+            result.factors.all fun entry =>
+              entry.1.degree? = some 1 && entry.2 = 1
+      | none => false
+    else
+      false
+  else
+    false
+
+end HexNumberFieldTowerChapter
+```
 
 # Adjoining and splitting
 %%%
@@ -86,20 +139,22 @@ tag := "hex-number-field-tower-flatten"
 {name}`Hex.NumberTower.flatten?` replaces a tower by one canonical
 `QAdjoin` presentation. It combines the fixed generators in deterministic
 signed-shift order, retries both degree and coordinate-recovery collisions,
-recovers old generators by exact gcd and row reduction, and checks a tower
-basis round trip plus the primitive polynomial relation before returning maps.
+recovers old generators by exact gcd, and checks direct-evaluation coordinate
+maps, a tower-basis round trip, and the primitive polynomial relation before
+returning maps.
 
 {docstring Hex.NumberTower.flatten?}
 
-# What the companion proves
+# Companion contracts
 %%%
 tag := "hex-number-field-tower-correspondence"
 %%%
 
-`HexNumberFieldTowerMathlib` interprets mixed-radix coordinates in the stored
-complex embedding. It proves arithmetic correspondence, relative-resultant
-agreement, factorization and adjoining completeness, splitting reconstruction
-and generation, and both flattening round trips.
+`HexNumberFieldTowerMathlib` currently exposes Phase-1 contract declarations;
+their proof bodies are not yet complete. Once discharged, they interpret
+mixed-radix coordinates in the stored complex embedding, establish arithmetic
+and relative-resultant correspondence, and make factorization, adjoining,
+splitting, and flattening complete.
 
 {docstring Hex.NumberTower.toComplex}
 
@@ -119,5 +174,5 @@ tag := "hex-number-field-tower-cross-references"
 * {ref "hex-number-field"}[HexNumberField] supplies selected algebraic roots,
   canonical exactification, and the one-generator target of flattening.
 * {ref "hex-resultant"}[HexResultant] supplies one-level relative elimination.
-* {ref "hex-row-reduce"}[HexRowReduce] supplies exact coordinate recovery for
-  primitive elements.
+* {ref "factor-tactics"}[Factor tactics] describes the
+  `HexBerlekampZassenhaus` integer factorizer used at the rational base case.

--- a/HexManual/Chapters/HexResultant.lean
+++ b/HexManual/Chapters/HexResultant.lean
@@ -30,9 +30,10 @@ points where the recurrence proves divisibility. This matters for the tower
 algorithms later in the manual: their coefficient rings are executable
 number-field presentations, not Mathlib fields.
 
-The computational library is Mathlib-free. `HexResultantMathlib` proves that
-the final executable value agrees with {name}`Polynomial.resultant`, including
-specialization, root-product, and discriminant conventions.
+The computational library is Mathlib-free. `HexResultantMathlib` states the
+correspondence between the final executable value and
+{name}`Polynomial.resultant`, including specialization and discriminant
+conventions.
 
 # The executable API
 %%%
@@ -79,24 +80,26 @@ private def g : DensePoly Int := DensePoly.ofList [-3, 1]
 end HexResultantChapter
 ```
 
-# What the companion proves
+# Companion contracts
 %%%
 tag := "hex-resultant-correspondence"
 %%%
 
-The central correspondence theorem identifies the executable scalar with
-Mathlib's determinant-defined resultant:
+These Phase-1 declarations fix the intended correspondence API; their proof
+bodies are not yet complete. The central contract identifies the executable
+scalar with Mathlib's determinant-defined resultant:
 
 {docstring Hex.DensePoly.toPolynomial_resultant}
 
-Two downstream forms are especially important. Specialization retains the
-original formal degrees, so degree drops after substituting a parameter do not
-silently change the resultant convention:
+The specialization contract retains the original formal degrees, so degree
+drops after substituting a parameter do not silently change the resultant
+convention:
 
 {docstring Hex.DensePoly.eval_resultant}
 
-The root-product form is the bridge from one-level tower elimination to field
-norms and to the finite collision bounds used by Trager factorization:
+Independently, Mathlib's resultant has the following proved root-product
+formula. It is the algebraic identity the later executable correspondence will
+carry into one-level field norms and Trager collision bounds:
 
 {docstring Hex.DensePoly.resultant_eq_leadingCoeff_mul_prod_roots}
 

--- a/HexManual/Chapters/HexResultant.lean
+++ b/HexManual/Chapters/HexResultant.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import VersoManual
+
+import HexResultantMathlib
+
+open Verso.Genre Manual
+open Verso.Genre.Manual.InlineLean
+
+set_option pp.rawOnError true
+
+#doc (Manual) "HexResultant: subresultants and discriminants" =>
+%%%
+tag := "hex-resultant"
+%%%
+
+# Introduction
+%%%
+tag := "hex-resultant-intro"
+%%%
+
+`HexResultant` computes polynomial resultants and discriminants without
+constructing a Sylvester matrix. Its Brown subresultant pseudo-remainder
+sequence stays in the coefficient ring and uses exact division only at the
+points where the recurrence proves divisibility. This matters for the tower
+algorithms later in the manual: their coefficient rings are executable
+number-field presentations, not Mathlib fields.
+
+The computational library is Mathlib-free. `HexResultantMathlib` proves that
+the final executable value agrees with {name}`Polynomial.resultant`, including
+specialization, root-product, and discriminant conventions.
+
+# The executable API
+%%%
+tag := "hex-resultant-api"
+%%%
+
+The public chain records its normalized inputs, every nonzero remainder, and
+the terminal principal-subresultant scalar. The scalar is separate because a
+defective degree drop can change the exact resultant without changing the last
+nonzero polynomial.
+
+{docstring Hex.PRSResult}
+
+{docstring Hex.DensePoly.subresultantChain}
+
+Most callers need only the scalar resultant:
+
+{docstring Hex.DensePoly.resultant}
+
+The discriminant uses the standard signed derivative-resultant formula, with
+the zero and constant conventions handled explicitly:
+
+{docstring Hex.DensePoly.disc}
+
+# A small exact computation
+%%%
+tag := "hex-resultant-example"
+%%%
+
+For `f = X² - 2` and `g = X - 3`, the resultant is `f(3) = 7`; the
+discriminant of `f` is `8`. Both checks below run the Mathlib-free algorithm.
+
+```lean
+open Hex
+
+namespace HexResultantChapter
+
+private def f : DensePoly Int := DensePoly.ofList [-2, 0, 1]
+private def g : DensePoly Int := DensePoly.ofList [-3, 1]
+
+#guard DensePoly.resultant f g = 7
+#guard DensePoly.disc f = 8
+
+end HexResultantChapter
+```
+
+# What the companion proves
+%%%
+tag := "hex-resultant-correspondence"
+%%%
+
+The central correspondence theorem identifies the executable scalar with
+Mathlib's determinant-defined resultant:
+
+{docstring Hex.DensePoly.toPolynomial_resultant}
+
+Two downstream forms are especially important. Specialization retains the
+original formal degrees, so degree drops after substituting a parameter do not
+silently change the resultant convention:
+
+{docstring Hex.DensePoly.eval_resultant}
+
+The root-product form is the bridge from one-level tower elimination to field
+norms and to the finite collision bounds used by Trager factorization:
+
+{docstring Hex.DensePoly.resultant_eq_leadingCoeff_mul_prod_roots}
+
+# Cross-references
+%%%
+tag := "hex-resultant-cross-references"
+%%%
+
+* {ref "hex-poly"}[HexPoly] supplies the normalized dense representation and
+  pseudo-division primitives.
+* {ref "hex-number-field"}[HexNumberField] uses bivariate specialization
+  vanishing to justify factorization-lazy arithmetic.
+* {ref "hex-number-field-tower"}[HexNumberFieldTower] uses the full value and
+  root-product correspondence for relative norms and Trager recovery.

--- a/progress/20260727T104302Z_number-field-documentation.md
+++ b/progress/20260727T104302Z_number-field-documentation.md
@@ -1,0 +1,29 @@
+# Number-field documentation milestone
+
+## Accomplished
+
+- Added HexManual reference chapters for `HexResultant`, `HexNumberField`, and
+  `HexNumberFieldTower`, including executable guards, totality conventions,
+  algorithm summaries, Mathlib correspondence contracts, and cross-references.
+- Added the three chapters to the manual table of contents and expanded the
+  introduction to cover exact number fields and root isolation.
+- Built each new chapter and the complete `HexManual` target successfully.
+- Ran the import-DAG check, whitespace check, and an axiom/`native_decide` scan
+  over the new documentation with no findings.
+
+## Current frontier
+
+- A full static HTML render is compiling the manual executable's native
+  dependency closure after successful document elaboration.
+- The independent review of `HexNumberFieldTowerMathlib` is still running in
+  the background.
+
+## Next step
+
+- Publish this documentation milestone, then add the still-missing
+  `HexResultant` and `HexNumberField` conformance and benchmark drivers from
+  their specifications while continuing to monitor the independent reviews.
+
+## Blockers
+
+- None.

--- a/progress/20260727T105920Z_number-field-documentation-review.md
+++ b/progress/20260727T105920Z_number-field-documentation-review.md
@@ -1,0 +1,30 @@
+# Number-field documentation review repair
+
+## Accomplished
+
+- Incorporated the independent review of the Resultant, NumberField, and
+  NumberFieldTower manual chapters.
+- Recast unfinished Mathlib statements as Phase-1 contracts instead of
+  completed proofs and removed the front-page claim that all number-field
+  functionality is verified.
+- Corrected the flattening account, approximation input, root type name,
+  resultant root-product framing, and dependency cross-references.
+- Added introductory sections and compiled worked examples for fixed-field
+  arithmetic in `ℚ(√2)` and relative factorization over `ℚ(√2)`.
+- Rebuilt all three chapters and the full `HexManual`, and rendered the static
+  manual successfully.
+
+## Current frontier
+
+- `ResultantTesting` is stacked above this documentation branch and needs one
+  more rebase after this repair is pushed.
+- Its independent testing review is still running in the background.
+
+## Next step
+
+- Push the documentation repair, restack `ResultantTesting`, and start the
+  NumberField testing milestone without waiting for the running review.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
## Summary

- add HexManual reference chapters for `HexResultant`, `HexNumberField`, and `HexNumberFieldTower`
- document totality conventions, executable examples, principal algorithms, and Mathlib correspondence contracts
- add the chapters to the manual table of contents and update the site introduction

## Validation

- `lake build HexManual.Chapters.HexResultant`
- `lake build HexManual.Chapters.HexNumberField`
- `lake build HexManual.Chapters.HexNumberFieldTower`
- `lake build HexManual`
- `lake exe hexmanual --output /tmp/hexmanual-numberfield.OOjJR3` (complete static render)
- `python3 scripts/check_dag.py`
- `git diff --check`
- axiom/`native_decide` scan over the new manual sources
