### PR TITLE
interval: validate rational certificate boundary

### DIFF
--- a/HexInterval/Experiment/RationalCertificate.lean
+++ b/HexInterval/Experiment/RationalCertificate.lean
@@ -18,6 +18,8 @@ Finite program literals and interval cuts refer to a complete, canonical
 `RawRat` table by typed indices.  The transparent boundary checker validates
 the whole table, every endpoint index, SSA and derivation indices, equality
 references, caller-owned sources and target, and structural budgets.
+Caller rows contain both indexed syntax and exact raw values, so the
+certificate-owned table cannot reinterpret the invocation boundary.
 
 No interval arithmetic or equality arithmetic is replayed here.  The module
 also does not choose a wire format or a production storage representation;
@@ -202,6 +204,76 @@ def lit (node : NodeId .real) (endpoint : EndpointId) : Row :=
 
 end Row
 
+/-! ## Caller-owned value boundary -/
+
+/-- Lower cut carrying a caller-owned raw rational value rather than an
+untrusted table reference. -/
+inductive ValueLower where
+  | unbounded
+  | finite (value : RationalTable.RawRat) (strict : Bool)
+  deriving DecidableEq, Repr
+
+/-- Upper cut carrying a caller-owned raw rational value rather than an
+untrusted table reference. -/
+inductive ValueUpper where
+  | finite (value : RationalTable.RawRat) (strict : Bool)
+  | unbounded
+  deriving DecidableEq, Repr
+
+/-- Caller-owned empty, bounded, open, closed, or unbounded interval value. -/
+inductive ValueRange where
+  | empty
+  | bounds (lower : ValueLower) (upper : ValueUpper)
+  deriving DecidableEq, Repr
+
+namespace ValueRange
+
+/-- Closed finite caller-owned interval value. -/
+def closed (lower upper : RationalTable.RawRat) : ValueRange :=
+  .bounds (.finite lower false) (.finite upper false)
+
+end ValueRange
+
+namespace Range
+
+/-- Resolve every finite table reference and require exact agreement with a
+caller-owned raw value, including empty/bounded and strictness shape. -/
+def agrees (table : List RationalTable.RawRat) : Range → ValueRange → Bool
+  | .empty, .empty => true
+  | .bounds lower upper, .bounds valueLower valueUpper =>
+      (match lower, valueLower with
+        | .unbounded, .unbounded => true
+        | .finite endpoint strict, .finite value valueStrict =>
+            strict == valueStrict && table[endpoint.index]? == some value
+        | _, _ => false) &&
+      (match upper, valueUpper with
+        | .finite endpoint strict, .finite value valueStrict =>
+            strict == valueStrict && table[endpoint.index]? == some value
+        | .unbounded, .unbounded => true
+        | _, _ => false)
+  | _, _ => false
+
+end Range
+
+/-- A caller-owned invocation row pins both the indexed syntax used by replay
+and the exact raw values those references must denote. -/
+structure ExpectedRow where
+  indexed : Row
+  value : ValueRange
+  deriving DecidableEq, Repr
+
+namespace ExpectedRow
+
+/-- Validate and resolve an expected row against the certificate table. -/
+def agrees (table : List RationalTable.RawRat) (row : ExpectedRow) : Bool :=
+  row.indexed.range.agrees table row.value
+
+/-- Exact table lookup work requested by the indexed half of an expected row. -/
+def lookupCost? (tableCount : Nat) (row : ExpectedRow) : Option Nat :=
+  row.indexed.lookupCost? tableCount
+
+end ExpectedRow
+
 /-! ## Structural recipes and references -/
 
 namespace CenterShape
@@ -222,7 +294,7 @@ def check (program : Program) (center : Center.Center) : Bool :=
 
 end CenterShape
 
-namespace EqEdge
+namespace EdgeShape
 
 /-- Check one equality edge's selected structural recipe and endpoints. -/
 def check (program : Program) (expectedBaseSize maxGeneration : Nat)
@@ -233,7 +305,7 @@ def check (program : Program) (expectedBaseSize maxGeneration : Nat)
         CenterShape.check program center && edge.left == center.prod &&
         edge.right == center.form
 
-end EqEdge
+end EdgeShape
 
 /-- A table-indexed row paired with the existing derivation reference language. -/
 structure Fact where
@@ -325,8 +397,8 @@ def checkFacts (table : List RationalTable.RawRat) (program : Program)
 
 /-! ## Complete certificate boundary -/
 
-/-- Exact endpoint-table lookup work for a row collection. -/
-def rowsLookupCost? (tableCount : Nat) : List Row → Option Nat
+/-- Exact endpoint-table lookup work for a caller-owned row collection. -/
+def rowsLookupCost? (tableCount : Nat) : List ExpectedRow → Option Nat
   | [] => some 0
   | row :: tail => do
       let headCost ← row.lookupCost? tableCount
@@ -349,8 +421,8 @@ structure ReferenceLimit where
   deriving DecidableEq, Repr
 
 /-- Complete rational endpoint certificate.  The table and all indexed syntax
-are untrusted; invocation sources, target, base size, and limits remain caller
-owned arguments to the checker. -/
+are untrusted; invocation source/target references and their exact values,
+base size, and limits remain caller-owned checker arguments. -/
 structure Certificate where
   table : List RationalTable.RawRat
   program : Program
@@ -364,7 +436,7 @@ namespace Certificate
 
 /-- Bounded structural preflight before table or indexed traversal. -/
 def structureOk (certificate : Certificate) (limit : Center.StructureLimit)
-    (expectedBaseSize : Nat) (expectedSources : List Row) : Bool :=
+    (expectedBaseSize : Nat) (expectedSources : List ExpectedRow) : Bool :=
   certificate.center.generation ≤ limit.maxGeneration &&
     expectedBaseSize ≤ limit.maxNodes && certificate.result < limit.maxFacts &&
     Center.lengthWithin limit.maxNodes certificate.program &&
@@ -372,11 +444,12 @@ def structureOk (certificate : Certificate) (limit : Center.StructureLimit)
     Center.lengthWithin limit.maxEdges certificate.edges &&
     Center.lengthWithin limit.maxFacts certificate.facts
 
-/-- Exact forward-list work for every endpoint-table lookup the boundary will
-perform.  Returning `none` rejects an out-of-range reference before any table
-lookup is attempted. -/
-def endpointLookupCost? (certificate : Certificate) (expectedSources : List Row)
-    (expectedTarget : Row) : Option Nat := do
+/-- Exact forward-list work for every indexed endpoint lookup the boundary
+will perform.  Returning `none` rejects an out-of-range reference before any
+indexed endpoint lookup is attempted. -/
+def endpointLookupCost? (certificate : Certificate)
+    (expectedSources : List ExpectedRow)
+    (expectedTarget : ExpectedRow) : Option Nat := do
   let tableCount := certificate.table.length
   let programCost ← certificate.program.lookupCost? tableCount
   let sourceCost ← rowsLookupCost? tableCount expectedSources
@@ -385,12 +458,13 @@ def endpointLookupCost? (certificate : Certificate) (expectedSources : List Row)
   pure (programCost + sourceCost + targetCost + factCost)
 
 /-- Check the complete table-indexed certificate boundary.  A successful
-result establishes table canonicality and all structural references, but no
+result establishes table canonicality, exact agreement with caller-owned
+source/target values, and all structural references, but no internal
 arithmetic equality or interval propagation claim. -/
 def check (certificate : Certificate) (tableLimit : RationalTable.RawRat.Limit)
     (referenceLimit : ReferenceLimit) (structureLimit : Center.StructureLimit)
-    (expectedBaseSize : Nat) (expectedSources : List Row)
-    (expectedTarget : Row) : Bool :=
+    (expectedBaseSize : Nat) (expectedSources : List ExpectedRow)
+    (expectedTarget : ExpectedRow) : Bool :=
   certificate.structureOk structureLimit expectedBaseSize expectedSources &&
     match RationalTable.Table.check tableLimit certificate.table with
     | .ready =>
@@ -402,27 +476,28 @@ def check (certificate : Certificate) (tableLimit : RationalTable.RawRat.Limit)
                 certificate.program.check &&
                 certificate.center.baseSize == expectedBaseSize &&
                 CenterShape.check certificate.program certificate.center &&
-                (expectedSources.all fun source =>
-                  source.refsOk certificate.table &&
-                    (certificate.program.node? source.node).isSome) &&
-                expectedTarget.refsOk certificate.table &&
-                (certificate.program.node? expectedTarget.node).isSome &&
+                expectedSources.all (fun source => source.agrees certificate.table) &&
+                expectedSources.all (fun source =>
+                  (certificate.program.node? source.indexed.node).isSome) &&
+                expectedTarget.agrees certificate.table &&
+                (certificate.program.node? expectedTarget.indexed.node).isSome &&
                 Center.EqEdge.containsCenter certificate.edges certificate.center &&
                 certificate.edges.all
-                  (EqEdge.check certificate.program expectedBaseSize
+                  (EdgeShape.check certificate.program expectedBaseSize
                     structureLimit.maxGeneration) &&
                 match Center.Fact.forwardDistance? certificate.facts.length
                     certificate.result with
                 | none => false
                 | some resultCost =>
                     if resultCost ≤ structureLimit.maxLookupSteps then
-                      checkFacts certificate.table certificate.program expectedSources
+                      checkFacts certificate.table certificate.program
+                          (expectedSources.map fun source => source.indexed)
                           certificate.edges certificate.program.length
                           expectedSources.length certificate.edges.length 0
                           (structureLimit.maxLookupSteps - resultCost)
-                          certificate.facts [] &&
+                        certificate.facts [] &&
                         certificate.facts[certificate.result]?.map
-                            (fun fact => fact.row) == some expectedTarget
+                            (fun fact => fact.row) == some expectedTarget.indexed
                     else
                       false
             else
@@ -433,7 +508,8 @@ def check (certificate : Certificate) (tableLimit : RationalTable.RawRat.Limit)
 theorem table_ready_of_check {certificate : Certificate}
     {tableLimit : RationalTable.RawRat.Limit}
     {referenceLimit : ReferenceLimit} {structureLimit : Center.StructureLimit}
-    {expectedBaseSize : Nat} {expectedSources : List Row} {expectedTarget : Row}
+    {expectedBaseSize : Nat} {expectedSources : List ExpectedRow}
+    {expectedTarget : ExpectedRow}
     (h : certificate.check tableLimit referenceLimit structureLimit
       expectedBaseSize expectedSources expectedTarget = true) :
     RationalTable.Table.check tableLimit certificate.table = .ready := by
@@ -443,11 +519,46 @@ theorem table_ready_of_check {certificate : Certificate}
   | malformed index reason => simp [htable] at h
   | resourceLimit index reason => simp [htable] at h
 
+/-- Success pins every indexed invocation row to its exact caller-owned value;
+the certificate table cannot reinterpret sources or target. -/
+theorem boundary_agrees_of_check {certificate : Certificate}
+    {tableLimit : RationalTable.RawRat.Limit}
+    {referenceLimit : ReferenceLimit} {structureLimit : Center.StructureLimit}
+    {expectedBaseSize : Nat} {expectedSources : List ExpectedRow}
+    {expectedTarget : ExpectedRow}
+    (h : certificate.check tableLimit referenceLimit structureLimit
+      expectedBaseSize expectedSources expectedTarget = true) :
+    expectedSources.all (fun source => source.agrees certificate.table) = true ∧
+      expectedTarget.agrees certificate.table = true := by
+  unfold check at h
+  have hbody := (Bool.and_eq_true_iff.mp h).2
+  cases htable : RationalTable.Table.check tableLimit certificate.table with
+  | malformed index reason => simp [htable] at hbody
+  | resourceLimit index reason => simp [htable] at hbody
+  | ready =>
+      simp only [htable] at hbody
+      cases hcost : certificate.endpointLookupCost? expectedSources expectedTarget with
+      | none => simp [hcost] at hbody
+      | some cost =>
+          simp only [hcost] at hbody
+          split at hbody
+          next =>
+            rcases Bool.and_eq_true_iff.mp hbody with ⟨hbody, _⟩
+            rcases Bool.and_eq_true_iff.mp hbody with ⟨hbody, _⟩
+            rcases Bool.and_eq_true_iff.mp hbody with ⟨hbody, _⟩
+            rcases Bool.and_eq_true_iff.mp hbody with ⟨hbody, _⟩
+            rcases Bool.and_eq_true_iff.mp hbody with ⟨hbody, htarget⟩
+            rcases Bool.and_eq_true_iff.mp hbody with ⟨hbody, _⟩
+            rcases Bool.and_eq_true_iff.mp hbody with ⟨_, hsources⟩
+            exact ⟨hsources, htarget⟩
+          next => contradiction
+
 /-- Every entry of an accepted certificate table is canonical. -/
 theorem table_canonical {certificate : Certificate}
     {tableLimit : RationalTable.RawRat.Limit}
     {referenceLimit : ReferenceLimit} {structureLimit : Center.StructureLimit}
-    {expectedBaseSize : Nat} {expectedSources : List Row} {expectedTarget : Row}
+    {expectedBaseSize : Nat} {expectedSources : List ExpectedRow}
+    {expectedTarget : ExpectedRow}
     (h : certificate.check tableLimit referenceLimit structureLimit
       expectedBaseSize expectedSources expectedTarget = true) :
     ∀ q ∈ certificate.table, q.Canonical :=
@@ -457,24 +568,22 @@ end Certificate
 
 /-! ## Endpoint-erased projection -/
 
-/-- Erase one rational program instruction.  A literal retains its program
-position as the backend-independent literal slot. -/
-def eraseOp (index : Nat) : Prim → RationalTable.Shape.Op
-  | .var source => .var source
-  | .lit _ => .lit index
-  | .sub left right => .sub left right
-  | .mul left right => .mul left right
-  | .sq input => .sq input
-
-/-- Erase a complete rational program from an explicit position. -/
-def eraseProgramFrom : Nat → Program → List RationalTable.Shape.Op
-  | _, [] => []
-  | index, instruction :: tail =>
-      eraseOp index instruction :: eraseProgramFrom (index + 1) tail
+/-- Erase a complete rational program while retaining literal-reference
+sharing.  Slots use the same first-occurrence rule as dyadic erasure. -/
+def eraseProgramFrom (seen : List EndpointId) : Program → List RationalTable.Shape.Op
+  | [] => []
+  | .var source :: tail => .var source :: eraseProgramFrom seen tail
+  | .lit endpoint :: tail =>
+      match RationalTable.firstIndex? endpoint 0 seen with
+      | some slot => .lit slot :: eraseProgramFrom seen tail
+      | none => .lit seen.length :: eraseProgramFrom (seen ++ [endpoint]) tail
+  | .sub left right :: tail => .sub left right :: eraseProgramFrom seen tail
+  | .mul left right :: tail => .mul left right :: eraseProgramFrom seen tail
+  | .sq input :: tail => .sq input :: eraseProgramFrom seen tail
 
 /-- Endpoint-erased rational program. -/
 def eraseProgram (program : Program) : List RationalTable.Shape.Op :=
-  eraseProgramFrom 0 program
+  eraseProgramFrom [] program
 
 /-- Erase a lower cut's table reference while retaining strictness. -/
 def eraseLower : Lower → RationalTable.Shape.Lower
@@ -501,7 +610,8 @@ def eraseFact (fact : Fact) : RationalTable.Shape.Fact :=
 
 /-- Backend-independent certificate skeleton. -/
 def eraseCertificate (certificate : Certificate) (baseSize : Nat)
-    (sources : List Row) (target : Row) (limit : Center.StructureLimit) :
+    (sources : List ExpectedRow) (target : ExpectedRow)
+    (limit : Center.StructureLimit) :
     RationalTable.Shape.Skeleton :=
   { program := eraseProgram certificate.program
     center := certificate.center
@@ -509,14 +619,16 @@ def eraseCertificate (certificate : Certificate) (baseSize : Nat)
     facts := certificate.facts.map eraseFact
     result := certificate.result
     baseSize
-    sources := sources.map eraseRow
-    target := eraseRow target
+    sources := sources.map fun source => eraseRow source.indexed
+    target := eraseRow target.indexed
     limit }
 
-/-- Rational projection retains its caller-owned table and endpoint-reference
-limits alongside the backend-independent skeleton. -/
+/-- Rational projection retains caller-owned boundary values and
+backend-specific limits alongside the endpoint-erased structural skeleton. -/
 structure Projection where
   skeleton : RationalTable.Shape.Skeleton
+  sourceValues : List ValueRange
+  targetValue : ValueRange
   tableLimit : RationalTable.RawRat.Limit
   referenceLimit : ReferenceLimit
   deriving DecidableEq
@@ -524,9 +636,11 @@ structure Projection where
 /-- Project a rational certificate and its complete caller-owned boundary. -/
 def projectCertificate (certificate : Certificate)
     (tableLimit : RationalTable.RawRat.Limit) (referenceLimit : ReferenceLimit)
-    (baseSize : Nat) (sources : List Row) (target : Row)
+    (baseSize : Nat) (sources : List ExpectedRow) (target : ExpectedRow)
     (structureLimit : Center.StructureLimit) : Projection :=
   { skeleton := eraseCertificate certificate baseSize sources target structureLimit
+    sourceValues := sources.map fun source => source.value
+    targetValue := target.value
     tableLimit
     referenceLimit }
 
@@ -559,6 +673,10 @@ def unitRange : Range := Range.closed zero one
 def centeredRange : Range := Range.closed negHalf half
 def quarterRange : Range := Range.closed zero quarter
 
+/-- Caller-owned values denoted by the fixture's indexed ranges. -/
+def unitValueRange : ValueRange := ValueRange.closed ⟨0, 1⟩ ⟨1, 1⟩
+def quarterValueRange : ValueRange := ValueRange.closed ⟨0, 1⟩ ⟨1, 4⟩
+
 /-- Rational-table rendering of all ten centered fixture facts. -/
 def fixtureFacts : List Fact :=
   [ ⟨⟨Center.node 0, unitRange⟩, .source 0⟩
@@ -581,13 +699,14 @@ def fixtureCert : Certificate :=
     facts := fixtureFacts
     result := 9 }
 
-/-- Caller-owned rational source rows. -/
-def fixtureSources : List Row :=
-  [⟨Center.node 0, unitRange⟩]
+/-- Caller-owned rational source rows, including exact values independent of
+the certificate's untrusted table. -/
+def fixtureSources : List ExpectedRow :=
+  [⟨⟨Center.node 0, unitRange⟩, unitValueRange⟩]
 
-/-- Caller-owned rational target row. -/
-def fixtureTarget : Row :=
-  ⟨Center.node 3, quarterRange⟩
+/-- Caller-owned rational target row and exact value. -/
+def fixtureTarget : ExpectedRow :=
+  ⟨⟨Center.node 3, quarterRange⟩, quarterValueRange⟩
 
 /-- Caller-owned table limit for the fixed rational certificate. -/
 def fixtureTableLimit : RationalTable.RawRat.Limit :=
@@ -620,6 +739,8 @@ backend-independent structure. -/
 def checksProjection : Bool :=
   fixtureProjection.skeleton == RationalTable.fixtureSkeleton &&
     fixtureProjection.skeleton == RationalTable.expectedSkeleton &&
+    fixtureProjection.sourceValues == [unitValueRange] &&
+    fixtureProjection.targetValue == quarterValueRange &&
     fixtureProjection.tableLimit == fixtureTableLimit &&
     fixtureProjection.referenceLimit == fixtureReferenceLimit
 
@@ -627,7 +748,9 @@ theorem checksProjection_eq_true : checksProjection = true := by
   decide +kernel
 
 /-- The fixture's endpoint-reference budget is exact and one step short is
-rejected before any endpoint-table traversal. -/
+rejected before any indexed endpoint lookup.  The later `refsOk`/`agrees`
+pass deliberately stands in for the real reads that arithmetic replay will
+perform, so this budget must not be optimized away as a redundant range check. -/
 def checksReferenceBudget : Bool :=
   fixtureCert.endpointLookupCost? fixtureSources fixtureTarget == some 73 &&
     checkFixture &&

--- a/HexInterval/Experiment/RationalCertificate.lean
+++ b/HexInterval/Experiment/RationalCertificate.lean
@@ -1,0 +1,662 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Experiment.RationalTable
+
+@[expose] public section
+
+/-!
+# Table-indexed rational certificate boundary
+
+This module adds the next proof-facing layer of the rational endpoint vertical.
+Finite program literals and interval cuts refer to a complete, canonical
+`RawRat` table by typed indices.  The transparent boundary checker validates
+the whole table, every endpoint index, SSA and derivation indices, equality
+references, caller-owned sources and target, and structural budgets.
+
+No interval arithmetic or equality arithmetic is replayed here.  The module
+also does not choose a wire format or a production storage representation;
+`List` is the deliberately transparent proof-facing experiment boundary.
+-/
+
+namespace Hex.Interval.Experiment.RationalCertificate
+
+open Center
+
+/-! ## Table-indexed syntax -/
+
+/-- Typed reference to one entry of the certificate's rational table. -/
+structure EndpointId where
+  index : Nat
+  deriving DecidableEq, Repr
+
+namespace EndpointId
+
+/-- A reference is in range exactly when optional table lookup succeeds. -/
+def valid (table : List RationalTable.RawRat) (endpoint : EndpointId) : Bool :=
+  table[endpoint.index]?.isSome
+
+/-- Exact forward-list lookup work for one endpoint reference.  This validates
+the index without traversing the table. -/
+def lookupCost? (tableCount : Nat) (endpoint : EndpointId) : Option Nat :=
+  Center.Fact.forwardDistance? tableCount endpoint.index
+
+end EndpointId
+
+/-- Lower cut whose finite endpoint is a table reference. -/
+inductive Lower where
+  | unbounded
+  | finite (endpoint : EndpointId) (strict : Bool)
+  deriving DecidableEq, Repr
+
+/-- Upper cut whose finite endpoint is a table reference. -/
+inductive Upper where
+  | finite (endpoint : EndpointId) (strict : Bool)
+  | unbounded
+  deriving DecidableEq, Repr
+
+/-- Empty or bounded table-indexed interval data. -/
+inductive Range where
+  | empty
+  | bounds (lower : Lower) (upper : Upper)
+  deriving DecidableEq, Repr
+
+namespace Lower
+
+/-- Validate a lower cut's optional endpoint reference. -/
+def refsOk (table : List RationalTable.RawRat) : Lower → Bool
+  | .unbounded => true
+  | .finite endpoint _ => endpoint.valid table
+
+/-- Exact table lookup work requested by a lower cut. -/
+def lookupCost? (tableCount : Nat) : Lower → Option Nat
+  | .unbounded => some 0
+  | .finite endpoint _ => endpoint.lookupCost? tableCount
+
+end Lower
+
+namespace Upper
+
+/-- Validate an upper cut's optional endpoint reference. -/
+def refsOk (table : List RationalTable.RawRat) : Upper → Bool
+  | .finite endpoint _ => endpoint.valid table
+  | .unbounded => true
+
+/-- Exact table lookup work requested by an upper cut. -/
+def lookupCost? (tableCount : Nat) : Upper → Option Nat
+  | .finite endpoint _ => endpoint.lookupCost? tableCount
+  | .unbounded => some 0
+
+end Upper
+
+namespace Range
+
+/-- Closed finite range over two table entries. -/
+def closed (lower upper : EndpointId) : Range :=
+  .bounds (.finite lower false) (.finite upper false)
+
+/-- Validate every finite endpoint reference in a range. -/
+def refsOk (table : List RationalTable.RawRat) : Range → Bool
+  | .empty => true
+  | .bounds lower upper => lower.refsOk table && upper.refsOk table
+
+/-- Exact table lookup work requested by every finite cut in a range. -/
+def lookupCost? (tableCount : Nat) : Range → Option Nat
+  | .empty => some 0
+  | .bounds lower upper => do
+      let lowerCost ← lower.lookupCost? tableCount
+      let upperCost ← upper.lookupCost? tableCount
+      pure (lowerCost + upperCost)
+
+end Range
+
+/-- Operations needed by the centered-product shape. -/
+inductive Prim where
+  | var (source : Nat)
+  | lit (endpoint : EndpointId)
+  | sub (left right : NodeId .real)
+  | mul (left right : NodeId .real)
+  | sq (input : NodeId .real)
+  deriving DecidableEq, Repr
+
+/-- Transparent proof-facing rational SSA program. -/
+abbrev Program := List Prim
+
+namespace Prim
+
+/-- Check that every operand precedes the instruction defining its result. -/
+def checkAt (index : Nat) : Prim → Bool
+  | .var _ | .lit _ => true
+  | .sub left right | .mul left right =>
+      left.index < index && right.index < index
+  | .sq input => input.index < index
+
+/-- Validate a literal's table reference. -/
+def refsOk (table : List RationalTable.RawRat) : Prim → Bool
+  | .lit endpoint => endpoint.valid table
+  | _ => true
+
+/-- Exact table lookup work requested by an instruction. -/
+def lookupCost? (tableCount : Nat) : Prim → Option Nat
+  | .lit endpoint => endpoint.lookupCost? tableCount
+  | _ => some 0
+
+end Prim
+
+namespace Program
+
+/-- Exact optional program lookup. -/
+def node? (program : Program) (node : NodeId .real) : Option Prim :=
+  program[node.index]?
+
+/-- Tail-recursive topology check from an explicit output position. -/
+def checkFrom : Nat → Program → Bool
+  | _, [] => true
+  | index, instruction :: tail =>
+      instruction.checkAt index && checkFrom (index + 1) tail
+
+/-- Check complete SSA topology. -/
+def check (program : Program) : Bool :=
+  checkFrom 0 program
+
+/-- Validate every literal reference in a complete program. -/
+def refsOk (table : List RationalTable.RawRat) : Program → Bool
+  | [] => true
+  | instruction :: tail =>
+      instruction.refsOk table && refsOk table tail
+
+/-- Exact endpoint-table lookup work for every literal in a program. -/
+def lookupCost? (tableCount : Nat) : Program → Option Nat
+  | [] => some 0
+  | instruction :: tail => do
+      let headCost ← instruction.lookupCost? tableCount
+      let tailCost ← lookupCost? tableCount tail
+      pure (headCost + tailCost)
+
+end Program
+
+/-- One node and its table-indexed interval range. -/
+structure Row where
+  node : NodeId .real
+  range : Range
+  deriving DecidableEq, Repr
+
+namespace Row
+
+/-- Validate every endpoint reference in a row. -/
+def refsOk (table : List RationalTable.RawRat) (row : Row) : Bool :=
+  row.range.refsOk table
+
+/-- Exact endpoint-table lookup work for one row. -/
+def lookupCost? (tableCount : Nat) (row : Row) : Option Nat :=
+  row.range.lookupCost? tableCount
+
+/-- Singleton range for a rational literal reference. -/
+def lit (node : NodeId .real) (endpoint : EndpointId) : Row :=
+  ⟨node, Range.closed endpoint endpoint⟩
+
+end Row
+
+/-! ## Structural recipes and references -/
+
+namespace CenterShape
+
+/-- Check the centered recipe's complete expression shape while deliberately
+leaving the three literal values to a later arithmetic layer. -/
+def check (program : Program) (center : Center.Center) : Bool :=
+  program.node? center.x == some (.var 0) &&
+    (match program.node? center.one with | some (.lit _) => true | _ => false) &&
+    program.node? center.gap == some (.sub center.one center.x) &&
+    program.node? center.prod == some (.mul center.x center.gap) &&
+    (match program.node? center.half with | some (.lit _) => true | _ => false) &&
+    program.node? center.shift == some (.sub center.x center.half) &&
+    program.node? center.square == some (.sq center.shift) &&
+    (match program.node? center.quarter with | some (.lit _) => true | _ => false) &&
+    program.node? center.form == some (.sub center.quarter center.square) &&
+    center.boundary && center.generation == center.inferredGeneration
+
+end CenterShape
+
+namespace EqEdge
+
+/-- Check one equality edge's selected structural recipe and endpoints. -/
+def check (program : Program) (expectedBaseSize maxGeneration : Nat)
+    (edge : Center.EqEdge) : Bool :=
+  match edge.recipe with
+  | .centerV1 center =>
+      center.baseSize == expectedBaseSize && center.generation ≤ maxGeneration &&
+        CenterShape.check program center && edge.left == center.prod &&
+        edge.right == center.form
+
+end EqEdge
+
+/-- A table-indexed row paired with the existing derivation reference language. -/
+structure Fact where
+  row : Row
+  derivation : Center.Derivation
+  deriving DecidableEq
+
+namespace Fact
+
+/-- Lookup preserving original fact numbering in a newest-first accumulator. -/
+def prior? (priorCount : Nat) (priorRev : List Row) (index : Nat) : Option Row :=
+  if index < priorCount then priorRev[priorCount - (index + 1)]? else none
+
+/-- Lookup work charged for one structural derivation check. -/
+def lookupCost? (programCount sourceCount edgeCount priorCount : Nat)
+    (fact : Fact) : Option Nat :=
+  match fact.derivation with
+  | .source source => Center.Fact.forwardDistance? sourceCount source
+  | .lit => Center.Fact.forwardDistance? programCount fact.row.node.index
+  | .sub left right | .mul left right => do
+      let programCost ← Center.Fact.forwardDistance? programCount fact.row.node.index
+      let leftCost ← Center.Fact.reverseDistance? priorCount left
+      let rightCost ← Center.Fact.reverseDistance? priorCount right
+      pure (programCost + leftCost + rightCost)
+  | .sq input => do
+      let programCost ← Center.Fact.forwardDistance? programCount fact.row.node.index
+      let inputCost ← Center.Fact.reverseDistance? priorCount input
+      pure (programCost + inputCost)
+  | .transport edge input => do
+      let edgeCost ← Center.Fact.forwardDistance? edgeCount edge
+      let inputCost ← Center.Fact.reverseDistance? priorCount input
+      pure (edgeCost + inputCost)
+
+/-- Validate endpoint, node, source, edge, and prior-fact references without
+replaying interval arithmetic.  Literal rows must use the program literal's
+exact table entry as a closed singleton. -/
+def check (table : List RationalTable.RawRat) (program : Program)
+    (sources : List Row) (edges : List Center.EqEdge) (priorCount : Nat)
+    (priorRev : List Row) (fact : Fact) : Bool :=
+  fact.row.refsOk table &&
+    match fact.derivation with
+    | .source source => sources[source]? == some fact.row
+    | .lit =>
+        match program.node? fact.row.node with
+        | some (.lit endpoint) => fact.row == Row.lit fact.row.node endpoint
+        | _ => false
+    | .sub left right =>
+        match program.node? fact.row.node, prior? priorCount priorRev left,
+            prior? priorCount priorRev right with
+        | some (.sub leftNode rightNode), some leftRow, some rightRow =>
+            leftRow.node == leftNode && rightRow.node == rightNode
+        | _, _, _ => false
+    | .mul left right =>
+        match program.node? fact.row.node, prior? priorCount priorRev left,
+            prior? priorCount priorRev right with
+        | some (.mul leftNode rightNode), some leftRow, some rightRow =>
+            leftRow.node == leftNode && rightRow.node == rightNode
+        | _, _, _ => false
+    | .sq input =>
+        match program.node? fact.row.node, prior? priorCount priorRev input with
+        | some (.sq inputNode), some inputRow => inputRow.node == inputNode
+        | _, _ => false
+    | .transport edge input =>
+        match edges[edge]?, prior? priorCount priorRev input with
+        | some equality, some inputRow =>
+            inputRow.range == fact.row.range &&
+              ((inputRow.node == equality.left && fact.row.node == equality.right) ||
+                (inputRow.node == equality.right && fact.row.node == equality.left))
+        | _, _ => false
+
+end Fact
+
+/-- Validate a complete fact list while charging every indexed lookup. -/
+def checkFacts (table : List RationalTable.RawRat) (program : Program)
+    (sources : List Row) (edges : List Center.EqEdge)
+    (programCount sourceCount edgeCount : Nat) :
+    Nat → Nat → List Fact → List Row → Bool
+  | _, _, [], _ => true
+  | priorCount, remainingSteps, fact :: tail, priorRev =>
+      match Fact.lookupCost? programCount sourceCount edgeCount priorCount fact with
+      | none => false
+      | some cost =>
+          if cost ≤ remainingSteps then
+            fact.check table program sources edges priorCount priorRev &&
+              checkFacts table program sources edges programCount sourceCount edgeCount
+                (priorCount + 1) (remainingSteps - cost) tail (fact.row :: priorRev)
+          else
+            false
+
+/-! ## Complete certificate boundary -/
+
+/-- Exact endpoint-table lookup work for a row collection. -/
+def rowsLookupCost? (tableCount : Nat) : List Row → Option Nat
+  | [] => some 0
+  | row :: tail => do
+      let headCost ← row.lookupCost? tableCount
+      let tailCost ← rowsLookupCost? tableCount tail
+      pure (headCost + tailCost)
+
+/-- Exact endpoint-table lookup work for every fact row. -/
+def factsLookupCost? (tableCount : Nat) : List Fact → Option Nat
+  | [] => some 0
+  | fact :: tail => do
+      let headCost ← fact.row.lookupCost? tableCount
+      let tailCost ← factsLookupCost? tableCount tail
+      pure (headCost + tailCost)
+
+/-- Caller-owned budget for forward traversals of the rational endpoint table.
+It is separate from structural derivation lookup work so backend-independent
+structural limits remain comparable. -/
+structure ReferenceLimit where
+  maxEndpointLookupSteps : Nat
+  deriving DecidableEq, Repr
+
+/-- Complete rational endpoint certificate.  The table and all indexed syntax
+are untrusted; invocation sources, target, base size, and limits remain caller
+owned arguments to the checker. -/
+structure Certificate where
+  table : List RationalTable.RawRat
+  program : Program
+  center : Center.Center
+  edges : List Center.EqEdge
+  facts : List Fact
+  result : Nat
+  deriving DecidableEq
+
+namespace Certificate
+
+/-- Bounded structural preflight before table or indexed traversal. -/
+def structureOk (certificate : Certificate) (limit : Center.StructureLimit)
+    (expectedBaseSize : Nat) (expectedSources : List Row) : Bool :=
+  certificate.center.generation ≤ limit.maxGeneration &&
+    expectedBaseSize ≤ limit.maxNodes && certificate.result < limit.maxFacts &&
+    Center.lengthWithin limit.maxNodes certificate.program &&
+    Center.lengthWithin limit.maxSources expectedSources &&
+    Center.lengthWithin limit.maxEdges certificate.edges &&
+    Center.lengthWithin limit.maxFacts certificate.facts
+
+/-- Exact forward-list work for every endpoint-table lookup the boundary will
+perform.  Returning `none` rejects an out-of-range reference before any table
+lookup is attempted. -/
+def endpointLookupCost? (certificate : Certificate) (expectedSources : List Row)
+    (expectedTarget : Row) : Option Nat := do
+  let tableCount := certificate.table.length
+  let programCost ← certificate.program.lookupCost? tableCount
+  let sourceCost ← rowsLookupCost? tableCount expectedSources
+  let targetCost ← expectedTarget.lookupCost? tableCount
+  let factCost ← factsLookupCost? tableCount certificate.facts
+  pure (programCost + sourceCost + targetCost + factCost)
+
+/-- Check the complete table-indexed certificate boundary.  A successful
+result establishes table canonicality and all structural references, but no
+arithmetic equality or interval propagation claim. -/
+def check (certificate : Certificate) (tableLimit : RationalTable.RawRat.Limit)
+    (referenceLimit : ReferenceLimit) (structureLimit : Center.StructureLimit)
+    (expectedBaseSize : Nat) (expectedSources : List Row)
+    (expectedTarget : Row) : Bool :=
+  certificate.structureOk structureLimit expectedBaseSize expectedSources &&
+    match RationalTable.Table.check tableLimit certificate.table with
+    | .ready =>
+        match certificate.endpointLookupCost? expectedSources expectedTarget with
+        | none => false
+        | some endpointCost =>
+            if endpointCost ≤ referenceLimit.maxEndpointLookupSteps then
+              certificate.program.refsOk certificate.table &&
+                certificate.program.check &&
+                certificate.center.baseSize == expectedBaseSize &&
+                CenterShape.check certificate.program certificate.center &&
+                (expectedSources.all fun source =>
+                  source.refsOk certificate.table &&
+                    (certificate.program.node? source.node).isSome) &&
+                expectedTarget.refsOk certificate.table &&
+                (certificate.program.node? expectedTarget.node).isSome &&
+                Center.EqEdge.containsCenter certificate.edges certificate.center &&
+                certificate.edges.all
+                  (EqEdge.check certificate.program expectedBaseSize
+                    structureLimit.maxGeneration) &&
+                match Center.Fact.forwardDistance? certificate.facts.length
+                    certificate.result with
+                | none => false
+                | some resultCost =>
+                    if resultCost ≤ structureLimit.maxLookupSteps then
+                      checkFacts certificate.table certificate.program expectedSources
+                          certificate.edges certificate.program.length
+                          expectedSources.length certificate.edges.length 0
+                          (structureLimit.maxLookupSteps - resultCost)
+                          certificate.facts [] &&
+                        certificate.facts[certificate.result]?.map
+                            (fun fact => fact.row) == some expectedTarget
+                    else
+                      false
+            else
+              false
+    | .malformed _ _ | .resourceLimit _ _ => false
+
+/-- Success implies that the complete raw table passed validation. -/
+theorem table_ready_of_check {certificate : Certificate}
+    {tableLimit : RationalTable.RawRat.Limit}
+    {referenceLimit : ReferenceLimit} {structureLimit : Center.StructureLimit}
+    {expectedBaseSize : Nat} {expectedSources : List Row} {expectedTarget : Row}
+    (h : certificate.check tableLimit referenceLimit structureLimit
+      expectedBaseSize expectedSources expectedTarget = true) :
+    RationalTable.Table.check tableLimit certificate.table = .ready := by
+  unfold check at h
+  cases htable : RationalTable.Table.check tableLimit certificate.table with
+  | ready => rfl
+  | malformed index reason => simp [htable] at h
+  | resourceLimit index reason => simp [htable] at h
+
+/-- Every entry of an accepted certificate table is canonical. -/
+theorem table_canonical {certificate : Certificate}
+    {tableLimit : RationalTable.RawRat.Limit}
+    {referenceLimit : ReferenceLimit} {structureLimit : Center.StructureLimit}
+    {expectedBaseSize : Nat} {expectedSources : List Row} {expectedTarget : Row}
+    (h : certificate.check tableLimit referenceLimit structureLimit
+      expectedBaseSize expectedSources expectedTarget = true) :
+    ∀ q ∈ certificate.table, q.Canonical :=
+  RationalTable.Table.canonical_of_check (table_ready_of_check h)
+
+end Certificate
+
+/-! ## Endpoint-erased projection -/
+
+/-- Erase one rational program instruction.  A literal retains its program
+position as the backend-independent literal slot. -/
+def eraseOp (index : Nat) : Prim → RationalTable.Shape.Op
+  | .var source => .var source
+  | .lit _ => .lit index
+  | .sub left right => .sub left right
+  | .mul left right => .mul left right
+  | .sq input => .sq input
+
+/-- Erase a complete rational program from an explicit position. -/
+def eraseProgramFrom : Nat → Program → List RationalTable.Shape.Op
+  | _, [] => []
+  | index, instruction :: tail =>
+      eraseOp index instruction :: eraseProgramFrom (index + 1) tail
+
+/-- Endpoint-erased rational program. -/
+def eraseProgram (program : Program) : List RationalTable.Shape.Op :=
+  eraseProgramFrom 0 program
+
+/-- Erase a lower cut's table reference while retaining strictness. -/
+def eraseLower : Lower → RationalTable.Shape.Lower
+  | .unbounded => .unbounded
+  | .finite _ strict => .finite strict
+
+/-- Erase an upper cut's table reference while retaining strictness. -/
+def eraseUpper : Upper → RationalTable.Shape.Upper
+  | .finite _ strict => .finite strict
+  | .unbounded => .unbounded
+
+/-- Erase table references while retaining every interval shape. -/
+def eraseRange : Range → RationalTable.Shape.Range
+  | .empty => .empty
+  | .bounds lower upper => .bounds (eraseLower lower) (eraseUpper upper)
+
+/-- Erase one rational row. -/
+def eraseRow (row : Row) : RationalTable.Shape.Row :=
+  ⟨row.node, eraseRange row.range⟩
+
+/-- Erase one rational fact without changing its derivation references. -/
+def eraseFact (fact : Fact) : RationalTable.Shape.Fact :=
+  ⟨eraseRow fact.row, fact.derivation⟩
+
+/-- Backend-independent certificate skeleton. -/
+def eraseCertificate (certificate : Certificate) (baseSize : Nat)
+    (sources : List Row) (target : Row) (limit : Center.StructureLimit) :
+    RationalTable.Shape.Skeleton :=
+  { program := eraseProgram certificate.program
+    center := certificate.center
+    edges := certificate.edges
+    facts := certificate.facts.map eraseFact
+    result := certificate.result
+    baseSize
+    sources := sources.map eraseRow
+    target := eraseRow target
+    limit }
+
+/-- Rational projection retains its caller-owned table and endpoint-reference
+limits alongside the backend-independent skeleton. -/
+structure Projection where
+  skeleton : RationalTable.Shape.Skeleton
+  tableLimit : RationalTable.RawRat.Limit
+  referenceLimit : ReferenceLimit
+  deriving DecidableEq
+
+/-- Project a rational certificate and its complete caller-owned boundary. -/
+def projectCertificate (certificate : Certificate)
+    (tableLimit : RationalTable.RawRat.Limit) (referenceLimit : ReferenceLimit)
+    (baseSize : Nat) (sources : List Row) (target : Row)
+    (structureLimit : Center.StructureLimit) : Projection :=
+  { skeleton := eraseCertificate certificate baseSize sources target structureLimit
+    tableLimit
+    referenceLimit }
+
+/-! ## Fixed rational rendering of the centered fixture -/
+
+def endpoint (index : Nat) : EndpointId := ⟨index⟩
+
+def zero : EndpointId := endpoint 0
+def one : EndpointId := endpoint 1
+def half : EndpointId := endpoint 2
+def negHalf : EndpointId := endpoint 3
+def quarter : EndpointId := endpoint 4
+
+/-- Canonical values used by the rational centered fixture. -/
+def fixtureTable : List RationalTable.RawRat :=
+  [⟨0, 1⟩, ⟨1, 1⟩, ⟨1, 2⟩, ⟨-1, 2⟩, ⟨1, 4⟩]
+
+/-- Rational-table rendering of the four-node source program. -/
+def baseProgram : Program :=
+  [.var 0, .lit one, .sub (Center.node 1) (Center.node 0),
+    .mul (Center.node 0) (Center.node 2)]
+
+/-- Rational-table rendering of the complete nine-node program. -/
+def extendedProgram : Program :=
+  baseProgram ++
+    [.lit half, .sub (Center.node 0) (Center.node 4), .sq (Center.node 5),
+      .lit quarter, .sub (Center.node 7) (Center.node 6)]
+
+def unitRange : Range := Range.closed zero one
+def centeredRange : Range := Range.closed negHalf half
+def quarterRange : Range := Range.closed zero quarter
+
+/-- Rational-table rendering of all ten centered fixture facts. -/
+def fixtureFacts : List Fact :=
+  [ ⟨⟨Center.node 0, unitRange⟩, .source 0⟩
+  , ⟨Row.lit (Center.node 1) one, .lit⟩
+  , ⟨⟨Center.node 2, unitRange⟩, .sub 1 0⟩
+  , ⟨⟨Center.node 3, unitRange⟩, .mul 0 2⟩
+  , ⟨Row.lit (Center.node 4) half, .lit⟩
+  , ⟨⟨Center.node 5, centeredRange⟩, .sub 0 4⟩
+  , ⟨⟨Center.node 6, quarterRange⟩, .sq 5⟩
+  , ⟨Row.lit (Center.node 7) quarter, .lit⟩
+  , ⟨⟨Center.node 8, quarterRange⟩, .sub 7 6⟩
+  , ⟨⟨Center.node 3, quarterRange⟩, .transport 0 8⟩ ]
+
+/-- Complete table-indexed centered certificate. -/
+def fixtureCert : Certificate :=
+  { table := fixtureTable
+    program := extendedProgram
+    center := Center.centerWitness
+    edges := [Center.centerEdge]
+    facts := fixtureFacts
+    result := 9 }
+
+/-- Caller-owned rational source rows. -/
+def fixtureSources : List Row :=
+  [⟨Center.node 0, unitRange⟩]
+
+/-- Caller-owned rational target row. -/
+def fixtureTarget : Row :=
+  ⟨Center.node 3, quarterRange⟩
+
+/-- Caller-owned table limit for the fixed rational certificate. -/
+def fixtureTableLimit : RationalTable.RawRat.Limit :=
+  RationalTable.fixtureTableLimit
+
+/-- Exact caller-owned budget for all endpoint-table traversals in the fixed
+rational certificate boundary. -/
+def fixtureReferenceLimit : ReferenceLimit :=
+  { maxEndpointLookupSteps := 73 }
+
+/-- Structural boundary shared exactly with the centered dyadic fixture. -/
+def fixtureStructureLimit : Center.StructureLimit :=
+  Center.fixtureStructureLimit
+
+/-- Transparent checker canary for the complete rational boundary. -/
+def checkFixture : Bool :=
+  fixtureCert.check fixtureTableLimit fixtureReferenceLimit fixtureStructureLimit
+    baseProgram.length fixtureSources fixtureTarget
+
+theorem checkFixture_eq_true : checkFixture = true := by
+  decide +kernel
+
+/-- Complete rational projection of the fixed certificate. -/
+def fixtureProjection : Projection :=
+  projectCertificate fixtureCert fixtureTableLimit fixtureReferenceLimit
+    baseProgram.length fixtureSources fixtureTarget fixtureStructureLimit
+
+/-- The table-indexed rational and dyadic certificates have exactly the same
+backend-independent structure. -/
+def checksProjection : Bool :=
+  fixtureProjection.skeleton == RationalTable.fixtureSkeleton &&
+    fixtureProjection.skeleton == RationalTable.expectedSkeleton &&
+    fixtureProjection.tableLimit == fixtureTableLimit &&
+    fixtureProjection.referenceLimit == fixtureReferenceLimit
+
+theorem checksProjection_eq_true : checksProjection = true := by
+  decide +kernel
+
+/-- The fixture's endpoint-reference budget is exact and one step short is
+rejected before any endpoint-table traversal. -/
+def checksReferenceBudget : Bool :=
+  fixtureCert.endpointLookupCost? fixtureSources fixtureTarget == some 73 &&
+    checkFixture &&
+    !fixtureCert.check fixtureTableLimit
+      { fixtureReferenceLimit with maxEndpointLookupSteps := 72 }
+      fixtureStructureLimit baseProgram.length fixtureSources fixtureTarget
+
+theorem checksReferenceBudget_eq_true : checksReferenceBudget = true := by
+  decide +kernel
+
+/-- Boundary canaries for invalid indices and an invalid unused table entry. -/
+def rejectsBadBoundary : Bool :=
+  let missing := endpoint fixtureTable.length
+  let roomy : RationalTable.RawRat.Limit :=
+    { fixtureTableLimit with maxEntries := fixtureTableLimit.maxEntries + 1 }
+  !({ fixtureCert with program :=
+        [Prim.var 0, Prim.lit missing] ++ fixtureCert.program.drop 2 }).check
+      fixtureTableLimit fixtureReferenceLimit fixtureStructureLimit
+      baseProgram.length fixtureSources fixtureTarget &&
+    !({ fixtureCert with facts :=
+        (⟨⟨Center.node 0, Range.closed zero missing⟩, .source 0⟩ : Fact) ::
+          fixtureFacts.drop 1 }).check fixtureTableLimit fixtureReferenceLimit
+      fixtureStructureLimit baseProgram.length fixtureSources fixtureTarget &&
+    !({ fixtureCert with table :=
+        fixtureTable ++ [RationalTable.RawRat.mk 0 7] }).check roomy
+      fixtureReferenceLimit fixtureStructureLimit baseProgram.length fixtureSources
+      fixtureTarget
+
+theorem rejectsBadBoundary_eq_true : rejectsBadBoundary = true := by
+  decide +kernel
+
+end Hex.Interval.Experiment.RationalCertificate

--- a/HexInterval/Experiment/RationalTable.lean
+++ b/HexInterval/Experiment/RationalTable.lean
@@ -1,0 +1,442 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Experiment.Scale
+
+@[expose] public section
+
+/-!
+# Endpoint-erased traces and canonical rational tables
+
+This module starts the Mathlib-free rational endpoint vertical without adding
+rational arithmetic to the planner or fixing a wire format.  It has two
+separate responsibilities:
+
+* erase every numeric endpoint from a centered certificate while retaining its
+  operation and literal slots, cut shapes, derivation references, equality
+  recipe, caller-owned boundary, and structural budget;
+* validate a complete table of raw integer/natural rational encodings before
+  a later arithmetic replay may inspect them.
+
+The table is untrusted.  Its caller owns all limits, every entry is checked
+even when no retained fact references it, and a rejected entry is never
+silently normalized.  Compiled Core `Rat` planning and arithmetic-edge replay
+are later phases and deliberately do not occur in this module.
+-/
+
+namespace Hex.Interval.Experiment.RationalTable
+
+open Center Scale
+
+/-! ## Endpoint-erased centered skeleton -/
+
+namespace Shape
+
+/-- Endpoint-free operation at one SSA position.  A literal retains its node
+index as a stable slot but not its numeric value. -/
+inductive Op where
+  | var (source : Nat)
+  | lit (slot : Nat)
+  | sub (left right : NodeId .real)
+  | mul (left right : NodeId .real)
+  | sq (input : NodeId .real)
+  deriving DecidableEq, Repr
+
+/-- Shape of a lower cut after erasing its finite endpoint. -/
+inductive Lower where
+  | unbounded
+  | finite (strict : Bool)
+  deriving DecidableEq, Repr
+
+/-- Shape of an upper cut after erasing its finite endpoint. -/
+inductive Upper where
+  | finite (strict : Bool)
+  | unbounded
+  deriving DecidableEq, Repr
+
+/-- Empty/bounded and open/closed structure of a range, without endpoints. -/
+inductive Range where
+  | empty
+  | bounds (lower : Lower) (upper : Upper)
+  deriving DecidableEq, Repr
+
+/-- Endpoint-free row shape. -/
+structure Row where
+  node : NodeId .real
+  range : Range
+  deriving DecidableEq, Repr
+
+/-- Endpoint-free fact shape.  The derivation already contains only structural
+references, so it is retained exactly. -/
+structure Fact where
+  row : Row
+  derivation : Center.Derivation
+  deriving DecidableEq
+
+/-- Complete structural boundary for one centered checker invocation.  Sources,
+target, base size, and limits are caller-owned even though the untrusted
+certificate supplies the other fields. -/
+structure Skeleton where
+  program : List Op
+  center : Center.Center
+  edges : List Center.EqEdge
+  facts : List Fact
+  result : Nat
+  baseSize : Nat
+  sources : List Row
+  target : Row
+  limit : Center.StructureLimit
+  deriving DecidableEq
+
+end Shape
+
+/-- Erase one program node while retaining the node index as its literal slot. -/
+def eraseOp (index : Nat) : Center.Prim .real → Shape.Op
+  | .var source => .var source
+  | .lit _ => .lit index
+  | .sub left right => .sub left right
+  | .mul left right => .mul left right
+  | .sq input => .sq input
+
+/-- Erase a complete SSA program, assigning every literal its program index. -/
+def eraseProgramFrom : Nat → Center.Program → List Shape.Op
+  | _, [] => []
+  | index, instruction :: tail =>
+      eraseOp index instruction :: eraseProgramFrom (index + 1) tail
+
+/-- Endpoint-erased program projection. -/
+def eraseProgram (program : Center.Program) : List Shape.Op :=
+  eraseProgramFrom 0 program
+
+/-- Erase a lower cut's numeric endpoint. -/
+def eraseLower : Hex.Interval.Lower → Shape.Lower
+  | .unbounded => .unbounded
+  | .finite _ strict => .finite strict
+
+/-- Erase an upper cut's numeric endpoint. -/
+def eraseUpper : Hex.Interval.Upper → Shape.Upper
+  | .finite _ strict => .finite strict
+  | .unbounded => .unbounded
+
+/-- Erase numeric endpoints while retaining empty, bounded, and closure shape. -/
+def eraseRange : Hex.Interval.Raw → Shape.Range
+  | .empty => .empty
+  | .bounds lower upper => .bounds (eraseLower lower) (eraseUpper upper)
+
+/-- Erase one interval row. -/
+def eraseRow (row : Center.Row) : Shape.Row :=
+  ⟨row.node, eraseRange row.range⟩
+
+/-- Erase one fact without changing its derivation references. -/
+def eraseFact (fact : Center.Fact) : Shape.Fact :=
+  ⟨eraseRow fact.row, fact.derivation⟩
+
+/-- Project a centered certificate together with its caller-owned invocation
+boundary to an endpoint-free skeleton. -/
+def eraseCertificate (certificate : Center.Certificate) (baseSize : Nat)
+    (sources : List Center.Row) (target : Center.Row)
+    (limit : Center.StructureLimit) : Shape.Skeleton :=
+  { program := eraseProgram certificate.program
+    center := certificate.center
+    edges := certificate.edges
+    facts := certificate.facts.map eraseFact
+    result := certificate.result
+    baseSize
+    sources := sources.map eraseRow
+    target := eraseRow target
+    limit }
+
+/-- Project one generated scaling workload using the same fixed caller-owned
+source and target as the centered fixture. -/
+def eraseWorkload (workload : Scale.Workload) : Shape.Skeleton :=
+  eraseCertificate workload.certificate Center.baseProgram.length
+    Center.fixtureSources Center.fixtureTarget
+    (workload.limitAt workload.lookupSteps)
+
+/-- Endpoint-free skeleton of the fixed centered certificate. -/
+def fixtureSkeleton : Shape.Skeleton :=
+  eraseCertificate Center.fixtureCert Center.baseProgram.length
+    Center.fixtureSources Center.fixtureTarget Center.fixtureStructureLimit
+
+/-- Explicit expected operation sequence for the nine-node centered program. -/
+def fixtureOps : List Shape.Op :=
+  [ .var 0
+  , .lit 1
+  , .sub (Center.node 1) (Center.node 0)
+  , .mul (Center.node 0) (Center.node 2)
+  , .lit 4
+  , .sub (Center.node 0) (Center.node 4)
+  , .sq (Center.node 5)
+  , .lit 7
+  , .sub (Center.node 7) (Center.node 6) ]
+
+/-- Closed finite range shape shared by every fixed fixture row. -/
+def closedShape : Shape.Range :=
+  .bounds (.finite false) (.finite false)
+
+/-- Explicit expected endpoint-free fact sequence for the fixed trace. -/
+def fixtureShapes : List Shape.Fact :=
+  [ ⟨⟨Center.node 0, closedShape⟩, .source 0⟩
+  , ⟨⟨Center.node 1, closedShape⟩, .lit⟩
+  , ⟨⟨Center.node 2, closedShape⟩, .sub 1 0⟩
+  , ⟨⟨Center.node 3, closedShape⟩, .mul 0 2⟩
+  , ⟨⟨Center.node 4, closedShape⟩, .lit⟩
+  , ⟨⟨Center.node 5, closedShape⟩, .sub 0 4⟩
+  , ⟨⟨Center.node 6, closedShape⟩, .sq 5⟩
+  , ⟨⟨Center.node 7, closedShape⟩, .lit⟩
+  , ⟨⟨Center.node 8, closedShape⟩, .sub 7 6⟩
+  , ⟨⟨Center.node 3, closedShape⟩, .transport 0 8⟩ ]
+
+/-- Independently written expected skeleton for the centered fixture. -/
+def expectedSkeleton : Shape.Skeleton :=
+  { program := fixtureOps
+    center := Center.centerWitness
+    edges := [Center.centerEdge]
+    facts := fixtureShapes
+    result := 9
+    baseSize := 4
+    sources := [⟨Center.node 0, closedShape⟩]
+    target := ⟨Center.node 3, closedShape⟩
+    limit := Center.fixtureStructureLimit }
+
+/-- Change every numeric program literal and row endpoint while retaining the
+same structural slots and cut shapes.  This is intentionally not a valid
+arithmetic certificate; it tests only the erasure boundary. -/
+def endpointChanged : Center.Certificate :=
+  { Center.fixtureCert with
+    program :=
+      [ .var 0, .lit 7, .sub (Center.node 1) (Center.node 0),
+        .mul (Center.node 0) (Center.node 2), .lit (-3),
+        .sub (Center.node 0) (Center.node 4), .sq (Center.node 5), .lit 11,
+        .sub (Center.node 7) (Center.node 6) ]
+    facts := Center.fixtureFacts.map fun fact =>
+      { fact with row := { fact.row with range := Center.closed (-5) 13 } } }
+
+/-- Sources corresponding only in shape to `endpointChanged`. -/
+def endpointChangedSources : List Center.Row :=
+  [⟨Center.node 0, Center.closed (-5) 13⟩]
+
+/-- Target corresponding only in shape to `endpointChanged`. -/
+def endpointChangedTarget : Center.Row :=
+  ⟨Center.node 3, Center.closed (-5) 13⟩
+
+/-- The projection agrees with an independent literal/fact skeleton, every
+base scaling family has that exact skeleton, and changing only endpoints does
+not change it. -/
+def checksErasure : Bool :=
+  fixtureSkeleton == expectedSkeleton &&
+    (Scale.deadNodes? 9).map eraseWorkload == some expectedSkeleton &&
+    (Scale.adjacent? 1).map eraseWorkload == some expectedSkeleton &&
+    (Scale.far? 1).map eraseWorkload == some expectedSkeleton &&
+    eraseWorkload (Scale.sourcePad 0) == expectedSkeleton &&
+    eraseCertificate endpointChanged Center.baseProgram.length
+      endpointChangedSources endpointChangedTarget Center.fixtureStructureLimit ==
+        expectedSkeleton &&
+    eraseCertificate { Center.fixtureCert with result := 8 }
+      Center.baseProgram.length Center.fixtureSources Center.fixtureTarget
+      Center.fixtureStructureLimit != expectedSkeleton
+
+/-- Ordinary-kernel canary for the endpoint erasure boundary. -/
+theorem checksErasure_eq_true : checksErasure = true := by
+  decide +kernel
+
+/-! ## Canonical raw rational table -/
+
+/-- Untrusted raw rational endpoint.  A natural nonzero denominator is
+positive; table validation additionally requires reduced form. -/
+structure RawRat where
+  num : Int
+  den : Nat
+  deriving DecidableEq, Repr
+
+namespace RawRat
+
+/-- Mathematical value of a raw endpoint.  This total interpretation is used
+only after validation; malformed zero denominators are rejected beforehand. -/
+def value (q : RawRat) : Rat :=
+  mkRat q.num q.den
+
+/-- Allocation-independent retained size of one raw endpoint. -/
+structure Cost where
+  numeratorBits : Nat
+  denominatorBits : Nat
+  deriving DecidableEq, Repr
+
+/-- Caller-owned limits for the first raw-table boundary.  Arithmetic temporary
+work and wire bytes belong to later phases and are not guessed here. -/
+structure Limit where
+  maxEntries : Nat
+  maxNumeratorBits : Nat
+  maxDenominatorBits : Nat
+  deriving DecidableEq, Repr
+
+/-- Semantic canonicality required of an admitted raw endpoint. -/
+def Canonical (q : RawRat) : Prop :=
+  q.den ≠ 0 ∧ q.num.natAbs.Coprime q.den
+
+/-- Inspect numerator and denominator bit lengths without multiplying them. -/
+def cost (q : RawRat) : Cost :=
+  { numeratorBits := EndpointCost.natBits q.num.natAbs
+    denominatorBits := EndpointCost.natBits q.den }
+
+/-- Logical malformed-entry reasons. -/
+inductive Invalid where
+  | zeroDenominator
+  | notReduced
+  deriving DecidableEq, Repr
+
+/-- Resource failures known before canonicality or arithmetic work. -/
+inductive Resource where
+  | entries
+  | numeratorBits
+  | denominatorBits
+  deriving DecidableEq, Repr
+
+/-- Result of validating one entry. -/
+inductive EntryResult where
+  | ready
+  | malformed (reason : Invalid)
+  | resourceLimit (reason : Resource)
+  deriving DecidableEq, Repr
+
+/-- Validate retained size first, then positivity and reduced form. -/
+def check (limit : Limit) (q : RawRat) : EntryResult :=
+  let size := q.cost
+  if size.numeratorBits > limit.maxNumeratorBits then
+    .resourceLimit .numeratorBits
+  else if size.denominatorBits > limit.maxDenominatorBits then
+    .resourceLimit .denominatorBits
+  else if q.den = 0 then
+    .malformed .zeroDenominator
+  else if q.num.natAbs.gcd q.den = 1 then
+    .ready
+  else
+    .malformed .notReduced
+
+/-- A ready entry has a positive, coprime denominator. -/
+theorem canonical_of_check {limit : Limit} {q : RawRat}
+    (h : q.check limit = .ready) : q.Canonical := by
+  unfold check at h
+  dsimp only at h
+  split at h <;> try contradiction
+  split at h <;> try contradiction
+  split at h <;> try contradiction
+  rename_i hden
+  split at h <;> try contradiction
+  rename_i hcop
+  exact ⟨hden, hcop⟩
+
+/-- A ready raw endpoint interprets to the same canonical numerator and
+denominator that were checked. -/
+theorem value_fields {limit : Limit} {q : RawRat}
+    (h : q.check limit = .ready) : q.value.num = q.num ∧ q.value.den = q.den := by
+  have hc := canonical_of_check h
+  have hvalue : q.value = Rat.mk' q.num q.den hc.1 hc.2 := by
+    exact (Rat.mk_eq_mkRat q.num q.den hc.1 hc.2).symm
+  rw [hvalue]
+  exact ⟨rfl, rfl⟩
+
+end RawRat
+
+namespace Table
+
+/-- Complete table-validation result with the first failing entry index.  A
+collection cap has no entry index because validation stops before traversal. -/
+inductive Result where
+  | ready
+  | malformed (index : Nat) (reason : RawRat.Invalid)
+  | resourceLimit (index : Option Nat) (reason : RawRat.Resource)
+  deriving DecidableEq, Repr
+
+/-- Validate every entry in order after bounded collection preflight. -/
+def checkFrom (limit : RawRat.Limit) : Nat → List RawRat → Result
+  | _, [] => .ready
+  | index, entry :: tail =>
+      match entry.check limit with
+      | .ready => checkFrom limit (index + 1) tail
+      | .malformed reason => .malformed index reason
+      | .resourceLimit reason => .resourceLimit (some index) reason
+
+/-- Validate an untrusted table under caller-owned entry and endpoint limits.
+The bounded length check precedes the whole-table scan. -/
+def check (limit : RawRat.Limit) (entries : List RawRat) : Result :=
+  if lengthWithin limit.maxEntries entries then
+    checkFrom limit 0 entries
+  else
+    .resourceLimit none .entries
+
+/-- A ready suffix scan contains only canonical raw endpoints. -/
+theorem canonical_of_checkFrom {limit : RawRat.Limit} {entries : List RawRat}
+    {index : Nat} (h : checkFrom limit index entries = .ready) :
+    ∀ q ∈ entries, q.Canonical := by
+  induction entries generalizing index with
+  | nil => simp
+  | cons head tail ih =>
+      simp only [checkFrom] at h
+      cases hhead : head.check limit with
+      | ready =>
+          simp only [hhead] at h
+          intro q hq
+          simp only [List.mem_cons] at hq
+          cases hq with
+          | inl hsame =>
+              subst q
+              exact RawRat.canonical_of_check hhead
+          | inr htail =>
+              exact ih h q htail
+      | malformed reason => simp [hhead] at h
+      | resourceLimit reason => simp [hhead] at h
+
+/-- A ready table contains only canonical raw endpoints. -/
+theorem canonical_of_check {limit : RawRat.Limit} {entries : List RawRat}
+    (h : check limit entries = .ready) : ∀ q ∈ entries, q.Canonical := by
+  unfold check at h
+  split at h
+  next _ => exact canonical_of_checkFrom h
+  next _ => contradiction
+
+end Table
+
+/-! ## Fixed rational-table canaries -/
+
+/-- Caller-owned limits for small canonical-table canaries. -/
+def fixtureTableLimit : RawRat.Limit :=
+  { maxEntries := 5
+    maxNumeratorBits := 8
+    maxDenominatorBits := 8 }
+
+/-- An accepted table including canonical zero, negative, and non-dyadic
+values. -/
+def fixtureTable : List RawRat :=
+  [⟨0, 1⟩, ⟨1, 2⟩, ⟨-1, 3⟩, ⟨2, 9⟩]
+
+/-- Whole-table acceptance and fail-closed malformed/resource behavior.  The
+last cases put the failure in an otherwise unused final entry. -/
+def checksTable : Bool :=
+  Table.check fixtureTableLimit fixtureTable == .ready &&
+    Table.check fixtureTableLimit [⟨0, 0⟩] ==
+      .malformed 0 .zeroDenominator &&
+    Table.check fixtureTableLimit [⟨0, 7⟩] ==
+      .malformed 0 .notReduced &&
+    Table.check fixtureTableLimit [⟨2, 6⟩] ==
+      .malformed 0 .notReduced &&
+    Table.check fixtureTableLimit (fixtureTable ++ [⟨0, 7⟩]) ==
+      .malformed 4 .notReduced &&
+    Table.check { fixtureTableLimit with maxEntries := 3 } fixtureTable ==
+      .resourceLimit none .entries &&
+    Table.check { fixtureTableLimit with maxNumeratorBits := 1 } [⟨4, 1⟩] ==
+      .resourceLimit (some 0) .numeratorBits &&
+    Table.check { fixtureTableLimit with maxDenominatorBits := 8 }
+      (fixtureTable ++ [⟨1, 256⟩]) ==
+        .resourceLimit (some 4) .denominatorBits
+
+/-- Ordinary-kernel canary for canonical whole-table validation. -/
+theorem checksTable_eq_true : checksTable = true := by
+  decide +kernel
+
+end Hex.Interval.Experiment.RationalTable

--- a/HexInterval/Experiment/RationalTable.lean
+++ b/HexInterval/Experiment/RationalTable.lean
@@ -37,8 +37,8 @@ open Center Scale
 
 namespace Shape
 
-/-- Endpoint-free operation at one SSA position.  A literal retains its node
-index as a stable slot but not its numeric value. -/
+/-- Endpoint-free operation at one SSA position.  A literal retains only its
+first-occurrence sharing slot, not its numeric value. -/
 inductive Op where
   | var (source : Nat)
   | lit (slot : Nat)
@@ -95,23 +95,31 @@ structure Skeleton where
 
 end Shape
 
-/-- Erase one program node while retaining the node index as its literal slot. -/
-def eraseOp (index : Nat) : Center.Prim .real → Shape.Op
-  | .var source => .var source
-  | .lit _ => .lit index
-  | .sub left right => .sub left right
-  | .mul left right => .mul left right
-  | .sq input => .sq input
+/-- First zero-based occurrence of a value in a list.  Keeping this helper
+transparent lets both endpoint backends use the same literal-sharing rule. -/
+def firstIndex? {α : Type} [DecidableEq α] (value : α) :
+    Nat → List α → Option Nat
+  | _, [] => none
+  | index, head :: tail =>
+      if value = head then some index else firstIndex? value (index + 1) tail
 
-/-- Erase a complete SSA program, assigning every literal its program index. -/
-def eraseProgramFrom : Nat → Center.Program → List Shape.Op
-  | _, [] => []
-  | index, instruction :: tail =>
-      eraseOp index instruction :: eraseProgramFrom (index + 1) tail
+/-- Erase a complete dyadic program while retaining the equality pattern of
+its literals.  The first distinct literal receives slot zero, the next unseen
+literal slot one, and later equal literals reuse the earlier slot. -/
+def eraseProgramFrom (seen : List Dyadic) : Center.Program → List Shape.Op
+  | [] => []
+  | .var source :: tail => .var source :: eraseProgramFrom seen tail
+  | .lit value :: tail =>
+      match firstIndex? value 0 seen with
+      | some slot => .lit slot :: eraseProgramFrom seen tail
+      | none => .lit seen.length :: eraseProgramFrom (seen ++ [value]) tail
+  | .sub left right :: tail => .sub left right :: eraseProgramFrom seen tail
+  | .mul left right :: tail => .mul left right :: eraseProgramFrom seen tail
+  | .sq input :: tail => .sq input :: eraseProgramFrom seen tail
 
 /-- Endpoint-erased program projection. -/
 def eraseProgram (program : Center.Program) : List Shape.Op :=
-  eraseProgramFrom 0 program
+  eraseProgramFrom [] program
 
 /-- Erase a lower cut's numeric endpoint. -/
 def eraseLower : Hex.Interval.Lower → Shape.Lower
@@ -166,13 +174,13 @@ def fixtureSkeleton : Shape.Skeleton :=
 /-- Explicit expected operation sequence for the nine-node centered program. -/
 def fixtureOps : List Shape.Op :=
   [ .var 0
-  , .lit 1
+  , .lit 0
   , .sub (Center.node 1) (Center.node 0)
   , .mul (Center.node 0) (Center.node 2)
-  , .lit 4
+  , .lit 1
   , .sub (Center.node 0) (Center.node 4)
   , .sq (Center.node 5)
-  , .lit 7
+  , .lit 2
   , .sub (Center.node 7) (Center.node 6) ]
 
 /-- Closed finite range shape shared by every fixed fixture row. -/
@@ -225,6 +233,16 @@ def endpointChangedSources : List Center.Row :=
 def endpointChangedTarget : Center.Row :=
   ⟨Center.node 3, Center.closed (-5) 13⟩
 
+/-- Reusing one literal in every literal position changes the sharing pattern
+even though it leaves the operation constructors in the same positions. -/
+def literalSharingChanged : Center.Certificate :=
+  { Center.fixtureCert with
+    program :=
+      [ .var 0, .lit 1, .sub (Center.node 1) (Center.node 0),
+        .mul (Center.node 0) (Center.node 2), .lit 1,
+        .sub (Center.node 0) (Center.node 4), .sq (Center.node 5), .lit 1,
+        .sub (Center.node 7) (Center.node 6) ] }
+
 /-- The projection agrees with an independent literal/fact skeleton, every
 base scaling family has that exact skeleton, and changing only endpoints does
 not change it. -/
@@ -236,6 +254,9 @@ def checksErasure : Bool :=
     eraseWorkload (Scale.sourcePad 0) == expectedSkeleton &&
     eraseCertificate endpointChanged Center.baseProgram.length
       endpointChangedSources endpointChangedTarget Center.fixtureStructureLimit ==
+        expectedSkeleton &&
+    eraseCertificate literalSharingChanged Center.baseProgram.length
+      Center.fixtureSources Center.fixtureTarget Center.fixtureStructureLimit !=
         expectedSkeleton &&
     eraseCertificate { Center.fixtureCert with result := 8 }
       Center.baseProgram.length Center.fixtureSources Center.fixtureTarget
@@ -431,6 +452,8 @@ def checksTable : Bool :=
       .resourceLimit none .entries &&
     Table.check { fixtureTableLimit with maxNumeratorBits := 1 } [⟨4, 1⟩] ==
       .resourceLimit (some 0) .numeratorBits &&
+    Table.check { fixtureTableLimit with maxNumeratorBits := 8 }
+      [⟨2, 6⟩, ⟨256, 1⟩] == .malformed 0 .notReduced &&
     Table.check { fixtureTableLimit with maxDenominatorBits := 8 }
       (fixtureTable ++ [⟨1, 256⟩]) ==
         .resourceLimit (some 4) .denominatorBits

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -289,6 +289,154 @@ measure compiled certificate production, interning, serialization, bounded
 decoding, table validation, and replay; they do not compare verifier-only work
 with end-to-end normalization as though the workloads were equal.
 
+The edge format is strategy-neutral. It stores an operation tag and table
+indices, not a normalization algorithm or cancellation witness. The first
+reference checker supports `add`, `sub`, `mul`, `inv`, `eq`, `le`, and `lt`;
+dyadic lower and upper projection are separate tags because their rounding
+claims differ. Let three validated canonical entries be
+`a = na / da`, `b = nb / db`, and `c = nc / dc`, with natural denominators
+coerced to integers. The transparent reference identities are:
+
+```text
+add: (na*db + nb*da)*dc = nc*(da*db)
+sub: (na*db - nb*da)*dc = nc*(da*db)
+mul: (na*nb)*dc         = nc*(da*db)
+inv: na = 0  -> nc = 0
+     na != 0 -> da*dc = nc*na
+eq:  na*db = nb*da
+le:  na*db <= nb*da
+lt:  na*db <  nb*da
+```
+
+Canonical whole-table validation is a precondition to every edge theorem. In
+particular, `nc = 0` in the inverse-zero arm uniquely denotes `0 / 1`; the edge
+does not need a second normalization convention. Soundness uses
+`Rat.mkRat_add_mkRat`, `Rat.add_def'`, `Rat.sub_def'`,
+`Rat.mkRat_mul_mkRat`, `Rat.mul_def'`, `Rat.inv_def`,
+`Rat.mkRat_eq_iff`, `Rat.eq_iff_mul_eq_mul`, `Rat.le_iff`, and `Rat.lt_iff` as
+appropriate. Core rational arithmetic is intentionally irreducible: closed
+`decide +kernel` probes reduce, but symbolic proofs rewrite through these
+equation lemmas rather than unfolding `Rat.add`, `Rat.sub`, `Rat.mul`, or
+`Rat.inv`. `Nat.gcd` is likewise treated through its theorem API and
+`Nat.gcd_def`, not by relying on an imported implementation body.
+
+This is already a complete Mathlib-free arithmetic substrate. Compiled Core
+`Rat` planning provides canonical arithmetic, gcd normalization,
+cross-cancellation, comparison, and dyadic projection. The engine does not
+import or depend on Grind for rational numeral closure; the existence of a
+Core Grind procedure is not part of the checker trust or performance model.
+
+#### Rational temporary-cost model
+
+The checker declares conservative bit bounds before it forms any integer
+cross-product. For a nonnegative bit count, define:
+
+```text
+M(x,y) = 0                 if x = 0 or y = 0
+         x+y               otherwise
+A(x,y) = y                 if x = 0
+         x                 if y = 0
+         max(x,y)+1        otherwise
+```
+
+`M` bounds multiplication and `A` bounds addition or subtraction; these are
+exact definitions of the declared resource model, not assertions that every
+result occupies the full bound. Write `N(n)` for the bit length of `|n|`,
+`D(d)` for the bit length of `d`, and abbreviate the input sizes by
+`NA`, `NB`, `NC`, `DA`, `DB`, and `DC`. The naive reference arm preflights the
+following complete temporary lists:
+
+```text
+add/sub:
+  x=M(NA,DB); y=M(NB,DA); n=A(x,y)
+  lhs=M(n,DC); d=M(DA,DB); rhs=M(NC,d)
+  [x,y,n,lhs,d,rhs]
+
+mul:
+  n=M(NA,NB); lhs=M(n,DC); d=M(DA,DB); rhs=M(NC,d)
+  [n,lhs,d,rhs]
+
+nonzero inv:
+  lhs=M(DA,DC); rhs=M(NC,NA)
+  [lhs,rhs]
+
+eq/le/lt:
+  lhs=M(NA,DB); rhs=M(NB,DA)
+  [lhs,rhs]
+```
+
+Every member must fit `maxTemporaryBits` before replay evaluates the
+corresponding expression. A separate deterministic work counter charges each
+multiplication, addition/subtraction, comparison, gcd, shift, and division.
+The initial policy may use conservative units such as
+`mulWork(x,y) = x*y`, `addWork(x,y) = max(x,y)+1`, and
+`compareWork(x,y) = max(x,y)`. It consumes one operation at a time by checking
+`cost <= remaining` and then subtracting; it never constructs an unchecked
+aggregate supplied by the certificate. These units are a stable policy and
+telemetry contract, not a claim about GMP or kernel wall time.
+
+Whole-table canonicality has its own `maxGcdInputBits` and `maxGcdWork` caps.
+Input-size and work preflight occur before calling `Nat.gcd` for every entry,
+including an unused tail. The first conservative gcd work unit may be the
+product of numerator and denominator bit lengths; alternative Euclidean-step
+models are benchmark candidates. Retained table bits, per-edge peak temporary
+bits, aggregate arithmetic work, and representation-level lookup work are
+distinct limits.
+
+Every table-index traversal is accounted for. The transparent `List` reference
+checker charges exact forward distance for literal and finite-cut indices in
+the program, sources, target, and every fact, as well as arithmetic-edge
+operands and outputs. A production table may instead provide validated random
+access with a correspondence theorem. Merely bounding the product of table
+entries and endpoint occurrences is acceptable only as an explicitly labelled
+reference experiment; it is not silent or the final production cost model.
+
+The checker may later add a cancellation-aware execution arm without changing
+the edge encoding. For addition, subtraction, and order it may divide by
+`gcd da db` before forming the two numerator products. For multiplication it
+may cancel `gcd |na| db` and `gcd |nb| da`, matching Core's cross-cancellation.
+The naive and cancellation-aware arms share the same semantic edge and are
+benchmarked on cancellation-friendly and hostile inputs. No strategy selector
+or gcd witness is frozen into the certificate unless evidence later shows that
+recomputing the choice is the wrong tradeoff.
+
+#### Rational validation order and failures
+
+Resource safety precedes logical arithmetic checking. The deterministic first
+implementation uses these phases:
+
+1. bound encoded collection lengths and integer byte lengths before bigint
+   decoding;
+2. bound table, edge, and skeleton counts;
+3. scan numerator and denominator bit lengths for the complete table;
+4. preflight complete-table gcd input and work budgets, then reject zero
+   denominators and noncoprime entries;
+5. validate the endpoint-erased skeleton, every table/program/source/fact/edge
+   index, and the representation lookup budget;
+6. preflight every edge's temporary bits, arithmetic work, projection shift,
+   and projected dyadic height without forming a cross-product or shift; and
+7. replay arithmetic and projection edges in order, reporting the first wrong
+   edge.
+
+Failures distinguish resource limits from malformed certificates. Resource
+reasons include collection entries, encoded bytes, numerator/denominator bits,
+gcd input/work, lookup steps, temporary bits, arithmetic work, projection
+shift, and dyadic height. Malformed reasons include skeleton mismatch, zero
+denominator, nonreduced entry, bad index, each wrong arithmetic/order edge, and
+wrong projection. The exact precedence among logical failures after resource
+safety remains an implementation choice, but it is deterministic and tested.
+
+For projection precision `p`, define `up = p.toNat` and
+`down = (-p).toNat`; at most one is nonzero. Before shifting, the checker
+bounds the shifted numerator by `N(na)+up` (or zero for a zero numerator), the
+shifted denominator by `D(da)+down`, the division work, and the output dyadic
+height. To avoid allocating even an oversized bound expression, additions use
+the guarded form `increment <= limit - base` after checking `base <= limit`.
+The lower projector follows Core `Rat.toDyadic`; the upper projector is the
+negation of the lower projection of `-a`. Soundness uses Core's one-sided
+`Rat.toRat_toDyadic_le` and `Rat.lt_toRat_toDyadic_add` theorems, with exact
+dyadic preservation checked separately.
+
 The immediate rational vertical first projects the centered certificate to the
 endpoint-erased structural skeleton below and requires exact skeleton equality
 for every Dyadic/rational comparison. Its phase boundary is:
@@ -1216,6 +1364,18 @@ typical, boundary, and adversarial inputs. In particular it includes:
   `0 / 1`, and rejection of zero denominators, noncoprime equivalent
   encodings, unused oversized entries, excessive projection shifts, and
   one-step-over-budget cross-products before allocation;
+- rational arithmetic edges for `1/3 + 1/6 = 1/2`,
+  `2/3 - 1/6 = 1/2`, `2/3 * 9/4 = 3/2`,
+  `(-2/3)⁻¹ = -3/2`, `0⁻¹ = 0`, signed equality and order, a wrong
+  output for every tag, and every missing operand/output index position;
+- exact-limit acceptance and one-step-over rejection for rational entry,
+  numerator-bit, denominator-bit, gcd-input, gcd-work, lookup, temporary-bit,
+  arithmetic-work, projection-shift, and dyadic-height limits; instrumented
+  canaries confirm that rejected preflight never reaches the prohibited
+  product, gcd, division, or shift;
+- dyadic projection of `1/3` and `-1/3` at precision four, exact preservation
+  of `1/2`, negative/coarse precisions, and the strictness distinction between
+  an exact and an outward-moved open or closed cut;
 - regularization idempotence, outward containment, moved closed cuts, and
   exact-grid open cuts;
 - a dependency worklist in which one fact wakes only the affected consumers;
@@ -1268,7 +1428,13 @@ The Mathlib-free benchmark target measures:
   interning, serialization, bounded decoding, table validation, and compiled
   replay; an external build-only probe measures ordinary-kernel replay of the
   same certificate, with dyadic-valued sources, `1 / 3`-valued sources, and a
-  denominator-height ladder.
+  denominator-height ladder;
+- naive and cancellation-aware rational replay on shared edge traces,
+  including coprime denominators, large shared denominator gcds,
+  multiplication with two large cross-gcds, zero numerators, deliberately
+  wrong late outputs, and one-step-short resource failures. The benchmark
+  records peak declared temporary bits, aggregate work units, gcd calls, and
+  compiled and ordinary-kernel time separately.
 
 The declared models follow the complexity section above. Scientific runs also
 record accepted actions, endpoint heights, live leaves, retained derivations,

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -383,48 +383,71 @@ models are benchmark candidates. Retained table bits, per-edge peak temporary
 bits, aggregate arithmetic work, and representation-level lookup work are
 distinct limits.
 
-Every table-index traversal is accounted for. The transparent `List` reference
-checker charges exact forward distance for literal and finite-cut indices in
-the program, sources, target, and every fact, as well as arithmetic-edge
-operands and outputs. A production table may instead provide validated random
-access with a correspondence theorem. Merely bounding the product of table
-entries and endpoint occurrences is acceptable only as an explicitly labelled
-reference experiment; it is not silent or the final production cost model.
+Every *endpoint-table* traversal is accounted for. The transparent `List`
+reference checker charges exact forward distance for literal and finite-cut
+indices in the program, sources, target, and every fact, as well as
+arithmetic-edge operands and outputs. Program-node lookups are a separate
+structural cost: the centered reference checker bounds them by the checked
+node/edge counts, and the scale experiment measures the exact recipe bound
+`9 * (maxEdges + 1) * maxNodes`. A production endpoint table may instead
+provide validated random access with a correspondence theorem. Merely bounding
+the product of table entries and endpoint occurrences is acceptable only as an
+explicitly labelled reference experiment; it is not silent or the final
+production cost model.
 
 The checker may later add a cancellation-aware execution arm without changing
 the edge encoding. For addition, subtraction, and order it may divide by
 `gcd da db` before forming the two numerator products. For multiplication it
 may cancel `gcd |na| db` and `gcd |nb| da`, matching Core's cross-cancellation.
-The naive and cancellation-aware arms share the same semantic edge and are
-benchmarked on cancellation-friendly and hostile inputs. No strategy selector
-or gcd witness is frozen into the certificate unless evidence later shows that
-recomputing the choice is the wrong tradeoff.
+More explicitly, if `da = g*da'` and `db = g*db'`, the reduced addition and
+subtraction identity is
+`(na*db' +/- nb*da')*dc = nc*(g*da'*db')`, while order compares
+`na*db'` with `nb*da'`. If `na = g1*na'`, `db = g1*db'`,
+`nb = g2*nb'`, and `da = g2*da'` after sign-insensitive cross-gcds, reduced
+multiplication checks `(na'*nb')*dc = nc*(da'*db')`. Each is the naive
+identity divided by a positive common factor, so both execution arms decide
+the same semantic edge. They are benchmarked on cancellation-friendly and
+hostile inputs. No strategy selector or gcd witness is frozen into the
+certificate unless evidence later shows that recomputing the choice is the
+wrong tradeoff.
 
 #### Rational validation order and failures
 
-Resource safety precedes logical arithmetic checking. The deterministic first
-implementation uses these phases:
+Allocation-causing work is preflighted before it is performed. Within a
+collection, validation is deterministic and sequential: a logical failure at
+an earlier size-bounded entry may therefore precede a resource failure at a
+later entry. The target pipeline uses these phases:
 
 1. bound encoded collection lengths and integer byte lengths before bigint
    decoding;
 2. bound table, edge, and skeleton counts;
-3. scan numerator and denominator bit lengths for the complete table;
-4. preflight complete-table gcd input and work budgets, then reject zero
-   denominators and noncoprime entries;
-5. validate the endpoint-erased skeleton, every table/program/source/fact/edge
+3. for each table entry in order, preflight numerator/denominator bits and gcd
+   input/work, then reject a zero denominator or noncoprime representation;
+4. validate the endpoint-erased skeleton, every table/program/source/fact/edge
    index, and the representation lookup budget;
-6. preflight every edge's temporary bits, arithmetic work, projection shift,
+5. preflight every edge's temporary bits, arithmetic work, projection shift,
    and projected dyadic height without forming a cross-product or shift; and
-7. replay arithmetic and projection edges in order, reporting the first wrong
+6. replay arithmetic and projection edges in order, reporting the first wrong
    edge.
+
+The current `RationalTable.Table.check` experiment implements the collection
+cap and the per-entry numerator/denominator/canonicality portion of phases 2
+and 3. It intentionally does not yet expose an independent encoded-byte or gcd
+work cap. `RationalCertificate.Certificate.check` adds canonical-table,
+endpoint-reference, caller-boundary, structural, and exact endpoint-lookup
+validation from phases 2 and 4. Arithmetic edges and projection implement the
+remaining preflight/replay pieces in separate experimental modules before
+they are composed. Thus declared limits below describe the composed target;
+they are not a claim that the first table module already exposes every field.
 
 Failures distinguish resource limits from malformed certificates. Resource
 reasons include collection entries, encoded bytes, numerator/denominator bits,
 gcd input/work, lookup steps, temporary bits, arithmetic work, projection
 shift, and dyadic height. Malformed reasons include skeleton mismatch, zero
 denominator, nonreduced entry, bad index, each wrong arithmetic/order edge, and
-wrong projection. The exact precedence among logical failures after resource
-safety remains an implementation choice, but it is deterministic and tested.
+wrong projection. Exact precedence is an implementation choice, but it is
+deterministic and tested; in particular, the reference table checker pins the
+earlier-entry logical / later-entry resource case.
 
 For projection precision `p`, define `up = p.toNat` and
 `down = (-p).toNat`; at most one is nonzero. Before shifting, the checker
@@ -722,13 +745,22 @@ resource proxy, and original-order `List` lookup remains a transparent
 reference checker rather than a production storage decision.
 
 The next general trace representation exposes an endpoint-erased structural
-skeleton. It records operation tags and operand references, literal slots,
+skeleton. It records operation tags and operand references, first-occurrence
+literal-sharing slots,
 trigger provenance and recomputed generations, proposal/deduplication keys,
 equality edges, derivation references, caller-bound source/target slots, and
 structural budgets, but not endpoint values. Endpoint backends may be compared
 only when their accepted certificates erase to the identical skeleton. This
 prevents Core rational normalization or dyadic projection cost from being
 misreported as scheduler or storage cost.
+
+The table-indexed rational boundary separately pins every caller source and
+target reference to an exact caller-owned raw value. The table remains
+untrusted certificate data, but changing it cannot reinterpret the goal or
+hypotheses: all finite boundary cuts must resolve to those exact values after
+whole-table canonicality succeeds. Endpoint erasure drops the values only for
+cross-backend structural comparison; the rational projection retains them
+alongside its backend-specific limits.
 
 Production experiments compare exact-index array, arena, and chunked layouts
 against the list reference in both compiled and ordinary-kernel replay. Every

--- a/conformance/HexInterval/RationalCertificateConformance.lean
+++ b/conformance/HexInterval/RationalCertificateConformance.lean
@@ -37,6 +37,8 @@ open Experiment.RationalCertificate
 #guard fixtureProjection.skeleton.target ==
   Experiment.RationalTable.expectedSkeleton.target
 #guard fixtureProjection.skeleton.limit == fixtureStructureLimit
+#guard fixtureProjection.sourceValues == [unitValueRange]
+#guard fixtureProjection.targetValue == quarterValueRange
 
 -- Erasure preserves every interval shape while discarding only table indices.
 #guard eraseRange .empty == Experiment.RationalTable.Shape.Range.empty
@@ -102,11 +104,11 @@ private def missingLiteralProgram : Program :=
 private def missingFact : Fact :=
   ⟨⟨Experiment.Center.node 0, Range.closed zero missing⟩, .source 0⟩
 
-private def missingSource : Row :=
-  ⟨Experiment.Center.node 0, Range.closed missing one⟩
+private def missingSource : ExpectedRow :=
+  ⟨⟨Experiment.Center.node 0, Range.closed missing one⟩, unitValueRange⟩
 
-private def missingTarget : Row :=
-  ⟨Experiment.Center.node 3, Range.closed zero missing⟩
+private def missingTarget : ExpectedRow :=
+  ⟨⟨Experiment.Center.node 3, Range.closed zero missing⟩, quarterValueRange⟩
 
 #guard !(endpoint 5).valid fixtureTable
 #guard !({ fixtureCert with program := missingLiteralProgram }).check fixtureTableLimit
@@ -132,18 +134,65 @@ private def badSourceFact : Fact :=
   fixtureReferenceLimit fixtureStructureLimit baseProgram.length fixtureSources
   fixtureTarget
 
--- Changing canonical table values alone preserves and passes this structural
--- layer.  Arithmetic recipe and propagation checks are intentionally later.
+private def wrongLiteralShape : Program :=
+  [Prim.var 0, Prim.var 0] ++ fixtureCert.program.drop 2
+
+private def wrongEdge : Experiment.Center.EqEdge :=
+  { Experiment.Center.centerEdge with left := Experiment.Center.node 8 }
+
+-- Every locally reimplemented structural rejection path has a rational-side
+-- canary, including the exact 74-step structural budget.
+#guard !({ fixtureCert with program := wrongLiteralShape }).check fixtureTableLimit
+  fixtureReferenceLimit fixtureStructureLimit baseProgram.length fixtureSources fixtureTarget
+#guard !({ fixtureCert with edges := [wrongEdge] }).check fixtureTableLimit
+  fixtureReferenceLimit fixtureStructureLimit baseProgram.length fixtureSources fixtureTarget
+#guard !({ fixtureCert with center :=
+    { Experiment.Center.centerWitness with generation := 0 } }).check
+  fixtureTableLimit fixtureReferenceLimit fixtureStructureLimit baseProgram.length
+  fixtureSources fixtureTarget
+#guard !({ fixtureCert with center :=
+    { Experiment.Center.centerWitness with generation := 2 } }).check
+  fixtureTableLimit fixtureReferenceLimit fixtureStructureLimit baseProgram.length
+  fixtureSources fixtureTarget
+#guard fixtureCert.check fixtureTableLimit fixtureReferenceLimit
+  { fixtureStructureLimit with maxLookupSteps := 74 } baseProgram.length
+  fixtureSources fixtureTarget
+#guard !fixtureCert.check fixtureTableLimit fixtureReferenceLimit
+  { fixtureStructureLimit with maxLookupSteps := 73 } baseProgram.length
+  fixtureSources fixtureTarget
+
+-- Changing canonical table values preserves the internal structural layer,
+-- but cannot change the caller-owned meaning of the invocation boundary.
 private def shapeOnlyTable : List Experiment.RationalTable.RawRat :=
   [⟨2, 1⟩, ⟨3, 1⟩, ⟨4, 1⟩, ⟨-5, 1⟩, ⟨6, 1⟩]
 
 private def shapeOnlyCert : Certificate :=
   { fixtureCert with table := shapeOnlyTable }
 
-#guard shapeOnlyCert.check fixtureTableLimit fixtureReferenceLimit
+private def shapeOnlySources : List ExpectedRow :=
+  [⟨⟨Experiment.Center.node 0, unitRange⟩, ValueRange.closed ⟨2, 1⟩ ⟨3, 1⟩⟩]
+
+private def shapeOnlyTarget : ExpectedRow :=
+  ⟨⟨Experiment.Center.node 3, quarterRange⟩, ValueRange.closed ⟨2, 1⟩ ⟨6, 1⟩⟩
+
+-- A certificate-chosen table cannot reinterpret the original caller boundary.
+#guard !shapeOnlyCert.check fixtureTableLimit fixtureReferenceLimit
   fixtureStructureLimit baseProgram.length fixtureSources fixtureTarget
-#guard (eraseCertificate shapeOnlyCert baseProgram.length fixtureSources fixtureTarget
+#guard shapeOnlyCert.check fixtureTableLimit fixtureReferenceLimit
+  fixtureStructureLimit baseProgram.length shapeOnlySources shapeOnlyTarget
+#guard (eraseCertificate shapeOnlyCert baseProgram.length shapeOnlySources shapeOnlyTarget
   fixtureStructureLimit) == fixtureProjection.skeleton
+
+-- Literal sharing is retained by endpoint erasure, not merely literal
+-- positions.  Reusing `one` for all three slots changes the skeleton.
+private def repeatedLiteralProgram : Program :=
+  [ .var 0, .lit one, .sub (Experiment.Center.node 1) (Experiment.Center.node 0),
+    .mul (Experiment.Center.node 0) (Experiment.Center.node 2), .lit one,
+    .sub (Experiment.Center.node 0) (Experiment.Center.node 4),
+    .sq (Experiment.Center.node 5), .lit one,
+    .sub (Experiment.Center.node 7) (Experiment.Center.node 6) ]
+
+#guard eraseProgram repeatedLiteralProgram != fixtureProjection.skeleton.program
 
 /-! ## Downstream kernel transparency -/
 
@@ -156,6 +205,10 @@ example : Experiment.RationalTable.Table.check fixtureTableLimit fixtureCert.tab
 
 example : ∀ q ∈ fixtureCert.table, q.Canonical := by
   exact Certificate.table_canonical checkFixture_eq_true
+
+example : fixtureSources.all (fun source => source.agrees fixtureCert.table) = true ∧
+    fixtureTarget.agrees fixtureCert.table = true := by
+  exact Certificate.boundary_agrees_of_check checkFixture_eq_true
 
 example : checksProjection = true := by
   decide +kernel

--- a/conformance/HexInterval/RationalCertificateConformance.lean
+++ b/conformance/HexInterval/RationalCertificateConformance.lean
@@ -1,0 +1,163 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexInterval.Experiment.RationalCertificate
+
+/-!
+Compiled conformance for the table-indexed rational certificate boundary.
+These checks exercise structural cross-backend identity, complete table
+validation, typed endpoint references, and downstream kernel transparency.
+-/
+
+namespace Hex.Interval.RationalCertificateConformance
+
+open Experiment.RationalCertificate
+
+/-! ## Cross-backend structural identity -/
+
+#guard checkFixture
+#guard checksProjection
+#guard fixtureProjection.skeleton == Experiment.RationalTable.fixtureSkeleton
+#guard fixtureProjection.skeleton == Experiment.RationalTable.expectedSkeleton
+#guard fixtureProjection.tableLimit == fixtureTableLimit
+#guard fixtureProjection.referenceLimit == fixtureReferenceLimit
+#guard fixtureProjection.skeleton.program ==
+  Experiment.RationalTable.expectedSkeleton.program
+#guard fixtureProjection.skeleton.center == Experiment.Center.centerWitness
+#guard fixtureProjection.skeleton.edges == [Experiment.Center.centerEdge]
+#guard fixtureProjection.skeleton.facts ==
+  Experiment.RationalTable.expectedSkeleton.facts
+#guard fixtureProjection.skeleton.result == 9
+#guard fixtureProjection.skeleton.baseSize == baseProgram.length
+#guard fixtureProjection.skeleton.sources ==
+  Experiment.RationalTable.expectedSkeleton.sources
+#guard fixtureProjection.skeleton.target ==
+  Experiment.RationalTable.expectedSkeleton.target
+#guard fixtureProjection.skeleton.limit == fixtureStructureLimit
+
+-- Erasure preserves every interval shape while discarding only table indices.
+#guard eraseRange .empty == Experiment.RationalTable.Shape.Range.empty
+#guard eraseRange (.bounds (.finite (endpoint 0) true) (.finite (endpoint 1) true)) ==
+  Experiment.RationalTable.Shape.Range.bounds (.finite true) (.finite true)
+#guard eraseRange (.bounds (.finite (endpoint 0) true) (.finite (endpoint 1) false)) ==
+  Experiment.RationalTable.Shape.Range.bounds (.finite true) (.finite false)
+#guard eraseRange (.bounds (.finite (endpoint 0) false) (.finite (endpoint 1) true)) ==
+  Experiment.RationalTable.Shape.Range.bounds (.finite false) (.finite true)
+#guard eraseRange (.bounds .unbounded (.finite (endpoint 1) false)) ==
+  Experiment.RationalTable.Shape.Range.bounds .unbounded (.finite false)
+#guard eraseRange (.bounds (.finite (endpoint 0) false) .unbounded) ==
+  Experiment.RationalTable.Shape.Range.bounds (.finite false) .unbounded
+#guard eraseRange (.bounds .unbounded .unbounded) ==
+  Experiment.RationalTable.Shape.Range.bounds .unbounded .unbounded
+
+-- Backend-specific table/reference limits remain part of the rational
+-- projection rather than being conflated with the shared structural skeleton.
+private def smallerTableLimit : Experiment.RationalTable.RawRat.Limit :=
+  { fixtureTableLimit with maxEntries := fixtureTableLimit.maxEntries - 1 }
+
+private def smallerProjection : Projection :=
+  projectCertificate fixtureCert smallerTableLimit fixtureReferenceLimit
+    baseProgram.length fixtureSources fixtureTarget fixtureStructureLimit
+
+#guard smallerProjection.skeleton == fixtureProjection.skeleton
+#guard smallerProjection.tableLimit == smallerTableLimit
+#guard smallerProjection.referenceLimit == fixtureReferenceLimit
+#guard smallerProjection != fixtureProjection
+
+/-! ## Complete table and index validation -/
+
+#guard rejectsBadBoundary
+#guard checksReferenceBudget
+#guard fixtureCert.endpointLookupCost? fixtureSources fixtureTarget == some 73
+#guard !fixtureCert.check fixtureTableLimit
+  { fixtureReferenceLimit with maxEndpointLookupSteps := 72 }
+  fixtureStructureLimit baseProgram.length fixtureSources fixtureTarget
+
+private def roomyTableLimit : Experiment.RationalTable.RawRat.Limit :=
+  { fixtureTableLimit with maxEntries := fixtureTableLimit.maxEntries + 1 }
+
+-- An invalid final entry is rejected even though no literal or cut refers to
+-- it.  Logical and resource failures both cross the complete table boundary.
+#guard !({ fixtureCert with table :=
+    fixtureTable ++ [Experiment.RationalTable.RawRat.mk 0 7] }).check
+  roomyTableLimit fixtureReferenceLimit fixtureStructureLimit baseProgram.length
+  fixtureSources fixtureTarget
+#guard !({ fixtureCert with table :=
+    fixtureTable ++ [Experiment.RationalTable.RawRat.mk 0 0] }).check
+  roomyTableLimit fixtureReferenceLimit fixtureStructureLimit baseProgram.length
+  fixtureSources fixtureTarget
+#guard !({ fixtureCert with table :=
+    fixtureTable ++ [Experiment.RationalTable.RawRat.mk 256 1] }).check
+  roomyTableLimit fixtureReferenceLimit fixtureStructureLimit baseProgram.length
+  fixtureSources fixtureTarget
+
+private def missing : EndpointId := endpoint fixtureTable.length
+
+private def missingLiteralProgram : Program :=
+  [Prim.var 0, Prim.lit missing] ++ fixtureCert.program.drop 2
+
+private def missingFact : Fact :=
+  ⟨⟨Experiment.Center.node 0, Range.closed zero missing⟩, .source 0⟩
+
+private def missingSource : Row :=
+  ⟨Experiment.Center.node 0, Range.closed missing one⟩
+
+private def missingTarget : Row :=
+  ⟨Experiment.Center.node 3, Range.closed zero missing⟩
+
+#guard !(endpoint 5).valid fixtureTable
+#guard !({ fixtureCert with program := missingLiteralProgram }).check fixtureTableLimit
+  fixtureReferenceLimit fixtureStructureLimit baseProgram.length fixtureSources
+  fixtureTarget
+#guard !({ fixtureCert with facts := missingFact :: fixtureFacts.drop 1 }).check
+  fixtureTableLimit fixtureReferenceLimit fixtureStructureLimit baseProgram.length
+  fixtureSources fixtureTarget
+#guard !fixtureCert.check fixtureTableLimit fixtureReferenceLimit
+  fixtureStructureLimit baseProgram.length [missingSource] fixtureTarget
+#guard !fixtureCert.check fixtureTableLimit fixtureReferenceLimit
+  fixtureStructureLimit baseProgram.length fixtureSources missingTarget
+
+-- Existing structural references remain checked at this boundary even though
+-- arithmetic replay is deferred.
+private def badSourceFact : Fact :=
+  ⟨⟨Experiment.Center.node 0, unitRange⟩, .source 1⟩
+
+#guard !({ fixtureCert with facts := badSourceFact :: fixtureFacts.drop 1 }).check
+  fixtureTableLimit fixtureReferenceLimit fixtureStructureLimit baseProgram.length
+  fixtureSources fixtureTarget
+#guard !({ fixtureCert with result := 10 }).check fixtureTableLimit
+  fixtureReferenceLimit fixtureStructureLimit baseProgram.length fixtureSources
+  fixtureTarget
+
+-- Changing canonical table values alone preserves and passes this structural
+-- layer.  Arithmetic recipe and propagation checks are intentionally later.
+private def shapeOnlyTable : List Experiment.RationalTable.RawRat :=
+  [⟨2, 1⟩, ⟨3, 1⟩, ⟨4, 1⟩, ⟨-5, 1⟩, ⟨6, 1⟩]
+
+private def shapeOnlyCert : Certificate :=
+  { fixtureCert with table := shapeOnlyTable }
+
+#guard shapeOnlyCert.check fixtureTableLimit fixtureReferenceLimit
+  fixtureStructureLimit baseProgram.length fixtureSources fixtureTarget
+#guard (eraseCertificate shapeOnlyCert baseProgram.length fixtureSources fixtureTarget
+  fixtureStructureLimit) == fixtureProjection.skeleton
+
+/-! ## Downstream kernel transparency -/
+
+example : checkFixture = true := by
+  decide +kernel
+
+example : Experiment.RationalTable.Table.check fixtureTableLimit fixtureCert.table =
+    .ready := by
+  exact Certificate.table_ready_of_check checkFixture_eq_true
+
+example : ∀ q ∈ fixtureCert.table, q.Canonical := by
+  exact Certificate.table_canonical checkFixture_eq_true
+
+example : checksProjection = true := by
+  decide +kernel
+
+end Hex.Interval.RationalCertificateConformance

--- a/conformance/HexInterval/RationalTableConformance.lean
+++ b/conformance/HexInterval/RationalTableConformance.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexInterval.Experiment.RationalTable
+
+/-!
+Compiled conformance for endpoint erasure and canonical raw rational tables.
+The ordinary-kernel examples also confirm that both public checker boundaries
+remain transparent from a downstream module.
+-/
+
+namespace Hex.Interval.RationalTableConformance
+
+open Experiment.Center Experiment.Scale Experiment.RationalTable
+
+/-! ## Endpoint-erased skeleton -/
+
+#guard checksErasure
+#guard fixtureSkeleton == expectedSkeleton
+#guard eraseCertificate endpointChanged baseProgram.length endpointChangedSources
+  endpointChangedTarget fixtureStructureLimit == expectedSkeleton
+#guard eraseCertificate { fixtureCert with result := 8 } baseProgram.length fixtureSources
+  fixtureTarget fixtureStructureLimit != expectedSkeleton
+
+-- The projection retains every interval shape required by the public model,
+-- including strictness and independently unbounded cuts.
+#guard eraseRange .empty == Shape.Range.empty
+#guard eraseRange (.bounds (.finite (-2) true) (.finite 3 true)) ==
+  Shape.Range.bounds (.finite true) (.finite true)
+#guard eraseRange (.bounds .unbounded (.finite 3 false)) ==
+  Shape.Range.bounds .unbounded (.finite false)
+#guard eraseRange (.bounds (.finite (-2) false) .unbounded) ==
+  Shape.Range.bounds (.finite false) .unbounded
+#guard eraseRange (.bounds .unbounded .unbounded) ==
+  Shape.Range.bounds .unbounded .unbounded
+
+private def openFinite (range : Hex.Interval.Raw) : Hex.Interval.Raw :=
+  match range with
+  | .bounds (.finite lower _) (.finite upper _) =>
+      .bounds (.finite lower true) (.finite upper true)
+  | other => other
+
+private def strictnessChangedCert : Certificate :=
+  { fixtureCert with
+    facts := fixtureFacts.map fun fact =>
+      { fact with row := { fact.row with range := openFinite fact.row.range } } }
+
+private def strictnessChangedSources : List Row :=
+  fixtureSources.map fun row => { row with range := openFinite row.range }
+
+private def strictnessChangedTarget : Row :=
+  { fixtureTarget with range := openFinite fixtureTarget.range }
+
+-- Endpoint values erase, but strictness at a fact, source, or target boundary
+-- is structural and therefore changes the projected skeleton.
+#guard eraseCertificate strictnessChangedCert baseProgram.length fixtureSources
+  fixtureTarget fixtureStructureLimit != expectedSkeleton
+#guard eraseCertificate fixtureCert baseProgram.length strictnessChangedSources
+  fixtureTarget fixtureStructureLimit != expectedSkeleton
+#guard eraseCertificate fixtureCert baseProgram.length fixtureSources
+  strictnessChangedTarget fixtureStructureLimit != expectedSkeleton
+
+private def hasShape (nodes facts result lookupSteps : Nat)
+    (workload : Option Workload) : Bool :=
+  match workload with
+  | none => false
+  | some accepted =>
+      let shape := eraseWorkload accepted
+      shape.program.length == nodes && shape.facts.length == facts &&
+        shape.result == result && shape.limit.maxLookupSteps == lookupSteps
+
+#guard hasShape 500 10 9 74 (deadNodes? 500)
+#guard hasShape 9 50 49 (adjacentLookupSteps 41) (adjacent? 41)
+#guard hasShape 9 50 49 (farLookupSteps 41) (far? 41)
+#guard hasShape 9 50 9 (sourcePadLookupSteps 40) (some (sourcePad 40))
+
+example : checksErasure = true := by
+  decide +kernel
+
+/-! ## Canonical raw rational table -/
+
+#guard checksTable
+#guard Table.check fixtureTableLimit fixtureTable == .ready
+#guard Table.check fixtureTableLimit [⟨0, 1⟩, ⟨-1, 3⟩, ⟨127, 255⟩] == .ready
+
+-- Logical malformed inputs are rejected rather than normalized.
+#guard Table.check fixtureTableLimit [⟨0, 0⟩] ==
+  .malformed 0 .zeroDenominator
+#guard Table.check fixtureTableLimit [⟨0, 7⟩] ==
+  .malformed 0 .notReduced
+#guard Table.check fixtureTableLimit [⟨2, 6⟩] ==
+  .malformed 0 .notReduced
+#guard Table.check fixtureTableLimit [⟨100, 200⟩] ==
+  .malformed 0 .notReduced
+
+-- Complete-table validation observes a malformed entry after valid retained
+-- values, even though no arithmetic fact refers to that final entry.
+#guard Table.check fixtureTableLimit (fixtureTable ++ [⟨0, 7⟩]) ==
+  .malformed 4 .notReduced
+
+-- Collection and endpoint caps are caller-owned. Size failure precedes both
+-- traversal and logical canonicality failure.
+#guard Table.check { fixtureTableLimit with maxEntries := 4 } fixtureTable == .ready
+#guard Table.check { fixtureTableLimit with maxEntries := 3 } fixtureTable ==
+  .resourceLimit none .entries
+#guard Table.check { fixtureTableLimit with maxEntries := 3 }
+  (fixtureTable ++ [⟨0, 0⟩]) == .resourceLimit none .entries
+#guard Table.check { fixtureTableLimit with maxNumeratorBits := 8 } [⟨255, 1⟩] ==
+  .ready
+#guard Table.check { fixtureTableLimit with maxNumeratorBits := 8 } [⟨256, 1⟩] ==
+  .resourceLimit (some 0) .numeratorBits
+#guard Table.check { fixtureTableLimit with maxNumeratorBits := 7 } [⟨128, 1⟩] ==
+  .resourceLimit (some 0) .numeratorBits
+#guard Table.check { fixtureTableLimit with maxDenominatorBits := 8 } [⟨1, 255⟩] ==
+  .ready
+#guard Table.check { fixtureTableLimit with maxDenominatorBits := 8 } [⟨1, 256⟩] ==
+  .resourceLimit (some 0) .denominatorBits
+#guard Table.check { fixtureTableLimit with maxDenominatorBits := 8 }
+  (fixtureTable ++ [⟨1, 256⟩]) == .resourceLimit (some 4) .denominatorBits
+
+-- Successful validation reconstructs exactly the checked Core numerator and
+-- denominator; it does not silently replace the raw encoding.
+example : (RawRat.value ⟨-1, 3⟩).num = -1 ∧ (RawRat.value ⟨-1, 3⟩).den = 3 := by
+  exact RawRat.value_fields (limit := fixtureTableLimit) (by decide +kernel)
+
+example : checksTable = true := by
+  decide +kernel
+
+end Hex.Interval.RationalTableConformance

--- a/conformance/HexInterval/RationalTableConformance.lean
+++ b/conformance/HexInterval/RationalTableConformance.lean
@@ -22,6 +22,8 @@ open Experiment.Center Experiment.Scale Experiment.RationalTable
 #guard fixtureSkeleton == expectedSkeleton
 #guard eraseCertificate endpointChanged baseProgram.length endpointChangedSources
   endpointChangedTarget fixtureStructureLimit == expectedSkeleton
+#guard eraseCertificate literalSharingChanged baseProgram.length fixtureSources
+  fixtureTarget fixtureStructureLimit != expectedSkeleton
 #guard eraseCertificate { fixtureCert with result := 8 } baseProgram.length fixtureSources
   fixtureTarget fixtureStructureLimit != expectedSkeleton
 
@@ -95,6 +97,11 @@ example : checksErasure = true := by
   .malformed 0 .notReduced
 #guard Table.check fixtureTableLimit [⟨100, 200⟩] ==
   .malformed 0 .notReduced
+
+-- Validation is deterministic and interleaved per entry: a logical failure
+-- at an earlier bounded entry precedes a resource failure at a later entry.
+#guard Table.check { fixtureTableLimit with maxNumeratorBits := 8 }
+  [⟨2, 6⟩, ⟨256, 1⟩] == .malformed 0 .notReduced
 
 -- Complete-table validation observes a malformed entry after valid retained
 -- values, even though no arithmetic fact refers to that final entry.

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -209,7 +209,8 @@ lean_lib HexGF2BenchSupport where
 lean_lib HexIntervalExperiment where
   globs := #[`HexInterval.Experiment.Representation,
     `HexInterval.Experiment.Rational, `HexInterval.Experiment.Center,
-    `HexInterval.Experiment.Scale, `HexInterval.Experiment.RationalTable]
+    `HexInterval.Experiment.Scale, `HexInterval.Experiment.RationalTable,
+    `HexInterval.Experiment.RationalCertificate]
 
 lean_lib HexIntervalMathlibExperiment where
   globs := #[`HexIntervalMathlib.Experiment.Center]
@@ -244,7 +245,8 @@ lean_lib HexIntervalMathlibReplayProbe where
 lean_lib HexConformance where
   srcDir := "conformance"
   globs := (#[`HexArith.Conformance, `HexArith.CrossCheck, `HexBerlekamp.Conformance, `HexBerlekampZassenhaus.Conformance, `HexBerlekampZassenhaus.CrossCheck, `HexConway.Conformance, `HexGF2.Conformance, `HexGF2.CrossCheck, `HexGF2.FastCheck, `HexGFq.Conformance, `HexGFq.CrossCheck, `HexGFqField.Conformance, `HexGFqRing.Conformance, `HexGramSchmidt.Conformance, `HexHensel.Conformance, `HexHensel.CrossCheck, `HexInterval.Conformance, `HexInterval.CenterConformance, `HexInterval.ScaleConformance, `HexLLL.Conformance, `HexMatrix.Conformance, `HexRowReduce.Conformance, `HexDeterminant.Conformance, `HexBareiss.Conformance, `HexModArith.Conformance, `HexModArith.FastCheck, `HexPoly.Conformance, `HexPolyFp.Conformance, `HexPolyZ.Conformance, `HexRealRoots.Conformance, `HexRealRootsMathlib.Conformance, `HexRoots.Conformance] : Array Glob)
-    ++ (#[`HexInterval.RationalTableConformance] : Array Glob)
+    ++ (#[`HexInterval.RationalTableConformance,
+      `HexInterval.RationalCertificateConformance] : Array Glob)
 
 -- Public umbrellas intentionally contain only the supported API. Executable
 -- examples and regression tests are compiled through this separate target so

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -209,7 +209,7 @@ lean_lib HexGF2BenchSupport where
 lean_lib HexIntervalExperiment where
   globs := #[`HexInterval.Experiment.Representation,
     `HexInterval.Experiment.Rational, `HexInterval.Experiment.Center,
-    `HexInterval.Experiment.Scale]
+    `HexInterval.Experiment.Scale, `HexInterval.Experiment.RationalTable]
 
 lean_lib HexIntervalMathlibExperiment where
   globs := #[`HexIntervalMathlib.Experiment.Center]
@@ -243,7 +243,8 @@ lean_lib HexIntervalMathlibReplayProbe where
 -- `*_emit_fixtures` exes below, carrying `srcDir := "conformance"`.
 lean_lib HexConformance where
   srcDir := "conformance"
-  globs := #[`HexArith.Conformance, `HexArith.CrossCheck, `HexBerlekamp.Conformance, `HexBerlekampZassenhaus.Conformance, `HexBerlekampZassenhaus.CrossCheck, `HexConway.Conformance, `HexGF2.Conformance, `HexGF2.CrossCheck, `HexGF2.FastCheck, `HexGFq.Conformance, `HexGFq.CrossCheck, `HexGFqField.Conformance, `HexGFqRing.Conformance, `HexGramSchmidt.Conformance, `HexHensel.Conformance, `HexHensel.CrossCheck, `HexInterval.Conformance, `HexInterval.CenterConformance, `HexInterval.ScaleConformance, `HexLLL.Conformance, `HexMatrix.Conformance, `HexRowReduce.Conformance, `HexDeterminant.Conformance, `HexBareiss.Conformance, `HexModArith.Conformance, `HexModArith.FastCheck, `HexPoly.Conformance, `HexPolyFp.Conformance, `HexPolyZ.Conformance, `HexRealRoots.Conformance, `HexRealRootsMathlib.Conformance, `HexRoots.Conformance]
+  globs := (#[`HexArith.Conformance, `HexArith.CrossCheck, `HexBerlekamp.Conformance, `HexBerlekampZassenhaus.Conformance, `HexBerlekampZassenhaus.CrossCheck, `HexConway.Conformance, `HexGF2.Conformance, `HexGF2.CrossCheck, `HexGF2.FastCheck, `HexGFq.Conformance, `HexGFq.CrossCheck, `HexGFqField.Conformance, `HexGFqRing.Conformance, `HexGramSchmidt.Conformance, `HexHensel.Conformance, `HexHensel.CrossCheck, `HexInterval.Conformance, `HexInterval.CenterConformance, `HexInterval.ScaleConformance, `HexLLL.Conformance, `HexMatrix.Conformance, `HexRowReduce.Conformance, `HexDeterminant.Conformance, `HexBareiss.Conformance, `HexModArith.Conformance, `HexModArith.FastCheck, `HexPoly.Conformance, `HexPolyFp.Conformance, `HexPolyZ.Conformance, `HexRealRoots.Conformance, `HexRealRootsMathlib.Conformance, `HexRoots.Conformance] : Array Glob)
+    ++ (#[`HexInterval.RationalTableConformance] : Array Glob)
 
 -- Public umbrellas intentionally contain only the supported API. Executable
 -- examples and regression tests are compiled through this separate target so

--- a/progress/20260727T103031Z.md
+++ b/progress/20260727T103031Z.md
@@ -1,0 +1,45 @@
+# Accomplished
+
+- Added `HexInterval.Experiment.RationalTable`, the first Mathlib-free rational
+  endpoint boundary stacked on the centered/scale experiments.
+- Added an endpoint-erased skeleton which retains SSA/literal slots, cut
+  strictness and unboundedness, derivation/equality references, caller-owned
+  sources and target, result selection, and structural limits.  Exact canaries
+  compare the fixed fixture with an independently written skeleton, show that
+  endpoint-only mutations erase identically, and show that fact, source,
+  target, and result structural mutations remain observable.
+- Added canonical `RawRat` table validation over `Int`/`Nat`.  Caller-owned
+  entry and per-endpoint bit limits are checked before logical validity; zero
+  denominators, non-coprime encodings, and noncanonical zero are rejected; and
+  every table entry is checked even when it is an unused tail entry.
+- Proved that admitted entries are canonical, that an admitted table contains
+  only canonical entries, and that the Core `Rat` interpretation recovers the
+  exact admitted numerator and denominator.
+- Added compiled downstream conformance for empty, open, one-sided unbounded,
+  and two-sided unbounded shapes; exact and one-over resource boundaries; all
+  scale families; and ordinary-kernel transparency.
+- Registered the module and conformance target.  `lake build
+  HexIntervalExperiment HexConformance` completed successfully (9103 jobs), as
+  did focused module/conformance builds, the DAG check, the Mathlib-free bench
+  import check, forbidden-token scans, and `git diff --check`.
+
+# Current frontier
+
+`eraseWorkload` projects any generated `Scale.Workload`; conformance establishes
+the exact base skeleton and exercises representative large shapes from every
+current scale family.  This slice does not yet claim cross-backend identity:
+there is no rational endpoint-bearing certificate projection to compare with
+the centered dyadic projection.  That identity becomes meaningful only when
+the rational certificate boundary exists.
+
+# Next step
+
+Introduce the rational endpoint-bearing certificate boundary and its erasure
+projection, then compare rational and dyadic projections on shared structural
+fixtures.  Keep arithmetic-edge replay and compiled planning as subsequent,
+separate phases, and continue to avoid freezing a wire format or table storage
+representation.
+
+# Blockers
+
+None.

--- a/progress/20260727T104022Z.md
+++ b/progress/20260727T104022Z.md
@@ -1,0 +1,53 @@
+# Accomplished
+
+- Added `HexInterval.Experiment.RationalCertificate`, a transparent `List`-based
+  certificate whose rational literals and finite interval cuts use typed
+  `EndpointId` references into an untrusted `RawRat` table.
+- Added a structural checker which performs bounded collection preflight,
+  validates the complete rational table under caller-owned limits, validates
+  every literal/cut endpoint reference, checks SSA topology, the centered
+  expression shape, equality endpoints, source/fact/result indices, caller-owned
+  sources and target, and charged lookup work.  Every endpoint-table traversal
+  is preflighted by exact forward distance and consumed from a separate
+  caller-owned reference budget before any indexed table lookup occurs.  The
+  checker deliberately does not replay equality arithmetic or interval
+  propagation.
+- Proved that checker success implies complete table acceptance and canonicality
+  of every table entry, including unreferenced entries.
+- Added endpoint erasure for the rational syntax and a projection which retains
+  the caller-owned rational table and endpoint-reference limits alongside the
+  backend-independent skeleton.  The skeleton retains sources, target,
+  structural limit, result, centered witness, equality edges, and every fact
+  derivation.
+- Rendered the centered fixture with canonical rational table entries and proved
+  that its erased skeleton is exactly both the centered dyadic projection and
+  the independent expected skeleton.
+- Added compiled conformance for every finite closure combination, empty and
+  one-/two-sided-unbounded shapes, invalid unused table entries, missing
+  literal/fact/source/target references, bad structural references, retained
+  limits, the exact 73-step endpoint-reference budget and its one-step-short
+  rejection, and downstream ordinary-kernel use of the table soundness
+  theorems.  A canonical value-mutated table is explicitly accepted by this
+  structural layer, recording the intended arithmetic-replay boundary.
+- Focused module and conformance builds, the DAG check, the Mathlib-free bench
+  import check, forbidden-token scans, and `git diff --check` all pass.  No
+  whole-repository build was launched for this layer.
+
+# Current frontier
+
+The rational certificate now has a checked, resource-bounded structural
+boundary and exact cross-backend erasure identity.  Its table entries are known
+canonical and every reference is known in range, but the checker intentionally
+does not yet establish that `1`, `1/2`, and `1/4` occupy the centered recipe's
+literal slots or that any fact range follows from rational interval arithmetic.
+
+# Next step
+
+Add a separately budgeted arithmetic-replay layer over admitted table entries,
+including literal-value obligations and rational operation/cut checks, while
+keeping the structural projection unchanged.  Continue to defer wire format
+and production table/state storage choices.
+
+# Blockers
+
+None.

--- a/progress/20260727T104256Z.md
+++ b/progress/20260727T104256Z.md
@@ -1,0 +1,35 @@
+# Rational replay design
+
+## Accomplished
+
+- Audited Core `Rat`, `RawRat` table validation, rational equation/order
+  lemmas, irreducibility behavior, gcd opacity, and dyadic projection support.
+- Specified a strategy-neutral arithmetic-edge format for addition,
+  subtraction, multiplication, inversion, equality, order, and outward dyadic
+  projection without relying on Mathlib, Grind, `norm_num`, or
+  `native_decide`.
+- Declared the naive reference identities and complete per-operation temporary
+  bit recurrences, aggregate arithmetic-work policy, whole-table gcd preflight,
+  exact endpoint-table lookup accounting, deterministic validation phases, and
+  fail-closed error taxonomy.
+- Kept cancellation-aware replay upgradeable behind the same semantic edge
+  format, with explicit cross-gcd alternatives and comparison benchmarks.
+- Expanded conformance and benchmark requirements with valid arithmetic,
+  wrong-result, bad-index, exact/one-over resource, projection, cancellation,
+  and forbidden-allocation canaries.
+
+## Current frontier
+
+The design is ready to stack onto the canonical rational table and
+table-indexed certificate slices. The naive arithmetic-edge implementation is
+proceeding independently in a separate worktree.
+
+## Next step
+
+Integrate this SPEC commit with the rational certificate branch, reconcile the
+implemented resource result names with the declared taxonomy, and measure the
+naive edge checker before implementing the cancellation arm.
+
+## Blockers
+
+None.

--- a/progress/20260727T111055Z.md
+++ b/progress/20260727T111055Z.md
@@ -1,0 +1,38 @@
+# Accomplished
+
+- Rebased the rational table/certificate boundary onto the squashed structural
+  scale merge so its PR can target `main` without replaying the scale diff.
+- Closed the independent review's trust-boundary issue by pairing every
+  caller-owned indexed source/target row with exact raw rational values.  The
+  checker now resolves and compares those values after complete table
+  validation, exports `boundary_agrees_of_check`, and rejects a certificate
+  table that tries to reinterpret the invocation boundary.
+- Strengthened endpoint erasure on both dyadic and rational programs: literal
+  slots now preserve first-occurrence sharing rather than merely recording the
+  instruction position.  Reusing one value in all centered literal positions
+  is an explicit negative canary.
+- Added rational-side negatives for literal shape, equality endpoints,
+  generation, and the exact 74/73 structural lookup boundary.  Added a mixed
+  table failure canary pinning per-entry validation precedence.
+- Reconciled the SPEC with the implemented/deferred rational validation phases,
+  distinguished endpoint-table from program lookups, and wrote out the
+  cancellation identities that justify strategy-neutral arithmetic edges.
+- Focused experiment/conformance builds, import-DAG validation, forbidden-token
+  scans, and whitespace checks pass.
+
+# Current frontier
+
+The table/certificate PR now has an explicit semantic invocation boundary as
+well as a backend-neutral sharing-aware skeleton.  Rational arithmetic edges,
+projection, and the compiled planner remain separate completed local commits
+under independent audit so they can stack without waiting for this PR's CI.
+
+# Next step
+
+Publish the rebased reviewed boundary, run a fresh asynchronous second opinion
+over the fixes, and adapt the planner/freezer to consume an independently
+reified `ExpectedRow` boundary while the edge and projection audits continue.
+
+# Blockers
+
+None.


### PR DESCRIPTION
## Summary

- add a backend-independent endpoint-erased skeleton for the centered/scale certificate family, preserving interval openness, unboundedness, derivations, equality recipes, caller sources/target, result, structural limits, and literal-sharing shape
- validate complete canonical raw rational tables with caller-owned entry and numerator/denominator-bit limits, rejecting zero denominators, nonreduced encodings, noncanonical zero, and invalid unused tail entries
- add a table-indexed rational certificate boundary with typed finite-cut/literal references, full SSA/source/fact/edge/result validation, and a separate exact caller-owned endpoint-table traversal budget
- pin every caller-owned indexed source and target to exact raw rational values, with an elimination theorem proving that a successful check cannot reinterpret the invocation through certificate-chosen table entries
- specify the next Mathlib-free Core-`Rat` arithmetic-edge identities, temporary-bit/work preflight, deterministic validation phases, projection requirements, and upgradeable cancellation arms

## Boundary guarantees

The transparent checker validates the complete table before accepting any certificate. A ready entry is proved canonical and its Core `Rat` interpretation has exactly the checked numerator and denominator. The table-indexed fixture consumes exactly 73 endpoint-list lookup steps; 72 rejects before any indexed endpoint lookup. Empty, open/closed, one-sided unbounded, and two-sided unbounded shapes survive erasure, while strictness and literal-sharing changes remain observable.

The rational and dyadic centered fixtures erase to the same independently written skeleton. Internal arithmetic recipe and interval propagation identities remain deliberately deferred, but changing the certificate table cannot change the caller's source or target meaning: exact caller values are checked and retained in the rational projection. A negative canary changes every canonical table value and demonstrates rejection against the original caller boundary.

## Validation

- initial whole-repository `lake build` for the canonical-table slice: 9,103 jobs
- focused: `lake build HexIntervalExperiment +HexInterval.RationalTableConformance:olean +HexInterval.RationalCertificateConformance:olean`
- `python3 scripts/check_file_line_counts.py`
- `python3 scripts/check_copyright_headers.py`
- `python3 scripts/check_dag.py`
- forbidden implementation-token scan and `git diff --check`

This branch is Mathlib-free and uses no `norm_num`, Grind, `native_decide`, `axiom`, or `sorry`. The first independent review's trust-boundary, validation-order, literal-sharing, and negative-coverage findings are fixed; a fresh follow-up Opus audit is running asynchronously on this head.
