### PR TITLE
RCF: build exact arithmetic witnesses

### DIFF
--- a/HexRCF.lean
+++ b/HexRCF.lean
@@ -23,6 +23,8 @@ public import HexRCF.CommonRoot
 public import HexRCF.CommonRootTests
 public import HexRCF.SignMatrix
 public import HexRCF.SignMatrixTests
+public import HexRCF.Builder
+public import HexRCF.BuilderTests
 public import HexRCF.Certificate
 public import HexRCF.Soundness
 public import HexRCF.CertificateTests
@@ -49,6 +51,9 @@ generalized replay per distinct nonconstant atom, with exact root-cell queries.
 The sign-matrix layer then recomputes guarded open and root signs, validates
 coefficient-equality package alignment, and reflects every Boolean formula
 to one exact truth value on each semantic cell.
+Compiled arithmetic preparation constructs checker-retained carrier witnesses
+and one aligned common-root package per distinct nonconstant atom, using exact
+rational arithmetic and denominator clearing outside kernel replay.
 The top-level certificate replay handles empty domains, constants, root-free
 carriers, and positive-root cell decompositions as distinct fail-closed
 branches. Strict option-valued folds propagate malformed active cells, and

--- a/HexRCF/Builder.lean
+++ b/HexRCF/Builder.lean
@@ -1,0 +1,206 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.Carrier
+public import HexRCF.CommonRoot
+public import HexRCF.SignMatrix
+public import HexRCF.SturmBuilder
+
+public section
+
+/-!
+# Compiled arithmetic preparation for RCF certificates
+
+This module performs the rational gcd, division, and denominator-clearing work
+that must remain outside kernel replay. Every public builder retains a candidate
+only after its multiplication-only checker accepts it.
+-/
+
+namespace Hex.RCF
+
+/-- A common positive denominator for all coefficients. -/
+private def ratCommonDen (p : DensePoly Rat) : Nat :=
+  p.toArray.foldl (fun den q => Nat.lcm den q.den) 1
+
+/-- Clear one rational coefficient at a known common denominator. -/
+private def clearRatCoeff (den : Nat) (q : Rat) : Int :=
+  q.num * Int.ofNat (den / q.den)
+
+/-- Clear all denominators and return the positive scale and integer
+polynomial. -/
+private def clearRatPoly (p : DensePoly Rat) : Int × ZPoly :=
+  let den := ratCommonDen p
+  (Int.ofNat den,
+    DensePoly.ofCoeffs (p.toArray.map (clearRatCoeff den)))
+
+/-- Clear a rational polynomial at an externally chosen common denominator. -/
+private def clearRatPolyAt (den : Nat) (p : DensePoly Rat) : ZPoly :=
+  DensePoly.ofCoeffs (p.toArray.map (clearRatCoeff den))
+
+/-- Convert a rational polynomial whose coefficients are already integral. -/
+private def ratPolyToZ? (p : DensePoly Rat) : Option ZPoly :=
+  if p.toArray.all (fun q => q.den == 1) then
+    some (DensePoly.ofCoeffs (p.toArray.map (fun q => q.num)))
+  else none
+
+/-- Recover the signed content relating the square-free decomposition product
+to the original atom product. -/
+private def factorScale? (q core repeated : ZPoly) : Option Int :=
+  let content := ZPoly.content q
+  if DensePoly.beqCoeffs q
+      (DensePoly.scale content (core * repeated)) then some content
+  else if DensePoly.beqCoeffs q
+      (DensePoly.scale (-content) (core * repeated)) then some (-content)
+  else none
+
+/-- Build a square-free carrier and retain it only after the kernel-facing
+checker accepts all multiplication identities and the generalized replay. -/
+def buildCarrier? (s : Sentence) : Option CarrierCert :=
+  let q := s.product
+  let decomposition := ZPoly.primitiveSquareFreeDecomposition q
+  let core := decomposition.squareFreeCore
+  let repeated := decomposition.repeatedPart
+  match factorScale? q core repeated with
+  | none => none
+  | some factorScale =>
+      let derivativeQuotient :=
+        ZPoly.toRatPoly (DensePoly.derivative q) / ZPoly.toRatPoly repeated
+      let (derivScale, derivPart) := clearRatPoly derivativeQuotient
+      match buildSturmReplay? core with
+      | none => none
+      | some replay =>
+          let cert : CarrierCert := {
+            carrier := core
+            repeated
+            derivPart
+            factorScale
+            derivScale
+            replay }
+          if cert.check s then some cert else none
+
+/-- Every carrier emitted by compiled preparation has passed its checker. -/
+theorem check_buildCarrier {s : Sentence} {cert : CarrierCert}
+    (h : buildCarrier? s = some cert) : cert.check s = true := by
+  unfold buildCarrier? at h
+  dsimp only at h
+  split at h <;> rename_i hfactor
+  · simp at h
+  · split at h <;> rename_i hreplay
+    · simp at h
+    · split at h <;> rename_i hcheck
+      · cases Option.some.inj h
+        exact hcheck
+      · simp at h
+
+/-- One denominator clearing both Bezout coefficients and the rational unit
+relating the executable rational gcd to its primitive integer representative. -/
+private def commonDen3 (left right : DensePoly Rat) (unit : Rat) : Nat :=
+  Nat.lcm (Nat.lcm (ratCommonDen left) (ratCommonDen right)) unit.den
+
+/-- Constants need no replay; nonconstant common-root polynomials do. -/
+private def buildGcdReplay? (gcd : ZPoly) : Option (Option SturmReplay) :=
+  if gcd.size = 1 then some none
+  else (buildSturmReplay? gcd).map some
+
+/-- Build one common-root package by rational extended gcd and retain it only
+after all divisibility, scaled Bezout, and replay checks pass. -/
+def buildCommonRoot? (atom carrier : ZPoly) : Option CommonRootCert :=
+  let atomRat := ZPoly.toRatPoly atom
+  let carrierRat := ZPoly.toRatPoly carrier
+  let result := DensePoly.xgcd atomRat carrierRat
+  let gcd := ZPoly.ratPolyPrimitivePart result.gcd
+  if gcd.isZero then none
+  else
+    let gcdRat := ZPoly.toRatPoly gcd
+    match ratPolyToZ? (atomRat / gcdRat),
+        ratPolyToZ? (carrierRat / gcdRat) with
+    | some atomFactor, some carrierFactor =>
+        let unit := DensePoly.leadingCoeff result.gcd /
+          ((DensePoly.leadingCoeff gcd : Int) : Rat)
+        let den := commonDen3 result.left result.right unit
+        let scaleRat := (den : Rat) * unit
+        if scaleRat.den != 1 then none
+        else
+          match buildGcdReplay? gcd with
+          | none => none
+          | some replay =>
+              let cert : CommonRootCert := {
+                gcd
+                atomFactor
+                carrierFactor
+                atomCoeff := clearRatPolyAt den result.left
+                carrierCoeff := clearRatPolyAt den result.right
+                scale := scaleRat.num
+                replay }
+              if cert.check atom carrier then some cert else none
+    | _, _ => none
+
+/-- Every common-root package emitted by compiled preparation has passed its
+checker against the external atom and carrier. -/
+theorem check_buildCommonRoot {atom carrier : ZPoly} {cert : CommonRootCert}
+    (h : buildCommonRoot? atom carrier = some cert) :
+    cert.check atom carrier = true := by
+  unfold buildCommonRoot? at h
+  dsimp only at h
+  split at h <;> rename_i hgcd
+  · simp at h
+  · split at h <;> rename_i hfactors
+    · split at h <;> rename_i hscale
+      · simp at h
+      · split at h <;> rename_i hreplay
+        · simp at h
+        · split at h <;> rename_i hcheck
+          · cases Option.some.inj h
+            exact hcheck
+          · simp at h
+    · simp at h
+
+/-- Build common-root packages in a prescribed polynomial order, failing if
+any individual package cannot be constructed and checked. -/
+private def buildCommonRootsFrom? (carrier : ZPoly) :
+    List ZPoly → Option (List CommonRootCert)
+  | [] => some []
+  | atom :: atoms => do
+      let common ← buildCommonRoot? atom carrier
+      let commons ← buildCommonRootsFrom? carrier atoms
+      some (common :: commons)
+
+/-- Successful list preparation produces packages aligned with and accepted
+against every polynomial in the supplied order. -/
+private theorem check_buildCommonRootsFrom {carrier : ZPoly} {atoms : List ZPoly}
+    {commons : List CommonRootCert}
+    (h : buildCommonRootsFrom? carrier atoms = some commons) :
+    checkCommon carrier atoms commons = true := by
+  induction atoms generalizing commons with
+  | nil =>
+      simp [buildCommonRootsFrom?] at h
+      subst commons
+      rfl
+  | cons atom atoms ih =>
+      simp only [buildCommonRootsFrom?] at h
+      obtain ⟨common, hcommon, hrest⟩ := Option.bind_eq_some_iff.mp h
+      obtain ⟨tail, htail, hpure⟩ := Option.bind_eq_some_iff.mp hrest
+      cases Option.some.inj hpure
+      simp only [checkCommon, Bool.and_eq_true]
+      exact ⟨check_buildCommonRoot hcommon, ih htail⟩
+
+/-- Build one checker-retained common-root package per distinct nonconstant
+sentence polynomial, in the exact order expected by the sign-matrix checker. -/
+def buildCommonRoots? (s : Sentence) (carrier : ZPoly) :
+    Option (List CommonRootCert) :=
+  buildCommonRootsFrom? carrier (dedupPolys s.polys)
+
+/-- Every emitted common-root list passes the sign-matrix alignment checker
+against the recomputed distinct polynomial order. -/
+theorem check_buildCommonRoots {s : Sentence} {carrier : ZPoly}
+    {commons : List CommonRootCert}
+    (h : buildCommonRoots? s carrier = some commons) :
+    checkCommon carrier (dedupPolys s.polys) commons = true := by
+  exact check_buildCommonRootsFrom h
+
+end Hex.RCF

--- a/HexRCF/BuilderTests.lean
+++ b/HexRCF/BuilderTests.lean
@@ -1,0 +1,131 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.Builder
+public meta import HexRCF.Builder
+public meta import HexRCF.Carrier
+public meta import HexRCF.CommonRoot
+public meta import HexRCF.SignMatrix
+public meta import HexRCF.SturmBuilder
+
+public section
+
+/-! Regression tests for compiled carrier and common-root preparation. -/
+
+namespace Hex.RCF.BuilderTests
+
+private def one : ZPoly := DensePoly.ofCoeffs #[(1 : Int)]
+private def two : ZPoly := DensePoly.ofCoeffs #[(2 : Int)]
+private def negTwelve : ZPoly := DensePoly.ofCoeffs #[(-12 : Int)]
+private def zero : ZPoly := DensePoly.ofCoeffs #[]
+private def x : ZPoly := DensePoly.ofCoeffs #[(0 : Int), 1]
+private def twiceX : ZPoly := DensePoly.ofCoeffs #[(0 : Int), 2]
+private def quad : ZPoly := DensePoly.ofCoeffs #[(-1 : Int), 0, 1]
+private def xMinusOne : ZPoly := DensePoly.ofCoeffs #[(-1 : Int), 1]
+private def xPlusOne : ZPoly := DensePoly.ofCoeffs #[(1 : Int), 1]
+private def repeated : ZPoly := DensePoly.scale (-6) (xMinusOne * xMinusOne)
+
+private def quadSentence : Sentence := .forallReal (.atom ⟨quad, .ge⟩)
+private def duplicateSentence : Sentence :=
+  .existsReal (.and (.atom ⟨x, .ge⟩) (.atom ⟨x, .le⟩))
+private def repeatedSentence : Sentence := .forallReal (.atom ⟨repeated, .ne⟩)
+private def constantSentence : Sentence := .forallReal (.atom ⟨one, .gt⟩)
+private def repeatedAtoms : Sentence := .existsReal
+  (.and (.atom ⟨x, .eq⟩) (.and (.atom ⟨quad, .gt⟩) (.atom ⟨x, .le⟩)))
+
+/-! Square-free, repeated-factor, nonprimitive, and constant carrier paths. -/
+
+#guard (buildCarrier? quadSentence).isSome
+#guard (match buildCarrier? quadSentence with
+    | some cert => cert.check quadSentence
+    | none => false)
+
+/- Repeated occurrences produce `Q = x²`, hence carrier and repeated part
+both equal `x`. -/
+#guard (match buildCarrier? duplicateSentence with
+    | some cert =>
+        DensePoly.beqCoeffs cert.carrier x &&
+          DensePoly.beqCoeffs cert.repeated x &&
+          cert.factorScale == 1 &&
+          cert.derivScale == 1 &&
+          DensePoly.beqCoeffs cert.derivPart two &&
+          cert.check duplicateSentence
+    | none => false)
+
+/- Negative nonprimitive content is retained in the signed factor scale. -/
+#guard (match buildCarrier? repeatedSentence with
+    | some cert =>
+        DensePoly.beqCoeffs cert.carrier xMinusOne &&
+        DensePoly.beqCoeffs cert.repeated xMinusOne &&
+          cert.factorScale == -6 &&
+          cert.derivScale == 1 &&
+          DensePoly.beqCoeffs cert.derivPart negTwelve &&
+          cert.check repeatedSentence
+    | none => false)
+
+/- Constant-only sentences belong to the carrier-free certificate branch. -/
+#guard (buildCarrier? constantSentence).isNone
+
+example {cert : CarrierCert} (h : buildCarrier? quadSentence = some cert) :
+    cert.check quadSentence = true := check_buildCarrier h
+
+/-! Coprime, scaled, shared, and equal common-root packages. -/
+
+#guard (match buildCommonRoot? x quad with
+    | some cert =>
+        DensePoly.beqCoeffs cert.gcd one &&
+          cert.replay.isNone && cert.check x quad
+    | none => false)
+
+/- Clearing the rational Bezout coefficients for `2*x` and `x²-1` produces a
+genuine nonunit scale. -/
+#guard (match buildCommonRoot? twiceX quad with
+    | some cert =>
+        DensePoly.beqCoeffs cert.gcd one &&
+          cert.scale.natAbs == 2 && cert.replay.isNone &&
+          cert.check twiceX quad
+    | none => false)
+
+#guard (match buildCommonRoot? xMinusOne quad with
+    | some cert =>
+        DensePoly.beqCoeffs cert.gcd xMinusOne &&
+          DensePoly.beqCoeffs cert.atomFactor one &&
+          DensePoly.beqCoeffs cert.carrierFactor xPlusOne &&
+          cert.replay.isSome && cert.check xMinusOne quad
+    | none => false)
+
+#guard (match buildCommonRoot? quad quad with
+    | some cert =>
+        DensePoly.beqCoeffs cert.gcd quad &&
+          DensePoly.beqCoeffs cert.atomFactor one &&
+          DensePoly.beqCoeffs cert.carrierFactor one &&
+          cert.replay.isSome && cert.check quad quad
+    | none => false)
+
+/- The undefined rational gcd case fails before emitting any certificate. -/
+#guard (buildCommonRoot? zero zero).isNone
+
+/- Common packages are constructed once per first-occurrence-preserving
+distinct atom and remain positionally aligned with the checker. -/
+#guard (match buildCommonRoots? repeatedAtoms (x * quad) with
+    | some [xCommon, quadCommon] =>
+        DensePoly.beqCoeffs xCommon.gcd x &&
+          DensePoly.beqCoeffs quadCommon.gcd quad &&
+          checkCommon (x * quad) (dedupPolys repeatedAtoms.polys)
+            [xCommon, quadCommon]
+    | _ => false)
+
+example {cert : CommonRootCert} (h : buildCommonRoot? xMinusOne quad = some cert) :
+    cert.check xMinusOne quad = true := check_buildCommonRoot h
+
+example {commons : List CommonRootCert}
+    (h : buildCommonRoots? repeatedAtoms (x * quad) = some commons) :
+    checkCommon (x * quad) (dedupPolys repeatedAtoms.polys) commons = true :=
+  check_buildCommonRoots h
+
+end Hex.RCF.BuilderTests

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -294,6 +294,14 @@ proved equivalences.
    responsibilities of the step-8 sign-matrix checker, not trusted fields of
    an individual package.
 
+   Compiled preparation computes the gcd and Bézout coefficients over
+   `ℚ[x]`, converts the exact factor quotients back to `ℤ[x]`, and clears one
+   positive common denominator across both Bézout coefficients and the
+   rational unit relating the executable gcd to its primitive integer
+   representative. `buildCommonRoots?` traverses exactly the
+   first-occurrence-preserving `dedupPolys s.polys` order and retains every
+   candidate only after `CommonRootCert.check` accepts it.
+
 8. **Sign matrix.** For each cell and each atom polynomial `pⱼ`:
    The checker first coefficient-deduplicates the recomputed nonconstant atom
    order and checks exactly one positional common-root package per result;
@@ -592,9 +600,12 @@ free to change.
   branches, three-valued replay, and `check`; `HexRCF/CertificateTests.lean`:
   all quantifiers, empty/reversed domains, constants, zero/single/multiple-root
   decompositions, endpoint equality, and malformed nested evidence.
-- `HexRCF/Builder.lean`: checker-retained compiled carrier, isolation,
-  common-root, endpoint, and certificate construction, plus the public
-  `decide` wrapper and its one-way soundness theorems.
+- `HexRCF/Builder.lean`: exact rational conversion and checker-retained
+  compiled carrier and deduplicated, aligned common-root construction;
+  `HexRCF/BuilderTests.lean`: signed-content, repeated-factor, rational-scale,
+  common-root alignment, and failure regressions. This module also owns the
+  later isolation, endpoint, certificate construction, and public `decide`
+  wrapper described below.
 - `HexRCF/Separation.lean`: replay-based strict-separation refinement,
   strict-gap checking, and endpoint classification for bounded sentences;
   `HexRCF/SeparationTests.lean`: midpoint ownership, close-root, scan,

--- a/progress/20260727T121201Z_rcf-arithmetic-builder.md
+++ b/progress/20260727T121201Z_rcf-arithmetic-builder.md
@@ -1,0 +1,39 @@
+# RCF arithmetic builder
+
+## Accomplished
+
+- Added exact rational-polynomial denominator clearing and integral conversion
+  for compiled certificate preparation.
+- Added checker-retained carrier construction from the recomputed sentence
+  product and primitive square-free decomposition.
+- Added checker-retained rational-xgcd common-root construction, including
+  exact factor conversion, one common denominator for the scaled Bezout
+  identity, and optional generalized replay construction.
+- Added first-occurrence-preserving construction of one common-root package per
+  distinct nonconstant atom, aligned with the sign-matrix checker order.
+- Proved that every emitted carrier, common-root package, and aligned package
+  list passes its corresponding checker.
+- Added compiled regressions for signed/nonprimitive content, repeated factors,
+  exact derivative quotients, coprime/shared/equal roots, nonunit Bezout scale,
+  duplicate alignment, constants, and zero-gcd failure.
+- Updated the umbrella and RCF SPEC file map. Focused builds, the full 9479-job
+  build, DAG/copyright/trust-surface checks, and diff checks pass.
+- Merged the preceding certificate/soundness PR after hosted CI completed
+  successfully.
+
+## Current frontier
+
+The arithmetic preparation layer required before top-level certificate
+assembly is complete locally and ready to publish as the issue #8952 PR.
+
+## Next step
+
+Rebase onto the merged certificate/soundness milestone, publish issue #8952,
+then implement compiled isolation/separation/endpoint/sign-matrix/certificate
+assembly and the public one-way-sound decision wrapper.
+
+## Blockers
+
+The fresh Opus review launcher could not authenticate because its OAuth session
+expired. The independent Sol audit completed; both of its required findings
+were addressed. There is no implementation blocker.


### PR DESCRIPTION
Closes #8952

## Summary

- build checker-retained carrier certificates from exact square-free decomposition witnesses
- build rational-xgcd common-root packages with exact denominator-cleared Bezout identities
- deduplicate and align one common-root package per distinct nonconstant atom
- add output-check theorems, adversarial compiled regressions, umbrella exports, and SPEC updates

## Verification

- lake build HexRCF.BuilderTests HexRCF
- lake build (9479 jobs)
- python3 scripts/check_copyright_headers.py
- python3 scripts/check_dag.py
- python3 scripts/release/check_trust_surface.py
- git diff --check origin/main...HEAD