### PR TITLE
prove(number-field-mathlib): preserve fixed-field evaluation

### DIFF
--- a/HexNumberFieldMathlib/AdjoinRoot.lean
+++ b/HexNumberFieldMathlib/AdjoinRoot.lean
@@ -47,30 +47,65 @@ theorem toAdjoinRoot_bijective [ZPoly.CheckedIrreducible p] :
 /-- Fixed-presentation zero evaluates to complex zero. -/
 theorem map_zero (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) :
     toComplex (0 : QAdjoin p x) rep h = 0 := by
-  sorry
+  change
+    (HexPolyMathlib.toPolynomial (0 : DensePoly Rat)).eval₂
+        (algebraMap Rat ℂ) rep.root = 0
+  rw [HexPolyMathlib.toPolynomial_zero, Polynomial.eval₂_zero]
 
 /-- Fixed-presentation one evaluates to complex one. -/
 theorem map_one (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) :
     toComplex (1 : QAdjoin p x) rep h = 1 := by
-  sorry
+  change
+    (HexPolyMathlib.toPolynomial (1 : DensePoly Rat)).eval₂
+        (algebraMap Rat ℂ) rep.root = 1
+  rw [HexPolyMathlib.toPolynomial_one, Polynomial.eval₂_one]
 
 /-- Fixed-presentation negation agrees with complex negation. -/
 theorem map_neg (a : QAdjoin p x) (rep : RefinedIsolation p)
     (h : SimpleRoot.mk rep = x) :
     toComplex (-a) rep h = -toComplex a rep h := by
-  sorry
+  change
+    (HexPolyMathlib.toPolynomial
+      (reduceCoeffs p (-a.coeffs))).eval₂
+        (algebraMap Rat ℂ) rep.root =
+      -(HexPolyMathlib.toPolynomial a.coeffs).eval₂
+        (algebraMap Rat ℂ) rep.root
+  rw [eval_reduceCoeffs, HexPolyMathlib.toPolynomial_neg,
+    Polynomial.eval₂_neg]
 
 /-- Fixed-presentation subtraction agrees with complex subtraction. -/
 theorem map_sub (a b : QAdjoin p x) (rep : RefinedIsolation p)
     (h : SimpleRoot.mk rep = x) :
     toComplex (a - b) rep h = toComplex a rep h - toComplex b rep h := by
-  sorry
+  change
+    (HexPolyMathlib.toPolynomial
+      (reduceCoeffs p (a.coeffs - b.coeffs))).eval₂
+        (algebraMap Rat ℂ) rep.root =
+      (HexPolyMathlib.toPolynomial a.coeffs).eval₂
+          (algebraMap Rat ℂ) rep.root -
+        (HexPolyMathlib.toPolynomial b.coeffs).eval₂
+          (algebraMap Rat ℂ) rep.root
+  rw [eval_reduceCoeffs, HexPolyMathlib.toPolynomial_sub,
+    Polynomial.eval₂_sub]
 
 /-- The executable rational scalar action is semantic scalar multiplication. -/
 theorem map_smul (q : Rat) (a : QAdjoin p x) (rep : RefinedIsolation p)
     (h : SimpleRoot.mk rep = x) :
     toComplex (q • a) rep h = (q : ℂ) * toComplex a rep h := by
-  sorry
+  change
+    (HexPolyMathlib.toPolynomial
+      (reduceCoeffs p (DensePoly.scale q a.coeffs))).eval₂
+        (algebraMap Rat ℂ) rep.root =
+      (q : ℂ) *
+        (HexPolyMathlib.toPolynomial a.coeffs).eval₂
+          (algebraMap Rat ℂ) rep.root
+  rw [eval_reduceCoeffs, HexPolyMathlib.toPolynomial_scale,
+    Polynomial.eval₂_mul, Polynomial.eval₂_C]
+  exact congrArg
+    (fun z : ℂ =>
+      z * (HexPolyMathlib.toPolynomial a.coeffs).eval₂
+        (algebraMap Rat ℂ) rep.root)
+    (map_ratCast (algebraMap Rat ℂ) q)
 
 /-- Fixed-presentation division agrees with complex division. -/
 theorem map_div [ZPoly.CheckedIrreducible p] (a b : QAdjoin p x)

--- a/HexNumberFieldMathlib/Basic.lean
+++ b/HexNumberFieldMathlib/Basic.lean
@@ -77,17 +77,67 @@ noncomputable def toComplex (a : QAdjoin p x)
   (HexPolyMathlib.toPolynomial a.coeffs).eval₂ (algebraMap Rat ℂ)
     rep.root
 
+/-- Reduction modulo the defining polynomial preserves evaluation at the
+selected root. -/
+theorem eval_reduceCoeffs (f : DensePoly Rat)
+    (rep : RefinedIsolation p) :
+    (HexPolyMathlib.toPolynomial (reduceCoeffs p f)).eval₂
+        (algebraMap Rat ℂ) rep.root =
+      (HexPolyMathlib.toPolynomial f).eval₂
+        (algebraMap Rat ℂ) rep.root := by
+  have hp :
+      (HexPolyMathlib.toPolynomial (ZPoly.toRatPoly p)).eval₂
+          (algebraMap Rat ℂ) rep.root = 0 := by
+    rw [HexPolyZMathlib.toPolynomial_toRatPoly,
+      Polynomial.eval₂_eq_eval_map]
+    have hcomp :
+        (algebraMap Rat ℂ).comp (Int.castRingHom Rat) =
+          Int.castRingHom ℂ :=
+      RingHom.ext_int _ _
+    rw [show
+        (HexPolyZMathlib.toPolyℚ p).map (algebraMap Rat ℂ) =
+          HexRootsMathlib.toPolyℂ p by
+      dsimp [HexPolyZMathlib.toPolyℚ, HexRootsMathlib.toPolyℂ]
+      rw [Polynomial.map_map, hcomp]]
+    exact HexRootsMathlib.RefinedIsolation.isRoot rep
+  have hdiv := congrArg
+    (fun g : DensePoly Rat =>
+      (HexPolyMathlib.toPolynomial g).eval₂
+        (algebraMap Rat ℂ) rep.root)
+    (DensePoly.div_mul_add_mod f (ZPoly.toRatPoly p))
+  simpa only [reduceCoeffs, HexPolyMathlib.toPolynomial_add,
+    HexPolyMathlib.toPolynomial_mul, Polynomial.eval₂_add,
+    Polynomial.eval₂_mul, hp, mul_zero, zero_add] using hdiv
+
 /-- Fixed-presentation addition agrees with complex addition. -/
 theorem map_add (a b : QAdjoin p x) (rep : RefinedIsolation p)
     (h : SimpleRoot.mk rep = x) :
     toComplex (a + b) rep h = toComplex a rep h + toComplex b rep h := by
-  sorry
+  change
+    (HexPolyMathlib.toPolynomial
+      (reduceCoeffs p (a.coeffs + b.coeffs))).eval₂
+        (algebraMap Rat ℂ) rep.root =
+      (HexPolyMathlib.toPolynomial a.coeffs).eval₂
+          (algebraMap Rat ℂ) rep.root +
+        (HexPolyMathlib.toPolynomial b.coeffs).eval₂
+          (algebraMap Rat ℂ) rep.root
+  rw [eval_reduceCoeffs, HexPolyMathlib.toPolynomial_add,
+    Polynomial.eval₂_add]
 
 /-- Fixed-presentation multiplication agrees with complex multiplication. -/
 theorem map_mul (a b : QAdjoin p x) (rep : RefinedIsolation p)
     (h : SimpleRoot.mk rep = x) :
     toComplex (a * b) rep h = toComplex a rep h * toComplex b rep h := by
-  sorry
+  change
+    (HexPolyMathlib.toPolynomial
+      (reduceCoeffs p (a.coeffs * b.coeffs))).eval₂
+        (algebraMap Rat ℂ) rep.root =
+      (HexPolyMathlib.toPolynomial a.coeffs).eval₂
+          (algebraMap Rat ℂ) rep.root *
+        (HexPolyMathlib.toPolynomial b.coeffs).eval₂
+          (algebraMap Rat ℂ) rep.root
+  rw [eval_reduceCoeffs, HexPolyMathlib.toPolynomial_mul,
+    Polynomial.eval₂_mul]
 
 /-- Fixed-presentation inversion agrees with complex inversion, including the
 computational convention `0⁻¹ = 0`. -/

--- a/HexPolyMathlib/Basic.lean
+++ b/HexPolyMathlib/Basic.lean
@@ -373,6 +373,17 @@ theorem toPolynomial_one [Semiring R] [DecidableEq R] :
   show toPolynomial (Hex.DensePoly.C 1) = 1
   rw [toPolynomial_C, Polynomial.C_1]
 
+/-- `toPolynomial` sends executable coefficient scaling to multiplication by
+the corresponding constant polynomial. -/
+@[simp, grind =]
+theorem toPolynomial_scale [Semiring R] [DecidableEq R]
+    (c : R) (p : Hex.DensePoly R) :
+    toPolynomial (Hex.DensePoly.scale c p) =
+      Polynomial.C c * toPolynomial p := by
+  ext n
+  rw [coeff_toPolynomial, Hex.DensePoly.coeff_scale_semiring,
+    Polynomial.coeff_C_mul, coeff_toPolynomial]
+
 /-- `toPolynomial` sends the executable monomial to Mathlib's monomial. -/
 @[simp, grind =]
 theorem toPolynomial_monomial [Semiring R] [DecidableEq R]

--- a/progress/20260727T124756Z_number-field-evaluation-laws.md
+++ b/progress/20260727T124756Z_number-field-evaluation-laws.md
@@ -1,0 +1,38 @@
+# Number-field evaluation laws
+
+## Accomplished
+
+- Proved that `QAdjoin.reduceCoeffs` preserves evaluation at the selected
+  complex root, using the executable division reconstruction identity and the
+  certified root equation.
+- Proved that fixed-presentation evaluation preserves addition,
+  multiplication, zero, one, negation, subtraction, and rational scalar
+  multiplication.
+- Added `HexPolyMathlib.toPolynomial_scale`, the reusable bridge identifying
+  executable coefficient scaling with multiplication by a constant Mathlib
+  polynomial.
+- Built `HexNumberFieldMathlib`, `HexNumberFieldTowerMathlib`, and `HexManual`
+  together successfully.
+- Kept the independent Claude review monitor running while continuing proof
+  work; its authentication remains expired.
+
+## Current frontier
+
+- `QAdjoin.map_inv` and the resulting division law remain the next semantic
+  laws for the fixed-presentation field interface.
+- The Resultant pseudo-division reconstruction proof now has an exact local
+  decomposition into fold/push indexing, powers, active recurrence,
+  convolution, and high-coefficient reindexing lemmas.
+
+## Next step
+
+- Publish this fixed-evaluation milestone as a stacked draft PR, then begin the
+  pseudo-division helper layer without waiting for review completion.
+- Continue reconciling and merging the bottom of the existing PR stack as CI
+  permits.
+
+## Blockers
+
+- The Claude second-opinion CLI cannot authenticate because its OAuth session
+  is expired; the retrying monitor remains active.
+- No implementation blocker for the next proof stage.


### PR DESCRIPTION
## Summary

- prove reduction modulo the defining polynomial preserves evaluation at the selected certified root
- prove fixed-presentation evaluation respects addition, multiplication, zero, one, negation, subtraction, and rational scalar multiplication
- add the reusable `HexPolyMathlib.toPolynomial_scale` correspondence lemma

## Validation

- `lake build HexNumberFieldMathlib HexNumberFieldTowerMathlib HexManual`
- `git diff --check`

This is intentionally stacked on #8960.