### PR TITLE
prove(number-field-tower): recognize zero and negation

### DIFF
--- a/HexNumberFieldTower/Arithmetic.lean
+++ b/HexNumberFieldTower/Arithmetic.lean
@@ -47,6 +47,37 @@ theorem zero_eq_ofRat (T : NumberTower) :
   · simp
   · simp
 
+/-- Zero exposes the all-zero fixed-width coordinate array. -/
+@[simp]
+theorem coeffs_zero (T : NumberTower) :
+    coeffs (0 : Elem T) = Array.replicate T.dim 0 := by
+  rw [zero_eq_ofRat, ofRat_eq_ofCoeffs, coeffs_ofCoeffs]
+  apply Array.ext
+  · simp [normalizeCoeffs]
+  · intro i hi₁ hi₂
+    rcases i with _ | i
+    · simp [normalizeCoeffs]
+    · simp [normalizeCoeffs, Array.getD]
+
+/-- The Boolean coordinate test recognizes exactly the tower zero. -/
+theorem isZero_iff_eq_zero {T : NumberTower} (a : Elem T) :
+    NumberTower.isZero a ↔ a = 0 := by
+  constructor
+  · intro h
+    apply Elem.ext
+    rw [coeffs_zero]
+    apply Array.ext
+    · simp
+    · intro i hi₁ hi₂
+      change (coeffs a).all (fun q => q = 0) = true at h
+      rw [Array.all_eq_true] at h
+      simpa using h i hi₁
+  · rintro rfl
+    change (coeffs (0 : Elem T)).all (fun q => q = 0) = true
+    rw [coeffs_zero, Array.all_eq_true]
+    intro i hi
+    simp
+
 /-- Multiplicative identity. -/
 @[expose]
 def one (T : NumberTower) : Elem T :=
@@ -123,6 +154,19 @@ theorem sub_eq_add_neg {T : NumberTower} (a b : Elem T) :
   simpa only [Array.getD_eq_getD_getElem?, Array.getElem?_ofFn,
     dif_pos i.isLt, Option.getD_some] using Rat.sub_eq_add_neg
       ((coeffs a).getD i 0) ((coeffs b).getD i 0)
+
+/-- Coordinatewise negation is an additive inverse. -/
+theorem add_neg_self {T : NumberTower} (a : Elem T) :
+    a + (-a) = 0 := by
+  apply Elem.ext
+  rw [coeffs_add, coeffs_neg, coeffs_zero]
+  apply Array.ext
+  · simp [Arithmetic.addCoords]
+  · intro i hi₁ hi₂
+    have hi : i < (coeffs a).size := by
+      simpa using hi₂
+    simpa [Arithmetic.addCoords, Arithmetic.negCoords] using
+      Rat.add_neg_cancel ((coeffs a)[i]'hi)
 
 /-- Recursive convolution and monic reduction. -/
 @[expose]

--- a/HexNumberFieldTower/Basic.lean
+++ b/HexNumberFieldTower/Basic.lean
@@ -145,6 +145,12 @@ def ofCoeffs (T : NumberTower) (coefficients : Array Rat) : Elem T :=
 def coeffs {T : NumberTower} (a : Elem T) : Array Rat :=
   a.data
 
+/-- Every element exposes exactly the tower's mixed-radix width. -/
+@[simp]
+theorem coeffs_size {T : NumberTower} (a : Elem T) :
+    (coeffs a).size = T.dim := by
+  exact a.size_eq
+
 /-- Reading a freshly normalized element returns its normalized coordinates. -/
 @[simp]
 theorem coeffs_ofCoeffs (T : NumberTower) (coefficients : Array Rat) :

--- a/HexNumberFieldTowerMathlib/Arithmetic.lean
+++ b/HexNumberFieldTowerMathlib/Arithmetic.lean
@@ -41,7 +41,9 @@ theorem map_add (T : NumberTower) (a b : Elem T) :
 /-- Coordinate negation computes complex negation. -/
 theorem map_neg (T : NumberTower) (a : Elem T) :
     T.toComplex (-a) = -T.toComplex a := by
-  sorry
+  have h := map_add T a (-a)
+  rw [NumberTower.add_neg_self, map_zero] at h
+  exact eq_neg_of_add_eq_zero_right h.symm
 
 /-- Coordinate subtraction computes complex subtraction. -/
 theorem map_sub (T : NumberTower) (a b : Elem T) :
@@ -75,7 +77,13 @@ theorem map_smul (T : NumberTower) (q : Rat) (a : Elem T) :
 /-- The Boolean zero test recognizes exactly semantic zero. -/
 theorem isZero_iff (T : NumberTower) (a : Elem T) :
     NumberTower.isZero a ↔ T.toComplex a = 0 := by
-  sorry
+  rw [NumberTower.isZero_iff_eq_zero]
+  constructor
+  · rintro rfl
+    exact map_zero T
+  · intro h
+    apply toComplex_injective T
+    rw [h, map_zero]
 
 /-- Mixed-radix coordinate equality is exactly semantic equality. -/
 theorem eq_iff_toComplex (T : NumberTower) (a b : Elem T) :

--- a/progress/20260727T142029Z_number-tower-zero-negation.md
+++ b/progress/20260727T142029Z_number-tower-zero-negation.md
@@ -1,0 +1,33 @@
+# Number-tower zero recognition and negation
+
+## Accomplished
+
+- Exposed the fixed coordinate width of every tower element and proved that
+  tower zero has the all-zero coordinate array.
+- Proved the executable Boolean zero test is equivalent to equality with the
+  tower zero, then transported that equivalence through the injective complex
+  interpretation to close semantic zero recognition.
+- Proved coordinatewise negation is an additive inverse and used `map_add` and
+  `map_zero` to derive the semantic negation correspondence, retiring another
+  bridge placeholder without duplicating the evaluator proof.
+- Validated `HexNumberFieldTowerMathlib` and `HexManual`, all 19 tower smoke
+  benchmarks, and the repository policy checks.
+
+## Current frontier
+
+- `map_add` is now the sole primitive additive semantic obligation: negation,
+  subtraction, and zero recognition are derived from it plus structural core
+  identities.
+- Its proof requires exposing the recursive lazy Horner evaluator as a linear
+  complex-valued interpretation of mixed-radix coordinates.
+
+## Next step
+
+- Open this milestone as a draft PR stacked on `NumberFieldZeroSemantic`.
+- On the next branch, prove the raw evaluator's Horner semantics and use its
+  coordinate linearity to close `map_add`.
+
+## Blockers
+
+- Claude second-opinion capacity remains unavailable until the provider quota
+  reset; implementation and GitHub CI continue independently.


### PR DESCRIPTION
## Summary

- expose fixed-width tower coordinates and the all-zero representation
- prove the Boolean zero test is exactly equality with tower zero
- transport coordinate zero recognition through the injective complex interpretation
- derive semantic negation from additive correspondence and the coordinate inverse law

## Validation

- `lake build HexNumberFieldTowerMathlib HexManual`
- `lake exe hexnumberfieldtower_bench verify` (19/19)
- copyright headers, file line counts, DAG, Phase 4, Mathlib-free benches, conformance targets, and diff checks