### PR TITLE
prove(number-field): identify zero semantics

### DIFF
--- a/HexNumberField/Basic.lean
+++ b/HexNumberField/Basic.lean
@@ -81,6 +81,21 @@ def ofNormalized?
   some (.mk p prim pos_lc pos_degree checked squarefree (SimpleRoot.mk canonical)
     canonical rfl)
 
+/-- Successful canonicalization retains the supplied normalized polynomial. -/
+theorem ofNormalized?_p
+    (p : ZPoly) (prim : ZPoly.Primitive p) (pos_lc : 0 < p.leadingCoeff)
+    (pos_degree : 0 < p.degree?.getD 0)
+    (checked : ZPoly.CheckedIrreducible p) (squarefree : HasOnlySimpleRoots p)
+    (rep : RefinedIsolation p) {a : AlgebraicNumber}
+    (h : ofNormalized? p prim pos_lc pos_degree checked squarefree rep = some a) :
+    a.p = p := by
+  unfold ofNormalized? at h
+  obtain ⟨isolations, _, h⟩ := Option.bind_eq_some_iff.mp h
+  obtain ⟨refined, _, h⟩ := Option.bind_eq_some_iff.mp h
+  obtain ⟨canonical, _, h⟩ := Option.bind_eq_some_iff.mp h
+  cases h
+  rfl
+
 private def zeroSquare : DyadicSquare :=
   ⟨0, 0, (mahlerPrec ZPoly.X : Int)⟩
 
@@ -113,6 +128,12 @@ private theorem zeroCandidate_isSome : zeroCandidate.isSome := by
 root of the normalized polynomial `X`. -/
 def zero : AlgebraicNumber :=
   Option.get zeroCandidate zeroCandidate_isSome
+
+/-- The canonical zero retains `X` as its normalized polynomial. -/
+theorem zero_p : zero.p = ZPoly.X := by
+  apply ofNormalized?_p ZPoly.X (by rfl) (by decide) (by decide)
+    ⟨zero_isIrreducible, by decide⟩ zero_squarefree zeroRep
+  exact (Option.some_get zeroCandidate_isSome).symm
 
 instance : Zero AlgebraicNumber := ⟨zero⟩
 

--- a/HexNumberFieldMathlib/Lazy.lean
+++ b/HexNumberFieldMathlib/Lazy.lean
@@ -154,7 +154,14 @@ namespace AlgebraicNumber
 
 /-- Canonical zero denotes complex zero. -/
 theorem zero_toComplex : (0 : AlgebraicNumber).toComplex = 0 := by
-  sorry
+  have hroot := AlgebraicRoot.toComplex_isRoot
+    (0 : AlgebraicNumber).toRoot
+  change (HexRootsMathlib.toPolyℂ (0 : AlgebraicNumber).p).eval
+    (0 : AlgebraicNumber).toComplex = 0 at hroot
+  have hp : (0 : AlgebraicNumber).p = ZPoly.X :=
+    AlgebraicNumber.zero_p
+  rw [hp] at hroot
+  simpa [HexRootsMathlib.toPolyℂ, ZPoly.X] using hroot
 
 /-- Canonical addition computes complex addition. -/
 theorem add_toComplex (a b : AlgebraicNumber) :

--- a/HexNumberFieldTower/Arithmetic.lean
+++ b/HexNumberFieldTower/Arithmetic.lean
@@ -34,12 +34,31 @@ def zero (T : NumberTower) : Elem T :=
 
 instance {T : NumberTower} : Zero (Elem T) := ⟨zero T⟩
 
+/-- The coordinate zero is the rational embedding of zero. -/
+theorem zero_eq_ofRat (T : NumberTower) :
+    (0 : Elem T) = T.ofRat 0 := by
+  change ofCoeffs T #[] = T.ofRat 0
+  rw [ofRat_eq_ofCoeffs]
+  apply Elem.ext
+  simp only [coeffs_ofCoeffs, normalizeCoeffs, Vector.toArray_ofFn]
+  congr 1
+  funext i
+  rcases i with ⟨_ | i, hi⟩
+  · simp
+  · simp
+
 /-- Multiplicative identity. -/
 @[expose]
 def one (T : NumberTower) : Elem T :=
   ofCoeffs T #[1]
 
 instance {T : NumberTower} : One (Elem T) := ⟨one T⟩
+
+/-- The coordinate one is the rational embedding of one. -/
+theorem one_eq_ofRat (T : NumberTower) :
+    (1 : Elem T) = T.ofRat 1 := by
+  rw [ofRat_eq_ofCoeffs]
+  rfl
 
 /-- Coordinatewise addition. -/
 @[expose]
@@ -48,6 +67,16 @@ def add {T : NumberTower} (a b : Elem T) : Elem T :=
 
 instance {T : NumberTower} : Add (Elem T) := ⟨add⟩
 
+/-- Addition exposes its fixed-width coordinate result. -/
+@[simp]
+theorem coeffs_add {T : NumberTower} (a b : Elem T) :
+    coeffs (a + b) = Arithmetic.addCoords T.dim (coeffs a) (coeffs b) := by
+  change coeffs (add a b) = _
+  unfold add
+  rw [coeffs_ofCoeffs]
+  apply normalizeCoeffs_eq_self
+  simp [Arithmetic.addCoords]
+
 /-- Coordinatewise subtraction. -/
 @[expose]
 def sub {T : NumberTower} (a b : Elem T) : Elem T :=
@@ -55,12 +84,45 @@ def sub {T : NumberTower} (a b : Elem T) : Elem T :=
 
 instance {T : NumberTower} : Sub (Elem T) := ⟨sub⟩
 
+/-- Subtraction exposes its fixed-width coordinate result. -/
+@[simp]
+theorem coeffs_sub {T : NumberTower} (a b : Elem T) :
+    coeffs (a - b) = Arithmetic.subCoords T.dim (coeffs a) (coeffs b) := by
+  change coeffs (sub a b) = _
+  unfold sub
+  rw [coeffs_ofCoeffs]
+  apply normalizeCoeffs_eq_self
+  simp [Arithmetic.subCoords]
+
 /-- Coordinatewise additive inverse. -/
 @[expose]
 def neg {T : NumberTower} (a : Elem T) : Elem T :=
   ofCoeffs T (Arithmetic.negCoords T.dim (coeffs a))
 
 instance {T : NumberTower} : Neg (Elem T) := ⟨neg⟩
+
+/-- Negation exposes its fixed-width coordinate result. -/
+@[simp]
+theorem coeffs_neg {T : NumberTower} (a : Elem T) :
+    coeffs (-a) = Arithmetic.negCoords T.dim (coeffs a) := by
+  change coeffs (neg a) = _
+  unfold neg
+  rw [coeffs_ofCoeffs]
+  apply normalizeCoeffs_eq_self
+  simp [Arithmetic.negCoords]
+
+/-- Coordinate subtraction is addition of the coordinatewise negation. -/
+theorem sub_eq_add_neg {T : NumberTower} (a b : Elem T) :
+    a - b = a + (-b) := by
+  apply Elem.ext
+  rw [coeffs_sub, coeffs_add, coeffs_neg]
+  simp only [Arithmetic.subCoords, Arithmetic.addCoords,
+    Arithmetic.negCoords, Vector.toArray_ofFn]
+  congr 1
+  funext i
+  simpa only [Array.getD_eq_getD_getElem?, Array.getElem?_ofFn,
+    dif_pos i.isLt, Option.getD_some] using Rat.sub_eq_add_neg
+      ((coeffs a).getD i 0) ((coeffs b).getD i 0)
 
 /-- Recursive convolution and monic reduction. -/
 @[expose]

--- a/HexNumberFieldTower/Basic.lean
+++ b/HexNumberFieldTower/Basic.lean
@@ -126,6 +126,15 @@ truncating excess coordinates and padding missing coordinates with zero. -/
 def normalizeCoeffs (T : NumberTower) (coefficients : Array Rat) : Array Rat :=
   (Vector.ofFn fun i : Fin T.dim => coefficients.getD i.val 0).toArray
 
+/-- Normalization fixes an array that already has the tower width. -/
+theorem normalizeCoeffs_eq_self (T : NumberTower) (coefficients : Array Rat)
+    (hsize : coefficients.size = T.dim) :
+    normalizeCoeffs T coefficients = coefficients := by
+  apply Array.ext
+  · simp [normalizeCoeffs, hsize]
+  · intro i hi₁ hi₂
+    simp [normalizeCoeffs, Array.getD, hi₂]
+
 /-- Construct the unique fixed-width element represented by a raw coordinate
 array. -/
 def ofCoeffs (T : NumberTower) (coefficients : Array Rat) : Elem T :=
@@ -135,6 +144,12 @@ def ofCoeffs (T : NumberTower) (coefficients : Array Rat) : Elem T :=
 @[expose]
 def coeffs {T : NumberTower} (a : Elem T) : Array Rat :=
   a.data
+
+/-- Reading a freshly normalized element returns its normalized coordinates. -/
+@[simp]
+theorem coeffs_ofCoeffs (T : NumberTower) (coefficients : Array Rat) :
+    coeffs (ofCoeffs T coefficients) = normalizeCoeffs T coefficients := by
+  rfl
 
 /-- Equality is exact coordinate equality inside a fixed tower. -/
 @[ext]
@@ -156,6 +171,11 @@ instance {T : NumberTower} : DecidableEq (Elem T) := fun a b =>
 /-- Embed a rational number into the constant mixed-radix coordinate. -/
 def ofRat (T : NumberTower) (q : Rat) : Elem T :=
   ofCoeffs T #[q]
+
+/-- Rational embedding is the singleton-coordinate constructor. -/
+theorem ofRat_eq_ofCoeffs (T : NumberTower) (q : Rat) :
+    T.ofRat q = T.ofCoeffs #[q] := by
+  rfl
 
 /-- A dependent extension result carries the canonical lower-field embedding,
 the new generator, and its selected absolute algebraic root. -/

--- a/HexNumberFieldTowerMathlib/Arithmetic.lean
+++ b/HexNumberFieldTowerMathlib/Arithmetic.lean
@@ -24,27 +24,30 @@ namespace Hex.NumberTower
 /-- Executable zero denotes complex zero. -/
 theorem map_zero (T : NumberTower) :
     T.toComplex (0 : Elem T) = 0 := by
-  sorry
+  rw [zero_eq_ofRat]
+  simpa using toComplex_ofRat T 0
 
 /-- Executable one denotes complex one. -/
 theorem map_one (T : NumberTower) :
     T.toComplex (1 : Elem T) = 1 := by
-  sorry
+  rw [one_eq_ofRat]
+  simpa using toComplex_ofRat T 1
 
 /-- Coordinate addition computes complex addition. -/
 theorem map_add (T : NumberTower) (a b : Elem T) :
     T.toComplex (a + b) = T.toComplex a + T.toComplex b := by
   sorry
 
-/-- Coordinate subtraction computes complex subtraction. -/
-theorem map_sub (T : NumberTower) (a b : Elem T) :
-    T.toComplex (a - b) = T.toComplex a - T.toComplex b := by
-  sorry
-
 /-- Coordinate negation computes complex negation. -/
 theorem map_neg (T : NumberTower) (a : Elem T) :
     T.toComplex (-a) = -T.toComplex a := by
   sorry
+
+/-- Coordinate subtraction computes complex subtraction. -/
+theorem map_sub (T : NumberTower) (a b : Elem T) :
+    T.toComplex (a - b) = T.toComplex a - T.toComplex b := by
+  rw [NumberTower.sub_eq_add_neg, map_add, map_neg]
+  rfl
 
 /-- Recursive reduced multiplication computes complex multiplication. -/
 theorem map_mul (T : NumberTower) (a b : Elem T) :

--- a/progress/20260727T140856Z_number-field-zero-semantics.md
+++ b/progress/20260727T140856Z_number-field-zero-semantics.md
@@ -1,0 +1,40 @@
+# Number-field zero semantics
+
+## Accomplished
+
+- Proved that successful `AlgebraicNumber.ofNormalized?` construction retains
+  its supplied normalized polynomial, and specialized this to identify the
+  canonical zero polynomial as `ZPoly.X`.
+- Used that structural identity and the existing root semantics to prove that
+  canonical algebraic zero denotes complex zero.
+- Added fixed-width normalization and coordinate exposure lemmas for number
+  tower elements, including the rational presentations of zero and one and the
+  identity `a - b = a + (-b)`.
+- Closed the tower Mathlib correspondence theorems `map_zero`, `map_one`, and
+  `map_sub` without adding `sorry`, `axiom`, or `native_decide`.
+- Validated `HexNumberFieldMathlib`, `HexNumberFieldTowerMathlib`, and
+  `HexManual`; all 8 number-field and all 19 tower smoke benchmarks; copyright,
+  line-count, DAG, Phase-4, Mathlib-free bench, conformance-target, and diff
+  checks.
+
+## Current frontier
+
+- The remaining tower arithmetic bridge obligations are the primitive semantic
+  proofs for coordinate addition, negation, multiplication, inversion, scalar
+  action, and zero recognition. Derived subtraction and division are now
+  discharged from those primitives.
+- The earlier resultant and number-field milestone PRs remain stacked while CI
+  and review complete.
+
+## Next step
+
+- Open this change as a draft PR stacked on `NumberFieldTotalWrappers`, then
+  attack the next primitive semantic bridge, starting with coordinate
+  evaluation for addition and negation.
+- Continue repairing and merging the earlier stacked PRs independently of the
+  proof work.
+
+## Blockers
+
+- Fresh Claude second-opinion runs are quota-blocked until the provider reset at
+  16:00 UTC; implementation and PR preparation can continue meanwhile.


### PR DESCRIPTION
## Summary

- retain the normalized polynomial through successful algebraic-number canonicalization and identify canonical zero with `ZPoly.X`
- prove canonical algebraic zero denotes complex zero
- expose fixed-width tower coordinates and rational presentations of zero and one
- derive tower subtraction from addition and negation, closing `map_zero`, `map_one`, and `map_sub`

## Validation

- `lake build HexNumberFieldMathlib HexNumberFieldTowerMathlib HexManual`
- `lake exe hexnumberfield_bench verify` (8/8)
- `lake exe hexnumberfieldtower_bench verify` (19/19)
- copyright headers, file line counts, DAG, Phase 4, Mathlib-free benches, conformance targets, and diff checks