### PR TITLE
Add external interval policy driver

### DIFF
--- a/HexInterval/Experiment/Policy.lean
+++ b/HexInterval/Experiment/Policy.lean
@@ -287,11 +287,6 @@ def State.suggestionKey? (state : State Fact) (suggestionId : SuggestionId) : Op
           state.engine.limits.splitEndpointLimit then none else pure ()
       some (.split source { node := request.node, version } request.point request.reason)
 
-/-- Whether losing a retained suggestion can leave propagation unfinished. -/
-def affectsClosure : Suggestion -> Bool
-  | .retry _ | .instantiate _ => true
-  | .split _ => false
-
 /-- Permanently tombstone suggestions whose freshness guard has failed.
 Dropping a retry or instantiation also records that fixed-point completeness
 is no longer available; a stale split affects search only. -/
@@ -305,7 +300,7 @@ private def pruneSuggestions (state : State Fact) : State Fact := Id.run do
           clocks := clocks.set! index { clock with active := false }
           match state.engine.suggestions[index]? with
           | some retained =>
-              if affectsClosure retained.suggestion then incomplete := true
+              if retained.suggestion.affectsClosure then incomplete := true
           | none => pure ()
     | none => pure ()
   return { state with suggestions := clocks, incomplete }
@@ -801,8 +796,7 @@ prefix will discard.  This must run against the pre-reply engine because the
 dropped suffix is intentionally absent from the accepted snapshot. -/
 def droppedAffectsClosure (state : Engine Fact) : Outcome Fact -> Bool
   | .success _ suggestions _ =>
-      let room := state.limits.maxRetainedSuggestions - state.suggestions.size
-      (suggestions.drop room).any affectsClosure
+      (state.droppedSuggestions suggestions).any Suggestion.affectsClosure
   | .noChange _ | .inapplicable | .resourceLimit _ | .failed _ => false
 
 inductive SubmitResult (Fact : Type) where

--- a/HexInterval/Experiment/Policy.lean
+++ b/HexInterval/Experiment/Policy.lean
@@ -195,18 +195,6 @@ def suggestionClocksFrom (engine : Engine Fact) (born : Nat) : Array SuggestionC
   engine.suggestions.map fun retained =>
     { active := true, born, splitVersion := retained.splitVersion }
 
-/-- Begin policy control over an existing engine snapshot. -/
-opaque State.start (engine : Engine Fact) (limits : Limits)
-    (scope : ScopeId := { index := 0 }) : State Fact :=
-  { scope
-    serial := 0
-    epoch := 0
-    engine
-    applications := clockArray engine.queued 0
-    equalities := clockArray engine.equalityQueued 0
-    suggestions := suggestionClocksFrom engine 0
-    limits }
-
 def syncClocks (epoch : Nat) (old : Array Clock) (bits : Array Bool) : Array Clock := Id.run do
   let mut clocks := #[]
   for index in [0:bits.size] do
@@ -299,16 +287,43 @@ def State.suggestionKey? (state : State Fact) (suggestionId : SuggestionId) : Op
           state.engine.limits.splitEndpointLimit then none else pure ()
       some (.split source { node := request.node, version } request.point request.reason)
 
-/-- Permanently tombstone suggestions whose freshness guard has failed. -/
+/-- Whether losing a retained suggestion can leave propagation unfinished. -/
+def affectsClosure : Suggestion -> Bool
+  | .retry _ | .instantiate _ => true
+  | .split _ => false
+
+/-- Permanently tombstone suggestions whose freshness guard has failed.
+Dropping a retry or instantiation also records that fixed-point completeness
+is no longer available; a stale split affects search only. -/
 private def pruneSuggestions (state : State Fact) : State Fact := Id.run do
   let mut clocks := state.suggestions
+  let mut incomplete := state.incomplete
   for index in [0:clocks.size] do
     match clocks[index]? with
     | some clock =>
         if clock.active && (state.suggestionKey? { index }).isNone then
           clocks := clocks.set! index { clock with active := false }
+          match state.engine.suggestions[index]? with
+          | some retained =>
+              if affectsClosure retained.suggestion then incomplete := true
+          | none => pure ()
     | none => pure ()
-  return { state with suggestions := clocks }
+  return { state with suggestions := clocks, incomplete }
+
+/-- Begin policy control over an existing engine snapshot.  Invalid retained
+retry and instantiation suggestions are accounted for before the first view,
+so adopting a snapshot cannot manufacture a false fixed point. -/
+opaque State.start (engine : Engine Fact) (limits : Limits)
+    (scope : ScopeId := { index := 0 }) : State Fact :=
+  pruneSuggestions
+    { scope
+      serial := 0
+      epoch := 0
+      engine
+      applications := clockArray engine.queued 0
+      equalities := clockArray engine.equalityQueued 0
+      suggestions := suggestionClocksFrom engine 0
+      limits }
 
 /-- Install a new engine snapshot, refresh live work clocks, and tombstone
 stale suggestions.  Previously consumed suggestions never reactivate. -/
@@ -681,7 +696,8 @@ private def selectSuggestion (state : State Fact) (suggestionId : SuggestionId)
           | .invalid error engine =>
               let selected := chargeDecision
                 (consumeSuggestion state suggestionId) .instantiate
-              .completed (.instanceRejected error) (advanceState selected engine)
+              let next := advanceState selected engine
+              .completed (.instanceRejected error) { next with incomplete := true }
           | .resourceLimit resource _ =>
               .engineResource resource (chargeDecision state .instantiate)
       | .split source target point reason, .split request =>
@@ -777,6 +793,15 @@ def emittedSuggestions (before after : Nat) : Array OfferId := Id.run do
     emitted := emitted.push (.suggestion { index := before + offset })
   return emitted
 
+/-- Detect narrowing-capable suggestions which the engine's bounded retained
+prefix will discard.  This must run against the pre-reply engine because the
+dropped suffix is intentionally absent from the accepted snapshot. -/
+def droppedAffectsClosure (state : Engine Fact) : Outcome Fact -> Bool
+  | .success _ suggestions _ =>
+      let room := state.limits.maxRetainedSuggestions - state.suggestions.size
+      (suggestions.drop room).any affectsClosure
+  | .noChange _ | .inapplicable | .resourceLimit _ | .failed _ => false
+
 inductive SubmitResult (Fact : Type) where
   | accepted (observation : RuleObservation Fact) (state : State Fact)
   | invalid (error : ReplyError) (state : State Fact)
@@ -805,7 +830,14 @@ opaque State.submit (state : State Fact) (reply : Reply Fact) : SubmitResult Fac
                   cost := outcomeCost reply.outcome
                   emittedSuggestions :=
                     emittedSuggestions before.suggestions.size engine.suggestions.size }
-              .accepted observation (advanceState state engine)
+              let next := advanceState state engine
+              let incomplete :=
+                droppedAffectsClosure before reply.outcome ||
+                  match reply.outcome with
+                  | .resourceLimit _ | .failed _ => true
+                  | .success _ _ _ | .noChange _ | .inapplicable => false
+              let next := if incomplete then { next with incomplete := true } else next
+              .accepted observation next
           | .invalid error engine => .invalid error (advanceState state engine)
           | .resourceLimit resource engine =>
               .engineResource resource (advanceState state engine)

--- a/HexInterval/Experiment/Policy.lean
+++ b/HexInterval/Experiment/Policy.lean
@@ -754,8 +754,9 @@ opaque State.dismiss (state : State Fact) (selection : Selection) : SelectResult
         | .suggestion suggestion =>
             let next := chargeDecision (consumeSuggestion state suggestion) .dismissal
             match offer.key with
-            | .retry _ _ | .instantiate _ _ => { next with incomplete := true }
-            | .split _ _ _ _ | .invoke _ | .equality _ => next
+            | .split _ _ _ _ => next
+            | .retry _ _ | .instantiate _ _ | .invoke _ | .equality _ =>
+                { next with incomplete := true }
       .completed .dismissed next
 
 /-! ## Exact rule observations -/
@@ -811,7 +812,10 @@ inductive SubmitResult (Fact : Type) where
 
 /-- Admit a reply through the underlying engine, then expose actual admitted
 fact deltas and newly engine-indexed suggestions.  Claimed candidate strength
-is never used as an observation. -/
+is never used as an observation.  A rejected or resource-limited reply which
+clears the pending latch has consumed its selected application and therefore
+makes propagation incomplete; a mismatched reply which preserves that latch
+remains directly resubmittable. -/
 opaque State.submit (state : State Fact) (reply : Reply Fact) : SubmitResult Fact :=
   match state.engine.pending with
   | none => .malformedState state
@@ -838,9 +842,16 @@ opaque State.submit (state : State Fact) (reply : Reply Fact) : SubmitResult Fac
                   | .success _ _ _ | .noChange _ | .inapplicable => false
               let next := if incomplete then { next with incomplete := true } else next
               .accepted observation next
-          | .invalid error engine => .invalid error (advanceState state engine)
+          | .invalid error engine =>
+              let next := advanceState state engine
+              let next :=
+                if engine.pending.isNone then { next with incomplete := true } else next
+              .invalid error next
           | .resourceLimit resource engine =>
-              .engineResource resource (advanceState state engine)
-          | .factResourceLimit budget engine => .factResource budget (advanceState state engine)
+              let next := advanceState state engine
+              .engineResource resource { next with incomplete := true }
+          | .factResourceLimit budget engine =>
+              let next := advanceState state engine
+              .factResource budget { next with incomplete := true }
 
 end Hex.Interval.Experiment.Propagator.Policy

--- a/HexInterval/Experiment/Policy.lean
+++ b/HexInterval/Experiment/Policy.lean
@@ -310,9 +310,10 @@ private def pruneSuggestions (state : State Fact) : State Fact := Id.run do
     | none => pure ()
   return { state with suggestions := clocks, incomplete }
 
-/-- Begin policy control over an existing engine snapshot.  Invalid retained
-retry and instantiation suggestions are accounted for before the first view,
-so adopting a snapshot cannot manufacture a false fixed point. -/
+/-- Begin policy control over an existing engine snapshot. Invalid retained
+retry and instantiation suggestions and an already-open reply latch are
+accounted for before the first view, so adopting a snapshot cannot manufacture
+a false fixed point. A pending action is not reconstructed as a new offer. -/
 opaque State.start (engine : Engine Fact) (limits : Limits)
     (scope : ScopeId := { index := 0 }) : State Fact :=
   pruneSuggestions
@@ -323,6 +324,7 @@ opaque State.start (engine : Engine Fact) (limits : Limits)
       applications := clockArray engine.queued 0
       equalities := clockArray engine.equalityQueued 0
       suggestions := suggestionClocksFrom engine 0
+      incomplete := engine.pending.isSome
       limits }
 
 /-- Install a new engine snapshot, refresh live work clocks, and tombstone
@@ -810,6 +812,14 @@ inductive SubmitResult (Fact : Type) where
   | factResource (budget : Nat) (state : State Fact)
   | malformedState (state : State Fact)
 
+/-- Synchronize an unsuccessful reply snapshot and remember loss exactly when
+the engine cleared its pending action. This common discriminator also remains
+correct if a future resource failure becomes resubmittable. -/
+private def afterReplyFailure (state : State Fact) (engine : Engine Fact) :
+    State Fact :=
+  let next := advanceState state engine
+  if engine.pending.isNone then { next with incomplete := true } else next
+
 /-- Admit a reply through the underlying engine, then expose actual admitted
 fact deltas and newly engine-indexed suggestions.  Claimed candidate strength
 is never used as an observation.  A rejected or resource-limited reply which
@@ -843,15 +853,10 @@ opaque State.submit (state : State Fact) (reply : Reply Fact) : SubmitResult Fac
               let next := if incomplete then { next with incomplete := true } else next
               .accepted observation next
           | .invalid error engine =>
-              let next := advanceState state engine
-              let next :=
-                if engine.pending.isNone then { next with incomplete := true } else next
-              .invalid error next
+              .invalid error (afterReplyFailure state engine)
           | .resourceLimit resource engine =>
-              let next := advanceState state engine
-              .engineResource resource { next with incomplete := true }
+              .engineResource resource (afterReplyFailure state engine)
           | .factResourceLimit budget engine =>
-              let next := advanceState state engine
-              .factResource budget { next with incomplete := true }
+              .factResource budget (afterReplyFailure state engine)
 
 end Hex.Interval.Experiment.Propagator.Policy

--- a/HexInterval/Experiment/Policy.lean
+++ b/HexInterval/Experiment/Policy.lean
@@ -717,12 +717,14 @@ opaque State.select (state : State Fact) (selection : Selection) : SelectResult 
       | .suggestion suggestion, key => selectSuggestion state suggestion key
       | _, _ => reject state .wrongKey
 
-/-- Dismissing ordinary propagation work makes the run incomplete; dismissing
-a suggestion merely declines one optional search action. -/
+/-- Dismissing ordinary propagation work, a retry, or an instantiation makes
+the run incomplete. A split is the only suggestion whose dismissal preserves
+fixed-point completeness: it changes proof search, not the propagation
+closure of the current scope. -/
 opaque State.dismiss (state : State Fact) (selection : Selection) : SelectResult Fact :=
   match state.validate selection with
   | .error reason => reject state reason
-  | .ok _ =>
+  | .ok offer =>
       let next := match selection.id with
         | .application application =>
             let engine :=
@@ -734,7 +736,10 @@ opaque State.dismiss (state : State Fact) (selection : Selection) : SelectResult
                 equalityQueued := state.engine.equalityQueued.set! equality.index false }
             { advanceState (chargeDecision state .dismissal) engine with incomplete := true }
         | .suggestion suggestion =>
-            chargeDecision (consumeSuggestion state suggestion) .dismissal
+            let next := chargeDecision (consumeSuggestion state suggestion) .dismissal
+            match offer.key with
+            | .retry _ _ | .instantiate _ _ => { next with incomplete := true }
+            | .split _ _ _ _ | .invoke _ | .equality _ => next
       .completed .dismissed next
 
 /-! ## Exact rule observations -/

--- a/HexInterval/Experiment/PolicyDriver.lean
+++ b/HexInterval/Experiment/PolicyDriver.lean
@@ -56,7 +56,7 @@ inductive Event (Fact : Type)
       (error : ReplyError)
   | equality (selection : Selection) (observation : EqualityObservation Fact)
   | instance (selection : Selection) (outcome : InstanceOutcome)
-  | dismissal (selection : Selection) (required : Bool)
+  | dismissal (selection : Selection) (halts : Bool) (causesIncomplete : Bool)
   | splitPrepared (selection : Selection) (plan : SplitPlan Fact)
   | choiceRejected (selection : Selection) (reason : Rejection)
   | engineResource (origin : ResourceOrigin) (resource : Resource)
@@ -122,9 +122,21 @@ def finish (controller : Controller Fact PolicyState) (event : Event Fact)
   let (policyState, events) := emit controller event policyState events
   { state, policy := controller.key, cache, policyState, events, stop }
 
-def requiredOffer : OfferId -> Bool
+def dismissalHalts : OfferId -> Bool
   | .application _ | .equality _ => true
   | .suggestion _ => false
+
+def dismissalAffects : OfferClass -> Bool
+  | .invoke | .equality | .retry | .instantiate => true
+  | .split => false
+
+/-- Whether this dismissal is responsible for completeness being unavailable.
+The offer class remains visible even if an earlier transition had already
+made the state incomplete. -/
+def dismissalCauses (before : State Fact) (selection : Selection)
+    (after : State Fact) : Bool :=
+  after.incomplete &&
+    (!before.incomplete || dismissalAffects selection.expected.offerClass)
 
 def invocationOfRequest (scope : ScopeId) (request : RuleRequest Fact) : InvocationKey :=
   invocationOfAction scope request.action
@@ -269,10 +281,12 @@ def driveFrom (controller : Controller Fact PolicyState)
                   | .dismiss selection next =>
                       match viewed.dismiss selection with
                       | .completed .dismissed afterDismissal =>
-                          let required := requiredOffer selection.id
+                          let halts := dismissalHalts selection.id
+                          let causesIncomplete :=
+                            dismissalCauses viewed selection afterDismissal
                           let (next, events) := emit controller
-                            (.dismissal selection required) next events
-                          if required then
+                            (.dismissal selection halts causesIncomplete) next events
+                          if halts then
                             { state := afterDismissal
                               policy := controller.key
                               cache

--- a/HexInterval/Experiment/PolicyDriver.lean
+++ b/HexInterval/Experiment/PolicyDriver.lean
@@ -1,0 +1,316 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Experiment.Policy
+
+@[expose] public section
+
+/-!
+# External driver for engine-owned interval-policy offers
+
+This module connects an arbitrary external search policy and an arbitrary
+external rule registry to `Policy.State`.  The policy sees only bounded views
+and returns `select`, `dismiss`, or `stop`; `Policy.State` remains the sole
+authority which freezes rule actions, contracts equalities, admits expression
+instances, and prepares split plans.
+
+Every completed transition is delivered to the policy and retained in one
+ordered typed event stream.  The driver does not branch on a split plan.  It
+returns that plan to the caller, which will eventually own proof-scope
+creation.
+-/
+
+namespace Hex.Interval.Experiment.Propagator.Policy.Driver
+
+/-! ## External policy protocol -/
+
+/-- One external policy decision.  Policy-private state has an arbitrary Lean
+type and remains outside the trusted engine. -/
+inductive Step (PolicyState : Type)
+  | select (selection : Selection) (next : PolicyState)
+  | dismiss (selection : Selection) (next : PolicyState)
+  | stop (next : PolicyState)
+
+/-- Outcome of selecting one retained instantiation offer. -/
+inductive InstanceOutcome
+  | admitted (newNodes : List NodeId)
+  | duplicate
+  | rejected (error : AdmissionError)
+  deriving Repr
+
+/-- The engine transition which exhausted a resource. -/
+inductive ResourceOrigin
+  | choice (selection : Selection)
+  | invocation (selection : Selection) (invocation : InvocationKey)
+
+/-- One ordered policy observation.  Successful choices retain the exact
+selection as well as the engine-produced semantic observation. -/
+inductive Event (Fact : Type)
+  | rule (selection : Selection) (observation : RuleObservation Fact)
+  | replyRejected (selection : Selection) (invocation : InvocationKey)
+      (error : ReplyError)
+  | equality (selection : Selection) (observation : EqualityObservation Fact)
+  | instance (selection : Selection) (outcome : InstanceOutcome)
+  | dismissal (selection : Selection) (required : Bool)
+  | splitPrepared (selection : Selection) (plan : SplitPlan Fact)
+  | choiceRejected (selection : Selection) (reason : Rejection)
+  | engineResource (origin : ResourceOrigin) (resource : Resource)
+  | factResource (origin : ResourceOrigin) (budget : Nat)
+  | decisionResource
+  | viewResource (error : ViewError)
+  | policyStop (liveOffers : Nat)
+  | saturated
+  | contradiction
+  | incomplete
+  | invalidState
+  | driverFuel
+
+/-- A policy learns from the same single ordered stream returned by the
+driver.  Neither callback is required to terminate; failure of arbitrary
+external code cannot establish a theorem. -/
+structure Controller (Fact PolicyState : Type) where
+  key : PolicyKey
+  update : PolicyState -> Event Fact -> PolicyState
+  choose : PolicyState -> View Fact -> Step PolicyState
+
+/-! ## Driver result -/
+
+inductive UnknownReason
+  | policyStop (liveOffers : Nat)
+  | requiredDismissal (selection : Selection)
+  | incomplete
+
+/-- Why policy execution stopped.  A prepared split is returned rather than
+executed, and `unknown` is distinct from a genuine empty-frontier fixed point. -/
+inductive Stop (Fact : Type)
+  | saturated
+  | contradiction
+  | split (plan : SplitPlan Fact)
+  | unknown (reason : UnknownReason)
+  | engineResource (resource : Resource)
+  | factResource (budget : Nat)
+  | decisionResource
+  | viewResource (error : ViewError)
+  | invalidReply (error : ReplyError)
+  | invalidState
+  | driverFuel
+
+/-- A run returns both kinds of arbitrary external state and the exact ordered
+event stream delivered to the policy. -/
+structure Result (Fact Cache PolicyState : Type) where
+  state : State Fact
+  cache : Cache
+  policyState : PolicyState
+  events : Array (Event Fact)
+  stop : Stop Fact
+
+def emit (controller : Controller Fact PolicyState) (event : Event Fact)
+    (policyState : PolicyState) (events : Array (Event Fact)) :
+    PolicyState × Array (Event Fact) :=
+  (controller.update policyState event, events.push event)
+
+def finish (controller : Controller Fact PolicyState) (event : Event Fact)
+    (stop : Stop Fact) (state : State Fact) (cache : Cache)
+    (policyState : PolicyState) (events : Array (Event Fact)) :
+    Result Fact Cache PolicyState :=
+  let (policyState, events) := emit controller event policyState events
+  { state, cache, policyState, events, stop }
+
+def requiredOffer : OfferId -> Bool
+  | .application _ | .equality _ => true
+  | .suggestion _ => false
+
+def invocationOfRequest (scope : ScopeId) (request : RuleRequest Fact) : InvocationKey :=
+  invocationOfAction scope request.action
+
+/-! ## Ordered execution -/
+
+/-- Internal fuelled loop.  The only action passed to the registry comes from
+`State.select`; the driver merely echoes it through `Action.reply`. -/
+def driveFrom (controller : Controller Fact PolicyState)
+    (invoke : Cache -> RuleRequest Fact -> Outcome Fact × Cache) :
+    Nat -> State Fact -> Cache -> PolicyState -> Array (Event Fact) ->
+      Result Fact Cache PolicyState
+  | fuel, state, cache, policyState, events =>
+      if state.engine.pending.isSome then
+        finish controller .invalidState .invalidState state cache policyState events
+      else if state.engine.contradictory then
+        finish controller .contradiction .contradiction state cache policyState events
+      else
+        match fuel with
+        | 0 =>
+            match state.view with
+            | .error error =>
+                finish controller (.viewResource error) (.viewResource error)
+                  state cache policyState events
+            | .ok (view, viewed) =>
+                if view.offers.isEmpty then
+                  if viewed.incomplete then
+                    finish controller .incomplete (.unknown .incomplete)
+                      viewed cache policyState events
+                  else
+                    finish controller .saturated .saturated viewed cache policyState events
+                else if viewed.limits.maxDecisions <= viewed.metrics.decisions then
+                  finish controller .decisionResource .decisionResource
+                    viewed cache policyState events
+                else
+                  finish controller .driverFuel .driverFuel viewed cache policyState events
+        | remaining + 1 =>
+            match state.view with
+            | .error error =>
+                finish controller (.viewResource error) (.viewResource error)
+                  state cache policyState events
+            | .ok (view, viewed) =>
+                if view.offers.isEmpty then
+                  if viewed.incomplete then
+                    finish controller .incomplete (.unknown .incomplete)
+                      viewed cache policyState events
+                  else
+                    finish controller .saturated .saturated viewed cache policyState events
+                else if viewed.limits.maxDecisions <= viewed.metrics.decisions then
+                  finish controller .decisionResource .decisionResource
+                    viewed cache policyState events
+                else
+                  match controller.choose policyState view with
+                  | .select selection next =>
+                      match viewed.select selection with
+                      | .request request awaiting =>
+                          let invocation := invocationOfRequest awaiting.scope request
+                          let (outcome, cache) := invoke cache request
+                          let reply := request.action.reply outcome
+                          match awaiting.submit reply with
+                          | .accepted observation afterReply =>
+                              let (next, events) := emit controller
+                                (.rule selection observation) next events
+                              driveFrom controller invoke remaining afterReply cache next events
+                          | .invalid error afterReply =>
+                              finish controller
+                                (.replyRejected selection invocation error) (.invalidReply error)
+                                afterReply cache next events
+                          | .engineResource resource afterReply =>
+                              finish controller
+                                (.engineResource (.invocation selection invocation) resource)
+                                (.engineResource resource) afterReply cache next events
+                          | .factResource budget afterReply =>
+                              finish controller
+                                (.factResource (.invocation selection invocation) budget)
+                                (.factResource budget) afterReply cache next events
+                          | .malformedState afterReply =>
+                              finish controller .invalidState .invalidState
+                                afterReply cache next events
+                      | .equality observation afterEquality =>
+                          let (next, events) := emit controller
+                            (.equality selection observation) next events
+                          match observation.outcome with
+                          | .invalid _ =>
+                              finish controller .invalidState .invalidState
+                                afterEquality cache next events
+                          | .noChange | .improved | .contradiction =>
+                              driveFrom controller invoke remaining afterEquality cache next events
+                          | .engineResource resource =>
+                              finish controller
+                                (.engineResource (.choice selection) resource)
+                                (.engineResource resource) afterEquality cache next events
+                          | .factResource budget =>
+                              finish controller (.factResource (.choice selection) budget)
+                                (.factResource budget) afterEquality cache next events
+                      | .completed completion afterCompletion =>
+                          match completion with
+                          | .instanceAdmitted nodes =>
+                              let (next, events) := emit controller
+                                (.instance selection (.admitted nodes)) next events
+                              driveFrom controller invoke remaining afterCompletion cache next
+                                events
+                          | .instanceDuplicate =>
+                              let (next, events) := emit controller
+                                (.instance selection .duplicate) next events
+                              driveFrom controller invoke remaining afterCompletion cache next
+                                events
+                          | .instanceRejected error =>
+                              let (next, events) := emit controller
+                                (.instance selection (.rejected error)) next events
+                              driveFrom controller invoke remaining afterCompletion cache next
+                                events
+                          | .dismissed =>
+                              finish controller .invalidState .invalidState
+                                afterCompletion cache next events
+                      | .split plan afterSplit =>
+                          finish controller (.splitPrepared selection plan) (.split plan)
+                            afterSplit cache next events
+                      | .rejected reason afterRejection =>
+                          let (next, events) := emit controller
+                            (.choiceRejected selection reason) next events
+                          match reason with
+                          | .decisionLimit =>
+                              finish controller .decisionResource .decisionResource
+                                afterRejection cache next events
+                          | .actionLimit =>
+                              finish controller
+                                (.engineResource (.choice selection) .actions)
+                                (.engineResource .actions) afterRejection cache next events
+                          | .malformedState =>
+                              finish controller .invalidState .invalidState
+                                afterRejection cache next events
+                          | .wrongScope | .staleSerial | .staleProgram |
+                              .missingOffer | .wrongKey =>
+                              driveFrom controller invoke remaining afterRejection cache next events
+                      | .engineResource resource afterResource =>
+                          finish controller (.engineResource (.choice selection) resource)
+                            (.engineResource resource) afterResource cache next events
+                      | .factResource budget afterResource =>
+                          finish controller (.factResource (.choice selection) budget)
+                            (.factResource budget) afterResource cache next events
+                  | .dismiss selection next =>
+                      match viewed.dismiss selection with
+                      | .completed .dismissed afterDismissal =>
+                          let required := requiredOffer selection.id
+                          let (next, events) := emit controller
+                            (.dismissal selection required) next events
+                          if required then
+                            { state := afterDismissal
+                              cache
+                              policyState := next
+                              events
+                              stop := .unknown (.requiredDismissal selection) }
+                          else
+                            driveFrom controller invoke remaining afterDismissal cache next events
+                      | .rejected reason afterRejection =>
+                          let (next, events) := emit controller
+                            (.choiceRejected selection reason) next events
+                          match reason with
+                          | .decisionLimit =>
+                              finish controller .decisionResource .decisionResource
+                                afterRejection cache next events
+                          | .actionLimit =>
+                              finish controller
+                                (.engineResource (.choice selection) .actions)
+                                (.engineResource .actions) afterRejection cache next events
+                          | .malformedState =>
+                              finish controller .invalidState .invalidState
+                                afterRejection cache next events
+                          | .wrongScope | .staleSerial | .staleProgram |
+                              .missingOffer | .wrongKey =>
+                              driveFrom controller invoke remaining afterRejection cache next events
+                      | .request _ invalid | .equality _ invalid | .completed _ invalid |
+                          .split _ invalid | .engineResource _ invalid |
+                          .factResource _ invalid =>
+                              finish controller .invalidState .invalidState
+                                invalid cache next events
+                  | .stop next =>
+                      finish controller (.policyStop view.offers.size)
+                        (.unknown (.policyStop view.offers.size)) viewed cache next events
+
+/-- Run an external policy and registry from one policy-controlled engine
+snapshot. -/
+def drive (controller : Controller Fact PolicyState)
+    (invoke : Cache -> RuleRequest Fact -> Outcome Fact × Cache)
+    (fuel : Nat) (state : State Fact) (cache : Cache)
+    (policyState : PolicyState) : Result Fact Cache PolicyState :=
+  driveFrom controller invoke fuel state cache policyState #[]
+
+end Hex.Interval.Experiment.Propagator.Policy.Driver

--- a/HexInterval/Experiment/PolicyDriver.lean
+++ b/HexInterval/Experiment/PolicyDriver.lean
@@ -104,6 +104,7 @@ inductive Stop (Fact : Type)
 event stream delivered to the policy. -/
 structure Result (Fact Cache PolicyState : Type) where
   state : State Fact
+  policy : PolicyKey
   cache : Cache
   policyState : PolicyState
   events : Array (Event Fact)
@@ -119,7 +120,7 @@ def finish (controller : Controller Fact PolicyState) (event : Event Fact)
     (policyState : PolicyState) (events : Array (Event Fact)) :
     Result Fact Cache PolicyState :=
   let (policyState, events) := emit controller event policyState events
-  { state, cache, policyState, events, stop }
+  { state, policy := controller.key, cache, policyState, events, stop }
 
 def requiredOffer : OfferId -> Bool
   | .application _ | .equality _ => true
@@ -273,6 +274,7 @@ def driveFrom (controller : Controller Fact PolicyState)
                             (.dismissal selection required) next events
                           if required then
                             { state := afterDismissal
+                              policy := controller.key
                               cache
                               policyState := next
                               events

--- a/HexInterval/Experiment/PolicyFrontier.lean
+++ b/HexInterval/Experiment/PolicyFrontier.lean
@@ -463,9 +463,8 @@ structure Step where
   work : Work
 
 /-- Execute the common policy choice.  Invocation and retry offers call the
-arbitrary registry.  The fixture deliberately dismisses optional split and
-instantiation suggestions; dismissing ordinary propagation would make the run
-incomplete and is never used here. -/
+arbitrary registry, instantiations go through engine-owned structural
+admission, and only optional split suggestions are dismissed. -/
 def execute (workload : Workload) (state : Policy.State Rank)
     (offer : OfferView) (work : Work) : Option Step :=
   let selection := selectionFor state offer
@@ -474,9 +473,20 @@ def execute (workload : Workload) (state : Policy.State Rank)
       selectionRechecks := work.selectionRechecks + 1
       semanticItems := work.semanticItems + offerSemanticItems state offer.id }
   match offer.offerClass with
-  | .split | .instantiate =>
+  | .split =>
       match state.dismiss selection with
       | .completed .dismissed next => some { state := next, work }
+      | _ => none
+  | .instantiate =>
+      let before := state.engine
+      match state.select selection with
+      | .completed completion next =>
+          match completion with
+          | .instanceAdmitted _ | .instanceDuplicate | .instanceRejected _ =>
+              some
+                { state := next
+                  work := (work.advance next).dependencies before next.engine }
+          | .dismissed => none
       | _ => none
   | .invoke | .retry =>
       match state.select selection with
@@ -496,6 +506,7 @@ def execute (workload : Workload) (state : Policy.State Rank)
 
 inductive Stop where
   | saturated
+  | incomplete
   | setupFailure
   | frontierResource
   | invalidTransition
@@ -595,7 +606,9 @@ def scanLoop (workload : Workload) (base : Policy.State Rank) :
             { work with
               priorityComparisons := work.priorityComparisons + comparisons }
           match choice with
-          | none => result .saturated base scanned work choices
+          | none =>
+              result (if scanned.incomplete then .incomplete else .saturated)
+                base scanned work choices
           | some offer =>
               match execute workload scanned offer work with
               | none => result .invalidTransition base scanned work choices
@@ -681,7 +694,9 @@ def indexedLoop (workload : Workload) (base : Policy.State Rank) :
   | 0, state, _, work, choices => result .fuel base state work choices
   | fuel + 1, state, index, work, choices =>
       match index.heap.pop with
-      | none => result .saturated base state work choices
+      | none =>
+          result (if state.incomplete then .incomplete else .saturated)
+            base state work choices
       | some (entry, heap, heapCost) =>
           let index := { index with heap }
           let work := (work.heap heapCost)

--- a/HexInterval/Experiment/Propagator.lean
+++ b/HexInterval/Experiment/Propagator.lean
@@ -483,6 +483,13 @@ inductive Suggestion where
   | instantiate (request : InstantiationRequest)
   | split (request : SplitRequest)
 
+/-- Whether losing this suggestion can leave propagation unfinished. Splits
+are optional proof search; retry and instantiation can expose further
+contraction in the current branch. -/
+def Suggestion.affectsClosure : Suggestion -> Bool
+  | .retry _ | .instantiate _ => true
+  | .split _ => false
+
 /-- A policy candidate paired with engine-owned invocation provenance.  Split
 proposals retain the target version at proposal time; later policy adoption
 must not re-arm a guard from the then-current fact. -/
@@ -1167,6 +1174,22 @@ def installCandidates (action : Action) :
           candidate.node :: changed
       pure (next, changed)
 
+/-- Remaining capacity in the engine-owned retained-suggestion prefix. -/
+def suggestionRoom (state : Engine Fact) : Nat :=
+  state.limits.maxRetainedSuggestions - state.suggestions.size
+
+/-- The exact suggestion prefix which `submit` will retain. Policy layers use
+this helper rather than duplicating the retention arithmetic when deciding
+whether discarded work affects completeness. -/
+def keptSuggestions (state : Engine Fact)
+    (suggestions : List Suggestion) : List Suggestion :=
+  suggestions.take state.suggestionRoom
+
+/-- The exact suggestion suffix which `submit` will discard. -/
+def droppedSuggestions (state : Engine Fact)
+    (suggestions : List Suggestion) : List Suggestion :=
+  suggestions.drop state.suggestionRoom
+
 /-- Validate and atomically admit one rule reply.  Candidate facts are all
 installed before the union of affected dependencies is woken. -/
 def submit (state : Engine Fact) (reply : Reply Fact) : ReplyResult Fact :=
@@ -1201,10 +1224,8 @@ def submit (state : Engine Fact) (reply : Reply Fact) : ReplyResult Fact :=
                 match candidatesAuthorized application.writes candidates with
                 | some error => .invalid error base
                 | none =>
-                    let suggestionRoom :=
-                      state.limits.maxRetainedSuggestions - state.suggestions.size
-                    let retainedSuggestions := suggestions.take suggestionRoom
-                    let droppedSuggestions := suggestions.length - retainedSuggestions.length
+                    let retainedSuggestions := state.keptSuggestions suggestions
+                    let droppedSuggestions := (state.droppedSuggestions suggestions).length
                     let working : Engine Fact :=
                       { base with
                         suggestions := retainedSuggestions.foldl

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -1253,8 +1253,13 @@ One `balancedV1` candidate uses a versioned priority queue over these offers.
 Changed facts insert or invalidate only affected offers; stale entries are
 discarded lazily when popped. Policies intended for diagnostics may use a
 simpler complete scan, but their complexity is reported honestly. An empty
-frontier means saturation. A `PolicyStep.stop` for a nonempty frontier is
-reported as `unknown`, not saturation.
+frontier means saturation only when no narrowing-capable work was dismissed.
+Declining an invocation, equality contractor, retry, or instantiation makes
+the run incomplete; declining a split does not, because it changes proof
+search rather than the propagation closure of the current scope. An empty
+frontier after an incomplete dismissal is reported as `unknown`. A
+`PolicyStep.stop` for a nonempty frontier is likewise reported as `unknown`,
+not saturation.
 
 The shown first interface supplies the authoritative bounded scan frontier in
 each `PolicyView`; transition events let the policy update historical state

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -1254,6 +1254,10 @@ resource limit or failed rule. An accepted `resourceLimit` or `failed` report
 clears the request/reply latch and remains an exact policy observation, but it
 also marks propagation incomplete: consuming that application did not
 establish either successful contraction or mathematical inapplicability.
+Reply rejection, engine-resource exhaustion, or fact-domain-resource
+exhaustion has the same status when it clears the pending latch. A mismatched
+reply which preserves that exact pending action remains resubmittable and does
+not by itself lose completeness.
 
 One `balancedV1` candidate uses a versioned priority queue over these offers.
 Changed facts insert or invalidate only affected offers; stale entries are
@@ -1332,7 +1336,10 @@ variant-specific freshness guard tombstones them permanently. A rejected
 instantiation, or automatic tombstoning of a retry or instantiation, marks the
 scope incomplete; a discarded stale split remains optional. This accounting
 also applies when policy control adopts an engine snapshot containing an
-already-invalid retained suggestion.
+already-invalid retained suggestion. The prototype conservatively treats
+every automatically tombstoned retry as completeness-relevant, including a
+weak or stale retry. Whether some failure reasons can be proved redundant and
+discarded without that penalty remains an open policy question.
 
 Freshness is offer-specific. An invocation or retry compares the concrete
 application and relevant current input versions. Instantiation initially uses

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -957,7 +957,10 @@ greater effort always gives a tighter answer. The solver intersects every
 result with existing facts, measures the actual improvement, and learns from
 that observation. Retained suggestions are advisory: when their cumulative
 storage cap is full, the engine retains the bounded prefix, records how many
-were dropped, and still commits independently valid candidate facts.
+were dropped, and still commits independently valid candidate facts. Before
+that suffix disappears, the policy wrapper checks its variants: dropping a
+retry or instantiation marks propagation incomplete, while dropping only
+split advice preserves fixed-point completeness.
 
 The base `Program` is static after validation. Generic cheap alternates may be
 present before search, and `rewrite` only changes which form in the current
@@ -1247,7 +1250,10 @@ containing an outcome tag, candidate list, suggestion list, and cost. That
 allows `noChange` to recommend a stronger effort or landmark split without
 encoding itself as `success` with no candidates. This is an open protocol
 experiment; negative mathematical information is never inferred from a
-resource limit or failed rule.
+resource limit or failed rule. An accepted `resourceLimit` or `failed` report
+clears the request/reply latch and remains an exact policy observation, but it
+also marks propagation incomplete: consuming that application did not
+establish either successful contraction or mathematical inapplicability.
 
 One `balancedV1` candidate uses a versioned priority queue over these offers.
 Changed facts insert or invalidate only affected offers; stale entries are
@@ -1259,7 +1265,9 @@ the run incomplete; declining a split does not, because it changes proof
 search rather than the propagation closure of the current scope. An empty
 frontier after an incomplete dismissal is reported as `unknown`. A
 `PolicyStep.stop` for a nonempty frontier is likewise reported as `unknown`,
-not saturation.
+not saturation. The dismissal event records these as two separate facts:
+whether the driver halts immediately, and whether the dismissed offer makes
+fixed-point completeness unavailable.
 
 The shown first interface supplies the authoritative bounded scan frontier in
 each `PolicyView`; transition events let the policy update historical state
@@ -1320,7 +1328,11 @@ application or equality keeps its birth time while its versioned semantic key
 refreshes, becomes inactive when selected, and receives a new birth time if a
 later dependency change wakes it again. Retained suggestions never refresh
 into different proposals: selection, dismissal, or failure of their
-variant-specific freshness guard tombstones them permanently.
+variant-specific freshness guard tombstones them permanently. A rejected
+instantiation, or automatic tombstoning of a retry or instantiation, marks the
+scope incomplete; a discarded stale split remains optional. This accounting
+also applies when policy control adopts an engine snapshot containing an
+already-invalid retained suggestion.
 
 Freshness is offer-specific. An invocation or retry compares the concrete
 application and relevant current input versions. Instantiation initially uses

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -1336,7 +1336,10 @@ variant-specific freshness guard tombstones them permanently. A rejected
 instantiation, or automatic tombstoning of a retry or instantiation, marks the
 scope incomplete; a discarded stale split remains optional. This accounting
 also applies when policy control adopts an engine snapshot containing an
-already-invalid retained suggestion. The prototype conservatively treats
+already-invalid retained suggestion. Adopting a snapshot with an open reply
+latch also marks the scope incomplete: the selected application is not exposed
+as a second offer, so an empty visible frontier is not a fixed point. The
+prototype conservatively treats
 every automatically tombstoned retry as completeness-relevant, including a
 weak or stale retry. Whether some failure reasons can be proved redundant and
 discarded without that penalty remains an open policy question.

--- a/conformance/HexInterval/PolicyConformance.lean
+++ b/conformance/HexInterval/PolicyConformance.lean
@@ -371,6 +371,15 @@ def afterReplyWith? (engineLimit : Experiment.Propagator.Limits)
   | .accepted _ next => some next
   | _ => none
 
+def observedWith? (engineLimit : Experiment.Propagator.Limits)
+    (reply : RuleRequest Rank -> Outcome Rank) :
+    Option (RuleObservation Rank × State Rank) := do
+  let state <- initialWithLimits? engineLimit policyLimits
+  let (request, state) <- request? state (.application (application 0))
+  match state.submit (request.action.reply (reply request)) with
+  | .accepted observation next => some (observation, next)
+  | _ => none
+
 def afterInitialWith? (engineLimit : Experiment.Propagator.Limits) : Option (State Rank) :=
   afterReplyWith? engineLimit invoke
 
@@ -589,6 +598,47 @@ def wrongGeneration (request : RuleRequest Rank) : Outcome Rank :=
   let proposal := { instantiateAt 113 (node 0) with claimedGeneration := 99 }
   .success [candidate request 1] [.instantiate proposal] {}
 
+def selfEqualityInstance (request : RuleRequest Rank) : Outcome Rank :=
+  .success []
+    [.instantiate
+      { key := 127
+        triggers := [request.action.node]
+        claimedGeneration := 1
+        nodes := []
+        equalities :=
+          [{ left := .existing (node 0)
+             right := .existing (node 0)
+             payload := { index := 131 } }]
+        payload := { index := 137 } }]
+    {}
+
+def weakRetry (_ : RuleRequest Rank) : Outcome Rank :=
+  .success [] [.retry 0] {}
+
+def overflowRetry (_ : RuleRequest Rank) : Outcome Rank :=
+  .success []
+    [.split { node := node 0, point := 0, reason := .midpoint }, .retry 1] {}
+
+def overflowInstance (request : RuleRequest Rank) : Outcome Rank :=
+  .success []
+    [.split { node := node 0, point := 0, reason := .midpoint },
+      .instantiate (instantiateG request)] {}
+
+def overflowSplit (_ : RuleRequest Rank) : Outcome Rank :=
+  .success []
+    [.split { node := node 0, point := 0, reason := .midpoint }] {}
+
+def startWithWeakRetry? : Option (State Rank) := do
+  let engine <- match Engine.start rankDomain program #[fRule, gRule] #[0, 0] engineLimits with
+    | .ok engine => some engine
+    | .error _ => none
+  match engine.poll with
+  | .request request awaiting =>
+      match awaiting.submit (request.action.reply (weakRetry request)) with
+      | .accepted next => some (State.start next policyLimits)
+      | _ => none
+  | _ => none
+
 -- The policy key exposes the engine-computed generation, and a proposal whose
 -- untrusted claim disagrees is never advertised as selectable work.
 #guard
@@ -602,8 +652,90 @@ def wrongGeneration (request : RuleRequest Rank) : Outcome Rank :=
 #guard
   match afterReplyWith? engineLimits wrongGeneration with
   | some state =>
-      state.engine.suggestions.size == 1 &&
-        (state.offer? (.suggestion (suggestion 0))).isNone
+      state.engine.suggestions.size == 1 && state.incomplete &&
+        (state.offer? (.suggestion (suggestion 0))).isNone &&
+        (state.view).toOption.any fun pair =>
+          pair.1.offers.isEmpty && pair.1.incomplete
+  | none => false
+
+-- A structurally advertised instantiation may still fail a later admission
+-- check. Consuming that rejected proposal leaves the current propagation
+-- closure incomplete.
+#guard
+  match afterReplyWith? engineLimits selfEqualityInstance with
+  | none => false
+  | some state =>
+      !state.incomplete &&
+        match selectOffer state (.suggestion (suggestion 0)) with
+        | .completed (.instanceRejected .invalidEquality) next =>
+            next.incomplete &&
+              (next.view).toOption.any fun pair =>
+                pair.1.offers.isEmpty && pair.1.incomplete
+        | _ => false
+
+-- A retry which fails its variant-specific freshness guard is tombstoned, but
+-- its disappearance cannot be mistaken for successful propagation.
+#guard
+  match afterReplyWith? engineLimits weakRetry with
+  | some state =>
+      state.engine.suggestions.size == 1 && state.incomplete &&
+        (state.offer? (.suggestion (suggestion 0))).isNone &&
+        (state.view).toOption.any fun pair =>
+          pair.1.offers.isEmpty && pair.1.incomplete
+  | none => false
+
+-- The same accounting occurs when policy control adopts an engine snapshot
+-- which already contains the unusable retained retry.
+#guard
+  match startWithWeakRetry? with
+  | some state =>
+      state.incomplete &&
+        (state.offer? (.suggestion (suggestion 0))).isNone &&
+        (state.view).toOption.any fun pair =>
+          pair.1.offers.isEmpty && pair.1.incomplete
+  | none => false
+
+-- Retained-suggestion overflow is inspected before the engine discards its
+-- suffix. Here the split is retained, but the dropped retry still makes
+-- fixed-point completeness unavailable.
+#guard
+  match observedWith?
+      { engineLimits with maxRetainedSuggestions := 1 } overflowRetry with
+  | some (observation, state) =>
+      observation.outcome == .success &&
+        observation.emittedSuggestions.toList == [.suggestion (suggestion 0)] &&
+        state.engine.suggestions.size == 1 &&
+        state.engine.metrics.droppedSuggestions == 1 && state.incomplete &&
+        match state.engine.suggestions[0]? with
+        | some retained =>
+            match retained.suggestion with
+            | .split _ => true
+            | .retry _ | .instantiate _ => false
+        | none => false
+  | none => false
+
+-- A dropped instantiation has the same closure consequence as a dropped
+-- retry, even though neither proposal survives in the retained prefix.
+#guard
+  match observedWith?
+      { engineLimits with maxRetainedSuggestions := 1 } overflowInstance with
+  | some (observation, state) =>
+      observation.outcome == .success &&
+        observation.emittedSuggestions.toList == [.suggestion (suggestion 0)] &&
+        state.engine.suggestions.size == 1 &&
+        state.engine.metrics.droppedSuggestions == 1 && state.incomplete
+  | none => false
+
+-- Dropping only optional split advice does not make propagation incomplete.
+#guard
+  match observedWith?
+      { engineLimits with maxRetainedSuggestions := 0 } overflowSplit with
+  | some (observation, state) =>
+      observation.outcome == .success && observation.emittedSuggestions.isEmpty &&
+        state.engine.suggestions.isEmpty &&
+        state.engine.metrics.droppedSuggestions == 1 && !state.incomplete &&
+        (state.view).toOption.any fun pair =>
+          pair.1.offers.isEmpty && !pair.1.incomplete
   | none => false
 
 def splitChangedTarget (request : RuleRequest Rank) : Outcome Rank :=
@@ -619,7 +751,8 @@ def splitChangedTarget (request : RuleRequest Rank) : Outcome Rank :=
   | some state =>
       match state.engine.suggestions[0]? with
       | some retained =>
-          retained.splitVersion == some 0 && state.engine.versions[1]? == some 1 &&
+          !state.incomplete && retained.splitVersion == some 0 &&
+            state.engine.versions[1]? == some 1 &&
             (state.offer? (.suggestion (suggestion 0))).isNone
       | none => false
   | none => false

--- a/conformance/HexInterval/PolicyConformance.lean
+++ b/conformance/HexInterval/PolicyConformance.lean
@@ -107,6 +107,16 @@ def initialWith? (limits : Experiment.Propagator.Policy.Limits) : Option (State 
 
 def initial? : Option (State Rank) := initialWith? policyLimits
 
+def pendingAdoption? : Option (State Rank) := do
+  let engine <- match Engine.start rankDomain program #[fRule, gRule] #[0, 0]
+      engineLimits with
+    | .ok engine => some engine
+    | .error _ => none
+  match engine.poll with
+  | .request _ awaiting => some (State.start awaiting policyLimits)
+  | .equality _ _ | .awaitingReply _ | .saturated _ | .contradiction _
+  | .resourceLimit _ _ | .invalidState _ => none
+
 def selectOffer (state : State Rank) (id : OfferId) : SelectResult Rank :=
   match state.offer? id with
   | none => .rejected .missingOffer state
@@ -383,6 +393,17 @@ def observedWith? (engineLimit : Experiment.Propagator.Limits)
 def afterInitialWith? (engineLimit : Experiment.Propagator.Limits) : Option (State Rank) :=
   afterReplyWith? engineLimit invoke
 
+-- Adopting a snapshot with an open reply latch cannot reconstruct the selected
+-- application as a fresh offer. It therefore records incompleteness before an
+-- empty frontier could be mistaken for a fixed point.
+#guard
+  match pendingAdoption? with
+  | some state =>
+      state.incomplete && state.engine.pending.isSome &&
+        (state.view).toOption.any fun pair =>
+          pair.1.offers.isEmpty && pair.1.incomplete
+  | none => false
+
 -- A structurally invalid reply clears the pending latch and consumes the
 -- selected application.  The wrapper must remember that the resulting empty
 -- frontier is incomplete.
@@ -399,6 +420,22 @@ def afterInitialWith? (engineLimit : Experiment.Propagator.Limits) : Option (Sta
               next.incomplete && next.engine.pending.isNone &&
                 (next.view).toOption.any fun pair =>
                   pair.1.offers.isEmpty && pair.1.incomplete
+          | _ => false
+
+-- Retry selection follows a different dirty-bit path from an initial
+-- invocation. A rejected retry reply still clears its pending latch and is
+-- therefore completeness-relevant.
+#guard
+  match afterInitial? with
+  | none => false
+  | some state =>
+      match request? state (.suggestion (suggestion 0)) with
+      | none => false
+      | some (request, awaiting) =>
+          match awaiting.submit (request.action.reply
+              (.success [] [.retry (engineLimits.maxEffort + 1)] {})) with
+          | .invalid .oversizedEffort next =>
+              next.incomplete && next.engine.pending.isNone
           | _ => false
 
 -- A mismatched action leaves the exact pending request intact.  Correcting

--- a/conformance/HexInterval/PolicyConformance.lean
+++ b/conformance/HexInterval/PolicyConformance.lean
@@ -383,6 +383,49 @@ def observedWith? (engineLimit : Experiment.Propagator.Limits)
 def afterInitialWith? (engineLimit : Experiment.Propagator.Limits) : Option (State Rank) :=
   afterReplyWith? engineLimit invoke
 
+-- A structurally invalid reply clears the pending latch and consumes the
+-- selected application.  The wrapper must remember that the resulting empty
+-- frontier is incomplete.
+#guard
+  match initial? with
+  | none => false
+  | some state =>
+      match request? state (.application (application 0)) with
+      | none => false
+      | some (request, awaiting) =>
+          match awaiting.submit (request.action.reply
+              (.success [] [.retry (engineLimits.maxEffort + 1)] {})) with
+          | .invalid .oversizedEffort next =>
+              next.incomplete && next.engine.pending.isNone &&
+                (next.view).toOption.any fun pair =>
+                  pair.1.offers.isEmpty && pair.1.incomplete
+          | _ => false
+
+-- A mismatched action leaves the exact pending request intact.  Correcting
+-- and resubmitting it remains complete, so the retryable mismatch must not
+-- poison the state.
+#guard
+  match initial? with
+  | none => false
+  | some state =>
+      match request? state (.application (application 0)) with
+      | none => false
+      | some (request, awaiting) =>
+          let mismatched : Reply Rank :=
+            { serial := request.action.serial + 1
+              programVersion := request.action.programVersion
+              application := request.action.application
+              outcome := .inapplicable }
+          match awaiting.submit mismatched with
+          | .invalid .mismatchedAction retryable =>
+              !retryable.incomplete && retryable.engine.pending.isSome &&
+                match retryable.submit (request.action.reply (invoke request)) with
+                | .accepted observation resumed =>
+                    exactInitialObservation observation && !resumed.incomplete &&
+                      resumed.engine.pending.isNone
+                | _ => false
+          | _ => false
+
 -- A policy cannot turn an engine-advertised effort-one retry into effort two.
 #guard
   match afterInitial? with
@@ -480,6 +523,43 @@ def leftMalformedDomain : FactDomain Rank where
   top _ := 0
   narrow _ current candidate :=
     if candidate < current then .malformed 91 else .noChange
+
+-- An engine resource failure during reply admission rolls back candidate
+-- effects, but the selected application is no longer live.
+#guard
+  match initialWithLimits?
+      { engineLimits with maxAcceptedFacts := 0 } policyLimits with
+  | none => false
+  | some state =>
+      match request? state (.application (application 0)) with
+      | none => false
+      | some (request, awaiting) =>
+          match awaiting.submit (request.action.reply (invoke request)) with
+          | .engineResource .acceptedFacts next =>
+              next.incomplete && next.engine.pending.isNone &&
+                next.engine.history.isEmpty &&
+                (next.view).toOption.any fun pair =>
+                  pair.1.offers.isEmpty && pair.1.incomplete
+          | _ => false
+
+-- A fact-domain resource failure has the same consumed-obligation boundary
+-- while retaining its exact domain budget.
+#guard
+  match Engine.start rightResourceDomain program #[fRule, gRule] #[0, 0]
+      engineLimits with
+  | .error _ => false
+  | .ok engine =>
+      let state := State.start engine policyLimits
+      match request? state (.application (application 0)) with
+      | none => false
+      | some (request, awaiting) =>
+          match awaiting.submit (request.action.reply (invoke request)) with
+          | .factResource 77 next =>
+              next.incomplete && next.engine.pending.isNone &&
+                next.engine.history.isEmpty &&
+                (next.view).toOption.any fun pair =>
+                  pair.1.offers.isEmpty && pair.1.incomplete
+          | _ => false
 
 -- Exhausting the accepted-fact budget reports a typed equality observation,
 -- charges no engine action, and leaves the equality live for a later run.

--- a/conformance/HexInterval/PolicyDriverConformance.lean
+++ b/conformance/HexInterval/PolicyDriverConformance.lean
@@ -86,6 +86,24 @@ def run? (fuel : Nat) (commands : List Command)
   let state <- state?
   some (drive controller invokeLogged fuel state [] commands)
 
+def contradictionDomain : FactDomain Rank where
+  top _ := 0
+  narrow _ current candidate :=
+    if current < candidate then .contradiction candidate else .noChange
+
+def contradictionInitial? : Option (State Rank) := do
+  let engine <- match Engine.start contradictionDomain program #[fRule, gRule] #[0, 0]
+      engineLimits with
+    | .ok engine => some engine
+    | .error _ => none
+  some (State.start engine policyLimits)
+
+def invokeUndeclared (calls : Calls) (request : RuleRequest Rank) :
+    Outcome Rank × Calls :=
+  (.success
+      [{ node := node 0, fact := 1, payload := { index := request.action.serial } }]
+      [] {}, calls ++ [(request.action.key.name, request.action.effort)])
+
 /-! ## Exact event predicates -/
 
 def exactSelection (selection : Selection) (serial programVersion : Nat)
@@ -210,7 +228,8 @@ def instantiationFirstCommands : List Command :=
 #guard
   match run? 7 retryFirstCommands with
   | some result =>
-      exactRetryFirstEvents result.events && result.state.engine.facts.toList == [0, 4, 4] &&
+      result.policy == controller.key &&
+        exactRetryFirstEvents result.events && result.state.engine.facts.toList == [0, 4, 4] &&
         result.cache == [(fKey.name, 0), (fKey.name, 1), (gKey.name, 0)] &&
         result.policyState.isEmpty && result.state.metrics.decisions == 7 &&
         match result.stop with
@@ -234,6 +253,11 @@ def instantiationFirstCommands : List Command :=
 
 def saturationCommands : List Command :=
   retryFirstCommands.dropLast ++ [.dismiss (.suggestion (suggestion 2))]
+
+def declineNarrowingCommands : List Command :=
+  [.dismiss (.suggestion (suggestion 0)),
+    .dismiss (.suggestion (suggestion 1)),
+    .dismiss (.suggestion (suggestion 2))]
 
 def exactSaturationPrefix (events : Array (Event Rank)) : Bool :=
   match events.toList with
@@ -270,6 +294,56 @@ def exactSaturationPrefix (events : Array (Event Rank)) : Bool :=
         | some .driverFuel, .driverFuel => true
         | _, _ => false
   | none => false
+
+-- A split is optional, but retries and instantiations can still improve the
+-- current scope. Declining all three empties the frontier without proving a
+-- propagation fixed point.
+#guard
+  match run? 3 declineNarrowingCommands afterInitial? with
+  | some result =>
+      result.state.incomplete && result.policyState.isEmpty &&
+        result.state.metrics.decisions == 4 &&
+        match result.events.toList, result.stop with
+        | [.dismissal retry false, .dismissal instanceSelection false,
+            .dismissal split false, .incomplete],
+            .unknown .incomplete =>
+              exactSelection retry 1 0 (.suggestion (suggestion 0)) &&
+                exactSelection instanceSelection 2 0 (.suggestion (suggestion 1)) &&
+                exactSelection split 3 0 (.suggestion (suggestion 2))
+        | _, _ => false
+  | none => false
+
+-- Contradiction reached on the final permitted transition is the answer, not
+-- driver-fuel exhaustion.
+#guard
+  match run? 1 [.select (.application (application 0))] contradictionInitial? with
+  | some result =>
+      result.state.engine.contradictory && result.state.engine.facts.toList == [0, 1] &&
+        match result.events.toList, result.stop with
+        | [.rule selection observation, .contradiction], .contradiction =>
+            exactInvokeSelection selection 0 0 (.application (application 0))
+                observation.invocation &&
+              observation.outcome == .success && observation.contradiction &&
+              oneChange observation.changes (node 1) 0 1 0 1
+        | _, _ => false
+  | none => false
+
+-- An arbitrary registry cannot write outside the selected registration. The
+-- rejection retains the exact invocation identity derived by the engine.
+#guard
+  match initial? with
+  | none => false
+  | some state =>
+      let result := drive controller invokeUndeclared 1 state []
+        [.select (.application (application 0))]
+      result.cache == [(fKey.name, 0)] && result.state.engine.pending.isNone &&
+        match result.events.toList, result.stop with
+        | [.replyRejected selection invocation (.undeclaredWrite target)],
+            .invalidReply (.undeclaredWrite stoppedTarget) =>
+              target == node 0 && stoppedTarget == node 0 &&
+                exactInvokeSelection selection 0 0 (.application (application 0))
+                  invocation
+        | _, _ => false
 
 #guard
   match run? 1 [.stop] with

--- a/conformance/HexInterval/PolicyDriverConformance.lean
+++ b/conformance/HexInterval/PolicyDriverConformance.lean
@@ -1,0 +1,416 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexInterval.Experiment.PolicyDriver
+import HexInterval.PolicyConformance
+
+/-!
+Conformance canaries for the external policy driver.
+
+The underlying fixture uses opaque `f` and `g` operations over synthetic
+facts.  These tests concern policy protocol semantics, not rational
+arithmetic: two schedules must produce the same fixed facts, while the event
+stream records their different causal histories exactly.
+-/
+
+namespace Hex.Interval.PolicyDriverConformance
+
+open Experiment.Propagator
+open Experiment.Propagator.Policy
+open Experiment.Propagator.Policy.Driver
+open PolicyConformance
+
+/-! ## A deterministic scripted policy -/
+
+inductive Command
+  | select (id : OfferId)
+  | dismiss (id : OfferId)
+  | wrongRetry (id : SuggestionId) (effort : Nat)
+  | stale (id : OfferId)
+  | stop
+
+def findOffer? (view : View Fact) (id : OfferId) : Option OfferView :=
+  view.offers.toList.find? fun offer => offer.id == id
+
+def selection? (view : View Fact) (id : OfferId) : Option Selection := do
+  let offer <- findOffer? view id
+  some
+    { scope := view.scope
+      serial := view.serial
+      programVersion := view.programVersion
+      id
+      expected := offer.key }
+
+def choose : List Command -> View Rank -> Step (List Command)
+  | [], _ => .stop []
+  | .stop :: rest, _ => .stop rest
+  | .select id :: rest, view =>
+      match selection? view id with
+      | some selection => .select selection rest
+      | none => .stop rest
+  | .dismiss id :: rest, view =>
+      match selection? view id with
+      | some selection => .dismiss selection rest
+      | none => .stop rest
+  | .wrongRetry id effort :: rest, view =>
+      match selection? view (.suggestion id) with
+      | some { expected := .retry source _, .. } =>
+          .select
+            { scope := view.scope
+              serial := view.serial
+              programVersion := view.programVersion
+              id := .suggestion id
+              expected := .retry source effort }
+            rest
+      | _ => .stop rest
+  | .stale id :: rest, view =>
+      match selection? view id with
+      | some selection => .select { selection with serial := selection.serial + 1 } rest
+      | none => .stop rest
+
+def controller : Controller Rank (List Command) where
+  key := { name := "policy-driver.script", version := 0 }
+  update state _ := state
+  choose := choose
+
+abbrev Calls := List (String × Nat)
+
+def invokeLogged (calls : Calls) (request : RuleRequest Rank) : Outcome Rank × Calls :=
+  (invoke request, calls ++ [(request.action.key.name, request.action.effort)])
+
+def run? (fuel : Nat) (commands : List Command)
+    (state? : Option (State Rank) := initial?) : Option (Result Rank Calls (List Command)) := do
+  let state <- state?
+  some (drive controller invokeLogged fuel state [] commands)
+
+/-! ## Exact event predicates -/
+
+def exactSelection (selection : Selection) (serial programVersion : Nat)
+    (id : OfferId) : Bool :=
+  selection.scope == { index := 0 } && selection.serial == serial &&
+    selection.programVersion == programVersion && selection.id == id
+
+def exactInvokeSelection (selection : Selection) (serial programVersion : Nat)
+    (id : OfferId) (invocation : InvocationKey) : Bool :=
+  exactSelection selection serial programVersion id &&
+    selection.expected == .invoke invocation
+
+def exactRetrySelection (selection : Selection) (serial programVersion : Nat)
+    (id : SuggestionId) (source : InvocationKey) (effort : Nat) : Bool :=
+  exactSelection selection serial programVersion (.suggestion id) &&
+    selection.expected == .retry source effort
+
+def exactInstanceSelection (selection : Selection) (serial programVersion : Nat)
+    (id : SuggestionId) (expectedSource : InvocationKey) : Bool :=
+  exactSelection selection serial programVersion (.suggestion id) &&
+    match selection.expected with
+    | .instantiate source request =>
+        source == expectedSource &&
+          request.family == 31 && request.triggers == [node 1] &&
+          request.generation == 1 &&
+          request.nodes ==
+            [{ domain := real
+               op := { index := 2 }
+               args := [.existing (node 0)] }] &&
+          request.equalities ==
+            [{ left := .existing (node 1), right := .proposed 0 }]
+    | _ => false
+
+def exactEqualitySelection (selection : Selection) (serial : Nat)
+    (observation : EqualityObservation Rank) : Bool :=
+  exactSelection selection serial 1 (.equality (equality 0)) &&
+    selection.expected == .equality observation.key
+
+def exactSplitSelection (selection : Selection) (serial programVersion : Nat)
+    (plan : SplitPlan Rank) : Bool :=
+  exactSelection selection serial programVersion (.suggestion (suggestion 2)) &&
+    selection.expected == .split plan.source
+      { node := plan.node, version := plan.version } plan.point plan.reason
+
+def exactRetryFirstEvents (events : Array (Event Rank)) : Bool :=
+  match events.toList with
+  | [.rule fSelection fObservation,
+      .rule retrySelection retryObservation,
+      .instance instanceSelection (.admitted [fresh]),
+      .equality firstEqualitySelection firstEquality,
+      .rule gSelection gObservation,
+      .equality lastEqualitySelection lastEquality,
+      .splitPrepared splitSelection plan] =>
+      exactInitialObservation fObservation &&
+        exactInvokeSelection fSelection 0 0 (.application (application 0))
+          fObservation.invocation &&
+        exactRetryObservation retryObservation true &&
+        exactRetrySelection retrySelection 1 0 (suggestion 0)
+          fObservation.invocation 1 &&
+        fresh == node 2 &&
+        exactInstanceSelection instanceSelection 2 0 (suggestion 1)
+          fObservation.invocation &&
+        exactEqualityObservation firstEquality .improved
+          (some (node 2, 0, 4, 0, 1)) &&
+        exactEqualitySelection firstEqualitySelection 3 firstEquality &&
+        exactGObservation gObservation 4 &&
+        exactInvokeSelection gSelection 4 1 (.application (application 1))
+          gObservation.invocation &&
+        exactEqualityObservation lastEquality .noChange none &&
+        exactEqualitySelection lastEqualitySelection 5 lastEquality &&
+        exactSplit plan && exactSplitSelection splitSelection 6 1 plan
+  | _ => false
+
+def exactInstantiationFirstEvents (events : Array (Event Rank)) : Bool :=
+  match events.toList with
+  | [.rule fSelection fObservation,
+      .instance instanceSelection (.admitted [fresh]),
+      .rule gSelection gObservation,
+      .equality firstEqualitySelection firstEquality,
+      .equality lastEqualitySelection lastEquality,
+      .dismissal retrySelection false,
+      .splitPrepared splitSelection plan] =>
+      exactInitialObservation fObservation &&
+        exactInvokeSelection fSelection 0 0 (.application (application 0))
+          fObservation.invocation &&
+        fresh == node 2 &&
+        exactInstanceSelection instanceSelection 1 0 (suggestion 1)
+          fObservation.invocation &&
+        exactGObservation gObservation 0 &&
+        exactInvokeSelection gSelection 2 1 (.application (application 1))
+          gObservation.invocation &&
+        exactEqualityObservation firstEquality .improved
+          (some (node 1, 1, 4, 1, 2)) &&
+        exactEqualitySelection firstEqualitySelection 3 firstEquality &&
+        exactEqualityObservation lastEquality .noChange none &&
+        exactEqualitySelection lastEqualitySelection 4 lastEquality &&
+        exactRetrySelection retrySelection 5 1 (suggestion 0)
+          fObservation.invocation 1 &&
+        exactSplit plan && exactSplitSelection splitSelection 6 1 plan
+  | _ => false
+
+def retryFirstCommands : List Command :=
+  [.select (.application (application 0)),
+    .select (.suggestion (suggestion 0)),
+    .select (.suggestion (suggestion 1)),
+    .select (.equality (equality 0)),
+    .select (.application (application 1)),
+    .select (.equality (equality 0)),
+    .select (.suggestion (suggestion 2))]
+
+def instantiationFirstCommands : List Command :=
+  [.select (.application (application 0)),
+    .select (.suggestion (suggestion 1)),
+    .select (.application (application 1)),
+    .select (.equality (equality 0)),
+    .select (.equality (equality 0)),
+    .dismiss (.suggestion (suggestion 0)),
+    .select (.suggestion (suggestion 2))]
+
+/-! ## Two valid schedules, one semantic result -/
+
+#guard
+  match run? 7 retryFirstCommands with
+  | some result =>
+      exactRetryFirstEvents result.events && result.state.engine.facts.toList == [0, 4, 4] &&
+        result.cache == [(fKey.name, 0), (fKey.name, 1), (gKey.name, 0)] &&
+        result.policyState.isEmpty && result.state.metrics.decisions == 7 &&
+        match result.stop with
+        | .split plan => exactSplit plan
+        | _ => false
+  | none => false
+
+#guard
+  match run? 7 instantiationFirstCommands with
+  | some result =>
+      exactInstantiationFirstEvents result.events &&
+        result.state.engine.facts.toList == [0, 4, 4] &&
+        result.cache == [(fKey.name, 0), (gKey.name, 0)] &&
+        result.policyState.isEmpty && result.state.metrics.decisions == 7 &&
+        match result.stop with
+        | .split plan => exactSplit plan
+        | _ => false
+  | none => false
+
+/-! ## Saturation and stopping boundaries -/
+
+def saturationCommands : List Command :=
+  retryFirstCommands.dropLast ++ [.dismiss (.suggestion (suggestion 2))]
+
+def exactSaturationPrefix (events : Array (Event Rank)) : Bool :=
+  match events.toList with
+  | [.rule _ initial, .rule _ retry, .instance _ (.admitted [fresh]),
+      .equality _ firstEquality, .rule _ gObservation, .equality _ lastEquality,
+      .dismissal splitSelection false, .saturated] =>
+      exactInitialObservation initial && exactRetryObservation retry true &&
+        fresh == node 2 &&
+        exactEqualityObservation firstEquality .improved (some (node 2, 0, 4, 0, 1)) &&
+        exactGObservation gObservation 4 &&
+        exactEqualityObservation lastEquality .noChange none &&
+        exactSelection splitSelection 6 1 (.suggestion (suggestion 2))
+  | _ => false
+
+-- The final permitted transition may expose a genuine fixed point.  The
+-- zero-fuel boundary must inspect that state and report saturation.
+#guard
+  match run? 7 saturationCommands with
+  | some result =>
+      exactSaturationPrefix result.events && result.policyState.isEmpty &&
+        result.state.metrics.decisions == 7 &&
+        match result.stop with
+        | .saturated => true
+        | _ => false
+  | none => false
+
+-- With one fewer transition, live split work remains and the same run reports
+-- fuel exhaustion rather than a false fixed point.
+#guard
+  match run? 6 saturationCommands with
+  | some result =>
+      result.events.size == 7 &&
+        match result.events.back?, result.stop with
+        | some .driverFuel, .driverFuel => true
+        | _, _ => false
+  | none => false
+
+#guard
+  match run? 1 [.stop] with
+  | some result =>
+      result.state.metrics.decisions == 0 &&
+        match result.events.toList, result.stop with
+        | [.policyStop 1], .unknown (.policyStop 1) => true
+        | _, _ => false
+  | none => false
+
+#guard
+  match run? 1 [.dismiss (.application (application 0))] with
+  | some result =>
+      result.state.metrics.decisions == 1 &&
+        match result.events.toList, result.stop with
+        | [.dismissal selection true], .unknown (.requiredDismissal stopped) =>
+            exactSelection selection 0 0 (.application (application 0)) &&
+              selection.serial == stopped.serial && selection.id == stopped.id
+        | _, _ => false
+  | none => false
+
+/-! ## Resource boundaries -/
+
+def initialWithLimits? (limits : Experiment.Propagator.Policy.Limits) : Option (State Rank) :=
+  initialWith? limits
+
+#guard
+  match run? 2 retryFirstCommands
+      (initialWithLimits? { policyLimits with maxDecisions := 1 }) with
+  | some result =>
+      result.state.metrics.decisions == 1 &&
+        match result.events.toList, result.stop with
+        | [.rule selection observation, .decisionResource], .decisionResource =>
+            exactInitialObservation observation &&
+              exactSelection selection 0 0 (.application (application 0))
+        | _, _ => false
+  | none => false
+
+#guard
+  match run? 2 retryFirstCommands
+      (initialWithLimits? { policyLimits with maxTraversal := 1 }) with
+  | some result =>
+      result.state.metrics.decisions == 1 && result.state.metrics.traversal == 1 &&
+        match result.events.toList, result.stop with
+        | [.rule selection observation, .viewResource .traversalLimit],
+            .viewResource .traversalLimit =>
+            exactInitialObservation observation &&
+              exactSelection selection 0 0 (.application (application 0))
+        | _, _ => false
+  | none => false
+
+/-! ## Typed equality stops -/
+
+-- Equality resource failures remain typed observations, then stop the driver
+-- with a second event which identifies the selected policy choice as origin.
+#guard
+  match run? 1 [.select (.equality (equality 0))]
+      (equalityReadyWith? { engineLimits with maxAcceptedFacts := 1 } rankDomain) with
+  | some result =>
+      result.cache.isEmpty && result.state.metrics.decisions == 2 &&
+        result.state.engine.equalityQueued[0]? == some true &&
+        match result.events.toList, result.stop with
+        | [.equality selection observation,
+            .engineResource (.choice origin) .acceptedFacts],
+            .engineResource .acceptedFacts =>
+              exactEqualitySelection selection 1 observation &&
+                exactEqualitySelection origin 1 observation &&
+                observation.outcome == .engineResource .acceptedFacts &&
+                observation.narrowCalls == 2 && observation.changes.isEmpty
+        | _, _ => false
+  | none => false
+
+#guard
+  match run? 1 [.select (.equality (equality 0))]
+      (equalityReadyWith? engineLimits rightResourceDomain) with
+  | some result =>
+      result.cache.isEmpty && result.state.metrics.decisions == 2 &&
+        result.state.engine.equalityQueued[0]? == some true &&
+        match result.events.toList, result.stop with
+        | [.equality selection observation, .factResource (.choice origin) 77],
+            .factResource 77 =>
+              exactEqualitySelection selection 1 observation &&
+                exactEqualitySelection origin 1 observation &&
+                observation.outcome == .factResource 77 &&
+                observation.narrowCalls == 2 && observation.changes.isEmpty
+        | _, _ => false
+  | none => false
+
+-- A domain fault carries its exact typed cause and actual call count in the
+-- equality event before the driver reports that the engine state is invalid.
+#guard
+  match run? 1 [.select (.equality (equality 0))]
+      (equalityReadyWith? engineLimits leftMalformedDomain) with
+  | some result =>
+      result.cache.isEmpty && result.state.metrics.decisions == 2 &&
+        result.state.engine.equalityQueued[0]? == some true &&
+        match result.events.toList, result.stop with
+        | [.equality selection observation, .invalidState], .invalidState =>
+            exactEqualitySelection selection 1 observation &&
+              observation.outcome == .invalid (.malformedFact 91) &&
+              observation.narrowCalls == 1 && observation.changes.isEmpty
+        | _, _ => false
+  | none => false
+
+/-! ## Revalidation of untrusted selections -/
+
+#guard
+  match run? 2 [.stale (.application (application 0)), .stop] with
+  | some result =>
+      result.state.metrics.decisions == 1 && result.state.metrics.rejected == 1 &&
+        match result.events.toList, result.stop with
+        | [.choiceRejected selection .staleSerial, .policyStop 1],
+            .unknown (.policyStop 1) =>
+            selection.serial == 1 && selection.id == .application (application 0)
+        | _, _ => false
+  | none => false
+
+#guard
+  match run? 2 [.wrongRetry (suggestion 0) 2, .stop] afterInitial? with
+  | some result =>
+      result.state.metrics.decisions == 2 && result.state.metrics.rejected == 1 &&
+        match result.events.toList, result.stop with
+        | [.choiceRejected selection .wrongKey, .policyStop 3],
+            .unknown (.policyStop 3) =>
+            match selection.expected with
+            | .retry source 2 => source.rule == fKey && source.effort == 0
+            | _ => false
+        | _, _ => false
+  | none => false
+
+/-! ## Split plans are returned, never executed by the driver -/
+
+#guard
+  match run? 1 [.select (.suggestion (suggestion 2))] afterInitial? with
+  | some result =>
+      result.cache.isEmpty && result.state.metrics.decisions == 2 &&
+        match result.events.toList, result.stop with
+        | [.splitPrepared selection plan], .split stopped =>
+            exactSplitSelection selection 1 0 plan &&
+              exactSplit plan && exactSplit stopped
+        | _, _ => false
+  | none => false
+
+end Hex.Interval.PolicyDriverConformance

--- a/conformance/HexInterval/PolicyDriverConformance.lean
+++ b/conformance/HexInterval/PolicyDriverConformance.lean
@@ -98,6 +98,13 @@ def contradictionInitial? : Option (State Rank) := do
     | .error _ => none
   some (State.start engine policyLimits)
 
+def factResourceInitial? : Option (State Rank) := do
+  let engine <- match Engine.start rightResourceDomain program #[fRule, gRule] #[0, 0]
+      engineLimits with
+    | .ok engine => some engine
+    | .error _ => none
+  some (State.start engine policyLimits)
+
 def invokeUndeclared (calls : Calls) (request : RuleRequest Rank) :
     Outcome Rank × Calls :=
   (.success
@@ -344,13 +351,18 @@ def exactSaturationPrefix (events : Array (Event Rank)) : Bool :=
   | some state =>
       let result := drive controller invokeUndeclared 1 state []
         [.select (.application (application 0))]
-      result.cache == [(fKey.name, 0)] && result.state.engine.pending.isNone &&
-        match result.events.toList, result.stop with
-        | [.replyRejected selection invocation (.undeclaredWrite target)],
-            .invalidReply (.undeclaredWrite stoppedTarget) =>
-              target == node 0 && stoppedTarget == node 0 &&
-                exactInvokeSelection selection 0 0 (.application (application 0))
-                  invocation
+      let resumed := drive controller invokeLogged 0 result.state result.cache []
+      result.cache == [(fKey.name, 0)] && result.state.incomplete &&
+        result.state.engine.pending.isNone &&
+        (match result.events.toList, result.stop with
+          | [.replyRejected selection invocation (.undeclaredWrite target)],
+              .invalidReply (.undeclaredWrite stoppedTarget) =>
+                target == node 0 && stoppedTarget == node 0 &&
+                  exactInvokeSelection selection 0 0 (.application (application 0))
+                    invocation
+          | _, _ => false) &&
+        match resumed.events.toList, resumed.stop with
+        | [.incomplete], .unknown .incomplete => resumed.state.incomplete
         | _, _ => false
 
 -- A registry failure is an accepted, typed observation, but it cannot close
@@ -412,6 +424,43 @@ def exactSaturationPrefix (events : Array (Event Rank)) : Bool :=
 
 def initialWithLimits? (limits : Experiment.Propagator.Policy.Limits) : Option (State Rank) :=
   initialWith? limits
+
+-- An engine resource stop rolls back the candidate transaction but consumes
+-- the selected application. Restarting from the returned snapshot therefore
+-- reports incomplete rather than saturation.
+#guard
+  match PolicyConformance.initialWithLimits?
+      { engineLimits with maxAcceptedFacts := 0 } policyLimits with
+  | none => false
+  | some state =>
+      let result := drive controller invokeLogged 1 state []
+        [.select (.application (application 0))]
+      let resumed := drive controller invokeLogged 0 result.state result.cache []
+      result.state.incomplete && result.state.engine.pending.isNone &&
+        (match result.events.toList, result.stop with
+          | [.engineResource (.invocation selection invocation) .acceptedFacts],
+              .engineResource .acceptedFacts =>
+                exactInvokeSelection selection 0 0 (.application (application 0))
+                  invocation
+          | _, _ => false) &&
+        match resumed.events.toList, resumed.stop with
+        | [.incomplete], .unknown .incomplete => resumed.state.incomplete
+        | _, _ => false
+
+-- Fact-domain resource exhaustion carries its exact budget and the same
+-- completeness status.
+#guard
+  match factResourceInitial? with
+  | none => false
+  | some state =>
+      let result := drive controller invokeLogged 1 state []
+        [.select (.application (application 0))]
+      result.state.incomplete && result.state.engine.pending.isNone &&
+        match result.events.toList, result.stop with
+        | [.factResource (.invocation selection invocation) 77], .factResource 77 =>
+            exactInvokeSelection selection 0 0 (.application (application 0))
+              invocation
+        | _, _ => false
 
 #guard
   match run? 2 retryFirstCommands

--- a/conformance/HexInterval/PolicyDriverConformance.lean
+++ b/conformance/HexInterval/PolicyDriverConformance.lean
@@ -104,6 +104,14 @@ def invokeUndeclared (calls : Calls) (request : RuleRequest Rank) :
       [{ node := node 0, fact := 1, payload := { index := request.action.serial } }]
       [] {}, calls ++ [(request.action.key.name, request.action.effort)])
 
+def invokeFailed (calls : Calls) (request : RuleRequest Rank) :
+    Outcome Rank × Calls :=
+  (.failed 73, calls ++ [(request.action.key.name, request.action.effort)])
+
+def invokeLimited (calls : Calls) (request : RuleRequest Rank) :
+    Outcome Rank × Calls :=
+  (.resourceLimit 59, calls ++ [(request.action.key.name, request.action.effort)])
+
 /-! ## Exact event predicates -/
 
 def exactSelection (selection : Selection) (serial programVersion : Nat)
@@ -184,7 +192,7 @@ def exactInstantiationFirstEvents (events : Array (Event Rank)) : Bool :=
       .rule gSelection gObservation,
       .equality firstEqualitySelection firstEquality,
       .equality lastEqualitySelection lastEquality,
-      .dismissal retrySelection false,
+      .dismissal retrySelection false true,
       .splitPrepared splitSelection plan] =>
       exactInitialObservation fObservation &&
         exactInvokeSelection fSelection 0 0 (.application (application 0))
@@ -263,7 +271,7 @@ def exactSaturationPrefix (events : Array (Event Rank)) : Bool :=
   match events.toList with
   | [.rule _ initial, .rule _ retry, .instance _ (.admitted [fresh]),
       .equality _ firstEquality, .rule _ gObservation, .equality _ lastEquality,
-      .dismissal splitSelection false, .saturated] =>
+      .dismissal splitSelection false false, .saturated] =>
       exactInitialObservation initial && exactRetryObservation retry true &&
         fresh == node 2 &&
         exactEqualityObservation firstEquality .improved (some (node 2, 0, 4, 0, 1)) &&
@@ -304,8 +312,8 @@ def exactSaturationPrefix (events : Array (Event Rank)) : Bool :=
       result.state.incomplete && result.policyState.isEmpty &&
         result.state.metrics.decisions == 4 &&
         match result.events.toList, result.stop with
-        | [.dismissal retry false, .dismissal instanceSelection false,
-            .dismissal split false, .incomplete],
+        | [.dismissal retry false true, .dismissal instanceSelection false true,
+            .dismissal split false false, .incomplete],
             .unknown .incomplete =>
               exactSelection retry 1 0 (.suggestion (suggestion 0)) &&
                 exactSelection instanceSelection 2 0 (.suggestion (suggestion 1)) &&
@@ -345,6 +353,41 @@ def exactSaturationPrefix (events : Array (Event Rank)) : Bool :=
                   invocation
         | _, _ => false
 
+-- A registry failure is an accepted, typed observation, but it cannot close
+-- the selected propagation obligation.  An empty frontier is therefore
+-- unknown rather than saturated.
+#guard
+  match initial? with
+  | none => false
+  | some state =>
+      let result := drive controller invokeFailed 1 state []
+        [.select (.application (application 0))]
+      result.state.incomplete && result.state.engine.pending.isNone &&
+        result.cache == [(fKey.name, 0)] &&
+        match result.events.toList, result.stop with
+        | [.rule selection observation, .incomplete], .unknown .incomplete =>
+            exactInvokeSelection selection 0 0 (.application (application 0))
+                observation.invocation &&
+              observation.outcome == .failed 73 && observation.changes.isEmpty
+        | _, _ => false
+
+-- A rule-declared resource limit has the same completeness boundary.  It is
+-- not an engine resource stop and cannot be reinterpreted as inapplicability.
+#guard
+  match initial? with
+  | none => false
+  | some state =>
+      let result := drive controller invokeLimited 1 state []
+        [.select (.application (application 0))]
+      result.state.incomplete && result.state.engine.pending.isNone &&
+        result.cache == [(fKey.name, 0)] &&
+        match result.events.toList, result.stop with
+        | [.rule selection observation, .incomplete], .unknown .incomplete =>
+            exactInvokeSelection selection 0 0 (.application (application 0))
+                observation.invocation &&
+              observation.outcome == .resourceLimit 59 && observation.changes.isEmpty
+        | _, _ => false
+
 #guard
   match run? 1 [.stop] with
   | some result =>
@@ -359,7 +402,7 @@ def exactSaturationPrefix (events : Array (Event Rank)) : Bool :=
   | some result =>
       result.state.metrics.decisions == 1 &&
         match result.events.toList, result.stop with
-        | [.dismissal selection true], .unknown (.requiredDismissal stopped) =>
+        | [.dismissal selection true true], .unknown (.requiredDismissal stopped) =>
             exactSelection selection 0 0 (.application (application 0)) &&
               selection.serial == stopped.serial && selection.id == stopped.id
         | _, _ => false

--- a/conformance/HexInterval/PolicyFrontierConformance.lean
+++ b/conformance/HexInterval/PolicyFrontierConformance.lean
@@ -5,6 +5,7 @@ Authors: Kim Morrison
 -/
 
 import HexInterval.Experiment.PolicyFrontier
+import HexInterval.PolicyConformance
 
 /-!
 Small merge-gated equivalence canaries for the two policy-frontier
@@ -23,11 +24,46 @@ def dense : Comparison := compare denseCanary
 
 def churn : Comparison := compare churnCanary
 
+def incomplete? : Option Comparison := do
+  let state <- prepare fanoutCanary
+  let offer <- state.offer? (.suggestion (suggestionId 0))
+  match state.dismiss (selectionFor state offer) with
+  | .completed .dismissed next => some (comparePrepared fanoutCanary next)
+  | _ => none
+
+def instanceStep? : Option Step := do
+  let state <- PolicyConformance.afterInitial?
+  let offer <- state.offer? (.suggestion (PolicyConformance.suggestion 1))
+  execute fanoutCanary state offer {}
+
 #guard comparisonValid fanoutCanary fanout
 
 #guard comparisonValid denseCanary dense
 
 #guard comparisonValid churnCanary churn
+
+-- Empty-frontier representation equivalence does not erase an earlier
+-- completeness loss. Neither loop may call this state saturated.
+#guard
+  match incomplete? with
+  | some comparison =>
+      semanticEqual comparison.scan comparison.indexed &&
+        comparison.scan.stop == .incomplete &&
+        comparison.indexed.stop == .incomplete &&
+        comparison.scan.incomplete && comparison.indexed.incomplete &&
+        comparison.scan.liveOffers == 0 && comparison.indexed.liveOffers == 0
+  | none => false
+
+-- The shared executor selects a structural offer and lets the engine admit it;
+-- it does not silently classify instantiation as an optional dismissal.
+#guard
+  match instanceStep? with
+  | some step =>
+      !step.state.incomplete && step.state.engine.programVersion == 1 &&
+        step.state.engine.program.nodes.size == 3 &&
+        step.state.metrics.selectedInstances == 1 &&
+        step.state.metrics.dismissals == 0
+  | none => false
 
 -- Both arms implement a maximum-priority policy rather than following the
 -- engine queue cursor in FIFO order.

--- a/conformance/HexInterval/PolicyFrontierConformance.lean
+++ b/conformance/HexInterval/PolicyFrontierConformance.lean
@@ -31,6 +31,9 @@ def incomplete? : Option Comparison := do
   | .completed .dismissed next => some (comparePrepared fanoutCanary next)
   | _ => none
 
+def pendingComparison? : Option Comparison :=
+  PolicyConformance.pendingAdoption?.map (comparePrepared fanoutCanary)
+
 def instanceStep? : Option Step := do
   let state <- PolicyConformance.afterInitial?
   let offer <- state.offer? (.suggestion (PolicyConformance.suggestion 1))
@@ -46,6 +49,18 @@ def instanceStep? : Option Step := do
 -- completeness loss. Neither loop may call this state saturated.
 #guard
   match incomplete? with
+  | some comparison =>
+      semanticEqual comparison.scan comparison.indexed &&
+        comparison.scan.stop == .incomplete &&
+        comparison.indexed.stop == .incomplete &&
+        comparison.scan.incomplete && comparison.indexed.incomplete &&
+        comparison.scan.liveOffers == 0 && comparison.indexed.liveOffers == 0
+  | none => false
+
+-- Neither frontier representation may call an adopted open reply latch a
+-- fixed point merely because that pending application has no visible offer.
+#guard
+  match pendingComparison? with
   | some comparison =>
       semanticEqual comparison.scan comparison.indexed &&
         comparison.scan.stop == .incomplete &&

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -223,7 +223,8 @@ lean_lib HexIntervalExperiment where
   globs := #[`HexInterval.Experiment.Representation,
     `HexInterval.Experiment.Rational, `HexInterval.Experiment.Center,
     `HexInterval.Experiment.Scale, `HexInterval.Experiment.Propagator,
-    `HexInterval.Experiment.Policy, `HexInterval.Experiment.PolicyFrontier]
+    `HexInterval.Experiment.Policy, `HexInterval.Experiment.PolicyFrontier,
+    `HexInterval.Experiment.PolicyDriver]
 
 lean_lib HexIntervalMathlibExperiment where
   globs := #[`HexIntervalMathlib.Experiment.Center]
@@ -276,7 +277,7 @@ lean_lib HexRCFProofProbeScientific where
 -- `*_emit_fixtures` exes below, carrying `srcDir := "conformance"`.
 lean_lib HexConformance where
   srcDir := "conformance"
-  globs := #[`HexArith.Conformance, `HexArith.CrossCheck, `HexBerlekamp.Conformance, `HexBerlekampZassenhaus.Conformance, `HexBerlekampZassenhaus.CrossCheck, `HexConway.Conformance, `HexGF2.Conformance, `HexGF2.CrossCheck, `HexGF2.FastCheck, `HexGFq.Conformance, `HexGFq.CrossCheck, `HexGFqField.Conformance, `HexGFqRing.Conformance, `HexGramSchmidt.Conformance, `HexHensel.Conformance, `HexHensel.CrossCheck, `HexInterval.Conformance, `HexInterval.CenterConformance, `HexInterval.ScaleConformance, `HexInterval.PropagatorConformance, `HexInterval.StructureViewConformance, `HexInterval.PolicyConformance, `HexInterval.PolicyFrontierConformance, `HexLLL.Conformance, `HexMatrix.Conformance, `HexRowReduce.Conformance, `HexDeterminant.Conformance, `HexBareiss.Conformance, `HexModArith.Conformance, `HexModArith.FastCheck, `HexNumberField.Conformance, `HexNumberFieldTower.Conformance, `HexPoly.Conformance, `HexPolyFp.Conformance, `HexPolyZ.Conformance, `HexRCF.Conformance, `HexRealRoots.Conformance, `HexRealRootsMathlib.Conformance, `HexResultant.Conformance, `HexRoots.Conformance].map Glob.one
+  globs := #[`HexArith.Conformance, `HexArith.CrossCheck, `HexBerlekamp.Conformance, `HexBerlekampZassenhaus.Conformance, `HexBerlekampZassenhaus.CrossCheck, `HexConway.Conformance, `HexGF2.Conformance, `HexGF2.CrossCheck, `HexGF2.FastCheck, `HexGFq.Conformance, `HexGFq.CrossCheck, `HexGFqField.Conformance, `HexGFqRing.Conformance, `HexGramSchmidt.Conformance, `HexHensel.Conformance, `HexHensel.CrossCheck, `HexInterval.Conformance, `HexInterval.CenterConformance, `HexInterval.ScaleConformance, `HexInterval.PropagatorConformance, `HexInterval.StructureViewConformance, `HexInterval.PolicyConformance, `HexInterval.PolicyFrontierConformance, `HexInterval.PolicyDriverConformance, `HexLLL.Conformance, `HexMatrix.Conformance, `HexRowReduce.Conformance, `HexDeterminant.Conformance, `HexBareiss.Conformance, `HexModArith.Conformance, `HexModArith.FastCheck, `HexNumberField.Conformance, `HexNumberFieldTower.Conformance, `HexPoly.Conformance, `HexPolyFp.Conformance, `HexPolyZ.Conformance, `HexRCF.Conformance, `HexRealRoots.Conformance, `HexRealRootsMathlib.Conformance, `HexResultant.Conformance, `HexRoots.Conformance].map Glob.one
 
 -- Public umbrellas intentionally contain only the supported API. Executable
 -- examples and regression tests are compiled through this separate target so

--- a/progress/20260727T133915Z.md
+++ b/progress/20260727T133915Z.md
@@ -1,0 +1,35 @@
+# External interval-policy driver conformance
+
+## Accomplished
+
+- Added the external driver which connects an arbitrary policy and arbitrary
+  propagator registry to the engine-owned policy frontier.
+- Added exact conformance coverage for retry-first and instantiation-first
+  schedules, including their complete ordered event streams and common final
+  facts.
+- Distinguished saturation at the exact fuel boundary from fuel exhaustion
+  with live work, policy stop, required-work dismissal, decision and traversal
+  resources, stale and fabricated selections, and returned split plans.
+- Wired the driver and its conformance module into the experiment and aggregate
+  conformance targets.
+- Built `HexInterval.Experiment.PolicyDriver` and
+  `HexInterval.PolicyDriverConformance`; the aggregate
+  `HexIntervalExperiment HexConformance` build was also started and continued
+  independently while this layer was reviewed.
+
+## Current frontier
+
+The scan-backed reference driver now exercises arbitrary rule propagation,
+retry, expression instantiation, equality contraction, optional dismissal,
+and split preparation through one checked policy protocol.  Its conformance
+fixture is synthetic and contains no rational-arithmetic dependency.
+
+## Next step
+
+Add concrete replaceable scheduling policies and a canonical replay key, then
+exercise the driver with real interval propagators rather than extending the
+synthetic scheduling layer further.
+
+## Blockers
+
+None.

--- a/progress/20260727T142132Z.md
+++ b/progress/20260727T142132Z.md
@@ -1,0 +1,32 @@
+# External interval-policy driver rebase
+
+## Accomplished
+
+- Rebased the external policy driver directly onto the reviewed policy
+  frontier at `fdd38ece` and retained both frontier and driver aggregate
+  targets.
+- Updated instantiation event checks to use the engine-derived semantic
+  generation exposed by the opaque policy transition API.
+- Added driver-level conformance for typed equality engine-resource,
+  fact-resource, and malformed-fact observations, including exact call counts,
+  event ordering, terminal reasons, and preservation of live equality work.
+- Rebuilt both focused driver targets, the interval experiment aggregate, and
+  both interval scheduling canaries; ran the repository structural, source,
+  trust-surface, bench-import, and conformance-matrix lints.
+
+## Current frontier
+
+The driver remains one commit above the reviewed policy frontier.  The
+frontier is now merged into `main`, so the driver PR can target `main` without
+another history rewrite.
+
+## Next step
+
+Let refreshed PR CI complete the full `HexConformance` graph, then review and
+merge the driver PR independently of subsequent concrete-policy work.
+
+## Blockers
+
+None.  The combined aggregate build was stopped after 8,060 of 9,114 jobs when
+it was found to be rebuilding Mathlib locally; it had no failures, and the
+focused targets and direct canaries are green.

--- a/progress/20260728T050026Z.md
+++ b/progress/20260728T050026Z.md
@@ -1,0 +1,32 @@
+# External policy driver review fixes
+
+## Accomplished
+
+- Rebased the external policy driver onto current `main` and preserved all
+  newly added conformance targets.
+- Corrected fixed-point reporting: dismissing a retry or an instantiation now
+  makes the run incomplete, while dismissing a split remains optional.
+- Added exact driver tests for incomplete dismissal, contradiction on the last
+  fuel step, and rejection of an arbitrary registry write outside its declared
+  target.
+- Retained the policy's versioned key in every driver result.
+- Built the focused policy and driver targets successfully. A complete
+  9,509-job build passed immediately before the review fixes; the affected
+  targets were rebuilt after them.
+
+## Current frontier
+
+The driver now distinguishes a genuine propagation fixed point from a policy
+which merely declined potentially narrowing work. The remaining review notes
+concern future API detail, such as typed invalid-state diagnostics and whether
+driver fuel is per call or shared across a branch tree.
+
+## Next step
+
+Run the short independent re-review and refreshed CI, then merge this layer
+after the structural-view dependency has landed and the branch is rebased
+once more.
+
+## Blockers
+
+None.

--- a/progress/20260728T052335Z.md
+++ b/progress/20260728T052335Z.md
@@ -1,0 +1,35 @@
+# Policy completeness review fixes
+
+## Accomplished
+
+- Made accepted rule `failed` and `resourceLimit` outcomes preserve an
+  incomplete propagation result instead of permitting false saturation.
+- Made rejected instantiations and automatically tombstoned retry or
+  instantiation suggestions preserve incompleteness, including when policy
+  control adopts an existing engine snapshot.
+- Accounted for the bounded suggestion suffix before engine submission:
+  dropping a retry or instantiation marks the run incomplete, while
+  split-only overflow remains optional.
+- Split dismissal observations into independent `halts` and
+  `causesIncomplete` fields.
+- Made both policy-frontier experiments return an explicit incomplete stop and
+  route instantiation offers through structural admission rather than
+  dismissal.
+- Added focused conformance canaries for every boundary above and updated the
+  SPEC.
+
+## Current frontier
+
+The policy layer now distinguishes an exhausted narrowing opportunity from
+successful propagation across callback, instantiation, pruning, dismissal,
+and both frontier representations.
+
+## Next step
+
+Integrate these uncommitted review fixes into the policy-driver PR, rerun its
+independent review, and refresh CI after the prerequisite structural-view PR
+lands.
+
+## Blockers
+
+None.

--- a/progress/20260728T054405Z.md
+++ b/progress/20260728T054405Z.md
@@ -1,0 +1,30 @@
+# Consumed reply-failure completeness
+
+## Accomplished
+
+- Marked reply rejection, engine-resource exhaustion, and fact-domain-resource
+  exhaustion incomplete when the engine has cleared the selected pending
+  action.
+- Preserved completeness and direct resubmission for a mismatched reply which
+  leaves the exact pending action intact.
+- Made suggestion dismissal fail safe: only a validated split key preserves
+  completeness.
+- Added direct and external-driver canaries for consumed invalid replies,
+  engine and fact resource stops, restart behavior, and mismatched-action
+  resubmission.
+- Documented the distinction and retained conservative stale/weak-retry
+  accounting as an open policy question.
+
+## Current frontier
+
+Every rule-reply exit now records whether its selected propagation obligation
+was discharged, remains resubmittable, or was consumed without a completeness
+result.
+
+## Next step
+
+Refresh the independent review and CI for the rebased policy-driver PR.
+
+## Blockers
+
+None.

--- a/progress/20260728T055439Z.md
+++ b/progress/20260728T055439Z.md
@@ -1,0 +1,27 @@
+# Pending policy snapshots
+
+## Accomplished
+
+- Made unsuccessful reply bookkeeping depend uniformly on whether the engine
+  retained or cleared its pending action.
+- Preserved exact resubmission for a mismatched reply.
+- Marked an adopted snapshot with an already-open reply latch incomplete,
+  preventing either frontier representation from calling its empty visible
+  offer set a fixed point.
+- Added direct invocation, retry, and both frontier canaries.
+- Rebuilt the focused policy, driver, frontier, and interval experiment
+  targets.
+
+## Current frontier
+
+Policy fixed-point reporting now accounts for consumed work both during a run
+and when control begins from an existing engine snapshot.
+
+## Next step
+
+Complete refreshed CI and merge the policy driver, then use the same invariant
+inside the private proof-producing policy session.
+
+## Blockers
+
+None.

--- a/progress/20260728T060716Z.md
+++ b/progress/20260728T060716Z.md
@@ -1,0 +1,30 @@
+# Shared suggestion-retention policy
+
+## Accomplished
+
+- Rebased the policy-driver series onto current `main` while preserving the
+  pending-action completeness semantics and conformance tests from `78c6a093`.
+- Moved closure relevance to `Suggestion.affectsClosure` and added
+  engine-owned helpers for remaining suggestion room and the exact retained
+  prefix and dropped suffix.
+- Routed both `Engine.submit` and policy completeness accounting through the
+  shared helpers so their retention arithmetic and closure classification
+  cannot drift.
+- Rebuilt the propagator, policy, driver, frontier, focused conformance
+  modules, and `HexIntervalExperiment`; scanned all PR Lean files without
+  finding `native_decide`, `axiom`, or `sorry`.
+
+## Current frontier
+
+The external policy driver and both frontier implementations now distinguish
+true fixed points from consumed or discarded narrowing work using the same
+engine-owned retention boundary.
+
+## Next step
+
+Let refreshed PR CI validate the full repository graph, then merge the policy
+driver and reuse the invariant in the proof-producing policy session.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## What changed

- adds a generic external driver over the engine-owned policy frontier;
- supports arbitrary policy-private state and arbitrary registry cache types;
- lets a policy select, dismiss, or stop while the engine validates propagation, equality, instantiation, retry, and split transitions;
- returns one ordered event stream and the exact versioned policy key;
- distinguishes genuine saturation from contradiction, prepared split, incomplete search, resource exhaustion, invalid replies, and fuel exhaustion;
- returns a validated split plan without claiming branch creation already exists.

## Review fixes

Independent reviews found several ways consumed work could empty the frontier and be mislabeled as saturation. The state now records incompleteness after failed/resource-limited rule outcomes, rejected instantiations, dropped or dismissed retries/instantiations, and invalid or resource-limited replies which clear the pending action. A mismatched reply retains the exact pending action and remains resubmittable without poisoning completeness. Only split loss/dismissal preserves propagation completeness.

## Evidence

Two policies drive the same opaque `f` and generated `g` network in different orders. They produce different event histories and callback counts but the same final facts and split plan. Tests cover typed failures, consumed-versus-resubmittable replies, suggestion overflow, stale/fabricated selections, decision/traversal limits, policy stop, contradiction at the fuel boundary, dismissal, and split preparation.

## Deliberately open

- branch creation and split interiority belong to the next scope layer;
- weak or stale retries are conservatively completeness-relevant until redundancy is proved;
- whether driver fuel is per call or shared over a complete branch tree remains experimental;
- immutable proof-payload freezing and replay are separate framework layers.

No part of this work uses `native_decide`, `axiom`, or `sorry`.

## Validation

- `lake build HexInterval.Experiment.Policy HexInterval.Experiment.PolicyDriver HexInterval.Experiment.PolicyFrontier HexInterval.PolicyConformance HexInterval.PolicyDriverConformance HexInterval.PolicyFrontierConformance HexIntervalExperiment`
- `git diff --check` and touched-file trust scan