### PR TITLE
Add engine-owned interval policy frontier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Define the hex-dev cache + build target sets
         run: |
           echo "HEX_LIB_TARGETS=HexBasic HexArith HexPoly HexModArith HexGF2 HexPolyZ HexRoots HexResultant HexInterval HexIntervalExperiment HexIntervalMathlibExperiment HexIntervalReplayProbe HexIntervalMathlibReplayProbe HexPolyFp HexGFqRing HexGFqField HexBerlekamp HexHensel HexConway HexGFq HexBerlekampZassenhaus HexRealRoots HexMatrix HexRowReduce HexDeterminant HexBareiss HexGramSchmidt HexLLL HexMatrixMathlib HexGramSchmidtMathlib HexLLLMathlib HexBerlekampZassenhausMathlib HexRealRootsMathlib HexRCF HexRootsMathlib HexResultantMathlib HexReleaseTests HexReleaseExamples" >> "$GITHUB_ENV"
-          echo "HEX_EXE_TARGETS=hexarith_bench hexpoly_bench hexpolyz_bench hexpolyfp_bench hexmodarith_bench hexgf2_bench hexgfqring_bench hexgfqfield_bench hexgfq_bench hexhensel_bench hexberlekamp_bench hexbz_bench hexconway_bench hexmatrix_bench hexstrassen_compare hexdeterminant_bench hexbareiss_bench hexgramschmidt_bench hexrealroots_bench hexroots_bench hexroots_demo hex_interval_representation_spike hex_interval_center_spike hex_interval_scale_spike hex_interval_scheduler_spike hexlll_bench hexlll_gram_bench hexlll_provider_probe" >> "$GITHUB_ENV"
+          echo "HEX_EXE_TARGETS=hexarith_bench hexpoly_bench hexpolyz_bench hexpolyfp_bench hexmodarith_bench hexgf2_bench hexgfqring_bench hexgfqfield_bench hexgfq_bench hexhensel_bench hexberlekamp_bench hexbz_bench hexconway_bench hexmatrix_bench hexstrassen_compare hexdeterminant_bench hexbareiss_bench hexgramschmidt_bench hexrealroots_bench hexroots_bench hexroots_demo hex_interval_representation_spike hex_interval_center_spike hex_interval_scale_spike hex_interval_scheduler_spike hex_interval_policy_frontier_spike hexlll_bench hexlll_gram_bench hexlll_provider_probe" >> "$GITHUB_ENV"
       # Shared build. The libraries, bench exes, conformance #guard drivers, and
       # emit-fixture exes are all elaborated here so the two verification tails
       # below only *run* things, never rebuild them -- which is what lets the
@@ -211,6 +211,10 @@ jobs:
             hexconway_bench hexdeterminant_bench hexmatrix_bench \
             hexgramschmidt_bench hexlll_gram_bench \
             hexrealroots_bench hexroots_bench
+          # The policy-frontier spike is an exact logical-count canary rather
+          # than a lean-bench timing registration. Build it above and exercise
+          # all three representation fixtures directly here.
+          .lake/build/bin/hex_interval_policy_frontier_spike canary
           touch "$RUNNER_TEMP/bench.ok"
       - name: Conformance oracles + BZ gates
         id: conformance

--- a/HexInterval/Experiment/Policy.lean
+++ b/HexInterval/Experiment/Policy.lean
@@ -381,7 +381,6 @@ def State.offer? (state : State Fact) : OfferId -> Option OfferView
 
 inductive ViewError where
   | malformedState
-  | decisionLimit
   | traversalLimit
   | liveOfferLimit
   deriving DecidableEq, Repr
@@ -422,7 +421,6 @@ structure View (Fact : Type) where
 def remaining (limit used : Nat) : Nat := limit - used
 
 def State.view (state : State Fact) : Except ViewError (View Fact × State Fact) := do
-  if state.limits.maxDecisions <= state.metrics.decisions then throw .decisionLimit
   let (offers, traversal) <- state.offers
   pure
     ({ scope := state.scope

--- a/HexInterval/Experiment/Policy.lean
+++ b/HexInterval/Experiment/Policy.lean
@@ -88,16 +88,16 @@ structure ProposedEqualityKey where
 structure InstantiationSemanticKey where
   family : Nat
   triggers : List NodeId
-  claimedGeneration : Nat
+  generation : Nat
   nodes : List ProposedNodeKey
   equalities : List ProposedEqualityKey
   deriving DecidableEq, Repr
 
 def InstantiationSemanticKey.ofRequest
-    (request : InstantiationRequest) : InstantiationSemanticKey :=
+    (request : InstantiationRequest) (generation : Nat) : InstantiationSemanticKey :=
   { family := request.key
     triggers := request.triggers
-    claimedGeneration := request.claimedGeneration
+    generation
     nodes := request.nodes.map fun node =>
       { domain := node.domain, op := node.op, args := node.args }
     equalities := request.equalities.map fun equality =>
@@ -129,24 +129,11 @@ def OfferKey.offerClass : OfferKey -> OfferClass
   | .instantiate _ _ => .instantiate
   | .split _ _ _ _ => .split
 
-structure PolicyFeature where
-  key : Nat
-  value : Int
-  deriving DecidableEq, Repr
-
-structure ObservationSummary where
-  outcome : Nat
-  changedFacts : Nat
-  logicalWork : Nat
-  deriving DecidableEq, Repr
-
 structure OfferView where
   id : OfferId
   key : OfferKey
   offerClass : OfferClass
   age : Nat
-  summary : Option ObservationSummary := none
-  features : Array PolicyFeature := #[]
 
 /-! ## Engine-owned frontier state -/
 
@@ -159,6 +146,7 @@ structure Limits where
 
 structure Clock where
   active : Bool
+  /-- Decision epoch at which this work most recently became active. -/
   born : Nat
   deriving DecidableEq, Repr
 
@@ -183,10 +171,14 @@ structure Metrics where
   deriving DecidableEq, Repr
 
 /-- Trusted frontier bookkeeping around the generic propagator engine.
-Arbitrary policy-private state lives outside this structure. -/
+Arbitrary policy-private state lives outside this structure.  Its constructor
+is private: callers may inspect projections, but only validated opaque entry
+points can replace the underlying engine or frontier bookkeeping. -/
 structure State (Fact : Type) where
+  private mk ::
   scope : ScopeId
   serial : Nat
+  /-- Uniform logical time: exactly one tick per charged policy decision. -/
   epoch : Nat
   engine : Engine Fact
   applications : Array Clock
@@ -199,17 +191,12 @@ structure State (Fact : Type) where
 def clockArray (bits : Array Bool) (born : Nat) : Array Clock :=
   bits.map fun active => { active, born }
 
-def splitVersion? (engine : Engine Fact) (suggestion : RetainedSuggestion) : Option Nat :=
-  match suggestion.suggestion with
-  | .split request => engine.versions[request.node.index]?
-  | .retry _ | .instantiate _ => none
-
 def suggestionClocksFrom (engine : Engine Fact) (born : Nat) : Array SuggestionClock :=
   engine.suggestions.map fun retained =>
-    { active := true, born, splitVersion := splitVersion? engine retained }
+    { active := true, born, splitVersion := retained.splitVersion }
 
 /-- Begin policy control over an existing engine snapshot. -/
-def State.start (engine : Engine Fact) (limits : Limits)
+opaque State.start (engine : Engine Fact) (limits : Limits)
     (scope : ScopeId := { index := 0 }) : State Fact :=
   { scope
     serial := 0
@@ -245,7 +232,7 @@ def syncSuggestionClocks (epoch : Nat) (engine : Engine Fact)
           | some retained =>
               { active := true
                 born := epoch
-                splitVersion := splitVersion? engine retained }
+                splitVersion := retained.splitVersion }
           | none => { active := false, born := epoch, splitVersion := none }
     clocks := clocks.push clock
   return clocks
@@ -287,15 +274,7 @@ def State.equalityKey? (state : State Fact) (equalityId : EqualityId) : Option E
       right := { node := equality.right, version := rightVersion } }
 
 def actionFresh (state : State Fact) (action : Action) : Bool :=
-  match state.engine.applications[action.application.index]?,
-      state.engine.rules[action.rule.index]?,
-      state.engine.seenVersions? (action.inputs.map fun input => input.node) with
-  | some application, some rule, some current =>
-      application.rule == action.rule && application.node == action.node &&
-        application.kind == action.kind && rule.key == action.key &&
-        action.inputs.map (fun input => input.node) == application.watches &&
-        current == action.inputs
-  | _, _, _ => false
+  state.engine.actionFresh action
 
 def State.suggestionKey? (state : State Fact) (suggestionId : SuggestionId) : Option OfferKey := do
   let clock <- state.suggestions[suggestionId.index]?
@@ -309,9 +288,9 @@ def State.suggestionKey? (state : State Fact) (suggestionId : SuggestionId) : Op
         some (.retry source effort)
       else none
   | .instantiate request =>
-      if retained.action.programVersion == state.engine.programVersion then
-        some (.instantiate source (.ofRequest request))
-      else none
+      let generation <- state.engine.instantiationGeneration? retained
+      if request.claimedGeneration != generation then none
+      else some (.instantiate source (.ofRequest request generation))
   | .split request => do
       let version <- clock.splitVersion
       let current <- state.engine.versions[request.node.index]?
@@ -321,7 +300,7 @@ def State.suggestionKey? (state : State Fact) (suggestionId : SuggestionId) : Op
       some (.split source { node := request.node, version } request.point request.reason)
 
 /-- Permanently tombstone suggestions whose freshness guard has failed. -/
-def State.pruneSuggestions (state : State Fact) : State Fact := Id.run do
+private def pruneSuggestions (state : State Fact) : State Fact := Id.run do
   let mut clocks := state.suggestions
   for index in [0:clocks.size] do
     match clocks[index]? with
@@ -333,16 +312,14 @@ def State.pruneSuggestions (state : State Fact) : State Fact := Id.run do
 
 /-- Install a new engine snapshot, refresh live work clocks, and tombstone
 stale suggestions.  Previously consumed suggestions never reactivate. -/
-def State.advance (state : State Fact) (engine : Engine Fact) : State Fact :=
-  let epoch := state.epoch + 1
+private def advanceState (state : State Fact) (engine : Engine Fact) : State Fact :=
   let next : State Fact :=
     { state with
-      epoch
       engine
-      applications := syncClocks epoch state.applications engine.queued
-      equalities := syncClocks epoch state.equalities engine.equalityQueued
-      suggestions := syncSuggestionClocks epoch engine state.suggestions }
-  next.pruneSuggestions
+      applications := syncClocks state.epoch state.applications engine.queued
+      equalities := syncClocks state.epoch state.equalities engine.equalityQueued
+      suggestions := syncSuggestionClocks state.epoch engine state.suggestions }
+  pruneSuggestions next
 
 def State.offer? (state : State Fact) : OfferId -> Option OfferView
   | .application application => do
@@ -380,13 +357,12 @@ def State.offer? (state : State Fact) : OfferId -> Option OfferView
           age := state.epoch - clock.born }
 
 inductive ViewError where
-  | malformedState
   | traversalLimit
   | liveOfferLimit
   deriving DecidableEq, Repr
 
 /-- Authoritative bounded scan of every live semantic offer. -/
-def State.offers (state : State Fact) : Except ViewError (Array OfferView × Nat) := do
+private def stateOffers (state : State Fact) : Except ViewError (Array OfferView × Nat) := do
   let traversal := state.applications.size + state.equalities.size + state.suggestions.size
   if state.limits.maxTraversal < state.metrics.traversal + traversal then
     throw .traversalLimit
@@ -407,7 +383,12 @@ structure EngineBudgetView where
   actions : Nat
   acceptedFacts : Nat
   nodes : Nat
+  applications : Nat
   equalities : Nat
+  retainedSuggestions : Nat
+  instances : Nat
+  queueEntries : Nat
+  generation : Nat
   deriving DecidableEq, Repr
 
 structure View (Fact : Type) where
@@ -417,22 +398,34 @@ structure View (Fact : Type) where
   offers : Array OfferView
   facts : Snapshot Fact
   remaining : EngineBudgetView
+  incomplete : Bool
 
 def remaining (limit used : Nat) : Nat := limit - used
 
-def State.view (state : State Fact) : Except ViewError (View Fact × State Fact) := do
-  let (offers, traversal) <- state.offers
+opaque State.view (state : State Fact) : Except ViewError (View Fact × State Fact) := do
+  let (offers, traversal) <- stateOffers state
   pure
     ({ scope := state.scope
        serial := state.serial
        programVersion := state.engine.programVersion
        offers
        facts := state.engine.snapshot
+       incomplete := state.incomplete
        remaining :=
         { actions := remaining state.engine.limits.maxActions state.engine.metrics.queuePops
           acceptedFacts := remaining state.engine.limits.maxAcceptedFacts state.engine.history.size
           nodes := remaining state.engine.limits.maxNodes state.engine.program.nodes.size
-          equalities := remaining state.engine.limits.maxEqualities state.engine.equalities.size } },
+          applications :=
+            remaining state.engine.limits.maxApplications state.engine.applications.size
+          equalities := remaining state.engine.limits.maxEqualities state.engine.equalities.size
+          retainedSuggestions :=
+            remaining state.engine.limits.maxRetainedSuggestions state.engine.suggestions.size
+          instances := remaining state.engine.limits.maxInstances state.engine.instances.length
+          queueEntries :=
+            remaining state.engine.limits.maxQueueEntries state.engine.queue.size
+          generation :=
+            remaining state.engine.limits.maxGeneration
+              (state.engine.generations.foldl Nat.max 0) } },
      { state with
        metrics := { state.metrics with traversal := state.metrics.traversal + traversal } })
 
@@ -471,7 +464,7 @@ inductive EqualityOutcome where
   | contradiction
   | engineResource (resource : Resource)
   | factResource (budget : Nat)
-  | invalid (code : Nat)
+  | invalid (fault : EqualityFault)
   deriving DecidableEq, Repr
 
 /-- Equality work gets the same typed observation treatment as external rule
@@ -509,18 +502,41 @@ inductive SelectResult (Fact : Type) where
   | engineResource (resource : Resource) (state : State Fact)
   | factResource (budget : Nat) (state : State Fact)
 
-def State.chargeDecision (state : State Fact) (rejected : Bool := false) : State Fact :=
+private inductive DecisionClass where
+  | rejected
+  | invocation
+  | equality
+  | retry
+  | instantiate
+  | split
+  | dismissal
+
+/-- Charge exactly one policy decision and advance its uniform logical clock.
+Every class-specific counter is updated in this one place. -/
+private def chargeDecision (state : State Fact) (decision : DecisionClass) : State Fact :=
   { state with
     serial := state.serial + 1
+    epoch := state.epoch + 1
     metrics :=
       { state.metrics with
         decisions := state.metrics.decisions + 1
-        rejected := state.metrics.rejected + if rejected then 1 else 0 } }
+        rejected := state.metrics.rejected + if decision matches .rejected then 1 else 0
+        selectedInvocations := state.metrics.selectedInvocations +
+          if decision matches .invocation then 1 else 0
+        selectedEqualities := state.metrics.selectedEqualities +
+          if decision matches .equality then 1 else 0
+        selectedRetries := state.metrics.selectedRetries +
+          if decision matches .retry then 1 else 0
+        selectedInstances := state.metrics.selectedInstances +
+          if decision matches .instantiate then 1 else 0
+        selectedSplits := state.metrics.selectedSplits +
+          if decision matches .split then 1 else 0
+        dismissals := state.metrics.dismissals + if decision matches .dismissal then 1 else 0 } }
 
-def State.reject (state : State Fact) (reason : Rejection) : SelectResult Fact :=
+private def reject (state : State Fact) (reason : Rejection) : SelectResult Fact :=
   match reason with
   | .decisionLimit => .rejected reason state
-  | _ => .rejected reason (state.chargeDecision true)
+  | _ => .rejected reason (chargeDecision state .rejected)
 
 def State.validate (state : State Fact) (selection : Selection) : Except Rejection OfferView := do
   if state.limits.maxDecisions <= state.metrics.decisions then throw .decisionLimit
@@ -545,13 +561,13 @@ def deltasFor (before after : Engine Fact) (nodes : List NodeId) : Array (FactDe
 
 /-- Freeze an application only after validating the selected semantic offer.
 The optional effort is supplied only by an engine-retained retry offer. -/
-def State.prepareApplication (state : State Fact) (applicationId : ApplicationId)
-    (effort : Option Nat) (clearDirty : Bool) : SelectResult Fact :=
+private def prepareApplication (state : State Fact) (applicationId : ApplicationId)
+    (effort : Option Nat) (clearDirty : Bool) (decision : DecisionClass) : SelectResult Fact :=
   if state.engine.limits.maxActions <= state.engine.metrics.queuePops then
-    .rejected .actionLimit (state.chargeDecision true)
+    reject state .actionLimit
   else
     match state.engine.applications[applicationId.index]? with
-    | none => state.reject .malformedState
+    | none => reject state .malformedState
     | some application =>
         match state.engine.rules[application.rule.index]?,
             state.engine.seenVersions? application.watches,
@@ -578,11 +594,11 @@ def State.prepareApplication (state : State Fact) (applicationId : ApplicationId
                   { state.engine.metrics with
                     queuePops := state.engine.metrics.queuePops + 1
                     requests := state.engine.metrics.requests + 1 } }
-            let state := (state.advance engine).chargeDecision
+            let state := advanceState (chargeDecision state decision) engine
             .request { action, inputs := views, writes := application.writes } state
-        | _, _, _ => state.reject .malformedState
+        | _, _, _ => reject state .malformedState
 
-def State.consumeSuggestion (state : State Fact) (suggestion : SuggestionId) : State Fact :=
+private def consumeSuggestion (state : State Fact) (suggestion : SuggestionId) : State Fact :=
   match state.suggestions[suggestion.index]? with
   | none => state
   | some clock =>
@@ -596,9 +612,9 @@ def equalityObservation (key : EqualityWorkKey) (before after : Engine Fact)
     changes := deltasFor before after [key.left.node, key.right.node]
     narrowCalls }
 
-def State.selectEquality (state : State Fact) (key : EqualityWorkKey) : SelectResult Fact :=
+private def selectEquality (state : State Fact) (key : EqualityWorkKey) : SelectResult Fact :=
   if state.engine.limits.maxActions <= state.engine.metrics.queuePops then
-    .rejected .actionLimit (state.chargeDecision true)
+    reject state .actionLimit
   else
     let running : Engine Fact :=
       { state.engine with
@@ -607,73 +623,68 @@ def State.selectEquality (state : State Fact) (key : EqualityWorkKey) : SelectRe
           { state.engine.metrics with
             queuePops := state.engine.metrics.queuePops + 1
             equalityRuns := state.engine.metrics.equalityRuns + 1 } }
-    let selected :=
+    let selectedClock :=
       match state.equalities[key.equality.index]? with
       | some clock =>
-          { state with
-            engine := running
-            equalities := state.equalities.set! key.equality.index { clock with active := false } }
-      | none => { state with engine := running }
+          { state with equalities :=
+              state.equalities.set! key.equality.index { clock with active := false } }
+      | none => state
     match running.contractEquality key.equality with
-    | .advanced engine =>
+    | .advanced narrowCalls engine =>
         let outcome :=
           if engine.contradictory && !state.engine.contradictory then .contradiction
           else if engine.history.size == state.engine.history.size then .noChange
           else .improved
-        let observation := equalityObservation key state.engine engine outcome 2
-        let next := selected.advance engine
-        .equality observation
-          { (next.chargeDecision) with
-            metrics :=
-              { next.metrics with
-                decisions := next.metrics.decisions + 1
-                selectedEqualities := next.metrics.selectedEqualities + 1 } }
-    | .invalid code engine =>
-        .equality (equalityObservation key state.engine engine (.invalid code) 0)
-          ((selected.advance engine).chargeDecision)
-    | .resourceLimit resource engine =>
-        .engineResource resource ((selected.advance engine).chargeDecision)
-    | .factResourceLimit budget engine =>
-        .factResource budget ((selected.advance engine).chargeDecision)
+        let observation := equalityObservation key state.engine engine outcome narrowCalls
+        .equality observation (advanceState (chargeDecision selectedClock .equality) engine)
+    | .invalid fault narrowCalls engine =>
+        .equality (equalityObservation key state.engine engine (.invalid fault) narrowCalls)
+          (chargeDecision state .equality)
+    | .resourceLimit resource narrowCalls engine =>
+        .equality (equalityObservation key state.engine engine
+            (.engineResource resource) narrowCalls)
+          (chargeDecision state .equality)
+    | .factResourceLimit budget narrowCalls engine =>
+        .equality (equalityObservation key state.engine engine
+            (.factResource budget) narrowCalls)
+          (chargeDecision state .equality)
 
-def State.selectSuggestion (state : State Fact) (suggestionId : SuggestionId)
+private def selectSuggestion (state : State Fact) (suggestionId : SuggestionId)
     (key : OfferKey) : SelectResult Fact :=
-  let consumed := state.consumeSuggestion suggestionId
   match state.engine.suggestions[suggestionId.index]? with
-  | none => state.reject .malformedState
+  | none => reject state .malformedState
   | some retained =>
       match key, retained.suggestion with
       | .retry _ effort, .retry retainedEffort =>
-          if effort != retainedEffort then state.reject .wrongKey
+          if effort != retainedEffort then reject state .wrongKey
           else
-            match consumed.prepareApplication retained.action.application (some effort) false with
+            match prepareApplication state retained.action.application (some effort) false
+                .retry with
             | .request request next =>
-                .request request
-                  { next with
-                    metrics :=
-                      { next.metrics with selectedRetries := next.metrics.selectedRetries + 1 } }
+                .request request (consumeSuggestion next suggestionId)
             | result => result
       | .instantiate _ _, .instantiate _ =>
-          match consumed.engine.admitInstantiation suggestionId with
+          match state.engine.admitInstantiation suggestionId with
           | .admitted nodes engine =>
-              let next := consumed.advance engine
-              .completed (.instanceAdmitted nodes)
-                { (next.chargeDecision) with
-                  metrics :=
-                    { next.metrics with
-                      decisions := next.metrics.decisions + 1
-                      selectedInstances := next.metrics.selectedInstances + 1 } }
+              let selected := chargeDecision
+                (consumeSuggestion state suggestionId) .instantiate
+              .completed (.instanceAdmitted nodes) (advanceState selected engine)
           | .duplicate engine =>
-              .completed .instanceDuplicate ((consumed.advance engine).chargeDecision)
+              let selected := chargeDecision
+                (consumeSuggestion state suggestionId) .instantiate
+              .completed .instanceDuplicate (advanceState selected engine)
           | .invalid error engine =>
-              .completed (.instanceRejected error) ((consumed.advance engine).chargeDecision)
-          | .resourceLimit resource engine =>
-              .engineResource resource ((consumed.advance engine).chargeDecision)
+              let selected := chargeDecision
+                (consumeSuggestion state suggestionId) .instantiate
+              .completed (.instanceRejected error) (advanceState selected engine)
+          | .resourceLimit resource _ =>
+              .engineResource resource (chargeDecision state .instantiate)
       | .split source target point reason, .split request =>
-          match consumed.engine.facts[target.node.index]? with
-          | none => state.reject .malformedState
+          match state.engine.facts[target.node.index]? with
+          | none => reject state .malformedState
           | some fact =>
-              let consumed := { consumed with epoch := consumed.epoch + 1 }
+              let selected := chargeDecision
+                (consumeSuggestion state suggestionId) .split
               .split
                 { scope := state.scope
                   node := request.node
@@ -684,54 +695,42 @@ def State.selectSuggestion (state : State Fact) (suggestionId : SuggestionId)
                   point
                   reason
                   source }
-                { (consumed.chargeDecision) with
-                  metrics :=
-                    { consumed.metrics with
-                      decisions := consumed.metrics.decisions + 1
-                      selectedSplits := consumed.metrics.selectedSplits + 1 } }
-      | _, _ => state.reject .wrongKey
+                selected
+      | _, _ => reject state .wrongKey
 
 /-- Recheck and execute one policy selection. -/
-def State.select (state : State Fact) (selection : Selection) : SelectResult Fact :=
+opaque State.select (state : State Fact) (selection : Selection) : SelectResult Fact :=
   match state.validate selection with
-  | .error reason => state.reject reason
+  | .error reason => reject state reason
   | .ok offer =>
       match selection.id, offer.key with
       | .application application, .invoke _ =>
-          match state.prepareApplication application none true with
-          | .request request next =>
-              .request request
-                { next with
-                  metrics :=
-                    { next.metrics with
-                      selectedInvocations := next.metrics.selectedInvocations + 1 } }
+          match prepareApplication state application none true .invocation with
+          | .request request next => .request request next
           | result => result
-      | .equality _, .equality key => state.selectEquality key
-      | .suggestion suggestion, key => state.selectSuggestion suggestion key
-      | _, _ => state.reject .wrongKey
+      | .equality _, .equality key => selectEquality state key
+      | .suggestion suggestion, key => selectSuggestion state suggestion key
+      | _, _ => reject state .wrongKey
 
 /-- Dismissing ordinary propagation work makes the run incomplete; dismissing
 a suggestion merely declines one optional search action. -/
-def State.dismiss (state : State Fact) (selection : Selection) : SelectResult Fact :=
+opaque State.dismiss (state : State Fact) (selection : Selection) : SelectResult Fact :=
   match state.validate selection with
-  | .error reason => state.reject reason
+  | .error reason => reject state reason
   | .ok _ =>
       let next := match selection.id with
         | .application application =>
             let engine :=
               { state.engine with queued := state.engine.queued.set! application.index false }
-            { state.advance engine with incomplete := true }
+            { advanceState (chargeDecision state .dismissal) engine with incomplete := true }
         | .equality equality =>
             let engine :=
               { state.engine with
                 equalityQueued := state.engine.equalityQueued.set! equality.index false }
-            { state.advance engine with incomplete := true }
+            { advanceState (chargeDecision state .dismissal) engine with incomplete := true }
         | .suggestion suggestion =>
-            let next := state.consumeSuggestion suggestion
-            { next with epoch := next.epoch + 1 }
-      let next := next.chargeDecision
-      .completed .dismissed
-        { next with metrics := { next.metrics with dismissals := next.metrics.dismissals + 1 } }
+            chargeDecision (consumeSuggestion state suggestion) .dismissal
+      .completed .dismissed next
 
 /-! ## Exact rule observations -/
 
@@ -778,7 +777,7 @@ inductive SubmitResult (Fact : Type) where
 /-- Admit a reply through the underlying engine, then expose actual admitted
 fact deltas and newly engine-indexed suggestions.  Claimed candidate strength
 is never used as an observation. -/
-def State.submit (state : State Fact) (reply : Reply Fact) : SubmitResult Fact :=
+opaque State.submit (state : State Fact) (reply : Reply Fact) : SubmitResult Fact :=
   match state.engine.pending with
   | none => .malformedState state
   | some action =>
@@ -796,10 +795,10 @@ def State.submit (state : State Fact) (reply : Reply Fact) : SubmitResult Fact :
                   cost := outcomeCost reply.outcome
                   emittedSuggestions :=
                     emittedSuggestions before.suggestions.size engine.suggestions.size }
-              .accepted observation (state.advance engine)
-          | .invalid error engine => .invalid error (state.advance engine)
+              .accepted observation (advanceState state engine)
+          | .invalid error engine => .invalid error (advanceState state engine)
           | .resourceLimit resource engine =>
-              .engineResource resource (state.advance engine)
-          | .factResourceLimit budget engine => .factResource budget (state.advance engine)
+              .engineResource resource (advanceState state engine)
+          | .factResourceLimit budget engine => .factResource budget (advanceState state engine)
 
 end Hex.Interval.Experiment.Propagator.Policy

--- a/HexInterval/Experiment/Policy.lean
+++ b/HexInterval/Experiment/Policy.lean
@@ -1,0 +1,807 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Experiment.Propagator
+
+@[expose] public section
+
+/-!
+# Engine-owned policy offers for arbitrary interval propagators
+
+This experiment puts a replaceable search policy in front of the generic
+propagator engine.  The policy sees bounded, semantic descriptions of live
+work.  It can echo one description back, but it cannot construct an action,
+change a fact, activate an equality, instantiate an expression, or prepare a
+split.  Those transitions remain engine-owned and are revalidated at the
+point of selection.
+
+The existing append-only FIFO queue remains available as a reference
+scheduler.  This layer deliberately derives a dense live frontier from the
+engine's dirty bits, so scan and event-indexed policy representations can be
+compared before either becomes the production representation.
+-/
+
+namespace Hex.Interval.Experiment.Propagator.Policy
+
+/-! ## Stable semantic offer descriptions -/
+
+/-- Scope identity is explicit even though the first experiment has one root
+scope.  It prevents a later branch-local choice from being transplanted. -/
+structure ScopeId where
+  index : Nat
+  deriving DecidableEq, Repr
+
+/-- Versioned name of a deterministic external policy. -/
+structure PolicyKey where
+  name : String
+  version : Nat
+  deriving DecidableEq, Repr
+
+/-- Collision-free engine identity for each kind of live work. -/
+inductive OfferId where
+  | application (application : ApplicationId)
+  | equality (equality : EqualityId)
+  | suggestion (suggestion : SuggestionId)
+  deriving DecidableEq, Repr
+
+/-- Complete payload-free identity of one concrete propagator invocation. -/
+structure InvocationKey where
+  scope : ScopeId
+  programVersion : Nat
+  application : ApplicationId
+  rule : RuleKey
+  anchor : NodeId
+  kind : ActionKind
+  effort : Nat
+  inputs : List SeenVersion
+  deriving DecidableEq, Repr
+
+/-- Complete identity of an equality contraction against two fact versions. -/
+structure EqualityWorkKey where
+  scope : ScopeId
+  programVersion : Nat
+  equality : EqualityId
+  left : SeenVersion
+  right : SeenVersion
+  deriving DecidableEq, Repr
+
+/-- Payload-erased proposed node.  Proposal order is retained in this first
+experiment; canonicalization alternatives are compared in conformance data. -/
+structure ProposedNodeKey where
+  domain : DomainId
+  op : OpId
+  args : List NodeRef
+  deriving DecidableEq, Repr
+
+/-- Payload-erased proposed equality. -/
+structure ProposedEqualityKey where
+  left : NodeRef
+  right : NodeRef
+  deriving DecidableEq, Repr
+
+/-- Payload-erased structural identity of an instantiation request. -/
+structure InstantiationSemanticKey where
+  family : Nat
+  triggers : List NodeId
+  claimedGeneration : Nat
+  nodes : List ProposedNodeKey
+  equalities : List ProposedEqualityKey
+  deriving DecidableEq, Repr
+
+def InstantiationSemanticKey.ofRequest
+    (request : InstantiationRequest) : InstantiationSemanticKey :=
+  { family := request.key
+    triggers := request.triggers
+    claimedGeneration := request.claimedGeneration
+    nodes := request.nodes.map fun node =>
+      { domain := node.domain, op := node.op, args := node.args }
+    equalities := request.equalities.map fun equality =>
+      { left := equality.left, right := equality.right } }
+
+inductive OfferClass where
+  | invoke
+  | equality
+  | retry
+  | instantiate
+  | split
+  deriving DecidableEq, Repr
+
+/-- Semantic key which a selection must echo exactly.  Split freshness
+includes the target fact version, not an unrelated whole-program version. -/
+inductive OfferKey where
+  | invoke (invocation : InvocationKey)
+  | equality (contractor : EqualityWorkKey)
+  | retry (source : InvocationKey) (effort : Nat)
+  | instantiate (source : InvocationKey) (request : InstantiationSemanticKey)
+  | split (source : InvocationKey) (target : SeenVersion) (point : Dyadic)
+      (reason : SplitReason)
+  deriving DecidableEq
+
+def OfferKey.offerClass : OfferKey -> OfferClass
+  | .invoke _ => .invoke
+  | .equality _ => .equality
+  | .retry _ _ => .retry
+  | .instantiate _ _ => .instantiate
+  | .split _ _ _ _ => .split
+
+structure PolicyFeature where
+  key : Nat
+  value : Int
+  deriving DecidableEq, Repr
+
+structure ObservationSummary where
+  outcome : Nat
+  changedFacts : Nat
+  logicalWork : Nat
+  deriving DecidableEq, Repr
+
+structure OfferView where
+  id : OfferId
+  key : OfferKey
+  offerClass : OfferClass
+  age : Nat
+  summary : Option ObservationSummary := none
+  features : Array PolicyFeature := #[]
+
+/-! ## Engine-owned frontier state -/
+
+/-- Policy resources are independent of proof-producing engine resources. -/
+structure Limits where
+  maxDecisions : Nat
+  maxTraversal : Nat
+  maxLiveOffers : Nat
+  deriving DecidableEq, Repr
+
+structure Clock where
+  active : Bool
+  born : Nat
+  deriving DecidableEq, Repr
+
+/-- A retained suggestion needs one additional guard that is not present in
+its source action: the target version against which a split was proposed. -/
+structure SuggestionClock where
+  active : Bool
+  born : Nat
+  splitVersion : Option Nat
+  deriving DecidableEq, Repr
+
+structure Metrics where
+  decisions : Nat := 0
+  rejected : Nat := 0
+  traversal : Nat := 0
+  selectedInvocations : Nat := 0
+  selectedEqualities : Nat := 0
+  selectedRetries : Nat := 0
+  selectedInstances : Nat := 0
+  selectedSplits : Nat := 0
+  dismissals : Nat := 0
+  deriving DecidableEq, Repr
+
+/-- Trusted frontier bookkeeping around the generic propagator engine.
+Arbitrary policy-private state lives outside this structure. -/
+structure State (Fact : Type) where
+  scope : ScopeId
+  serial : Nat
+  epoch : Nat
+  engine : Engine Fact
+  applications : Array Clock
+  equalities : Array Clock
+  suggestions : Array SuggestionClock
+  incomplete : Bool := false
+  metrics : Metrics := {}
+  limits : Limits
+
+def clockArray (bits : Array Bool) (born : Nat) : Array Clock :=
+  bits.map fun active => { active, born }
+
+def splitVersion? (engine : Engine Fact) (suggestion : RetainedSuggestion) : Option Nat :=
+  match suggestion.suggestion with
+  | .split request => engine.versions[request.node.index]?
+  | .retry _ | .instantiate _ => none
+
+def suggestionClocksFrom (engine : Engine Fact) (born : Nat) : Array SuggestionClock :=
+  engine.suggestions.map fun retained =>
+    { active := true, born, splitVersion := splitVersion? engine retained }
+
+/-- Begin policy control over an existing engine snapshot. -/
+def State.start (engine : Engine Fact) (limits : Limits)
+    (scope : ScopeId := { index := 0 }) : State Fact :=
+  { scope
+    serial := 0
+    epoch := 0
+    engine
+    applications := clockArray engine.queued 0
+    equalities := clockArray engine.equalityQueued 0
+    suggestions := suggestionClocksFrom engine 0
+    limits }
+
+def syncClocks (epoch : Nat) (old : Array Clock) (bits : Array Bool) : Array Clock := Id.run do
+  let mut clocks := #[]
+  for index in [0:bits.size] do
+    let active := bits[index]!
+    let clock := match old[index]? with
+      | some previous =>
+          if active then
+            if previous.active then previous else { active := true, born := epoch }
+          else
+            { previous with active := false }
+      | none => { active, born := epoch }
+    clocks := clocks.push clock
+  return clocks
+
+def syncSuggestionClocks (epoch : Nat) (engine : Engine Fact)
+    (old : Array SuggestionClock) : Array SuggestionClock := Id.run do
+  let mut clocks := #[]
+  for index in [0:engine.suggestions.size] do
+    let clock := match old[index]? with
+      | some previous => previous
+      | none =>
+          match engine.suggestions[index]? with
+          | some retained =>
+              { active := true
+                born := epoch
+                splitVersion := splitVersion? engine retained }
+          | none => { active := false, born := epoch, splitVersion := none }
+    clocks := clocks.push clock
+  return clocks
+
+def invocationOfAction (scope : ScopeId) (action : Action) : InvocationKey :=
+  { scope
+    programVersion := action.programVersion
+    application := action.application
+    rule := action.key
+    anchor := action.node
+    kind := action.kind
+    effort := action.effort
+    inputs := action.inputs }
+
+def State.invocationKey? (state : State Fact) (applicationId : ApplicationId)
+    (effort : Option Nat := none) : Option InvocationKey := do
+  let application <- state.engine.applications[applicationId.index]?
+  let rule <- state.engine.rules[application.rule.index]?
+  let inputs <- state.engine.seenVersions? application.watches
+  some
+    { scope := state.scope
+      programVersion := state.engine.programVersion
+      application := applicationId
+      rule := rule.key
+      anchor := application.node
+      kind := application.kind
+      effort := effort.getD application.effort
+      inputs }
+
+def State.equalityKey? (state : State Fact) (equalityId : EqualityId) : Option EqualityWorkKey := do
+  let equality <- state.engine.equalities[equalityId.index]?
+  let leftVersion <- state.engine.versions[equality.left.index]?
+  let rightVersion <- state.engine.versions[equality.right.index]?
+  some
+    { scope := state.scope
+      programVersion := state.engine.programVersion
+      equality := equalityId
+      left := { node := equality.left, version := leftVersion }
+      right := { node := equality.right, version := rightVersion } }
+
+def actionFresh (state : State Fact) (action : Action) : Bool :=
+  match state.engine.applications[action.application.index]?,
+      state.engine.rules[action.rule.index]?,
+      state.engine.seenVersions? (action.inputs.map fun input => input.node) with
+  | some application, some rule, some current =>
+      application.rule == action.rule && application.node == action.node &&
+        application.kind == action.kind && rule.key == action.key &&
+        action.inputs.map (fun input => input.node) == application.watches &&
+        current == action.inputs
+  | _, _, _ => false
+
+def State.suggestionKey? (state : State Fact) (suggestionId : SuggestionId) : Option OfferKey := do
+  let clock <- state.suggestions[suggestionId.index]?
+  if !clock.active then none else pure ()
+  let retained <- state.engine.suggestions[suggestionId.index]?
+  if !actionFresh state retained.action then none else pure ()
+  let source := invocationOfAction state.scope retained.action
+  match retained.suggestion with
+  | .retry effort =>
+      if retained.action.effort < effort && effort <= state.engine.limits.maxEffort then
+        some (.retry source effort)
+      else none
+  | .instantiate request =>
+      if retained.action.programVersion == state.engine.programVersion then
+        some (.instantiate source (.ofRequest request))
+      else none
+  | .split request => do
+      let version <- clock.splitVersion
+      let current <- state.engine.versions[request.node.index]?
+      if current != version then none else pure ()
+      if !(EndpointCost.ofDyadic request.point).allowed
+          state.engine.limits.splitEndpointLimit then none else pure ()
+      some (.split source { node := request.node, version } request.point request.reason)
+
+/-- Permanently tombstone suggestions whose freshness guard has failed. -/
+def State.pruneSuggestions (state : State Fact) : State Fact := Id.run do
+  let mut clocks := state.suggestions
+  for index in [0:clocks.size] do
+    match clocks[index]? with
+    | some clock =>
+        if clock.active && (state.suggestionKey? { index }).isNone then
+          clocks := clocks.set! index { clock with active := false }
+    | none => pure ()
+  return { state with suggestions := clocks }
+
+/-- Install a new engine snapshot, refresh live work clocks, and tombstone
+stale suggestions.  Previously consumed suggestions never reactivate. -/
+def State.advance (state : State Fact) (engine : Engine Fact) : State Fact :=
+  let epoch := state.epoch + 1
+  let next : State Fact :=
+    { state with
+      epoch
+      engine
+      applications := syncClocks epoch state.applications engine.queued
+      equalities := syncClocks epoch state.equalities engine.equalityQueued
+      suggestions := syncSuggestionClocks epoch engine state.suggestions }
+  next.pruneSuggestions
+
+def State.offer? (state : State Fact) : OfferId -> Option OfferView
+  | .application application => do
+      let clock <- state.applications[application.index]?
+      if !clock.active || state.engine.pending.isSome || state.engine.contradictory then none
+      else pure ()
+      let queued <- state.engine.queued[application.index]?
+      if !queued then none else pure ()
+      let key <- state.invocationKey? application
+      some
+        { id := .application application
+          key := .invoke key
+          offerClass := .invoke
+          age := state.epoch - clock.born }
+  | .equality equality => do
+      let clock <- state.equalities[equality.index]?
+      if !clock.active || state.engine.pending.isSome || state.engine.contradictory then none
+      else pure ()
+      let queued <- state.engine.equalityQueued[equality.index]?
+      if !queued then none else pure ()
+      let key <- state.equalityKey? equality
+      some
+        { id := .equality equality
+          key := .equality key
+          offerClass := .equality
+          age := state.epoch - clock.born }
+  | .suggestion suggestion => do
+      if state.engine.pending.isSome || state.engine.contradictory then none else pure ()
+      let clock <- state.suggestions[suggestion.index]?
+      let key <- state.suggestionKey? suggestion
+      some
+        { id := .suggestion suggestion
+          key
+          offerClass := key.offerClass
+          age := state.epoch - clock.born }
+
+inductive ViewError where
+  | malformedState
+  | decisionLimit
+  | traversalLimit
+  | liveOfferLimit
+  deriving DecidableEq, Repr
+
+/-- Authoritative bounded scan of every live semantic offer. -/
+def State.offers (state : State Fact) : Except ViewError (Array OfferView × Nat) := do
+  let traversal := state.applications.size + state.equalities.size + state.suggestions.size
+  if state.limits.maxTraversal < state.metrics.traversal + traversal then
+    throw .traversalLimit
+  let mut offers := #[]
+  for index in [0:state.applications.size] do
+    if let some offer := state.offer? (.application { index }) then
+      offers := offers.push offer
+  for index in [0:state.equalities.size] do
+    if let some offer := state.offer? (.equality { index }) then
+      offers := offers.push offer
+  for index in [0:state.suggestions.size] do
+    if let some offer := state.offer? (.suggestion { index }) then
+      offers := offers.push offer
+  if state.limits.maxLiveOffers < offers.size then throw .liveOfferLimit
+  pure (offers, traversal)
+
+structure EngineBudgetView where
+  actions : Nat
+  acceptedFacts : Nat
+  nodes : Nat
+  equalities : Nat
+  deriving DecidableEq, Repr
+
+structure View (Fact : Type) where
+  scope : ScopeId
+  serial : Nat
+  programVersion : Nat
+  offers : Array OfferView
+  facts : Snapshot Fact
+  remaining : EngineBudgetView
+
+def remaining (limit used : Nat) : Nat := limit - used
+
+def State.view (state : State Fact) : Except ViewError (View Fact × State Fact) := do
+  if state.limits.maxDecisions <= state.metrics.decisions then throw .decisionLimit
+  let (offers, traversal) <- state.offers
+  pure
+    ({ scope := state.scope
+       serial := state.serial
+       programVersion := state.engine.programVersion
+       offers
+       facts := state.engine.snapshot
+       remaining :=
+        { actions := remaining state.engine.limits.maxActions state.engine.metrics.queuePops
+          acceptedFacts := remaining state.engine.limits.maxAcceptedFacts state.engine.history.size
+          nodes := remaining state.engine.limits.maxNodes state.engine.program.nodes.size
+          equalities := remaining state.engine.limits.maxEqualities state.engine.equalities.size } },
+     { state with
+       metrics := { state.metrics with traversal := state.metrics.traversal + traversal } })
+
+/-! ## Validated selection -/
+
+/-- A policy echoes both the engine identity and the semantic key from one
+particular view. -/
+structure Selection where
+  scope : ScopeId
+  serial : Nat
+  programVersion : Nat
+  id : OfferId
+  expected : OfferKey
+
+inductive Rejection where
+  | decisionLimit
+  | wrongScope
+  | staleSerial
+  | staleProgram
+  | missingOffer
+  | wrongKey
+  | actionLimit
+  | malformedState
+  deriving DecidableEq, Repr
+
+structure FactDelta (Fact : Type) where
+  node : NodeId
+  before : Fact
+  after : Fact
+  beforeVersion : Nat
+  afterVersion : Nat
+
+inductive EqualityOutcome where
+  | noChange
+  | improved
+  | contradiction
+  | engineResource (resource : Resource)
+  | factResource (budget : Nat)
+  | invalid (code : Nat)
+  deriving DecidableEq, Repr
+
+/-- Equality work gets the same typed observation treatment as external rule
+work; otherwise a policy could not learn from every selectable transition. -/
+structure EqualityObservation (Fact : Type) where
+  key : EqualityWorkKey
+  outcome : EqualityOutcome
+  changes : Array (FactDelta Fact)
+  narrowCalls : Nat
+
+structure SplitPlan (Fact : Type) where
+  scope : ScopeId
+  suggestion : SuggestionId
+  origin : Action
+  node : NodeId
+  version : Nat
+  fact : Fact
+  point : Dyadic
+  reason : SplitReason
+  source : InvocationKey
+
+inductive Completed where
+  | instanceAdmitted (newNodes : List NodeId)
+  | instanceDuplicate
+  | instanceRejected (error : AdmissionError)
+  | dismissed
+  deriving Repr
+
+inductive SelectResult (Fact : Type) where
+  | request (request : RuleRequest Fact) (state : State Fact)
+  | equality (observation : EqualityObservation Fact) (state : State Fact)
+  | completed (completion : Completed) (state : State Fact)
+  | split (plan : SplitPlan Fact) (state : State Fact)
+  | rejected (reason : Rejection) (state : State Fact)
+  | engineResource (resource : Resource) (state : State Fact)
+  | factResource (budget : Nat) (state : State Fact)
+
+def State.chargeDecision (state : State Fact) (rejected : Bool := false) : State Fact :=
+  { state with
+    serial := state.serial + 1
+    metrics :=
+      { state.metrics with
+        decisions := state.metrics.decisions + 1
+        rejected := state.metrics.rejected + if rejected then 1 else 0 } }
+
+def State.reject (state : State Fact) (reason : Rejection) : SelectResult Fact :=
+  match reason with
+  | .decisionLimit => .rejected reason state
+  | _ => .rejected reason (state.chargeDecision true)
+
+def State.validate (state : State Fact) (selection : Selection) : Except Rejection OfferView := do
+  if state.limits.maxDecisions <= state.metrics.decisions then throw .decisionLimit
+  if selection.scope != state.scope then throw .wrongScope
+  if selection.serial != state.serial then throw .staleSerial
+  if selection.programVersion != state.engine.programVersion then throw .staleProgram
+  let some offer := state.offer? selection.id | throw .missingOffer
+  if selection.expected != offer.key then throw .wrongKey
+  pure offer
+
+def deltasFor (before after : Engine Fact) (nodes : List NodeId) : Array (FactDelta Fact) := Id.run do
+  let mut deltas := #[]
+  for node in dedupList nodes do
+    match before.facts[node.index]?, after.facts[node.index]?,
+        before.versions[node.index]?, after.versions[node.index]? with
+    | some beforeFact, some afterFact, some beforeVersion, some afterVersion =>
+        if beforeVersion != afterVersion then
+          deltas := deltas.push
+            { node, before := beforeFact, after := afterFact, beforeVersion, afterVersion }
+    | _, _, _, _ => pure ()
+  return deltas
+
+/-- Freeze an application only after validating the selected semantic offer.
+The optional effort is supplied only by an engine-retained retry offer. -/
+def State.prepareApplication (state : State Fact) (applicationId : ApplicationId)
+    (effort : Option Nat) (clearDirty : Bool) : SelectResult Fact :=
+  if state.engine.limits.maxActions <= state.engine.metrics.queuePops then
+    .rejected .actionLimit (state.chargeDecision true)
+  else
+    match state.engine.applications[applicationId.index]? with
+    | none => state.reject .malformedState
+    | some application =>
+        match state.engine.rules[application.rule.index]?,
+            state.engine.seenVersions? application.watches,
+            state.engine.factViews? application.watches with
+        | some rule, some inputs, some views =>
+            let action : Action :=
+              { serial := state.engine.metrics.requests
+                programVersion := state.engine.programVersion
+                application := applicationId
+                rule := application.rule
+                key := rule.key
+                node := application.node
+                kind := application.kind
+                effort := effort.getD application.effort
+                inputs }
+            let queued :=
+              if clearDirty then state.engine.queued.set! applicationId.index false
+              else state.engine.queued
+            let engine : Engine Fact :=
+              { state.engine with
+                queued
+                pending := some action
+                metrics :=
+                  { state.engine.metrics with
+                    queuePops := state.engine.metrics.queuePops + 1
+                    requests := state.engine.metrics.requests + 1 } }
+            let state := (state.advance engine).chargeDecision
+            .request { action, inputs := views, writes := application.writes } state
+        | _, _, _ => state.reject .malformedState
+
+def State.consumeSuggestion (state : State Fact) (suggestion : SuggestionId) : State Fact :=
+  match state.suggestions[suggestion.index]? with
+  | none => state
+  | some clock =>
+      { state with
+        suggestions := state.suggestions.set! suggestion.index { clock with active := false } }
+
+def equalityObservation (key : EqualityWorkKey) (before after : Engine Fact)
+    (outcome : EqualityOutcome) (narrowCalls : Nat) : EqualityObservation Fact :=
+  { key
+    outcome
+    changes := deltasFor before after [key.left.node, key.right.node]
+    narrowCalls }
+
+def State.selectEquality (state : State Fact) (key : EqualityWorkKey) : SelectResult Fact :=
+  if state.engine.limits.maxActions <= state.engine.metrics.queuePops then
+    .rejected .actionLimit (state.chargeDecision true)
+  else
+    let running : Engine Fact :=
+      { state.engine with
+        equalityQueued := state.engine.equalityQueued.set! key.equality.index false
+        metrics :=
+          { state.engine.metrics with
+            queuePops := state.engine.metrics.queuePops + 1
+            equalityRuns := state.engine.metrics.equalityRuns + 1 } }
+    let selected :=
+      match state.equalities[key.equality.index]? with
+      | some clock =>
+          { state with
+            engine := running
+            equalities := state.equalities.set! key.equality.index { clock with active := false } }
+      | none => { state with engine := running }
+    match running.contractEquality key.equality with
+    | .advanced engine =>
+        let outcome :=
+          if engine.contradictory && !state.engine.contradictory then .contradiction
+          else if engine.history.size == state.engine.history.size then .noChange
+          else .improved
+        let observation := equalityObservation key state.engine engine outcome 2
+        let next := selected.advance engine
+        .equality observation
+          { (next.chargeDecision) with
+            metrics :=
+              { next.metrics with
+                decisions := next.metrics.decisions + 1
+                selectedEqualities := next.metrics.selectedEqualities + 1 } }
+    | .invalid code engine =>
+        .equality (equalityObservation key state.engine engine (.invalid code) 0)
+          ((selected.advance engine).chargeDecision)
+    | .resourceLimit resource engine =>
+        .engineResource resource ((selected.advance engine).chargeDecision)
+    | .factResourceLimit budget engine =>
+        .factResource budget ((selected.advance engine).chargeDecision)
+
+def State.selectSuggestion (state : State Fact) (suggestionId : SuggestionId)
+    (key : OfferKey) : SelectResult Fact :=
+  let consumed := state.consumeSuggestion suggestionId
+  match state.engine.suggestions[suggestionId.index]? with
+  | none => state.reject .malformedState
+  | some retained =>
+      match key, retained.suggestion with
+      | .retry _ effort, .retry retainedEffort =>
+          if effort != retainedEffort then state.reject .wrongKey
+          else
+            match consumed.prepareApplication retained.action.application (some effort) false with
+            | .request request next =>
+                .request request
+                  { next with
+                    metrics :=
+                      { next.metrics with selectedRetries := next.metrics.selectedRetries + 1 } }
+            | result => result
+      | .instantiate _ _, .instantiate _ =>
+          match consumed.engine.admitInstantiation suggestionId with
+          | .admitted nodes engine =>
+              let next := consumed.advance engine
+              .completed (.instanceAdmitted nodes)
+                { (next.chargeDecision) with
+                  metrics :=
+                    { next.metrics with
+                      decisions := next.metrics.decisions + 1
+                      selectedInstances := next.metrics.selectedInstances + 1 } }
+          | .duplicate engine =>
+              .completed .instanceDuplicate ((consumed.advance engine).chargeDecision)
+          | .invalid error engine =>
+              .completed (.instanceRejected error) ((consumed.advance engine).chargeDecision)
+          | .resourceLimit resource engine =>
+              .engineResource resource ((consumed.advance engine).chargeDecision)
+      | .split source target point reason, .split request =>
+          match consumed.engine.facts[target.node.index]? with
+          | none => state.reject .malformedState
+          | some fact =>
+              let consumed := { consumed with epoch := consumed.epoch + 1 }
+              .split
+                { scope := state.scope
+                  node := request.node
+                  suggestion := suggestionId
+                  origin := retained.action
+                  version := target.version
+                  fact
+                  point
+                  reason
+                  source }
+                { (consumed.chargeDecision) with
+                  metrics :=
+                    { consumed.metrics with
+                      decisions := consumed.metrics.decisions + 1
+                      selectedSplits := consumed.metrics.selectedSplits + 1 } }
+      | _, _ => state.reject .wrongKey
+
+/-- Recheck and execute one policy selection. -/
+def State.select (state : State Fact) (selection : Selection) : SelectResult Fact :=
+  match state.validate selection with
+  | .error reason => state.reject reason
+  | .ok offer =>
+      match selection.id, offer.key with
+      | .application application, .invoke _ =>
+          match state.prepareApplication application none true with
+          | .request request next =>
+              .request request
+                { next with
+                  metrics :=
+                    { next.metrics with
+                      selectedInvocations := next.metrics.selectedInvocations + 1 } }
+          | result => result
+      | .equality _, .equality key => state.selectEquality key
+      | .suggestion suggestion, key => state.selectSuggestion suggestion key
+      | _, _ => state.reject .wrongKey
+
+/-- Dismissing ordinary propagation work makes the run incomplete; dismissing
+a suggestion merely declines one optional search action. -/
+def State.dismiss (state : State Fact) (selection : Selection) : SelectResult Fact :=
+  match state.validate selection with
+  | .error reason => state.reject reason
+  | .ok _ =>
+      let next := match selection.id with
+        | .application application =>
+            let engine :=
+              { state.engine with queued := state.engine.queued.set! application.index false }
+            { state.advance engine with incomplete := true }
+        | .equality equality =>
+            let engine :=
+              { state.engine with
+                equalityQueued := state.engine.equalityQueued.set! equality.index false }
+            { state.advance engine with incomplete := true }
+        | .suggestion suggestion =>
+            let next := state.consumeSuggestion suggestion
+            { next with epoch := next.epoch + 1 }
+      let next := next.chargeDecision
+      .completed .dismissed
+        { next with metrics := { next.metrics with dismissals := next.metrics.dismissals + 1 } }
+
+/-! ## Exact rule observations -/
+
+inductive OutcomeTag where
+  | success
+  | noChange
+  | inapplicable
+  | resourceLimit (budget : Nat)
+  | failed (code : Nat)
+  deriving DecidableEq, Repr
+
+def outcomeTag : Outcome Fact -> OutcomeTag
+  | .success _ _ _ => .success
+  | .noChange _ => .noChange
+  | .inapplicable => .inapplicable
+  | .resourceLimit budget => .resourceLimit budget
+  | .failed code => .failed code
+
+def outcomeCost : Outcome Fact -> CostObservation
+  | .success _ _ cost | .noChange cost => cost
+  | .inapplicable | .resourceLimit _ | .failed _ => {}
+
+structure RuleObservation (Fact : Type) where
+  invocation : InvocationKey
+  outcome : OutcomeTag
+  changes : Array (FactDelta Fact)
+  contradiction : Bool
+  cost : CostObservation
+  emittedSuggestions : Array OfferId
+
+def emittedSuggestions (before after : Nat) : Array OfferId := Id.run do
+  let mut emitted := #[]
+  for offset in [0:after - before] do
+    emitted := emitted.push (.suggestion { index := before + offset })
+  return emitted
+
+inductive SubmitResult (Fact : Type) where
+  | accepted (observation : RuleObservation Fact) (state : State Fact)
+  | invalid (error : ReplyError) (state : State Fact)
+  | engineResource (resource : Resource) (state : State Fact)
+  | factResource (budget : Nat) (state : State Fact)
+  | malformedState (state : State Fact)
+
+/-- Admit a reply through the underlying engine, then expose actual admitted
+fact deltas and newly engine-indexed suggestions.  Claimed candidate strength
+is never used as an observation. -/
+def State.submit (state : State Fact) (reply : Reply Fact) : SubmitResult Fact :=
+  match state.engine.pending with
+  | none => .malformedState state
+  | some action =>
+      match state.engine.applications[action.application.index]? with
+      | none => .malformedState state
+      | some application =>
+          let before := state.engine
+          match before.submit reply with
+          | .accepted engine =>
+              let observation : RuleObservation Fact :=
+                { invocation := invocationOfAction state.scope action
+                  outcome := outcomeTag reply.outcome
+                  changes := deltasFor before engine application.writes
+                  contradiction := engine.contradictory && !before.contradictory
+                  cost := outcomeCost reply.outcome
+                  emittedSuggestions :=
+                    emittedSuggestions before.suggestions.size engine.suggestions.size }
+              .accepted observation (state.advance engine)
+          | .invalid error engine => .invalid error (state.advance engine)
+          | .resourceLimit resource engine =>
+              .engineResource resource (state.advance engine)
+          | .factResourceLimit budget engine => .factResource budget (state.advance engine)
+
+end Hex.Interval.Experiment.Propagator.Policy

--- a/HexInterval/Experiment/PolicyFrontier.lean
+++ b/HexInterval/Experiment/PolicyFrontier.lean
@@ -1,0 +1,781 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexInterval.Experiment.Policy
+
+/-!
+# Policy-frontier representation experiment
+
+This experiment compares a complete frontier scan with a maintained binary
+max-heap over the same engine-owned semantic offers.  Both arms run the same
+non-FIFO policy and cross the same validated selection boundary.  The indexed
+arm is seeded by one complete view, then consumes only newly appended engine
+work and suggestion events.
+
+The accounting deliberately includes work omitted by the first spike:
+
+* every backing slot inspected and live offer emitted by `Policy.State.view`;
+* every clock slot rebuilt when the policy wrapper advances and every retained
+  suggestion revisited by pruning;
+* every dependency insertion attempt, including suppressed dense wakes;
+* every appended event consumed by the maintained frontier;
+* every explicit semantic-offer recheck, priority comparison, and heap move.
+
+These are deterministic logical counts, not a wall-clock cost model.  In
+particular, one unit in two different columns need not have the same machine
+cost.  The vector is useful for finding missing work and asymptotic regimes;
+it does not by itself choose a production representation.
+-/
+
+namespace Hex.Interval.Experiment.Propagator.PolicyFrontier
+
+open Policy
+
+abbrev Rank := Nat
+
+/-! ## Workloads over opaque arbitrary functions -/
+
+/-- One public-API workload.  In a dense workload every sink watches every
+root; otherwise every sink watches only root zero.  Each post-trigger sink
+reply also emits `churn` disposable split suggestions. -/
+structure Workload where
+  name : String
+  roots : Nat
+  sinks : Nat
+  churn : Nat
+  dense : Bool
+  deriving DecidableEq, Repr
+
+def Workload.valid (workload : Workload) : Bool :=
+  0 < workload.roots && 0 < workload.sinks
+
+def fanoutCanary : Workload :=
+  { name := "fanout", roots := 1, sinks := 6, churn := 0, dense := false }
+
+def denseCanary : Workload :=
+  { name := "dense", roots := 4, sinks := 5, churn := 0, dense := true }
+
+def churnCanary : Workload :=
+  { name := "churn", roots := 1, sinks := 5, churn := 3, dense := false }
+
+def rankDomainId : DomainId := { index := 0 }
+
+def sourceKey : OpKey := { name := "policy-frontier.source" }
+
+def controlKey : OpKey := { name := "policy-frontier.control" }
+
+def sinkKey : OpKey := { name := "policy-frontier.sink" }
+
+def controlRuleKey : RuleKey := { name := "policy-frontier.control-trigger" }
+
+def sinkRuleKey : RuleKey := { name := "policy-frontier.sink-forward" }
+
+def nodeId (index : Nat) : NodeId := { index }
+
+def applicationId (index : Nat) : ApplicationId := { index }
+
+def suggestionId (index : Nat) : SuggestionId := { index }
+
+def rootIds (workload : Workload) : List NodeId :=
+  (List.range workload.roots).map nodeId
+
+def argumentSlots (count : Nat) : List Slot :=
+  (List.range count).map Slot.argument
+
+def sinkArity (workload : Workload) : Nat :=
+  if workload.dense then workload.roots else 1
+
+def operations (workload : Workload) : Array Operation :=
+  #[{ key := sourceKey, inputs := [], output := rankDomainId },
+    { key := controlKey
+      inputs := List.replicate workload.roots rankDomainId
+      output := rankDomainId },
+    { key := sinkKey
+      inputs := List.replicate (sinkArity workload) rankDomainId
+      output := rankDomainId }]
+
+def program (workload : Workload) : Program := Id.run do
+  let mut nodes := #[]
+  for _ in [0:workload.roots] do
+    nodes := nodes.push
+      { domain := rankDomainId, op := { index := 0 }, args := [] }
+  nodes := nodes.push
+    { domain := rankDomainId
+      op := { index := 1 }
+      args := rootIds workload }
+  let sinkArgs :=
+    if workload.dense then rootIds workload else [nodeId 0]
+  for _ in [0:workload.sinks] do
+    nodes := nodes.push
+      { domain := rankDomainId, op := { index := 2 }, args := sinkArgs }
+  return { operations := operations workload, nodes }
+
+def rules (workload : Workload) : Array Registration :=
+  #[{ key := controlRuleKey
+      head := controlKey
+      kind := .improve
+      watches := []
+      writes := argumentSlots workload.roots },
+    { key := sinkRuleKey
+      head := sinkKey
+      kind := .forward
+      watches := argumentSlots (sinkArity workload)
+      writes := [.result] }]
+
+def applicationCount (workload : Workload) : Nat := workload.sinks + 1
+
+def nodeCount (workload : Workload) : Nat := workload.roots + 1 + workload.sinks
+
+def retainedCount (workload : Workload) : Nat :=
+  1 + workload.sinks * workload.churn
+
+def expectedDecisions (workload : Workload) : Nat :=
+  1 + workload.sinks + workload.sinks * workload.churn
+
+def expectedWakeAttempts (workload : Workload) : Nat :=
+  if workload.dense then workload.roots * workload.sinks else workload.sinks
+
+def expectedSuppressed (workload : Workload) : Nat :=
+  expectedWakeAttempts workload - workload.sinks
+
+/-- Larger ranks are strictly stronger synthetic facts. -/
+def rankDomain : FactDomain Rank where
+  top _ := 0
+  narrow _ current candidate :=
+    if current < candidate then .improved candidate else .noChange
+
+def engineLimits (workload : Workload) : Experiment.Propagator.Limits :=
+  let arity := Nat.max workload.roots (sinkArity workload)
+  let applications := applicationCount workload
+  { maxOperations := 3
+    maxNodes := nodeCount workload
+    maxRules := 2
+    maxArity := arity
+    maxApplications := applications
+    maxQueueEntries := 4 * applications
+    maxActions := 4 * applications + retainedCount workload
+    maxAcceptedFacts := 4 * nodeCount workload
+    maxRetainedSuggestions := retainedCount workload
+    maxEffort := 1
+    maxObservationValue := 1
+    maxOutcomeCandidates := Nat.max workload.roots 1
+    maxOutcomeSuggestions := Nat.max workload.churn 1
+    maxProposalItems := 0
+    maxInstances := 0
+    maxGeneration := 0
+    maxEqualities := 0
+    splitEndpointLimit :=
+      { maxEndpointHeight := 1, maxAlignmentShift := 0 } }
+
+def policyLimits (workload : Workload) : Policy.Limits :=
+  let backing := applicationCount workload + retainedCount workload
+  let decisions := expectedDecisions workload
+  { maxDecisions := decisions + 1
+    maxTraversal := backing * (decisions + 3)
+    maxLiveOffers := backing }
+
+def candidate (node : NodeId) (fact : Rank) : Candidate Rank :=
+  { node, fact, payload := { index := node.index } }
+
+def maximumInput (inputs : List (FactView Rank)) : Rank :=
+  inputs.foldl (fun current input => Nat.max current input.fact) 0
+
+def churnSuggestions (workload : Workload) : List Suggestion :=
+  (List.range workload.churn).map fun code =>
+    .split
+      { node := nodeId 0
+        point := 0
+        reason := .custom code }
+
+/-- The companion registry gives meaning to the two opaque rule keys.  The
+control's first run retains a retry; retrying it strengthens every root in one
+atomic reply.  Sink calls are arbitrary unary or n-ary functions and emit
+optional search suggestions only after that trigger. -/
+def invoke (workload : Workload) (request : RuleRequest Rank) : Outcome Rank :=
+  if request.action.key == controlRuleKey then
+    if request.action.effort == 0 then
+      .success [] [.retry 1]
+        { arithmeticWork := 1, visitedEntries := 1, estimatedProofNodes := 1 }
+    else
+      .success ((rootIds workload).map fun root => candidate root 1) []
+        { arithmeticWork := 1, visitedEntries := 1, estimatedProofNodes := 1 }
+  else if request.action.key == sinkRuleKey then
+    let input := maximumInput request.inputs
+    .success [candidate request.action.node (input + 1)]
+      (if input == 0 then [] else churnSuggestions workload)
+      { arithmeticWork := 1, visitedEntries := 1, estimatedProofNodes := 1 }
+  else
+    .failed 1
+
+/-- Build and saturate through the public engine request/reply API.  The only
+live offer at policy adoption is the control retry; no fact, version, queue,
+or metric field is patched by the fixture. -/
+def prepare (workload : Workload) : Option (Policy.State Rank) := do
+  if !workload.valid then none else pure ()
+  let initial <-
+    match Engine.start rankDomain (program workload) (rules workload)
+        (Array.replicate (nodeCount workload) 0) (engineLimits workload) with
+    | .ok engine => some engine
+    | .error _ => none
+  let driven := drive
+    (fun (_ : Unit) request => (invoke workload request, ()))
+    (applicationCount workload + 2) initial ()
+  if driven.stop != .saturated || driven.state.suggestions.size != 1 then none
+  else some (Policy.State.start driven.state (policyLimits workload))
+
+/-! ## One deterministic non-FIFO policy -/
+
+structure Priority where
+  tier : Nat
+  index : Nat
+  deriving DecidableEq, Repr
+
+instance : Inhabited Priority := ⟨{ tier := 0, index := 0 }⟩
+
+def classPriority : OfferClass -> Nat
+  | .retry => 5
+  | .invoke => 4
+  | .equality => 3
+  | .instantiate => 2
+  | .split => 1
+
+def offerIndex : OfferId -> Nat
+  | .application application => application.index
+  | .equality equality => equality.index
+  | .suggestion suggestion => suggestion.index
+
+def priorityOf (offer : OfferView) : Priority :=
+  { tier := classPriority offer.offerClass, index := offerIndex offer.id }
+
+def Priority.higher (left right : Priority) : Bool :=
+  right.tier < left.tier ||
+    (left.tier == right.tier && right.index < left.index)
+
+def offerHigher (left right : OfferView) : Bool :=
+  (priorityOf left).higher (priorityOf right)
+
+/-- Select the maximum semantic offer and report exact policy comparisons.
+This is intentionally not `offers[0]?`: both representations exercise a real
+choice over the frontier. -/
+def chooseMaximum (offers : Array OfferView) : Option OfferView × Nat := Id.run do
+  let mut best : Option OfferView := none
+  let mut comparisons := 0
+  for offer in offers do
+    match best with
+    | none => best := some offer
+    | some previous =>
+        comparisons := comparisons + 1
+        if offerHigher offer previous then best := some offer
+  return (best, comparisons)
+
+/-! ## Maintained event-indexed max-heap -/
+
+structure Entry where
+  id : OfferId
+  priority : Priority
+  deriving DecidableEq, Repr
+
+instance : Inhabited Entry :=
+  ⟨{ id := .application (applicationId 0), priority := default }⟩
+
+structure HeapCost where
+  comparisons : Nat := 0
+  moves : Nat := 0
+  deriving DecidableEq, Repr
+
+def HeapCost.add (left right : HeapCost) : HeapCost :=
+  { comparisons := left.comparisons + right.comparisons
+    moves := left.moves + right.moves }
+
+structure Heap where
+  entries : Array Entry := #[]
+  deriving Repr
+
+def swapEntries (entries : Array Entry) (left right : Nat) : Array Entry :=
+  let leftEntry := entries[left]!
+  let rightEntry := entries[right]!
+  (entries.set! left rightEntry).set! right leftEntry
+
+partial def siftUp (entries : Array Entry) (index : Nat) (cost : HeapCost) :
+    Array Entry × HeapCost :=
+  if index == 0 then (entries, cost)
+  else
+    let parent := (index - 1) / 2
+    let cost := { cost with comparisons := cost.comparisons + 1 }
+    if entries[index]!.priority.higher entries[parent]!.priority then
+      siftUp (swapEntries entries index parent) parent
+        { cost with moves := cost.moves + 2 }
+    else
+      (entries, cost)
+
+def Heap.push (heap : Heap) (entry : Entry) : Heap × HeapCost :=
+  let entries := heap.entries.push entry
+  let (entries, cost) := siftUp entries (entries.size - 1) { moves := 1 }
+  ({ entries }, cost)
+
+partial def siftDown (entries : Array Entry) (index : Nat) (cost : HeapCost) :
+    Array Entry × HeapCost :=
+  let left := 2 * index + 1
+  if entries.size <= left then (entries, cost)
+  else
+    let right := left + 1
+    let (child, cost) :=
+      if right < entries.size then
+        let cost := { cost with comparisons := cost.comparisons + 1 }
+        if entries[right]!.priority.higher entries[left]!.priority then
+          (right, cost)
+        else
+          (left, cost)
+      else
+        (left, cost)
+    let cost := { cost with comparisons := cost.comparisons + 1 }
+    if entries[child]!.priority.higher entries[index]!.priority then
+      siftDown (swapEntries entries child index) child
+        { cost with moves := cost.moves + 2 }
+    else
+      (entries, cost)
+
+def Heap.pop (heap : Heap) : Option (Entry × Heap × HeapCost) :=
+  if heap.entries.isEmpty then none
+  else
+    let first := heap.entries[0]!
+    if heap.entries.size == 1 then
+      some (first, { entries := #[] }, { moves := 1 })
+    else
+      let last := heap.entries[heap.entries.size - 1]!
+      let entries := (heap.entries.pop).set! 0 last
+      let (entries, cost) := siftDown entries 0 { moves := 2 }
+      some (first, { entries }, cost)
+
+def Heap.ofOffers (offers : Array OfferView) : Heap × HeapCost := Id.run do
+  let mut heap : Heap := {}
+  let mut cost : HeapCost := {}
+  for offer in offers do
+    let (next, step) := heap.push { id := offer.id, priority := priorityOf offer }
+    heap := next
+    cost := cost.add step
+  return (heap, cost)
+
+/-! ## Complete logical accounting -/
+
+structure Work where
+  /-- Backing application, equality, and retained-suggestion slots inspected
+  by complete views. -/
+  frontierSlots : Nat := 0
+  /-- Live offers appended to complete view arrays. -/
+  frontierEmits : Nat := 0
+  /-- Application, equality, and suggestion clock slots rebuilt by
+  each wrapper state advance. -/
+  clockSyncSlots : Nat := 0
+  /-- Suggestion clocks revisited by `pruneSuggestions` after an advance. -/
+  suggestionPruneSlots : Nat := 0
+  /-- Dependency watcher entries attempted, including suppressed insertions. -/
+  dependencyVisits : Nat := 0
+  /-- Newly appended queue and retained-suggestion events consumed by the
+  maintained index. -/
+  eventVisits : Nat := 0
+  /-- Explicit `offer?` calls made by the maintained adapter. -/
+  offerRechecks : Nat := 0
+  /-- Engine-side semantic revalidations caused by select or dismiss. -/
+  selectionRechecks : Nat := 0
+  /-- Variable-length watched inputs and proposal items traversed while
+  constructing or refreshing semantic keys, including successful suggestion
+  checks performed by pruning. -/
+  semanticItems : Nat := 0
+  priorityComparisons : Nat := 0
+  priorityMoves : Nat := 0
+  deriving DecidableEq, Repr
+
+def Work.total (work : Work) : Nat :=
+  work.frontierSlots + work.frontierEmits + work.clockSyncSlots +
+    work.suggestionPruneSlots + work.dependencyVisits + work.eventVisits +
+    work.offerRechecks + work.selectionRechecks + work.semanticItems +
+    work.priorityComparisons + work.priorityMoves
+
+def retainedSemanticItems (retained : RetainedSuggestion) : Nat :=
+  retained.action.inputs.length +
+    match retained.suggestion with
+    | .retry _ | .split _ => 0
+    | .instantiate request =>
+        request.triggers.length + request.nodes.length + request.equalities.length +
+          (request.nodes.foldl (fun count node => count + node.args.length) 0)
+
+def offerSemanticItems (state : Policy.State Fact) : OfferId -> Nat
+  | .application application =>
+      (state.engine.applications[application.index]?).map
+        (fun value => value.watches.length) |>.getD 0
+  | .equality _ => 2
+  | .suggestion suggestion =>
+      (state.engine.suggestions[suggestion.index]?).map retainedSemanticItems |>.getD 0
+
+def offersSemanticItems (state : Policy.State Fact) (offers : Array OfferView) : Nat :=
+  offers.foldl (fun count offer => count + offerSemanticItems state offer.id) 0
+
+def pruneSemanticItems (state : Policy.State Fact) : Nat := Id.run do
+  let mut count := 0
+  for index in [0:state.suggestions.size] do
+    match state.suggestions[index]?, state.engine.suggestions[index]? with
+    | some clock, some retained =>
+        if clock.active then count := count + retainedSemanticItems retained
+    | _, _ => pure ()
+  return count
+
+def frontierBacking (state : Policy.State Fact) : Nat :=
+  state.applications.size + state.equalities.size + state.suggestions.size
+
+def Work.view (work : Work) (state : Policy.State Fact) (offers : Array OfferView) : Work :=
+  { work with
+    frontierSlots := work.frontierSlots + frontierBacking state
+    frontierEmits := work.frontierEmits + offers.size
+    semanticItems := work.semanticItems + offersSemanticItems state offers }
+
+def Work.advance (work : Work) (state : Policy.State Fact) : Work :=
+  { work with
+    clockSyncSlots := work.clockSyncSlots + frontierBacking state
+    suggestionPruneSlots := work.suggestionPruneSlots + state.suggestions.size
+    semanticItems := work.semanticItems + pruneSemanticItems state }
+
+def Work.heap (work : Work) (cost : HeapCost) : Work :=
+  { work with
+    priorityComparisons := work.priorityComparisons + cost.comparisons
+    priorityMoves := work.priorityMoves + cost.moves }
+
+def metricDelta (before after : Nat) : Nat := after - before
+
+def Work.dependencies (work : Work) (before after : Engine Rank) : Work :=
+  let inserted := metricDelta before.metrics.queueInsertions after.metrics.queueInsertions
+  let suppressed :=
+    metricDelta before.metrics.suppressedInsertions after.metrics.suppressedInsertions
+  { work with dependencyVisits := work.dependencyVisits + inserted + suppressed }
+
+def selectionFor (state : Policy.State Rank) (offer : OfferView) : Selection :=
+  { scope := state.scope
+    serial := state.serial
+    programVersion := state.engine.programVersion
+    id := offer.id
+    expected := offer.key }
+
+structure Step where
+  state : Policy.State Rank
+  work : Work
+
+/-- Execute the common policy choice.  Invocation and retry offers call the
+arbitrary registry.  The fixture deliberately dismisses optional split and
+instantiation suggestions; dismissing ordinary propagation would make the run
+incomplete and is never used here. -/
+def execute (workload : Workload) (state : Policy.State Rank)
+    (offer : OfferView) (work : Work) : Option Step :=
+  let selection := selectionFor state offer
+  let work :=
+    { work with
+      selectionRechecks := work.selectionRechecks + 1
+      semanticItems := work.semanticItems + offerSemanticItems state offer.id }
+  match offer.offerClass with
+  | .split | .instantiate =>
+      match state.dismiss selection with
+      | .completed .dismissed next => some { state := next, work }
+      | _ => none
+  | .invoke | .retry =>
+      match state.select selection with
+      | .request request awaiting =>
+          let work := work.advance awaiting
+          let before := awaiting.engine
+          match awaiting.submit (request.action.reply (invoke workload request)) with
+          | .accepted _ next =>
+              some
+                { state := next
+                  work := (work.advance next).dependencies before next.engine }
+          | _ => none
+      | _ => none
+  | .equality => none
+
+/-! ## Complete-scan run -/
+
+inductive Stop where
+  | saturated
+  | setupFailure
+  | frontierResource
+  | invalidTransition
+  | fuel
+  deriving DecidableEq, Repr
+
+structure Result where
+  stop : Stop
+  work : Work
+  decisions : Nat
+  calls : Nat
+  improvements : Nat
+  dismissals : Nat
+  queueInsertions : Nat
+  suppressedInsertions : Nat
+  retainedSuggestions : Nat
+  liveOffers : Nat
+  facts : Array Rank
+  versions : Array Nat
+  history : Nat
+  incomplete : Bool
+  checksum : Nat
+  choices : List OfferId
+  deriving DecidableEq, Repr
+
+def factsChecksum (facts : Array Rank) : Nat := Id.run do
+  let mut checksum := 0
+  for index in [0:facts.size] do
+    checksum := checksum + (index + 1) * (facts[index]! + 1)
+  return checksum
+
+/-- Uncharged full scan used only as a post-run conformance oracle.  It is not
+part of either representation's measured work. -/
+def oracleLiveOffers (state : Policy.State Rank) : Nat := Id.run do
+  let mut live := 0
+  for index in [0:state.applications.size] do
+    if (state.offer? (.application (applicationId index))).isSome then
+      live := live + 1
+  for index in [0:state.equalities.size] do
+    if (state.offer? (.equality { index })).isSome then live := live + 1
+  for index in [0:state.suggestions.size] do
+    if (state.offer? (.suggestion (suggestionId index))).isSome then
+      live := live + 1
+  return live
+
+def result (stop : Stop) (base state : Policy.State Rank) (work : Work)
+    (choicesRev : List OfferId) : Result :=
+  { stop
+    work
+    decisions := metricDelta base.metrics.decisions state.metrics.decisions
+    calls := metricDelta base.engine.metrics.requests state.engine.metrics.requests
+    improvements :=
+      metricDelta base.engine.metrics.improvements state.engine.metrics.improvements
+    dismissals := metricDelta base.metrics.dismissals state.metrics.dismissals
+    queueInsertions :=
+      metricDelta base.engine.metrics.queueInsertions state.engine.metrics.queueInsertions
+    suppressedInsertions :=
+      metricDelta base.engine.metrics.suppressedInsertions
+        state.engine.metrics.suppressedInsertions
+    retainedSuggestions := state.engine.suggestions.size - base.engine.suggestions.size
+    liveOffers := oracleLiveOffers state
+    facts := state.engine.facts
+    versions := state.engine.versions
+    history := state.engine.history.size - base.engine.history.size
+    incomplete := state.incomplete
+    checksum := factsChecksum state.engine.facts
+    choices := choicesRev.reverse }
+
+def failedResult (stop : Stop) : Result :=
+  { stop
+    work := {}
+    decisions := 0
+    calls := 0
+    improvements := 0
+    dismissals := 0
+    queueInsertions := 0
+    suppressedInsertions := 0
+    retainedSuggestions := 0
+    liveOffers := 0
+    facts := #[]
+    versions := #[]
+    history := 0
+    incomplete := false
+    checksum := 0
+    choices := [] }
+
+def scanLoop (workload : Workload) (base : Policy.State Rank) :
+    Nat -> Policy.State Rank -> Work -> List OfferId -> Result
+  | 0, state, work, choices => result .fuel base state work choices
+  | fuel + 1, state, work, choices =>
+      match state.view with
+      | .error _ => result .frontierResource base state work choices
+      | .ok (view, scanned) =>
+          let work := work.view state view.offers
+          let (choice, comparisons) := chooseMaximum view.offers
+          let work :=
+            { work with
+              priorityComparisons := work.priorityComparisons + comparisons }
+          match choice with
+          | none => result .saturated base scanned work choices
+          | some offer =>
+              match execute workload scanned offer work with
+              | none => result .invalidTransition base scanned work choices
+              | some step => scanLoop workload base fuel step.state step.work
+                  (offer.id :: choices)
+
+@[noinline]
+def runScanPrepared (workload : Workload) (state : Policy.State Rank) : Result :=
+  scanLoop workload state (expectedDecisions workload + 2) state {} []
+
+def runScan (workload : Workload) : Result :=
+  match prepare workload with
+  | none => failedResult .setupFailure
+  | some state => runScanPrepared workload state
+
+/-! ## Maintained event-indexed run -/
+
+structure Index where
+  heap : Heap
+  queueCursor : Nat
+  suggestionCursor : Nat
+  deriving Repr
+
+def offerIdOfWork : WorkItem -> OfferId
+  | .application application => .application application
+  | .equality equality => .equality equality
+
+def Index.seed (state : Policy.State Rank) : Except ViewError (Index × Policy.State Rank × Work) := do
+  let (view, scanned) <- state.view
+  let (heap, heapCost) := Heap.ofOffers view.offers
+  let work := (({} : Work).view state view.offers).heap heapCost
+  pure
+    ({ heap
+       queueCursor := state.engine.queue.size
+       suggestionCursor := state.engine.suggestions.size },
+     scanned, work)
+
+/-- Consume exactly the newly appended work and suggestion suffixes.  The
+engine's dirty bits and freshness guards remain authoritative: every event is
+re-read through `offer?` before it enters the maintained heap. -/
+def Index.sync (index : Index) (state : Policy.State Rank) (work : Work) :
+    Index × Work := Id.run do
+  let mut heap := index.heap
+  let mut work := work
+  for cursor in [index.queueCursor:state.engine.queue.size] do
+    work :=
+      { work with
+        eventVisits := work.eventVisits + 1
+        offerRechecks := work.offerRechecks + 1 }
+    match state.engine.queue[cursor]? with
+    | none => pure ()
+    | some item =>
+        match state.offer? (offerIdOfWork item) with
+        | none => pure ()
+        | some offer =>
+            work :=
+              { work with
+                semanticItems := work.semanticItems + offerSemanticItems state offer.id }
+            let (next, cost) := heap.push { id := offer.id, priority := priorityOf offer }
+            heap := next
+            work := work.heap cost
+  for cursor in [index.suggestionCursor:state.engine.suggestions.size] do
+    work :=
+      { work with
+        eventVisits := work.eventVisits + 1
+        offerRechecks := work.offerRechecks + 1 }
+    match state.offer? (.suggestion (suggestionId cursor)) with
+    | none => pure ()
+    | some offer =>
+        work :=
+          { work with
+            semanticItems := work.semanticItems + offerSemanticItems state offer.id }
+        let (next, cost) := heap.push { id := offer.id, priority := priorityOf offer }
+        heap := next
+        work := work.heap cost
+  ({ heap
+     queueCursor := state.engine.queue.size
+     suggestionCursor := state.engine.suggestions.size },
+   work)
+
+def indexedLoop (workload : Workload) (base : Policy.State Rank) :
+    Nat -> Policy.State Rank -> Index -> Work -> List OfferId -> Result
+  | 0, state, _, work, choices => result .fuel base state work choices
+  | fuel + 1, state, index, work, choices =>
+      match index.heap.pop with
+      | none => result .saturated base state work choices
+      | some (entry, heap, heapCost) =>
+          let index := { index with heap }
+          let work := (work.heap heapCost)
+          let work := { work with offerRechecks := work.offerRechecks + 1 }
+          match state.offer? entry.id with
+          | none => indexedLoop workload base fuel state index work choices
+          | some offer =>
+              let work :=
+                { work with
+                  semanticItems := work.semanticItems + offerSemanticItems state offer.id }
+              match execute workload state offer work with
+              | none => result .invalidTransition base state work choices
+              | some step =>
+                  let (index, work) := index.sync step.state step.work
+                  indexedLoop workload base fuel step.state index work (offer.id :: choices)
+
+@[noinline]
+def runIndexedPrepared (workload : Workload) (state : Policy.State Rank) : Result :=
+  match Index.seed state with
+  | .error _ => failedResult .frontierResource
+  | .ok (index, seeded, work) =>
+      indexedLoop workload state (3 * expectedDecisions workload + 3)
+        seeded index work []
+
+def runIndexed (workload : Workload) : Result :=
+  match prepare workload with
+  | none => failedResult .setupFailure
+  | some state => runIndexedPrepared workload state
+
+structure Comparison where
+  scan : Result
+  indexed : Result
+  deriving DecidableEq, Repr
+
+def comparePrepared (workload : Workload) (state : Policy.State Rank) : Comparison :=
+  { scan := runScanPrepared workload state
+    indexed := runIndexedPrepared workload state }
+
+def compare (workload : Workload) : Comparison :=
+  match prepare workload with
+  | none => { scan := failedResult .setupFailure, indexed := failedResult .setupFailure }
+  | some state => comparePrepared workload state
+
+def expectedFacts (workload : Workload) : Array Rank := Id.run do
+  let mut facts := #[]
+  for _ in [0:workload.roots] do facts := facts.push 1
+  facts := facts.push 0
+  for _ in [0:workload.sinks] do facts := facts.push 2
+  return facts
+
+def expectedVersions (workload : Workload) : Array Nat := Id.run do
+  let mut versions := #[]
+  for _ in [0:workload.roots] do versions := versions.push 1
+  versions := versions.push 0
+  for _ in [0:workload.sinks] do versions := versions.push 2
+  return versions
+
+def semanticEqual (left right : Result) : Bool :=
+  left.stop == right.stop && left.decisions == right.decisions &&
+    left.calls == right.calls && left.improvements == right.improvements &&
+    left.dismissals == right.dismissals &&
+    left.queueInsertions == right.queueInsertions &&
+    left.suppressedInsertions == right.suppressedInsertions &&
+    left.retainedSuggestions == right.retainedSuggestions &&
+    left.liveOffers == right.liveOffers && left.facts == right.facts &&
+    left.versions == right.versions && left.history == right.history &&
+    left.incomplete == right.incomplete && left.checksum == right.checksum &&
+    left.choices == right.choices
+
+def expectedResult (workload : Workload) (value : Result) : Bool :=
+  value.stop == .saturated && value.decisions == expectedDecisions workload &&
+    value.calls == workload.sinks + 1 &&
+    value.improvements == workload.roots + workload.sinks &&
+    value.dismissals == workload.sinks * workload.churn &&
+    value.queueInsertions == workload.sinks &&
+    value.suppressedInsertions == expectedSuppressed workload &&
+    value.retainedSuggestions == workload.sinks * workload.churn &&
+    value.liveOffers == 0 && value.facts == expectedFacts workload &&
+    value.versions == expectedVersions workload &&
+    value.history == workload.roots + workload.sinks && !value.incomplete &&
+    value.checksum == factsChecksum (expectedFacts workload)
+
+def comparisonValid (workload : Workload) (comparison : Comparison) : Bool :=
+  workload.valid && semanticEqual comparison.scan comparison.indexed &&
+    expectedResult workload comparison.scan && expectedResult workload comparison.indexed
+
+/-- The first post-trigger choice is the highest application id, while the
+FIFO queue contains the lowest sink id first.  This canary prevents the
+indexed arm from degenerating back into a queue cursor. -/
+def nonFifoChoice (workload : Workload) (result : Result) : Bool :=
+  match result.choices with
+  | .suggestion retry :: .application first :: _ =>
+      retry == suggestionId 0 && first == applicationId workload.sinks &&
+        workload.sinks != 1
+  | _ => false
+
+end Hex.Interval.Experiment.Propagator.PolicyFrontier

--- a/HexInterval/Experiment/Propagator.lean
+++ b/HexInterval/Experiment/Propagator.lean
@@ -397,8 +397,9 @@ structure ProposedNode where
 
 /-- An equality proposed alongside new expressions.  This experiment retains
 the opaque payload and endpoints as untrusted replay data.  Once admitted, the
-edge is search-active: the engine may use it to transport facts, but replay
-must reconstruct this payload before any transported fact can prove a goal. -/
+edge is scheduler-active: its typed endpoints drive equality contraction, and
+replay must reconstruct and check the payload before any transported fact can
+prove a goal. -/
 structure ProposedEquality where
   left : NodeRef
   right : NodeRef
@@ -441,10 +442,13 @@ inductive Suggestion where
   | instantiate (request : InstantiationRequest)
   | split (request : SplitRequest)
 
-/-- A policy candidate paired with engine-owned invocation provenance. -/
+/-- A policy candidate paired with engine-owned invocation provenance.  Split
+proposals retain the target version at proposal time; later policy adoption
+must not re-arm a guard from the then-current fact. -/
 structure RetainedSuggestion where
   action : Action
   suggestion : Suggestion
+  splitVersion : Option Nat
 
 /-- Engine-owned index of one retained policy suggestion. -/
 structure SuggestionId where
@@ -792,6 +796,20 @@ def factViews? (state : Engine Fact) : List NodeId -> Option (List (FactView Fac
       let rest <- factViews? state nodes
       some ({ node, fact, version } :: rest)
 
+/-- An invocation remains usable across an append-only program extension only
+when its concrete application, registration, and every watched fact version
+still agree with the engine-owned provenance captured in the action. -/
+def actionFresh (state : Engine Fact) (action : Action) : Bool :=
+  match state.applications[action.application.index]?,
+      state.rules[action.rule.index]?,
+      state.seenVersions? (action.inputs.map fun input => input.node) with
+  | some application, some rule, some current =>
+      application.rule == action.rule && application.node == action.node &&
+        application.kind == action.kind && rule.key == action.key &&
+        action.inputs.map (fun input => input.node) == application.watches &&
+        current == action.inputs
+  | _, _, _ => false
+
 /-- Insert work unless it is already dirty.  The queue is an append-only work
 log in this experiment, so its trusted cap also bounds total dependency churn. -/
 def enqueue (state : Engine Fact) (work : WorkItem) : Except Resource (Engine Fact) := do
@@ -920,6 +938,7 @@ inductive ReplyError where
   | tooManyCandidates
   | tooManySuggestions
   | oversizedProposal
+  | oversizedEffort
   | oversizedObservation
   | duplicateWrite
   | undeclaredWrite (node : NodeId)
@@ -947,12 +966,21 @@ inductive EqualityFactError where
   | malformed (code : Nat)
   | resourceLimit (budget : Nat)
 
+/-- Structural or fact-domain failure of an equality contraction. -/
+inductive EqualityFault where
+  | pendingReply
+  | missingEquality
+  | domainMismatch
+  | missingState
+  | malformedFact (code : Nat)
+  deriving DecidableEq, Repr
+
 /-- Equality contractors are internal, atomic scheduler transitions. -/
 inductive EqualityResult (Fact : Type) where
-  | advanced (state : Engine Fact)
-  | invalid (code : Nat) (state : Engine Fact)
-  | resourceLimit (resource : Resource) (state : Engine Fact)
-  | factResourceLimit (budget : Nat) (state : Engine Fact)
+  | advanced (narrowCalls : Nat) (state : Engine Fact)
+  | invalid (fault : EqualityFault) (narrowCalls : Nat) (state : Engine Fact)
+  | resourceLimit (resource : Resource) (narrowCalls : Nat) (state : Engine Fact)
+  | factResourceLimit (budget : Nat) (narrowCalls : Nat) (state : Engine Fact)
 
 def existingRefBounded (nodeCount : Nat) : NodeRef -> Bool
   | .existing node => node.index < nodeCount
@@ -978,6 +1006,13 @@ def suggestionBounded (limits : Limits) (nodeCount : Nat) : Suggestion -> Bool
 def suggestionsBounded (limits : Limits) (nodeCount : Nat)
     (suggestions : List Suggestion) : Bool :=
   suggestions.all (suggestionBounded limits nodeCount)
+
+def suggestionEffortBounded (limit : Nat) : Suggestion -> Bool
+  | .retry effort => effort <= limit
+  | .instantiate _ | .split _ => true
+
+def suggestionsEffortBounded (limit : Nat) (suggestions : List Suggestion) : Bool :=
+  suggestions.all (suggestionEffortBounded limit)
 
 namespace Engine
 
@@ -1006,6 +1041,16 @@ def outcomeNegative (state : Engine Fact) (outcome : Outcome Fact) : Engine Fact
       { state with
         metrics := { state.metrics with ruleFailures := state.metrics.ruleFailures + 1 } }
   | .success _ _ _ => state
+
+/-- Attach proposal-time guards before any candidates from the same reply can
+change facts. -/
+def retainSuggestion (state : Engine Fact) (action : Action)
+    (suggestion : Suggestion) : RetainedSuggestion :=
+  { action
+    suggestion
+    splitVersion := match suggestion with
+      | .split request => state.versions[request.node.index]?
+      | .retry _ | .instantiate _ => none }
 
 def candidateNodesUnique (candidates : List (Candidate Fact)) : Bool :=
   uniqueList (candidates.map (fun candidate => candidate.node))
@@ -1090,6 +1135,8 @@ def submit (state : Engine Fact) (reply : Reply Fact) : ReplyResult Fact :=
             .invalid .tooManyCandidates base
           else if !listWithin state.limits.maxOutcomeSuggestions suggestions then
             .invalid .tooManySuggestions base
+          else if !suggestionsEffortBounded state.limits.maxEffort suggestions then
+            .invalid .oversizedEffort base
           else if !suggestionsBounded state.limits state.program.nodes.size suggestions then
             .invalid .oversizedProposal base
           else if !candidateNodesUnique candidates then
@@ -1109,7 +1156,7 @@ def submit (state : Engine Fact) (reply : Reply Fact) : ReplyResult Fact :=
                       { base with
                         suggestions := retainedSuggestions.foldl
                           (fun retained suggestion => retained.push
-                            { action, suggestion })
+                            (state.retainSuggestion action suggestion))
                           base.suggestions
                         metrics :=
                           { base.metrics with
@@ -1173,9 +1220,9 @@ commit all improvements together, then wake their dependency union. -/
 def contractEquality (state : Engine Fact) (equalityId : EqualityId) :
     EqualityResult Fact :=
   if state.pending.isSome then
-    .invalid 3 state
+    .invalid .pendingReply 0 state
   else match state.equalities[equalityId.index]? with
-  | none => .invalid 0 state
+  | none => .invalid .missingEquality 0 state
   | some equality =>
       match state.program.node? equality.left, state.program.node? equality.right,
           state.facts[equality.left.index]?, state.facts[equality.right.index]?,
@@ -1183,28 +1230,29 @@ def contractEquality (state : Engine Fact) (equalityId : EqualityId) :
       | some leftNode, some rightNode, some leftFact, some rightFact,
           some leftVersion, some rightVersion =>
           if leftNode.domain != rightNode.domain then
-            .invalid 1 state
+            .invalid .domainMismatch 0 state
           else
-            let updates : Except EqualityFactError (List (TransportUpdate Fact)) := do
-              let left <- transportUpdate equality.left equality.right leftVersion rightVersion
-                (state.factDomain.narrow leftNode.domain leftFact rightFact)
-              let right <- transportUpdate equality.right equality.left rightVersion leftVersion
-                (state.factDomain.narrow leftNode.domain rightFact leftFact)
-              pure ([left, right].filterMap id)
-            match updates with
-            | .error (.malformed code) => .invalid code state
-            | .error (.resourceLimit budget) => .factResourceLimit budget state
-            | .ok updates =>
-                if state.limits.maxAcceptedFacts < state.history.size + updates.length then
-                  .resourceLimit .acceptedFacts state
-                else
-                  let working := updates.foldl
-                    (fun state update => installTransport equalityId update state) state
-                  let changed := updates.map fun update => update.target
-                  match working.wakeNodes changed with
-                  | .error resource => .resourceLimit resource state
-                  | .ok next => .advanced next
-      | _, _, _, _, _, _ => .invalid 2 state
+            match transportUpdate equality.left equality.right leftVersion rightVersion
+                (state.factDomain.narrow leftNode.domain leftFact rightFact) with
+            | .error (.malformed code) => .invalid (.malformedFact code) 1 state
+            | .error (.resourceLimit budget) => .factResourceLimit budget 1 state
+            | .ok left =>
+                match transportUpdate equality.right equality.left rightVersion leftVersion
+                    (state.factDomain.narrow leftNode.domain rightFact leftFact) with
+                | .error (.malformed code) => .invalid (.malformedFact code) 2 state
+                | .error (.resourceLimit budget) => .factResourceLimit budget 2 state
+                | .ok right =>
+                    let updates := [left, right].filterMap id
+                    if state.limits.maxAcceptedFacts < state.history.size + updates.length then
+                      .resourceLimit .acceptedFacts 2 state
+                    else
+                      let working := updates.foldl
+                        (fun state update => installTransport equalityId update state) state
+                      let changed := updates.map fun update => update.target
+                      match working.wakeNodes changed with
+                      | .error resource => .resourceLimit resource 2 state
+                      | .ok next => .advanced 2 next
+      | _, _, _, _, _, _ => .invalid .missingState 0 state
 
 end Engine
 
@@ -1250,11 +1298,11 @@ def drive (invoke : Cache -> RuleRequest Fact -> Outcome Fact × Cache) :
           { state, cache, stop := .engineResource resource }
       | .equality equality state =>
           match state.contractEquality equality with
-          | .advanced next => drive invoke fuel next cache
-          | .invalid _ next => { state := next, cache, stop := .invalidEngine }
-          | .resourceLimit resource next =>
+          | .advanced _ next => drive invoke fuel next cache
+          | .invalid _ _ next => { state := next, cache, stop := .invalidEngine }
+          | .resourceLimit resource _ next =>
               { state := next, cache, stop := .engineResource resource }
-          | .factResourceLimit budget next =>
+          | .factResourceLimit budget _ next =>
               { state := next, cache, stop := .factResource budget }
       | .awaitingReply state | .invalidState state =>
           { state, cache, stop := .invalidEngine }
@@ -1371,6 +1419,16 @@ def inferredGeneration? (generations : Array Nat) (baseSize : Nat)
     greatest := Nat.max greatest generation
   some (greatest + 1)
 
+/-- Recompute the generation advertised to policy from current engine-owned
+structure.  The rule's claimed generation is deliberately not trusted. -/
+def Engine.instantiationGeneration? (state : Engine Fact)
+    (retained : RetainedSuggestion) : Option Nat := do
+  if !state.actionFresh retained.action then none else pure ()
+  let .instantiate request := retained.suggestion | none
+  let baseSize := state.program.nodes.size
+  let (_, resolved) <- resolveDrafts baseSize state.program [] request.nodes
+  inferredGeneration? state.generations baseSize retained.action request resolved
+
 /-- Treat equality endpoints as unordered for structural deduplication. -/
 def EqualityEdge.sameEndpoints (edge : EqualityEdge) (left right : NodeId) : Bool :=
   (edge.left == left && edge.right == right) ||
@@ -1461,6 +1519,8 @@ def admitRetained (state : Engine Fact)
     | .instantiate request =>
         if !proposalBounded state.program.nodes.size state.limits.maxProposalItems request then
           .invalid .oversizedProposal state
+        else if !state.actionFresh retained.action then
+          .invalid (.staleSuggestion retained.action.programVersion state.programVersion) state
         else
           let baseSize := state.program.nodes.size
           match resolveDrafts baseSize state.program [] request.nodes with
@@ -1479,8 +1539,6 @@ def admitRetained (state : Engine Fact)
                   equalities := equalityPairs?.getD [] }
               if state.instances.contains instanceKey then
                 duplicateInstance state
-              else if retained.action.programVersion != state.programVersion then
-                .invalid (.staleSuggestion retained.action.programVersion state.programVersion) state
               else
                 match inferredGeneration? state.generations baseSize retained.action request resolved with
                 | none => .invalid .badReferenceOrShape state

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -1240,17 +1240,42 @@ with append-only stale entries and decide how much of a generic fact, as
 opposed to exact bounded policy features, a reusable policy should see. These
 choices change cost and convenience, not the admission or replay boundary.
 
-The logical frontier benchmark makes the first representation choice less
-open. After one root changes in one of `p` disconnected depth-`l` chains, a
-complete view before each of `l` choices and the final saturation check visits
-`p·l·(l+1)` application slots. Adapting only the `l` dependency events visits
-`l` entries. Both paths cross the same validated semantic-selection boundary
-and are required to produce identical facts, decisions, calls, improvements,
-and checksum; the `p = 4`, `l = 8` canary is `288` versus `8` visits. Therefore
-the production candidate is event-indexed, while the bounded complete scan is
-retained as the simple executable reference and differential oracle. The
-choice of coalesced mutable entries versus an append-only stale log within the
-event-indexed family remains experimental.
+The corrected logical frontier experiment does **not** yet select a production
+representation. Its indexed arm maintains a binary maximum-priority heap from
+one seed view and newly appended work and suggestion events; it is not a FIFO
+queue cursor. Both arms execute the same maximum policy through
+`Policy.State.select`, start from a fixed point reached through the public
+request/reply API, and must agree on the complete choice trace, facts,
+decisions, calls, improvements, queue coalescing, dismissals, and checksum.
+
+The experiment reports a vector rather than the earlier incomplete
+`288`-versus-`8` scalar. It counts complete-view backing slots and emitted
+offers, clock slots rebuilt by each wrapper state advance, suggestion-pruning visits,
+dependency watcher visits including suppressed insertions, appended events,
+semantic rechecks, variable-length semantic-key items, priority comparisons,
+and heap moves. These logical units are shown separately: their machine costs
+are not assumed equal. On the small merge-gated fixtures:
+
+- one root fanning out to six sinks gives scan/index aggregate touch counts
+  `267/242`, while both arms already share `112` clock synchronizations and
+  `14` suggestion-pruning visits;
+- four roots densely waking five sinks records all `20` watcher visits—five
+  insertions and fifteen suppressed duplicates—and gives `277/250`;
+- five sinks each emitting three disposable split suggestions gives
+  `1267/754`; the scan inspects `424` historical backing slots, while the
+  index consumes five work plus fifteen suggestion events from a single
+  seven-slot seed view.
+
+The aggregate is only a convenient checksum over the reported columns, not a
+wall-time prediction. In particular, the current wrapper still rebuilds every
+application, equality, and retained-suggestion clock array on each
+request/reply transition. That shared work is often dominant and must itself
+be made incremental before an event-indexed production frontier can realize
+its intended asymptotics. The bounded complete scan remains the executable
+reference and differential oracle. Coalesced mutable entries, a versioned
+stale heap, and other incremental layouts remain open candidates until they
+are implemented at the clock-synchronization boundary and compared with
+scientific timing and larger traces.
 
 The first policy wrapper treats age as continuous eligibility age. A dirty
 application or equality keeps its birth time while its versioned semantic key
@@ -1878,6 +1903,16 @@ position-sensitive fact checksum. For `t > 0` chains of depth `d`, the current
 fixture records `d` incremental calls versus `2*t*d` structural calls. These
 counts motivate the incremental baseline without freezing queue coalescing,
 priority policy, or state storage.
+
+The separate policy-frontier canary compares complete scans with a genuinely
+maintained maximum-priority heap on fan-out, dense multi-output wake, and
+retained-suggestion churn workloads. Its executable prints the full logical
+work vector described in the policy section, and small instances are
+merge-gated twice: ordinary `#guard` equivalence checks build with
+`HexConformance`, while the compiled spike's `canary` mode builds and runs in
+the existing single CI job. This is deterministic representation evidence,
+not scientific timing; it neither uses a custom timing loop nor freezes the
+current touch-count aggregates as performance contracts.
 
 The declared models follow the complexity section above. Scientific runs also
 record accepted actions, endpoint heights, live leaves, retained derivations,

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -1094,6 +1094,20 @@ structure RuleObservation (Fact : Type) where
   contradiction : Bool
   cost          : CostObservation
 
+inductive EqualityOutcome
+  | noChange
+  | improved
+  | contradiction
+  | engineResource (resource : Resource)
+  | factResource (budget : Nat)
+  | invalid (code : Nat)
+
+structure EqualityObservation (Fact : Type) where
+  key         : EqualityWorkKey
+  outcome     : EqualityOutcome
+  changes     : Array (FactDelta Fact)
+  narrowCalls : Nat
+
 structure OfferView where
   id       : OfferId
   key      : OfferKey
@@ -1121,6 +1135,7 @@ structure Selection where
 inductive PolicyEvent (Fact : Type)
   | frontier (added : Array OfferView) (removed : Array OfferId)
   | rule (observation : RuleObservation Fact)
+  | equality (observation : EqualityObservation Fact)
   | instanceAdmitted (programVersion : Nat) (added : Array OfferView)
   | splitPrepared (scope : ScopeId) (node : NodeId) (point : Dyadic)
   | choiceRejected (choice : Selection) (reason : Nat)
@@ -1179,8 +1194,12 @@ fact domain or registry and influence search only.
 
 The concrete `RuleObservation` shown above records actual admitted deltas
 rather than a rule's claimed gain. Other `PolicyEvent` constructors distinguish
-structural admission, split preparation, rejected choices, and engine resource
-exhaustion from a rule-declared outcome.
+structural admission, equality contraction, split preparation, rejected
+choices, and engine resource exhaustion from a rule-declared outcome. Equality
+has its own typed observation because it is selectable engine work, not a fake
+registry invocation. A fixed-point equality run with no delta is still an
+observation; the generic fact interface supplies no idempotence law that would
+justify silently omitting it.
 
 `PolicyEvent` is the single ordered transition stream. It wraps rule
 observations, instance admission, split preparation, offer additions and
@@ -1206,12 +1225,35 @@ reported as `unknown`, not saturation.
 
 The shown first interface supplies the authoritative bounded scan frontier in
 each `PolicyView`; transition events let the policy update historical state
-without reconstructing it. An event-only priority implementation may later
-remove that repeated batch behind a different adapter while preserving
+without reconstructing it. Its traversal budget is cumulative across views,
+not merely a per-view size check, and counts inactive backing slots honestly.
+`maxLiveOffers` is initially a policy-view/output budget: making it an atomic
+frontier-mutation budget would require preflighting replies and instantiations
+before their already-atomic commits. An event-only priority implementation may
+later remove the repeated scan behind a different adapter while preserving
 `Selection` and `Policy.State.select`. We must also compare coalesced live offers
 with append-only stale entries and decide how much of a generic fact, as
 opposed to exact bounded policy features, a reusable policy should see. These
 choices change cost and convenience, not the admission or replay boundary.
+
+The logical frontier benchmark makes the first representation choice less
+open. After one root changes in one of `p` disconnected depth-`l` chains, a
+complete view before each of `l` choices and the final saturation check visits
+`p·l·(l+1)` application slots. Adapting only the `l` dependency events visits
+`l` entries. Both paths cross the same validated semantic-selection boundary
+and are required to produce identical facts, decisions, calls, improvements,
+and checksum; the `p = 4`, `l = 8` canary is `288` versus `8` visits. Therefore
+the production candidate is event-indexed, while the bounded complete scan is
+retained as the simple executable reference and differential oracle. The
+choice of coalesced mutable entries versus an append-only stale log within the
+event-indexed family remains experimental.
+
+The first policy wrapper treats age as continuous eligibility age. A dirty
+application or equality keeps its birth time while its versioned semantic key
+refreshes, becomes inactive when selected, and receives a new birth time if a
+later dependency change wakes it again. Retained suggestions never refresh
+into different proposals: selection, dismissal, or failure of their
+variant-specific freshness guard tombstones them permanently.
 
 Freshness is offer-specific. An invocation or retry compares the concrete
 application and relevant current input versions. Instantiation initially uses
@@ -1227,7 +1269,10 @@ decision step, preventing a faulty policy from looping for free. A rule defines
 the meaning of its own bounded effort ladder: pieces, Taylor degree, reduction
 precision, or another function-specific choice. Different incomparable
 methods remain separate registrations rather than pretending their effort
-numbers share a scale.
+numbers share a scale. The engine also bounds every reply-provided effort,
+outcome code, resource report, and `CostObservation` component before it can
+enter policy state. These bounds limit representation size; they do not assign
+cross-rule semantic meaning to an effort or cost number.
 
 The engine bounds every choice attempt and every value it supplies, but it
 cannot force an arbitrary external callback to terminate. Shipped policies are
@@ -1243,13 +1288,16 @@ reports divergence without state mutation when the expected offer is absent.
 Proof replay ignores this policy log and checks only fact, equality, instance,
 and split derivations.
 
-Canonical instantiation keys remain an experiment. They preserve proposed SSA
-dependency order while sorting/deduplicating equality sets and never deduplicate
-the ordered input-slot list. Payload erasure can leave two semantic duplicates
-with different proof recipes. The engine must either retain the first by
-bounded response ordinal, include that ordinal in the offer key, or require a
-stable registry-defined recipe key; freshly allocated payload identifiers are
-never canonical tie-breakers.
+Canonical instantiation keys remain an experiment. Version `v0` preserves
+proposed SSA dependency order, preserves the proposal equality order, and
+never deduplicates the ordered input-slot list; this makes the initial
+implementation exact and easy to test but not yet canonical under reordered
+equality reports. A later candidate sorts/deduplicates unordered equality
+pairs. Payload erasure can leave two semantic duplicates with different proof
+recipes. The engine must either retain the first by bounded response ordinal,
+include that ordinal in the offer key, or require a stable registry-defined
+recipe key; freshly allocated payload identifiers are never canonical
+tie-breakers.
 
 The policy experiment proceeds in replaceable increments:
 
@@ -1261,6 +1309,13 @@ The policy experiment proceeds in replaceable increments:
    admission;
 5. add the external policy driver and compare scan, staged, replay, and
    versioned-priority implementations on identical semantic offers.
+
+Once policy control begins, the wrapper is the sole scheduling authority for
+that state: callers use its `view`, `select`, `submit`, equality, and admission
+transitions. Mixing those calls with the reference FIFO `poll` would leave
+tombstoned append-log entries and conflicting action serial authority. The FIFO
+path remains a separate reference run for trace comparison, not an interleaved
+API.
 
 Only after those transition traces agree do we choose the production frontier
 representation. This keeps scheduling experiments independent of any rational

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -1227,6 +1227,10 @@ The shown first interface supplies the authoritative bounded scan frontier in
 each `PolicyView`; transition events let the policy update historical state
 without reconstructing it. Its traversal budget is cumulative across views,
 not merely a per-view size check, and counts inactive backing slots honestly.
+The decision budget does not suppress a read-only view: after the last allowed
+decision the driver may still use its separately charged traversal budget to
+distinguish a genuinely empty frontier from live work that must be reported as
+`unknown`.
 `maxLiveOffers` is initially a policy-view/output budget: making it an atomic
 frontier-mutation budget would require preflighting replies and instantiations
 before their already-atomic commits. An event-only priority implementation may

--- a/bench/HexInterval/IntervalPolicyFrontierSpike.lean
+++ b/bench/HexInterval/IntervalPolicyFrontierSpike.lean
@@ -1,0 +1,414 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexInterval.Experiment.Policy
+
+/-!
+# Policy-frontier representation spike
+
+This benchmark compares two ways of exposing the same engine-owned semantic
+offers to an external policy after one local fact improvement.
+
+* `runScan` uses the current complete `Policy.State.view`.  Every decision and
+  the final saturation check traverse all application, equality, and
+  suggestion slots.
+* `runDirect` adapts each new engine work event directly to an `OfferId`, then
+  asks `Policy.State.offer?` for the current semantic offer.  Selection still
+  crosses the same engine validation boundary; the adapter cannot manufacture
+  an action.
+
+The workload is a forest of disconnected chains of opaque unary operations.
+Facts are monotone `Nat` ranks, and the external registry gives both operation
+keys the same behavior, `output := input + 1`.  Thus this file measures policy
+frontier discovery rather than endpoint or rational arithmetic.
+
+Both representations must make the same decisions, invoke the same arbitrary
+propagators, and produce the same final facts and position-sensitive checksum.
+The primary evidence is the exact logical frontier-visit count.  Wall time is
+reported only after those equalities and count formulas have been checked.
+-/
+
+namespace Hex.Interval.Experiment.Propagator.PolicyFrontierBench
+
+open Policy
+
+abbrev Rank := Nat
+
+/-! ## Opaque generic-propagator workload -/
+
+def rankDomainId : DomainId := { index := 0 }
+
+def sourceKey : OpKey := { name := "policy-frontier.source" }
+
+def unaryFKey : OpKey := { name := "policy-frontier.f" }
+
+def unaryGKey : OpKey := { name := "policy-frontier.g" }
+
+def operations : Array Operation :=
+  #[{ key := sourceKey, inputs := [], output := rankDomainId },
+    { key := unaryFKey, inputs := [rankDomainId], output := rankDomainId },
+    { key := unaryGKey, inputs := [rankDomainId], output := rankDomainId }]
+
+def rules : Array Registration :=
+  #[{ key := { name := "policy-frontier.f-forward" }
+      head := unaryFKey
+      kind := .forward
+      watches := [.argument 0]
+      writes := [.result] },
+    { key := { name := "policy-frontier.g-forward" }
+      head := unaryGKey
+      kind := .forward
+      watches := [.argument 0]
+      writes := [.result] }]
+
+/-- `trees` disconnected chains, each with one source and `depth` opaque unary
+applications.  Alternating operation keys ensures that the scheduler is not
+silently relying on one distinguished function. -/
+def forestProgram (trees depth : Nat) : Program := Id.run do
+  let mut nodes := #[]
+  for _tree in [0:trees] do
+    let root : NodeId := { index := nodes.size }
+    nodes := nodes.push
+      { domain := rankDomainId, op := { index := 0 }, args := [] }
+    let mut previous := root
+    for level in [0:depth] do
+      let operation : OpId := { index := if level % 2 = 0 then 1 else 2 }
+      let output : NodeId := { index := nodes.size }
+      nodes := nodes.push
+        { domain := rankDomainId, op := operation, args := [previous] }
+      previous := output
+  return { operations, nodes }
+
+/-- Facts at the old fixed point: every chain stores ranks
+`0, 1, ..., depth`. -/
+def saturatedFacts (trees depth : Nat) : Array Rank := Id.run do
+  let mut facts := #[]
+  for _tree in [0:trees] do
+    for level in [0:depth + 1] do
+      facts := facts.push level
+  return facts
+
+def firstRoot : NodeId := { index := 0 }
+
+def applicationCount (trees depth : Nat) : Nat := trees * depth
+
+/-- Larger ranks are strictly stronger synthetic facts. -/
+def rankDomain : FactDomain Rank where
+  top _ := 0
+  narrow _ current candidate :=
+    if current < candidate then .improved candidate else .noChange
+
+def engineLimits (trees depth : Nat) : Experiment.Propagator.Limits :=
+  let nodes := trees * (depth + 1)
+  let applications := applicationCount trees depth
+  { maxOperations := operations.size
+    maxNodes := nodes
+    maxRules := rules.size
+    maxArity := 1
+    maxApplications := applications
+    maxQueueEntries := applications + 1
+    maxActions := depth + 1
+    maxAcceptedFacts := depth + 1
+    maxRetainedSuggestions := 0
+    maxEffort := 0
+    maxObservationValue := 1
+    maxOutcomeCandidates := 1
+    maxOutcomeSuggestions := 0
+    maxProposalItems := 0
+    maxInstances := 0
+    maxGeneration := 0
+    maxEqualities := 0
+    splitEndpointLimit :=
+      { maxEndpointHeight := 1, maxAlignmentShift := 0 } }
+
+def expectedScanVisits (trees depth : Nat) : Nat :=
+  applicationCount trees depth * (depth + 1)
+
+def policyLimits (trees depth : Nat) : Policy.Limits :=
+  { maxDecisions := depth + 1
+    maxTraversal := expectedScanVisits trees depth
+    maxLiveOffers := applicationCount trees depth }
+
+/-- Start from an already-saturated forest, strengthen only the first source,
+and retain only the resulting dependency event.  Clearing the engine's initial
+all-applications queue makes both frontier measurements start at the same
+local-refinement boundary. -/
+def prepare (trees depth : Nat) : Option (Policy.State Rank) := do
+  if trees = 0 then none else pure ()
+  let initial <-
+    match Engine.start rankDomain (forestProgram trees depth) rules
+        (saturatedFacts trees depth) (engineLimits trees depth) with
+    | .ok engine => some engine
+    | .error _ => none
+  let _ <- initial.facts[firstRoot.index]?
+  let idle : Engine Rank :=
+    { initial with
+      facts := initial.facts.set! firstRoot.index 1
+      versions := initial.versions.set! firstRoot.index 1
+      queue := #[]
+      queueHead := 0
+      queued := Array.replicate initial.applications.size false
+      metrics := {} }
+  let ready <- match idle.wakeNode firstRoot with
+    | .ok engine => some engine
+    | .error _ => none
+  some (Policy.State.start ready (policyLimits trees depth))
+
+/-! ## Shared selection and observations -/
+
+/-- The registry, rather than the scheduler, supplies the semantics of both
+opaque unary rule keys. -/
+def invokeUnary (request : RuleRequest Rank) : Outcome Rank :=
+  match request.inputs, request.writes with
+  | [input], [output] =>
+      .success
+        [{ node := output
+           fact := input.fact + 1
+           payload := { index := request.action.serial } }]
+        []
+        { arithmeticWork := 1, visitedEntries := 1, estimatedProofNodes := 1 }
+  | _, _ => .failed 1
+
+/-- Execute one engine-issued semantic offer through the validated selection
+and request/reply boundaries. -/
+def executeOffer? (state : Policy.State Rank) (offer : OfferView) : Option (Policy.State Rank) :=
+  let selection : Selection :=
+    { scope := state.scope
+      serial := state.serial
+      programVersion := state.engine.programVersion
+      id := offer.id
+      expected := offer.key }
+  match state.select selection with
+  | .request request awaiting =>
+      match awaiting.submit (request.action.reply (invokeUnary request)) with
+      | .accepted _ next => some next
+      | _ => none
+  | _ => none
+
+/-- Position-sensitive checksum of all final facts. -/
+def factsChecksum (facts : Array Rank) : Nat := Id.run do
+  let mut checksum := 0
+  for index in [0:facts.size] do
+    checksum := checksum + (index + 1) * (facts[index]! + 1)
+  return checksum
+
+/-- Independent construction of the expected fixed point. -/
+def expectedFacts (trees depth : Nat) : Array Rank := Id.run do
+  let mut facts := #[]
+  for tree in [0:trees] do
+    for level in [0:depth + 1] do
+      facts := facts.push (if tree = 0 then level + 1 else level)
+  return facts
+
+inductive Stop where
+  | saturated
+  | setupFailure
+  | frontierResource
+  | invalidTransition
+  | fuel
+  deriving DecidableEq, Repr
+
+structure LogicalResult where
+  stop : Stop
+  frontierVisits : Nat
+  decisions : Nat
+  invocations : Nat
+  improvements : Nat
+  facts : Array Rank
+  checksum : Nat
+  deriving DecidableEq, Repr
+
+def result (stop : Stop) (frontierVisits : Nat) (state : Policy.State Rank) : LogicalResult :=
+  { stop
+    frontierVisits
+    decisions := state.metrics.decisions
+    invocations := state.engine.metrics.requests
+    improvements := state.engine.metrics.improvements
+    facts := state.engine.facts
+    checksum := factsChecksum state.engine.facts }
+
+def failedResult (stop : Stop) : LogicalResult :=
+  { stop
+    frontierVisits := 0
+    decisions := 0
+    invocations := 0
+    improvements := 0
+    facts := #[]
+    checksum := 0 }
+
+/-! ## Complete frontier scan -/
+
+def scanLoop : Nat -> Policy.State Rank -> LogicalResult
+  | 0, state => result .fuel state.metrics.traversal state
+  | fuel + 1, state =>
+      match state.view with
+      | .error _ => result .frontierResource state.metrics.traversal state
+      | .ok (view, scanned) =>
+          match view.offers[0]? with
+          | none => result .saturated scanned.metrics.traversal scanned
+          | some offer =>
+              match executeOffer? scanned offer with
+              | none => result .invalidTransition scanned.metrics.traversal scanned
+              | some next => scanLoop fuel next
+
+/-- Current reference policy path: construct a complete bounded view before
+every choice and once more to establish saturation. -/
+@[noinline]
+def runScanPrepared (state : Policy.State Rank) (depth : Nat) : LogicalResult :=
+  scanLoop (depth + 2) state
+
+def runScan (trees depth : Nat) : LogicalResult :=
+  match prepare trees depth with
+  | none => failedResult .setupFailure
+  | some state => runScanPrepared state depth
+
+/-! ## Event-indexed semantic-offer adapter -/
+
+def offerIdOfWork : WorkItem -> OfferId
+  | .application application => .application application
+  | .equality equality => .equality equality
+
+def noDirtyWork (state : Policy.State Rank) : Bool :=
+  !state.engine.queued.any id && !state.engine.equalityQueued.any id &&
+    state.engine.suggestions.isEmpty && state.engine.pending.isNone
+
+/-- Follow the append-only dependency-event log by exact index.  Every event
+is converted to a semantic `OfferId` and re-read through `State.offer?`; this
+does not hand a raw engine action to the external policy. -/
+def directLoop : Nat -> Nat -> Nat -> Policy.State Rank -> LogicalResult
+  | 0, _, visits, state => result .fuel visits state
+  | fuel + 1, cursor, visits, state =>
+      if state.engine.queue.size <= cursor then
+        if noDirtyWork state then result .saturated visits state
+        else result .invalidTransition visits state
+      else
+        match state.engine.queue[cursor]? with
+        | none => result .invalidTransition visits state
+        | some work =>
+            let visits := visits + 1
+            match state.offer? (offerIdOfWork work) with
+            | none => directLoop fuel (cursor + 1) visits state
+            | some offer =>
+                match executeOffer? state offer with
+                | none => result .invalidTransition visits state
+                | some next => directLoop fuel (cursor + 1) visits next
+
+/-- Candidate frontier representation: adapt only emitted work events to
+semantic offers, while retaining the same selection revalidation. -/
+@[noinline]
+def runDirectPrepared (state : Policy.State Rank) (depth : Nat) : LogicalResult :=
+  directLoop (depth + 2) 0 0 state
+
+def runDirect (trees depth : Nat) : LogicalResult :=
+  match prepare trees depth with
+  | none => failedResult .setupFailure
+  | some state => runDirectPrepared state depth
+
+structure Comparison where
+  scan : LogicalResult
+  direct : LogicalResult
+  deriving DecidableEq, Repr
+
+def compareFrontiers (trees depth : Nat) : Comparison :=
+  { scan := runScan trees depth, direct := runDirect trees depth }
+
+def comparePrepared (state : Policy.State Rank) (depth : Nat) : Comparison :=
+  { scan := runScanPrepared state depth, direct := runDirectPrepared state depth }
+
+def expectedDirectVisits (depth : Nat) : Nat := depth
+
+def resultValid (trees depth : Nat) (comparison : Comparison) : Bool :=
+  0 < trees && comparison.scan.stop == .saturated &&
+    comparison.direct.stop == .saturated &&
+    comparison.scan.frontierVisits == expectedScanVisits trees depth &&
+    comparison.direct.frontierVisits == expectedDirectVisits depth &&
+    comparison.scan.decisions == depth && comparison.direct.decisions == depth &&
+    comparison.scan.invocations == depth && comparison.direct.invocations == depth &&
+    comparison.scan.improvements == depth && comparison.direct.improvements == depth &&
+    comparison.scan.facts == comparison.direct.facts &&
+    comparison.scan.facts == expectedFacts trees depth &&
+    comparison.scan.checksum == comparison.direct.checksum &&
+    comparison.scan.checksum == factsChecksum (expectedFacts trees depth)
+
+/-! ## Compiled timing driver -/
+
+def mix (acc value : UInt64) : UInt64 :=
+  acc * 0x9E3779B97F4A7C15 + value + 0xBF58476D1CE4E5B9
+
+def stopCode : Stop -> Nat
+  | .saturated => 1
+  | .setupFailure => 2
+  | .frontierResource => 3
+  | .invalidTransition => 4
+  | .fuel => 5
+
+def observe (acc : UInt64) (iteration : Nat) (value : LogicalResult) : UInt64 :=
+  mix
+    (mix
+      (mix
+        (mix
+          (mix
+            (mix acc (UInt64.ofNat iteration))
+            (UInt64.ofNat (stopCode value.stop)))
+          (UInt64.ofNat value.frontierVisits))
+        (UInt64.ofNat value.decisions))
+      (UInt64.ofNat value.invocations))
+    (UInt64.ofNat (value.improvements + value.checksum))
+
+/-- Time only repeated policy runs from one prevalidated immutable snapshot;
+program construction and application compilation stay outside the timed loop. -/
+def timeMode (mode : String) (trees depth repeats : Nat)
+    (initial : Policy.State Rank) (expected : LogicalResult)
+    (work : Policy.State Rank -> Nat -> LogicalResult) : IO Bool := do
+  let mut sink : UInt64 := 0
+  for iteration in [0:4] do
+    let value := work initial depth
+    if value != expected then
+      IO.eprintln s!"{mode}: warmup changed the logical result"
+      return false
+    sink := observe sink iteration value
+  let start <- IO.monoNanosNow
+  for iteration in [0:repeats] do
+    let value := work initial depth
+    sink := observe sink iteration value
+  let stop <- IO.monoNanosNow
+  IO.println <|
+    s!"{mode} {trees} {depth} {applicationCount trees depth} {repeats} " ++
+      s!"{stop - start} {expected.frontierVisits} {expected.decisions} " ++
+      s!"{expected.invocations} {expected.improvements} {expected.checksum} {sink}"
+  return true
+
+def usage : String :=
+  "usage: hex_interval_policy_frontier_spike TREES DEPTH REPEATS"
+
+end Hex.Interval.Experiment.Propagator.PolicyFrontierBench
+
+open Hex.Interval.Experiment.Propagator.PolicyFrontierBench
+
+def main (args : List String) : IO UInt32 := do
+  match args with
+  | [treesText, depthText, repeatsText] =>
+      let some trees := treesText.toNat? | IO.eprintln usage; return 2
+      let some depth := depthText.toNat? | IO.eprintln usage; return 2
+      let some repeats := repeatsText.toNat? | IO.eprintln usage; return 2
+      if trees = 0 || repeats = 0 then
+        IO.eprintln usage
+        return 2
+      let some initial := prepare trees depth
+        | IO.eprintln "policy-frontier setup failed"
+          return 2
+      let comparison := comparePrepared initial depth
+      if !resultValid trees depth comparison then
+        IO.eprintln "policy-frontier logical canary failed"
+        return 2
+      let scanOk <-
+        timeMode "scan" trees depth repeats initial comparison.scan runScanPrepared
+      let directOk <-
+        timeMode "direct" trees depth repeats initial comparison.direct runDirectPrepared
+      return if scanOk && directOk then 0 else 2
+  | _ =>
+      IO.eprintln usage
+      return 2

--- a/bench/HexInterval/IntervalPolicyFrontierSpike.lean
+++ b/bench/HexInterval/IntervalPolicyFrontierSpike.lean
@@ -4,411 +4,89 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
-import HexInterval.Experiment.Policy
+import HexInterval.Experiment.PolicyFrontier
 
 /-!
-# Policy-frontier representation spike
+# Policy-frontier representation spike driver
 
-This benchmark compares two ways of exposing the same engine-owned semantic
-offers to an external policy after one local fact improvement.
-
-* `runScan` uses the current complete `Policy.State.view`.  Every decision and
-  the final saturation check traverse all application, equality, and
-  suggestion slots.
-* `runDirect` adapts each new engine work event directly to an `OfferId`, then
-  asks `Policy.State.offer?` for the current semantic offer.  Selection still
-  crosses the same engine validation boundary; the adapter cannot manufacture
-  an action.
-
-The workload is a forest of disconnected chains of opaque unary operations.
-Facts are monotone `Nat` ranks, and the external registry gives both operation
-keys the same behavior, `output := input + 1`.  Thus this file measures policy
-frontier discovery rather than endpoint or rational arithmetic.
-
-Both representations must make the same decisions, invoke the same arbitrary
-propagators, and produce the same final facts and position-sensitive checksum.
-The primary evidence is the exact logical frontier-visit count.  Wall time is
-reported only after those equalities and count formulas have been checked.
+This executable reports deterministic logical-work vectors for the complete
+scan and maintained event-indexed priority frontier.  It deliberately does not
+run an in-process timing loop: the columns have exact meanings, while machine
+timing belongs in the repository's common benchmark harness once a production
+adapter exists.
 -/
 
-namespace Hex.Interval.Experiment.Propagator.PolicyFrontierBench
+namespace Hex.Interval.IntervalPolicyFrontierSpike
 
-open Policy
+open Experiment.Propagator.PolicyFrontier
 
-abbrev Rank := Nat
+def workText (work : Work) : String :=
+  s!"total={work.total} frontier-slots={work.frontierSlots} " ++
+    s!"frontier-emits={work.frontierEmits} clock-sync={work.clockSyncSlots} " ++
+    s!"suggestion-prune={work.suggestionPruneSlots} " ++
+    s!"dependency-visits={work.dependencyVisits} event-visits={work.eventVisits} " ++
+    s!"offer-rechecks={work.offerRechecks} " ++
+    s!"selection-rechecks={work.selectionRechecks} " ++
+    s!"semantic-items={work.semanticItems} " ++
+    s!"priority-comparisons={work.priorityComparisons} " ++
+    s!"priority-moves={work.priorityMoves}"
 
-/-! ## Opaque generic-propagator workload -/
+def resultText (mode : String) (result : Result) : String :=
+  s!"{mode} stop={repr result.stop} decisions={result.decisions} " ++
+    s!"calls={result.calls} improvements={result.improvements} " ++
+    s!"dismissals={result.dismissals} insertions={result.queueInsertions} " ++
+    s!"suppressed={result.suppressedInsertions} " ++
+    s!"retained={result.retainedSuggestions} checksum={result.checksum} " ++
+    workText result.work
 
-def rankDomainId : DomainId := { index := 0 }
+def report (workload : Workload) : IO Bool := do
+  let comparison := compare workload
+  IO.println <| s!"workload={workload.name} roots={workload.roots} " ++
+    s!"sinks={workload.sinks} churn={workload.churn} dense={workload.dense}"
+  IO.println (resultText "scan" comparison.scan)
+  IO.println (resultText "indexed" comparison.indexed)
+  let valid := comparisonValid workload comparison &&
+    (workload.sinks == 1 ||
+      (nonFifoChoice workload comparison.scan &&
+        nonFifoChoice workload comparison.indexed))
+  if !valid then IO.eprintln "policy-frontier equivalence canary failed"
+  return valid
 
-def sourceKey : OpKey := { name := "policy-frontier.source" }
-
-def unaryFKey : OpKey := { name := "policy-frontier.f" }
-
-def unaryGKey : OpKey := { name := "policy-frontier.g" }
-
-def operations : Array Operation :=
-  #[{ key := sourceKey, inputs := [], output := rankDomainId },
-    { key := unaryFKey, inputs := [rankDomainId], output := rankDomainId },
-    { key := unaryGKey, inputs := [rankDomainId], output := rankDomainId }]
-
-def rules : Array Registration :=
-  #[{ key := { name := "policy-frontier.f-forward" }
-      head := unaryFKey
-      kind := .forward
-      watches := [.argument 0]
-      writes := [.result] },
-    { key := { name := "policy-frontier.g-forward" }
-      head := unaryGKey
-      kind := .forward
-      watches := [.argument 0]
-      writes := [.result] }]
-
-/-- `trees` disconnected chains, each with one source and `depth` opaque unary
-applications.  Alternating operation keys ensures that the scheduler is not
-silently relying on one distinguished function. -/
-def forestProgram (trees depth : Nat) : Program := Id.run do
-  let mut nodes := #[]
-  for _tree in [0:trees] do
-    let root : NodeId := { index := nodes.size }
-    nodes := nodes.push
-      { domain := rankDomainId, op := { index := 0 }, args := [] }
-    let mut previous := root
-    for level in [0:depth] do
-      let operation : OpId := { index := if level % 2 = 0 then 1 else 2 }
-      let output : NodeId := { index := nodes.size }
-      nodes := nodes.push
-        { domain := rankDomainId, op := operation, args := [previous] }
-      previous := output
-  return { operations, nodes }
-
-/-- Facts at the old fixed point: every chain stores ranks
-`0, 1, ..., depth`. -/
-def saturatedFacts (trees depth : Nat) : Array Rank := Id.run do
-  let mut facts := #[]
-  for _tree in [0:trees] do
-    for level in [0:depth + 1] do
-      facts := facts.push level
-  return facts
-
-def firstRoot : NodeId := { index := 0 }
-
-def applicationCount (trees depth : Nat) : Nat := trees * depth
-
-/-- Larger ranks are strictly stronger synthetic facts. -/
-def rankDomain : FactDomain Rank where
-  top _ := 0
-  narrow _ current candidate :=
-    if current < candidate then .improved candidate else .noChange
-
-def engineLimits (trees depth : Nat) : Experiment.Propagator.Limits :=
-  let nodes := trees * (depth + 1)
-  let applications := applicationCount trees depth
-  { maxOperations := operations.size
-    maxNodes := nodes
-    maxRules := rules.size
-    maxArity := 1
-    maxApplications := applications
-    maxQueueEntries := applications + 1
-    maxActions := depth + 1
-    maxAcceptedFacts := depth + 1
-    maxRetainedSuggestions := 0
-    maxEffort := 0
-    maxObservationValue := 1
-    maxOutcomeCandidates := 1
-    maxOutcomeSuggestions := 0
-    maxProposalItems := 0
-    maxInstances := 0
-    maxGeneration := 0
-    maxEqualities := 0
-    splitEndpointLimit :=
-      { maxEndpointHeight := 1, maxAlignmentShift := 0 } }
-
-def expectedScanVisits (trees depth : Nat) : Nat :=
-  applicationCount trees depth * (depth + 1)
-
-def policyLimits (trees depth : Nat) : Policy.Limits :=
-  { maxDecisions := depth + 1
-    maxTraversal := expectedScanVisits trees depth
-    maxLiveOffers := applicationCount trees depth }
-
-/-- Start from an already-saturated forest, strengthen only the first source,
-and retain only the resulting dependency event.  Clearing the engine's initial
-all-applications queue makes both frontier measurements start at the same
-local-refinement boundary. -/
-def prepare (trees depth : Nat) : Option (Policy.State Rank) := do
-  if trees = 0 then none else pure ()
-  let initial <-
-    match Engine.start rankDomain (forestProgram trees depth) rules
-        (saturatedFacts trees depth) (engineLimits trees depth) with
-    | .ok engine => some engine
-    | .error _ => none
-  let _ <- initial.facts[firstRoot.index]?
-  let idle : Engine Rank :=
-    { initial with
-      facts := initial.facts.set! firstRoot.index 1
-      versions := initial.versions.set! firstRoot.index 1
-      queue := #[]
-      queueHead := 0
-      queued := Array.replicate initial.applications.size false
-      metrics := {} }
-  let ready <- match idle.wakeNode firstRoot with
-    | .ok engine => some engine
-    | .error _ => none
-  some (Policy.State.start ready (policyLimits trees depth))
-
-/-! ## Shared selection and observations -/
-
-/-- The registry, rather than the scheduler, supplies the semantics of both
-opaque unary rule keys. -/
-def invokeUnary (request : RuleRequest Rank) : Outcome Rank :=
-  match request.inputs, request.writes with
-  | [input], [output] =>
-      .success
-        [{ node := output
-           fact := input.fact + 1
-           payload := { index := request.action.serial } }]
-        []
-        { arithmeticWork := 1, visitedEntries := 1, estimatedProofNodes := 1 }
-  | _, _ => .failed 1
-
-/-- Execute one engine-issued semantic offer through the validated selection
-and request/reply boundaries. -/
-def executeOffer? (state : Policy.State Rank) (offer : OfferView) : Option (Policy.State Rank) :=
-  let selection : Selection :=
-    { scope := state.scope
-      serial := state.serial
-      programVersion := state.engine.programVersion
-      id := offer.id
-      expected := offer.key }
-  match state.select selection with
-  | .request request awaiting =>
-      match awaiting.submit (request.action.reply (invokeUnary request)) with
-      | .accepted _ next => some next
-      | _ => none
-  | _ => none
-
-/-- Position-sensitive checksum of all final facts. -/
-def factsChecksum (facts : Array Rank) : Nat := Id.run do
-  let mut checksum := 0
-  for index in [0:facts.size] do
-    checksum := checksum + (index + 1) * (facts[index]! + 1)
-  return checksum
-
-/-- Independent construction of the expected fixed point. -/
-def expectedFacts (trees depth : Nat) : Array Rank := Id.run do
-  let mut facts := #[]
-  for tree in [0:trees] do
-    for level in [0:depth + 1] do
-      facts := facts.push (if tree = 0 then level + 1 else level)
-  return facts
-
-inductive Stop where
-  | saturated
-  | setupFailure
-  | frontierResource
-  | invalidTransition
-  | fuel
-  deriving DecidableEq, Repr
-
-structure LogicalResult where
-  stop : Stop
-  frontierVisits : Nat
-  decisions : Nat
-  invocations : Nat
-  improvements : Nat
-  facts : Array Rank
-  checksum : Nat
-  deriving DecidableEq, Repr
-
-def result (stop : Stop) (frontierVisits : Nat) (state : Policy.State Rank) : LogicalResult :=
-  { stop
-    frontierVisits
-    decisions := state.metrics.decisions
-    invocations := state.engine.metrics.requests
-    improvements := state.engine.metrics.improvements
-    facts := state.engine.facts
-    checksum := factsChecksum state.engine.facts }
-
-def failedResult (stop : Stop) : LogicalResult :=
-  { stop
-    frontierVisits := 0
-    decisions := 0
-    invocations := 0
-    improvements := 0
-    facts := #[]
-    checksum := 0 }
-
-/-! ## Complete frontier scan -/
-
-def scanLoop : Nat -> Policy.State Rank -> LogicalResult
-  | 0, state => result .fuel state.metrics.traversal state
-  | fuel + 1, state =>
-      match state.view with
-      | .error _ => result .frontierResource state.metrics.traversal state
-      | .ok (view, scanned) =>
-          match view.offers[0]? with
-          | none => result .saturated scanned.metrics.traversal scanned
-          | some offer =>
-              match executeOffer? scanned offer with
-              | none => result .invalidTransition scanned.metrics.traversal scanned
-              | some next => scanLoop fuel next
-
-/-- Current reference policy path: construct a complete bounded view before
-every choice and once more to establish saturation. -/
-@[noinline]
-def runScanPrepared (state : Policy.State Rank) (depth : Nat) : LogicalResult :=
-  scanLoop (depth + 2) state
-
-def runScan (trees depth : Nat) : LogicalResult :=
-  match prepare trees depth with
-  | none => failedResult .setupFailure
-  | some state => runScanPrepared state depth
-
-/-! ## Event-indexed semantic-offer adapter -/
-
-def offerIdOfWork : WorkItem -> OfferId
-  | .application application => .application application
-  | .equality equality => .equality equality
-
-def noDirtyWork (state : Policy.State Rank) : Bool :=
-  !state.engine.queued.any id && !state.engine.equalityQueued.any id &&
-    state.engine.suggestions.isEmpty && state.engine.pending.isNone
-
-/-- Follow the append-only dependency-event log by exact index.  Every event
-is converted to a semantic `OfferId` and re-read through `State.offer?`; this
-does not hand a raw engine action to the external policy. -/
-def directLoop : Nat -> Nat -> Nat -> Policy.State Rank -> LogicalResult
-  | 0, _, visits, state => result .fuel visits state
-  | fuel + 1, cursor, visits, state =>
-      if state.engine.queue.size <= cursor then
-        if noDirtyWork state then result .saturated visits state
-        else result .invalidTransition visits state
-      else
-        match state.engine.queue[cursor]? with
-        | none => result .invalidTransition visits state
-        | some work =>
-            let visits := visits + 1
-            match state.offer? (offerIdOfWork work) with
-            | none => directLoop fuel (cursor + 1) visits state
-            | some offer =>
-                match executeOffer? state offer with
-                | none => result .invalidTransition visits state
-                | some next => directLoop fuel (cursor + 1) visits next
-
-/-- Candidate frontier representation: adapt only emitted work events to
-semantic offers, while retaining the same selection revalidation. -/
-@[noinline]
-def runDirectPrepared (state : Policy.State Rank) (depth : Nat) : LogicalResult :=
-  directLoop (depth + 2) 0 0 state
-
-def runDirect (trees depth : Nat) : LogicalResult :=
-  match prepare trees depth with
-  | none => failedResult .setupFailure
-  | some state => runDirectPrepared state depth
-
-structure Comparison where
-  scan : LogicalResult
-  direct : LogicalResult
-  deriving DecidableEq, Repr
-
-def compareFrontiers (trees depth : Nat) : Comparison :=
-  { scan := runScan trees depth, direct := runDirect trees depth }
-
-def comparePrepared (state : Policy.State Rank) (depth : Nat) : Comparison :=
-  { scan := runScanPrepared state depth, direct := runDirectPrepared state depth }
-
-def expectedDirectVisits (depth : Nat) : Nat := depth
-
-def resultValid (trees depth : Nat) (comparison : Comparison) : Bool :=
-  0 < trees && comparison.scan.stop == .saturated &&
-    comparison.direct.stop == .saturated &&
-    comparison.scan.frontierVisits == expectedScanVisits trees depth &&
-    comparison.direct.frontierVisits == expectedDirectVisits depth &&
-    comparison.scan.decisions == depth && comparison.direct.decisions == depth &&
-    comparison.scan.invocations == depth && comparison.direct.invocations == depth &&
-    comparison.scan.improvements == depth && comparison.direct.improvements == depth &&
-    comparison.scan.facts == comparison.direct.facts &&
-    comparison.scan.facts == expectedFacts trees depth &&
-    comparison.scan.checksum == comparison.direct.checksum &&
-    comparison.scan.checksum == factsChecksum (expectedFacts trees depth)
-
-/-! ## Compiled timing driver -/
-
-def mix (acc value : UInt64) : UInt64 :=
-  acc * 0x9E3779B97F4A7C15 + value + 0xBF58476D1CE4E5B9
-
-def stopCode : Stop -> Nat
-  | .saturated => 1
-  | .setupFailure => 2
-  | .frontierResource => 3
-  | .invalidTransition => 4
-  | .fuel => 5
-
-def observe (acc : UInt64) (iteration : Nat) (value : LogicalResult) : UInt64 :=
-  mix
-    (mix
-      (mix
-        (mix
-          (mix
-            (mix acc (UInt64.ofNat iteration))
-            (UInt64.ofNat (stopCode value.stop)))
-          (UInt64.ofNat value.frontierVisits))
-        (UInt64.ofNat value.decisions))
-      (UInt64.ofNat value.invocations))
-    (UInt64.ofNat (value.improvements + value.checksum))
-
-/-- Time only repeated policy runs from one prevalidated immutable snapshot;
-program construction and application compilation stay outside the timed loop. -/
-def timeMode (mode : String) (trees depth repeats : Nat)
-    (initial : Policy.State Rank) (expected : LogicalResult)
-    (work : Policy.State Rank -> Nat -> LogicalResult) : IO Bool := do
-  let mut sink : UInt64 := 0
-  for iteration in [0:4] do
-    let value := work initial depth
-    if value != expected then
-      IO.eprintln s!"{mode}: warmup changed the logical result"
-      return false
-    sink := observe sink iteration value
-  let start <- IO.monoNanosNow
-  for iteration in [0:repeats] do
-    let value := work initial depth
-    sink := observe sink iteration value
-  let stop <- IO.monoNanosNow
-  IO.println <|
-    s!"{mode} {trees} {depth} {applicationCount trees depth} {repeats} " ++
-      s!"{stop - start} {expected.frontierVisits} {expected.decisions} " ++
-      s!"{expected.invocations} {expected.improvements} {expected.checksum} {sink}"
-  return true
+def reportAll : List Workload -> IO Bool
+  | [] => pure true
+  | workload :: workloads => do
+      let current <- report workload
+      let rest <- reportAll workloads
+      return current && rest
 
 def usage : String :=
-  "usage: hex_interval_policy_frontier_spike TREES DEPTH REPEATS"
+  "usage: hex_interval_policy_frontier_spike canary | " ++
+    "fanout SINKS | dense WIDTH | churn SINKS SUGGESTIONS_PER_SINK"
 
-end Hex.Interval.Experiment.Propagator.PolicyFrontierBench
+end Hex.Interval.IntervalPolicyFrontierSpike
 
-open Hex.Interval.Experiment.Propagator.PolicyFrontierBench
+open Hex.Interval.Experiment.Propagator.PolicyFrontier
+open Hex.Interval.IntervalPolicyFrontierSpike
 
 def main (args : List String) : IO UInt32 := do
-  match args with
-  | [treesText, depthText, repeatsText] =>
-      let some trees := treesText.toNat? | IO.eprintln usage; return 2
-      let some depth := depthText.toNat? | IO.eprintln usage; return 2
-      let some repeats := repeatsText.toNat? | IO.eprintln usage; return 2
-      if trees = 0 || repeats = 0 then
+  let workload? : Option (List Workload) :=
+    match args with
+    | ["canary"] => some [fanoutCanary, denseCanary, churnCanary]
+    | ["fanout", sinksText] => do
+        let sinks <- sinksText.toNat?
+        some [{ name := "fanout", roots := 1, sinks, churn := 0, dense := false }]
+    | ["dense", widthText] => do
+        let width <- widthText.toNat?
+        some [{ name := "dense", roots := width, sinks := width, churn := 0, dense := true }]
+    | ["churn", sinksText, churnText] => do
+        let sinks <- sinksText.toNat?
+        let churn <- churnText.toNat?
+        some [{ name := "churn", roots := 1, sinks, churn, dense := false }]
+    | _ => none
+  match workload? with
+  | none => IO.eprintln usage; return 2
+  | some workloads =>
+      if workloads.any (fun workload => !workload.valid) then
         IO.eprintln usage
         return 2
-      let some initial := prepare trees depth
-        | IO.eprintln "policy-frontier setup failed"
-          return 2
-      let comparison := comparePrepared initial depth
-      if !resultValid trees depth comparison then
-        IO.eprintln "policy-frontier logical canary failed"
-        return 2
-      let scanOk <-
-        timeMode "scan" trees depth repeats initial comparison.scan runScanPrepared
-      let directOk <-
-        timeMode "direct" trees depth repeats initial comparison.direct runDirectPrepared
-      return if scanOk && directOk then 0 else 2
-  | _ =>
-      IO.eprintln usage
-      return 2
+      return if <- reportAll workloads then 0 else 2

--- a/conformance/HexInterval/PolicyConformance.lean
+++ b/conformance/HexInterval/PolicyConformance.lean
@@ -1,0 +1,424 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexInterval.Experiment.Policy
+
+/-!
+Conformance canaries for engine-owned policy offers.
+
+The fixture uses opaque `f` and `g` operations over a synthetic rank domain.
+It checks two deliberately different valid schedules, exact observations, and
+revalidation of selections at the engine boundary.  No policy test depends on
+arithmetic semantics.
+-/
+
+namespace Hex.Interval.PolicyConformance
+
+open Experiment.Propagator
+open Experiment.Propagator.Policy
+
+abbrev Rank := Nat
+
+/-- Larger ranks are strictly stronger synthetic facts. -/
+def rankDomain : FactDomain Rank where
+  top _ := 0
+  narrow _ current candidate :=
+    if current < candidate then .improved candidate else .noChange
+
+def real : DomainId := { index := 0 }
+
+def sourceOp : OpKey := { name := "policy.source" }
+def fOp : OpKey := { name := "policy.f" }
+def gOp : OpKey := { name := "policy.g" }
+
+def fKey : RuleKey := { name := "policy.f.contract" }
+def gKey : RuleKey := { name := "policy.g.contract" }
+
+def node (index : Nat) : NodeId := { index }
+def application (index : Nat) : ApplicationId := { index }
+def equality (index : Nat) : EqualityId := { index }
+def suggestion (index : Nat) : SuggestionId := { index }
+
+def sourceNode : Node := { domain := real, op := { index := 0 }, args := [] }
+
+def unaryNode (op : Nat) (input : Nat) : Node :=
+  { domain := real, op := { index := op }, args := [node input] }
+
+def operations : Array Operation :=
+  #[{ key := sourceOp, inputs := [], output := real },
+    { key := fOp, inputs := [real], output := real },
+    { key := gOp, inputs := [real], output := real }]
+
+def program : Program :=
+  { operations, nodes := #[sourceNode, unaryNode 1 0] }
+
+def fRule : Registration :=
+  { key := fKey
+    head := fOp
+    kind := .improve
+    watches := [.argument 0]
+    writes := [.result] }
+
+def gRule : Registration :=
+  { key := gKey
+    head := gOp
+    kind := .improve
+    watches := [.argument 0]
+    writes := [.result] }
+
+def engineLimits : Experiment.Propagator.Limits :=
+  { maxOperations := 8
+    maxNodes := 8
+    maxRules := 8
+    maxArity := 4
+    maxApplications := 16
+    maxQueueEntries := 64
+    maxActions := 32
+    maxAcceptedFacts := 32
+    maxRetainedSuggestions := 16
+    maxEffort := 4
+    maxObservationValue := 64
+    maxOutcomeCandidates := 8
+    maxOutcomeSuggestions := 8
+    maxProposalItems := 8
+    maxInstances := 8
+    maxGeneration := 4
+    maxEqualities := 8
+    splitEndpointLimit :=
+      { maxEndpointHeight := 32, maxAlignmentShift := 16 } }
+
+def policyLimits : Experiment.Propagator.Policy.Limits :=
+  { maxDecisions := 32
+    maxTraversal := 512
+    maxLiveOffers := 32 }
+
+def initialWith? (limits : Experiment.Propagator.Policy.Limits) : Option (State Rank) := do
+  let engine <- match Engine.start rankDomain program #[fRule, gRule] #[0, 0] engineLimits with
+    | .ok engine => some engine
+    | .error _ => none
+  some (State.start engine limits)
+
+def initial? : Option (State Rank) := initialWith? policyLimits
+
+def selectOffer (state : State Rank) (id : OfferId) : SelectResult Rank :=
+  match state.offer? id with
+  | none => state.reject .missingOffer
+  | some offer =>
+      state.select
+        { scope := state.scope
+          serial := state.serial
+          programVersion := state.engine.programVersion
+          id
+          expected := offer.key }
+
+def candidate (request : RuleRequest Rank) (rank : Rank) : Candidate Rank :=
+  { node := request.action.node
+    fact := rank
+    payload := { index := request.action.serial } }
+
+def proposedG : ProposedNode :=
+  { domain := real, op := { index := 2 }, args := [.existing (node 0)] }
+
+def instantiateG (request : RuleRequest Rank) : InstantiationRequest :=
+  { key := 31
+    triggers := [request.action.node]
+    claimedGeneration := 1
+    nodes := [proposedG]
+    equalities :=
+      [{ left := .existing request.action.node
+         right := .proposed 0
+         payload := { index := 37 } }]
+    payload := { index := 41 } }
+
+def fSuggestions (request : RuleRequest Rank) : List Suggestion :=
+  [.retry 1,
+    .instantiate (instantiateG request),
+    .split { node := node 0, point := 0, reason := .midpoint }]
+
+def invoke (request : RuleRequest Rank) : Outcome Rank :=
+  if request.action.key == fKey then
+    if request.action.effort == 0 then
+      .success [candidate request 1] (fSuggestions request)
+        { arithmeticWork := 3, visitedEntries := 5, estimatedProofNodes := 7 }
+    else
+      .success [candidate request 4] []
+        { arithmeticWork := 11, visitedEntries := 13, estimatedProofNodes := 17 }
+  else if request.action.key == gKey then
+    .success [candidate request 4] []
+      { arithmeticWork := 19, visitedEntries := 23, estimatedProofNodes := 29 }
+  else
+    .failed 43
+
+def submitInvoke (state : State Rank) (request : RuleRequest Rank) : SubmitResult Rank :=
+  state.submit (request.action.reply (invoke request))
+
+def request? (state : State Rank) (id : OfferId) :
+    Option (RuleRequest Rank × State Rank) :=
+  match selectOffer state id with
+  | .request request next => some (request, next)
+  | _ => none
+
+def submit? (state : State Rank) (request : RuleRequest Rank) :
+    Option (RuleObservation Rank × State Rank) :=
+  match submitInvoke state request with
+  | .accepted observation next => some (observation, next)
+  | _ => none
+
+def instantiate? (state : State Rank) (id : SuggestionId) : Option (State Rank) :=
+  match selectOffer state (.suggestion id) with
+  | .completed (.instanceAdmitted [fresh]) next =>
+      if fresh == node 2 then some next else none
+  | _ => none
+
+def contract? (state : State Rank) (id : EqualityId) :
+    Option (EqualityObservation Rank × State Rank) :=
+  match selectOffer state (.equality id) with
+  | .equality observation next => some (observation, next)
+  | _ => none
+
+def split? (state : State Rank) (id : SuggestionId) :
+    Option (SplitPlan Rank × State Rank) :=
+  match selectOffer state (.suggestion id) with
+  | .split plan next => some (plan, next)
+  | _ => none
+
+def oneChange (changes : Array (FactDelta Rank)) (changed : NodeId)
+    (before after beforeVersion afterVersion : Nat) : Bool :=
+  match changes.toList with
+  | [delta] =>
+      delta.node == changed && delta.before == before && delta.after == after &&
+        delta.beforeVersion == beforeVersion && delta.afterVersion == afterVersion
+  | _ => false
+
+def noChanges (changes : Array (FactDelta Rank)) : Bool := changes.isEmpty
+
+def exactCost (cost : CostObservation) (arithmetic visited proof : Nat) : Bool :=
+  cost.arithmeticWork == arithmetic && cost.visitedEntries == visited &&
+    cost.estimatedProofNodes == proof
+
+def exactInitialObservation (observation : RuleObservation Rank) : Bool :=
+  observation.invocation.rule == fKey && observation.invocation.effort == 0 &&
+    observation.invocation.inputs == [{ node := node 0, version := 0 }] &&
+    observation.outcome == .success && oneChange observation.changes (node 1) 0 1 0 1 &&
+    !observation.contradiction && exactCost observation.cost 3 5 7 &&
+    observation.emittedSuggestions.toList ==
+      [.suggestion (suggestion 0), .suggestion (suggestion 1), .suggestion (suggestion 2)]
+
+def exactRetryObservation (observation : RuleObservation Rank) (changed : Bool) : Bool :=
+  observation.invocation.rule == fKey && observation.invocation.effort == 1 &&
+    observation.outcome == .success &&
+    (if changed then oneChange observation.changes (node 1) 1 4 1 2
+      else noChanges observation.changes) &&
+    !observation.contradiction && exactCost observation.cost 11 13 17 &&
+    observation.emittedSuggestions.isEmpty
+
+def exactGObservation (observation : RuleObservation Rank) (before : Nat) : Bool :=
+  observation.invocation.rule == gKey && observation.invocation.effort == 0 &&
+    observation.outcome == .success &&
+    (if before < 4 then oneChange observation.changes (node 2) before 4
+        (if before == 0 then 0 else 1) (if before == 0 then 1 else 2)
+      else noChanges observation.changes) &&
+    !observation.contradiction && exactCost observation.cost 19 23 29 &&
+    observation.emittedSuggestions.isEmpty
+
+def exactEqualityObservation (observation : EqualityObservation Rank)
+    (outcome : EqualityOutcome) (changed : Option (NodeId × Nat × Nat × Nat × Nat)) : Bool :=
+  observation.key.equality == equality 0 && observation.outcome == outcome &&
+    observation.narrowCalls == 2 &&
+    match changed with
+    | none => noChanges observation.changes
+    | some (changed, before, after, beforeVersion, afterVersion) =>
+        oneChange observation.changes changed before after beforeVersion afterVersion
+
+def exactSplit (plan : SplitPlan Rank) : Bool :=
+  plan.scope == { index := 0 } && plan.suggestion == suggestion 2 &&
+    plan.origin.key == fKey && plan.origin.effort == 0 &&
+    plan.node == node 0 && plan.version == 0 &&
+    plan.fact == 0 && plan.point == 0 && plan.reason == .midpoint &&
+    plan.source.rule == fKey && plan.source.effort == 0 &&
+    plan.source.inputs == [{ node := node 0, version := 0 }]
+
+structure ScheduleResult where
+  state : State Rank
+  calls : List (String × Nat)
+  observationsExact : Bool
+
+/-! ## Retry-first schedule -/
+
+def retryFirst? : Option ScheduleResult := do
+  let state <- initial?
+  let (f0Request, state) <- request? state (.application (application 0))
+  let (f0Observation, state) <- submit? state f0Request
+  let (retryRequest, state) <- request? state (.suggestion (suggestion 0))
+  let (retryObservation, state) <- submit? state retryRequest
+  let state <- instantiate? state (suggestion 1)
+  let (firstEquality, state) <- contract? state (equality 0)
+  let (gRequest, state) <- request? state (.application (application 1))
+  let (gObservation, state) <- submit? state gRequest
+  let (lastEquality, state) <- contract? state (equality 0)
+  let (splitPlan, state) <- split? state (suggestion 2)
+  some
+    { state
+      calls :=
+        [(f0Request.action.key.name, f0Request.action.effort),
+          (retryRequest.action.key.name, retryRequest.action.effort),
+          (gRequest.action.key.name, gRequest.action.effort)]
+      observationsExact :=
+        exactInitialObservation f0Observation &&
+          exactRetryObservation retryObservation true &&
+          exactEqualityObservation firstEquality .improved
+            (some (node 2, 0, 4, 0, 1)) &&
+          exactGObservation gObservation 4 &&
+          exactEqualityObservation lastEquality .noChange none &&
+          exactSplit splitPlan }
+
+#guard
+  match retryFirst? with
+  | some result =>
+      result.state.engine.facts.toList == [0, 4, 4] &&
+        result.calls == [(fKey.name, 0), (fKey.name, 1), (gKey.name, 0)] &&
+        result.observationsExact && result.state.engine.pending.isNone &&
+        result.state.engine.metrics.requests == 3 &&
+        result.state.engine.metrics.improvements == 3 &&
+        result.state.engine.metrics.equalityRuns == 2 &&
+        result.state.engine.metrics.equalityImprovements == 1 &&
+        result.state.engine.metrics.admittedInstances == 1 &&
+        result.state.metrics.decisions == 7 &&
+        result.state.metrics.selectedInvocations == 2 &&
+        result.state.metrics.selectedRetries == 1 &&
+        result.state.metrics.selectedInstances == 1 &&
+        result.state.metrics.selectedEqualities == 2 &&
+        result.state.metrics.selectedSplits == 1 &&
+        (result.state.offers).toOption.any (fun pair => pair.1.isEmpty)
+  | none => false
+
+/-! ## Instantiation-first schedule -/
+
+def instantiateFirst? : Option ScheduleResult := do
+  let state <- initial?
+  let (f0Request, state) <- request? state (.application (application 0))
+  let (f0Observation, state) <- submit? state f0Request
+  let state <- instantiate? state (suggestion 1)
+  let (gRequest, state) <- request? state (.application (application 1))
+  let (gObservation, state) <- submit? state gRequest
+  let (firstEquality, state) <- contract? state (equality 0)
+  let (lastEquality, state) <- contract? state (equality 0)
+  let retryOffer <- state.offer? (.suggestion (suggestion 0))
+  let state <- match state.dismiss
+      { scope := state.scope
+        serial := state.serial
+        programVersion := state.engine.programVersion
+        id := .suggestion (suggestion 0)
+        expected := retryOffer.key } with
+    | .completed .dismissed next => some next
+    | _ => none
+  let (splitPlan, state) <- split? state (suggestion 2)
+  some
+    { state
+      calls :=
+        [(f0Request.action.key.name, f0Request.action.effort),
+          (gRequest.action.key.name, gRequest.action.effort)]
+      observationsExact :=
+        exactInitialObservation f0Observation &&
+          exactGObservation gObservation 0 &&
+          exactEqualityObservation firstEquality .improved
+            (some (node 1, 1, 4, 1, 2)) &&
+          exactEqualityObservation lastEquality .noChange none &&
+          exactSplit splitPlan }
+
+#guard
+  match instantiateFirst? with
+  | some result =>
+      result.state.engine.facts.toList == [0, 4, 4] &&
+        result.calls == [(fKey.name, 0), (gKey.name, 0)] &&
+        result.observationsExact && result.state.engine.pending.isNone &&
+        result.state.engine.metrics.requests == 2 &&
+        result.state.engine.metrics.improvements == 3 &&
+        result.state.engine.metrics.equalityRuns == 2 &&
+        result.state.engine.metrics.equalityImprovements == 1 &&
+        result.state.metrics.decisions == 7 &&
+        result.state.metrics.selectedInvocations == 2 &&
+        result.state.metrics.selectedRetries == 0 &&
+        result.state.metrics.selectedInstances == 1 &&
+        result.state.metrics.selectedEqualities == 2 &&
+        result.state.metrics.selectedSplits == 1 &&
+        result.state.metrics.dismissals == 1 &&
+        (result.state.offers).toOption.any (fun pair => pair.1.isEmpty)
+  | none => false
+
+/-! ## Boundary revalidation and policy resources -/
+
+def afterInitial? : Option (State Rank) := do
+  let state <- initial?
+  let (request, state) <- request? state (.application (application 0))
+  let (_, state) <- submit? state request
+  some state
+
+-- A policy cannot turn an engine-advertised effort-one retry into effort two.
+#guard
+  match afterInitial? with
+  | none => false
+  | some state =>
+      match state.offer? (.suggestion (suggestion 0)) with
+      | some { key := .retry source 1, .. } =>
+          let fabricated : Selection :=
+            { scope := state.scope
+              serial := state.serial
+              programVersion := state.engine.programVersion
+              id := .suggestion (suggestion 0)
+              expected := .retry source 2 }
+          match state.select fabricated with
+          | .rejected .wrongKey next =>
+              next.metrics.decisions == state.metrics.decisions + 1 &&
+                next.metrics.rejected == state.metrics.rejected + 1 &&
+                (next.offer? (.suggestion (suggestion 0))).isSome
+          | _ => false
+      | _ => false
+
+def staleEqualityResult? : Option (SelectResult Rank) := do
+  let state <- afterInitial?
+  let state <- instantiate? state (suggestion 1)
+  let oldOffer <- state.offer? (.equality (equality 0))
+  let (gRequest, state) <- request? state (.application (application 1))
+  let (_, state) <- submit? state gRequest
+  some <| state.select
+    { scope := state.scope
+      serial := state.serial
+      programVersion := state.engine.programVersion
+      id := .equality (equality 0)
+      expected := oldOffer.key }
+
+-- A still-dirty equality is rejected when either endpoint version has moved.
+#guard
+  match staleEqualityResult? with
+  | some (.rejected .wrongKey state) =>
+      state.metrics.rejected == 1 && state.engine.equalityQueued[0]? == some true
+  | _ => false
+
+def oneDecisionState? : Option (State Rank) :=
+  initialWith? { policyLimits with maxDecisions := 1 }
+
+-- The decision budget is independent of the engine action budget and does not
+-- charge a rejected over-budget selection a second time.
+#guard
+  match oneDecisionState? with
+  | none => false
+  | some state =>
+      match request? state (.application (application 0)) with
+      | none => false
+      | some (request, selected) =>
+          match submit? selected request with
+          | none => false
+          | some (_, submitted) =>
+              match selectOffer submitted (.suggestion (suggestion 0)) with
+              | .rejected .decisionLimit rejected =>
+                  rejected.metrics.decisions == 1 && rejected.metrics.rejected == 0 &&
+                    match rejected.view with
+                    | .error .decisionLimit => true
+                    | _ => false
+              | _ => false
+
+end Hex.Interval.PolicyConformance

--- a/conformance/HexInterval/PolicyConformance.lean
+++ b/conformance/HexInterval/PolicyConformance.lean
@@ -95,17 +95,21 @@ def policyLimits : Experiment.Propagator.Policy.Limits :=
     maxTraversal := 512
     maxLiveOffers := 32 }
 
-def initialWith? (limits : Experiment.Propagator.Policy.Limits) : Option (State Rank) := do
-  let engine <- match Engine.start rankDomain program #[fRule, gRule] #[0, 0] engineLimits with
+def initialWithLimits? (engineLimit : Experiment.Propagator.Limits)
+    (policyLimit : Experiment.Propagator.Policy.Limits) : Option (State Rank) := do
+  let engine <- match Engine.start rankDomain program #[fRule, gRule] #[0, 0] engineLimit with
     | .ok engine => some engine
     | .error _ => none
-  some (State.start engine limits)
+  some (State.start engine policyLimit)
+
+def initialWith? (limits : Experiment.Propagator.Policy.Limits) : Option (State Rank) :=
+  initialWithLimits? engineLimits limits
 
 def initial? : Option (State Rank) := initialWith? policyLimits
 
 def selectOffer (state : State Rank) (id : OfferId) : SelectResult Rank :=
   match state.offer? id with
-  | none => state.reject .missingOffer
+  | none => .rejected .missingOffer state
   | some offer =>
       state.select
         { scope := state.scope
@@ -292,7 +296,8 @@ def retryFirst? : Option ScheduleResult := do
         result.state.metrics.selectedInstances == 1 &&
         result.state.metrics.selectedEqualities == 2 &&
         result.state.metrics.selectedSplits == 1 &&
-        (result.state.offers).toOption.any (fun pair => pair.1.isEmpty)
+        result.state.epoch == result.state.metrics.decisions &&
+        (result.state.view).toOption.any (fun pair => pair.1.offers.isEmpty)
   | none => false
 
 /-! ## Instantiation-first schedule -/
@@ -346,7 +351,8 @@ def instantiateFirst? : Option ScheduleResult := do
         result.state.metrics.selectedEqualities == 2 &&
         result.state.metrics.selectedSplits == 1 &&
         result.state.metrics.dismissals == 1 &&
-        (result.state.offers).toOption.any (fun pair => pair.1.isEmpty)
+        result.state.epoch == result.state.metrics.decisions &&
+        (result.state.view).toOption.any (fun pair => pair.1.offers.isEmpty)
   | none => false
 
 /-! ## Boundary revalidation and policy resources -/
@@ -356,6 +362,17 @@ def afterInitial? : Option (State Rank) := do
   let (request, state) <- request? state (.application (application 0))
   let (_, state) <- submit? state request
   some state
+
+def afterReplyWith? (engineLimit : Experiment.Propagator.Limits)
+    (reply : RuleRequest Rank -> Outcome Rank) : Option (State Rank) := do
+  let state <- initialWithLimits? engineLimit policyLimits
+  let (request, state) <- request? state (.application (application 0))
+  match state.submit (request.action.reply (reply request)) with
+  | .accepted _ next => some next
+  | _ => none
+
+def afterInitialWith? (engineLimit : Experiment.Propagator.Limits) : Option (State Rank) :=
+  afterReplyWith? engineLimit invoke
 
 -- A policy cannot turn an engine-advertised effort-one retry into effort two.
 #guard
@@ -374,7 +391,10 @@ def afterInitial? : Option (State Rank) := do
           | .rejected .wrongKey next =>
               next.metrics.decisions == state.metrics.decisions + 1 &&
                 next.metrics.rejected == state.metrics.rejected + 1 &&
-                (next.offer? (.suggestion (suggestion 0))).isSome
+                next.epoch == next.metrics.decisions &&
+                match next.offer? (.suggestion (suggestion 0)) with
+                | some retry => retry.age == 1
+                | none => false
           | _ => false
       | _ => false
 
@@ -422,5 +442,263 @@ def oneDecisionState? : Option (State Rank) :=
                     | .ok (view, _) => !view.offers.isEmpty
                     | _ => false
               | _ => false
+
+/-! ## Resource preservation and exact equality observations -/
+
+def retainedEngineWith? (limits : Experiment.Propagator.Limits) : Option (Engine Rank) := do
+  let engine <- match Engine.start rankDomain program #[fRule, gRule] #[0, 0] limits with
+    | .ok engine => some engine
+    | .error _ => none
+  match engine.poll with
+  | .request request awaiting =>
+      match awaiting.submit (request.action.reply (invoke request)) with
+      | .accepted next => some next
+      | _ => none
+  | _ => none
+
+def equalityReadyWith? (limits : Experiment.Propagator.Limits)
+    (domain : FactDomain Rank) : Option (State Rank) := do
+  let engine <- retainedEngineWith? limits
+  let state := State.start { engine with factDomain := domain } policyLimits
+  instantiate? state (suggestion 1)
+
+def rightResourceDomain : FactDomain Rank where
+  top _ := 0
+  narrow _ current candidate :=
+    if current < candidate then .resourceLimit 77 else .noChange
+
+def leftMalformedDomain : FactDomain Rank where
+  top _ := 0
+  narrow _ current candidate :=
+    if candidate < current then .malformed 91 else .noChange
+
+-- Exhausting the accepted-fact budget reports a typed equality observation,
+-- charges no engine action, and leaves the equality live for a later run.
+#guard
+  match equalityReadyWith? { engineLimits with maxAcceptedFacts := 1 } rankDomain with
+  | none => false
+  | some state =>
+      let beforePops := state.engine.metrics.queuePops
+      let beforeRuns := state.engine.metrics.equalityRuns
+      match selectOffer state (.equality (equality 0)) with
+      | .equality observation next =>
+          observation.outcome == .engineResource .acceptedFacts &&
+            observation.narrowCalls == 2 && observation.changes.isEmpty &&
+            next.engine.metrics.queuePops == beforePops &&
+            next.engine.metrics.equalityRuns == beforeRuns &&
+            next.engine.equalityQueued[0]? == some true &&
+            (next.offer? (.equality (equality 0))).isSome
+      | _ => false
+
+-- A fact-domain resource stop after the second endpoint call is likewise
+-- observed exactly and does not destroy the live contractor.
+#guard
+  match equalityReadyWith? engineLimits rightResourceDomain with
+  | none => false
+  | some state =>
+      match selectOffer state (.equality (equality 0)) with
+      | .equality observation next =>
+          observation.outcome == .factResource 77 && observation.narrowCalls == 2 &&
+            observation.changes.isEmpty && next.engine.equalityQueued[0]? == some true &&
+            (next.offer? (.equality (equality 0))).isSome
+      | _ => false
+
+-- Malformation on the first endpoint records one actual call rather than a
+-- fabricated zero or two.
+#guard
+  match equalityReadyWith? engineLimits leftMalformedDomain with
+  | none => false
+  | some state =>
+      match selectOffer state (.equality (equality 0)) with
+      | .equality observation next =>
+          observation.outcome == .invalid (.malformedFact 91) &&
+            observation.narrowCalls == 1 && observation.changes.isEmpty &&
+            next.engine.equalityQueued[0]? == some true
+      | _ => false
+
+/-! ## Proposal lifetime and program extension -/
+
+def proposedGAt (input : NodeId) : ProposedNode :=
+  { domain := real, op := { index := 2 }, args := [.existing input] }
+
+def instantiateAt (family : Nat) (input : NodeId) : InstantiationRequest :=
+  { key := family
+    triggers := [input]
+    claimedGeneration := 1
+    nodes := [proposedGAt input]
+    equalities := []
+    payload := { index := family } }
+
+def twoInstances (request : RuleRequest Rank) : Outcome Rank :=
+  .success [candidate request 1]
+    [.instantiate (instantiateAt 101 (node 0)),
+      .instantiate (instantiateAt 102 (node 1))]
+    {}
+
+def twoInstancesFinal? : Option (State Rank) := do
+  let state <- afterReplyWith? engineLimits twoInstances
+  let first <- match selectOffer state (.suggestion (suggestion 0)) with
+    | .completed (.instanceAdmitted [fresh]) next =>
+        if fresh == node 2 then some next else none
+    | _ => none
+  let secondOffer <- first.offer? (.suggestion (suggestion 1))
+  match secondOffer.key with
+  | .instantiate _ semantic =>
+      if semantic.generation != 1 then none else pure ()
+  | _ => none
+  match selectOffer first (.suggestion (suggestion 1)) with
+  | .completed (.instanceAdmitted [fresh]) next =>
+      if fresh == node 3 then some next else none
+  | _ => none
+
+-- Admitting one append-only extension does not tombstone an independent
+-- retained instantiation from the same still-fresh source invocation.
+#guard
+  match twoInstancesFinal? with
+  | some state =>
+      state.engine.programVersion == 2 && state.engine.program.nodes.size == 4 &&
+        state.engine.instanceHistory.size == 2 && state.metrics.selectedInstances == 2
+  | none => false
+
+def emptyInstance (request : RuleRequest Rank) : Outcome Rank :=
+  .success [candidate request 1]
+    [.instantiate
+      { key := 107
+        triggers := [request.action.node]
+        claimedGeneration := 1
+        nodes := []
+        equalities := []
+        payload := { index := 109 } }]
+    {}
+
+-- A structurally valid instantiation with no new node or equality is a
+-- duplicate: it consumes no instance slot and does not bump programVersion.
+#guard
+  match afterReplyWith?
+      { engineLimits with maxInstances := 0, maxGeneration := 0 } emptyInstance with
+  | none => false
+  | some state =>
+      match selectOffer state (.suggestion (suggestion 0)) with
+      | .completed .instanceDuplicate next =>
+          next.engine.programVersion == 0 && next.engine.instances.isEmpty &&
+            next.engine.instanceHistory.isEmpty &&
+            next.engine.metrics.duplicateInstances == 1
+      | _ => false
+
+def wrongGeneration (request : RuleRequest Rank) : Outcome Rank :=
+  let proposal := { instantiateAt 113 (node 0) with claimedGeneration := 99 }
+  .success [candidate request 1] [.instantiate proposal] {}
+
+-- The policy key exposes the engine-computed generation, and a proposal whose
+-- untrusted claim disagrees is never advertised as selectable work.
+#guard
+  match afterInitial? with
+  | some state =>
+      match state.offer? (.suggestion (suggestion 1)) with
+      | some { key := .instantiate _ semantic, .. } => semantic.generation == 1
+      | _ => false
+  | none => false
+
+#guard
+  match afterReplyWith? engineLimits wrongGeneration with
+  | some state =>
+      state.engine.suggestions.size == 1 &&
+        (state.offer? (.suggestion (suggestion 0))).isNone
+  | none => false
+
+def splitChangedTarget (request : RuleRequest Rank) : Outcome Rank :=
+  .success [candidate request 1]
+    [.split { node := request.action.node, point := 0, reason := .midpoint }]
+    {}
+
+-- The split guard is captured before candidates from the same reply commit.
+-- Starting or advancing policy control cannot launder version zero into the
+-- improved target's version one.
+#guard
+  match afterReplyWith? engineLimits splitChangedTarget with
+  | some state =>
+      match state.engine.suggestions[0]? with
+      | some retained =>
+          retained.splitVersion == some 0 && state.engine.versions[1]? == some 1 &&
+            (state.offer? (.suggestion (suggestion 0))).isNone
+      | none => false
+  | none => false
+
+/-! ## Rejections, completeness, clocks, and policy-visible budgets -/
+
+-- An action-limit rejection cannot consume the retry it failed to prepare.
+#guard
+  match afterInitialWith? { engineLimits with maxActions := 1 } with
+  | some state =>
+      match selectOffer state (.suggestion (suggestion 0)) with
+      | .rejected .actionLimit next =>
+          (next.offer? (.suggestion (suggestion 0))).isSome &&
+            next.metrics.selectedRetries == 0 && next.metrics.rejected == 1
+      | _ => false
+  | none => false
+
+-- A resource stop while admitting an instantiation is not a verdict on the
+-- proposal, so the offer remains available.
+#guard
+  match afterInitialWith? { engineLimits with maxInstances := 0 } with
+  | some state =>
+      match selectOffer state (.suggestion (suggestion 1)) with
+      | .engineResource .instances next =>
+          (next.offer? (.suggestion (suggestion 1))).isSome &&
+            next.metrics.selectedInstances == 1
+      | _ => false
+  | none => false
+
+-- Dismissing required propagation is visible in the bounded view; an empty
+-- frontier cannot then be mistaken for a proved fixed point.
+#guard
+  match initial? with
+  | some state =>
+      match state.offer? (.application (application 0)) with
+      | some offer =>
+          match state.dismiss
+              { scope := state.scope
+                serial := state.serial
+                programVersion := state.engine.programVersion
+                id := offer.id
+                expected := offer.key } with
+          | .completed .dismissed next =>
+              match next.view with
+              | .ok (view, _) => view.offers.isEmpty && view.incomplete
+              | _ => false
+          | _ => false
+      | none => false
+  | none => false
+
+-- The policy sees every structural budget that can reject its next
+-- instantiation, not only facts and node counts.
+#guard
+  match afterInitial? with
+  | some state =>
+      match state.view with
+      | .ok (view, _) =>
+          view.remaining.actions == 31 && view.remaining.acceptedFacts == 31 &&
+            view.remaining.nodes == 6 && view.remaining.applications == 15 &&
+            view.remaining.equalities == 8 && view.remaining.retainedSuggestions == 13 &&
+            view.remaining.instances == 8 && view.remaining.queueEntries == 63 &&
+            view.remaining.generation == 4
+      | _ => false
+  | none => false
+
+#guard
+  match initialWith? { policyLimits with maxTraversal := 0 } with
+  | some state =>
+      match state.view with
+      | .error .traversalLimit => true
+      | _ => false
+  | none => false
+
+#guard
+  match initialWith? { policyLimits with maxLiveOffers := 0 } with
+  | some state =>
+      match state.view with
+      | .error .liveOfferLimit => true
+      | _ => false
+  | none => false
 
 end Hex.Interval.PolicyConformance

--- a/conformance/HexInterval/PolicyConformance.lean
+++ b/conformance/HexInterval/PolicyConformance.lean
@@ -402,7 +402,9 @@ def oneDecisionState? : Option (State Rank) :=
   initialWith? { policyLimits with maxDecisions := 1 }
 
 -- The decision budget is independent of the engine action budget and does not
--- charge a rejected over-budget selection a second time.
+-- charge a rejected over-budget selection a second time.  A post-decision
+-- view remains available under its separate traversal budget, so a driver can
+-- distinguish saturation from live work it no longer has permission to run.
 #guard
   match oneDecisionState? with
   | none => false
@@ -417,7 +419,7 @@ def oneDecisionState? : Option (State Rank) :=
               | .rejected .decisionLimit rejected =>
                   rejected.metrics.decisions == 1 && rejected.metrics.rejected == 0 &&
                     match rejected.view with
-                    | .error .decisionLimit => true
+                    | .ok (view, _) => !view.offers.isEmpty
                     | _ => false
               | _ => false
 

--- a/conformance/HexInterval/PolicyFrontierConformance.lean
+++ b/conformance/HexInterval/PolicyFrontierConformance.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexInterval.Experiment.PolicyFrontier
+
+/-!
+Small merge-gated equivalence canaries for the two policy-frontier
+representations.  The fixtures use only opaque arbitrary propagators; no test
+depends on rational arithmetic.
+-/
+
+namespace Hex.Interval.PolicyFrontierConformance
+
+open Experiment.Propagator
+open Experiment.Propagator.PolicyFrontier
+
+def fanout : Comparison := compare fanoutCanary
+
+def dense : Comparison := compare denseCanary
+
+def churn : Comparison := compare churnCanary
+
+#guard comparisonValid fanoutCanary fanout
+
+#guard comparisonValid denseCanary dense
+
+#guard comparisonValid churnCanary churn
+
+-- Both arms implement a maximum-priority policy rather than following the
+-- engine queue cursor in FIFO order.
+#guard nonFifoChoice fanoutCanary fanout.scan
+
+#guard nonFifoChoice fanoutCanary fanout.indexed
+
+-- The SPEC's small-fixture numbers are exact deterministic counts, not
+-- remembered console output.
+#guard fanout.scan.work.total == 267
+
+#guard fanout.indexed.work.total == 242
+
+#guard fanout.scan.work.clockSyncSlots == 112
+
+#guard fanout.scan.work.suggestionPruneSlots == 14
+
+-- The dense fixture changes four roots at once.  Five sink applications are
+-- inserted once and the remaining fifteen watcher visits are coalesced, but
+-- both kinds of dependency work remain in the accounting.
+#guard dense.scan.work.dependencyVisits == 20
+
+#guard dense.indexed.work.dependencyVisits == 20
+
+#guard dense.scan.suppressedInsertions == 15
+
+#guard dense.indexed.suppressedInsertions == 15
+
+#guard dense.scan.work.total == 277
+
+#guard dense.indexed.work.total == 250
+
+-- Five sink events and fifteen newly retained split-suggestion events are the
+-- exact suffix consumed by the maintained index in the churn fixture.
+#guard churn.indexed.work.eventVisits == 20
+
+#guard churn.scan.work.total == 1267
+
+#guard churn.indexed.work.total == 754
+
+#guard churn.scan.work.frontierSlots == 424
+
+#guard churn.indexed.work.frontierSlots == 7
+
+-- Historical tombstones remain backing slots.  Consequently the complete
+-- scan does strictly more frontier traversal than the maintained adapter once
+-- suggestion churn begins; the shared clock/prune cost is compared separately.
+#guard churn.scan.work.frontierSlots > churn.indexed.work.frontierSlots
+
+#guard churn.scan.work.clockSyncSlots == churn.indexed.work.clockSyncSlots
+
+#guard churn.scan.work.suggestionPruneSlots == churn.indexed.work.suggestionPruneSlots
+
+end Hex.Interval.PolicyFrontierConformance

--- a/conformance/HexInterval/PropagatorConformance.lean
+++ b/conformance/HexInterval/PropagatorConformance.lean
@@ -518,7 +518,9 @@ def ladderFinal? : Option (RunResult Rank (List String)) := do
               equalities := []
               payload := { index := 101 } }
           match first.state.admitRetained
-              { action := retained.action, suggestion := .instantiate proposal } with
+              { action := retained.action
+                suggestion := .instantiate proposal
+                splitVersion := none } with
           | .invalid (.generationMismatch 1 2) state =>
               state.programVersion == 1 && state.program.nodes.size == 3 &&
                 state.generations.toList == [0, 0, 1]
@@ -669,7 +671,7 @@ def pairReuseAdmitted? : Option (Engine PairRank) := do
       payload := { index := 109 } }
   let action := { retained.action with programVersion := state.programVersion }
   match state.admitRetained
-      { action, suggestion := .instantiate proposal } with
+      { action, suggestion := .instantiate proposal, splitVersion := none } with
   | .admitted [newNode] next => if newNode == node 3 then some next else none
   | _ => none
 
@@ -709,8 +711,9 @@ def pairReuseAdmitted? : Option (Engine PairRank) := do
         | _, _ => false
   | none => false
 
--- A differently labelled request whose complete structural effect already
--- exists is a no-op: it consumes neither a snapshot nor an instance slot.
+-- A differently labelled request from the same engine-owned invocation whose
+-- complete structural effect already exists is a no-op: an untrusted request
+-- label cannot manufacture a new family, snapshot, or instance slot.
 #guard
   match pairAdmitted? with
   | some state =>
@@ -726,12 +729,12 @@ def pairReuseAdmitted? : Option (Engine PairRank) := do
                    right := .existing (node 1)
                    payload := { index := 127 } }]
               payload := { index := 131 } }
-          let otherAction :=
-            { retained.action with
-              programVersion := state.programVersion
-              key := { name := "shape.other-no-op" } }
+          let currentAction :=
+            { retained.action with programVersion := state.programVersion }
           match state.admitRetained
-              { action := otherAction, suggestion := .instantiate proposal } with
+              { action := currentAction
+                suggestion := .instantiate proposal
+                splitVersion := none } with
           | .duplicate next =>
               next.programVersion == 1 && next.instances.length == 1 &&
                 next.instanceHistory.size == 1 && next.equalities.size == 1
@@ -748,7 +751,7 @@ def pairReuseAdmitted? : Option (Engine PairRank) := do
       | some edge =>
           let pending := { state with pending := some edge.origin }
           match pending.contractEquality { index := 0 } with
-          | .invalid 3 next =>
+          | .invalid .pendingReply 0 next =>
               next.pending.isSome && next.facts == pending.facts &&
                 next.versions == pending.versions && next.history.isEmpty
           | _ => false
@@ -988,7 +991,7 @@ def firstChainRequest? : Option (RuleRequest Rank × Engine Rank) := do
   | some (request, awaiting) =>
       match awaiting.submit (request.action.reply
           (.success [] [.retry (generous.maxEffort + 1)] {})) with
-      | .invalid .oversizedProposal state =>
+      | .invalid .oversizedEffort state =>
           state.pending.isNone && state.history.isEmpty && state.suggestions.isEmpty
       | _ => false
   | none => false

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -212,7 +212,8 @@ lean_lib HexGF2BenchSupport where
 lean_lib HexIntervalExperiment where
   globs := #[`HexInterval.Experiment.Representation,
     `HexInterval.Experiment.Rational, `HexInterval.Experiment.Center,
-    `HexInterval.Experiment.Scale, `HexInterval.Experiment.Propagator]
+    `HexInterval.Experiment.Scale, `HexInterval.Experiment.Propagator,
+    `HexInterval.Experiment.Policy]
 
 lean_lib HexIntervalMathlibExperiment where
   globs := #[`HexIntervalMathlib.Experiment.Center]
@@ -246,7 +247,7 @@ lean_lib HexIntervalMathlibReplayProbe where
 -- `*_emit_fixtures` exes below, carrying `srcDir := "conformance"`.
 lean_lib HexConformance where
   srcDir := "conformance"
-  globs := #[`HexArith.Conformance, `HexArith.CrossCheck, `HexBerlekamp.Conformance, `HexBerlekampZassenhaus.Conformance, `HexBerlekampZassenhaus.CrossCheck, `HexConway.Conformance, `HexGF2.Conformance, `HexGF2.CrossCheck, `HexGF2.FastCheck, `HexGFq.Conformance, `HexGFq.CrossCheck, `HexGFqField.Conformance, `HexGFqRing.Conformance, `HexGramSchmidt.Conformance, `HexHensel.Conformance, `HexHensel.CrossCheck, `HexInterval.Conformance, `HexInterval.CenterConformance, `HexInterval.ScaleConformance, `HexInterval.PropagatorConformance, `HexLLL.Conformance, `HexMatrix.Conformance, `HexRowReduce.Conformance, `HexDeterminant.Conformance, `HexBareiss.Conformance, `HexModArith.Conformance, `HexModArith.FastCheck, `HexPoly.Conformance, `HexPolyFp.Conformance, `HexPolyZ.Conformance, `HexRealRoots.Conformance, `HexRealRootsMathlib.Conformance, `HexRoots.Conformance].map Glob.one
+  globs := #[`HexArith.Conformance, `HexArith.CrossCheck, `HexBerlekamp.Conformance, `HexBerlekampZassenhaus.Conformance, `HexBerlekampZassenhaus.CrossCheck, `HexConway.Conformance, `HexGF2.Conformance, `HexGF2.CrossCheck, `HexGF2.FastCheck, `HexGFq.Conformance, `HexGFq.CrossCheck, `HexGFqField.Conformance, `HexGFqRing.Conformance, `HexGramSchmidt.Conformance, `HexHensel.Conformance, `HexHensel.CrossCheck, `HexInterval.Conformance, `HexInterval.CenterConformance, `HexInterval.ScaleConformance, `HexInterval.PropagatorConformance, `HexInterval.PolicyConformance, `HexLLL.Conformance, `HexMatrix.Conformance, `HexRowReduce.Conformance, `HexDeterminant.Conformance, `HexBareiss.Conformance, `HexModArith.Conformance, `HexModArith.FastCheck, `HexPoly.Conformance, `HexPolyFp.Conformance, `HexPolyZ.Conformance, `HexRealRoots.Conformance, `HexRealRootsMathlib.Conformance, `HexRoots.Conformance].map Glob.one
 
 -- Public umbrellas intentionally contain only the supported API. Executable
 -- examples and regression tests are compiled through this separate target so
@@ -362,6 +363,10 @@ lean_exe hex_interval_scale_spike where
 lean_exe hex_interval_scheduler_spike where
   srcDir := "bench"
   root := `HexInterval.IntervalSchedulerSpike
+
+lean_exe hex_interval_policy_frontier_spike where
+  srcDir := "bench"
+  root := `HexInterval.IntervalPolicyFrontierSpike
 
 lean_exe hexbz_factor_service where
   srcDir := "bench"

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -213,7 +213,7 @@ lean_lib HexIntervalExperiment where
   globs := #[`HexInterval.Experiment.Representation,
     `HexInterval.Experiment.Rational, `HexInterval.Experiment.Center,
     `HexInterval.Experiment.Scale, `HexInterval.Experiment.Propagator,
-    `HexInterval.Experiment.Policy]
+    `HexInterval.Experiment.Policy, `HexInterval.Experiment.PolicyFrontier]
 
 lean_lib HexIntervalMathlibExperiment where
   globs := #[`HexIntervalMathlib.Experiment.Center]
@@ -247,7 +247,7 @@ lean_lib HexIntervalMathlibReplayProbe where
 -- `*_emit_fixtures` exes below, carrying `srcDir := "conformance"`.
 lean_lib HexConformance where
   srcDir := "conformance"
-  globs := #[`HexArith.Conformance, `HexArith.CrossCheck, `HexBerlekamp.Conformance, `HexBerlekampZassenhaus.Conformance, `HexBerlekampZassenhaus.CrossCheck, `HexConway.Conformance, `HexGF2.Conformance, `HexGF2.CrossCheck, `HexGF2.FastCheck, `HexGFq.Conformance, `HexGFq.CrossCheck, `HexGFqField.Conformance, `HexGFqRing.Conformance, `HexGramSchmidt.Conformance, `HexHensel.Conformance, `HexHensel.CrossCheck, `HexInterval.Conformance, `HexInterval.CenterConformance, `HexInterval.ScaleConformance, `HexInterval.PropagatorConformance, `HexInterval.PolicyConformance, `HexLLL.Conformance, `HexMatrix.Conformance, `HexRowReduce.Conformance, `HexDeterminant.Conformance, `HexBareiss.Conformance, `HexModArith.Conformance, `HexModArith.FastCheck, `HexPoly.Conformance, `HexPolyFp.Conformance, `HexPolyZ.Conformance, `HexRealRoots.Conformance, `HexRealRootsMathlib.Conformance, `HexRoots.Conformance].map Glob.one
+  globs := #[`HexArith.Conformance, `HexArith.CrossCheck, `HexBerlekamp.Conformance, `HexBerlekampZassenhaus.Conformance, `HexBerlekampZassenhaus.CrossCheck, `HexConway.Conformance, `HexGF2.Conformance, `HexGF2.CrossCheck, `HexGF2.FastCheck, `HexGFq.Conformance, `HexGFq.CrossCheck, `HexGFqField.Conformance, `HexGFqRing.Conformance, `HexGramSchmidt.Conformance, `HexHensel.Conformance, `HexHensel.CrossCheck, `HexInterval.Conformance, `HexInterval.CenterConformance, `HexInterval.ScaleConformance, `HexInterval.PropagatorConformance, `HexInterval.PolicyConformance, `HexInterval.PolicyFrontierConformance, `HexLLL.Conformance, `HexMatrix.Conformance, `HexRowReduce.Conformance, `HexDeterminant.Conformance, `HexBareiss.Conformance, `HexModArith.Conformance, `HexModArith.FastCheck, `HexPoly.Conformance, `HexPolyFp.Conformance, `HexPolyZ.Conformance, `HexRealRoots.Conformance, `HexRealRootsMathlib.Conformance, `HexRoots.Conformance].map Glob.one
 
 -- Public umbrellas intentionally contain only the supported API. Executable
 -- examples and regression tests are compiled through this separate target so

--- a/progress/20260727T131855Z.md
+++ b/progress/20260727T131855Z.md
@@ -1,0 +1,47 @@
+# Engine-owned policy frontier
+
+## Accomplished
+
+- Added a bounded policy control plane over the arbitrary-function propagator
+  engine. Policies see semantic invocation, equality, retry, instantiation,
+  and split offers, but every selected identity and complete key is rechecked
+  before the engine creates an action or changes state.
+- Added exact rule and equality observations, post-admission fact deltas,
+  retained-suggestion guards, cumulative traversal and decision budgets,
+  dismissal/incompleteness tracking, and resource-checked split plans.
+- Added two opaque-function schedules which reach the same final facts. The
+  retry-first schedule makes three registry calls; the instantiation-first
+  schedule makes two and obtains the missing fact through an admitted alternate
+  expression and equality contraction.
+- Added negative conformance for fabricated retry effort, stale equality keys,
+  pending-reply/equality interleaving, effort and observation bounds, and
+  one-step-short policy decisions.
+- Made instantiation identity include canonical unordered equality endpoint
+  pairs, validated append-only application-prefix stability, and retained the
+  exact state-membership proof for the structural-admission entry point.
+- Added a scan-versus-event frontier benchmark. Four disconnected depth-eight
+  chains require 288 complete-scan visits versus 8 dependency-event visits,
+  with identical calls, improvements, final facts, and checksum.
+- Updated the SPEC with the policy observations, freshness and age semantics,
+  resource boundaries, exclusive policy-control rule, and evidence favoring an
+  event-indexed production frontier while keeping the scan as an oracle.
+- Passed the focused conformance targets, both interval scheduler executables,
+  repository structural lints, and a combined 9,109-job Lake build.
+
+## Current frontier
+
+The engine-owned scan frontier and validated selection boundary are executable.
+The next layer is the external driver with arbitrary policy-private state, a
+single ordered event stream, and pinned reference/staged/replay policies.
+
+## Next step
+
+Open this work as a stacked draft PR, obtain an asynchronous Opus review, then
+implement the external policy driver and compare event-indexed staged and replay
+policies on the same semantic traces.
+
+## Blockers
+
+The stacked PR depends on the generic propagator framework PR. Opus reviewed
+that base as safe after two required fixes; those fixes are being applied and
+revalidated before the base PR is merged.

--- a/progress/20260727T135120Z.md
+++ b/progress/20260727T135120Z.md
@@ -1,0 +1,52 @@
+# Policy-frontier representation evidence
+
+## Accomplished
+
+- Replaced the FIFO queue-cursor spike with a maintained binary
+  maximum-priority frontier and an independent complete-scan reference.
+- Built every fixture to a fixed point through the public engine
+  request/reply API; the experiment no longer patches facts, versions, queue
+  bits, or metrics by hand.
+- Added fan-out, dense multi-output wake, and retained-suggestion churn
+  workloads over opaque arbitrary propagators.
+- Accounted separately for complete-view slots and output writes, clock-array
+  synchronization, suggestion pruning, variable-length semantic-key inputs,
+  dependency visits including suppressed insertions, event consumption,
+  semantic rechecks, priority comparisons, and heap moves.
+- Added merge-gated semantic and choice-trace equivalence canaries, exact
+  logical-count canaries, a compiled `canary` driver, and existing-single-job
+  CI wiring.
+- Corrected the SPEC: the old `288` versus `8` counter omitted dominant shared
+  work and does not settle the production representation.
+- Built `HexIntervalExperiment`, `HexConformance`, and the compiled frontier
+  spike together (9,109 jobs), ran the three compiled canaries, and passed all
+  structural, trust-surface, phase-4, Mathlib-free-bench, and conformance-target
+  lints.
+
+## Current frontier
+
+The merge-gated small fixtures report scan/index aggregate logical touches of
+`267/242` for six-way fan-out, `277/250` for a four-by-five dense wake, and
+`1267/754` for five sinks emitting three disposable suggestions each. The
+dense case records all 20 watcher visits (5 insertions plus 15 suppressed
+duplicates). The churn case records 424 complete-scan backing-slot visits
+versus one seven-slot index seed and 20 appended events. Both representations
+produce identical non-FIFO choice traces, facts, versions, history lengths,
+decisions, calls, improvements, queue metrics, dismissals, and checksums.
+
+## Next step
+
+Keep the complete scan as a differential oracle. Before choosing an indexed
+production frontier, implement clock/suggestion synchronization incrementally
+at the engine boundary, then compare larger traces and scientific wall-clock
+measurements through the shared benchmark harness. Extend the representation
+experiment to equality and instantiation offers when those transition streams
+stabilize.
+
+## Blockers
+
+None. The current heap deliberately uses a class-and-engine-id priority, so it
+does not test policies whose score changes with age or semantic-key contents.
+The deterministic aggregate adds unlike logical columns only as a checksum;
+it is not a wall-time model. Setup and the uncharged post-run oracle scan are
+excluded equally from both arms.

--- a/progress/20260727T135308Z.md
+++ b/progress/20260727T135308Z.md
@@ -1,0 +1,38 @@
+# Policy transition correctness
+
+## Accomplished
+
+- Preserved equality, retry, and instantiation work when a selected transition
+  cannot proceed because of a resource limit.
+- Made equality observations cover successful, invalid, and resource outcomes
+  with the exact number of domain-narrowing calls.
+- Captured split target versions when suggestions are produced and allowed
+  structurally valid instantiations to survive unrelated append-only program
+  extensions.
+- Used engine-computed instantiation generation in policy keys and treated
+  structurally empty proposals as duplicates without consuming resources.
+- Hid construction and mutation of policy-managed state behind validated
+  transitions, exposed incompleteness and complete remaining-budget data, and
+  centralized one-clock-tick decision accounting.
+- Replaced numeric equality faults and overloaded retry errors with typed
+  results and added focused conformance for resource rollback, freshness,
+  generation, dismissal, age, and view limits.
+- Built the focused policy/propagator targets and the complete interval
+  experiment/conformance aggregate successfully.
+
+## Current frontier
+
+The policy layer now preserves live mathematical work across failed attempts
+and reports every selectable equality transition. The corrected frontier
+representation experiment is present in the same worktree and independently
+validated.
+
+## Next step
+
+Commit the combined correctness and benchmark response, rebase it onto the
+hardened propagator framework, rerun the complete validation, and obtain a
+fresh independent review before merging the policy PR.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Summary

Adds the first replaceable policy layer for the function-agnostic propagator host.

- presents engine-owned offers for arbitrary propagator calls, equality contraction, retries, structural instantiation, and split preparation
- lets a policy choose among those offers without granting it authority to construct actions or mutate facts
- revalidates the selected identity, versions, dependencies, guards, and budgets before every transition
- preserves dirty equality work across policy resource limits and records its exact fact changes
- captures split guards when a suggestion is produced and keeps structural admission engine-owned
- keeps the policy state opaque and exposes bounded views and transitions

## Why

Search order must be flexible and upgradeable without tying the engine to rational arithmetic or any particular function. The engine remains responsible for sound state changes; policies affect only which valid operation is tried next.

## Evidence

The opaque-function conformance fixture compares retry-first and instantiation-first schedules. Both reach the same final facts, while the instantiation-first path can use an admitted alternate expression and equality propagation instead of a stronger retry.

The corrected frontier experiment compares a complete scan with an actually maintained binary heap under a non-FIFO policy. It checks identical choices and semantic state on fan-out, dense wake, and suggestion-churn workloads. Aggregate logical work is scan/heap 267/242, 277/250, and 1267/754. The experiment does not claim that a heap is already the production answer: clock reconstruction and suggestion pruning remain shared dominant costs, and equality/instantiation workloads plus timing evidence are still open.

## Validation

- `lake build HexInterval.PropagatorConformance HexInterval.PolicyConformance HexInterval.PolicyFrontierConformance hex_interval_policy_frontier_spike`
- `lake build HexIntervalExperiment HexConformance hex_interval_scheduler_spike hex_interval_policy_frontier_spike` (9,112 jobs)
- three-workload frontier canary
- repository copyright, DAG, release-manifest, trust-surface, phase, conformance-target, and Mathlib-free bench checks
- no `native_decide`, axioms, or sorries