### PR TITLE
RCF: assemble checker-retained decisions

### DIFF
--- a/HexRCF.lean
+++ b/HexRCF.lean
@@ -28,6 +28,8 @@ public import HexRCF.BuilderTests
 public import HexRCF.Certificate
 public import HexRCF.Soundness
 public import HexRCF.CertificateTests
+public import HexRCF.Decision
+public import HexRCF.DecisionTests
 
 public section
 
@@ -58,4 +60,8 @@ The top-level certificate replay handles empty domains, constants, root-free
 carriers, and positive-root cell decompositions as distinct fail-closed
 branches. Strict option-valued folds propagate malformed active cells, and
 the soundness theorem lifts every accepted verdict to the quantified sentence.
+Compiled decision assembly runs isolation, strict separation, endpoint
+classification, and arithmetic preparation outside the kernel, retains only
+well-formed replay verdicts, and returns `true` only after the proof-producing
+certificate checker accepts.
 -/

--- a/HexRCF/Decision.lean
+++ b/HexRCF/Decision.lean
@@ -1,0 +1,190 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.Builder
+public import HexRCF.Soundness
+public import HexRealRoots.Isolate
+
+public section
+
+/-!
+# Compiled RCF certificate assembly
+
+This module runs root search, strict separation, endpoint classification, and
+arithmetic witness construction outside kernel replay. It retains a candidate
+only when the small certificate replay produces a well-formed verdict. A true
+verdict is checked once more before the public decision wrapper returns it.
+-/
+
+namespace Hex.RCF
+
+/-- Erase the proof fields tied to the executable Sturm chain, retaining only
+the raw intervals that the generalized replay checker will validate. -/
+private def rawIsolations {p : ZPoly} (roots : Hex.RealRootIsolations p) :
+    IsolationCert :=
+  ⟨roots.isolations.map (fun isolation => isolation.interval)⟩
+
+/-- Run executable isolation, validate the raw intervals against the carrier's
+literal replay, and refine touching intervals to strict separation. -/
+def buildIsolations? (carrier : CarrierCert) : Option IsolationCert :=
+  match Hex.isolate? carrier.carrier with
+  | none => none
+  | some roots =>
+      let raw := rawIsolations roots
+      if raw.check carrier.replay then
+        Separation.separate? carrier.carrier carrier.replay raw
+      else none
+
+/-- Every emitted isolation array passes the generalized strict checker. -/
+theorem check_buildIsolations {carrier : CarrierCert}
+    {isolations : IsolationCert}
+    (h : buildIsolations? carrier = some isolations) :
+    isolations.checkStrict carrier.replay = true := by
+  unfold buildIsolations? at h
+  split at h <;> rename_i hroots
+  · simp at h
+  · dsimp only at h
+    split at h
+    · exact Separation.check_of_separate_eq_some h
+    · simp at h
+
+/-- Classify every isolated carrier root against one exact endpoint. -/
+def buildRootCmps? (carrier : CarrierCert) (isolations : IsolationCert)
+    (endpoint : Dyadic) :
+    Option (Vector Separation.RootCmp isolations.intervals.size) :=
+  Vector.ofFnM fun i =>
+    Separation.classify? carrier.carrier carrier.replay
+      isolations.intervals[i] endpoint
+
+/-- Build both size-indexed endpoint-comparison vectors and retain them only
+after the endpoint checker accepts every position. -/
+def buildIocCmps? (carrier : CarrierCert) (isolations : IsolationCert)
+    (a b : Dyadic) : Option (IocCmps isolations.intervals.size) := do
+  let lower ← buildRootCmps? carrier isolations a
+  let upper ← buildRootCmps? carrier isolations b
+  let cmps : IocCmps isolations.intervals.size := { lower, upper }
+  if cmps.check carrier.carrier carrier.replay isolations a b then
+    some cmps
+  else none
+
+/-- Every emitted endpoint package passes its positional checker. -/
+theorem check_buildIocCmps {carrier : CarrierCert}
+    {isolations : IsolationCert} {a b : Dyadic}
+    {cmps : IocCmps isolations.intervals.size}
+    (h : buildIocCmps? carrier isolations a b = some cmps) :
+    cmps.check carrier.carrier carrier.replay isolations a b = true := by
+  unfold buildIocCmps? at h
+  obtain ⟨lower, _hlower, h⟩ := Option.bind_eq_some_iff.mp h
+  obtain ⟨upper, _hupper, h⟩ := Option.bind_eq_some_iff.mp h
+  dsimp only at h
+  split at h <;> rename_i hcheck
+  · cases Option.some.inj h
+    exact hcheck
+  · simp at h
+
+/-- Wrap the aligned common-root list as a sign-matrix certificate, retaining
+it only after the sign-matrix alignment checker accepts it. -/
+def buildSignMatrix? (s : Sentence) (carrier : CarrierCert) :
+    Option SignMatrixCert := do
+  let commons ← buildCommonRoots? s carrier.carrier
+  let cert : SignMatrixCert := { commonRoots := commons }
+  if cert.check s carrier then some cert else none
+
+/-- Every emitted sign-matrix package passes its alignment checker. -/
+theorem check_buildSignMatrix {s : Sentence} {carrier : CarrierCert}
+    {signs : SignMatrixCert}
+    (h : buildSignMatrix? s carrier = some signs) :
+    signs.check s carrier = true := by
+  unfold buildSignMatrix? at h
+  obtain ⟨commons, _hcommons, h⟩ := Option.bind_eq_some_iff.mp h
+  dsimp only at h
+  split at h <;> rename_i hcheck
+  · cases Option.some.inj h
+    exact hcheck
+  · simp at h
+
+/-- Assemble the constant or carrier decomposition for a domain already known
+not to be empty. Common-root work is skipped for root-free carriers. -/
+private def buildDecomposition? (s : Sentence) : Option Certificate :=
+  if s.polys.isEmpty then some .constants
+  else do
+    let carrier ← buildCarrier? s
+    let isolations ← buildIsolations? carrier
+    if isolations.intervals.isEmpty then
+      some (.noRoots { carrier, isolations })
+    else do
+      let signs ← buildSignMatrix? s carrier
+      match s with
+      | .forallReal _ | .existsReal _ =>
+          some (.cells { carrier, isolations, signs, iocCmps := none })
+      | .forallIoc a b _ | .existsIoc a b _ => do
+          let cmps ← buildIocCmps? carrier isolations a b
+          some (.cells { carrier, isolations, signs, iocCmps := some cmps })
+
+/-- Choose the empty-domain branch before performing any arithmetic work. -/
+private def buildCandidate? (s : Sentence) : Option Certificate :=
+  match s with
+  | .forallIoc a b _ | .existsIoc a b _ =>
+      if a < b then buildDecomposition? s else some .emptyIoc
+  | .forallReal _ | .existsReal _ => buildDecomposition? s
+
+/-- A compiled build result retains the certificate that produced its
+diagnostic or proof-producing verdict. -/
+structure BuildResult where
+  certificate : Certificate
+  verdict : Bool
+
+/-- Assemble a certificate and reject it if replay finds malformed evidence. -/
+def build? (s : Sentence) : Option BuildResult := do
+  let certificate ← buildCandidate? s
+  match certificate.replay? s with
+  | none => none
+  | some verdict => some { certificate, verdict }
+
+/-- A retained build result records exactly the certificate's replay verdict. -/
+theorem replay_build {s : Sentence} {result : BuildResult}
+    (h : build? s = some result) :
+    result.certificate.replay? s = some result.verdict := by
+  unfold build? at h
+  obtain ⟨certificate, _hcandidate, h⟩ := Option.bind_eq_some_iff.mp h
+  split at h <;> rename_i hreplay
+  · simp at h
+  · cases Option.some.inj h
+    exact hreplay
+
+/-- Compiled convenience decision. False is diagnostic; true is returned only
+after the kernel-facing Boolean checker accepts the retained certificate. -/
+def decide (s : Sentence) : Option Bool :=
+  match build? s with
+  | none => none
+  | some result =>
+      if result.verdict then
+        if result.certificate.check s then some true else none
+      else some false
+
+/-- A true compiled verdict exposes a certificate accepted by the checker. -/
+theorem decide_eq_some_true_imp_exists_cert {s : Sentence}
+    (h : decide s = some true) :
+    ∃ cert, Certificate.check s cert = true := by
+  unfold decide at h
+  split at h
+  · simp at h
+  · rename_i result hresult
+    split at h
+    · split at h
+      · rename_i hcheck
+        exact ⟨result.certificate, hcheck⟩
+      · simp at h
+    · simp at h
+
+/-- Every true compiled verdict proves the reflected sentence. -/
+theorem decide_sound (s : Sentence) (h : decide s = some true) : s.toProp := by
+  obtain ⟨cert, hcert⟩ := decide_eq_some_true_imp_exists_cert h
+  exact check_sound s cert hcert
+
+end Hex.RCF

--- a/HexRCF/DecisionTests.lean
+++ b/HexRCF/DecisionTests.lean
@@ -1,0 +1,183 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.Decision
+public meta import HexRCF.Decision
+
+public section
+
+/-! Compiled regressions for certificate assembly and decision. -/
+
+namespace Hex.RCF.DecisionTests
+
+private def one : ZPoly := DensePoly.ofCoeffs #[(1 : Int)]
+private def x : ZPoly := DensePoly.ofCoeffs #[(0 : Int), 1]
+private def posQuad : ZPoly := DensePoly.ofCoeffs #[(1 : Int), 0, 1]
+private def square : ZPoly := DensePoly.ofCoeffs #[(0 : Int), 0, 1]
+private def quad : ZPoly := DensePoly.ofCoeffs #[(-1 : Int), 0, 1]
+private def xMinusOne : ZPoly := DensePoly.ofCoeffs #[(-1 : Int), 1]
+
+private def constantTrue : Sentence := .forallReal (.atom ⟨one, .gt⟩)
+private def constantFalse : Sentence := .existsReal (.atom ⟨one, .lt⟩)
+private def emptyForall : Sentence := .forallIoc 0 0 (.atom ⟨x, .lt⟩)
+private def reversedExists : Sentence :=
+  .existsIoc (Dyadic.ofInt 2) (Dyadic.ofInt 1) (.atom ⟨x, .eq⟩)
+private def noRootTrue : Sentence := .forallReal (.atom ⟨posQuad, .gt⟩)
+private def noRootFalse : Sentence := .existsReal (.atom ⟨posQuad, .eq⟩)
+private def squareTrue : Sentence := .forallReal (.atom ⟨square, .ge⟩)
+private def rootExists : Sentence := .existsReal (.atom ⟨x, .eq⟩)
+private def upperIncluded : Sentence :=
+  .existsIoc 0 1 (.atom ⟨xMinusOne, .eq⟩)
+private def lowerExcluded : Sentence :=
+  .existsIoc 1 2 (.atom ⟨xMinusOne, .eq⟩)
+private def boundedForall : Sentence :=
+  .forallIoc 0 1 (.atom ⟨xMinusOne, .le⟩)
+private def twoRoots : Sentence := .existsReal (.atom ⟨quad, .eq⟩)
+private def sharedRepeated : Sentence := .forallReal
+  (.and (.atom ⟨square, .ge⟩) (.atom ⟨x, .eq⟩))
+private def mixed : Sentence := .existsReal
+  (.and (.atom ⟨one, .gt⟩) (.atom ⟨x, .eq⟩))
+
+/- Equal and reversed bounded domains bypass every arithmetic builder. -/
+#guard (match build? emptyForall with
+    | some result => match result.certificate with
+      | .emptyIoc => result.verdict
+      | _ => false
+    | none => false)
+#guard (match build? reversedExists with
+    | some result => match result.certificate with
+      | .emptyIoc => !result.verdict
+      | _ => false
+    | none => false)
+
+/- Constant true and false results retain the carrier-free branch. -/
+#guard (match build? constantTrue with
+    | some result => match result.certificate with
+      | .constants => result.verdict
+      | _ => false
+    | none => false)
+#guard (match build? constantFalse with
+    | some result => match result.certificate with
+      | .constants => !result.verdict
+      | _ => false
+    | none => false)
+
+/- A checked empty isolation array uses the no-roots branch for either
+diagnostic value and performs no common-root work. -/
+#guard (match build? noRootTrue with
+    | some result => match result.certificate with
+      | .noRoots data => result.verdict && data.isolations.intervals.isEmpty
+      | _ => false
+    | none => false)
+#guard (match build? noRootFalse with
+    | some result => match result.certificate with
+      | .noRoots data => !result.verdict && data.isolations.intervals.isEmpty
+      | _ => false
+    | none => false)
+
+/- Real positive-root certificates omit endpoint data. -/
+#guard (match build? rootExists with
+    | some result => match result.certificate with
+      | .cells data => result.verdict && data.iocCmps.isNone &&
+          0 < data.isolations.intervals.size
+      | _ => false
+    | none => false)
+
+/- Bounded positive-root certificates include checked endpoint data. -/
+#guard (match build? upperIncluded with
+    | some result => match result.certificate with
+      | .cells data => result.verdict && data.iocCmps.isSome
+      | _ => false
+    | none => false)
+
+/- Multiple roots produce one strictly separated interval per carrier root. -/
+#guard (match build? twoRoots with
+    | some result => match result.certificate with
+      | .cells data => result.verdict && data.isolations.intervals.size == 2
+      | _ => false
+    | none => false)
+
+/- Repeated factors and two distinct atoms sharing the same root produce a
+square-free carrier and one common package per distinct polynomial. -/
+#guard (match build? sharedRepeated with
+    | some result => match result.certificate with
+      | .cells data =>
+          DensePoly.beqCoeffs data.carrier.carrier x &&
+            DensePoly.beqCoeffs data.carrier.repeated square &&
+            data.signs.commonRoots.length == 2 && !result.verdict
+      | _ => false
+    | none => false)
+
+/- Constant atoms coexist with one nonconstant common-root package. -/
+#guard (match build? mixed with
+    | some result => match result.certificate with
+      | .cells data => result.verdict && data.signs.commonRoots.length == 1
+      | _ => false
+    | none => false)
+
+/- All four quantifier forms and half-open endpoint ownership. -/
+#guard Hex.RCF.decide emptyForall == some true
+#guard Hex.RCF.decide reversedExists == some false
+#guard Hex.RCF.decide squareTrue == some true
+#guard Hex.RCF.decide rootExists == some true
+#guard Hex.RCF.decide boundedForall == some true
+#guard Hex.RCF.decide upperIncluded == some true
+#guard Hex.RCF.decide lowerExcluded == some false
+#guard Hex.RCF.decide constantFalse == some false
+#guard Hex.RCF.decide noRootFalse == some false
+
+/- Retained false evidence remains diagnostic, while retained true evidence
+passes the proof-producing checker. -/
+#guard (match build? constantFalse with
+    | some result => !result.certificate.check constantFalse
+    | none => false)
+#guard (match build? constantTrue with
+    | some result => result.certificate.check constantTrue
+    | none => false)
+
+/- A replay belonging to another carrier is rejected before separation. -/
+#guard (match buildCarrier? twoRoots, buildCarrier? rootExists with
+    | some quadCarrier, some xCarrier =>
+        (buildIsolations? { quadCarrier with replay := xCarrier.replay }).isNone
+    | _, _ => false)
+
+private def wide : IsolationCert := ⟨#[
+  DyadicInterval.mk (Dyadic.ofInt (-2)) (Dyadic.ofInt 2) (by decide)]⟩
+
+/- A malformed interval whose endpoint prefix contains two roots makes batch
+classification fail instead of inventing a comparison. -/
+#guard (match buildCarrier? twoRoots with
+    | some carrier =>
+        (buildIocCmps? carrier wide (Dyadic.ofInt 2) (Dyadic.ofInt 3)).isNone
+    | none => false)
+
+example {carrier : CarrierCert} {isolations : IsolationCert}
+    (h : buildIsolations? carrier = some isolations) :
+    isolations.checkStrict carrier.replay = true := check_buildIsolations h
+
+example {carrier : CarrierCert} {isolations : IsolationCert} {a b : Dyadic}
+    {cmps : IocCmps isolations.intervals.size}
+    (h : buildIocCmps? carrier isolations a b = some cmps) :
+    cmps.check carrier.carrier carrier.replay isolations a b = true :=
+  check_buildIocCmps h
+
+example {s : Sentence} {carrier : CarrierCert} {signs : SignMatrixCert}
+    (h : buildSignMatrix? s carrier = some signs) :
+    signs.check s carrier = true := check_buildSignMatrix h
+
+example {s : Sentence} {result : BuildResult} (h : build? s = some result) :
+    result.certificate.replay? s = some result.verdict := replay_build h
+
+example {s : Sentence} (h : Hex.RCF.decide s = some true) :
+    ∃ cert : Certificate, cert.check s = true :=
+  decide_eq_some_true_imp_exists_cert h
+
+example {s : Sentence} (h : Hex.RCF.decide s = some true) : s.toProp :=
+  decide_sound s h
+
+end Hex.RCF.DecisionTests

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -603,9 +603,13 @@ free to change.
 - `HexRCF/Builder.lean`: exact rational conversion and checker-retained
   compiled carrier and deduplicated, aligned common-root construction;
   `HexRCF/BuilderTests.lean`: signed-content, repeated-factor, rational-scale,
-  common-root alignment, and failure regressions. This module also owns the
-  later isolation, endpoint, certificate construction, and public `decide`
-  wrapper described below.
+  common-root alignment, and failure regressions.
+- `HexRCF/Decision.lean`: compiled root isolation, strict separation, endpoint
+  classification, sign-matrix and certificate assembly, retained diagnostic
+  build results, and the public one-way-sound `decide` wrapper;
+  `HexRCF/DecisionTests.lean`: all four certificate branches and quantifiers,
+  half-open endpoint ownership, multiple/repeated/shared roots, helper failure,
+  and output-check regressions.
 - `HexRCF/Separation.lean`: replay-based strict-separation refinement,
   strict-gap checking, and endpoint classification for bounded sentences;
   `HexRCF/SeparationTests.lean`: midpoint ownership, close-root, scan,

--- a/progress/20260727T122533Z_rcf-decision.md
+++ b/progress/20260727T122533Z_rcf-decision.md
@@ -1,0 +1,44 @@
+# RCF compiled decision assembly
+
+## Accomplished
+
+- Added `HexRCF.Decision` as the compiled boundary above arithmetic witness
+  construction, kernel certificate replay, and soundness.
+- Added checker-retained executable isolation, strict separation, endpoint
+  comparison vectors, and sign-matrix construction.
+- Added branch-ordered certificate assembly: empty bounded domains bypass all
+  arithmetic, constant sentences bypass carriers, root-free carriers bypass
+  common-root work, and positive-root bounded sentences carry checked endpoint
+  evidence.
+- Added `BuildResult`, whose recorded verdict is proved to equal certificate
+  replay, and the option-valued public `decide` wrapper. Diagnostic false
+  results remain separate from proof-producing true results.
+- Proved that a true decision exposes an accepted certificate and therefore
+  proves `Sentence.toProp`, without asserting totality or false-result
+  soundness.
+- Added compiled regressions covering all four quantifiers and certificate
+  branches, equal/reversed domains, lower-excluded and upper-included roots,
+  no-root and multiple-root carriers, repeated/shared roots, mixed constants,
+  replay mismatch, malformed endpoint evidence, output-check theorems, and
+  true/false checker behavior.
+- Corrected issue #8955 before implementation so its retention requirement
+  matches the SPEC's diagnostic-false channel.
+- Updated the umbrella and SPEC file map. Focused builds, the full 9481-job
+  build, copyright/DAG/trust-surface checks, and diff checks pass.
+- Merged the preceding arithmetic-builder PR after hosted CI completed
+  successfully. Two independent Sol audits found no remaining must-fix defect.
+
+## Current frontier
+
+Compiled decision and certificate assembly is complete locally and ready to
+publish as the issue #8955 PR.
+
+## Next step
+
+Rebase onto the merged arithmetic-builder milestone, publish issue #8955, then
+implement proof-producing goal reification and the `rcf` tactic front end.
+
+## Blockers
+
+The fresh Opus launcher remains unavailable because its OAuth session expired.
+This did not block implementation or the independent Sol reviews.


### PR DESCRIPTION
Closes #8955

## Summary

- assemble all four certificate branches with empty-domain dispatch before arithmetic
- run compiled isolation, strict separation, endpoint classification, and aligned sign-matrix preparation
- retain exact diagnostic verdicts and gate true results through Certificate.check
- prove accepted-certificate extraction and one-way decision soundness
- add compiled branch, quantifier, endpoint, shared-root, and failure regressions

## Verification

- lake build HexRCF.DecisionTests HexRCF
- lake build (9481 jobs)
- python3 scripts/check_copyright_headers.py
- python3 scripts/check_dag.py
- python3 scripts/release/check_trust_surface.py
- git diff --check origin/main...HEAD