### PR TITLE
RCF: certify quantified sentences

### DIFF
--- a/HexRCF.lean
+++ b/HexRCF.lean
@@ -23,6 +23,9 @@ public import HexRCF.CommonRoot
 public import HexRCF.CommonRootTests
 public import HexRCF.SignMatrix
 public import HexRCF.SignMatrixTests
+public import HexRCF.Certificate
+public import HexRCF.Soundness
+public import HexRCF.CertificateTests
 
 public section
 
@@ -46,4 +49,8 @@ generalized replay per distinct nonconstant atom, with exact root-cell queries.
 The sign-matrix layer then recomputes guarded open and root signs, validates
 coefficient-equality package alignment, and reflects every Boolean formula
 to one exact truth value on each semantic cell.
+The top-level certificate replay handles empty domains, constants, root-free
+carriers, and positive-root cell decompositions as distinct fail-closed
+branches. Strict option-valued folds propagate malformed active cells, and
+the soundness theorem lifts every accepted verdict to the quantified sentence.
 -/

--- a/HexRCF/Certificate.lean
+++ b/HexRCF/Certificate.lean
@@ -1,0 +1,165 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.SignMatrix
+
+public section
+
+/-!
+# Kernel certificate replay
+
+This module assembles the already-checked carrier, isolation, endpoint, and
+sign-matrix layers into a three-valued replay. `none` means malformed data,
+`some false` is a valid diagnostic result, and the public Boolean checker
+accepts only `some true`.
+-/
+
+namespace Hex.RCF
+
+namespace OptionFold
+
+/-- Universal option fold that does not Boolean-short-circuit a false value. -/
+@[expose]
+def all (f : α → Option Bool) : List α → Option Bool
+  | [] => some true
+  | x :: xs => do
+      let head ← f x
+      let tail ← all f xs
+      pure (head && tail)
+
+/-- Existential option fold that does not Boolean-short-circuit a true value. -/
+@[expose]
+def any (f : α → Option Bool) : List α → Option Bool
+  | [] => some false
+  | x :: xs => do
+      let head ← f x
+      let tail ← any f xs
+      pure (head || tail)
+
+/-- Universal fold over an array. -/
+@[expose]
+def allArray (xs : Array α) (f : α → Option Bool) : Option Bool :=
+  all f xs.toList
+
+/-- Existential fold over an array. -/
+@[expose]
+def anyArray (xs : Array α) (f : α → Option Bool) : Option Bool :=
+  any f xs.toList
+
+/-- Filter irrelevant entries before a strict universal fold. -/
+@[expose]
+def allWhereArray (xs : Array α) (relevant : α → Bool)
+    (f : α → Option Bool) : Option Bool :=
+  all f (xs.toList.filter relevant)
+
+/-- Filter irrelevant entries before a strict existential fold. -/
+@[expose]
+def anyWhereArray (xs : Array α) (relevant : α → Bool)
+    (f : α → Option Bool) : Option Bool :=
+  any f (xs.toList.filter relevant)
+
+end OptionFold
+
+/-- Carrier and isolation data for a carrier with no real roots. -/
+structure DecompCert where
+  carrier : CarrierCert
+  isolations : IsolationCert
+
+/-- Full positive-root decomposition data. Endpoint comparisons are present
+exactly for bounded sentences. -/
+structure CellsCert where
+  carrier : CarrierCert
+  isolations : IsolationCert
+  signs : SignMatrixCert
+  iocCmps : Option (IocCmps isolations.intervals.size)
+
+/-- The four disjoint replay branches. -/
+inductive Certificate
+  /-- Equal or reversed bounded endpoints. -/
+  | emptyIoc
+  /-- A formula containing no nonconstant atom polynomial. -/
+  | constants
+  /-- A checked carrier with no real roots. -/
+  | noRoots (data : DecompCert)
+  /-- A checked carrier with at least one real root. -/
+  | cells (data : CellsCert)
+
+/-- Evaluate one open cell without constructing common-root packages. -/
+@[expose]
+def Sentence.evalOpen? (s : Sentence) (isolations : IsolationCert)
+    (cut : Fin (isolations.intervals.size + 1)) : Option Bool :=
+  s.formula.evalSigns fun p => openCellSign? p isolations cut
+
+/-- Replay the carrier-free constant branch. Nonempty bounded domains are
+checked here; empty domains belong to `Certificate.emptyIoc`. -/
+@[expose]
+def Sentence.replayConstants? (s : Sentence) : Option Bool :=
+  if s.polys.isEmpty then
+    match s with
+    | .forallReal formula | .existsReal formula => formula.evalConstants?
+    | .forallIoc a b formula | .existsIoc a b formula =>
+        if a < b then formula.evalConstants? else none
+  else none
+
+/-- Replay a checked decomposition whose carrier has no real roots. -/
+@[expose]
+def Sentence.replayNoRoots? (s : Sentence) (data : DecompCert) : Option Bool :=
+  if data.carrier.check s &&
+      data.isolations.checkStrict data.carrier.replay &&
+      data.isolations.intervals.isEmpty then
+    let cut := Fin.last data.isolations.intervals.size
+    match s with
+    | .forallReal _ | .existsReal _ => s.evalOpen? data.isolations cut
+    | .forallIoc a b _ | .existsIoc a b _ =>
+        if a < b then s.evalOpen? data.isolations cut else none
+  else none
+
+/-- Replay a checked positive-root decomposition. Real sentences forbid
+endpoint data; bounded sentences require and verify it. -/
+@[expose]
+def Sentence.replayCells? (s : Sentence) (data : CellsCert) : Option Bool :=
+  if data.carrier.check s &&
+      data.isolations.checkStrict data.carrier.replay &&
+      decide (0 < data.isolations.intervals.size) &&
+      data.signs.check s data.carrier then
+    let cells := Cell.all data.isolations.intervals.size
+    let value := data.signs.evalCell? s data.isolations
+    match s, data.iocCmps with
+    | .forallReal _, none => OptionFold.allArray cells value
+    | .existsReal _, none => OptionFold.anyArray cells value
+    | .forallIoc a b _, some cmps =>
+        if a < b && cmps.check data.carrier.carrier data.carrier.replay
+            data.isolations a b then
+          OptionFold.allWhereArray cells (Cell.meetsIocOn a b cmps) value
+        else none
+    | .existsIoc a b _, some cmps =>
+        if a < b && cmps.check data.carrier.carrier data.carrier.replay
+            data.isolations a b then
+          OptionFold.anyWhereArray cells (Cell.meetsIocOn a b cmps) value
+        else none
+    | _, _ => none
+  else none
+
+/-- Three-valued certificate replay. -/
+@[expose]
+def Certificate.replay? (s : Sentence) : Certificate → Option Bool
+  | .emptyIoc =>
+      match s with
+      | .forallIoc a b _ => if a < b then none else some true
+      | .existsIoc a b _ => if a < b then none else some false
+      | _ => none
+  | .constants => s.replayConstants?
+  | .noRoots data => s.replayNoRoots? data
+  | .cells data => s.replayCells? data
+
+/-- The kernel boundary accepts only a fully replayed true verdict. -/
+@[expose]
+def Certificate.check (s : Sentence) (cert : Certificate) : Bool :=
+  cert.replay? s == some true
+
+end Hex.RCF

--- a/HexRCF/CertificateTests.lean
+++ b/HexRCF/CertificateTests.lean
@@ -1,0 +1,295 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.Soundness
+
+public section
+
+/-! Regression tests for quantified certificate replay and rejection paths. -/
+
+namespace Hex.RCF.CertificateTests
+
+open HexRealRootsMathlib
+
+private def zero : ZPoly := 0
+private def one : ZPoly := DensePoly.ofCoeffs #[(1 : Int)]
+private def minusOne : ZPoly := DensePoly.ofCoeffs #[(-1 : Int)]
+private def x : ZPoly := DensePoly.ofCoeffs #[(0 : Int), 1]
+private def twiceX : ZPoly := DensePoly.ofCoeffs #[(0 : Int), 2]
+private def quad : ZPoly := DensePoly.ofCoeffs #[(-1 : Int), 0, 1]
+private def posQuad : ZPoly := DensePoly.ofCoeffs #[(1 : Int), 0, 1]
+
+/-! Strict option folds propagate active failures past decisive Booleans, but
+bounded filtering ignores failures in irrelevant cells. -/
+
+private def failAtOne (n : Nat) : Option Bool :=
+  if n = 1 then none else some (n = 0)
+
+private def falseThenFail (n : Nat) : Option Bool :=
+  if n = 1 then none else some false
+
+example : OptionFold.all failAtOne [0, 1] = none := by decide
+example : OptionFold.any failAtOne [0, 1] = none := by decide
+example : OptionFold.all falseThenFail [0, 1] = none := by decide
+example : OptionFold.allArray #[] failAtOne = some true := by decide
+example : OptionFold.anyArray #[] failAtOne = some false := by decide
+example : OptionFold.allWhereArray #[0, 1] (fun n => n == 0) failAtOne =
+    some true := by decide
+example : OptionFold.anyWhereArray #[0, 1] (fun n => n == 0) failAtOne =
+    some true := by decide
+example : OptionFold.allWhereArray #[0, 1] (fun _ => true) falseThenFail =
+    none := by decide
+example : OptionFold.anyWhereArray #[0, 1] (fun _ => true) failAtOne =
+    none := by decide
+example : OptionFold.allWhereArray #[0, 1] (fun _ => false) failAtOne =
+    some true := by decide
+example : OptionFold.anyWhereArray #[0, 1] (fun _ => false) failAtOne =
+    some false := by decide
+
+/-! Empty bounded domains bypass every decomposition layer. -/
+
+private def emptyForall : Sentence := .forallIoc 0 0 .ff
+private def emptyExists : Sentence := .existsIoc 0 0 .tt
+private def reverseForall : Sentence :=
+  .forallIoc (Dyadic.ofInt 1) (Dyadic.ofInt (-1)) (.atom ⟨x, .eq⟩)
+private def reverseExists : Sentence :=
+  .existsIoc (Dyadic.ofInt 1) (Dyadic.ofInt (-1)) (.atom ⟨x, .eq⟩)
+
+example : Certificate.emptyIoc.replay? emptyForall = some true := by decide
+example : Certificate.emptyIoc.check emptyForall = true := by decide
+example : Certificate.emptyIoc.replay? emptyExists = some false := by decide
+example : Certificate.emptyIoc.check emptyExists = false := by decide
+example : Certificate.emptyIoc.replay? reverseForall = some true := by decide
+example : Certificate.emptyIoc.replay? reverseExists = some false := by decide
+example : Certificate.emptyIoc.replay? (.forallReal .tt) = none := by decide
+example : Certificate.emptyIoc.replay?
+    (.forallIoc 0 (Dyadic.ofInt 1) .tt) = none := by decide
+example : emptyForall.toProp := check_sound emptyForall .emptyIoc (by decide)
+example : reverseForall.toProp := check_sound reverseForall .emptyIoc (by decide)
+
+/-! Constant-only sentences never construct a carrier. -/
+
+private def constantTrue : Formula :=
+  .and (.atom ⟨zero, .eq⟩) (.atom ⟨one, .gt⟩)
+private def constantFalse : Formula := .atom ⟨one, .lt⟩
+
+example : Certificate.constants.replay? (.forallReal constantTrue) =
+    some true := by decide
+example : Certificate.constants.replay? (.existsReal constantTrue) =
+    some true := by decide
+example : Certificate.constants.replay?
+    (.forallIoc 0 (Dyadic.ofInt 1) constantTrue) = some true := by decide
+example : Certificate.constants.replay?
+    (.existsIoc 0 (Dyadic.ofInt 1) constantTrue) = some true := by decide
+example : Certificate.constants.replay? (.forallReal constantFalse) =
+    some false := by decide
+example : Certificate.constants.check (.forallReal constantFalse) = false := by decide
+example : Certificate.constants.replay? (.forallReal (.atom ⟨x, .eq⟩)) =
+    none := by decide
+example : Certificate.constants.replay? (.forallIoc 0 0 constantTrue) =
+    none := by decide
+example : Sentence.toProp (.forallReal constantTrue) :=
+  check_sound _ .constants (by decide)
+example : Sentence.toProp (.existsIoc 0 (Dyadic.ofInt 1) constantTrue) :=
+  check_sound _ .constants (by decide)
+
+/-! A positive quadratic exercises the carrier branch with no real roots. -/
+
+private def posReplay : SturmReplay where
+  chain := #[posQuad, x, minusOne]
+  derivScale := 2
+  steps := #[{ leftScale := 1, quotient := x, rightScale := 1 }]
+
+private def posCarrier : CarrierCert where
+  carrier := posQuad
+  repeated := one
+  derivPart := twiceX
+  factorScale := 1
+  derivScale := 1
+  replay := posReplay
+
+private def posCommon : CommonRootCert where
+  gcd := posQuad
+  atomFactor := one
+  carrierFactor := one
+  atomCoeff := one
+  carrierCoeff := 0
+  scale := 1
+  replay := some posReplay
+
+private def noRoots : IsolationCert := ⟨#[]⟩
+private def noRootCert : Certificate :=
+  .noRoots ⟨posCarrier, noRoots⟩
+
+private def posGt : Formula := .atom ⟨posQuad, .gt⟩
+private def posLt : Formula := .atom ⟨posQuad, .lt⟩
+
+example : noRootCert.replay? (.forallReal posGt) = some true := by decide
+example : noRootCert.replay? (.existsReal posGt) = some true := by decide
+example : noRootCert.replay?
+    (.forallIoc 0 (Dyadic.ofInt 1) posGt) = some true := by decide
+example : noRootCert.replay?
+    (.existsIoc 0 (Dyadic.ofInt 1) posGt) = some true := by decide
+example : noRootCert.replay? (.forallReal posLt) = some false := by decide
+example : noRootCert.replay? (.existsReal posLt) = some false := by decide
+example : noRootCert.replay? (.forallIoc 0 0 posGt) = none := by decide
+example : Sentence.toProp (.forallReal posGt) :=
+  check_sound _ noRootCert (by decide)
+example : Sentence.toProp (.existsIoc 0 (Dyadic.ofInt 1) posGt) :=
+  check_sound _ noRootCert (by decide)
+
+private def badNoRoots : Certificate :=
+  .noRoots ⟨{ posCarrier with factorScale := 0 }, noRoots⟩
+example : badNoRoots.replay? (.forallReal posGt) = none := by decide
+
+/-! A singleton carrier covers all quantifiers and endpoint equality. -/
+
+private def linearReplay : SturmReplay where
+  chain := #[x, one]
+  derivScale := 1
+  steps := #[]
+
+private def linearCarrier : CarrierCert where
+  carrier := x
+  repeated := one
+  derivPart := one
+  factorScale := 1
+  derivScale := 1
+  replay := linearReplay
+
+private def linearCommon : CommonRootCert where
+  gcd := x
+  atomFactor := one
+  carrierFactor := one
+  atomCoeff := one
+  carrierCoeff := 0
+  scale := 1
+  replay := some linearReplay
+
+private def singleton : IsolationCert := ⟨#[
+  DyadicInterval.mk (Dyadic.ofInt (-1)) (Dyadic.ofInt 1) (by decide)]⟩
+private def linearMatrix : SignMatrixCert := ⟨[linearCommon]⟩
+
+private def lowerGt : Vector Separation.RootCmp 1 := ⟨#[.gt], by decide⟩
+private def lowerEq : Vector Separation.RootCmp 1 := ⟨#[.eq], by decide⟩
+private def upperEq : Vector Separation.RootCmp 1 := ⟨#[.eq], by decide⟩
+private def upperLt : Vector Separation.RootCmp 1 := ⟨#[.lt], by decide⟩
+private def leftCmps : IocCmps 1 := ⟨lowerGt, upperEq⟩
+private def rightCmps : IocCmps 1 := ⟨lowerEq, upperLt⟩
+
+private def realLinear : Certificate := .cells
+  ⟨linearCarrier, singleton, linearMatrix, none⟩
+private def wrongNoRoots : Certificate := .noRoots
+  ⟨linearCarrier, singleton⟩
+private def leftLinear : Certificate := .cells
+  ⟨linearCarrier, singleton, linearMatrix, some leftCmps⟩
+private def rightLinear : Certificate := .cells
+  ⟨linearCarrier, singleton, linearMatrix, some rightCmps⟩
+
+private def xEq : Formula := .atom ⟨x, .eq⟩
+private def xLe : Formula := .atom ⟨x, .le⟩
+private def xGt : Formula := .atom ⟨x, .gt⟩
+
+private def badRootCount : Certificate := .noRoots
+  ⟨linearCarrier, noRoots⟩
+
+example : realLinear.replay? (.existsReal xEq) = some true := by decide
+example : wrongNoRoots.replay? (.existsReal xEq) = none := by decide
+example : badRootCount.replay? (.forallReal xGt) = none := by decide
+example : realLinear.replay? (.forallReal xEq) = some false := by decide
+example : leftLinear.replay?
+    (.forallIoc (Dyadic.ofInt (-1)) 0 xLe) = some true := by decide
+example : leftLinear.replay?
+    (.existsIoc (Dyadic.ofInt (-1)) 0 xEq) = some true := by decide
+/-- Equality at the lower endpoint is excluded. -/
+example : rightLinear.replay?
+    (.existsIoc 0 (Dyadic.ofInt 1) xEq) = some false := by decide
+example : rightLinear.replay?
+    (.forallIoc 0 (Dyadic.ofInt 1) xGt) = some true := by decide
+example : Sentence.toProp (.existsReal xEq) :=
+  check_sound _ realLinear (by decide)
+example : Sentence.toProp (.forallIoc 0 (Dyadic.ofInt 1) xGt) :=
+  check_sound _ rightLinear (by decide)
+
+/-! Real/bounded shape mismatches and malformed nested evidence fail closed. -/
+
+example : leftLinear.replay? (.existsReal xEq) = none := by decide
+example : realLinear.replay?
+    (.existsIoc (Dyadic.ofInt (-1)) 0 xEq) = none := by decide
+private def badMatrix : Certificate := .cells
+  ⟨linearCarrier, singleton, ⟨[]⟩, none⟩
+example : badMatrix.replay? (.existsReal xEq) = none := by decide
+private def wrongSingleton : IsolationCert := ⟨#[
+  DyadicInterval.mk (Dyadic.ofInt 1) (Dyadic.ofInt 2) (by decide)]⟩
+private def badIsolation : Certificate := .cells
+  ⟨linearCarrier, wrongSingleton, linearMatrix, none⟩
+example : badIsolation.replay? (.existsReal xEq) = none := by decide
+private def badCmps : IocCmps 1 := ⟨lowerEq, upperEq⟩
+private def badEndpoint : Certificate := .cells
+  ⟨linearCarrier, singleton, linearMatrix, some badCmps⟩
+example : badEndpoint.replay?
+    (.existsIoc (Dyadic.ofInt (-1)) 0 xEq) = none := by decide
+private def zeroCells : Certificate := .cells
+  ⟨posCarrier, noRoots, ⟨[posCommon]⟩, none⟩
+example : zeroCells.replay? (.forallReal posGt) = none := by decide
+
+/-! A two-root carrier exercises a nontrivial five-cell fold. -/
+
+private def quadReplay : SturmReplay where
+  chain := #[quad, x, one]
+  derivScale := 2
+  steps := #[{ leftScale := 1, quotient := x, rightScale := 1 }]
+
+private def quadCarrier : CarrierCert where
+  carrier := quad
+  repeated := one
+  derivPart := twiceX
+  factorScale := 1
+  derivScale := 1
+  replay := quadReplay
+
+private def quadCommon : CommonRootCert where
+  gcd := quad
+  atomFactor := one
+  carrierFactor := one
+  atomCoeff := one
+  carrierCoeff := 0
+  scale := 1
+  replay := some quadReplay
+
+private def negHalf : Dyadic := Dyadic.ofInt (-1) >>> (1 : Int)
+private def half : Dyadic := Dyadic.ofInt 1 >>> (1 : Int)
+private def twoRoots : IsolationCert := ⟨#[
+  DyadicInterval.mk (Dyadic.ofInt (-2)) negHalf (by decide),
+  DyadicInterval.mk half (Dyadic.ofInt 2) (by decide)]⟩
+private def realQuad : Certificate := .cells
+  ⟨quadCarrier, twoRoots, ⟨[quadCommon]⟩, none⟩
+private def quadEq : Formula := .atom ⟨quad, .eq⟩
+private def quadNe : Formula := .atom ⟨quad, .ne⟩
+private def quadLt : Formula := .atom ⟨quad, .lt⟩
+
+private def gapLower : Vector Separation.RootCmp 2 :=
+  ⟨#[.lt, .gt], by decide⟩
+private def gapUpper : Vector Separation.RootCmp 2 :=
+  ⟨#[.lt, .gt], by decide⟩
+private def gapCmps : IocCmps 2 := ⟨gapLower, gapUpper⟩
+private def boundedQuad : Certificate := .cells
+  ⟨quadCarrier, twoRoots, ⟨[quadCommon]⟩, some gapCmps⟩
+
+example : realQuad.replay? (.existsReal quadEq) = some true := by decide
+example : realQuad.replay? (.forallReal quadNe) = some false := by decide
+example : boundedQuad.replay? (.forallIoc negHalf half quadLt) =
+    some true := by decide
+example : boundedQuad.replay? (.existsIoc negHalf half quadLt) =
+    some true := by decide
+example : Sentence.toProp (.existsReal quadEq) :=
+  check_sound _ realQuad (by decide)
+example : Sentence.toProp (.forallIoc negHalf half quadLt) :=
+  check_sound _ boundedQuad (by decide)
+
+end Hex.RCF.CertificateTests

--- a/HexRCF/SignMatrix.lean
+++ b/HexRCF/SignMatrix.lean
@@ -386,6 +386,54 @@ theorem openSign?_eq_some {p : ZPoly} {isolations : IsolationCert}
   cases hsign : evalSign p (isolations.openPoint cut) <;>
     simp_all [openSign?]
 
+/-- Exact sign on an open cell, with constant polynomials evaluated once at
+zero and nonconstant polynomials guarded against an impossible zero sample. -/
+@[expose]
+def openCellSign? (p : ZPoly) (isolations : IsolationCert)
+    (cut : Fin (isolations.intervals.size + 1)) : Option Sign :=
+  if 0 < p.degree?.getD 0 then openSign? p isolations cut
+  else some (evalSign p 0)
+
+/-- The shared open-cell lookup is total and exact for every formula atom of a
+checked carrier, including constants. -/
+theorem openCellSign_spec {sentence : Sentence} {carrier : CarrierCert}
+    (hcarrier : carrier.check sentence = true)
+    {isolations : IsolationCert}
+    (hstrict : isolations.checkStrict carrier.replay = true)
+    {p : ZPoly} (hp : p ∈ sentence.formula.polys)
+    (cut : Fin (isolations.intervals.size + 1)) {x : ℝ}
+    (hx : Cell.Sem
+      (isolations.rootModel (CarrierCert.replay_of_check hcarrier) hstrict)
+      (.open cut) x) :
+    ∃ sign, openCellSign? p isolations cut = some sign ∧
+      SignType.sign (((sign.toInt : Int) : ℝ)) =
+        SignType.sign ((toPolyℝ p).eval x) := by
+  by_cases hdegree : 0 < p.degree?.getD 0
+  · have hpmem : p ∈ sentence.polys := by
+      simp only [Sentence.polys, List.mem_filter, decide_eq_true_eq]
+      exact ⟨hp, hdegree⟩
+    let hreplay := CarrierCert.replay_of_check hcarrier
+    let model := isolations.rootModel hreplay hstrict
+    have hroot : ∀ z, (toPolyℝ p).IsRoot z →
+        (toPolyℝ carrier.carrier).IsRoot z := by
+      intro z hz
+      exact (carrier.isRoot_iff_atom hcarrier z).2 ⟨p, hpmem, hz⟩
+    have hsample : Cell.Sem model (.open cut)
+        (Dyadic.toReal (isolations.openPoint cut)) :=
+      Cell.openPoint_mem isolations hreplay hstrict cut
+    have hnotroot : ¬(toPolyℝ p).IsRoot
+        (Dyadic.toReal (isolations.openPoint cut)) := by
+      intro hpRoot
+      exact Cell.open_not_root model hsample (hroot _ hpRoot)
+    have hnonzero : evalSign p (isolations.openPoint cut) ≠ .zero :=
+      evalSign_ne_zero_of_not_root p _ hnotroot
+    refine ⟨evalSign p (isolations.openPoint cut), ?_, ?_⟩
+    · simp [openCellSign?, hdegree, openSign?_eq_some hnonzero]
+    · exact evalSign_open_of_atom hcarrier hstrict hpmem cut hx
+  · refine ⟨evalSign p 0, by simp [openCellSign?, hdegree], ?_⟩
+    rw [eval_eq_eval_zero_of_degree_nonpos p hdegree x]
+    simpa using evalSign_spec p 0
+
 /-- One cached sign associated with its literal polynomial. -/
 structure SignEntry where
   poly : ZPoly
@@ -479,13 +527,13 @@ common-root package. -/
 def signWith? (cert : SignMatrixCert) (commonPolys : List ZPoly)
     (isolations : IsolationCert) (cell : Cell isolations.intervals.size)
     (p : ZPoly) : Option Sign :=
-  if 0 < p.degree?.getD 0 then
-    match cell with
-    | .open cut => openSign? p isolations cut
-    | .root i => do
+  match cell with
+  | .open cut => openCellSign? p isolations cut
+  | .root i =>
+      if 0 < p.degree?.getD 0 then do
         let common ← Hex.RCF.findCommon? p commonPolys cert.commonRoots
         rootSign? p common isolations i
-  else some (evalSign p 0)
+      else some (evalSign p 0)
 
 /-- Public atom-sign lookup, recomputing the deterministic package order. -/
 @[expose]
@@ -527,16 +575,15 @@ theorem signWith?_spec {sentence : Sentence} {carrier : CarrierCert}
         have hsample : Cell.Sem model (.open cut)
             (Dyadic.toReal (isolations.openPoint cut)) :=
           Cell.openPoint_mem isolations hreplay hstrict cut
-        have hnotroot : ¬(toPolyℝ p).IsRoot
-            (Dyadic.toReal (isolations.openPoint cut)) := by
-          intro hpRoot
-          exact Cell.open_not_root model hsample (hroot _ hpRoot)
-        have hnonzero : evalSign p (isolations.openPoint cut) ≠ .zero :=
-          evalSign_ne_zero_of_not_root p _ hnotroot
-        refine ⟨evalSign p (isolations.openPoint cut), ?_, ?_⟩
-        · simp [signWith?, hdegree, openSign?_eq_some hnonzero]
-        · intro x hx
-          exact evalSign_open_of_atom hcarrier hstrict hpmem cut hx
+        obtain ⟨sign, hsign, _⟩ :=
+          openCellSign_spec hcarrier hstrict hp cut hsample
+        refine ⟨sign, by simpa [signWith?] using hsign, ?_⟩
+        intro x hx
+        obtain ⟨other, hother, hsound⟩ :=
+          openCellSign_spec hcarrier hstrict hp cut hx
+        rw [hsign] at hother
+        cases Option.some.inj hother
+        exact hsound
     | root i =>
         obtain ⟨common, hfind, hcommon⟩ :=
           cert.findCommon?_of_check hmatrix hpmem
@@ -585,10 +632,17 @@ theorem signWith?_spec {sentence : Sentence} {carrier : CarrierCert}
             rw [hxroot]
             exact evalSign_commonLeft hcarrier hstrict hpmem
               hcommon i hhasFalse
-  · refine ⟨evalSign p 0, by simp [signWith?, hdegree], ?_⟩
-    intro x _hx
-    rw [eval_eq_eval_zero_of_degree_nonpos p hdegree x]
-    simpa using evalSign_spec p 0
+  · cases cell with
+    | «open» cut =>
+        refine ⟨evalSign p 0, by simp [signWith?, openCellSign?, hdegree], ?_⟩
+        intro x _hx
+        rw [eval_eq_eval_zero_of_degree_nonpos p hdegree x]
+        simpa using evalSign_spec p 0
+    | root i =>
+        refine ⟨evalSign p 0, by simp [signWith?, hdegree], ?_⟩
+        intro x _hx
+        rw [eval_eq_eval_zero_of_degree_nonpos p hdegree x]
+        simpa using evalSign_spec p 0
 
 /-- Public atom-sign lookup is total and exact under the combined checker. -/
 theorem sign?_spec {sentence : Sentence} {carrier : CarrierCert}

--- a/HexRCF/Soundness.lean
+++ b/HexRCF/Soundness.lean
@@ -1,0 +1,590 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.Certificate
+
+public section
+
+/-! Soundness of quantified RCF certificate replay. -/
+
+namespace Hex.RCF
+
+open HexRealRootsMathlib
+
+namespace OptionFold
+
+theorem all_eq_none_iff {f : α → Option Bool} {xs : List α} :
+    all f xs = none ↔ ∃ x ∈ xs, f x = none := by
+  induction xs with
+  | nil => simp [all]
+  | cons x xs ih =>
+      constructor
+      · intro hnone
+        cases hx : f x with
+        | none => exact ⟨x, by simp, hx⟩
+        | some head =>
+            have htail : all f xs = none := by
+              cases h : all f xs with
+              | none => rfl
+              | some tail => simp [all, hx, h] at hnone
+            obtain ⟨y, hy, hfy⟩ := ih.mp htail
+            exact ⟨y, by simp [hy], hfy⟩
+      · rintro ⟨y, hy, hfy⟩
+        simp only [List.mem_cons] at hy
+        rcases hy with rfl | hy
+        · simp [all, hfy]
+        · have htail := ih.mpr ⟨y, hy, hfy⟩
+          cases hx : f x <;> simp [all, hx, htail]
+
+theorem any_eq_none_iff {f : α → Option Bool} {xs : List α} :
+    any f xs = none ↔ ∃ x ∈ xs, f x = none := by
+  induction xs with
+  | nil => simp [any]
+  | cons x xs ih =>
+      constructor
+      · intro hnone
+        cases hx : f x with
+        | none => exact ⟨x, by simp, hx⟩
+        | some head =>
+            have htail : any f xs = none := by
+              cases h : any f xs with
+              | none => rfl
+              | some tail => simp [any, hx, h] at hnone
+            obtain ⟨y, hy, hfy⟩ := ih.mp htail
+            exact ⟨y, by simp [hy], hfy⟩
+      · rintro ⟨y, hy, hfy⟩
+        simp only [List.mem_cons] at hy
+        rcases hy with rfl | hy
+        · simp [any, hfy]
+        · have htail := ih.mpr ⟨y, hy, hfy⟩
+          cases hx : f x <;> simp [any, hx, htail]
+
+theorem all_spec {f : α → Option Bool} {xs : List α}
+    (htotal : ∀ x ∈ xs, ∃ value, f x = some value) :
+    ∃ value, all f xs = some value ∧
+      (value = true ↔ ∀ x ∈ xs, f x = some true) := by
+  induction xs with
+  | nil => exact ⟨true, by simp [all]⟩
+  | cons x xs ih =>
+      obtain ⟨head, hhead⟩ := htotal x (by simp)
+      obtain ⟨tail, htail, htailSpec⟩ := ih (by
+        intro y hy
+        exact htotal y (by simp [hy]))
+      refine ⟨head && tail, by simp [all, hhead, htail], ?_⟩
+      cases head <;> cases tail <;> simp_all
+
+theorem any_spec {f : α → Option Bool} {xs : List α}
+    (htotal : ∀ x ∈ xs, ∃ value, f x = some value) :
+    ∃ value, any f xs = some value ∧
+      (value = true ↔ ∃ x ∈ xs, f x = some true) := by
+  induction xs with
+  | nil => exact ⟨false, by simp [any]⟩
+  | cons x xs ih =>
+      obtain ⟨head, hhead⟩ := htotal x (by simp)
+      obtain ⟨tail, htail, htailSpec⟩ := ih (by
+        intro y hy
+        exact htotal y (by simp [hy]))
+      refine ⟨head || tail, by simp [any, hhead, htail], ?_⟩
+      cases head <;> cases tail <;> simp_all
+
+theorem allArray_none {xs : Array α} {f : α → Option Bool} :
+    allArray xs f = none ↔ ∃ x ∈ xs, f x = none := by
+  simpa [allArray] using all_eq_none_iff (xs := xs.toList) (f := f)
+
+theorem anyArray_none {xs : Array α} {f : α → Option Bool} :
+    anyArray xs f = none ↔ ∃ x ∈ xs, f x = none := by
+  simpa [anyArray] using any_eq_none_iff (xs := xs.toList) (f := f)
+
+theorem allWhereArray_none {xs : Array α}
+    {relevant : α → Bool} {f : α → Option Bool} :
+    allWhereArray xs relevant f = none ↔
+      ∃ x ∈ xs, relevant x = true ∧ f x = none := by
+  rw [allWhereArray, all_eq_none_iff]
+  simp only [List.mem_filter]
+  aesop
+
+theorem anyWhereArray_none {xs : Array α}
+    {relevant : α → Bool} {f : α → Option Bool} :
+    anyWhereArray xs relevant f = none ↔
+      ∃ x ∈ xs, relevant x = true ∧ f x = none := by
+  rw [anyWhereArray, any_eq_none_iff]
+  simp only [List.mem_filter]
+  aesop
+
+theorem allArray_spec {xs : Array α} {f : α → Option Bool}
+    (htotal : ∀ x ∈ xs, ∃ value, f x = some value) :
+    ∃ value, allArray xs f = some value ∧
+      (value = true ↔ ∀ x ∈ xs, f x = some true) := by
+  simpa [allArray] using
+    all_spec (xs := xs.toList) (f := f) (by
+      intro x hx
+      exact htotal x (by simpa using hx))
+
+theorem anyArray_spec {xs : Array α} {f : α → Option Bool}
+    (htotal : ∀ x ∈ xs, ∃ value, f x = some value) :
+    ∃ value, anyArray xs f = some value ∧
+      (value = true ↔ ∃ x ∈ xs, f x = some true) := by
+  simpa [anyArray] using
+    any_spec (xs := xs.toList) (f := f) (by
+      intro x hx
+      exact htotal x (by simpa using hx))
+
+theorem allWhereArray_spec {xs : Array α} {relevant : α → Bool}
+    {f : α → Option Bool}
+    (htotal : ∀ x ∈ xs, relevant x = true → ∃ value, f x = some value) :
+    ∃ value, allWhereArray xs relevant f = some value ∧
+      (value = true ↔
+        ∀ x ∈ xs, relevant x = true → f x = some true) := by
+  obtain ⟨value, hvalue, hspec⟩ := all_spec
+    (xs := xs.toList.filter relevant) (f := f) (by
+      intro x hx
+      simp only [List.mem_filter] at hx
+      exact htotal x (by simpa using hx.1) hx.2)
+  refine ⟨value, by simpa [allWhereArray] using hvalue, ?_⟩
+  rw [hspec]
+  simp only [List.mem_filter]
+  aesop
+
+theorem anyWhereArray_spec {xs : Array α} {relevant : α → Bool}
+    {f : α → Option Bool}
+    (htotal : ∀ x ∈ xs, relevant x = true → ∃ value, f x = some value) :
+    ∃ value, anyWhereArray xs relevant f = some value ∧
+      (value = true ↔
+        ∃ x ∈ xs, relevant x = true ∧ f x = some true) := by
+  obtain ⟨value, hvalue, hspec⟩ := any_spec
+    (xs := xs.toList.filter relevant) (f := f) (by
+      intro x hx
+      simp only [List.mem_filter] at hx
+      exact htotal x (by simpa using hx.1) hx.2)
+  refine ⟨value, by simpa [anyWhereArray] using hvalue, ?_⟩
+  rw [hspec]
+  simp only [List.mem_filter]
+  aesop
+
+end OptionFold
+
+namespace CellFold
+
+open OptionFold
+
+theorem forall_spec {carrier : ZPoly} {cert : IsolationCert}
+    (M : RootModel carrier cert) (eval : Cell cert.intervals.size → Option Bool)
+    (P : ℝ → Prop)
+    (hcell : ∀ c, ∃ value, eval c = some value ∧
+      ∀ x, Cell.Sem M c x → (value = true ↔ P x)) :
+    ∃ value, allArray (Cell.all cert.intervals.size) eval = some value ∧
+      (value = true ↔ ∀ x, P x) := by
+  obtain ⟨value, hvalue, hfold⟩ := allArray_spec
+    (xs := Cell.all cert.intervals.size) (f := eval) (by
+      intro c _
+      obtain ⟨v, hv, _⟩ := hcell c
+      exact ⟨v, hv⟩)
+  refine ⟨value, hvalue, ?_⟩
+  constructor
+  · intro hv x
+    obtain ⟨c, hcx⟩ := Cell.exists_mem M x
+    have heval := (hfold.mp hv) c (Cell.mem_all c)
+    obtain ⟨v, hev, hsound⟩ := hcell c
+    have hvtrue : v = true := by
+      rw [hev] at heval
+      exact Option.some.inj heval
+    exact (hsound x hcx).mp hvtrue
+  · intro hP
+    apply hfold.mpr
+    intro c _
+    obtain ⟨v, hev, hsound⟩ := hcell c
+    obtain ⟨x, hx⟩ := Cell.exists_point M c
+    have hvtrue : v = true := (hsound x hx).mpr (hP x)
+    simpa [hvtrue] using hev
+
+theorem exists_spec {carrier : ZPoly} {cert : IsolationCert}
+    (M : RootModel carrier cert) (eval : Cell cert.intervals.size → Option Bool)
+    (P : ℝ → Prop)
+    (hcell : ∀ c, ∃ value, eval c = some value ∧
+      ∀ x, Cell.Sem M c x → (value = true ↔ P x)) :
+    ∃ value, anyArray (Cell.all cert.intervals.size) eval = some value ∧
+      (value = true ↔ ∃ x, P x) := by
+  obtain ⟨value, hvalue, hfold⟩ := anyArray_spec
+    (xs := Cell.all cert.intervals.size) (f := eval) (by
+      intro c _
+      obtain ⟨v, hv, _⟩ := hcell c
+      exact ⟨v, hv⟩)
+  refine ⟨value, hvalue, ?_⟩
+  constructor
+  · intro hv
+    obtain ⟨c, _, heval⟩ := hfold.mp hv
+    obtain ⟨v, hev, hsound⟩ := hcell c
+    obtain ⟨x, hx⟩ := Cell.exists_point M c
+    have hvtrue : v = true := by
+      rw [hev] at heval
+      exact Option.some.inj heval
+    exact ⟨x, (hsound x hx).mp hvtrue⟩
+  · rintro ⟨x, hPx⟩
+    obtain ⟨c, hcx⟩ := Cell.exists_mem M x
+    apply hfold.mpr
+    refine ⟨c, Cell.mem_all c, ?_⟩
+    obtain ⟨v, hev, hsound⟩ := hcell c
+    have hvtrue : v = true := (hsound x hcx).mpr hPx
+    simpa [hvtrue] using hev
+
+theorem forallWhere_spec {carrier : ZPoly} {cert : IsolationCert}
+    (M : RootModel carrier cert) (eval : Cell cert.intervals.size → Option Bool)
+    (relevant : Cell cert.intervals.size → Bool) (D P : ℝ → Prop)
+    (hcell : ∀ c, ∃ value, eval c = some value ∧
+      ∀ x, Cell.Sem M c x → (value = true ↔ P x))
+    (hrelevant : ∀ c, relevant c = true ↔
+      ∃ x, Cell.Sem M c x ∧ D x) :
+    ∃ value,
+      allWhereArray (Cell.all cert.intervals.size) relevant eval = some value ∧
+      (value = true ↔ ∀ x, D x → P x) := by
+  obtain ⟨value, hvalue, hfold⟩ := allWhereArray_spec
+    (xs := Cell.all cert.intervals.size) (f := eval) (relevant := relevant) (by
+      intro c _ _
+      obtain ⟨v, hv, _⟩ := hcell c
+      exact ⟨v, hv⟩)
+  refine ⟨value, hvalue, ?_⟩
+  constructor
+  · intro hv x hDx
+    obtain ⟨c, hcx⟩ := Cell.exists_mem M x
+    have hrel : relevant c = true := (hrelevant c).mpr ⟨x, hcx, hDx⟩
+    have heval := (hfold.mp hv) c (Cell.mem_all c) hrel
+    obtain ⟨v, hev, hsound⟩ := hcell c
+    have hvtrue : v = true := by
+      rw [hev] at heval
+      exact Option.some.inj heval
+    exact (hsound x hcx).mp hvtrue
+  · intro hP
+    apply hfold.mpr
+    intro c _ hrel
+    obtain ⟨x, hcx, hDx⟩ := (hrelevant c).mp hrel
+    obtain ⟨v, hev, hsound⟩ := hcell c
+    have hvtrue : v = true := (hsound x hcx).mpr (hP x hDx)
+    simpa [hvtrue] using hev
+
+theorem existsWhere_spec {carrier : ZPoly} {cert : IsolationCert}
+    (M : RootModel carrier cert) (eval : Cell cert.intervals.size → Option Bool)
+    (relevant : Cell cert.intervals.size → Bool) (D P : ℝ → Prop)
+    (hcell : ∀ c, ∃ value, eval c = some value ∧
+      ∀ x, Cell.Sem M c x → (value = true ↔ P x))
+    (hrelevant : ∀ c, relevant c = true ↔
+      ∃ x, Cell.Sem M c x ∧ D x) :
+    ∃ value,
+      anyWhereArray (Cell.all cert.intervals.size) relevant eval = some value ∧
+      (value = true ↔ ∃ x, D x ∧ P x) := by
+  obtain ⟨value, hvalue, hfold⟩ := anyWhereArray_spec
+    (xs := Cell.all cert.intervals.size) (f := eval) (relevant := relevant) (by
+      intro c _ _
+      obtain ⟨v, hv, _⟩ := hcell c
+      exact ⟨v, hv⟩)
+  refine ⟨value, hvalue, ?_⟩
+  constructor
+  · intro hv
+    obtain ⟨c, _, hrel, heval⟩ := hfold.mp hv
+    obtain ⟨x, hcx, hDx⟩ := (hrelevant c).mp hrel
+    obtain ⟨v, hev, hsound⟩ := hcell c
+    have hvtrue : v = true := by
+      rw [hev] at heval
+      exact Option.some.inj heval
+    exact ⟨x, hDx, (hsound x hcx).mp hvtrue⟩
+  · rintro ⟨x, hDx, hPx⟩
+    obtain ⟨c, hcx⟩ := Cell.exists_mem M x
+    apply hfold.mpr
+    refine ⟨c, Cell.mem_all c, (hrelevant c).mpr ⟨x, hcx, hDx⟩, ?_⟩
+    obtain ⟨v, hev, hsound⟩ := hcell c
+    have hvtrue : v = true := (hsound x hcx).mpr hPx
+    simpa [hvtrue] using hev
+
+theorem forallIoc_spec {carrier : ZPoly} {replay : SturmReplay}
+    (hreplay : replay.check carrier = true) {cert : IsolationCert}
+    (hstrict : cert.checkStrict replay = true)
+    (a b : Dyadic) (cmps : IocCmps cert.intervals.size)
+    (hcmps : IocCmps.check carrier replay cert a b cmps = true)
+    (eval : Cell cert.intervals.size → Option Bool) (P : ℝ → Prop)
+    (hcell : ∀ c, ∃ value, eval c = some value ∧
+      ∀ x, Cell.Sem (cert.rootModel hreplay hstrict) c x →
+        (value = true ↔ P x)) :
+    ∃ value,
+      allWhereArray (Cell.all cert.intervals.size)
+        (Cell.meetsIocOn a b cmps) eval = some value ∧
+      (value = true ↔ ∀ x, x ∈ Set.Ioc (Dyadic.toReal a) (Dyadic.toReal b) → P x) := by
+  apply forallWhere_spec (cert.rootModel hreplay hstrict) eval
+    (Cell.meetsIocOn a b cmps)
+    (fun x => x ∈ Set.Ioc (Dyadic.toReal a) (Dyadic.toReal b)) P hcell
+  exact fun c => Cell.meetsIocOn_iff_of_check cmps a b hreplay hstrict hcmps c
+
+theorem existsIoc_spec {carrier : ZPoly} {replay : SturmReplay}
+    (hreplay : replay.check carrier = true) {cert : IsolationCert}
+    (hstrict : cert.checkStrict replay = true)
+    (a b : Dyadic) (cmps : IocCmps cert.intervals.size)
+    (hcmps : IocCmps.check carrier replay cert a b cmps = true)
+    (eval : Cell cert.intervals.size → Option Bool) (P : ℝ → Prop)
+    (hcell : ∀ c, ∃ value, eval c = some value ∧
+      ∀ x, Cell.Sem (cert.rootModel hreplay hstrict) c x →
+        (value = true ↔ P x)) :
+    ∃ value,
+      anyWhereArray (Cell.all cert.intervals.size)
+        (Cell.meetsIocOn a b cmps) eval = some value ∧
+      (value = true ↔ ∃ x, x ∈ Set.Ioc (Dyadic.toReal a) (Dyadic.toReal b) ∧ P x) := by
+  apply existsWhere_spec (cert.rootModel hreplay hstrict) eval
+    (Cell.meetsIocOn a b cmps)
+    (fun x => x ∈ Set.Ioc (Dyadic.toReal a) (Dyadic.toReal b)) P hcell
+  exact fun c => Cell.meetsIocOn_iff_of_check cmps a b hreplay hstrict hcmps c
+
+end CellFold
+
+theorem Certificate.replay_true {s : Sentence}
+    {cert : Certificate} (h : cert.check s = true) :
+    cert.replay? s = some true := by
+  simpa [Certificate.check] using h
+
+/-- Constant-only sentence replay is exact at every real point. -/
+theorem Sentence.evalConstants_of_empty {s : Sentence}
+    (hempty : s.polys.isEmpty = true) (x : ℝ) :
+    s.formula.evalConstants? = some true ↔ s.formula.toProp x := by
+  apply Formula.evalConstants_eq_true_iff
+  intro p hp hdegree
+  have hmem : p ∈ s.polys := by
+    simp only [Sentence.polys, List.mem_filter, decide_eq_true_eq]
+    exact ⟨hp, hdegree⟩
+  cases hpolys : s.polys with
+  | nil => simp [hpolys] at hmem
+  | cons q qs => simp [hpolys] at hempty
+
+/-- The empty bounded-domain branch is sound independently of its body. -/
+theorem Certificate.emptyIoc_sound {s : Sentence}
+    (h : Certificate.emptyIoc.replay? s = some true) : s.toProp := by
+  cases s with
+  | forallReal formula => simp [Certificate.replay?] at h
+  | existsReal formula => simp [Certificate.replay?] at h
+  | forallIoc a b formula =>
+      simp only [Certificate.replay?] at h
+      split at h
+      · simp at h
+      · rename_i hab
+        intro x hx
+        have hreal : ¬Dyadic.toReal a < Dyadic.toReal b := by
+          simpa [toReal_lt_toReal_iff] using hab
+        exact (hreal (lt_of_lt_of_le hx.1 hx.2)).elim
+  | existsIoc a b formula =>
+      simp only [Certificate.replay?] at h
+      split at h <;> simp_all
+
+/-- A successfully replayed constants-only branch proves the sentence. -/
+theorem Certificate.constants_sound {s : Sentence}
+    (h : Certificate.constants.replay? s = some true) : s.toProp := by
+  cases s with
+  | forallReal formula =>
+      simp only [Certificate.replay?, Sentence.replayConstants?] at h
+      split at h
+      · rename_i hempty
+        intro x
+        exact (Sentence.evalConstants_of_empty hempty x).mp h
+      · simp at h
+  | existsReal formula =>
+      simp only [Certificate.replay?, Sentence.replayConstants?] at h
+      split at h
+      · rename_i hempty
+        exact ⟨0, (Sentence.evalConstants_of_empty hempty 0).mp h⟩
+      · simp at h
+  | forallIoc a b formula =>
+      simp only [Certificate.replay?, Sentence.replayConstants?] at h
+      split at h
+      · rename_i hempty
+        split at h
+        · intro x _
+          exact (Sentence.evalConstants_of_empty hempty x).mp h
+        · simp at h
+      · simp at h
+  | existsIoc a b formula =>
+      simp only [Certificate.replay?, Sentence.replayConstants?] at h
+      split at h
+      · rename_i hempty
+        split at h
+        · rename_i hab
+          obtain ⟨x, hax, hxb⟩ := exists_between (toReal_lt_toReal hab)
+          exact ⟨x, ⟨hax, hxb.le⟩,
+            (Sentence.evalConstants_of_empty hempty x).mp h⟩
+        · simp at h
+      · simp at h
+
+/-- The matrix-free open-cell evaluator is exact under the carrier and strict
+isolation checks. -/
+theorem Sentence.evalOpen_eq_true_iff {s : Sentence} {carrier : CarrierCert}
+    (hcarrier : carrier.check s = true) {isolations : IsolationCert}
+    (hstrict : isolations.checkStrict carrier.replay = true)
+    (cut : Fin (isolations.intervals.size + 1)) {x : ℝ}
+    (hx : Cell.Sem
+      (isolations.rootModel (CarrierCert.replay_of_check hcarrier) hstrict)
+      (.open cut) x) :
+    s.evalOpen? isolations cut = some true ↔ s.formula.toProp x := by
+  unfold Sentence.evalOpen?
+  apply Formula.evalSigns_eq_true_iff
+  intro p hp
+  exact openCellSign_spec hcarrier hstrict hp cut hx
+
+/-- A checked empty isolation set gives the single-cell decomposition. -/
+theorem Certificate.noRoots_sound {s : Sentence} {data : DecompCert}
+    (h : (Certificate.noRoots data).replay? s = some true) : s.toProp := by
+  simp only [Certificate.replay?, Sentence.replayNoRoots?] at h
+  split at h
+  · rename_i hvalid
+    simp only [Bool.and_eq_true] at hvalid
+    obtain ⟨⟨hcarrier, hstrict⟩, hempty⟩ := hvalid
+    have hsize : data.isolations.intervals.size = 0 := by
+      simpa [Array.isEmpty] using hempty
+    let cut : Fin (data.isolations.intervals.size + 1) :=
+      Fin.last data.isolations.intervals.size
+    have formulaAt (x : ℝ)
+        (hvalue : s.evalOpen? data.isolations cut = some true) :
+        s.formula.toProp x := by
+      have hx : Cell.Sem
+          (data.isolations.rootModel
+            (CarrierCert.replay_of_check hcarrier) hstrict)
+          (.open cut) x := by
+        simp [Cell.Sem, hsize]
+      exact (Sentence.evalOpen_eq_true_iff hcarrier hstrict cut hx).mp hvalue
+    cases s with
+    | forallReal formula =>
+        intro x
+        exact formulaAt x h
+    | existsReal formula =>
+        exact ⟨0, formulaAt 0 h⟩
+    | forallIoc a b formula =>
+        change (if a < b then
+          Sentence.evalOpen? (.forallIoc a b formula) data.isolations
+            (Fin.last data.isolations.intervals.size)
+          else none) = some true at h
+        split at h
+        · intro x _
+          exact formulaAt x h
+        · simp at h
+    | existsIoc a b formula =>
+        change (if a < b then
+          Sentence.evalOpen? (.existsIoc a b formula) data.isolations
+            (Fin.last data.isolations.intervals.size)
+          else none) = some true at h
+        split at h
+        · rename_i hab
+          obtain ⟨x, hax, hxb⟩ := exists_between (toReal_lt_toReal hab)
+          exact ⟨x, ⟨hax, hxb.le⟩, formulaAt x h⟩
+        · simp at h
+  · simp at h
+
+/-- A checked positive-root decomposition proves the quantified sentence. -/
+theorem Certificate.cells_sound {s : Sentence} {data : CellsCert}
+    (h : (Certificate.cells data).replay? s = some true) : s.toProp := by
+  simp only [Certificate.replay?, Sentence.replayCells?] at h
+  split at h
+  · rename_i hvalid
+    simp only [Bool.and_eq_true] at hvalid
+    obtain ⟨⟨⟨hcarrier, hstrict⟩, _hpositive⟩, hmatrix⟩ := hvalid
+    cases s with
+    | forallReal formula =>
+        cases hopt : data.iocCmps with
+        | none =>
+            simp only [hopt] at h
+            change OptionFold.allArray (Cell.all data.isolations.intervals.size)
+              (data.signs.evalCell? (.forallReal formula) data.isolations) =
+              some true at h
+            obtain ⟨value, hvalue, hspec⟩ := CellFold.forall_spec
+              (data.isolations.rootModel
+                (CarrierCert.replay_of_check hcarrier) hstrict)
+              (data.signs.evalCell? (.forallReal formula) data.isolations)
+              formula.toProp
+              (fun c => data.signs.evalCell_spec hcarrier hstrict hmatrix c)
+            have htrue : value = true := by
+              rw [hvalue] at h
+              exact Option.some.inj h
+            exact hspec.mp htrue
+        | some cmps => simp [hopt] at h
+    | existsReal formula =>
+        cases hopt : data.iocCmps with
+        | none =>
+            simp only [hopt] at h
+            change OptionFold.anyArray (Cell.all data.isolations.intervals.size)
+              (data.signs.evalCell? (.existsReal formula) data.isolations) =
+              some true at h
+            obtain ⟨value, hvalue, hspec⟩ := CellFold.exists_spec
+              (data.isolations.rootModel
+                (CarrierCert.replay_of_check hcarrier) hstrict)
+              (data.signs.evalCell? (.existsReal formula) data.isolations)
+              formula.toProp
+              (fun c => data.signs.evalCell_spec hcarrier hstrict hmatrix c)
+            have htrue : value = true := by
+              rw [hvalue] at h
+              exact Option.some.inj h
+            exact hspec.mp htrue
+        | some cmps => simp [hopt] at h
+    | forallIoc a b formula =>
+        cases hopt : data.iocCmps with
+        | none => simp [hopt] at h
+        | some cmps =>
+            simp only [hopt] at h
+            change (if a < b &&
+                cmps.check data.carrier.carrier data.carrier.replay
+                  data.isolations a b then
+              OptionFold.allWhereArray
+                (Cell.all data.isolations.intervals.size)
+                (Cell.meetsIocOn a b cmps)
+                (data.signs.evalCell? (.forallIoc a b formula) data.isolations)
+              else none) = some true at h
+            split at h
+            · rename_i hguard
+              simp only [Bool.and_eq_true] at hguard
+              obtain ⟨_hab, hcmps⟩ := hguard
+              obtain ⟨value, hvalue, hspec⟩ := CellFold.forallIoc_spec
+                (CarrierCert.replay_of_check hcarrier) hstrict a b cmps hcmps
+                (data.signs.evalCell? (.forallIoc a b formula) data.isolations)
+                formula.toProp
+                (fun c => data.signs.evalCell_spec hcarrier hstrict hmatrix c)
+              have htrue : value = true := by
+                rw [hvalue] at h
+                exact Option.some.inj h
+              exact hspec.mp htrue
+            · simp at h
+    | existsIoc a b formula =>
+        cases hopt : data.iocCmps with
+        | none => simp [hopt] at h
+        | some cmps =>
+            simp only [hopt] at h
+            change (if a < b &&
+                cmps.check data.carrier.carrier data.carrier.replay
+                  data.isolations a b then
+              OptionFold.anyWhereArray
+                (Cell.all data.isolations.intervals.size)
+                (Cell.meetsIocOn a b cmps)
+                (data.signs.evalCell? (.existsIoc a b formula) data.isolations)
+              else none) = some true at h
+            split at h
+            · rename_i hguard
+              simp only [Bool.and_eq_true] at hguard
+              obtain ⟨_hab, hcmps⟩ := hguard
+              obtain ⟨value, hvalue, hspec⟩ := CellFold.existsIoc_spec
+                (CarrierCert.replay_of_check hcarrier) hstrict a b cmps hcmps
+                (data.signs.evalCell? (.existsIoc a b formula) data.isolations)
+                formula.toProp
+                (fun c => data.signs.evalCell_spec hcarrier hstrict hmatrix c)
+              have htrue : value = true := by
+                rw [hvalue] at h
+                exact Option.some.inj h
+              exact hspec.mp htrue
+            · simp at h
+  · simp at h
+
+/-- The public Boolean certificate checker is sound. -/
+theorem check_sound (s : Sentence) (cert : Certificate) :
+    cert.check s = true → s.toProp := by
+  intro h
+  have hreplay := Certificate.replay_true h
+  cases cert with
+  | emptyIoc => exact Certificate.emptyIoc_sound hreplay
+  | constants => exact Certificate.constants_sound hreplay
+  | noRoots data => exact Certificate.noRoots_sound hreplay
+  | cells data => exact Certificate.cells_sound hreplay
+
+end Hex.RCF

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -345,6 +345,13 @@ proved equivalences.
       false for every cell when `a ≥ b`; `Cell.meetsIocOn_iff_of_check` is
       the corresponding all-endpoint-order theorem.
 
+    The executable quantifier folds are strict in their option-valued cell
+    results: Boolean `false`/`true` never short-circuits a later malformed
+    active cell. Bounded folds filter by the checked `meetsIocOn` predicate
+    first, so failures in irrelevant cells do not poison the result, while a
+    failure in any relevant cell returns `none`. Empty universal and
+    existential folds have the usual identities `true` and `false`.
+
 11. **Reflect.** A successful kernel replay gives
     `Sentence.toProp s`; the reifier's equivalence transports that
     proof to the original goal. A false result produces the diagnostic
@@ -358,7 +365,7 @@ the kernel would be far slower. Following the compiled-prep /
 kernel-verify pattern of the `factor_poly` / `irreducibility` tactics
 (hex-berlekamp), the tactic runs the search compiled, embeds a
 `Certificate`, and emits a proof of
-`Sentence.check s cert = true` by kernel reduction.
+`Certificate.check s cert = true` by kernel reduction.
 
 ### Generalized Sturm replay
 
@@ -440,6 +447,21 @@ variation reads to `Sturm.sturmVar` at finite endpoints and infinity.
 
 ### Certificate contents
 
+`Certificate` has four constructors matching the disjoint replay cases:
+`emptyIoc`, `constants`, `noRoots`, and `cells`. The no-root branch carries a
+checked carrier and an empty strict isolation set. The positive-root branch
+additionally carries the sign-matrix packages and an optional size-indexed
+`IocCmps`: real sentences require `none`, while bounded sentences require a
+checked `some`. Thus endpoint evidence cannot be silently ignored or omitted.
+
+Internally, `Certificate.replay?` returns `Option Bool`: `none` means malformed
+or shape-mismatched evidence, while `some false` is a valid diagnostic verdict.
+`Certificate.check` accepts exactly `some true`. Empty or reversed bounded
+domains are handled before all certificate data, so their universal and
+existential results are respectively `some true` and `some false` even when no
+decomposition exists. Every nonempty branch rejects data meant for a different
+shape.
+
 The certificate contains:
 
 - when needed, the carrier `P`, its generalized replay, and the
@@ -476,21 +498,21 @@ soundness.
 
 ```lean
 theorem check_sound (s : Sentence) (cert : Certificate) :
-    check s cert = true → s.toProp
+    Certificate.check s cert = true → s.toProp
 ```
 
 `decide : Sentence → Option Bool` is a convenience wrapper used by
 conformance and the external oracle. Internally, the builder returns
 either a diagnostic false result or a candidate true certificate.
 `decide` returns `some false` for the former; for the latter it runs
-`check s cert` and returns `some true` only when that check succeeds,
+`Certificate.check s cert` and returns `some true` only when that check succeeds,
 otherwise `none`. An internal builder or certificate failure therefore
 cannot pass a fixture expecting either verdict. The required one-way
 connections are
 
 ```lean
 theorem decide_eq_some_true_imp_exists_cert :
-    decide s = some true → ∃ cert, check s cert = true
+    decide s = some true → ∃ cert, Certificate.check s cert = true
 
 theorem decide_sound (s : Sentence) :
     decide s = some true → s.toProp
@@ -566,7 +588,13 @@ free to change.
 - `HexRCF/Isolations.lean`: the raw generalized isolation checker and its
   bridge to literal isolation semantics; `HexRCF/IsolationsTests.lean`:
   count, order, completeness, and no-real-root regressions.
-- `HexRCF/Certificate.lean`: `Certificate`, `check`, `decide`.
+- `HexRCF/Certificate.lean`: strict option folds, the four `Certificate`
+  branches, three-valued replay, and `check`; `HexRCF/CertificateTests.lean`:
+  all quantifiers, empty/reversed domains, constants, zero/single/multiple-root
+  decompositions, endpoint equality, and malformed nested evidence.
+- `HexRCF/Builder.lean`: checker-retained compiled carrier, isolation,
+  common-root, endpoint, and certificate construction, plus the public
+  `decide` wrapper and its one-way soundness theorems.
 - `HexRCF/Separation.lean`: replay-based strict-separation refinement,
   strict-gap checking, and endpoint classification for bounded sentences;
   `HexRCF/SeparationTests.lean`: midpoint ownership, close-root, scan,
@@ -587,7 +615,8 @@ free to change.
   `HexRCF/SignMatrixTests.lean`: exhaustive comparisons/connectives,
   zero/singleton/multiple-root cells, shared roots, constants, deduplication,
   and malformed-alignment regressions.
-- `HexRCF/Soundness.lean`: `check_sound` and its four factors.
+- `HexRCF/Soundness.lean`: strict-fold reflection, quantified cell lifting,
+  the four replay factors, and `check_sound`.
 - `HexRCF/Reify.lean`: `Qq`/`MetaM` reification, normalisation,
   fall-through messages.
 - `HexRCF/Tactic.lean`: the `rcf` front end.

--- a/progress/20260727T115257Z_rcf-certificate.md
+++ b/progress/20260727T115257Z_rcf-certificate.md
@@ -1,0 +1,43 @@
+# Accomplished
+
+- Merged the sign-matrix milestone in PR #8949 after its hosted build,
+  conformance, and bench gates passed, while continuing work on this stacked
+  branch.
+- Added four fail-closed certificate branches for empty bounded domains,
+  constant-only formulas, root-free carriers, and positive-root cell
+  decompositions, with three-valued replay and a true-only Boolean checker.
+- Added strict option-valued universal and existential folds. Boolean results
+  do not hide later active failures, bounded folds skip irrelevant cells, and
+  exact failure and value specifications are proved.
+- Lifted checked per-cell formula reflection through all four quantifiers and
+  proved soundness for every certificate branch and the public `check_sound`.
+- Added executable regressions for every quantifier, equal/reversed intervals,
+  constants, zero/single/multiple-root decompositions, endpoint equality,
+  interior-gap relevance, branch exclusivity, strict root counts, and malformed
+  nested evidence.
+- Factored constant/nonconstant open-cell signs into one shared implementation
+  and proof used by both the sign matrix and root-free certificate branch.
+- Updated the umbrella and SPEC with the exact branch shapes, strict-fold
+  behavior, three-valued boundary, file map, and future builder home for
+  `decide`.
+- Focused builds and the full 9477-target build pass. Source lints, DAG checks,
+  trust-surface scan, and `git diff --check` pass. Independent Sol and Opus
+  reviews found no soundness or fail-closed defect; their coverage and
+  maintainability suggestions were incorporated.
+
+# Current frontier
+
+Issue #8946 is implemented and locally green. The branch is stacked on the
+pre-squash sign-matrix commit and must be rebased onto merged `origin/main`
+before its PR is opened.
+
+# Next step
+
+Commit and rebase this milestone, open and merge its PR after hosted CI, and
+begin issue #8952. A compiling scratch prototype already establishes the exact
+rational clearing, carrier construction, and common-root construction APIs for
+that next milestone.
+
+# Blockers
+
+None.


### PR DESCRIPTION
Closes #8946.

Adds the four fail-closed certificate branches, three-valued replay, strict option-valued cell folds, quantified cell lifting, and the public check_sound theorem. Open-cell sign evaluation is shared with the sign matrix so the root-free path needs no common-root packages.

Regression coverage includes all quantifiers, empty and reversed Ioc domains, constants, zero/single/multiple-root carriers, endpoint equality, interior-gap relevance, exact guard isolation, and malformed nested evidence.

Validation:
- lake build (9477 targets)
- focused Certificate, Soundness, SignMatrix, and test builds
- file-line, copyright, DAG, and trust-surface checks
- git diff --check
- independent Sol audit and two fresh Opus reviews; no must-fix findings remain