### PR TITLE
prove(resultant): close primitive power and degree bounds

### DIFF
--- a/HexNumberFieldMathlib/Roots.lean
+++ b/HexNumberFieldMathlib/Roots.lean
@@ -108,13 +108,15 @@ theorem coeff_toPolynomialAt (f : DensePoly (QAdjoin p x))
 
 /-- Fixed-field executable zero detection agrees with semantic polynomial
 zero. -/
-theorem poly_isZero_iff (f : DensePoly (QAdjoin p x))
+theorem poly_isZero_iff [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x))
     (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) :
     f.isZero ↔ QAdjoin.toPolynomialAt f rep h = 0 := by
   sorry
 
 /-- A nonzero fixed-field polynomial has the expected semantic degree. -/
-theorem natDegree_toPolynomialAt (f : DensePoly (QAdjoin p x))
+theorem natDegree_toPolynomialAt [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x))
     (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x)
     (hf : !f.isZero) :
     (QAdjoin.toPolynomialAt f rep h).natDegree = f.degree?.getD 0 := by

--- a/HexResultant/Basic.lean
+++ b/HexResultant/Basic.lean
@@ -42,7 +42,7 @@ for the degree-ordered case.
 -/
 namespace Hex.DensePoly
 
-universe u
+universe u v w
 
 variable {R : Type u} [Zero R] [DecidableEq R]
 
@@ -127,6 +127,14 @@ theorem pseudoDivMod_of_size_lt [One R] [Add R] [Sub R] [Mul R]
     (isZero_eq_false_iff g).2 (by omega)
   simp [pseudoDivMod, hg, h]
 
+/-- A fold that appends one value per input has the expected output size. -/
+private theorem size_foldl_push {A : Type v} {B : Type w}
+    (xs : Array A) (init : Array B)
+    (f : A → B) :
+    (xs.foldl (fun acc x => acc.push (f x)) init).size = init.size + xs.size := by
+  rw [Array.foldl_push_eq_append (stop := xs.size) rfl]
+  simp
+
 /-- Pseudo-division reconstructs the fixed leading-coefficient multiple of the dividend.
 
 This theorem deliberately uses a fresh coefficient type: an ambient `Zero`
@@ -144,7 +152,21 @@ theorem pseudoDivMod_remainder_lt_core {S : Type u}
     [Lean.Grind.CommRing S] [DecidableEq S]
     (f g : DensePoly S) (hg : g ≠ 0) (hfg : g.size ≤ f.size) :
     (pseudoDivMod f g).2.size < g.size := by
-  sorry
+  have hgpos : 0 < g.size := by
+    apply Nat.pos_of_ne_zero
+    intro hsize
+    apply hg
+    apply ext_coeff
+    intro i
+    rw [coeff_zero]
+    exact coeff_eq_zero_of_size_le g (by omega)
+  have hgzero : g.isZero = false := (isZero_eq_false_iff g).2 hgpos
+  simp only [pseudoDivMod, hgzero, Bool.false_eq_true, ↓reduceIte,
+    Nat.not_lt_of_ge hfg]
+  exact Nat.lt_of_le_of_lt (size_ofCoeffs_le _) (by
+    rw [size_foldl_push]
+    simp only [Array.size_empty, Array.size_range]
+    omega)
 
 /-! Small compiled regressions for the pseudo-division loop. -/
 

--- a/HexResultant/ExactDiv.lean
+++ b/HexResultant/ExactDiv.lean
@@ -96,10 +96,39 @@ def powNat [One R] [Mul R] (x : R) (n : Nat) : R :=
 termination_by n
 decreasing_by omega
 
+/-- Iterating a lightweight-semiring power multiplies its exponents. -/
+private theorem pow_pow {S : Type u} [Lean.Grind.Semiring S]
+    (x : S) (m n : Nat) : (x ^ m) ^ n = x ^ (m * n) := by
+  induction n with
+  | zero => simp [Lean.Grind.Semiring.pow_zero]
+  | succ n ih =>
+      rw [Lean.Grind.Semiring.pow_succ, ih,
+        ← Lean.Grind.Semiring.pow_add]
+      congr 1
+
 /-- The executable binary power agrees with the lightweight semiring power. -/
 theorem powNat_eq_pow {S : Type u} [Lean.Grind.Semiring S]
     (x : S) (n : Nat) : powNat x n = x ^ n := by
-  sorry
+  induction n using Nat.strongRecOn generalizing x with
+  | ind n ih =>
+      rw [powNat]
+      by_cases hn : n = 0
+      · subst n
+        simp [Lean.Grind.Semiring.pow_zero]
+      · rw [if_neg hn]
+        have hlt : n / 2 < n :=
+          Nat.div_lt_self (Nat.pos_of_ne_zero hn) (by decide : 1 < 2)
+        rw [ih (n / 2) hlt (x * x)]
+        have hdiv := Nat.mod_add_div n 2
+        by_cases heven : n % 2 = 0
+        · rw [if_pos heven, ← Lean.Grind.Semiring.pow_two, pow_pow]
+          congr 1
+          omega
+        · rw [if_neg heven, ← Lean.Grind.Semiring.pow_two, pow_pow,
+            ← Lean.Grind.Semiring.pow_succ]
+          congr 1
+          have hmod := Nat.mod_lt n (by decide : 0 < 2)
+          omega
 
 /-- Brown's scalar update `x^n / y^(n-1)`, with the same total zero behavior
 as `exactDiv`. -/

--- a/progress/20260727T122324Z_resultant-phase4-ci-and-proof.md
+++ b/progress/20260727T122324Z_resultant-phase4-ci-and-proof.md
@@ -1,0 +1,43 @@
+# Resultant proof kernel and testing-stack repair
+
+## Accomplished
+
+- Merged PR #8882, the exact Brown PRS milestone, after verifying the successful
+  GitHub Actions run and retargeted PR #8883 to `main`.
+- Diagnosed PR #8945's CI failure as a Phase-4 derivation-comment lint, repaired
+  the benchmark comment, and restacked/pushed PRs #8945, #8947, and #8948.
+- Proved `powNat_eq_pow` over the lightweight noncommutative semiring interface.
+- Proved the strict pseudo-remainder size bound directly from the output-fold
+  invariant and normalized dense-polynomial representation.
+- Corrected two false NumberField companion contracts by requiring checked
+  irreducibility for semantic zero detection and degree preservation.
+- Completed focused audits of Resultant, NumberField, and NumberFieldTower,
+  including proof inventories, test/documentation gaps, and sound next slices.
+- Rebuilt `HexResultant`, `HexNumberFieldMathlib`, and all three benchmark
+  executables affected by the testing restack.
+
+## Current frontier
+
+`pseudoDivMod_reconstruct_core` is the remaining primitive Resultant proof.
+Its proof needs explicit coefficient/index invariants for the powers, active,
+quotient, and remainder folds.  Brown-chain validity should be decomposed only
+after that primitive reconstruction theorem is available.
+
+PRs #8945, #8947, and #8948 have fresh Actions runs in progress.  PR #8883 is
+retargeted to `main` but needs its stacked branch reconciled with the newly
+merged PR #8882 before it can merge.
+
+## Next step
+
+Publish the proof-kernel milestone and leave its independent review monitor
+running.  Continue meanwhile with the two local Tower semantic projections
+(`NumberTower.toComplex_eq` and `NumberTower.dim_pos`), then return to the
+pseudo-division coefficient invariants and the fixed-presentation NumberField
+evaluation bridge.
+
+## Blockers
+
+The configured Claude second-opinion OAuth session currently cannot be
+refreshed, so no replacement external reviewer is active.  The local Python
+environment also lacks `python-flint` and `cypari2`; CI remains the available
+external-oracle verification path.


### PR DESCRIPTION
## Summary

- prove the binary `powNat` implementation agrees with lightweight-semiring exponentiation, without assuming commutative multiplication
- prove the pseudo-division remainder has size strictly below the nonzero divisor by tracking the output fold size
- require checked irreducibility for the NumberField semantic zero and degree contracts, excluding reducible-presentation counterexamples

## Why

These are the first proof-bearing obligations in the Resultant correctness kernel. The power theorem supports Brown scalar updates, while the remainder bound supplies the local degree descent needed before decomposing the Brown-chain validity proof. The NumberField assumptions repair two theorem signatures that were false for reducible presentations such as `X² - 1` at the selected root `1`.

## Validation

- `lake build HexResultant HexNumberFieldMathlib HexConformance HexManual` (9,527 jobs)
- `lake exe hexresultant_bench verify` (all four targets)
- `python3 scripts/check_phase4.py`
- `git diff --check`

An asynchronous Claude second-opinion monitor has been launched, but its OAuth refresh is currently unavailable; implementation work is continuing independently.