### PR TITLE
Add checked dyadic interval fact domain

### DIFF
--- a/HexInterval/Experiment/DyadicInterval.lean
+++ b/HexInterval/Experiment/DyadicInterval.lean
@@ -557,24 +557,34 @@ def unscaleExact (limit : EndpointLimit) (scalar : Dyadic) (image : Fact) : Resu
 
 /-! ## Precision-indexed reciprocal -/
 
+/-- Lower cut of a sign-separated reciprocal component.  A zero endpoint is
+the one-sided unbounded limit and is never passed to pointwise inversion;
+`reciprocal` separately rejects a closed zero in the original interval. -/
 def inverseLower (limit : EndpointLimit) (precision : Precision)
     (upper : Upper) : Except WorkCost Lower := do
   match upper with
   | .unbounded => pure (.finite 0 true)
   | .finite value strict =>
-      if value = 0 && strict then
+      -- Zero is a boundary limit, never an input to `invAtPrec`.  The outer
+      -- component check decides whether a closed zero makes the whole
+      -- reciprocal inapplicable.
+      if value = 0 then
         pure .unbounded
       else
         let rounded ← inverseChecked limit precision value
         let exact ← exactReciprocal? limit value
         pure (.finite rounded (strict || exact != some rounded))
 
+/-- Upper cut of a sign-separated reciprocal component, with the same
+zero-limit contract as `inverseLower`. -/
 def inverseUpper (limit : EndpointLimit) (precision : Precision)
     (lower : Lower) : Except WorkCost Upper := do
   match lower with
   | .unbounded => pure (.finite 0 true)
   | .finite value strict =>
-      if value = 0 && strict then
+      -- As above, zero denotes the unbounded component limit and must not be
+      -- passed to the pointwise inverse implementation.
+      if value = 0 then
         pure .unbounded
       else
         let roundedDown ← inverseChecked limit precision (-value)
@@ -669,8 +679,8 @@ def factDomain (limit : EndpointLimit) : FactDomain Fact where
     | .inapplicable => .malformed 1
     | .resourceLimit cost => .resourceLimit (workMagnitude cost)
     | .ready result =>
-        if result.isEmpty then .contradiction result
-        else if result = current then .noChange
+        if result = current then .noChange
+        else if result.isEmpty then .contradiction result
         else .improved result
 
 /-- Error at the checked initial-fact boundary. -/

--- a/HexInterval/Experiment/DyadicInterval.lean
+++ b/HexInterval/Experiment/DyadicInterval.lean
@@ -1,0 +1,689 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Experiment.Propagator
+
+@[expose] public section
+
+/-!
+# Checked dyadic interval facts
+
+This module is the first concrete fact domain for the function-agnostic
+propagation experiment.  It retains open, closed, and independently unbounded
+cuts exactly.  Every comparison and endpoint-producing arithmetic operation is
+preceded by a deterministic size preflight.
+
+`Fact` carries a dependent consistency witness, so malformed cuts cannot enter
+a propagation engine through this API.  `start` additionally rejects an
+initially empty fact; an empty interval is reserved for a contradiction
+discovered by narrowing.
+
+The arithmetic surface is deliberately honest about its current boundary.
+Finite multiplication is exact and attainment-sensitive, while multiplication
+with an unbounded factor is reported as `inapplicable`.  Reciprocal handles the
+positive and negative components (including an open zero endpoint) and reports
+mixed-sign input as `inapplicable` until interval-set support is available.
+-/
+
+namespace Hex.Interval.Experiment.DyadicInterval
+
+open Propagator
+
+/-! ## Checked representation and resource results -/
+
+/-- A canonical raw interval.  Constructing one from malformed raw cuts would
+require a proof of a false consistency check; ordinary callers instead use the
+smart constructors below or cross the checked `importRaw` boundary. -/
+structure Fact where
+  raw : Raw
+  isConsistent : raw.CutConsistent
+
+namespace Fact
+
+instance : DecidableEq Fact := fun left right =>
+  if h : left.raw = right.raw then
+    isTrue (by cases left; cases right; simp_all)
+  else
+    isFalse fun equality => h (congrArg Fact.raw equality)
+
+/-- Exact raw view used by conformance and, later, certificate freezing. -/
+def view (fact : Fact) : Raw := fact.raw
+
+/-- The unique canonical empty fact.  It is an operation result, never an
+accepted initial engine fact. -/
+def empty : Fact := ⟨.empty, Raw.cutConsistent_empty⟩
+
+/-- The interval with neither a lower nor an upper bound. -/
+def whole : Fact := ⟨.bounds .unbounded .unbounded, rfl⟩
+
+def isEmpty (fact : Fact) : Bool :=
+  match fact.raw with
+  | .empty => true
+  | .bounds _ _ => false
+
+def isWhole (fact : Fact) : Bool := fact.raw == .bounds .unbounded .unbounded
+
+end Fact
+
+/-- The work whose configured limit was exceeded.  Values are computed without
+first performing the potentially allocating comparison or arithmetic step. -/
+inductive WorkCost where
+  | endpoint (cost : EndpointCost)
+  | comparison (cost : CompareCost)
+  | arithmetic (left right : EndpointCost)
+  | inverse (input : EndpointCost) (precisionMagnitude alignmentShift : Nat)
+  deriving DecidableEq, Repr
+
+/-- Result of a canonical smart constructor or interval operation. -/
+inductive Result where
+  | ready (fact : Fact)
+  | inapplicable
+  | resourceLimit (cost : WorkCost)
+  deriving DecidableEq
+
+/-- Result of importing an untrusted raw fact.  Inconsistent raw cuts are
+malformed, rather than silently being reinterpreted as a proved empty set. -/
+inductive ImportResult where
+  | ready (fact : Fact)
+  | malformed
+  | resourceLimit (cost : WorkCost)
+  deriving DecidableEq
+
+def workMagnitude : WorkCost -> Nat
+  | .endpoint cost => cost.numeratorBits + cost.exponentMagnitude
+  | .comparison cost =>
+      cost.lower.numeratorBits + cost.lower.exponentMagnitude +
+        cost.upper.numeratorBits + cost.upper.exponentMagnitude + cost.alignmentShift
+  | .arithmetic left right =>
+      left.numeratorBits + left.exponentMagnitude +
+        right.numeratorBits + right.exponentMagnitude
+  | .inverse input precisionMagnitude alignmentShift =>
+      input.numeratorBits + input.exponentMagnitude + precisionMagnitude + alignmentShift
+
+/-! ## Preflight helpers -/
+
+def endpointChecked (limit : EndpointLimit) (value : Dyadic) : Except WorkCost Unit :=
+  let cost := EndpointCost.ofDyadic value
+  if cost.allowed limit then pure () else throw (.endpoint cost)
+
+def compareChecked (limit : EndpointLimit) (left right : Dyadic) :
+    Except WorkCost Ordering := do
+  let cost := CompareCost.ofDyadic left right
+  if !cost.allowed limit then throw (.comparison cost)
+  if left < right then pure .lt
+  else if left = right then pure .eq
+  else pure .gt
+
+/-- Check several bounded size contributions without constructing their sum. -/
+def fitHeight (remaining : Nat) : List Nat -> Bool
+  | [] => true
+  | cost :: costs =>
+      if cost ≤ remaining then fitHeight (remaining - cost) costs else false
+
+def subtractionChecked (limit : EndpointLimit) (left right : Dyadic) :
+    Except WorkCost Dyadic := do
+  let comparison := CompareCost.ofDyadic left right
+  if !comparison.allowed limit then throw (.comparison comparison)
+  let result := left - right
+  endpointChecked limit result
+  pure result
+
+def multiplicationAllowed (limit : EndpointLimit) (left right : Dyadic) : Bool :=
+  let leftCost := EndpointCost.ofDyadic left
+  let rightCost := EndpointCost.ofDyadic right
+  leftCost.allowed limit && rightCost.allowed limit &&
+    match left, right with
+    | .zero, _ | _, .zero => true
+    | .ofOdd _ leftExponent _, .ofOdd _ rightExponent _ =>
+        fitHeight limit.maxEndpointHeight
+          [leftCost.numeratorBits, rightCost.numeratorBits,
+            (leftExponent + rightExponent).natAbs]
+
+def multiplicationChecked (limit : EndpointLimit) (left right : Dyadic) :
+    Except WorkCost Dyadic := do
+  let leftCost := EndpointCost.ofDyadic left
+  let rightCost := EndpointCost.ofDyadic right
+  if !multiplicationAllowed limit left right then
+    throw (.arithmetic leftCost rightCost)
+  let result := left * right
+  endpointChecked limit result
+  pure result
+
+def negationChecked (limit : EndpointLimit) (value : Dyadic) : Except WorkCost Dyadic := do
+  endpointChecked limit value
+  let result := -value
+  endpointChecked limit result
+  pure result
+
+/-- Preflight the shift and retained endpoint work performed by `invAtPrec`.
+The check is deliberately conservative: a requested precision and the
+canonical input exponent must each fit the endpoint budget, and their combined
+shift must fit the alignment budget before Core's rational conversion runs. -/
+def inverseChecked (limit : EndpointLimit) (precision : Precision) (value : Dyadic) :
+    Except WorkCost Dyadic := do
+  let inputCost := EndpointCost.ofDyadic value
+  let precisionMagnitude := precision.natAbs
+  if !inputCost.allowed limit ||
+      EndpointCost.natBits precisionMagnitude > limit.maxEndpointHeight ||
+      precisionMagnitude > limit.maxEndpointHeight then
+    throw (.inverse inputCost precisionMagnitude 0)
+  let alignmentShift :=
+    match value with
+    | .zero => 0
+    | .ofOdd _ exponent _ => (exponent + precision).natAbs
+  if alignmentShift > limit.maxAlignmentShift then
+    throw (.inverse inputCost precisionMagnitude alignmentShift)
+  let result := value.invAtPrec precision
+  endpointChecked limit result
+  pure result
+
+/-! ## Smart constructors -/
+
+/-- Normalize a trusted operation result after resource preflight. -/
+def normalize (limit : EndpointLimit) (raw : Raw) : Result :=
+  let cost := raw.normalizeCost
+  if !cost.allowed limit then
+    .resourceLimit (.comparison cost)
+  else
+    let normalized := raw.normalizeUnchecked
+    .ready ⟨normalized, Raw.consistent_normalizeUnchecked raw⟩
+
+/-- Import untrusted raw cuts without normalizing malformed input to empty. -/
+def importRaw (limit : EndpointLimit) (raw : Raw) : ImportResult :=
+  let cost := raw.normalizeCost
+  if !cost.allowed limit then
+    .resourceLimit (.comparison cost)
+  else if h : raw.CutConsistent then
+    .ready ⟨raw, h⟩
+  else
+    .malformed
+
+def empty : Fact := Fact.empty
+
+def whole : Fact := Fact.whole
+
+/-- Smart constructor for arbitrary lower and upper cut shapes.  Inconsistent
+cuts canonicalize to `empty`; malformed *imported* cuts use `importRaw`. -/
+def bounds (limit : EndpointLimit) (lower : Lower) (upper : Upper) : Result :=
+  normalize limit (.bounds lower upper)
+
+def closed (limit : EndpointLimit) (lower upper : Dyadic) : Result :=
+  bounds limit (.finite lower false) (.finite upper false)
+
+def openInterval (limit : EndpointLimit) (lower upper : Dyadic) : Result :=
+  bounds limit (.finite lower true) (.finite upper true)
+
+def closedOpen (limit : EndpointLimit) (lower upper : Dyadic) : Result :=
+  bounds limit (.finite lower false) (.finite upper true)
+
+def openClosed (limit : EndpointLimit) (lower upper : Dyadic) : Result :=
+  bounds limit (.finite lower true) (.finite upper false)
+
+def atLeast (limit : EndpointLimit) (lower : Dyadic) : Result :=
+  bounds limit (.finite lower false) .unbounded
+
+def greaterThan (limit : EndpointLimit) (lower : Dyadic) : Result :=
+  bounds limit (.finite lower true) .unbounded
+
+def atMost (limit : EndpointLimit) (upper : Dyadic) : Result :=
+  bounds limit .unbounded (.finite upper false)
+
+def lessThan (limit : EndpointLimit) (upper : Dyadic) : Result :=
+  bounds limit .unbounded (.finite upper true)
+
+/-! ## Exact intersection -/
+
+def intersectLower (limit : EndpointLimit) (left right : Lower) :
+    Except WorkCost Lower := do
+  match left, right with
+  | .unbounded, cut | cut, .unbounded => pure cut
+  | .finite leftValue leftStrict, .finite rightValue rightStrict =>
+      match ← compareChecked limit leftValue rightValue with
+      | .lt => pure right
+      | .gt => pure left
+      | .eq => pure (.finite leftValue (leftStrict || rightStrict))
+
+def intersectUpper (limit : EndpointLimit) (left right : Upper) :
+    Except WorkCost Upper := do
+  match left, right with
+  | .unbounded, cut | cut, .unbounded => pure cut
+  | .finite leftValue leftStrict, .finite rightValue rightStrict =>
+      match ← compareChecked limit leftValue rightValue with
+      | .lt => pure left
+      | .gt => pure right
+      | .eq => pure (.finite leftValue (leftStrict || rightStrict))
+
+/-- Exact set intersection.  Equal-valued cuts are open when either input cut
+is open. -/
+def intersect (limit : EndpointLimit) (left right : Fact) : Result :=
+  match left.raw, right.raw with
+  | .empty, _ | _, .empty => .ready .empty
+  | .bounds leftLower leftUpper, .bounds rightLower rightUpper =>
+      match intersectLower limit leftLower rightLower with
+      | .error cost => .resourceLimit cost
+      | .ok lower =>
+          match intersectUpper limit leftUpper rightUpper with
+          | .error cost => .resourceLimit cost
+          | .ok upper => normalize limit (.bounds lower upper)
+
+/-! ## Unary negation and subtraction -/
+
+def negateLower (limit : EndpointLimit) : Upper -> Except WorkCost Lower
+  | .unbounded => pure .unbounded
+  | .finite value strict => do
+      pure (.finite (← negationChecked limit value) strict)
+
+def negateUpper (limit : EndpointLimit) : Lower -> Except WorkCost Upper
+  | .unbounded => pure .unbounded
+  | .finite value strict => do
+      pure (.finite (← negationChecked limit value) strict)
+
+def neg (limit : EndpointLimit) (input : Fact) : Result :=
+  match input.raw with
+  | .empty => .ready .empty
+  | .bounds lower upper =>
+      match negateLower limit upper with
+      | .error cost => .resourceLimit cost
+      | .ok resultLower =>
+          match negateUpper limit lower with
+          | .error cost => .resourceLimit cost
+          | .ok resultUpper => normalize limit (.bounds resultLower resultUpper)
+
+def subtractLower (limit : EndpointLimit) (left : Lower) (right : Upper) :
+    Except WorkCost Lower := do
+  match left, right with
+  | .finite leftValue leftStrict, .finite rightValue rightStrict =>
+      pure (.finite (← subtractionChecked limit leftValue rightValue)
+        (leftStrict || rightStrict))
+  | _, _ => pure .unbounded
+
+def subtractUpper (limit : EndpointLimit) (left : Upper) (right : Lower) :
+    Except WorkCost Upper := do
+  match left, right with
+  | .finite leftValue leftStrict, .finite rightValue rightStrict =>
+      pure (.finite (← subtractionChecked limit leftValue rightValue)
+        (leftStrict || rightStrict))
+  | _, _ => pure .unbounded
+
+/-- Exact interval subtraction, including independently unbounded sides. -/
+def sub (limit : EndpointLimit) (left right : Fact) : Result :=
+  match left.raw, right.raw with
+  | .empty, _ | _, .empty => .ready .empty
+  | .bounds leftLower leftUpper, .bounds rightLower rightUpper =>
+      match subtractLower limit leftLower rightUpper with
+      | .error cost => .resourceLimit cost
+      | .ok lower =>
+          match subtractUpper limit leftUpper rightLower with
+          | .error cost => .resourceLimit cost
+          | .ok upper => normalize limit (.bounds lower upper)
+
+/-! ## Extrema with endpoint-attainment witnesses -/
+
+structure Candidate where
+  value : Dyadic
+  attained : Bool
+
+def chooseMin (limit : EndpointLimit) (left right : Candidate) :
+    Except WorkCost Candidate := do
+  match ← compareChecked limit left.value right.value with
+  | .lt => pure left
+  | .gt => pure right
+  | .eq => pure { value := left.value, attained := left.attained || right.attained }
+
+def chooseMax (limit : EndpointLimit) (left right : Candidate) :
+    Except WorkCost Candidate := do
+  match ← compareChecked limit left.value right.value with
+  | .lt => pure right
+  | .gt => pure left
+  | .eq => pure { value := left.value, attained := left.attained || right.attained }
+
+def minCandidates (limit : EndpointLimit) (first : Candidate) :
+    List Candidate -> Except WorkCost Candidate
+  | [] => pure first
+  | next :: rest => do
+      minCandidates limit (← chooseMin limit first next) rest
+
+def maxCandidates (limit : EndpointLimit) (first : Candidate) :
+    List Candidate -> Except WorkCost Candidate
+  | [] => pure first
+  | next :: rest => do
+      maxCandidates limit (← chooseMax limit first next) rest
+
+def containsZeroFinite (limit : EndpointLimit)
+    (lower : Dyadic) (lowerStrict : Bool) (upper : Dyadic) (upperStrict : Bool) :
+    Except WorkCost Bool := do
+  let lowerOrder ← compareChecked limit lower 0
+  let upperOrder ← compareChecked limit upper 0
+  let lowerAllows := lowerOrder == .lt || (lowerOrder == .eq && !lowerStrict)
+  let upperAllows := upperOrder == .gt || (upperOrder == .eq && !upperStrict)
+  pure (lowerAllows && upperAllows)
+
+def endpointCandidate (limit : EndpointLimit)
+    (left : Dyadic × Bool) (right : Dyadic × Bool) : Except WorkCost Candidate := do
+  pure
+    { value := ← multiplicationChecked limit left.1 right.1
+      attained := !left.2 && !right.2 }
+
+/-! ## Finite multiplication and square -/
+
+/-- Exact multiplication for two finite intervals.  Unbounded multiplication
+is intentionally left to a later sign-partitioned implementation and returns
+`inapplicable`.  Tied extrema combine attainment witnesses, including the
+special fact that multiplication by any contained zero attains zero. -/
+def mul (limit : EndpointLimit) (left right : Fact) : Result :=
+  match left.raw, right.raw with
+  | .empty, _ | _, .empty => .ready .empty
+  | .bounds (.finite ll lls) (.finite lu lus),
+      .bounds (.finite rl rls) (.finite ru rus) =>
+      match (do
+        let llc ← endpointCandidate limit (ll, lls) (rl, rls)
+        let luc ← endpointCandidate limit (ll, lls) (ru, rus)
+        let ulc ← endpointCandidate limit (lu, lus) (rl, rls)
+        let uuc ← endpointCandidate limit (lu, lus) (ru, rus)
+        let minimum ← minCandidates limit llc [luc, ulc, uuc]
+        let maximum ← maxCandidates limit llc [luc, ulc, uuc]
+        let leftZero ← containsZeroFinite limit ll lls lu lus
+        let rightZero ← containsZeroFinite limit rl rls ru rus
+        let zeroAttained := leftZero || rightZero
+        let minimum :=
+          if minimum.value = 0 && zeroAttained then { minimum with attained := true }
+          else minimum
+        let maximum :=
+          if maximum.value = 0 && zeroAttained then { maximum with attained := true }
+          else maximum
+        pure (minimum, maximum)) with
+      | .error cost => .resourceLimit cost
+      | .ok (minimum, maximum) =>
+          normalize limit (.bounds (.finite minimum.value (!minimum.attained))
+            (.finite maximum.value (!maximum.attained)))
+  | _, _ => .inapplicable
+
+def squareFinite (limit : EndpointLimit)
+    (lower : Dyadic) (lowerStrict : Bool) (upper : Dyadic) (upperStrict : Bool) :
+    Except WorkCost (Lower × Upper) := do
+  let lowerOrder ← compareChecked limit lower 0
+  let upperOrder ← compareChecked limit upper 0
+  let lowerSquare ← multiplicationChecked limit lower lower
+  let upperSquare ← multiplicationChecked limit upper upper
+  if upperOrder == .lt || upperOrder == .eq then
+    pure (.finite upperSquare upperStrict, .finite lowerSquare lowerStrict)
+  else if lowerOrder == .gt || lowerOrder == .eq then
+    pure (.finite lowerSquare lowerStrict, .finite upperSquare upperStrict)
+  else
+    let upperCandidate ← chooseMax limit
+      { value := lowerSquare, attained := !lowerStrict }
+      { value := upperSquare, attained := !upperStrict }
+    pure (.finite 0 false, .finite upperCandidate.value (!upperCandidate.attained))
+
+/-- Tight square image.  A straddled zero is attained even when both finite
+endpoints are open; tied squared maxima are closed when either source endpoint
+is closed. -/
+def square (limit : EndpointLimit) (input : Fact) : Result :=
+  match input.raw with
+  | .empty => .ready .empty
+  | .bounds .unbounded .unbounded =>
+      normalize limit (.bounds (.finite 0 false) .unbounded)
+  | .bounds .unbounded (.finite upper upperStrict) =>
+      match compareChecked limit upper 0 with
+      | .error cost => .resourceLimit cost
+      | .ok order =>
+          if order == .lt || order == .eq then
+            match multiplicationChecked limit upper upper with
+            | .error cost => .resourceLimit cost
+            | .ok lower => normalize limit
+                (.bounds (.finite lower upperStrict) .unbounded)
+          else
+            normalize limit (.bounds (.finite 0 false) .unbounded)
+  | .bounds (.finite lower lowerStrict) .unbounded =>
+      match compareChecked limit lower 0 with
+      | .error cost => .resourceLimit cost
+      | .ok order =>
+          if order == .gt || order == .eq then
+            match multiplicationChecked limit lower lower with
+            | .error cost => .resourceLimit cost
+            | .ok lowerSquare => normalize limit
+                (.bounds (.finite lowerSquare lowerStrict) .unbounded)
+          else
+            normalize limit (.bounds (.finite 0 false) .unbounded)
+  | .bounds (.finite lower lowerStrict) (.finite upper upperStrict) =>
+      match squareFinite limit lower lowerStrict upper upperStrict with
+      | .error cost => .resourceLimit cost
+      | .ok (resultLower, resultUpper) => normalize limit (.bounds resultLower resultUpper)
+
+/-! ## Singleton scaling and exact backward scaling -/
+
+def scaleLowerPositive (limit : EndpointLimit) (scalar : Dyadic) :
+    Lower -> Except WorkCost Lower
+  | .unbounded => pure .unbounded
+  | .finite value strict => do
+      pure (.finite (← multiplicationChecked limit scalar value) strict)
+
+def scaleUpperPositive (limit : EndpointLimit) (scalar : Dyadic) :
+    Upper -> Except WorkCost Upper
+  | .unbounded => pure .unbounded
+  | .finite value strict => do
+      pure (.finite (← multiplicationChecked limit scalar value) strict)
+
+/-- Exact image under multiplication by a singleton dyadic. -/
+def scale (limit : EndpointLimit) (scalar : Dyadic) (input : Fact) : Result :=
+  match input.raw with
+  | .empty => .ready .empty
+  | .bounds lower upper =>
+      match compareChecked limit scalar 0 with
+      | .error cost => .resourceLimit cost
+      | .ok .eq => normalize limit (.bounds (.finite 0 false) (.finite 0 false))
+      | .ok .gt =>
+          match scaleLowerPositive limit scalar lower with
+          | .error cost => .resourceLimit cost
+          | .ok resultLower =>
+              match scaleUpperPositive limit scalar upper with
+              | .error cost => .resourceLimit cost
+              | .ok resultUpper => normalize limit (.bounds resultLower resultUpper)
+      | .ok .lt =>
+          match scaleLowerPositive limit scalar
+              (match upper with
+               | .unbounded => .unbounded
+               | .finite value strict => .finite value strict) with
+          | .error cost => .resourceLimit cost
+          | .ok provisionalLower =>
+              match scaleUpperPositive limit scalar
+                  (match lower with
+                   | .unbounded => .unbounded
+                   | .finite value strict => .finite value strict) with
+              | .error cost => .resourceLimit cost
+              | .ok provisionalUpper =>
+                  let resultLower :=
+                    match provisionalLower with
+                    | .unbounded => .unbounded
+                    | .finite value strict => .finite value strict
+                  let resultUpper :=
+                    match provisionalUpper with
+                    | .unbounded => .unbounded
+                    | .finite value strict => .finite value strict
+                  normalize limit (.bounds resultLower resultUpper)
+
+/-- Exact reciprocal exists precisely for a nonzero dyadic whose canonical odd
+mantissa is `1` or `-1`. -/
+def exactReciprocal? (limit : EndpointLimit) : Dyadic -> Except WorkCost (Option Dyadic)
+  | .zero => pure none
+  | value@(.ofOdd numerator exponent _) => do
+      endpointChecked limit value
+      if numerator = 1 || numerator = -1 then
+        let result := Dyadic.ofIntWithPrec numerator (-exponent)
+        endpointChecked limit result
+        pure (some result)
+      else
+        pure none
+
+/-- Backward image under singleton multiplication when division is exactly
+dyadic.  Nondyadic reciprocal and zero scalar are explicitly inapplicable. -/
+def unscaleExact (limit : EndpointLimit) (scalar : Dyadic) (image : Fact) : Result :=
+  match exactReciprocal? limit scalar with
+  | .error cost => .resourceLimit cost
+  | .ok none => .inapplicable
+  | .ok (some reciprocal) => scale limit reciprocal image
+
+/-! ## Precision-indexed reciprocal -/
+
+def inverseLower (limit : EndpointLimit) (precision : Precision)
+    (upper : Upper) : Except WorkCost Lower := do
+  match upper with
+  | .unbounded => pure (.finite 0 true)
+  | .finite value strict =>
+      if value = 0 && strict then
+        pure .unbounded
+      else
+        let rounded ← inverseChecked limit precision value
+        let exact ← exactReciprocal? limit value
+        pure (.finite rounded (strict || exact != some rounded))
+
+def inverseUpper (limit : EndpointLimit) (precision : Precision)
+    (lower : Lower) : Except WorkCost Upper := do
+  match lower with
+  | .unbounded => pure (.finite 0 true)
+  | .finite value strict =>
+      if value = 0 && strict then
+        pure .unbounded
+      else
+        let roundedDown ← inverseChecked limit precision (-value)
+        let rounded := -roundedDown
+        endpointChecked limit rounded
+        let exact ← exactReciprocal? limit value
+        pure (.finite rounded (strict || exact != some rounded))
+
+def strictlyPositiveLower (limit : EndpointLimit) : Lower -> Except WorkCost Bool
+  | .unbounded => pure false
+  | .finite value strict => do
+      match ← compareChecked limit value 0 with
+      | .gt => pure true
+      | .eq => pure strict
+      | .lt => pure false
+
+def strictlyNegativeUpper (limit : EndpointLimit) : Upper -> Except WorkCost Bool
+  | .unbounded => pure false
+  | .finite value strict => do
+      match ← compareChecked limit value 0 with
+      | .lt => pure true
+      | .eq => pure strict
+      | .gt => pure false
+
+/-- Reciprocal enclosure for intervals wholly on the positive or negative side
+of zero.  An open zero endpoint maps to an unbounded side.  Mixed-sign input,
+closed zero, and the singleton zero are `inapplicable` in this first component
+backend rather than being assigned a misleading connected image. -/
+def reciprocal (limit : EndpointLimit) (precision : Precision) (input : Fact) : Result :=
+  match input.raw with
+  | .empty => .ready .empty
+  | .bounds lower upper =>
+      match strictlyPositiveLower limit lower with
+      | .error cost => .resourceLimit cost
+      | .ok true =>
+          match inverseLower limit precision upper with
+          | .error cost => .resourceLimit cost
+          | .ok resultLower =>
+              match inverseUpper limit precision lower with
+              | .error cost => .resourceLimit cost
+              | .ok resultUpper => normalize limit (.bounds resultLower resultUpper)
+      | .ok false =>
+          match strictlyNegativeUpper limit upper with
+          | .error cost => .resourceLimit cost
+          | .ok false => .inapplicable
+          | .ok true =>
+              match inverseLower limit precision upper with
+              | .error cost => .resourceLimit cost
+              | .ok resultLower =>
+                  match inverseUpper limit precision lower with
+                  | .error cost => .resourceLimit cost
+                  | .ok resultUpper => normalize limit (.bounds resultLower resultUpper)
+
+/-! ## Split and propagator fact domain -/
+
+/-- Split `input` into `input ∩ (-∞, point]` and
+`input ∩ (point, +∞)`.  The equal cut belongs only to the left child. -/
+def split (limit : EndpointLimit) (input : Fact) (point : Dyadic) :
+    Except WorkCost (Fact × Fact) :=
+  if input.isEmpty then
+    pure (.empty, .empty)
+  else do
+    endpointChecked limit point
+    let leftCut ←
+      match normalize limit (.bounds .unbounded (.finite point false)) with
+      | .ready fact => pure fact
+      | .resourceLimit cost => throw cost
+      | .inapplicable => throw (.endpoint (EndpointCost.ofDyadic point))
+    let rightCut ←
+      match normalize limit (.bounds (.finite point true) .unbounded) with
+      | .ready fact => pure fact
+      | .resourceLimit cost => throw cost
+      | .inapplicable => throw (.endpoint (EndpointCost.ofDyadic point))
+    let left ←
+      match intersect limit input leftCut with
+      | .ready fact => pure fact
+      | .resourceLimit cost => throw cost
+      | .inapplicable => throw (.endpoint (EndpointCost.ofDyadic point))
+    let right ←
+      match intersect limit input rightCut with
+      | .ready fact => pure fact
+      | .resourceLimit cost => throw cost
+      | .inapplicable => throw (.endpoint (EndpointCost.ofDyadic point))
+    pure (left, right)
+
+/-- Concrete domain adapter.  Its only possible malformed result would require
+constructing a `Fact` with a false consistency proof. -/
+def factDomain (limit : EndpointLimit) : FactDomain Fact where
+  top _ := .whole
+  narrow _ current candidate :=
+    match intersect limit current candidate with
+    | .inapplicable => .malformed 1
+    | .resourceLimit cost => .resourceLimit (workMagnitude cost)
+    | .ready result =>
+        if result.isEmpty then .contradiction result
+        else if result = current then .noChange
+        else .improved result
+
+/-- Error at the checked initial-fact boundary. -/
+inductive StartError where
+  | malformedFact (index : Nat)
+  | emptyFact (index : Nat)
+  | factResource (index : Nat) (cost : WorkCost)
+  | engine (error : Propagator.StartError)
+  deriving DecidableEq, Repr
+
+def importInitialFacts (limit : EndpointLimit) :
+    Nat -> List Raw -> Except StartError (List Fact)
+  | _, [] => pure []
+  | index, raw :: raws => do
+      let fact ←
+        match importRaw limit raw with
+        | .malformed => throw (.malformedFact index)
+        | .resourceLimit cost => throw (.factResource index cost)
+        | .ready fact => pure fact
+      if fact.isEmpty then throw (.emptyFact index)
+      pure (fact :: (← importInitialFacts limit (index + 1) raws))
+
+/-- Checked wrapper around `Engine.start`.  Raw initial facts must already be
+canonical and nonempty; malformed cuts, empty cuts, and resource failures are
+reported before the generic scheduler can observe them. -/
+def start (endpointLimit : EndpointLimit) (program : Program)
+    (rules : Array Registration) (rawFacts : Array Raw) (limits : Limits) :
+    Except StartError (Engine Fact) := do
+  -- Bound the raw-fact scan with the same early structural checks used by the
+  -- generic engine.  In particular, a wrong-sized untrusted array is never
+  -- converted to an unbounded intermediate list.
+  if limits.maxOperations < program.operations.size then
+    throw (.engine (.resourceLimit .operations))
+  if limits.maxNodes < program.nodes.size then
+    throw (.engine (.resourceLimit .nodes))
+  if rawFacts.size != program.nodes.size then
+    throw (.engine .wrongFactCount)
+  let facts ← importInitialFacts endpointLimit 0 rawFacts.toList
+  match Engine.start (factDomain endpointLimit) program rules facts.toArray limits with
+  | .ok engine => pure engine
+  | .error error => throw (.engine error)
+
+end Hex.Interval.Experiment.DyadicInterval

--- a/HexInterval/Experiment/DyadicInterval.lean
+++ b/HexInterval/Experiment/DyadicInterval.lean
@@ -125,10 +125,14 @@ def fitHeight (remaining : Nat) : List Nat -> Bool
   | cost :: costs =>
       if cost ≤ remaining then fitHeight (remaining - cost) costs else false
 
-def subtractionChecked (limit : EndpointLimit) (left right : Dyadic) :
-    Except WorkCost Dyadic := do
+def preflightSubtraction (limit : EndpointLimit) (left right : Dyadic) :
+    Except WorkCost Unit := do
   let comparison := CompareCost.ofDyadic left right
   if !comparison.allowed limit then throw (.comparison comparison)
+
+def subtractionChecked (limit : EndpointLimit) (left right : Dyadic) :
+    Except WorkCost Dyadic := do
+  preflightSubtraction limit left right
   let result := left - right
   endpointChecked limit result
   pure result
@@ -162,8 +166,10 @@ def negationChecked (limit : EndpointLimit) (value : Dyadic) : Except WorkCost D
 
 /-- Preflight the shift and retained endpoint work performed by `invAtPrec`.
 The check is deliberately conservative: a requested precision and the
-canonical input exponent must each fit the endpoint budget, and their combined
-shift must fit the alignment budget before Core's rational conversion runs. -/
+canonical input exponent must each fit the endpoint budget, and the sum of
+their magnitudes must fit the alignment budget before Core's two separate
+rational-conversion shifts run.  In particular, opposite-signed exponents do
+not cancel in the preflight merely because their signed sum is small. -/
 def inverseChecked (limit : EndpointLimit) (precision : Precision) (value : Dyadic) :
     Except WorkCost Dyadic := do
   let inputCost := EndpointCost.ofDyadic value
@@ -175,7 +181,7 @@ def inverseChecked (limit : EndpointLimit) (precision : Precision) (value : Dyad
   let alignmentShift :=
     match value with
     | .zero => 0
-    | .ofOdd _ exponent _ => (exponent + precision).natAbs
+    | .ofOdd _ exponent _ => exponent.natAbs + precisionMagnitude
   if alignmentShift > limit.maxAlignmentShift then
     throw (.inverse inputCost precisionMagnitude alignmentShift)
   let result := value.invAtPrec precision
@@ -310,17 +316,38 @@ def subtractUpper (limit : EndpointLimit) (left : Upper) (right : Lower) :
         (leftStrict || rightStrict))
   | _, _ => pure .unbounded
 
-/-- Exact interval subtraction, including independently unbounded sides. -/
+def preflightLowerSubtraction (limit : EndpointLimit) (left : Lower) (right : Upper) :
+    Except WorkCost Unit := do
+  match left, right with
+  | .finite leftValue _, .finite rightValue _ =>
+      preflightSubtraction limit leftValue rightValue
+  | _, _ => pure ()
+
+def preflightUpperSubtraction (limit : EndpointLimit) (left : Upper) (right : Lower) :
+    Except WorkCost Unit := do
+  match left, right with
+  | .finite leftValue _, .finite rightValue _ =>
+      preflightSubtraction limit leftValue rightValue
+  | _, _ => pure ()
+
+/-- Exact interval subtraction, including independently unbounded sides.  Both
+finite endpoint-alignment pairs are preflighted before either subtraction is
+evaluated. -/
 def sub (limit : EndpointLimit) (left right : Fact) : Result :=
   match left.raw, right.raw with
   | .empty, _ | _, .empty => .ready .empty
   | .bounds leftLower leftUpper, .bounds rightLower rightUpper =>
-      match subtractLower limit leftLower rightUpper with
+      match (do
+        preflightLowerSubtraction limit leftLower rightUpper
+        preflightUpperSubtraction limit leftUpper rightLower) with
       | .error cost => .resourceLimit cost
-      | .ok lower =>
-          match subtractUpper limit leftUpper rightLower with
+      | .ok () =>
+          match subtractLower limit leftLower rightUpper with
           | .error cost => .resourceLimit cost
-          | .ok upper => normalize limit (.bounds lower upper)
+          | .ok lower =>
+              match subtractUpper limit leftUpper rightLower with
+              | .error cost => .resourceLimit cost
+              | .ok upper => normalize limit (.bounds lower upper)
 
 /-! ## Extrema with endpoint-attainment witnesses -/
 

--- a/conformance/HexInterval/DyadicIntervalConformance.lean
+++ b/conformance/HexInterval/DyadicIntervalConformance.lean
@@ -110,15 +110,25 @@ private def unboundedNeg : Option Result := do
 
 private def inverseShiftInput : Dyadic := .ofOdd 1 64 (by decide)
 
+private def wide : Dyadic :=
+  Dyadic.ofInt (Int.ofNat (2 ^ 128 - 1))
+
 private def subtractionPreflight : Option Result := do
   let left ← imported?
-    (.bounds (.finite inverseShiftInput false) (.finite 1 false))
+    (.bounds (.finite (-wide) false) (.finite 1 false))
   let right ← imported?
-    (.bounds (.finite inverseShiftInput false) (.finite inverseShiftInput false))
+    (.bounds (.finite inverseShiftInput false) (.finite wide false))
   pure (sub tightAlignmentLimit left right)
 
--- The cheap lower pair must not be subtracted before the upper pair's
--- 64-place alignment has also passed preflight.
+-- The lower subtraction itself would exceed the endpoint budget.
+#guard
+  match subtractionChecked tightAlignmentLimit (-wide) wide with
+  | .error (.endpoint cost) => !cost.allowed tightAlignmentLimit
+  | _ => false
+
+-- Nevertheless, the whole operation reports the later upper-pair alignment
+-- failure.  This distinguishes complete preflight from an implementation that
+-- performs the lower subtraction before checking the upper pair.
 #guard
   match subtractionPreflight with
   | some (.resourceLimit (.comparison cost)) => cost.alignmentShift == 64
@@ -343,6 +353,19 @@ private def roundedReciprocal : Option Result := do
           (.finite half true))
   | none => false
 
+-- Cut inversion treats zero only as a component limit.  In particular, a
+-- closed zero never reaches `invAtPrec`; the interval-level operation still
+-- rejects intervals containing closed zero.
+#guard
+  match inverseLower endpointLimit 8 (.finite 0 false) with
+  | .ok .unbounded => true
+  | _ => false
+
+#guard
+  match inverseUpper endpointLimit 8 (.finite 0 false) with
+  | .ok .unbounded => true
+  | _ => false
+
 private def reciprocalPreflight : Option Result := do
   let input ← imported? (finite 1 false 2 false)
   pure (reciprocal tightAlignmentLimit 16 input)
@@ -448,6 +471,13 @@ private def domainNoChange : Option (NarrowResult Fact) := do
 #guard
   match domainNoChange with
   | some .noChange => true
+  | _ => false
+
+-- Re-narrowing an already contradictory branch with the same empty fact is a
+-- fixed point, not a newly discovered contradiction.
+#guard
+  match (factDomain endpointLimit).narrow { index := 0 } .empty .whole with
+  | .noChange => true
   | _ => false
 
 private def real : DomainId := { index := 0 }

--- a/conformance/HexInterval/DyadicIntervalConformance.lean
+++ b/conformance/HexInterval/DyadicIntervalConformance.lean
@@ -1,0 +1,489 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexInterval.Experiment.DyadicInterval
+
+/-!
+Conformance checks for the first concrete propagator fact domain.  These tests
+exercise exact openness and endpoint attainment rather than merely checking
+coarse numerical hulls.
+-/
+
+namespace Hex.Interval.DyadicIntervalConformance
+
+open Experiment Propagator
+open DyadicInterval
+
+private def d (value : Int) : Dyadic := Dyadic.ofInt value
+
+private def half : Dyadic := Dyadic.ofIntWithPrec 1 1
+
+private def endpointLimit : EndpointLimit where
+  maxEndpointHeight := 128
+  maxAlignmentShift := 64
+
+private def readyAs (result : Result) (expected : Raw) : Bool :=
+  match result with
+  | .ready fact => fact.view == expected
+  | .inapplicable | .resourceLimit _ => false
+
+private def finite (lower : Int) (lowerStrict : Bool)
+    (upper : Int) (upperStrict : Bool) : Raw :=
+  .bounds (.finite (d lower) lowerStrict) (.finite (d upper) upperStrict)
+
+private def imported? (raw : Raw) : Option Fact :=
+  match importRaw endpointLimit raw with
+  | .ready fact => some fact
+  | .malformed | .resourceLimit _ => none
+
+/-! ## Canonical construction and checked import -/
+
+#guard Fact.empty.view == .empty
+#guard Fact.whole.view == .bounds .unbounded .unbounded
+#guard readyAs (closed endpointLimit 0 1) (finite 0 false 1 false)
+#guard readyAs (openInterval endpointLimit 0 1) (finite 0 true 1 true)
+#guard readyAs (closedOpen endpointLimit 0 1) (finite 0 false 1 true)
+#guard readyAs (openClosed endpointLimit 0 1) (finite 0 true 1 false)
+#guard
+  readyAs (atLeast endpointLimit 0)
+    (.bounds (.finite 0 false) .unbounded)
+#guard
+  readyAs (lessThan endpointLimit 1)
+    (.bounds .unbounded (.finite 1 true))
+
+-- Smart construction canonicalizes inconsistent cuts to the unique empty
+-- value, while the untrusted import boundary rejects the same shape.
+#guard readyAs (openInterval endpointLimit 1 1) .empty
+#guard readyAs (closed endpointLimit 2 1) .empty
+#guard importRaw endpointLimit (finite 1 true 1 false) == .malformed
+#guard importRaw endpointLimit (finite 2 false 1 false) == .malformed
+
+/-! ## Intersection, unbounded sides, negation, and subtraction -/
+
+private def intersectionExample : Option Result := do
+  let left ← imported? (finite 0 false 2 false)
+  let right ← imported? (finite 0 true 3 false)
+  pure (intersect endpointLimit left right)
+
+#guard
+  match intersectionExample with
+  | some result => readyAs result (finite 0 true 2 false)
+  | none => false
+
+private def upperTie : Option Result := do
+  let left ← imported? (finite (-2) false 1 false)
+  let right ← imported? (finite (-3) false 1 true)
+  pure (intersect endpointLimit left right)
+
+#guard
+  match upperTie with
+  | some result => readyAs result (finite (-2) false 1 true)
+  | none => false
+
+private def unboundedSub : Option Result := do
+  let left ← imported? (.bounds (.finite 1 false) .unbounded)
+  let right ← imported? (.bounds .unbounded (.finite 2 false))
+  pure (sub endpointLimit left right)
+
+#guard
+  match unboundedSub with
+  | some result =>
+      readyAs result (.bounds (.finite (-1) false) .unbounded)
+  | none => false
+
+private def unboundedNeg : Option Result := do
+  let input ← imported? (.bounds (.finite 1 true) .unbounded)
+  pure (neg endpointLimit input)
+
+#guard
+  match unboundedNeg with
+  | some result =>
+      readyAs result (.bounds .unbounded (.finite (-1) true))
+  | none => false
+
+/-! ## Attainment-sensitive multiplication and square -/
+
+private def closedZeroTimesOpenZero : Option Result := do
+  let left ← imported? (finite 0 false 1 false)
+  let right ← imported? (finite 0 true 1 false)
+  pure (mul endpointLimit left right)
+
+-- `[0,1] * (0,1] = [0,1]`: zero is attained through the left
+-- factor even though the right lower cut is open.
+#guard
+  match closedZeroTimesOpenZero with
+  | some result => readyAs result (finite 0 false 1 false)
+  | none => false
+
+private def zeroSingletonTimesOpen : Option Result := do
+  let left ← imported? (finite 0 false 0 false)
+  let right ← imported? (finite 0 true 1 true)
+  pure (mul endpointLimit left right)
+
+-- Interior points of the open factor still multiply the zero singleton to
+-- an attained zero; corner openness alone would get this case wrong.
+#guard
+  match zeroSingletonTimesOpen with
+  | some result => readyAs result (finite 0 false 0 false)
+  | none => false
+
+private def positiveOpenSquare : Option Result := do
+  let input ← imported? (finite 0 true 1 false)
+  pure (square endpointLimit input)
+
+#guard
+  match positiveOpenSquare with
+  | some result => readyAs result (finite 0 true 1 false)
+  | none => false
+
+private def straddlingOpenSquare : Option Result := do
+  let input ← imported? (finite (-1) true 1 true)
+  pure (square endpointLimit input)
+
+#guard
+  match straddlingOpenSquare with
+  | some result => readyAs result (finite 0 false 1 true)
+  | none => false
+
+private def tiedSquareOneClosed : Option Result := do
+  let input ← imported? (finite (-1) false 1 true)
+  pure (square endpointLimit input)
+
+-- The tied upper magnitude is attained through the closed `-1` endpoint.
+#guard
+  match tiedSquareOneClosed with
+  | some result => readyAs result (finite 0 false 1 false)
+  | none => false
+
+private def openProduct : Option Result := do
+  let left ← imported? (finite 0 true 1 true)
+  let right ← imported? (finite 0 true 1 true)
+  pure (mul endpointLimit left right)
+
+#guard
+  match openProduct with
+  | some result => readyAs result (finite 0 true 1 true)
+  | none => false
+
+private def attainedZeroProduct : Option Result := do
+  let left ← imported? (finite 0 false 1 false)
+  let right ← imported? (finite (-1) true 0 true)
+  pure (mul endpointLimit left right)
+
+#guard
+  match attainedZeroProduct with
+  | some result => readyAs result (finite (-1) true 0 false)
+  | none => false
+
+private def unboundedProduct : Option Result := do
+  let left ← imported? (.bounds (.finite 1 false) .unbounded)
+  let right ← imported? (finite 1 false 2 false)
+  pure (mul endpointLimit left right)
+
+#guard unboundedProduct == some .inapplicable
+
+private def unboundedSquare : Option Result := do
+  let input ← imported? (.bounds .unbounded (.finite (-1) true))
+  pure (square endpointLimit input)
+
+#guard
+  match unboundedSquare with
+  | some result =>
+      readyAs result (.bounds (.finite 1 true) .unbounded)
+  | none => false
+
+/-! ## Singleton scaling and exact backward division -/
+
+private def negativeScale : Option Result := do
+  let input ← imported? (finite 1 true 3 false)
+  pure (scale endpointLimit (-2) input)
+
+#guard
+  match negativeScale with
+  | some result => readyAs result (finite (-6) false (-2) true)
+  | none => false
+
+private def unboundedScale : Option Result := do
+  let input ← imported? (.bounds (.finite 1 false) .unbounded)
+  pure (scale endpointLimit (-2) input)
+
+#guard
+  match unboundedScale with
+  | some result =>
+      readyAs result (.bounds .unbounded (.finite (-2) false))
+  | none => false
+
+private def exactBackward : Option Result := do
+  let image ← imported? (finite 2 false 4 false)
+  pure (unscaleExact endpointLimit 2 image)
+
+#guard
+  match exactBackward with
+  | some result =>
+      readyAs result
+        (.bounds (.finite 1 false) (.finite (d 2) false))
+  | none => false
+
+private def nondyadicBackward : Option Result := do
+  let image ← imported? (finite 3 false 6 false)
+  pure (unscaleExact endpointLimit 3 image)
+
+#guard nondyadicBackward == some .inapplicable
+
+private def zeroBackward : Option Result := do
+  let image ← imported? (finite 0 false 0 false)
+  pure (unscaleExact endpointLimit 0 image)
+
+#guard zeroBackward == some .inapplicable
+
+/-! ## Positive and negative reciprocal components -/
+
+private def positiveReciprocal : Option Result := do
+  let input ← imported? (finite 1 false 2 false)
+  pure (reciprocal endpointLimit 8 input)
+
+#guard
+  match positiveReciprocal with
+  | some result =>
+      readyAs result
+        (.bounds (.finite half false) (.finite 1 false))
+  | none => false
+
+private def negativeReciprocal : Option Result := do
+  let input ← imported? (finite (-2) false (-1) false)
+  pure (reciprocal endpointLimit 8 input)
+
+#guard
+  match negativeReciprocal with
+  | some result =>
+      readyAs result
+        (.bounds (.finite (-1) false) (.finite (-half) false))
+  | none => false
+
+private def positiveOpenZeroReciprocal : Option Result := do
+  let input ← imported? (finite 0 true 2 false)
+  pure (reciprocal endpointLimit 8 input)
+
+#guard
+  match positiveOpenZeroReciprocal with
+  | some result =>
+      readyAs result (.bounds (.finite half false) .unbounded)
+  | none => false
+
+private def positiveUnboundedReciprocal : Option Result := do
+  let input ← imported? (.bounds (.finite 1 false) .unbounded)
+  pure (reciprocal endpointLimit 8 input)
+
+#guard
+  match positiveUnboundedReciprocal with
+  | some result =>
+      readyAs result (.bounds (.finite 0 true) (.finite 1 false))
+  | none => false
+
+private def negativeOpenZeroReciprocal : Option Result := do
+  let input ← imported? (finite (-2) false 0 true)
+  pure (reciprocal endpointLimit 8 input)
+
+#guard
+  match negativeOpenZeroReciprocal with
+  | some result =>
+      readyAs result (.bounds .unbounded (.finite (-half) false))
+  | none => false
+
+private def negativeUnboundedReciprocal : Option Result := do
+  let input ← imported? (.bounds .unbounded (.finite (-1) false))
+  pure (reciprocal endpointLimit 8 input)
+
+#guard
+  match negativeUnboundedReciprocal with
+  | some result =>
+      readyAs result (.bounds (.finite (-1) false) (.finite 0 true))
+  | none => false
+
+private def mixedReciprocal : Option Result := do
+  let input ← imported? (finite (-1) false 1 false)
+  pure (reciprocal endpointLimit 8 input)
+
+#guard mixedReciprocal == some .inapplicable
+
+private def roundedReciprocal : Option Result := do
+  let input ← imported? (finite 3 false 3 false)
+  pure (reciprocal endpointLimit 2 input)
+
+-- `1 / 3` is bracketed on the quarter grid.  Both moved bounds are open
+-- because neither outward endpoint is attained by the singleton input.
+#guard
+  match roundedReciprocal with
+  | some result =>
+      readyAs result
+        (.bounds (.finite (Dyadic.ofIntWithPrec 1 2) true)
+          (.finite half true))
+  | none => false
+
+private def tightInverseLimit : EndpointLimit where
+  maxEndpointHeight := 128
+  maxAlignmentShift := 4
+
+private def reciprocalPreflight : Option Result := do
+  let input ← imported? (finite 1 false 2 false)
+  pure (reciprocal tightInverseLimit 16 input)
+
+#guard
+  match reciprocalPreflight with
+  | some (.resourceLimit (.inverse _ 16 shift)) => shift > 4
+  | _ => false
+
+/-! ## Splitting -/
+
+private def splitAtZero : Option (Fact × Fact) := do
+  let input ← imported? (finite 0 false 1 false)
+  match split endpointLimit input 0 with
+  | .ok children => some children
+  | .error _ => none
+
+#guard
+  match splitAtZero with
+  | some (left, right) =>
+      left.view == finite 0 false 0 false &&
+        right.view == finite 0 true 1 false
+  | none => false
+
+private def splitOpenCut : Option (Fact × Fact) := do
+  let input ← imported? (finite 0 true 1 false)
+  match split endpointLimit input 0 with
+  | .ok children => some children
+  | .error _ => none
+
+#guard
+  match splitOpenCut with
+  | some (left, right) =>
+      left.view == .empty && right.view == finite 0 true 1 false
+  | none => false
+
+/-! ## Preflight and checked engine start -/
+
+private def far : Dyadic := .ofOdd 1 1000000000 (by decide)
+
+-- Empty splitting short-circuits before inspecting an otherwise over-budget
+-- cut point, preserving the canonical empty image law.
+#guard
+  match split endpointLimit .empty far with
+  | .ok (left, right) => left.isEmpty && right.isEmpty
+  | .error _ => false
+
+private def largeHeight : EndpointLimit where
+  maxEndpointHeight := 1000000100
+  maxAlignmentShift := 64
+
+private def preflightedIntersection : Option Result := do
+  let lower ←
+    match importRaw largeHeight
+        (.bounds (.finite 1 false) .unbounded) with
+    | .ready fact => some fact
+    | _ => none
+  let upper ←
+    match importRaw largeHeight
+        (.bounds .unbounded (.finite far false)) with
+    | .ready fact => some fact
+    | _ => none
+  pure (intersect largeHeight lower upper)
+
+#guard
+  match preflightedIntersection with
+  | some (.resourceLimit (.comparison cost)) =>
+      cost.alignmentShift == 1000000000
+  | _ => false
+
+private def domainImprovement : Option (NarrowResult Fact) := do
+  let current ← imported? (finite 0 false 2 false)
+  let candidate ← imported? (finite 0 true 3 false)
+  pure ((factDomain endpointLimit).narrow { index := 0 } current candidate)
+
+#guard
+  match domainImprovement with
+  | some (.improved fact) => fact.view == finite 0 true 2 false
+  | _ => false
+
+private def domainContradiction : Option (NarrowResult Fact) := do
+  let current ← imported? (finite 0 false 1 false)
+  let candidate ← imported? (finite 1 true 2 false)
+  pure ((factDomain endpointLimit).narrow { index := 0 } current candidate)
+
+#guard
+  match domainContradiction with
+  | some (.contradiction fact) => fact.isEmpty
+  | _ => false
+
+private def domainNoChange : Option (NarrowResult Fact) := do
+  let current ← imported? (finite 0 false 1 false)
+  let candidate ← imported? (finite (-1) false 2 false)
+  pure ((factDomain endpointLimit).narrow { index := 0 } current candidate)
+
+#guard
+  match domainNoChange with
+  | some .noChange => true
+  | _ => false
+
+private def real : DomainId := { index := 0 }
+
+private def sourceOp : OpKey := { name := "dyadic.source" }
+
+private def sourceProgram : Program :=
+  { operations := #[{ key := sourceOp, inputs := [], output := real }]
+    nodes := #[{ domain := real, op := { index := 0 }, args := [] }] }
+
+private def engineLimits : Limits :=
+  { maxOperations := 4
+    maxNodes := 4
+    maxRules := 0
+    maxArity := 2
+    maxApplications := 0
+    maxQueueEntries := 0
+    maxActions := 4
+    maxAcceptedFacts := 4
+    maxRetainedSuggestions := 0
+    maxEffort := 4
+    maxObservationValue := 16
+    maxOutcomeCandidates := 2
+    maxOutcomeSuggestions := 0
+    maxProposalItems := 2
+    maxInstances := 0
+    maxGeneration := 0
+    maxEqualities := 0
+    splitEndpointLimit := endpointLimit }
+
+#guard
+  match start endpointLimit sourceProgram #[] #[.empty] engineLimits with
+  | .error (.emptyFact 0) => true
+  | _ => false
+
+#guard
+  match start endpointLimit sourceProgram #[] #[] engineLimits with
+  | .error (.engine .wrongFactCount) => true
+  | _ => false
+
+#guard
+  match start endpointLimit sourceProgram #[]
+      #[.bounds (.finite 1 true) (.finite 1 false)] engineLimits with
+  | .error (.malformedFact 0) => true
+  | _ => false
+
+#guard
+  match start endpointLimit sourceProgram #[]
+      #[.bounds .unbounded (.finite far false)] engineLimits with
+  | .error (.factResource 0 _) => true
+  | _ => false
+
+#guard
+  match start endpointLimit sourceProgram #[]
+      #[.bounds (.finite 0 false) (.finite 1 false)] engineLimits with
+  | .ok engine =>
+      engine.facts.size == 1 &&
+        (engine.facts[0]?).any fun fact =>
+          fact.view == finite 0 false 1 false
+  | .error _ => false
+
+end Hex.Interval.DyadicIntervalConformance

--- a/conformance/HexInterval/DyadicIntervalConformance.lean
+++ b/conformance/HexInterval/DyadicIntervalConformance.lean
@@ -7,6 +7,8 @@ Authors: Kim Morrison
 import HexInterval.Experiment.DyadicInterval
 
 /-!
+# Concrete dyadic interval conformance
+
 Conformance checks for the first concrete propagator fact domain.  These tests
 exercise exact openness and endpoint attainment rather than merely checking
 coarse numerical hulls.

--- a/conformance/HexInterval/DyadicIntervalConformance.lean
+++ b/conformance/HexInterval/DyadicIntervalConformance.lean
@@ -25,6 +25,10 @@ private def endpointLimit : EndpointLimit where
   maxEndpointHeight := 128
   maxAlignmentShift := 64
 
+private def tightAlignmentLimit : EndpointLimit where
+  maxEndpointHeight := 128
+  maxAlignmentShift := 4
+
 private def readyAs (result : Result) (expected : Raw) : Bool :=
   match result with
   | .ready fact => fact.view == expected
@@ -103,6 +107,22 @@ private def unboundedNeg : Option Result := do
   | some result =>
       readyAs result (.bounds .unbounded (.finite (-1) true))
   | none => false
+
+private def inverseShiftInput : Dyadic := .ofOdd 1 64 (by decide)
+
+private def subtractionPreflight : Option Result := do
+  let left ← imported?
+    (.bounds (.finite inverseShiftInput false) (.finite 1 false))
+  let right ← imported?
+    (.bounds (.finite inverseShiftInput false) (.finite inverseShiftInput false))
+  pure (sub tightAlignmentLimit left right)
+
+-- The cheap lower pair must not be subtracted before the upper pair's
+-- 64-place alignment has also passed preflight.
+#guard
+  match subtractionPreflight with
+  | some (.resourceLimit (.comparison cost)) => cost.alignmentShift == 64
+  | _ => false
 
 /-! ## Attainment-sensitive multiplication and square -/
 
@@ -323,17 +343,20 @@ private def roundedReciprocal : Option Result := do
           (.finite half true))
   | none => false
 
-private def tightInverseLimit : EndpointLimit where
-  maxEndpointHeight := 128
-  maxAlignmentShift := 4
-
 private def reciprocalPreflight : Option Result := do
   let input ← imported? (finite 1 false 2 false)
-  pure (reciprocal tightInverseLimit 16 input)
+  pure (reciprocal tightAlignmentLimit 16 input)
 
 #guard
   match reciprocalPreflight with
   | some (.resourceLimit (.inverse _ 16 shift)) => shift > 4
+  | _ => false
+
+-- Core performs these two shifts separately: their signed exponents cancel,
+-- but their allocation work does not.
+#guard
+  match inverseChecked tightAlignmentLimit (-64) inverseShiftInput with
+  | .error (.inverse _ 64 shift) => shift == 128
   | _ => false
 
 /-! ## Splitting -/

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -230,7 +230,8 @@ lean_lib HexIntervalExperiment where
     `HexInterval.Experiment.Rational, `HexInterval.Experiment.Center,
     `HexInterval.Experiment.Scale, `HexInterval.Experiment.Propagator,
     `HexInterval.Experiment.Policy, `HexInterval.Experiment.PolicyFrontier,
-    `HexInterval.Experiment.PolicyDriver]
+    `HexInterval.Experiment.PolicyDriver,
+    `HexInterval.Experiment.DyadicInterval]
 
 lean_lib HexIntervalMathlibExperiment where
   globs := #[`HexIntervalMathlib.Experiment.Center]
@@ -297,7 +298,7 @@ lean_lib HexRCFProofProbeScientific where
 -- `*_emit_fixtures` exes below, carrying `srcDir := "conformance"`.
 lean_lib HexConformance where
   srcDir := "conformance"
-  globs := #[`HexArith.Conformance, `HexArith.CrossCheck, `HexBerlekamp.Conformance, `HexBerlekampZassenhaus.Conformance, `HexBerlekampZassenhaus.CrossCheck, `HexConway.Conformance, `HexGF2.Conformance, `HexGF2.CrossCheck, `HexGF2.FastCheck, `HexGFq.Conformance, `HexGFq.CrossCheck, `HexGFqField.Conformance, `HexGFqRing.Conformance, `HexGramSchmidt.Conformance, `HexHensel.Conformance, `HexHensel.CrossCheck, `HexInterval.Conformance, `HexInterval.CenterConformance, `HexInterval.ScaleConformance, `HexInterval.PropagatorConformance, `HexInterval.StructureViewConformance, `HexInterval.PolicyConformance, `HexInterval.PolicyFrontierConformance, `HexInterval.PolicyDriverConformance, `HexLLL.Conformance, `HexMatrix.Conformance, `HexRowReduce.Conformance, `HexDeterminant.Conformance, `HexBareiss.Conformance, `HexModArith.Conformance, `HexModArith.FastCheck, `HexNumberField.Conformance, `HexNumberFieldTower.Conformance, `HexPoly.Conformance, `HexPolyFp.Conformance, `HexPolyZ.Conformance, `HexRCF.Conformance, `HexRealRoots.Conformance, `HexRealRootsMathlib.Conformance, `HexResultant.Conformance, `HexRoots.Conformance].map Glob.one
+  globs := #[`HexArith.Conformance, `HexArith.CrossCheck, `HexBerlekamp.Conformance, `HexBerlekampZassenhaus.Conformance, `HexBerlekampZassenhaus.CrossCheck, `HexConway.Conformance, `HexGF2.Conformance, `HexGF2.CrossCheck, `HexGF2.FastCheck, `HexGFq.Conformance, `HexGFq.CrossCheck, `HexGFqField.Conformance, `HexGFqRing.Conformance, `HexGramSchmidt.Conformance, `HexHensel.Conformance, `HexHensel.CrossCheck, `HexInterval.Conformance, `HexInterval.CenterConformance, `HexInterval.ScaleConformance, `HexInterval.PropagatorConformance, `HexInterval.StructureViewConformance, `HexInterval.PolicyConformance, `HexInterval.PolicyFrontierConformance, `HexInterval.PolicyDriverConformance, `HexInterval.DyadicIntervalConformance, `HexLLL.Conformance, `HexMatrix.Conformance, `HexRowReduce.Conformance, `HexDeterminant.Conformance, `HexBareiss.Conformance, `HexModArith.Conformance, `HexModArith.FastCheck, `HexNumberField.Conformance, `HexNumberFieldTower.Conformance, `HexPoly.Conformance, `HexPolyFp.Conformance, `HexPolyZ.Conformance, `HexRCF.Conformance, `HexRealRoots.Conformance, `HexRealRootsMathlib.Conformance, `HexResultant.Conformance, `HexRoots.Conformance].map Glob.one
 
 -- Public umbrellas intentionally contain only the supported API. Executable
 -- examples and regression tests are compiled through this separate target so

--- a/progress/20260727T142058Z.md
+++ b/progress/20260727T142058Z.md
@@ -1,0 +1,35 @@
+# Concrete dyadic interval facts
+
+## Accomplished
+
+- Added a checked dyadic interval fact representation with canonical empty,
+  whole, finite open/closed, and independently unbounded smart constructors.
+- Added resource-preflighted exact intersection and the concrete propagator
+  `FactDomain`, plus a checked engine-start boundary that rejects malformed,
+  empty, over-budget, and wrongly sized initial facts.
+- Added exact negation, subtraction, square, finite multiplication with endpoint
+  attainment, singleton scaling, exact dyadic backward scaling, sign-separated
+  reciprocal enclosure, and disjoint split-at-point construction.
+- Added conformance coverage for equal-cut openness, unbounded cases, tied
+  extrema, zero attainment, exact and rounded reciprocals, unsupported cases,
+  resource rejection, splitting, and initial-fact validation.
+- Wired the implementation and conformance modules into the experiment and
+  aggregate conformance targets.  The focused conformance build and repository
+  lints pass.
+
+## Current frontier
+
+The arbitrary-function engine now has a real open/closed/unbounded interval
+fact domain rather than synthetic ranks.  Finite multiplication is exact;
+unbounded multiplication and reciprocal across a closed zero remain explicit
+`inapplicable` cases rather than silently loose results.
+
+## Next step
+
+Register concrete forward and backward propagators over these facts and drive
+them through nonlinear, instantiation, retry, and subdivision examples before
+expanding the arithmetic surface.
+
+## Blockers
+
+None.

--- a/progress/20260727T144000Z.md
+++ b/progress/20260727T144000Z.md
@@ -1,0 +1,29 @@
+# Dyadic preflight audit fixes
+
+## Accomplished
+
+- Corrected reciprocal resource preflight so the input exponent shift and
+  requested-precision shift cannot cancel in the accounting while Core still
+  performs both allocations.
+- Changed interval subtraction to preflight both finite endpoint pairs before
+  evaluating either subtraction.
+- Added focused regressions for opposite-signed inverse shifts and for a cheap
+  lower subtraction paired with an over-budget upper alignment.
+- Rebuilt the dyadic interval module and its conformance target successfully.
+
+## Current frontier
+
+The checked dyadic fact substrate has passed a dedicated semantic and resource
+audit.  Its intentionally incomplete arithmetic surface is now frozen for this
+prototype; the active work is the arbitrary-function rule framework built on
+top of it.
+
+## Next step
+
+Carry these two safety fixes into the arbitrary-rule branch, then continue the
+end-to-end registration, structural instantiation, retry, and subdivision
+experiments for nonlinear functions.
+
+## Blockers
+
+None.

--- a/progress/20260728T051304Z.md
+++ b/progress/20260728T051304Z.md
@@ -1,0 +1,25 @@
+# Dyadic propagator review hardening
+
+## Accomplished
+
+- Made an unchanged empty narrowing a fixed point rather than a second
+  contradiction report.
+- Kept zero endpoints out of pointwise reciprocal arithmetic while preserving
+  the interval-level rejection of closed-zero inputs.
+- Replaced the subtraction preflight canary with one that distinguishes full
+  two-endpoint preflight from eagerly computing the first result.
+- Rebuilt the dyadic conformance target and the complete Mathlib-free interval
+  experiment library.
+
+## Current frontier
+
+- The concrete dyadic fact domain has focused regression coverage for the
+  three review findings without adding new arithmetic functionality.
+
+## Next step
+
+- Integrate these review fixes into PR #8977 and let its existing CI rerun.
+
+## Blockers
+
+- None.

--- a/progress/20260728T060509Z.md
+++ b/progress/20260728T060509Z.md
@@ -1,0 +1,26 @@
+# Dyadic propagator rebase
+
+## Accomplished
+
+- Rebased the three concrete dyadic fact commits onto current `origin/main`.
+- Resolved the `lakefile.lean` conformance-glob conflict by retaining the
+  NumberFieldTower registration from main and adding only the dyadic target.
+- Rebuilt the dyadic implementation and conformance modules and the complete
+  `HexIntervalExperiment` library.
+- Confirmed the changed Lean files contain no `native_decide`, `axiom`, or
+  `sorry`, and that the rebased diff has no whitespace errors.
+- Force-pushed the rebased branch with a lease and verified that PR #8977 is
+  conflict-free, ready, and still has auto-merge enabled.
+
+## Current frontier
+
+- The concrete dyadic fact work is rebased and locally green. Its refreshed CI
+  run is pending before PR #8977 can auto-merge.
+
+## Next step
+
+- Let the refreshed CI run complete and auto-merge PR #8977.
+
+## Blockers
+
+- None.

--- a/progress/20260729T052145Z.md
+++ b/progress/20260729T052145Z.md
@@ -1,0 +1,25 @@
+# Dyadic fact CI refresh
+
+## Accomplished
+
+- Rebased the concrete dyadic fact commits onto current `origin/main`, which
+  includes the generic external-policy invariants and the complete conformance
+  target manifest.
+- Resolved the Lake target conflict by preserving every current target and
+  adding only the dyadic experiment and conformance modules.
+- Added the module title required by the current documentation-header check.
+- Verified the conformance target matrix, rebuilt the dyadic implementation and
+  conformance module, and rebuilt `HexIntervalExperiment` successfully.
+
+## Current frontier
+
+The concrete fact domain is current and locally green. It remains plumbing for
+the arbitrary-propagator framework rather than the focus of further design.
+
+## Next step
+
+Refresh PR #8977 CI and let its existing auto-merge complete.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Summary

Adds the first concrete fact domain for the function-agnostic interval engine.

- represents empty, whole, finite, one-sided-unbounded, open, closed, and half-open intervals with a checked consistency witness
- rejects malformed or initially empty raw facts before generic engine startup
- implements exact intersection, negation, subtraction, square, finite multiplication, singleton scaling, exact backward scaling, sign-separated reciprocal, and complementary splitting
- preserves endpoint attainment when extrema tie, including zero attained through a non-corner point
- preflights endpoint, alignment, multiplication, and inverse work before admitting results
- exposes a `FactDomain` adapter so arbitrary propagators can use these facts without putting function semantics in the scheduler

## Deliberate boundaries

This experiment reports unbounded multiplication as inapplicable rather than guessing a connected image. Reciprocal currently handles positive and negative components, including an open zero endpoint; intervals containing zero are left for the complete total-inverse hull and interval-set/splitting experiments. These are explicit follow-up decisions, not silent approximations.

## Evidence

Conformance covers all endpoint closure combinations used here, malformed and empty initialization, unbounded sides, tied extrema, zero attainment away from corners, exact and inexact inverse endpoints, exact backward scaling, resource preflight, fact improvement/no-change/contradiction, and empty split children.

## Validation

- `lake build HexInterval.DyadicIntervalConformance`
- copyright and line-count checks
- DAG and release-manifest checks
- trust-surface and phase checks
- Mathlib-free bench and conformance-target checks
- no `native_decide`, axioms, or sorries