### PR TITLE
refactor(rcf): extract Mathlib-free reflected syntax

### DIFF
--- a/HexRCF.lean
+++ b/HexRCF.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexRCF.Syntax
 public import HexRCF.Language
 public import HexRCF.LanguageTests
 public import HexRCF.SturmReplay

--- a/HexRCF/Carrier.lean
+++ b/HexRCF/Carrier.lean
@@ -27,30 +27,6 @@ namespace Hex.RCF
 
 open HexRealRootsMathlib Polynomial
 
-/-- All atom polynomials in a formula, in deterministic left-to-right order. -/
-@[expose]
-def Formula.polys : Formula → List ZPoly
-  | .atom a => [a.p]
-  | .tt | .ff => []
-  | .not φ => φ.polys
-  | .and φ ψ | .or φ ψ | .imp φ ψ => φ.polys ++ ψ.polys
-
-/-- The body of a one-quantifier sentence. -/
-@[expose]
-def Sentence.formula : Sentence → Formula
-  | .forallReal φ | .existsReal φ | .forallIoc _ _ φ | .existsIoc _ _ φ => φ
-
-/-- The positive-degree atom polynomials used by the carrier decomposition.
-Constant atoms remain in the reflected formula but, after their truth values
-are evaluated, do not contribute carrier boundaries. -/
-@[expose]
-def Sentence.polys (s : Sentence) : List ZPoly :=
-  s.formula.polys.filter fun p => decide (0 < p.degree?.getD 0)
-
-/-- The product of all nonconstant atom polynomials. -/
-@[expose]
-def Sentence.product (s : Sentence) : ZPoly := s.polys.prod
-
 /-- Check that every polynomial in a literal list has positive degree. -/
 @[expose]
 def checkPosDegrees : List ZPoly → Bool

--- a/HexRCF/Language.lean
+++ b/HexRCF/Language.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexRCF.Syntax
 public import HexRealRootsMathlib.Separation
 
 public section
@@ -13,11 +14,8 @@ public section
 /-!
 # Reflected univariate real-closed-field sentences
 
-This module defines the object language consumed by the `rcf` decision
-procedure. A formula is a Boolean combination of comparisons between an
-integer polynomial evaluated at one real variable and zero. A sentence places
-exactly one universal or existential quantifier around a formula, either over
-all real numbers or over a half-open interval with dyadic endpoints.
+This module defines the real-valued semantics of the Mathlib-free object
+language in `HexRCF.Syntax`.
 
 Nested quantifiers and additional variables are unrepresentable by
 construction. Rational coefficients are handled by the tactic's reifier,
@@ -31,16 +29,6 @@ definitionally equal to the source goal.
 
 namespace Hex.RCF
 
-/-- The six comparisons supported by reflected polynomial atoms. -/
-inductive Cmp where
-  | lt
-  | le
-  | eq
-  | ge
-  | gt
-  | ne
-  deriving DecidableEq
-
 /-- Interpret a reflected comparison between two real numbers. -/
 @[expose]
 def Cmp.toProp : Cmp → ℝ → ℝ → Prop
@@ -51,37 +39,10 @@ def Cmp.toProp : Cmp → ℝ → ℝ → Prop
   | .gt, a, b => a > b
   | .ne, a, b => a ≠ b
 
-/-- An atomic predicate asserting that an integer polynomial at `x` compares
-with zero according to `cmp`. -/
-structure Atom where
-  /-- The integer polynomial on the left of the comparison. -/
-  p : ZPoly
-  /-- The comparison with zero. -/
-  cmp : Cmp
-  deriving DecidableEq
-
 /-- Interpret an atomic polynomial comparison at a real point. -/
 @[expose]
 def Atom.toProp (a : Atom) (x : ℝ) : Prop :=
   a.cmp.toProp (Polynomial.aeval x (HexPolyZMathlib.toPolynomial a.p)) 0
-
-/-- Boolean combinations of univariate polynomial atoms. -/
-inductive Formula where
-  /-- A polynomial comparison. -/
-  | atom (a : Atom)
-  /-- Truth. -/
-  | tt
-  /-- Falsity. -/
-  | ff
-  /-- Boolean negation. -/
-  | not (φ : Formula)
-  /-- Boolean conjunction. -/
-  | and (φ ψ : Formula)
-  /-- Boolean disjunction. -/
-  | or (φ ψ : Formula)
-  /-- Boolean implication. -/
-  | imp (φ ψ : Formula)
-  deriving DecidableEq
 
 /-- Interpret a reflected formula at a real point. -/
 @[expose]
@@ -93,20 +54,6 @@ def Formula.toProp : Formula → ℝ → Prop
   | .and φ ψ, x => φ.toProp x ∧ ψ.toProp x
   | .or φ ψ, x => φ.toProp x ∨ ψ.toProp x
   | .imp φ ψ, x => φ.toProp x → ψ.toProp x
-
-/-- A quantifier-free formula under exactly one real or bounded-real
-quantifier. Bounded quantifiers use the half-open convention `(a, b]` inherited
-from real-root isolations. -/
-inductive Sentence where
-  /-- Universal quantification over all real numbers. -/
-  | forallReal (φ : Formula)
-  /-- Existential quantification over all real numbers. -/
-  | existsReal (φ : Formula)
-  /-- Universal quantification over the half-open dyadic interval `(a, b]`. -/
-  | forallIoc (a b : Dyadic) (φ : Formula)
-  /-- Existential quantification over the half-open dyadic interval `(a, b]`. -/
-  | existsIoc (a b : Dyadic) (φ : Formula)
-  deriving DecidableEq
 
 /-- Interpret a reflected sentence as a Lean proposition. -/
 @[expose]

--- a/HexRCF/Syntax.lean
+++ b/HexRCF/Syntax.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRealRoots.Basic
+
+public section
+
+/-!
+# Reflected syntax for univariate real-closed-field sentences
+
+This module contains the Mathlib-free data consumed by the compiled `rcf`
+decision pipeline. A formula is a Boolean combination of comparisons between
+an integer polynomial and zero. A sentence places exactly one universal or
+existential quantifier around a formula, either over the whole domain or over
+a half-open interval with dyadic endpoints.
+
+Real-valued semantics live separately in `HexRCF.Language`. Keeping the
+syntax and its structural polynomial traversals here allows compiled consumers
+to depend on the reflected input without importing those semantics.
+-/
+
+namespace Hex.RCF
+
+/-- The six comparisons supported by reflected polynomial atoms. -/
+inductive Cmp where
+  | lt
+  | le
+  | eq
+  | ge
+  | gt
+  | ne
+  deriving DecidableEq
+
+/-- An atomic comparison between an integer polynomial and zero. -/
+structure Atom where
+  /-- The integer polynomial on the left of the comparison. -/
+  p : ZPoly
+  /-- The comparison with zero. -/
+  cmp : Cmp
+  deriving DecidableEq
+
+/-- Boolean combinations of univariate polynomial atoms. -/
+inductive Formula where
+  /-- A polynomial comparison. -/
+  | atom (a : Atom)
+  /-- Truth. -/
+  | tt
+  /-- Falsity. -/
+  | ff
+  /-- Boolean negation. -/
+  | not (φ : Formula)
+  /-- Boolean conjunction. -/
+  | and (φ ψ : Formula)
+  /-- Boolean disjunction. -/
+  | or (φ ψ : Formula)
+  /-- Boolean implication. -/
+  | imp (φ ψ : Formula)
+  deriving DecidableEq
+
+/-- A quantifier-free formula under exactly one real or bounded-real
+quantifier. Bounded quantifiers use the half-open convention `(a, b]` inherited
+from real-root isolations. -/
+inductive Sentence where
+  /-- Universal quantification over the whole domain. -/
+  | forallReal (φ : Formula)
+  /-- Existential quantification over the whole domain. -/
+  | existsReal (φ : Formula)
+  /-- Universal quantification over the half-open dyadic interval `(a, b]`. -/
+  | forallIoc (a b : Dyadic) (φ : Formula)
+  /-- Existential quantification over the half-open dyadic interval `(a, b]`. -/
+  | existsIoc (a b : Dyadic) (φ : Formula)
+  deriving DecidableEq
+
+/-- All atom polynomials in a formula, in deterministic left-to-right order. -/
+@[expose]
+def Formula.polys : Formula → List ZPoly
+  | .atom a => [a.p]
+  | .tt | .ff => []
+  | .not φ => φ.polys
+  | .and φ ψ | .or φ ψ | .imp φ ψ => φ.polys ++ ψ.polys
+
+/-- The body of a one-quantifier sentence. -/
+@[expose]
+def Sentence.formula : Sentence → Formula
+  | .forallReal φ | .existsReal φ | .forallIoc _ _ φ | .existsIoc _ _ φ => φ
+
+/-- The positive-degree atom polynomials used by the carrier decomposition.
+Constant atoms remain in the reflected formula but, after their truth values
+are evaluated, do not contribute carrier boundaries. -/
+@[expose]
+def Sentence.polys (s : Sentence) : List ZPoly :=
+  s.formula.polys.filter fun p => decide (0 < p.degree?.getD 0)
+
+/-- The product of all nonconstant atom polynomials. -/
+@[expose]
+def Sentence.product (s : Sentence) : ZPoly := s.polys.prod
+
+end Hex.RCF

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -581,7 +581,9 @@ free to change.
 
 ## File organisation
 
-- `HexRCF/Language.lean`: `Atom`, `Formula`, `Sentence`, `toProp`;
+- `HexRCF/Syntax.lean`: Mathlib-free `Cmp`, `Atom`, `Formula`, `Sentence`, and
+  their structural polynomial traversals; `HexRCF/Language.lean`: real-valued
+  `toProp` semantics;
   `HexRCF/LanguageTests.lean`: executable language-semantics tests.
 - `HexRCF/SturmReplay.lean`: generalized multiplication-only chain
   replay and literal root counts.

--- a/progress/20260727T143956Z_rcf-syntax-seam.md
+++ b/progress/20260727T143956Z_rcf-syntax-seam.md
@@ -1,0 +1,31 @@
+# HexRCF Mathlib-free syntax seam
+
+## Accomplished
+
+- Opened #8982 after auditing the concrete import paths blocking a Mathlib-free
+  RCF runtime.
+- Added `HexRCF.Syntax` with the unchanged reflected syntax declarations and
+  pure polynomial traversals formerly split between `Language` and `Carrier`.
+- Left real-valued semantics in `HexRCF.Language`, updated the umbrella and
+  SPEC file map, and preserved all existing declaration names.
+- Verified the `HexRCF.Syntax` transitive import closure contains no
+  `Mathlib.*` module.
+- Built `HexRCF.Syntax`, `HexRCF.Language`, `HexRCF.Carrier`, and the complete
+  `HexRCF` library; the DAG and diff checks pass.
+
+## Current frontier
+
+The reflected input layer now has a genuine Mathlib-free boundary. The rest of
+the compiled decision pipeline still imports proof semantics through the
+literal Sturm replay, isolation, sign-matrix, and top-level soundness layers.
+
+## Next step
+
+Split the data, Boolean checks, and literal counts in `HexRCF.SturmReplay` from
+its Mathlib-facing validity and soundness theorems, preserving public names and
+using the new syntax seam as the start of a staged runtime import closure.
+
+## Blockers
+
+None for this slice. Phase 4 itself remains gated on #8972 and the broader
+evidence contract in #8973; this refactor makes no phase claim.


### PR DESCRIPTION
Closes #8982.

This is the first bounded extraction required by #8973. It moves the reflected `Cmp`, `Atom`, `Formula`, and `Sentence` types plus their pure polynomial traversals into `HexRCF.Syntax`, importing only `HexRealRoots.Basic`. Real-valued `toProp` semantics remain in `HexRCF.Language`; existing declaration names and consumers are unchanged.

The `HexRCF.Syntax` transitive import closure was mechanically checked to contain no `Mathlib.*` module. `lake build HexRCF.Syntax HexRCF.Language HexRCF.Carrier`, the complete `lake build HexRCF`, `scripts/check_dag.py`, and `git diff --check` all pass.

No benchmark, report, or `done_through` change is included. This stays draft only while its stacked base #8970 is open; the slice itself is implementation-complete.