### PR TITLE
prove(number-field-tower): establish additive evaluation

### DIFF
--- a/HexNumberFieldTower/Basic.lean
+++ b/HexNumberFieldTower/Basic.lean
@@ -80,6 +80,11 @@ namespace NumberTower
 def rat : NumberTower :=
   .mk #[] (by simp [LevelsValid])
 
+/-- The rational tower has no proper extension levels. -/
+@[simp]
+theorem rat_levels : rat.levels.toList = [] := by
+  rfl
+
 /-- Absolute dimension over `Rat`. -/
 @[expose]
 def dim (T : NumberTower) : Nat :=

--- a/HexNumberFieldTower/RawArithmetic.lean
+++ b/HexNumberFieldTower/RawArithmetic.lean
@@ -45,6 +45,25 @@ def negCoords (n : Nat) (a : Array Rat) : Array Rat :=
 def block (a : Array Rat) (index width : Nat) : Array Rat :=
   (Vector.ofFn fun i : Fin width => a.getD (index * width + i.val) 0).toArray
 
+/-- A block of fixed-width coordinate addition is the sum of the blocks. -/
+theorem block_add (count width index : Nat) (a b : Array Rat)
+    (hindex : index < count) :
+    block (addCoords (count * width) a b) index width =
+      addCoords width (block a index width) (block b index width) := by
+  apply Array.ext
+  · simp [block, addCoords]
+  · intro i hi₁ hi₂
+    have hi : i < width := by
+      simpa [addCoords] using hi₂
+    have hglobal : index * width + i < count * width := by
+      calc
+        index * width + i < index * width + width :=
+          Nat.add_lt_add_left hi _
+        _ = (index + 1) * width := by simp [Nat.add_mul]
+        _ ≤ count * width :=
+          Nat.mul_le_mul_right width (Nat.succ_le_of_lt hindex)
+    simp [block, addCoords, Array.getD, hglobal]
+
 /-- Flatten a fixed number of equally wide coordinate blocks. -/
 @[expose]
 def flattenBlocks (count width : Nat) (blocks : Array (Array Rat)) : Array Rat :=

--- a/HexNumberFieldTowerMathlib/Arithmetic.lean
+++ b/HexNumberFieldTowerMathlib/Arithmetic.lean
@@ -36,7 +36,11 @@ theorem map_one (T : NumberTower) :
 /-- Coordinate addition computes complex addition. -/
 theorem map_add (T : NumberTower) (a b : Elem T) :
     T.toComplex (a + b) = T.toComplex a + T.toComplex b := by
-  sorry
+  rw [LevelSemantics.toComplex_eq_denote T (a + b),
+    LevelSemantics.toComplex_eq_denote T a,
+    LevelSemantics.toComplex_eq_denote T b, coeffs_add]
+  simpa [dim] using
+    LevelSemantics.denote_add T.levels.toList (coeffs a) (coeffs b)
 
 /-- Coordinate negation computes complex negation. -/
 theorem map_neg (T : NumberTower) (a : Elem T) :

--- a/HexNumberFieldTowerMathlib/Basic.lean
+++ b/HexNumberFieldTowerMathlib/Basic.lean
@@ -77,6 +77,186 @@ theorem dim_pos (T : NumberTower) : 0 < T.dim := by
 
 namespace LevelSemantics
 
+/-- Direct complex Horner interpretation of raw mixed-radix coordinates. -/
+@[expose]
+noncomputable def denote : (levels : List Level) → Array Rat → ℂ
+  | [], data => (data.getD 0 0 : ℂ)
+  | level :: lower, data =>
+      let lowerDim := levelsDim lower
+      let coefficients := (List.range level.degree).map fun i =>
+        denote lower (Arithmetic.block data i lowerDim)
+      coefficients.reverse.foldl
+        (fun value coefficient =>
+          value * level.root.toComplex + coefficient)
+        0
+
+private theorem foldl_add {ι : Type} (x : ℂ) (indices : List ι)
+    (f g : ι → ℂ) (a b : ℂ) :
+    (indices.map fun i => f i + g i).foldl
+        (fun value coefficient => value * x + coefficient) (a + b) =
+      (indices.map f).foldl
+          (fun value coefficient => value * x + coefficient) a +
+        (indices.map g).foldl
+          (fun value coefficient => value * x + coefficient) b := by
+  induction indices generalizing a b with
+  | nil => rfl
+  | cons i indices ih =>
+      simp only [List.map_cons, List.foldl_cons]
+      rw [show (a + b) * x + (f i + g i) =
+          (a * x + f i) + (b * x + g i) by ring]
+      exact ih (a * x + f i) (b * x + g i)
+
+/-- Direct tower denotation is additive on fixed-width coordinates. -/
+theorem denote_add (levels : List Level) (a b : Array Rat) :
+    denote levels (Arithmetic.addCoords (levelsDim levels) a b) =
+      denote levels a + denote levels b := by
+  induction levels generalizing a b with
+  | nil =>
+      simp [denote, Arithmetic.addCoords, levelsDim, Array.getD]
+  | cons level lower ih =>
+      simp only [denote, levelsDim]
+      have hcoeff :
+          (List.range level.degree).map (fun i =>
+              denote lower (Arithmetic.block
+                (Arithmetic.addCoords (level.degree * levelsDim lower) a b)
+                i (levelsDim lower))) =
+            (List.range level.degree).map (fun i =>
+              denote lower (Arithmetic.block a i (levelsDim lower)) +
+                denote lower (Arithmetic.block b i (levelsDim lower))) := by
+        apply List.map_congr_left
+        intro i hi
+        rw [Arithmetic.block_add level.degree (levelsDim lower) i a b
+          (List.mem_range.mp hi), ih]
+      rw [hcoeff]
+      simpa only [← List.map_reverse, zero_add] using
+        foldl_add level.root.toComplex (List.range level.degree).reverse
+          (fun i => denote lower (Arithmetic.block a i (levelsDim lower)))
+          (fun i => denote lower (Arithmetic.block b i (levelsDim lower))) 0 0
+
+private theorem foldlM_sound (x : AlgebraicRoot)
+    (coefficients : List AlgebraicRoot) (acc : AlgebraicRoot)
+    {out : AlgebraicRoot}
+    (h : coefficients.foldlM
+      (fun value coefficient => do
+        let product ← value.mul? x
+        product.add? coefficient) acc = some out) :
+    out.toComplex =
+      (coefficients.map AlgebraicRoot.toComplex).foldl
+        (fun value coefficient => value * x.toComplex + coefficient)
+        acc.toComplex := by
+  induction coefficients generalizing acc out with
+  | nil =>
+      have hout : acc = out := by simpa using h
+      cases hout
+      rfl
+  | cons coefficient coefficients ih =>
+      simp only [List.foldlM_cons] at h
+      cases hproduct : acc.mul? x with
+      | none => simp [hproduct] at h
+      | some product =>
+          cases hsum : product.add? coefficient with
+          | none => simp [hproduct, hsum] at h
+          | some next =>
+              have htail :
+                  coefficients.foldlM
+                    (fun value coefficient => do
+                      let product ← value.mul? x
+                      product.add? coefficient) next = some out := by
+                simpa [hproduct, hsum] using h
+              rw [ih next htail]
+              simp only [List.map_cons, List.foldl_cons]
+              rw [AlgebraicRoot.add?_sound product coefficient hsum,
+                AlgebraicRoot.mul?_sound acc x hproduct]
+
+private theorem mapM_sound {ι : Type} (indices : List ι)
+    (f : ι → Option AlgebraicRoot) (g : ι → ℂ)
+    (hsound : ∀ i root, f i = some root → root.toComplex = g i)
+    {roots : List AlgebraicRoot} (h : indices.mapM f = some roots) :
+    roots.map AlgebraicRoot.toComplex = indices.map g := by
+  induction indices generalizing roots with
+  | nil =>
+      have hroots : roots = [] := by simpa using h.symm
+      subst roots
+      rfl
+  | cons i indices ih =>
+      cases hi : f i with
+      | none => simp [List.mapM_cons, hi] at h
+      | some root =>
+          cases htail : indices.mapM f with
+          | none => simp [List.mapM_cons, hi, htail] at h
+          | some tail =>
+              have hroots : roots = root :: tail := by
+                simpa [List.mapM_cons, hi, htail] using h.symm
+              subst roots
+              simp only [List.map_cons, List.cons.injEq]
+              exact ⟨hsound i root hi, ih htail⟩
+
+/-- Successful raw evaluation agrees with direct complex Horner denotation. -/
+theorem evalCoords_sound (levels : List Level) (data : Array Rat)
+    {root : AlgebraicRoot}
+    (h : RawEvaluation.evalCoords? levels data = some root) :
+    root.toComplex = denote levels data := by
+  induction levels generalizing data root with
+  | nil =>
+      let q := data.getD 0 0
+      have hq :
+          (coeffs (NumberTower.rat.ofRat q)).getD 0 0 = q := by
+        rw [NumberTower.ofRat_eq_ofCoeffs, NumberTower.coeffs_ofCoeffs]
+        simp [NumberTower.normalizeCoeffs, dim_pos]
+      have hrat :
+          RawEvaluation.evalCoords? []
+              (coeffs (NumberTower.rat.ofRat q)) = some root := by
+        change
+          (do
+            let value ← AlgebraicPoly.Common.rational?
+              ((coeffs (NumberTower.rat.ofRat q)).getD 0 0)
+            some value.toRoot) = some root
+        rw [hq]
+        simpa [RawEvaluation.evalCoords?, q] using h
+      have hrat' :
+          RawEvaluation.evalCoords? NumberTower.rat.levels.toList
+              (coeffs (NumberTower.rat.ofRat q)) = some root := by
+        simpa [NumberTower.rat_levels] using hrat
+      calc
+        root.toComplex = NumberTower.rat.toComplex
+            (NumberTower.rat.ofRat q) :=
+          (toComplex_eq NumberTower.rat (NumberTower.rat.ofRat q) hrat').symm
+        _ = (q : ℂ) := toComplex_ofRat NumberTower.rat q
+        _ = denote [] data := rfl
+  | cons level lower ih =>
+      simp only [RawEvaluation.evalCoords?] at h
+      obtain ⟨roots, hroots, hfold⟩ := Option.bind_eq_some_iff.mp h
+      have hsem :
+          roots.map AlgebraicRoot.toComplex =
+            (List.range level.degree).map (fun i =>
+              denote lower
+                (Arithmetic.block data i (levelsDim lower))) := by
+        apply mapM_sound (List.range level.degree)
+          (fun i => RawEvaluation.evalCoords? lower
+            (Arithmetic.block data i (levelsDim lower)))
+        intro i coefficient hi
+        exact ih _ hi
+        exact hroots
+      rw [foldlM_sound level.root roots.reverse
+        AlgebraicNumber.zero.toRoot hfold]
+      rw [List.map_reverse, hsem]
+      have hzero : AlgebraicNumber.zero.toRoot.toComplex = 0 := by
+        rw [AlgebraicNumber.toRoot_toComplex]
+        exact AlgebraicNumber.zero_toComplex
+      rw [hzero]
+      rfl
+
+/-- The selected complex interpretation is the direct Horner denotation of
+the element's mixed-radix coordinates. -/
+theorem toComplex_eq_denote (T : NumberTower) (a : Elem T) :
+    T.toComplex a = denote T.levels.toList (coeffs a) := by
+  cases h : RawEvaluation.evalCoords? T.levels.toList (coeffs a) with
+  | none =>
+      have hsome := eval?_isSome T a
+      simp [eval?, h] at hsome
+  | some root =>
+      rw [NumberTower.toComplex_eq T a h, evalCoords_sound _ _ h]
+
 /-- Interpret raw lower-tower coordinates through their selected complex
 embedding. Validity makes the fallback unreachable. -/
 @[expose]

--- a/progress/20260727T143259Z_number-tower-additive-evaluation.md
+++ b/progress/20260727T143259Z_number-tower-additive-evaluation.md
@@ -1,0 +1,31 @@
+# Number-tower additive evaluation
+
+## Accomplished
+
+- Defined a direct complex Horner denotation for raw mixed-radix coordinates
+  and proved that every successful lazy evaluation agrees with it.
+- Proved fixed-width block extraction commutes with coordinate addition and
+  used this to establish additivity of the recursive Horner denotation.
+- Connected the direct denotation to the tower's selected `toComplex`
+  interpretation and retired the `map_add` placeholder.
+- Validated `HexNumberFieldTowerMathlib` and `HexManual`, all 19 tower smoke
+  benchmarks, and the repository policy checks.
+
+## Current frontier
+
+- The additive semantic API is complete: zero, addition, negation,
+  subtraction, and zero recognition are all proved.
+- The next primitive field obligation is `map_mul`; inversion and rational
+  scalar multiplication remain after it.
+
+## Next step
+
+- Open this milestone as a draft PR stacked on
+  `NumberFieldTowerMapAddNeg`.
+- On the next branch, prove that recursive reduced multiplication preserves
+  the direct Horner denotation, then use it to close `map_mul`.
+
+## Blockers
+
+- Claude second-opinion capacity remains unavailable until the provider quota
+  reset; implementation and GitHub CI continue independently.


### PR DESCRIPTION
## Summary

- define direct complex Horner semantics for mixed-radix tower coordinates
- prove successful lazy evaluation agrees with direct semantics
- prove coordinate addition is preserved and retire the tower map_add placeholder

## Validation

- lake build HexNumberFieldTowerMathlib HexManual
- lake exe hexnumberfieldtower_bench verify (19/19)
- no new sorry, axiom, or native_decide

Stacked on #8976.
