### PR TITLE
RCF: certify sign matrices and formula reflection

### DIFF
--- a/HexRCF.lean
+++ b/HexRCF.lean
@@ -21,6 +21,8 @@ public import HexRCF.Cells
 public import HexRCF.CellsTests
 public import HexRCF.CommonRoot
 public import HexRCF.CommonRootTests
+public import HexRCF.SignMatrix
+public import HexRCF.SignMatrixTests
 
 public section
 
@@ -41,4 +43,7 @@ size-indexed partition into root and open cells with exact dyadic samples and
 exact guarded intersection tests for half-open bounded domains.
 Checked common-root packages cache one multiplication-only gcd witness and
 generalized replay per distinct nonconstant atom, with exact root-cell queries.
+The sign-matrix layer then recomputes guarded open and root signs, validates
+coefficient-equality package alignment, and reflects every Boolean formula
+to one exact truth value on each semantic cell.
 -/

--- a/HexRCF/Cells.lean
+++ b/HexRCF/Cells.lean
@@ -488,6 +488,80 @@ theorem open_not_root {f : ZPoly} {cert : IsolationCert}
 
 end Cell
 
+namespace RootModel
+
+/-- The closed-on-the-right span from the open cell immediately left of root
+`i` to that root. -/
+def leftSpan {carrier : ZPoly} {cert : IsolationCert}
+    (M : RootModel carrier cert) (i : Fin cert.intervals.size) : Set ℝ :=
+  if hi : i.val = 0 then Set.Iic (M.root i)
+  else Set.Ioc (M.root ⟨i.val - 1, by omega⟩) (M.root i)
+
+/-- A root and the open cell immediately to its left form an interval. -/
+theorem isPreconnected_leftSpan {carrier : ZPoly} {cert : IsolationCert}
+    (M : RootModel carrier cert) (i : Fin cert.intervals.size) :
+    IsPreconnected (M.leftSpan i) := by
+  by_cases hi : i.val = 0
+  · simpa [leftSpan, hi] using isPreconnected_Iic
+  · simpa [leftSpan, hi] using isPreconnected_Ioc
+
+/-- The open cell immediately left of root `i` lies in its left span. -/
+theorem leftOpen_mem_leftSpan {carrier : ZPoly} {cert : IsolationCert}
+    (M : RootModel carrier cert) (i : Fin cert.intervals.size) {x : ℝ}
+    (hx : Cell.Sem M (.open i.castSucc) x) : x ∈ M.leftSpan i := by
+  have hsize : cert.intervals.size ≠ 0 := by
+    have := i.isLt
+    omega
+  by_cases hi : i.val = 0
+  · simp only [leftSpan, hi, dite_true, Set.mem_Iic]
+    have hx0 : x < M.root ⟨0, by omega⟩ := by
+      simpa [Cell.Sem, hsize, hi] using hx
+    have hieq : i = ⟨0, by omega⟩ := Fin.ext hi
+    rw [hieq]
+    exact hx0.le
+  · have hright : i.val ≠ cert.intervals.size := by omega
+    have hx' : M.root ⟨i.val - 1, by omega⟩ < x ∧ x < M.root i := by
+      simpa [Cell.Sem, hsize, hi, hright] using hx
+    simpa [leftSpan, hi] using And.intro hx'.1 hx'.2.le
+
+/-- Root `i` is the right endpoint of its left span. -/
+theorem root_mem_leftSpan {carrier : ZPoly} {cert : IsolationCert}
+    (M : RootModel carrier cert) (i : Fin cert.intervals.size) :
+    M.root i ∈ M.leftSpan i := by
+  by_cases hi : i.val = 0
+  · simp [leftSpan, hi]
+  · simp only [leftSpan, hi, dite_false, Set.mem_Ioc]
+    exact ⟨M.strictMono (Fin.mk_lt_mk.mpr (by omega)), le_rfl⟩
+
+/-- A carrier root in the left span of root `i` is root `i` itself. -/
+theorem root_eq_of_mem_leftSpan
+    {carrier : ZPoly} {cert : IsolationCert}
+    (M : RootModel carrier cert) (i : Fin cert.intervals.size) {x : ℝ}
+    (hxroot : (toPolyℝ carrier).IsRoot x) (hx : x ∈ M.leftSpan i) :
+    x = M.root i := by
+  obtain ⟨j, hj, _⟩ := M.complete x hxroot
+  rw [← hj] at hx ⊢
+  congr 1
+  apply Fin.ext
+  by_cases hi : i.val = 0
+  · simp only [leftSpan, hi, dite_true, Set.mem_Iic] at hx
+    by_contra hne
+    have hij : i < j := by omega
+    exact (not_lt_of_ge hx) (M.strictMono hij)
+  · simp only [leftSpan, hi, dite_false, Set.mem_Ioc] at hx
+    by_contra hne
+    rcases lt_or_gt_of_ne hne with hji | hij
+    · let prev : Fin cert.intervals.size := ⟨i.val - 1, by omega⟩
+      have hjprevIndex : j ≤ prev := by
+        apply Fin.mk_le_mk.mpr
+        omega
+      have hjprev : M.root j ≤ M.root ⟨i.val - 1, by omega⟩ :=
+        M.strictMono.monotone hjprevIndex
+      exact (not_lt_of_ge hjprev) hx.1
+    · exact (not_lt_of_ge hx.2) (M.strictMono (Fin.mk_lt_mk.mpr hij))
+
+end RootModel
+
 /-- Claimed carrier-root comparisons against the lower and upper endpoints of
 a bounded domain. -/
 structure IocCmps (n : Nat) where

--- a/HexRCF/SignMatrix.lean
+++ b/HexRCF/SignMatrix.lean
@@ -1,0 +1,872 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.Carrier
+public import HexRCF.CommonRoot
+public import Mathlib.Topology.Instances.Sign
+
+public section
+
+/-!
+# Certified sign matrices for RCF cells
+
+This file computes exact polynomial signs on the semantic cells cut out by a
+checked square-free carrier.  Open-cell signs come from exact dyadic Horner
+evaluation and preconnected root-free sign constancy. Root-cell zero tests use
+the cached common-root packages; nonzero root signs are transferred from an
+adjacent open cell. Formula evaluation is option-valued so missing or
+misaligned certificate data fails closed.
+-/
+
+namespace Hex.RCF
+
+open HexRealRootsMathlib Polynomial
+
+/-- The three possible signs stored by an RCF sign matrix. -/
+inductive Sign where
+  | neg
+  | zero
+  | pos
+  deriving DecidableEq, Repr
+
+namespace Sign
+
+/-- Canonical integer representative used to connect signs to Mathlib's
+`SignType.sign`. -/
+@[expose]
+def toInt : Sign → Int
+  | .neg => -1
+  | .zero => 0
+  | .pos => 1
+
+/-- Collapse an arbitrary integer to its three-way sign. -/
+@[expose]
+def ofInt (value : Int) : Sign :=
+  if value < 0 then .neg else if 0 < value then .pos else .zero
+
+/-- Collapsing an integer preserves its mathematical sign. -/
+theorem ofInt_spec (value : Int) :
+    SignType.sign (((Sign.ofInt value).toInt : Int) : ℝ) =
+      SignType.sign ((value : Int) : ℝ) := by
+  by_cases hneg : value < 0
+  · have hcast : ((value : Int) : ℝ) < 0 := by exact_mod_cast hneg
+    have hsign : SignType.sign ((value : Int) : ℝ) = -1 :=
+      sign_eq_neg_one_iff.mpr hcast
+    rw [hsign]
+    simp [ofInt, hneg, toInt]
+  by_cases hpos : 0 < value
+  · have hcast : (0 : ℝ) < (value : Int) := by exact_mod_cast hpos
+    have hsign : SignType.sign ((value : Int) : ℝ) = 1 :=
+      sign_eq_one_iff.mpr hcast
+    rw [hsign]
+    simp [ofInt, hneg, hpos, toInt]
+  · have hzero : value = 0 := by omega
+    subst value
+    simp [ofInt, toInt]
+
+end Sign
+
+/-- The sign of a continuous polynomial evaluation is constant on a
+preconnected set containing no root of the polynomial. -/
+theorem sign_eval_eq_of_noRoot {p : Polynomial ℝ} {s : Set ℝ}
+    (hs : IsPreconnected s) (hnz : ∀ z ∈ s, ¬p.IsRoot z)
+    {x y : ℝ} (hx : x ∈ s) (hy : y ∈ s) :
+    SignType.sign (p.eval x) = SignType.sign (p.eval y) := by
+  have hcont : ContinuousOn (SignType.sign ∘ fun z => p.eval z) s := by
+    refine (continuousOn_of_forall_continuousAt fun q hq => ?_).comp
+      p.continuousOn (Set.mapsTo_image (fun z => p.eval z) s)
+    obtain ⟨z, hz, rfl⟩ := hq
+    exact continuousAt_sign_of_ne_zero (fun hzero => hnz z hz hzero)
+  exact (hs.image _ hcont).subsingleton
+    (Set.mem_image_of_mem _ hx) (Set.mem_image_of_mem _ hy)
+
+/-- Exact executable sign of an integer polynomial at a dyadic point. -/
+@[expose]
+def evalSign (p : ZPoly) (x : Dyadic) : Sign :=
+  Sign.ofInt (Hex.dyadicSign (p.evalDyadic x))
+
+/-- Exact dyadic Horner evaluation computes the sign of the corresponding
+real-polynomial evaluation. -/
+theorem evalSign_spec (p : ZPoly) (x : Dyadic) :
+    SignType.sign (((evalSign p x).toInt : Int) : ℝ) =
+      SignType.sign ((toPolyℝ p).eval (Dyadic.toReal x)) := by
+  rw [evalSign, Sign.ofInt_spec, ← toReal_evalDyadic]
+  exact sign_dyadicSign _
+
+/-- A polynomial whose executable degree is not positive is constant after
+casting, including the zero polynomial. -/
+theorem eval_eq_eval_zero_of_degree_nonpos (p : ZPoly)
+    (hdegree : ¬0 < p.degree?.getD 0) (x : ℝ) :
+    (toPolyℝ p).eval x = (toPolyℝ p).eval 0 := by
+  have hnat : (toPolyℝ p).natDegree = 0 := by
+    rw [natDegree_toPolyℝ]
+    omega
+  rw [Polynomial.eq_C_of_natDegree_eq_zero hnat,
+    Polynomial.eval_C, Polynomial.eval_C]
+
+/-- Sign constancy on an open carrier cell from root containment. -/
+theorem sign_eval_eq_open {carrier : ZPoly} {replay : SturmReplay}
+    (hreplay : replay.check carrier = true) {isolations : IsolationCert}
+    (hstrict : isolations.checkStrict replay = true) {atom : ZPoly}
+    (hroot : ∀ z, (toPolyℝ atom).IsRoot z →
+      (toPolyℝ carrier).IsRoot z)
+    (cut : Fin (isolations.intervals.size + 1)) {x : ℝ}
+    (hx : Cell.Sem (isolations.rootModel hreplay hstrict) (.open cut) x) :
+    SignType.sign ((toPolyℝ atom).eval
+      (Dyadic.toReal (isolations.openPoint cut))) =
+      SignType.sign ((toPolyℝ atom).eval x) := by
+  let model := isolations.rootModel hreplay hstrict
+  apply sign_eval_eq_of_noRoot (Cell.isPreconnected_open model cut)
+  · intro z hz hatom
+    exact Cell.open_not_root model hz (hroot z hatom)
+  · exact Cell.openPoint_mem isolations hreplay hstrict cut
+  · exact hx
+
+/-- The exact dyadic sign is valid at every point of an open carrier cell. -/
+theorem evalSign_open_spec {carrier : ZPoly} {replay : SturmReplay}
+    (hreplay : replay.check carrier = true) {isolations : IsolationCert}
+    (hstrict : isolations.checkStrict replay = true) {atom : ZPoly}
+    (hroot : ∀ z, (toPolyℝ atom).IsRoot z →
+      (toPolyℝ carrier).IsRoot z)
+    (cut : Fin (isolations.intervals.size + 1)) {x : ℝ}
+    (hx : Cell.Sem (isolations.rootModel hreplay hstrict) (.open cut) x) :
+    SignType.sign (((evalSign atom (isolations.openPoint cut)).toInt : Int) : ℝ) =
+      SignType.sign ((toPolyℝ atom).eval x) :=
+  (evalSign_spec atom (isolations.openPoint cut)).trans
+    (sign_eval_eq_open hreplay hstrict hroot cut hx)
+
+/-- Every nonconstant sentence atom has its exact sampled sign throughout an
+open cell of an accepted carrier decomposition. -/
+theorem evalSign_open_of_atom {sentence : Sentence} {carrier : CarrierCert}
+    (hcarrier : carrier.check sentence = true)
+    {isolations : IsolationCert}
+    (hstrict : isolations.checkStrict carrier.replay = true)
+    {atom : ZPoly} (hatom : atom ∈ sentence.polys)
+    (cut : Fin (isolations.intervals.size + 1)) {x : ℝ}
+    (hx : Cell.Sem
+      (isolations.rootModel (CarrierCert.replay_of_check hcarrier) hstrict)
+      (.open cut) x) :
+    SignType.sign (((evalSign atom (isolations.openPoint cut)).toInt : Int) : ℝ) =
+      SignType.sign ((toPolyℝ atom).eval x) := by
+  apply evalSign_open_spec (CarrierCert.replay_of_check hcarrier) hstrict
+  · intro z hroot
+    exact (CarrierCert.isRoot_iff_atom hcarrier z).2 ⟨atom, hatom, hroot⟩
+  · exact hx
+
+/-- A nonzero atom has the same sign at carrier root `i` as on the open cell
+immediately to its left. -/
+theorem sign_eval_eq_leftRoot {carrier atom : ZPoly} {cert : IsolationCert}
+    (model : RootModel carrier cert)
+    (hroot : ∀ z, (toPolyℝ atom).IsRoot z →
+      (toPolyℝ carrier).IsRoot z)
+    (i : Fin cert.intervals.size)
+    (hnonzero : ¬(toPolyℝ atom).IsRoot (model.root i))
+    {sample : ℝ} (hsample : Cell.Sem model (.open i.castSucc) sample) :
+    SignType.sign ((toPolyℝ atom).eval sample) =
+      SignType.sign ((toPolyℝ atom).eval (model.root i)) := by
+  apply sign_eval_eq_of_noRoot (model.isPreconnected_leftSpan i) _
+      (model.leftOpen_mem_leftSpan i hsample) (model.root_mem_leftSpan i)
+  intro z hz hzroot
+  exact hnonzero (by
+    rw [← model.root_eq_of_mem_leftSpan i (hroot z hzroot) hz]
+    exact hzroot)
+
+/-- Exact left-open sample sign at a carrier root where the atom does not
+vanish. -/
+theorem evalSign_leftRoot {carrier atom : ZPoly} {replay : SturmReplay}
+    {isolations : IsolationCert} (hreplay : replay.check carrier = true)
+    (hstrict : isolations.checkStrict replay = true)
+    (hroot : ∀ z, (toPolyℝ atom).IsRoot z →
+      (toPolyℝ carrier).IsRoot z)
+    (i : Fin isolations.intervals.size)
+    (hnonzero : ¬(toPolyℝ atom).IsRoot
+      ((isolations.rootModel hreplay hstrict).root i)) :
+    SignType.sign
+      (((evalSign atom (isolations.openPoint i.castSucc)).toInt : Int) : ℝ) =
+      SignType.sign ((toPolyℝ atom).eval
+        ((isolations.rootModel hreplay hstrict).root i)) := by
+  rw [evalSign_spec]
+  exact sign_eval_eq_leftRoot (isolations.rootModel hreplay hstrict)
+    hroot i hnonzero (Cell.openPoint_mem isolations hreplay hstrict i.castSucc)
+
+/-- A false cached common-root query certifies the exact nonzero root-cell
+sign using the canonical left open sample. -/
+theorem evalSign_commonLeft
+    {sentence : Sentence} {carrier : CarrierCert}
+    (hcarrier : carrier.check sentence = true)
+    {isolations : IsolationCert}
+    (hstrict : isolations.checkStrict carrier.replay = true)
+    {atom : ZPoly} (hatom : atom ∈ sentence.polys)
+    {common : CommonRootCert}
+    (hcommon : common.check atom carrier.carrier = true)
+    (i : Fin isolations.intervals.size)
+    (hnonroot : common.hasRoot isolations.intervals[i] = false) :
+    SignType.sign
+      (((evalSign atom (isolations.openPoint i.castSucc)).toInt : Int) : ℝ) =
+      SignType.sign ((toPolyℝ atom).eval
+        ((isolations.rootModel (CarrierCert.replay_of_check hcarrier)
+          hstrict).root i)) := by
+  let hreplay := CarrierCert.replay_of_check hcarrier
+  let model := isolations.rootModel hreplay hstrict
+  have hroot : ∀ z, (toPolyℝ atom).IsRoot z →
+      (toPolyℝ carrier.carrier).IsRoot z := by
+    intro z hz
+    exact (carrier.isRoot_iff_atom hcarrier z).2 ⟨atom, hatom, hz⟩
+  have hnonzero : ¬(toPolyℝ atom).IsRoot (model.root i) := by
+    intro hz
+    have hyes : common.hasRoot isolations.intervals[i] = true :=
+      (common.hasRoot_model_iff hreplay hstrict hcommon i).2 hz
+    rw [hnonroot] at hyes
+    contradiction
+  exact evalSign_leftRoot hreplay hstrict hroot i hnonzero
+
+/-- Exact evaluation cannot report zero at a certified nonroot. -/
+theorem evalSign_ne_zero_of_not_root (p : ZPoly) (x : Dyadic)
+    (hroot : ¬(toPolyℝ p).IsRoot (Dyadic.toReal x)) :
+    evalSign p x ≠ .zero := by
+  intro hzero
+  have hsign := evalSign_spec p x
+  rw [hzero] at hsign
+  have heval : (toPolyℝ p).eval (Dyadic.toReal x) = 0 := by
+    apply sign_eq_zero_iff.mp
+    simpa [Sign.toInt] using hsign.symm
+  exact hroot heval
+
+/-- Coefficient-equality membership test for literal polynomials. This avoids
+the derived array equality that does not kernel-reduce through modules. -/
+@[expose]
+def containsPoly (p : ZPoly) : List ZPoly → Bool
+  | [] => false
+  | q :: qs => DensePoly.beqCoeffs p q || containsPoly p qs
+
+theorem containsPoly_iff {p : ZPoly} {ps : List ZPoly} :
+    containsPoly p ps = true ↔ p ∈ ps := by
+  induction ps with
+  | nil => simp [containsPoly]
+  | cons q qs ih =>
+      simp [containsPoly, Bool.or_eq_true, DensePoly.beqCoeffs_iff_eq, ih]
+
+/-- The coefficient-equality membership test is false exactly on
+nonmembership. -/
+theorem containsPoly_eq_false_iff {p : ZPoly} {ps : List ZPoly} :
+    containsPoly p ps = false ↔ p ∉ ps := by
+  rw [Bool.eq_false_iff]
+  exact not_congr containsPoly_iff
+
+/-- First-occurrence-preserving duplicate removal with an explicit seen set. -/
+@[expose]
+def dedupPolysAux (seen : List ZPoly) : List ZPoly → List ZPoly
+  | [] => []
+  | p :: ps =>
+      if containsPoly p seen then dedupPolysAux seen ps
+      else p :: dedupPolysAux (p :: seen) ps
+
+/-- Deterministic first-occurrence-preserving duplicate removal using only
+coefficient equality. -/
+@[expose]
+def dedupPolys (ps : List ZPoly) : List ZPoly := dedupPolysAux [] ps
+
+theorem mem_dedupPolysAux {p : ZPoly} {seen ps : List ZPoly} :
+    p ∈ dedupPolysAux seen ps ↔ p ∈ ps ∧ p ∉ seen := by
+  classical
+  induction ps generalizing seen p with
+  | nil => simp [dedupPolysAux]
+  | cons q qs ih =>
+      simp only [dedupPolysAux]
+      split <;> rename_i hq
+      · have hqmem : q ∈ seen := containsPoly_iff.mp hq
+        simp only [ih, List.mem_cons]
+        by_cases hpq : p = q
+        · subst p
+          simp [hqmem]
+        · simp [hpq]
+      · have hqmem : q ∉ seen :=
+          containsPoly_eq_false_iff.mp (Bool.eq_false_of_not_eq_true hq)
+        simp only [List.mem_cons, ih]
+        by_cases hpq : p = q
+        · subst p
+          simp [hqmem]
+        · simp [hpq]
+
+theorem mem_dedupPolys {p : ZPoly} {ps : List ZPoly} :
+    p ∈ dedupPolys ps ↔ p ∈ ps := by
+  simp [dedupPolys, mem_dedupPolysAux]
+
+theorem dedupPolysAux_nodup (seen ps : List ZPoly) :
+    (dedupPolysAux seen ps).Nodup := by
+  induction ps generalizing seen with
+  | nil => simp [dedupPolysAux]
+  | cons p ps ih =>
+      simp only [dedupPolysAux]
+      split
+      · exact ih seen
+      · apply List.nodup_cons.mpr
+        exact ⟨by simp [mem_dedupPolysAux], ih (p :: seen)⟩
+
+theorem dedupPolys_nodup (ps : List ZPoly) : (dedupPolys ps).Nodup :=
+  dedupPolysAux_nodup [] ps
+
+/-- Pair a recomputed polynomial order with common-root packages and validate
+every package. Length mismatches and malformed packages are rejected. -/
+@[expose]
+def checkCommon (carrier : ZPoly) :
+    List ZPoly → List CommonRootCert → Bool
+  | [], [] => true
+  | p :: ps, common :: commons =>
+      common.check p carrier && checkCommon carrier ps commons
+  | _, _ => false
+
+/-- Positional lookup in an aligned common-root package list. -/
+@[expose]
+def findCommon? (p : ZPoly) :
+    List ZPoly → List CommonRootCert → Option CommonRootCert
+  | q :: qs, common :: commons =>
+      if DensePoly.beqCoeffs p q then some common
+      else findCommon? p qs commons
+  | _, _ => none
+
+/-- Checked alignment makes positional lookup total and validates the package
+against the requested external polynomial. -/
+theorem findCommon?_of_check {carrier p : ZPoly} {ps : List ZPoly}
+    {commons : List CommonRootCert} (hcheck : checkCommon carrier ps commons = true)
+    (hmem : p ∈ ps) :
+    ∃ common, findCommon? p ps commons = some common ∧
+      common.check p carrier = true := by
+  induction ps generalizing commons with
+  | nil => simp at hmem
+  | cons q qs ih =>
+      cases commons with
+      | nil => simp [checkCommon] at hcheck
+      | cons common commons =>
+          simp only [checkCommon, Bool.and_eq_true] at hcheck
+          rcases hcheck with ⟨hhead, htail⟩
+          by_cases hpq : p = q
+          · subst q
+            exact ⟨common, by simp [findCommon?, DensePoly.beqCoeffs_iff_eq], hhead⟩
+          · have htailMem : p ∈ qs := by
+              simpa [hpq] using hmem
+            obtain ⟨found, hfind, hfound⟩ := ih htail htailMem
+            refine ⟨found, ?_, hfound⟩
+            simp [findCommon?, DensePoly.beqCoeffs_iff_eq, hpq, hfind]
+
+/-- Common-root data carried by the sign-matrix layer.  No signs or formula
+truth values are trusted fields: both are recomputed exactly. -/
+structure SignMatrixCert where
+  commonRoots : List CommonRootCert
+
+/-- Exact sign on an open cell, rejecting the impossible zero result for a
+nonconstant atom of a valid carrier decomposition. -/
+@[expose]
+def openSign? (p : ZPoly) (isolations : IsolationCert)
+    (cut : Fin (isolations.intervals.size + 1)) : Option Sign :=
+  match evalSign p (isolations.openPoint cut) with
+  | .zero => none
+  | sign => some sign
+
+/-- Exact sign on a root cell from the cached common-root zero test, or from
+the canonical left open sample when the atom does not vanish. -/
+@[expose]
+def rootSign? (p : ZPoly) (common : CommonRootCert)
+    (isolations : IsolationCert) (i : Fin isolations.intervals.size) :
+    Option Sign :=
+  match common.hasRoot isolations.intervals[i] with
+  | true => some .zero
+  | false => openSign? p isolations i.castSucc
+
+theorem openSign?_eq_some {p : ZPoly} {isolations : IsolationCert}
+    {cut : Fin (isolations.intervals.size + 1)}
+    (hnonzero : evalSign p (isolations.openPoint cut) ≠ .zero) :
+    openSign? p isolations cut =
+      some (evalSign p (isolations.openPoint cut)) := by
+  cases hsign : evalSign p (isolations.openPoint cut) <;>
+    simp_all [openSign?]
+
+/-- One cached sign associated with its literal polynomial. -/
+structure SignEntry where
+  poly : ZPoly
+  sign : Sign
+
+/-- Coefficient-equality lookup in a cached sign row. -/
+@[expose]
+def findSign? (p : ZPoly) : List SignEntry → Option Sign
+  | [] => none
+  | entry :: entries =>
+      if DensePoly.beqCoeffs p entry.poly then some entry.sign
+      else findSign? p entries
+
+/-- Materialize a sign row once for each polynomial in a recomputed distinct
+order. Any missing sign fails the whole row. -/
+@[expose]
+def buildSigns? (signOf : ZPoly → Option Sign) :
+    List ZPoly → Option (List SignEntry)
+  | [] => some []
+  | p :: ps => do
+      let sign ← signOf p
+      let entries ← buildSigns? signOf ps
+      pure (⟨p, sign⟩ :: entries)
+
+/-- A row built from an option-valued environment returns exactly that
+environment on every polynomial included in the row order. -/
+theorem findSign?_of_build {signOf : ZPoly → Option Sign} {ps : List ZPoly}
+    {entries : List SignEntry} (hbuild : buildSigns? signOf ps = some entries)
+    {p : ZPoly} (hmem : p ∈ ps) : findSign? p entries = signOf p := by
+  induction ps generalizing entries with
+  | nil => simp at hmem
+  | cons q qs ih =>
+      cases hq : signOf q with
+      | none => simp [buildSigns?, hq] at hbuild
+      | some sign =>
+          cases hrest : buildSigns? signOf qs with
+          | none => simp [buildSigns?, hq, hrest] at hbuild
+          | some rest =>
+              have hentries : entries = ⟨q, sign⟩ :: rest := by
+                simpa [buildSigns?, hq, hrest] using hbuild.symm
+              subst entries
+              by_cases hpq : p = q
+              · subst q
+                simp [findSign?, DensePoly.beqCoeffs_iff_eq, hq]
+              · have htail : p ∈ qs := by simpa [hpq] using hmem
+                simp [findSign?, DensePoly.beqCoeffs_iff_eq, hpq,
+                  ih hrest htail]
+
+/-- A total option-valued environment builds a complete cached row. -/
+theorem buildSigns?_total {signOf : ZPoly → Option Sign} {ps : List ZPoly}
+    (htotal : ∀ p ∈ ps, ∃ sign, signOf p = some sign) :
+    ∃ entries, buildSigns? signOf ps = some entries := by
+  induction ps with
+  | nil => exact ⟨[], rfl⟩
+  | cons p ps ih =>
+      obtain ⟨sign, hsign⟩ := htotal p (by simp)
+      obtain ⟨entries, hentries⟩ := ih (by
+        intro q hq
+        exact htotal q (by simp [hq]))
+      exact ⟨⟨p, sign⟩ :: entries, by simp [buildSigns?, hsign, hentries]⟩
+
+namespace SignMatrixCert
+
+/-- Recompute the distinct nonconstant atom order and validate exact package
+alignment against the checked carrier. -/
+@[expose]
+def check (sentence : Sentence) (carrier : CarrierCert)
+    (cert : SignMatrixCert) : Bool :=
+  checkCommon carrier.carrier (dedupPolys sentence.polys) cert.commonRoots
+
+/-- Look up the package associated with one nonconstant atom. -/
+@[expose]
+def findCommon? (sentence : Sentence) (cert : SignMatrixCert)
+    (p : ZPoly) : Option CommonRootCert :=
+  Hex.RCF.findCommon? p (dedupPolys sentence.polys) cert.commonRoots
+
+/-- Every recomputed nonconstant atom has a checked package after successful
+alignment. -/
+theorem findCommon?_of_check {sentence : Sentence} {carrier : CarrierCert}
+    {cert : SignMatrixCert} (hcheck : cert.check sentence carrier = true)
+    {p : ZPoly} (hmem : p ∈ sentence.polys) :
+    ∃ common, cert.findCommon? sentence p = some common ∧
+      common.check p carrier.carrier = true := by
+  apply Hex.RCF.findCommon?_of_check hcheck
+  exact mem_dedupPolys.mpr hmem
+
+/-- Recompute one atom sign on one carrier cell using a precomputed distinct
+nonconstant order. Constants use evaluation at zero and consume no
+common-root package. -/
+@[expose]
+def signWith? (cert : SignMatrixCert) (commonPolys : List ZPoly)
+    (isolations : IsolationCert) (cell : Cell isolations.intervals.size)
+    (p : ZPoly) : Option Sign :=
+  if 0 < p.degree?.getD 0 then
+    match cell with
+    | .open cut => openSign? p isolations cut
+    | .root i => do
+        let common ← Hex.RCF.findCommon? p commonPolys cert.commonRoots
+        rootSign? p common isolations i
+  else some (evalSign p 0)
+
+/-- Public atom-sign lookup, recomputing the deterministic package order. -/
+@[expose]
+def sign? (cert : SignMatrixCert) (sentence : Sentence)
+    (isolations : IsolationCert) (cell : Cell isolations.intervals.size)
+    (p : ZPoly) : Option Sign :=
+  cert.signWith? (dedupPolys sentence.polys) isolations cell p
+
+/-- A checked sign-matrix package returns a total exact sign for every atom on
+every semantic carrier cell when given the checker-derived package order. -/
+theorem signWith?_spec {sentence : Sentence} {carrier : CarrierCert}
+    {cert : SignMatrixCert} {isolations : IsolationCert}
+    (hcarrier : carrier.check sentence = true)
+    (hstrict : isolations.checkStrict carrier.replay = true)
+    (hmatrix : cert.check sentence carrier = true)
+    {commonPolys : List ZPoly}
+    (hpolys : commonPolys = dedupPolys sentence.polys)
+    {p : ZPoly} (hp : p ∈ sentence.formula.polys)
+    (cell : Cell isolations.intervals.size) :
+    ∃ sign, cert.signWith? commonPolys isolations cell p = some sign ∧
+      ∀ x, Cell.Sem
+        (isolations.rootModel (CarrierCert.replay_of_check hcarrier) hstrict)
+        cell x →
+        SignType.sign (((sign.toInt : Int) : ℝ)) =
+          SignType.sign ((toPolyℝ p).eval x) := by
+  subst commonPolys
+  by_cases hdegree : 0 < p.degree?.getD 0
+  · have hpmem : p ∈ sentence.polys := by
+      simp only [Sentence.polys, List.mem_filter, decide_eq_true_eq]
+      exact ⟨hp, hdegree⟩
+    have hreplay := CarrierCert.replay_of_check hcarrier
+    let model := isolations.rootModel hreplay hstrict
+    have hroot : ∀ z, (toPolyℝ p).IsRoot z →
+        (toPolyℝ carrier.carrier).IsRoot z := by
+      intro z hz
+      exact (carrier.isRoot_iff_atom hcarrier z).2 ⟨p, hpmem, hz⟩
+    cases cell with
+    | «open» cut =>
+        have hsample : Cell.Sem model (.open cut)
+            (Dyadic.toReal (isolations.openPoint cut)) :=
+          Cell.openPoint_mem isolations hreplay hstrict cut
+        have hnotroot : ¬(toPolyℝ p).IsRoot
+            (Dyadic.toReal (isolations.openPoint cut)) := by
+          intro hpRoot
+          exact Cell.open_not_root model hsample (hroot _ hpRoot)
+        have hnonzero : evalSign p (isolations.openPoint cut) ≠ .zero :=
+          evalSign_ne_zero_of_not_root p _ hnotroot
+        refine ⟨evalSign p (isolations.openPoint cut), ?_, ?_⟩
+        · simp [signWith?, hdegree, openSign?_eq_some hnonzero]
+        · intro x hx
+          exact evalSign_open_of_atom hcarrier hstrict hpmem cut hx
+    | root i =>
+        obtain ⟨common, hfind, hcommon⟩ :=
+          cert.findCommon?_of_check hmatrix hpmem
+        have hfind' : Hex.RCF.findCommon? p (dedupPolys sentence.polys)
+            cert.commonRoots = some common := by
+          simpa [findCommon?] using hfind
+        by_cases hhas : common.hasRoot isolations.intervals[i] = true
+        · refine ⟨.zero, ?_, ?_⟩
+          · have hhas' : common.hasRoot isolations.intervals[↑i] = true := by
+              simpa using hhas
+            simp only [signWith?, if_pos hdegree]
+            rw [hfind']
+            change rootSign? p common isolations i = some .zero
+            unfold rootSign?
+            rw [hhas']
+          · intro x hx
+            have hxroot : x = model.root i := by simpa [Cell.Sem] using hx
+            rw [hxroot]
+            have hpRoot : (toPolyℝ p).IsRoot (model.root i) :=
+              (common.hasRoot_model_iff hreplay hstrict hcommon i).1 hhas
+            simp only [Polynomial.IsRoot] at hpRoot
+            rw [hpRoot]
+            simp [Sign.toInt]
+        · have hhasFalse : common.hasRoot isolations.intervals[i] = false :=
+            Bool.eq_false_of_not_eq_true hhas
+          have hhasFalse' : common.hasRoot isolations.intervals[↑i] = false := by
+            simpa using hhasFalse
+          have hsample : Cell.Sem model (.open i.castSucc)
+              (Dyadic.toReal (isolations.openPoint i.castSucc)) :=
+            Cell.openPoint_mem isolations hreplay hstrict i.castSucc
+          have hnotroot : ¬(toPolyℝ p).IsRoot
+              (Dyadic.toReal (isolations.openPoint i.castSucc)) := by
+            intro hpRoot
+            exact Cell.open_not_root model hsample (hroot _ hpRoot)
+          have hnonzero : evalSign p (isolations.openPoint i.castSucc) ≠ .zero :=
+            evalSign_ne_zero_of_not_root p _ hnotroot
+          refine ⟨evalSign p (isolations.openPoint i.castSucc), ?_, ?_⟩
+          · simp only [signWith?, if_pos hdegree]
+            rw [hfind']
+            change rootSign? p common isolations i =
+              some (evalSign p (isolations.openPoint i.castSucc))
+            unfold rootSign?
+            rw [hhasFalse', openSign?_eq_some hnonzero]
+          · intro x hx
+            have hxroot : x = model.root i := by simpa [Cell.Sem] using hx
+            rw [hxroot]
+            exact evalSign_commonLeft hcarrier hstrict hpmem
+              hcommon i hhasFalse
+  · refine ⟨evalSign p 0, by simp [signWith?, hdegree], ?_⟩
+    intro x _hx
+    rw [eval_eq_eval_zero_of_degree_nonpos p hdegree x]
+    simpa using evalSign_spec p 0
+
+/-- Public atom-sign lookup is total and exact under the combined checker. -/
+theorem sign?_spec {sentence : Sentence} {carrier : CarrierCert}
+    {cert : SignMatrixCert} {isolations : IsolationCert}
+    (hcarrier : carrier.check sentence = true)
+    (hstrict : isolations.checkStrict carrier.replay = true)
+    (hmatrix : cert.check sentence carrier = true)
+    {p : ZPoly} (hp : p ∈ sentence.formula.polys)
+    (cell : Cell isolations.intervals.size) :
+    ∃ sign, cert.sign? sentence isolations cell p = some sign ∧
+      ∀ x, Cell.Sem
+        (isolations.rootModel (CarrierCert.replay_of_check hcarrier) hstrict)
+        cell x →
+        SignType.sign (((sign.toInt : Int) : ℝ)) =
+          SignType.sign ((toPolyℝ p).eval x) := by
+  exact cert.signWith?_spec hcarrier hstrict hmatrix rfl hp cell
+
+end SignMatrixCert
+
+namespace Cmp
+
+/-- Evaluate a comparison from the sign of its left-hand side. -/
+@[expose]
+def evalSign (cmp : Cmp) (sign : Sign) : Bool :=
+  match cmp with
+  | .lt => sign == .neg
+  | .le => sign != .pos
+  | .eq => sign == .zero
+  | .ge => sign != .neg
+  | .gt => sign == .pos
+  | .ne => sign != .zero
+
+/-- Comparison evaluation depends only on the mathematical sign. -/
+theorem evalSign_iff {cmp : Cmp} {sign : Sign} {value : ℝ}
+    (hsign : SignType.sign (((sign.toInt : Int) : ℝ)) = SignType.sign value) :
+    cmp.evalSign sign = true ↔ cmp.toProp value 0 := by
+  cases sign with
+  | neg =>
+      have hv : SignType.sign value = -1 := by
+        simpa [Sign.toInt] using hsign.symm
+      have hvneg : value < 0 := sign_eq_neg_one_iff.mp hv
+      have hvnotge : ¬0 ≤ value := not_le.mpr hvneg
+      cases cmp <;> simp [evalSign, toProp, hvneg, hvneg.le,
+        hvneg.ne, hvnotge]
+  | zero =>
+      have hv : SignType.sign value = 0 := by
+        simpa [Sign.toInt] using hsign.symm
+      have hvzero : value = 0 := sign_eq_zero_iff.mp hv
+      subst value
+      cases cmp <;> simp [evalSign, toProp]
+  | pos =>
+      have hv : SignType.sign value = 1 := by
+        simpa [Sign.toInt] using hsign.symm
+      have hvpos : 0 < value := sign_eq_one_iff.mp hv
+      have hvnotle : ¬value ≤ 0 := not_le.mpr hvpos
+      cases cmp <;> simp [evalSign, toProp, hvpos, hvpos.le,
+        hvpos.ne', hvnotle]
+
+end Cmp
+
+/-- Bridge the reflected atom semantics to real-cast polynomial evaluation. -/
+theorem Atom.toProp_iff_eval (a : Atom) (x : ℝ) :
+    a.toProp x ↔ a.cmp.toProp ((toPolyℝ a.p).eval x) 0 := by
+  unfold Atom.toProp
+  rw [Polynomial.aeval_def, ← Polynomial.eval_map]
+  rfl
+
+namespace Formula
+
+/-- Evaluate a formula from an option-valued polynomial-sign environment.
+Every Boolean branch evaluates both children, so any missing sign fails closed.
+-/
+@[expose]
+def evalSigns (signOf : ZPoly → Option Sign) : Formula → Option Bool
+  | .atom a => do
+      let sign ← signOf a.p
+      pure (a.cmp.evalSign sign)
+  | .tt => some true
+  | .ff => some false
+  | .not φ => do
+      let value ← φ.evalSigns signOf
+      pure (!value)
+  | .and φ ψ => do
+      let left ← φ.evalSigns signOf
+      let right ← ψ.evalSigns signOf
+      pure (left && right)
+  | .or φ ψ => do
+      let left ← φ.evalSigns signOf
+      let right ← ψ.evalSigns signOf
+      pure (left || right)
+  | .imp φ ψ => do
+      let left ← φ.evalSigns signOf
+      let right ← ψ.evalSigns signOf
+      pure (!left || right)
+
+/-- Formula evaluation returns a Boolean whose truth is exactly the semantic
+formula, provided every referenced polynomial lookup carries its exact sign.
+The existential result also supplies the false direction required by negation
+and implication. -/
+theorem evalSigns_spec {formula : Formula} {signOf : ZPoly → Option Sign}
+    {x : ℝ}
+    (hlookup : ∀ p ∈ formula.polys, ∃ sign,
+      signOf p = some sign ∧
+      SignType.sign (((sign.toInt : Int) : ℝ)) =
+        SignType.sign ((toPolyℝ p).eval x)) :
+    ∃ value, formula.evalSigns signOf = some value ∧
+      (value = true ↔ formula.toProp x) := by
+  induction formula with
+  | atom a =>
+      obtain ⟨sign, hsign, hsound⟩ := hlookup a.p (by simp [Formula.polys])
+      refine ⟨a.cmp.evalSign sign, by simp [evalSigns, hsign], ?_⟩
+      rw [Formula.toProp, a.toProp_iff_eval]
+      exact Cmp.evalSign_iff hsound
+  | tt => exact ⟨true, rfl, by simp [Formula.toProp]⟩
+  | ff => exact ⟨false, rfl, by simp [Formula.toProp]⟩
+  | not φ ih =>
+      obtain ⟨value, hvalue, hsound⟩ := ih (by
+        intro p hp
+        exact hlookup p (by simpa [Formula.polys] using hp))
+      refine ⟨!value, by simp [evalSigns, hvalue], ?_⟩
+      cases value <;>
+        simp_all only [Bool.not_false, Bool.not_true, Bool.false_eq_true,
+          eq_self, Formula.toProp, false_iff, true_iff,
+          not_false_eq_true, not_true_eq_false]
+  | and φ ψ ihφ ihψ =>
+      obtain ⟨left, hleft, hleftSound⟩ := ihφ (by
+        intro p hp
+        exact hlookup p (by simp [Formula.polys, hp]))
+      obtain ⟨right, hright, hrightSound⟩ := ihψ (by
+        intro p hp
+        exact hlookup p (by simp [Formula.polys, hp]))
+      refine ⟨left && right, by simp [evalSigns, hleft, hright], ?_⟩
+      cases left <;> cases right <;>
+        simp_all only [Bool.false_and, Bool.true_and, Bool.false_eq_true,
+          eq_self, Formula.toProp, false_iff, true_iff] <;> simp
+  | or φ ψ ihφ ihψ =>
+      obtain ⟨left, hleft, hleftSound⟩ := ihφ (by
+        intro p hp
+        exact hlookup p (by simp [Formula.polys, hp]))
+      obtain ⟨right, hright, hrightSound⟩ := ihψ (by
+        intro p hp
+        exact hlookup p (by simp [Formula.polys, hp]))
+      refine ⟨left || right, by simp [evalSigns, hleft, hright], ?_⟩
+      cases left <;> cases right <;>
+        simp_all only [Bool.false_or, Bool.true_or, Bool.false_eq_true,
+          eq_self, Formula.toProp, false_iff, true_iff] <;> simp
+  | imp φ ψ ihφ ihψ =>
+      obtain ⟨left, hleft, hleftSound⟩ := ihφ (by
+        intro p hp
+        exact hlookup p (by simp [Formula.polys, hp]))
+      obtain ⟨right, hright, hrightSound⟩ := ihψ (by
+        intro p hp
+        exact hlookup p (by simp [Formula.polys, hp]))
+      refine ⟨!left || right, by simp [evalSigns, hleft, hright], ?_⟩
+      cases left <;> cases right <;>
+        simp_all only [Bool.not_false, Bool.not_true, Bool.false_or,
+          Bool.true_or, Bool.false_eq_true, eq_self, Formula.toProp,
+          false_iff, true_iff] <;> simp
+
+/-- Successful true formula evaluation is equivalent to the reflected
+semantics at the point. -/
+theorem evalSigns_eq_true_iff {formula : Formula}
+    {signOf : ZPoly → Option Sign} {x : ℝ}
+    (hlookup : ∀ p ∈ formula.polys, ∃ sign,
+      signOf p = some sign ∧
+      SignType.sign (((sign.toInt : Int) : ℝ)) =
+        SignType.sign ((toPolyℝ p).eval x)) :
+    formula.evalSigns signOf = some true ↔ formula.toProp x := by
+  obtain ⟨value, hvalue, hsound⟩ := evalSigns_spec hlookup
+  constructor
+  · intro htrue
+    exact hsound.mp (Option.some.inj (hvalue.symm.trans htrue))
+  · intro hprop
+    have : value = true := hsound.mpr hprop
+    simpa [this] using hvalue
+
+/-- Evaluate a formula whose atoms are all constant, without constructing a
+carrier decomposition. -/
+@[expose]
+def evalConstants? (formula : Formula) : Option Bool :=
+  formula.evalSigns fun p => some (Hex.RCF.evalSign p 0)
+
+/-- Constant-only formula evaluation is exact at every real point, including
+formulas containing the zero polynomial. -/
+theorem evalConstants_eq_true_iff {formula : Formula}
+    (hconstant : ∀ p ∈ formula.polys, ¬0 < p.degree?.getD 0) (x : ℝ) :
+    formula.evalConstants? = some true ↔ formula.toProp x := by
+  apply evalSigns_eq_true_iff
+  intro p hp
+  refine ⟨Hex.RCF.evalSign p 0, rfl, ?_⟩
+  rw [eval_eq_eval_zero_of_degree_nonpos p (hconstant p hp) x]
+  simpa using Hex.RCF.evalSign_spec p 0
+
+end Formula
+
+namespace SignMatrixCert
+
+/-- Recompute the formula truth value on one carrier cell after materializing
+one exact sign per distinct polynomial. Repeated atom occurrences reuse the
+cached row entry. -/
+@[expose]
+def evalCell? (cert : SignMatrixCert) (sentence : Sentence)
+    (isolations : IsolationCert) (cell : Cell isolations.intervals.size) :
+    Option Bool := do
+  let commonPolys := dedupPolys sentence.polys
+  let entries ← buildSigns? (cert.signWith? commonPolys isolations cell)
+    (dedupPolys sentence.formula.polys)
+  sentence.formula.evalSigns (findSign? · entries)
+
+/-- A checked package computes one Boolean valid uniformly throughout each
+semantic carrier cell. -/
+theorem evalCell_spec {sentence : Sentence} {carrier : CarrierCert}
+    {cert : SignMatrixCert} {isolations : IsolationCert}
+    (hcarrier : carrier.check sentence = true)
+    (hstrict : isolations.checkStrict carrier.replay = true)
+    (hmatrix : cert.check sentence carrier = true)
+    (cell : Cell isolations.intervals.size) :
+    ∃ value, cert.evalCell? sentence isolations cell = some value ∧
+      ∀ x, Cell.Sem
+        (isolations.rootModel (CarrierCert.replay_of_check hcarrier) hstrict)
+        cell x →
+        (value = true ↔ sentence.formula.toProp x) := by
+  let model := isolations.rootModel (CarrierCert.replay_of_check hcarrier) hstrict
+  let commonPolys := dedupPolys sentence.polys
+  obtain ⟨sample, hsample⟩ := Cell.exists_point model cell
+  obtain ⟨entries, hentries⟩ := buildSigns?_total
+      (signOf := cert.signWith? commonPolys isolations cell)
+      (ps := dedupPolys sentence.formula.polys) (by
+    intro p hp
+    have hpFormula : p ∈ sentence.formula.polys := mem_dedupPolys.mp hp
+    obtain ⟨sign, hsign, _hsound⟩ :=
+      cert.signWith?_spec hcarrier hstrict hmatrix rfl hpFormula cell
+    exact ⟨sign, hsign⟩)
+  obtain ⟨value, hvalue, _hsampleSound⟩ := Formula.evalSigns_spec
+    (x := sample) (by
+      intro p hp
+      obtain ⟨sign, hsign, hsound⟩ :=
+        cert.signWith?_spec hcarrier hstrict hmatrix rfl hp cell
+      have hfind := findSign?_of_build hentries (mem_dedupPolys.mpr hp)
+      rw [hsign] at hfind
+      exact ⟨sign, hfind, hsound sample hsample⟩)
+  refine ⟨value, by simp [evalCell?, commonPolys, hentries, hvalue], ?_⟩
+  intro x hx
+  have hformula := Formula.evalSigns_eq_true_iff
+    (formula := sentence.formula)
+    (signOf := fun p => findSign? p entries) (x := x) (by
+      intro p hp
+      obtain ⟨sign, hsign, hsound⟩ :=
+        cert.signWith?_spec hcarrier hstrict hmatrix rfl hp cell
+      have hfind := findSign?_of_build hentries (mem_dedupPolys.mpr hp)
+      rw [hsign] at hfind
+      exact ⟨sign, hfind, hsound x hx⟩)
+  rw [← hformula, hvalue]
+  simp
+
+/-- The computed true value is exactly the reflected formula semantics at
+every point of the checked cell. -/
+theorem evalCell_eq_true_iff {sentence : Sentence} {carrier : CarrierCert}
+    {cert : SignMatrixCert} {isolations : IsolationCert}
+    (hcarrier : carrier.check sentence = true)
+    (hstrict : isolations.checkStrict carrier.replay = true)
+    (hmatrix : cert.check sentence carrier = true)
+    {cell : Cell isolations.intervals.size} {x : ℝ}
+    (hx : Cell.Sem
+      (isolations.rootModel (CarrierCert.replay_of_check hcarrier) hstrict)
+      cell x) :
+    cert.evalCell? sentence isolations cell = some true ↔
+      sentence.formula.toProp x := by
+  obtain ⟨value, hvalue, hsound⟩ :=
+    cert.evalCell_spec hcarrier hstrict hmatrix cell
+  constructor
+  · intro htrue
+    have : value = true := Option.some.inj (hvalue.symm.trans htrue)
+    exact (hsound x hx).1 this
+  · intro hprop
+    have : value = true := (hsound x hx).2 hprop
+    simpa [this] using hvalue
+
+end SignMatrixCert
+
+end Hex.RCF

--- a/HexRCF/SignMatrixTests.lean
+++ b/HexRCF/SignMatrixTests.lean
@@ -1,0 +1,315 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.SignMatrix
+
+public section
+
+/-! Regression tests for exact signs, package alignment, and cell formulas. -/
+
+namespace Hex.RCF.SignMatrixTests
+
+open HexRealRootsMathlib
+
+private def zero : ZPoly := 0
+private def minusOne : ZPoly := DensePoly.ofCoeffs #[(-1 : Int)]
+private def minusTwo : ZPoly := DensePoly.ofCoeffs #[(-2 : Int)]
+private def one : ZPoly := DensePoly.ofCoeffs #[(1 : Int)]
+private def x : ZPoly := DensePoly.ofCoeffs #[(0 : Int), 1]
+private def twiceX : ZPoly := DensePoly.ofCoeffs #[(0 : Int), 2]
+private def fourX : ZPoly := DensePoly.ofCoeffs #[(0 : Int), 4]
+private def xMinusOne : ZPoly := DensePoly.ofCoeffs #[(-1 : Int), 1]
+private def xPlusOne : ZPoly := DensePoly.ofCoeffs #[(1 : Int), 1]
+private def quad : ZPoly := DensePoly.ofCoeffs #[(-1 : Int), 0, 1]
+private def posQuad : ZPoly := DensePoly.ofCoeffs #[(1 : Int), 0, 1]
+private def threeXPlusOne : ZPoly := DensePoly.ofCoeffs #[(1 : Int), 3]
+
+/-! Three-way exact evaluation and all eighteen comparison outcomes. -/
+
+example : evalSign x (Dyadic.ofInt (-1)) = .neg := by decide
+example : evalSign x 0 = .zero := by decide
+example : evalSign x (Dyadic.ofInt 1) = .pos := by decide
+
+example : Cmp.lt.evalSign .neg = true := by decide
+example : Cmp.le.evalSign .neg = true := by decide
+example : Cmp.eq.evalSign .neg = false := by decide
+example : Cmp.ge.evalSign .neg = false := by decide
+example : Cmp.gt.evalSign .neg = false := by decide
+example : Cmp.ne.evalSign .neg = true := by decide
+example : Cmp.lt.evalSign .zero = false := by decide
+example : Cmp.le.evalSign .zero = true := by decide
+example : Cmp.eq.evalSign .zero = true := by decide
+example : Cmp.ge.evalSign .zero = true := by decide
+example : Cmp.gt.evalSign .zero = false := by decide
+example : Cmp.ne.evalSign .zero = false := by decide
+example : Cmp.lt.evalSign .pos = false := by decide
+example : Cmp.le.evalSign .pos = false := by decide
+example : Cmp.eq.evalSign .pos = false := by decide
+example : Cmp.ge.evalSign .pos = true := by decide
+example : Cmp.gt.evalSign .pos = true := by decide
+example : Cmp.ne.evalSign .pos = true := by decide
+
+/-! Every Boolean connective is executable in both truth states. -/
+
+example : Formula.evalSigns (fun _ => none) (.not .tt) = some false := by decide
+example : Formula.evalSigns (fun _ => none) (.not .ff) = some true := by decide
+example : Formula.evalSigns (fun _ => none) (.and .ff .ff) = some false := by decide
+example : Formula.evalSigns (fun _ => none) (.and .ff .tt) = some false := by decide
+example : Formula.evalSigns (fun _ => none) (.and .tt .ff) = some false := by decide
+example : Formula.evalSigns (fun _ => none) (.and .tt .tt) = some true := by decide
+example : Formula.evalSigns (fun _ => none) (.or .ff .ff) = some false := by decide
+example : Formula.evalSigns (fun _ => none) (.or .ff .tt) = some true := by decide
+example : Formula.evalSigns (fun _ => none) (.or .tt .ff) = some true := by decide
+example : Formula.evalSigns (fun _ => none) (.or .tt .tt) = some true := by decide
+example : Formula.evalSigns (fun _ => none) (.imp .ff .ff) = some true := by decide
+example : Formula.evalSigns (fun _ => none) (.imp .ff .tt) = some true := by decide
+example : Formula.evalSigns (fun _ => none) (.imp .tt .ff) = some false := by decide
+example : Formula.evalSigns (fun _ => none) (.imp .tt .tt) = some true := by decide
+
+private def missing : Formula := .atom ⟨x, .eq⟩
+example : Formula.evalSigns (fun _ => none) (.and .ff missing) = none := by decide
+example : Formula.evalSigns (fun _ => none) (.or .tt missing) = none := by decide
+example : Formula.evalSigns (fun _ => none) (.imp .ff missing) = none := by decide
+example : Formula.evalSigns (fun _ => none) (.not missing) = none := by decide
+example : Formula.evalSigns (fun _ => none) (.and missing .ff) = none := by decide
+
+/-! A two-root carrier exercises shared roots and nonzero root transfer. -/
+
+private def quadReplay : SturmReplay where
+  chain := #[quad, x, one]
+  derivScale := 2
+  steps := #[{ leftScale := 1, quotient := x, rightScale := 1 }]
+
+private def minusReplay : SturmReplay where
+  chain := #[xMinusOne, one]
+  derivScale := 1
+  steps := #[]
+
+private def sharedFormula : Formula :=
+  .and (.atom ⟨quad, .eq⟩) (.atom ⟨xMinusOne, .ne⟩)
+
+private def sharedSentence : Sentence := .forallReal sharedFormula
+
+/-- The atom product is `(x - 1)^2 * (x + 1)`, so the repeated factor is
+`x - 1` and its derivative quotient is `3*x + 1`. -/
+private def sharedCarrier : CarrierCert where
+  carrier := quad
+  repeated := xMinusOne
+  derivPart := threeXPlusOne
+  factorScale := 1
+  derivScale := 1
+  replay := quadReplay
+
+private def negHalf : Dyadic := Dyadic.ofInt (-1) >>> (1 : Int)
+private def half : Dyadic := Dyadic.ofInt 1 >>> (1 : Int)
+
+private def twoRoots : IsolationCert := ⟨#[
+  DyadicInterval.mk (Dyadic.ofInt (-2)) negHalf (by decide),
+  DyadicInterval.mk half (Dyadic.ofInt 2) (by decide)]⟩
+
+private def equalQuad : CommonRootCert where
+  gcd := quad
+  atomFactor := one
+  carrierFactor := one
+  atomCoeff := one
+  carrierCoeff := 0
+  scale := 1
+  replay := some quadReplay
+
+private def sharedMinus : CommonRootCert where
+  gcd := xMinusOne
+  atomFactor := one
+  carrierFactor := xPlusOne
+  atomCoeff := one
+  carrierCoeff := 0
+  scale := 1
+  replay := some minusReplay
+
+private def sharedMatrix : SignMatrixCert :=
+  ⟨[equalQuad, sharedMinus]⟩
+
+private theorem sharedCarrier_ok : sharedCarrier.check sharedSentence = true := by decide
+private theorem twoRoots_ok : twoRoots.checkStrict sharedCarrier.replay = true := by decide
+private theorem sharedMatrix_ok : sharedMatrix.check sharedSentence sharedCarrier = true := by
+  decide
+
+example : dedupPolys sharedSentence.polys = [quad, xMinusOne] := by decide
+example : sharedMatrix.sign? sharedSentence twoRoots (.open ⟨0, by decide⟩)
+    quad = some .pos := by decide
+example : sharedMatrix.sign? sharedSentence twoRoots (.root ⟨0, by decide⟩)
+    quad = some .zero := by decide
+example : sharedMatrix.sign? sharedSentence twoRoots (.open ⟨1, by decide⟩)
+    quad = some .neg := by decide
+example : sharedMatrix.sign? sharedSentence twoRoots (.root ⟨1, by decide⟩)
+    quad = some .zero := by decide
+example : sharedMatrix.sign? sharedSentence twoRoots (.open ⟨2, by decide⟩)
+    quad = some .pos := by decide
+
+/-- `x - 1` does not vanish at the left carrier root, so its negative sign is
+transferred from the left open sample; it vanishes at the right root. -/
+example : sharedMatrix.sign? sharedSentence twoRoots (.root ⟨0, by decide⟩)
+    xMinusOne = some .neg := by decide
+example : sharedMatrix.sign? sharedSentence twoRoots (.open ⟨0, by decide⟩)
+    xMinusOne = some .neg := by decide
+example : sharedMatrix.sign? sharedSentence twoRoots (.open ⟨1, by decide⟩)
+    xMinusOne = some .neg := by decide
+example : sharedMatrix.sign? sharedSentence twoRoots (.root ⟨1, by decide⟩)
+    xMinusOne = some .zero := by decide
+example : sharedMatrix.evalCell? sharedSentence twoRoots
+    (.root ⟨0, by decide⟩) = some true := by decide
+example : sharedMatrix.evalCell? sharedSentence twoRoots
+    (.root ⟨1, by decide⟩) = some false := by decide
+example : sharedMatrix.evalCell? sharedSentence twoRoots
+    (.open ⟨0, by decide⟩) = some false := by decide
+example : (⟨[]⟩ : SignMatrixCert).evalCell? sharedSentence twoRoots
+    (.root ⟨0, by decide⟩) = none := by decide
+
+example (c : Cell twoRoots.intervals.size) :
+    ∃ value, sharedMatrix.evalCell? sharedSentence twoRoots c = some value ∧
+      ∀ z, Cell.Sem
+        (twoRoots.rootModel (CarrierCert.replay_of_check sharedCarrier_ok)
+          twoRoots_ok) c z → (value = true ↔ sharedFormula.toProp z) :=
+  sharedMatrix.evalCell_spec sharedCarrier_ok twoRoots_ok sharedMatrix_ok c
+
+/-! Alignment is exact: missing, extra, swapped, and malformed packages fail. -/
+
+example : (⟨[equalQuad]⟩ : SignMatrixCert).check
+    sharedSentence sharedCarrier = false := by decide
+example : (⟨[equalQuad, sharedMinus, sharedMinus]⟩ : SignMatrixCert).check
+    sharedSentence sharedCarrier = false := by decide
+example : (⟨[sharedMinus, equalQuad]⟩ : SignMatrixCert).check
+    sharedSentence sharedCarrier = false := by decide
+example : (⟨[equalQuad, { sharedMinus with scale := 0 }]⟩ : SignMatrixCert).check
+    sharedSentence sharedCarrier = false := by decide
+
+private def repeatedSentence : Sentence :=
+  .forallReal (.and (.atom ⟨quad, .le⟩) (.atom ⟨quad, .ge⟩))
+private def repeatedCarrier : CarrierCert :=
+  { sharedCarrier with repeated := quad, derivPart := fourX }
+private def repeatedMatrix : SignMatrixCert := ⟨[equalQuad]⟩
+
+example : dedupPolys repeatedSentence.polys = [quad] := by decide
+example : dedupPolys [quad, xMinusOne, quad] = [quad, xMinusOne] := by decide
+example : repeatedCarrier.check repeatedSentence = true := by decide
+example : repeatedMatrix.check repeatedSentence repeatedCarrier = true := by decide
+
+/-! Constants in mixed formulas bypass common-root packages on every cell. -/
+
+private def mixedFormula : Formula :=
+  .and (.atom ⟨quad, .ge⟩)
+    (.and (.atom ⟨minusTwo, .lt⟩)
+      (.and (.atom ⟨zero, .eq⟩) (.atom ⟨one, .gt⟩)))
+private def mixedSentence : Sentence := .forallReal mixedFormula
+private def mixedCarrier : CarrierCert :=
+  { sharedCarrier with repeated := one, derivPart := twiceX }
+private def mixedMatrix : SignMatrixCert := ⟨[equalQuad]⟩
+
+example : mixedCarrier.check mixedSentence = true := by decide
+example : mixedMatrix.check mixedSentence mixedCarrier = true := by decide
+example : mixedMatrix.sign? mixedSentence twoRoots (.root ⟨0, by decide⟩)
+    minusTwo = some .neg := by decide
+example : mixedMatrix.sign? mixedSentence twoRoots (.root ⟨1, by decide⟩)
+    zero = some .zero := by decide
+example : mixedMatrix.sign? mixedSentence twoRoots (.open ⟨2, by decide⟩)
+    one = some .pos := by decide
+
+private def constantFormula : Formula :=
+  .and (.atom ⟨minusTwo, .lt⟩)
+    (.and (.atom ⟨zero, .eq⟩) (.atom ⟨one, .gt⟩))
+
+example : constantFormula.evalConstants? = some true := by decide
+
+private def falseConstantFormula : Formula := .atom ⟨one, .lt⟩
+example : falseConstantFormula.evalConstants? = some false := by decide
+
+/-! Zero-root and singleton carriers cover the remaining cell shapes. -/
+
+private def posReplay : SturmReplay where
+  chain := #[posQuad, x, minusOne]
+  derivScale := 2
+  steps := #[{ leftScale := 1, quotient := x, rightScale := 1 }]
+
+private def posSentence : Sentence := .forallReal (.atom ⟨posQuad, .gt⟩)
+private def posCarrier : CarrierCert where
+  carrier := posQuad
+  repeated := one
+  derivPart := twiceX
+  factorScale := 1
+  derivScale := 1
+  replay := posReplay
+private def posCommon : CommonRootCert where
+  gcd := posQuad
+  atomFactor := one
+  carrierFactor := one
+  atomCoeff := one
+  carrierCoeff := 0
+  scale := 1
+  replay := some posReplay
+private def noRoots : IsolationCert := ⟨#[]⟩
+private def posMatrix : SignMatrixCert := ⟨[posCommon]⟩
+
+example : posCarrier.check posSentence = true := by decide
+example : noRoots.checkStrict posReplay = true := by decide
+example : posMatrix.check posSentence posCarrier = true := by decide
+example : posMatrix.sign? posSentence noRoots (.open ⟨0, by decide⟩)
+    posQuad = some .pos := by decide
+/-- Defensive failure for an atom inconsistent with the claimed root-free
+carrier cell. -/
+example : openSign? x noRoots ⟨0, by decide⟩ = none := by decide
+
+/-- A nonzero constant gcd takes the nonvanishing root-sign transfer branch. -/
+private def coprimePos : CommonRootCert where
+  gcd := one
+  atomFactor := posQuad
+  carrierFactor := quad
+  atomCoeff := one
+  carrierCoeff := minusOne
+  scale := 2
+  replay := none
+
+example : coprimePos.check posQuad quad = true := by decide
+example : rootSign? posQuad coprimePos twoRoots ⟨0, by decide⟩ = some .pos := by decide
+example : rootSign? posQuad coprimePos twoRoots ⟨1, by decide⟩ = some .pos := by decide
+example : sharedMatrix.sign? sharedSentence twoRoots (.root ⟨0, by decide⟩)
+    posQuad = none := by decide
+
+private def linearReplay : SturmReplay where
+  chain := #[x, one]
+  derivScale := 1
+  steps := #[]
+private def linearSentence : Sentence := .forallReal (.atom ⟨x, .eq⟩)
+private def linearCarrier : CarrierCert where
+  carrier := x
+  repeated := one
+  derivPart := one
+  factorScale := 1
+  derivScale := 1
+  replay := linearReplay
+private def linearCommon : CommonRootCert where
+  gcd := x
+  atomFactor := one
+  carrierFactor := one
+  atomCoeff := one
+  carrierCoeff := 0
+  scale := 1
+  replay := some linearReplay
+private def singleton : IsolationCert := ⟨#[
+  DyadicInterval.mk (Dyadic.ofInt (-1)) (Dyadic.ofInt 1) (by decide)]⟩
+private def linearMatrix : SignMatrixCert := ⟨[linearCommon]⟩
+
+example : linearCarrier.check linearSentence = true := by decide
+example : singleton.checkStrict linearReplay = true := by decide
+example : linearMatrix.check linearSentence linearCarrier = true := by decide
+example : linearMatrix.sign? linearSentence singleton (.open ⟨0, by decide⟩)
+    x = some .neg := by decide
+example : linearMatrix.sign? linearSentence singleton (.root ⟨0, by decide⟩)
+    x = some .zero := by decide
+example : linearMatrix.sign? linearSentence singleton (.open ⟨1, by decide⟩)
+    x = some .pos := by decide
+
+end Hex.RCF.SignMatrixTests

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -156,11 +156,12 @@ proved equivalences.
    the original goal described above.
 
 2. **Collect** the atom polynomials. Constant atoms (degree ≤ 0,
-   including the zero polynomial) are evaluated to `tt`/`ff` by the
-   decision pipeline and never reach the decomposition. The reifier
-   may perform the same fold as an optimisation, but `decide` and
-   `check` must also handle arbitrary directly constructed
-   `Sentence`s containing constant atoms.
+   including the zero polynomial) never contribute carrier boundaries or
+   common-root packages. Mixed formulas cache their constant signs alongside
+   nonconstant signs in each cell row; a constant-only formula is folded once
+   without constructing a carrier. The reifier may perform the same fold as
+   an optimisation, but `decide` and `check` must also handle arbitrary
+   directly constructed `Sentence`s containing constant atoms.
 
 3. **Handle empty bounded domains.** Before any cell reasoning, compare
    the dyadic endpoints. If `a < b` is false, `(a,b]` is empty:
@@ -253,6 +254,12 @@ proved equivalences.
    each open cell: a sign change would put a root of `pⱼ`, hence of
    `P`, strictly between consecutive roots of `P`.
 
+   For root-cell transfer, `RootModel.leftSpan` is the interval from the open
+   cell immediately left of root `i` through that root. Its preconnectedness,
+   open-sample and root membership lemmas, together with
+   `RootModel.root_eq_of_mem_leftSpan`, show that the only carrier root in the
+   span is root `i` itself.
+
 7. **Prepare common-root packages.** Do the expensive work once per
    distinct nonconstant atom, not once per root cell. For each `pⱼ`,
    the builder computes a rational gcd representative `gⱼ` and emits a
@@ -288,6 +295,11 @@ proved equivalences.
    an individual package.
 
 8. **Sign matrix.** For each cell and each atom polynomial `pⱼ`:
+   The checker first coefficient-deduplicates the recomputed nonconstant atom
+   order and checks exactly one positional common-root package per result;
+   missing, extra, swapped, or malformed packages fail. It also deduplicates
+   all formula polynomials and materializes one option-valued sign row per
+   cell, so repeated atom occurrences reuse the same arithmetic result.
    - Open cells: exact Horner evaluation at the cell's dyadic test
      point. The value is nonzero (the test point is in no isolation,
      and roots of `pⱼ` are roots of `P`). A zero value would refute
@@ -298,12 +310,18 @@ proved equivalences.
      Since `gⱼ ∣ P`, the interval contains at most one such root; the
      common-root identities make that root exist exactly when
      `pⱼ(rᵢ) = 0`. When `pⱼ(rᵢ) ≠ 0`, its sign at `rᵢ` equals its sign
-     on either adjacent open cell. The two adjacent signs agree,
-     because otherwise `pⱼ` would have another root before the next
-     carrier root.
+     on either adjacent open cell. The executable checker canonically uses
+     the open cell immediately to the left, which exists for every root.
+     Where both adjacent cells exist, their signs agree because otherwise
+     `pⱼ` would have another root before the next carrier root.
 
-9. **Evaluate.** Substitute each cell's signs into the atoms, fold
-   the Boolean structure: one truth value per cell.
+9. **Evaluate.** Look up each atom in the cached sign row and fold the Boolean
+   structure to one truth value per cell. All children are evaluated before a
+   connective is combined, so a missing sign returns `none` even when ordinary
+   Boolean short-circuiting could already determine the truth value. Under the
+   checked alignment and carrier hypotheses, the sign and formula evaluators
+   are total and their returned Boolean is equivalent to `Formula.toProp` at
+   every point of the semantic cell.
 
 10. **Quantify.**
 
@@ -430,11 +448,11 @@ The certificate contains:
 - isolating intervals whose `count_one`, ordering, and completeness
   fields are expressed using the literal carrier replay, plus the
   strict-gap checks;
-- all endpoint classifications, open-cell test points and their exact
-  polynomial evaluations, per-cell formula values, and the quantified
-  result; `check` re-evaluates these fields and derives every root-cell
-  sign from a `gⱼ` count (zero) or an adjacent open-cell sign
-  (nonzero), rather than trusting a supplied sign;
+- all endpoint classifications and the quantified result; open-cell test
+  points are deterministic, and exact polynomial signs and per-cell formula
+  values are recomputed rather than stored as redundant claims. `check`
+  derives every root-cell sign from a `gⱼ` count (zero) or the canonical
+  left-adjacent open-cell sign (nonzero), rather than trusting a supplied sign;
 - one common-root package per distinct nonconstant atom, with its
   three identities and at most one generalized replay for its `gⱼ`.
 
@@ -554,16 +572,21 @@ free to change.
   `HexRCF/SeparationTests.lean`: midpoint ownership, close-root, scan,
   malformed-input, and endpoint regressions.
 - `HexRCF/Cells.lean`: size-indexed executable cells, checked root models,
-  semantic partition, exact samples, endpoint-comparison vectors, and exact
-  `Ioc` intersection; `HexRCF/CellsTests.lean`: enumeration,
+  semantic partition, exact samples, canonical left-root spans,
+  endpoint-comparison vectors, and exact `Ioc` intersection;
+  `HexRCF/CellsTests.lean`: enumeration,
   zero/singleton/multiple-root samples, endpoint equality/order guards,
   relevance tables, and malformed lower/upper claim regressions.
 - `HexRCF/CommonRoot.lean`: multiplication-checkable common-root packages,
   constant/nonconstant replay branches, exact common-root semantics, and
   cached root-cell queries; `HexRCF/CommonRootTests.lean`: shared-factor,
   coprime, equal-polynomial, and tampered-evidence regressions.
-- `HexRCF/SignMatrix.lean`: test-point evaluation, the `gⱼ` root-cell
-  computation, Boolean folding.
+- `HexRCF/SignMatrix.lean`: three-way exact signs, coefficient-equality
+  atom deduplication and common-package alignment, guarded open-cell
+  evaluation, the `gⱼ` root-cell computation, and full Boolean reflection;
+  `HexRCF/SignMatrixTests.lean`: exhaustive comparisons/connectives,
+  zero/singleton/multiple-root cells, shared roots, constants, deduplication,
+  and malformed-alignment regressions.
 - `HexRCF/Soundness.lean`: `check_sound` and its four factors.
 - `HexRCF/Reify.lean`: `Qq`/`MetaM` reification, normalisation,
   fall-through messages.
@@ -631,7 +654,8 @@ Per [SPEC/testing.md](../testing.md):
 
 ## Complexity contract
 
-For a sentence with `m` atoms of degrees summing to `n`:
+For a sentence with `u` atom occurrences of degrees summing to `n`, of which
+`m` are distinct nonconstant polynomials and `c` are distinct constants:
 
 - Reification: linear in the goal.
 - `P`: one product and one `squareFreeCore`, `deg P ≤ n`.
@@ -641,8 +665,14 @@ For a sentence with `m` atoms of degrees summing to `n`:
   strict pairs pay no bisection cost and `k ≤ n` roots.
 - Common-root preparation: one gcd and one generalized chain per
   distinct nonconstant `gⱼ`, reused across all `k` root cells.
-- Sign matrix: `k·m` literal variation-count reads plus
-  `(k + 1)·m` open-cell evaluations; no per-root gcd computation.
+- Sign matrix: one cached sign per distinct polynomial and cell, so repeated
+  atom occurrences do not repeat arithmetic. There are `k·m` literal
+  variation-count reads, `(k + 1)·m` open-cell evaluations, and at most `k·m`
+  additional evaluations of the canonical left sample for nonzero root-cell
+  signs, plus `(2k + 1)·c` constant evaluations. The current cell-wise API
+  recomputes both distinct orders and performs coefficient-equality row lookups
+  in every row, contributing `O((2k + 1)·u² + k·m²)` coefficient-array
+  comparisons. There is no per-root gcd computation.
 - Certificate replay in the kernel: one pass over the certificate,
   using polynomial multiplication/subtraction, evaluation, and
   comparison only.

--- a/progress/20260727T111822Z_rcf-sign-matrix.md
+++ b/progress/20260727T111822Z_rcf-sign-matrix.md
@@ -1,0 +1,37 @@
+# Accomplished
+
+- Merged the cached common-root milestone in PR #8939 after its hosted CI,
+  bench, and conformance gates passed.
+- Implemented three-way exact signs, dyadic sign correspondence, constant
+  evaluation including the zero polynomial, and sign constancy on semantic
+  open cells.
+- Added canonical left-root spans and proved nonzero root-cell signs transfer
+  from the immediately preceding open sample.
+- Added deterministic coefficient-equality deduplication, exact common-package
+  alignment, missing/extra/swapped/malformed rejection, and checked lookup.
+- Materialized one sign per distinct polynomial in each cell row, then proved
+  full option-valued comparison and Boolean formula reflection, including
+  negation and implication.
+- Added carrier-free constant-formula reflection and exhaustive regressions for
+  all comparisons/connectives, constants, zero/singleton/multiple-root cells,
+  shared and coprime roots, row caching, and fail-closed malformed data.
+- Updated the umbrella and SPEC, including the exact implemented cost model.
+  Focused builds, the full 9474-target build, structural lints, and the trust
+  scan pass. Three fresh Opus reviews found no soundness defect; their required
+  SPEC, caching, fail-closed, and progress-file findings were incorporated.
+
+# Current frontier
+
+Issue #8940 is complete locally and ready for its milestone PR and hosted CI.
+The implementation is rebased on the merged common-root milestone.
+
+# Next step
+
+Open and merge the #8940 PR after hosted CI, while beginning issue #8946: the
+top-level quantified certificate checker and `check_sound`. Compiling scratch
+prototypes already cover the certificate branches, strict option folds, and
+the four quantified semantic lifts.
+
+# Blockers
+
+None.


### PR DESCRIPTION
Closes #8940.

Implements exact three-way signs, open-cell constancy, canonical left-root transfer, constant handling, deterministic package alignment, cached distinct sign rows, and full option-valued formula reflection. Adds exhaustive executable and semantic regressions and updates the SPEC cost contract.

Validation:
- lake build HexRCF.SignMatrix HexRCF.SignMatrixTests
- lake build (9474 targets)
- file-line, copyright, DAG, and trust-surface checks
- three fresh Claude Opus reviews; no remaining soundness or correctness blockers