### PR TITLE
Compose arbitrary interval function packages

### DIFF
--- a/HexInterval/Experiment/DyadicInterval.lean
+++ b/HexInterval/Experiment/DyadicInterval.lean
@@ -105,6 +105,15 @@ def workMagnitude : WorkCost -> Nat
   | .inverse input precisionMagnitude alignmentShift =>
       input.numeratorBits + input.exponentMagnitude + precisionMagnitude + alignmentShift
 
+/-- Bounded category code for generic engine and policy diagnostics.  The full
+preflight magnitude remains local typed data; it is not copied into an
+unbounded generic `Nat` event. -/
+def workCode : WorkCost -> Nat
+  | .endpoint _ => 1
+  | .comparison _ => 2
+  | .arithmetic _ _ => 3
+  | .inverse _ _ _ => 4
+
 /-! ## Preflight helpers -/
 
 def endpointChecked (limit : EndpointLimit) (value : Dyadic) : Except WorkCost Unit :=
@@ -677,7 +686,7 @@ def factDomain (limit : EndpointLimit) : FactDomain Fact where
   narrow _ current candidate :=
     match intersect limit current candidate with
     | .inapplicable => .malformed 1
-    | .resourceLimit cost => .resourceLimit (workMagnitude cost)
+    | .resourceLimit cost => .resourceLimit (workCode cost)
     | .ready result =>
         if result = current then .noChange
         else if result.isEmpty then .contradiction result
@@ -709,15 +718,12 @@ reported before the generic scheduler can observe them. -/
 def start (endpointLimit : EndpointLimit) (program : Program)
     (rules : Array Registration) (rawFacts : Array Raw) (limits : Limits) :
     Except StartError (Engine Fact) := do
-  -- Bound the raw-fact scan with the same early structural checks used by the
-  -- generic engine.  In particular, a wrong-sized untrusted array is never
-  -- converted to an unbounded intermediate list.
-  if limits.maxOperations < program.operations.size then
-    throw (.engine (.resourceLimit .operations))
-  if limits.maxNodes < program.nodes.size then
-    throw (.engine (.resourceLimit .nodes))
-  if rawFacts.size != program.nodes.size then
-    throw (.engine .wrongFactCount)
+  -- Bound the raw-fact scan with the same resource-first validation used by
+  -- the generic engine.  In particular, no oversized program, registry, or
+  -- wrong-sized fact array is traversed into an unbounded intermediate list.
+  match preflightStart program rules rawFacts.size limits with
+  | .error error => throw (.engine error)
+  | .ok () => pure ()
   let facts ← importInitialFacts endpointLimit 0 rawFacts.toList
   match Engine.start (factDomain endpointLimit) program rules facts.toArray limits with
   | .ok engine => pure engine

--- a/HexInterval/Experiment/DyadicRules.lean
+++ b/HexInterval/Experiment/DyadicRules.lean
@@ -7,17 +7,20 @@ Authors: Kim Morrison
 module
 
 public import HexInterval.Experiment.DyadicInterval
+public import HexInterval.Experiment.PackageRegistry
 
 @[expose] public section
 
 /-!
 # Concrete dyadic propagators
 
-This module is the first registry whose rules assign real function semantics to
-the otherwise opaque interval engine.  The engine still interprets none of the
-operation or rule keys below.  Each callback sees only its declared facts plus
-the immutable structural program view, and every proposed fact crosses the
-engine-owned intersection boundary.
+This module is the first composed registry whose rules assign real function
+semantics to the otherwise opaque interval engine.  Arithmetic and the
+centered function are independent packages with callback routes assembled from
+the same registrations given to the engine.  The engine still interprets none
+of the operation or rule keys below.  Each callback sees only its declared
+facts plus the immutable structural program view, and every proposed fact
+crosses the engine-owned intersection boundary.
 
 The arithmetic surface is intentionally smaller than the eventual registry.
 Multiplication contracts backwards only when the other factor is a singleton
@@ -40,8 +43,10 @@ def subOp : OpKey := { name := "real.sub" }
 def mulOp : OpKey := { name := "real.mul" }
 def squareOp : OpKey := { name := "real.square" }
 def reciprocalOp : OpKey := { name := "real.reciprocal" }
+/-- Version 1 denotes exactly the function `x ↦ 1/4 - (x - 1/2)^2`. -/
 def centeredOp : OpKey := { name := "real.centered-product" }
 
+def oneForwardKey : RuleKey := { name := "real.one.forward" }
 def negForwardKey : RuleKey := { name := "real.neg.forward" }
 def negBackwardKey : RuleKey := { name := "real.neg.backward" }
 def subForwardKey : RuleKey := { name := "real.sub.forward" }
@@ -54,20 +59,37 @@ def squareForwardKey : RuleKey := { name := "real.square.forward" }
 def reciprocalForwardKey : RuleKey := { name := "real.reciprocal.forward" }
 def reciprocalBackwardKey : RuleKey := { name := "real.reciprocal.backward" }
 def centeredForwardKey : RuleKey := { name := "real.centered-product.forward" }
+def centeredSplitKey : RuleKey := { name := "real.centered-product.split-critical" }
 def centeredInstantiateKey : RuleKey := { name := "real.centered-product.instantiate" }
 
-/-- Operation signatures which a real-valued frontend may splice into its own
-operation table.  The registry dispatches by key, never by these positions. -/
-def operations (real : DomainId) : Array Operation :=
+/-- Operation signatures for the elementary arithmetic package. -/
+def arithmeticOperations (real : DomainId) : Array Operation :=
   #[{ key := oneOp, inputs := [], output := real },
     { key := negOp, inputs := [real], output := real },
     { key := subOp, inputs := [real, real], output := real },
     { key := mulOp, inputs := [real, real], output := real },
     { key := squareOp, inputs := [real], output := real },
-    { key := reciprocalOp, inputs := [real], output := real },
-    { key := centeredOp, inputs := [real], output := real }]
+    { key := reciprocalOp, inputs := [real], output := real }]
+
+/-- Operation signatures for the independent centered-product package. -/
+def centeredOperations (real : DomainId) : Array Operation :=
+  #[{ key := centeredOp, inputs := [real], output := real }]
+
+/-- Arithmetic signatures whose shape and meaning the centered matcher uses
+without owning their implementations. -/
+def centeredRequirements (real : DomainId) : Array Operation :=
+  #[{ key := oneOp, inputs := [], output := real },
+    { key := subOp, inputs := [real, real], output := real },
+    { key := mulOp, inputs := [real, real], output := real }]
 
 /-! ## Registrations -/
+
+def oneForward : Registration :=
+  { key := oneForwardKey
+    head := oneOp
+    kind := .forward
+    watches := []
+    writes := [.result] }
 
 def negForward : Registration :=
   { key := negForwardKey
@@ -153,6 +175,15 @@ def centeredForward : Registration :=
     watches := [.argument 0]
     writes := [.result] }
 
+/-- A function-owned semantic landmark.  Selecting it creates solver branches;
+the rule itself has no branch-construction authority. -/
+def centeredSplit : Registration :=
+  { key := centeredSplitKey
+    head := centeredOp
+    kind := .split
+    watches := [.argument 0]
+    writes := [] }
+
 /-- A discovery rule for products.  It reads no interval facts: its semantic
 dependency is the immutable nested expression shape. -/
 def centeredInstantiate : Registration :=
@@ -160,13 +191,8 @@ def centeredInstantiate : Registration :=
     head := mulOp
     kind := .instantiate
     watches := []
-    writes := [] }
-
-def registrations : Array Registration :=
-  #[negForward, negBackward, subForward, subLeft, subRight,
-    mulForward, mulLeft, mulRight, squareForward,
-    reciprocalForward, reciprocalBackward, centeredForward,
-    centeredInstantiate]
+    writes := []
+    watchesProgram := true }
 
 /-! ## Registry configuration and result conversion -/
 
@@ -175,8 +201,29 @@ structure Config where
   reciprocalBasePrecision : Precision
   maxReciprocalEffort : Nat
 
-structure Registry where
-  config : Config
+/-! ## Stable replay payload keys
+
+These identifiers name rule-specific proof recipes; effort is already retained
+in the engine-owned action and therefore is not encoded into a payload number.
+-/
+
+def onePayload : PayloadId := { index := 1 }
+def negForwardPayload : PayloadId := { index := 10 }
+def negBackwardPayload : PayloadId := { index := 11 }
+def subForwardPayload : PayloadId := { index := 20 }
+def subLeftPayload : PayloadId := { index := 21 }
+def subRightPayload : PayloadId := { index := 22 }
+def mulForwardPayload : PayloadId := { index := 30 }
+def mulLeftPayload : PayloadId := { index := 31 }
+def mulRightPayload : PayloadId := { index := 32 }
+def squareForwardPayload : PayloadId := { index := 40 }
+def reciprocalForwardPayload : PayloadId := { index := 50 }
+def reciprocalBackwardPayload : PayloadId := { index := 60 }
+def centeredForwardPayload : PayloadId := { index := 70 }
+def centeredInstancePayload : PayloadId := { index := 80 }
+/-- Replay obligation: `x * (1 - x) = 1/4 - (x - 1/2)^2`. -/
+def centeredEqualityPayload : PayloadId := { index := 81 }
+def centeredFamilyKey : Nat := 1
 
 def Config.precisionAt (config : Config) (effort : Nat) : Precision :=
   config.reciprocalBasePrecision + Int.ofNat effort
@@ -184,13 +231,13 @@ def Config.precisionAt (config : Config) (effort : Nat) : Precision :=
 def successCost (arithmeticWork proofNodes : Nat) : CostObservation :=
   { arithmeticWork, estimatedProofNodes := proofNodes }
 
-def outcomeOfResult (target : NodeId) (payload work proofNodes : Nat)
+def outcomeOfResult (target : NodeId) (payload : PayloadId) (work proofNodes : Nat)
     (suggestions : List Suggestion) : DyadicInterval.Result -> Outcome Fact
   | .ready fact =>
-      .success [{ node := target, fact, payload := { index := payload } }]
+      .success [{ node := target, fact, payload }]
         suggestions (successCost work proofNodes)
   | .inapplicable => .inapplicable
-  | .resourceLimit cost => .resourceLimit (DyadicInterval.workMagnitude cost)
+  | .resourceLimit cost => .resourceLimit (DyadicInterval.workCode cost)
 
 def bindResult (result : DyadicInterval.Result)
     (next : Fact -> DyadicInterval.Result) : DyadicInterval.Result :=
@@ -205,6 +252,8 @@ def addViaSub (limit : EndpointLimit) (left right : Fact) : DyadicInterval.Resul
   bindResult (DyadicInterval.neg limit right) fun negative =>
     DyadicInterval.sub limit left negative
 
+/-- Recognize an attained singleton.  Canonical `Dyadic` equality is structural
+and does not align exponents or allocate shifted integers. -/
 def singleton? (fact : Fact) : Option Dyadic :=
   match fact.view with
   | .bounds (.finite lower false) (.finite upper false) =>
@@ -219,43 +268,52 @@ def retrySuggestion (config : Config) (action : Action) : List Suggestion :=
 
 /-! ## Arithmetic callbacks -/
 
+def invokeOneForward (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
+  match request.inputs, request.writes with
+  | [], [target] =>
+      outcomeOfResult target onePayload 1 1 []
+        (DyadicInterval.closed config.endpointLimit 1 1)
+  | _, _ => .failed 1
+
 def invokeNegForward (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
   match request.inputs, request.writes with
   | [input], [target] =>
-      outcomeOfResult target 10 1 1 [] (DyadicInterval.neg config.endpointLimit input.fact)
+      outcomeOfResult target negForwardPayload 1 1 []
+        (DyadicInterval.neg config.endpointLimit input.fact)
   | _, _ => .failed 10
 
 def invokeNegBackward (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
   match request.inputs, request.writes with
   | [output], [target] =>
-      outcomeOfResult target 11 1 1 [] (DyadicInterval.neg config.endpointLimit output.fact)
+      outcomeOfResult target negBackwardPayload 1 1 []
+        (DyadicInterval.neg config.endpointLimit output.fact)
   | _, _ => .failed 11
 
 def invokeSubForward (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
   match request.inputs, request.writes with
   | [left, right], [target] =>
-      outcomeOfResult target 20 1 1 []
+      outcomeOfResult target subForwardPayload 1 1 []
         (DyadicInterval.sub config.endpointLimit left.fact right.fact)
   | _, _ => .failed 20
 
 def invokeSubLeft (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
   match request.inputs, request.writes with
   | [output, right], [target] =>
-      outcomeOfResult target 21 2 2 []
+      outcomeOfResult target subLeftPayload 2 2 []
         (addViaSub config.endpointLimit output.fact right.fact)
   | _, _ => .failed 21
 
 def invokeSubRight (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
   match request.inputs, request.writes with
   | [left, output], [target] =>
-      outcomeOfResult target 22 1 1 []
+      outcomeOfResult target subRightPayload 1 1 []
         (DyadicInterval.sub config.endpointLimit left.fact output.fact)
   | _, _ => .failed 22
 
 def invokeMulForward (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
   match request.inputs, request.writes with
   | [left, right], [target] =>
-      outcomeOfResult target 30 1 1 []
+      outcomeOfResult target mulForwardPayload 1 1 []
         (DyadicInterval.mul config.endpointLimit left.fact right.fact)
   | _, _ => .failed 30
 
@@ -265,7 +323,7 @@ def invokeMulLeft (config : Config) (request : RuleRequest Fact) : Outcome Fact 
       match singleton? right.fact with
       | none => .inapplicable
       | some scalar =>
-          outcomeOfResult target 31 1 1 []
+          outcomeOfResult target mulLeftPayload 1 1 []
             (DyadicInterval.unscaleExact config.endpointLimit scalar output.fact)
   | _, _ => .failed 31
 
@@ -275,14 +333,14 @@ def invokeMulRight (config : Config) (request : RuleRequest Fact) : Outcome Fact
       match singleton? left.fact with
       | none => .inapplicable
       | some scalar =>
-          outcomeOfResult target 32 1 1 []
+          outcomeOfResult target mulRightPayload 1 1 []
             (DyadicInterval.unscaleExact config.endpointLimit scalar output.fact)
   | _, _ => .failed 32
 
 def invokeSquareForward (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
   match request.inputs, request.writes with
   | [input], [target] =>
-      outcomeOfResult target 40 1 1 []
+      outcomeOfResult target squareForwardPayload 1 1 []
         (DyadicInterval.square config.endpointLimit input.fact)
   | _, _ => .failed 40
 
@@ -290,7 +348,7 @@ def invokeReciprocalForward (config : Config)
     (request : RuleRequest Fact) : Outcome Fact :=
   match request.inputs, request.writes with
   | [input], [target] =>
-      outcomeOfResult target (50 + request.action.effort) 1 1
+      outcomeOfResult target reciprocalForwardPayload 1 1
         (retrySuggestion config request.action)
         (DyadicInterval.reciprocal config.endpointLimit
           (config.precisionAt request.action.effort) input.fact)
@@ -300,7 +358,7 @@ def invokeReciprocalBackward (config : Config)
     (request : RuleRequest Fact) : Outcome Fact :=
   match request.inputs, request.writes with
   | [output], [target] =>
-      outcomeOfResult target (60 + request.action.effort) 1 1
+      outcomeOfResult target reciprocalBackwardPayload 1 1
         (retrySuggestion config request.action)
         (DyadicInterval.reciprocal config.endpointLimit
           (config.precisionAt request.action.effort) output.fact)
@@ -324,9 +382,17 @@ def invokeCenteredForward (config : Config)
     (request : RuleRequest Fact) : Outcome Fact :=
   match request.inputs, request.writes with
   | [input], [target] =>
-      outcomeOfResult target 70 4 4 []
+      outcomeOfResult target centeredForwardPayload 4 4 []
         (centeredImage config.endpointLimit input.fact)
   | _, _ => .failed 70
+
+def invokeCenteredSplit (request : RuleRequest Fact) : Outcome Fact :=
+  match request.inputs, request.writes with
+  | [input], [] =>
+      .success []
+        [.split { node := input.node, point := half, reason := .criticalPoint }]
+        { visitedEntries := 1, estimatedProofNodes := 1 }
+  | _, _ => .failed 71
 
 structure CenteredBinding where
   anchor : NodeId
@@ -371,21 +437,23 @@ def centeredProposal? (request : RuleRequest Fact)
     (binding : CenteredBinding) : Option InstantiationRequest := do
   let input <- request.program.node? binding.input
   let operation <- operationWithKey? request.program centeredOp
-  let centered : Node := { domain := input.domain, op := operation, args := [binding.input] }
+  let signature <- request.program.operation? operation
+  if input.domain != signature.output then none else pure ()
+  let centered : Node := { domain := signature.output, op := operation, args := [binding.input] }
   let generation <- centeredGeneration? request binding centered
   pure
-    { key := 1
+    { key := centeredFamilyKey
       triggers := [binding.anchor, binding.input, binding.complement, binding.one]
       claimedGeneration := generation
       nodes :=
-        [{ domain := input.domain
+        [{ domain := signature.output
            op := operation
            args := [.existing binding.input] }]
       equalities :=
         [{ left := .existing binding.anchor
            right := .proposed 0
-           payload := { index := 81 } }]
-      payload := { index := 80 } }
+           payload := centeredEqualityPayload }]
+      payload := centeredInstancePayload }
 
 def invokeCenteredInstantiate (request : RuleRequest Fact) : Outcome Fact :=
   match centeredBinding? request >>= centeredProposal? request with
@@ -395,27 +463,80 @@ def invokeCenteredInstantiate (request : RuleRequest Fact) : Outcome Fact :=
         { visitedEntries := request.program.operations.size + request.program.nodes.size
           estimatedProofNodes := 1 }
 
-/-! ## Versioned dispatch -/
+/-! ## Independently composable function packages -/
 
-def Registry.invoke (registry : Registry) (request : RuleRequest Fact) : Outcome Fact :=
-  let key := request.action.key
-  if key == negForwardKey then invokeNegForward registry.config request
-  else if key == negBackwardKey then invokeNegBackward registry.config request
-  else if key == subForwardKey then invokeSubForward registry.config request
-  else if key == subLeftKey then invokeSubLeft registry.config request
-  else if key == subRightKey then invokeSubRight registry.config request
-  else if key == mulForwardKey then invokeMulForward registry.config request
-  else if key == mulLeftKey then invokeMulLeft registry.config request
-  else if key == mulRightKey then invokeMulRight registry.config request
-  else if key == squareForwardKey then invokeSquareForward registry.config request
-  else if key == reciprocalForwardKey then invokeReciprocalForward registry.config request
-  else if key == reciprocalBackwardKey then invokeReciprocalBackward registry.config request
-  else if key == centeredForwardKey then invokeCenteredForward registry.config request
-  else if key == centeredInstantiateKey then invokeCenteredInstantiate request
-  else .failed 255
+def arithmeticPackage (config : Config) (real : DomainId) : Package Fact :=
+  { Cache := Unit
+    cache := ()
+    operations := arithmeticOperations real
+    handlers :=
+      #[Handler.stateless oneForward (invokeOneForward config),
+        Handler.stateless negForward (invokeNegForward config),
+        Handler.stateless negBackward (invokeNegBackward config),
+        Handler.stateless subForward (invokeSubForward config),
+        Handler.stateless subLeft (invokeSubLeft config),
+        Handler.stateless subRight (invokeSubRight config),
+        Handler.stateless mulForward (invokeMulForward config),
+        Handler.stateless mulLeft (invokeMulLeft config),
+        Handler.stateless mulRight (invokeMulRight config),
+        Handler.stateless squareForward (invokeSquareForward config),
+        Handler.stateless reciprocalForward (invokeReciprocalForward config),
+        Handler.stateless reciprocalBackward (invokeReciprocalBackward config)]
+    acceptsLimits := fun _ limits =>
+      config.maxReciprocalEffort ≤ limits.maxEffort &&
+        2 ≤ limits.maxObservationValue && 60 ≤ limits.maxDiagnosticValue &&
+        1 ≤ limits.maxOutcomeCandidates &&
+        (config.maxReciprocalEffort == 0 || 1 ≤ limits.maxOutcomeSuggestions) }
 
-def Registry.invokeWithCache (registry : Registry) (cache : Cache)
-    (request : RuleRequest Fact) : Outcome Fact × Cache :=
-  (registry.invoke request, cache)
+/-- This package contributes one operation but also attaches its structural
+matcher to multiplication from the arithmetic package. -/
+def centeredPackage (config : Config) (real : DomainId) : Package Fact :=
+  { Cache := Unit
+    cache := ()
+    operations := centeredOperations real
+    requiredOperations := centeredRequirements real
+    handlers :=
+      #[Handler.stateless centeredForward (invokeCenteredForward config),
+        Handler.stateless centeredSplit invokeCenteredSplit,
+        Handler.stateless centeredInstantiate invokeCenteredInstantiate]
+    acceptsLimits := fun _ limits =>
+      4 ≤ limits.maxObservationValue &&
+        71 ≤ limits.maxDiagnosticValue &&
+        1 ≤ limits.maxOutcomeCandidates && 1 ≤ limits.maxOutcomeSuggestions &&
+        4 ≤ limits.maxProposalItems &&
+        (EndpointCost.ofDyadic half).allowed limits.splitEndpointLimit &&
+        limits.maxOperations ≤ limits.maxObservationValue &&
+        limits.maxNodes ≤ limits.maxObservationValue - limits.maxOperations }
+
+def buildRegistry (config : Config) (real : DomainId) (limits : Limits) :
+    Except RegistryError (Propagator.Registry Fact) :=
+  Propagator.Registry.buildWithin limits
+    #[arithmeticPackage config real, centeredPackage config real]
+
+inductive StartError where
+  | incompatibleLimits
+  | registry (error : RegistryError)
+  | operationMismatch
+  | engine (error : DyadicInterval.StartError)
+  deriving DecidableEq, Repr
+
+/-- The checked entry point binds the exact flattened registrations to their
+callbacks and retains the existential registry as the driver's cache. -/
+def start (config : Config) (real : DomainId) (program : Program)
+    (rawFacts : Array Raw) (limits : Limits) :
+    Except StartError (Engine Fact × Propagator.Registry Fact) :=
+  match buildRegistry config real limits with
+  | .error error => .error (.registry error)
+  | .ok registry =>
+      match preflightStart program registry.registrations rawFacts.size limits with
+      | .error error => .error (.engine (.engine error))
+      | .ok () =>
+          if !registry.acceptsProgram program then .error .operationMismatch
+          else if !registry.acceptsLimits program limits then .error .incompatibleLimits
+          else
+            match DyadicInterval.start config.endpointLimit program registry.registrations
+                rawFacts limits with
+            | .error error => .error (.engine error)
+            | .ok engine => .ok (engine, registry)
 
 end Hex.Interval.Experiment.DyadicRules

--- a/HexInterval/Experiment/DyadicRules.lean
+++ b/HexInterval/Experiment/DyadicRules.lean
@@ -1,0 +1,421 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Experiment.DyadicInterval
+
+@[expose] public section
+
+/-!
+# Concrete dyadic propagators
+
+This module is the first registry whose rules assign real function semantics to
+the otherwise opaque interval engine.  The engine still interprets none of the
+operation or rule keys below.  Each callback sees only its declared facts plus
+the immutable structural program view, and every proposed fact crosses the
+engine-owned intersection boundary.
+
+The arithmetic surface is intentionally smaller than the eventual registry.
+Multiplication contracts backwards only when the other factor is a singleton
+with an exact dyadic reciprocal.  Reciprocal uses the sign-separated component
+operation from `DyadicInterval`; a fact containing zero remains explicitly
+inapplicable until the total-inverse hull and interval-set experiments land.
+-/
+
+namespace Hex.Interval.Experiment.DyadicRules
+
+open Propagator
+
+abbrev Fact := DyadicInterval.Fact
+
+/-! ## Stable semantic keys -/
+
+def oneOp : OpKey := { name := "real.one" }
+def negOp : OpKey := { name := "real.neg" }
+def subOp : OpKey := { name := "real.sub" }
+def mulOp : OpKey := { name := "real.mul" }
+def squareOp : OpKey := { name := "real.square" }
+def reciprocalOp : OpKey := { name := "real.reciprocal" }
+def centeredOp : OpKey := { name := "real.centered-product" }
+
+def negForwardKey : RuleKey := { name := "real.neg.forward" }
+def negBackwardKey : RuleKey := { name := "real.neg.backward" }
+def subForwardKey : RuleKey := { name := "real.sub.forward" }
+def subLeftKey : RuleKey := { name := "real.sub.backward-left" }
+def subRightKey : RuleKey := { name := "real.sub.backward-right" }
+def mulForwardKey : RuleKey := { name := "real.mul.forward" }
+def mulLeftKey : RuleKey := { name := "real.mul.backward-left-singleton" }
+def mulRightKey : RuleKey := { name := "real.mul.backward-right-singleton" }
+def squareForwardKey : RuleKey := { name := "real.square.forward" }
+def reciprocalForwardKey : RuleKey := { name := "real.reciprocal.forward" }
+def reciprocalBackwardKey : RuleKey := { name := "real.reciprocal.backward" }
+def centeredForwardKey : RuleKey := { name := "real.centered-product.forward" }
+def centeredInstantiateKey : RuleKey := { name := "real.centered-product.instantiate" }
+
+/-- Operation signatures which a real-valued frontend may splice into its own
+operation table.  The registry dispatches by key, never by these positions. -/
+def operations (real : DomainId) : Array Operation :=
+  #[{ key := oneOp, inputs := [], output := real },
+    { key := negOp, inputs := [real], output := real },
+    { key := subOp, inputs := [real, real], output := real },
+    { key := mulOp, inputs := [real, real], output := real },
+    { key := squareOp, inputs := [real], output := real },
+    { key := reciprocalOp, inputs := [real], output := real },
+    { key := centeredOp, inputs := [real], output := real }]
+
+/-! ## Registrations -/
+
+def negForward : Registration :=
+  { key := negForwardKey
+    head := negOp
+    kind := .forward
+    watches := [.argument 0]
+    writes := [.result] }
+
+def negBackward : Registration :=
+  { key := negBackwardKey
+    head := negOp
+    kind := .backward
+    watches := [.result]
+    writes := [.argument 0] }
+
+def subForward : Registration :=
+  { key := subForwardKey
+    head := subOp
+    kind := .forward
+    watches := [.argument 0, .argument 1]
+    writes := [.result] }
+
+def subLeft : Registration :=
+  { key := subLeftKey
+    head := subOp
+    kind := .backward
+    watches := [.result, .argument 1]
+    writes := [.argument 0] }
+
+def subRight : Registration :=
+  { key := subRightKey
+    head := subOp
+    kind := .backward
+    watches := [.argument 0, .result]
+    writes := [.argument 1] }
+
+def mulForward : Registration :=
+  { key := mulForwardKey
+    head := mulOp
+    kind := .forward
+    watches := [.argument 0, .argument 1]
+    writes := [.result] }
+
+def mulLeft : Registration :=
+  { key := mulLeftKey
+    head := mulOp
+    kind := .backward
+    watches := [.result, .argument 1]
+    writes := [.argument 0] }
+
+def mulRight : Registration :=
+  { key := mulRightKey
+    head := mulOp
+    kind := .backward
+    watches := [.result, .argument 0]
+    writes := [.argument 1] }
+
+def squareForward : Registration :=
+  { key := squareForwardKey
+    head := squareOp
+    kind := .forward
+    watches := [.argument 0]
+    writes := [.result] }
+
+def reciprocalForward : Registration :=
+  { key := reciprocalForwardKey
+    head := reciprocalOp
+    kind := .forward
+    watches := [.argument 0]
+    writes := [.result] }
+
+def reciprocalBackward : Registration :=
+  { key := reciprocalBackwardKey
+    head := reciprocalOp
+    kind := .backward
+    watches := [.result]
+    writes := [.argument 0] }
+
+def centeredForward : Registration :=
+  { key := centeredForwardKey
+    head := centeredOp
+    kind := .forward
+    watches := [.argument 0]
+    writes := [.result] }
+
+/-- A discovery rule for products.  It reads no interval facts: its semantic
+dependency is the immutable nested expression shape. -/
+def centeredInstantiate : Registration :=
+  { key := centeredInstantiateKey
+    head := mulOp
+    kind := .instantiate
+    watches := []
+    writes := [] }
+
+def registrations : Array Registration :=
+  #[negForward, negBackward, subForward, subLeft, subRight,
+    mulForward, mulLeft, mulRight, squareForward,
+    reciprocalForward, reciprocalBackward, centeredForward,
+    centeredInstantiate]
+
+/-! ## Registry configuration and result conversion -/
+
+structure Config where
+  endpointLimit : EndpointLimit
+  reciprocalBasePrecision : Precision
+  maxReciprocalEffort : Nat
+
+structure Registry where
+  config : Config
+
+def Config.precisionAt (config : Config) (effort : Nat) : Precision :=
+  config.reciprocalBasePrecision + Int.ofNat effort
+
+def successCost (arithmeticWork proofNodes : Nat) : CostObservation :=
+  { arithmeticWork, estimatedProofNodes := proofNodes }
+
+def outcomeOfResult (target : NodeId) (payload work proofNodes : Nat)
+    (suggestions : List Suggestion) : DyadicInterval.Result -> Outcome Fact
+  | .ready fact =>
+      .success [{ node := target, fact, payload := { index := payload } }]
+        suggestions (successCost work proofNodes)
+  | .inapplicable => .inapplicable
+  | .resourceLimit cost => .resourceLimit (DyadicInterval.workMagnitude cost)
+
+def bindResult (result : DyadicInterval.Result)
+    (next : Fact -> DyadicInterval.Result) : DyadicInterval.Result :=
+  match result with
+  | .ready fact => next fact
+  | .inapplicable => .inapplicable
+  | .resourceLimit cost => .resourceLimit cost
+
+/-- Addition expressed through the already checked primitives.  This is used
+only by the backward contractor for `z = x - y`. -/
+def addViaSub (limit : EndpointLimit) (left right : Fact) : DyadicInterval.Result :=
+  bindResult (DyadicInterval.neg limit right) fun negative =>
+    DyadicInterval.sub limit left negative
+
+def singleton? (fact : Fact) : Option Dyadic :=
+  match fact.view with
+  | .bounds (.finite lower false) (.finite upper false) =>
+      if lower = upper then some lower else none
+  | .empty | .bounds _ _ => none
+
+def retrySuggestion (config : Config) (action : Action) : List Suggestion :=
+  if action.effort < config.maxReciprocalEffort then
+    [.retry (action.effort + 1)]
+  else
+    []
+
+/-! ## Arithmetic callbacks -/
+
+def invokeNegForward (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
+  match request.inputs, request.writes with
+  | [input], [target] =>
+      outcomeOfResult target 10 1 1 [] (DyadicInterval.neg config.endpointLimit input.fact)
+  | _, _ => .failed 10
+
+def invokeNegBackward (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
+  match request.inputs, request.writes with
+  | [output], [target] =>
+      outcomeOfResult target 11 1 1 [] (DyadicInterval.neg config.endpointLimit output.fact)
+  | _, _ => .failed 11
+
+def invokeSubForward (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
+  match request.inputs, request.writes with
+  | [left, right], [target] =>
+      outcomeOfResult target 20 1 1 []
+        (DyadicInterval.sub config.endpointLimit left.fact right.fact)
+  | _, _ => .failed 20
+
+def invokeSubLeft (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
+  match request.inputs, request.writes with
+  | [output, right], [target] =>
+      outcomeOfResult target 21 2 2 []
+        (addViaSub config.endpointLimit output.fact right.fact)
+  | _, _ => .failed 21
+
+def invokeSubRight (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
+  match request.inputs, request.writes with
+  | [left, output], [target] =>
+      outcomeOfResult target 22 1 1 []
+        (DyadicInterval.sub config.endpointLimit left.fact output.fact)
+  | _, _ => .failed 22
+
+def invokeMulForward (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
+  match request.inputs, request.writes with
+  | [left, right], [target] =>
+      outcomeOfResult target 30 1 1 []
+        (DyadicInterval.mul config.endpointLimit left.fact right.fact)
+  | _, _ => .failed 30
+
+def invokeMulLeft (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
+  match request.inputs, request.writes with
+  | [output, right], [target] =>
+      match singleton? right.fact with
+      | none => .inapplicable
+      | some scalar =>
+          outcomeOfResult target 31 1 1 []
+            (DyadicInterval.unscaleExact config.endpointLimit scalar output.fact)
+  | _, _ => .failed 31
+
+def invokeMulRight (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
+  match request.inputs, request.writes with
+  | [output, left], [target] =>
+      match singleton? left.fact with
+      | none => .inapplicable
+      | some scalar =>
+          outcomeOfResult target 32 1 1 []
+            (DyadicInterval.unscaleExact config.endpointLimit scalar output.fact)
+  | _, _ => .failed 32
+
+def invokeSquareForward (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
+  match request.inputs, request.writes with
+  | [input], [target] =>
+      outcomeOfResult target 40 1 1 []
+        (DyadicInterval.square config.endpointLimit input.fact)
+  | _, _ => .failed 40
+
+def invokeReciprocalForward (config : Config)
+    (request : RuleRequest Fact) : Outcome Fact :=
+  match request.inputs, request.writes with
+  | [input], [target] =>
+      outcomeOfResult target (50 + request.action.effort) 1 1
+        (retrySuggestion config request.action)
+        (DyadicInterval.reciprocal config.endpointLimit
+          (config.precisionAt request.action.effort) input.fact)
+  | _, _ => .failed 50
+
+def invokeReciprocalBackward (config : Config)
+    (request : RuleRequest Fact) : Outcome Fact :=
+  match request.inputs, request.writes with
+  | [output], [target] =>
+      outcomeOfResult target (60 + request.action.effort) 1 1
+        (retrySuggestion config request.action)
+        (DyadicInterval.reciprocal config.endpointLimit
+          (config.precisionAt request.action.effort) output.fact)
+  | _, _ => .failed 60
+
+/-! ## Centered arbitrary function and shape-triggered instantiation -/
+
+def half : Dyadic := Dyadic.ofIntWithPrec 1 1
+def quarter : Dyadic := Dyadic.ofIntWithPrec 1 2
+
+/-- Enclose `1/4 - (x - 1/2)^2`.  This is a function-specific propagator, not
+an identity known by the engine. -/
+def centeredImage (limit : EndpointLimit) (input : Fact) : DyadicInterval.Result :=
+  bindResult (DyadicInterval.closed limit half half) fun halfFact =>
+    bindResult (DyadicInterval.sub limit input halfFact) fun shifted =>
+      bindResult (DyadicInterval.square limit shifted) fun squared =>
+        bindResult (DyadicInterval.closed limit quarter quarter) fun quarterFact =>
+          DyadicInterval.sub limit quarterFact squared
+
+def invokeCenteredForward (config : Config)
+    (request : RuleRequest Fact) : Outcome Fact :=
+  match request.inputs, request.writes with
+  | [input], [target] =>
+      outcomeOfResult target 70 4 4 []
+        (centeredImage config.endpointLimit input.fact)
+  | _, _ => .failed 70
+
+structure CenteredBinding where
+  anchor : NodeId
+  input : NodeId
+  complement : NodeId
+  one : NodeId
+
+def operationWithKey? (view : ProgramView) (key : OpKey) : Option OpId := do
+  for index in [0:view.operations.size] do
+    let operation <- view.operations[index]?
+    if operation.key == key then return { index }
+  none
+
+def findProgramNode? (view : ProgramView) (target : Node) : Option NodeId :=
+  Propagator.findNodeFrom 0 view.nodes.toList target
+
+def centeredBinding? (request : RuleRequest Fact) : Option CenteredBinding := do
+  if request.program.programVersion != request.action.programVersion then none else pure ()
+  let product <- request.program.node? request.action.node
+  if request.program.operationKey? request.action.node != some mulOp then none else pure ()
+  let [input, complement] := product.args | none
+  let difference <- request.program.node? complement
+  if request.program.operationKey? complement != some subOp then none else pure ()
+  let [one, repeated] := difference.args | none
+  if repeated != input then none else pure ()
+  if request.program.operationKey? one != some oneOp then none else pure ()
+  pure { anchor := request.action.node, input, complement, one }
+
+/-- Match the engine's authoritative generation calculation for this concrete
+proposal: invocation substitution, existing proposal references, and a CSE hit
+if the centered node already exists. -/
+def centeredGeneration? (request : RuleRequest Fact) (binding : CenteredBinding)
+    (centered : Node) : Option Nat := do
+  let cse := findProgramNode? request.program centered
+  let references := dedupList
+    (request.action.node :: request.action.inputs.map (fun input => input.node) ++
+      [binding.input] ++ cse.toList)
+  let generations <- references.mapM request.program.generation?
+  pure (generations.foldl Nat.max 0 + 1)
+
+def centeredProposal? (request : RuleRequest Fact)
+    (binding : CenteredBinding) : Option InstantiationRequest := do
+  let input <- request.program.node? binding.input
+  let operation <- operationWithKey? request.program centeredOp
+  let centered : Node := { domain := input.domain, op := operation, args := [binding.input] }
+  let generation <- centeredGeneration? request binding centered
+  pure
+    { key := 1
+      triggers := [binding.anchor, binding.input, binding.complement, binding.one]
+      claimedGeneration := generation
+      nodes :=
+        [{ domain := input.domain
+           op := operation
+           args := [.existing binding.input] }]
+      equalities :=
+        [{ left := .existing binding.anchor
+           right := .proposed 0
+           payload := { index := 81 } }]
+      payload := { index := 80 } }
+
+def invokeCenteredInstantiate (request : RuleRequest Fact) : Outcome Fact :=
+  match centeredBinding? request >>= centeredProposal? request with
+  | none => .inapplicable
+  | some proposal =>
+      .success [] [.instantiate proposal]
+        { visitedEntries := request.program.operations.size + request.program.nodes.size
+          estimatedProofNodes := 1 }
+
+/-! ## Versioned dispatch -/
+
+def Registry.invoke (registry : Registry) (request : RuleRequest Fact) : Outcome Fact :=
+  let key := request.action.key
+  if key == negForwardKey then invokeNegForward registry.config request
+  else if key == negBackwardKey then invokeNegBackward registry.config request
+  else if key == subForwardKey then invokeSubForward registry.config request
+  else if key == subLeftKey then invokeSubLeft registry.config request
+  else if key == subRightKey then invokeSubRight registry.config request
+  else if key == mulForwardKey then invokeMulForward registry.config request
+  else if key == mulLeftKey then invokeMulLeft registry.config request
+  else if key == mulRightKey then invokeMulRight registry.config request
+  else if key == squareForwardKey then invokeSquareForward registry.config request
+  else if key == reciprocalForwardKey then invokeReciprocalForward registry.config request
+  else if key == reciprocalBackwardKey then invokeReciprocalBackward registry.config request
+  else if key == centeredForwardKey then invokeCenteredForward registry.config request
+  else if key == centeredInstantiateKey then invokeCenteredInstantiate request
+  else .failed 255
+
+def Registry.invokeWithCache (registry : Registry) (cache : Cache)
+    (request : RuleRequest Fact) : Outcome Fact × Cache :=
+  (registry.invoke request, cache)
+
+end Hex.Interval.Experiment.DyadicRules

--- a/HexInterval/Experiment/DyadicRules.lean
+++ b/HexInterval/Experiment/DyadicRules.lean
@@ -409,8 +409,6 @@ def invokeCenteredSplit (request : RuleRequest Fact) : Outcome Fact :=
 structure CenteredBinding where
   anchor : NodeId
   input : NodeId
-  complement : NodeId
-  one : NodeId
 
 def centeredBinding? (request : RuleRequest Fact) : Option CenteredBinding := do
   if request.program.programVersion != request.action.programVersion then none else pure ()
@@ -422,7 +420,7 @@ def centeredBinding? (request : RuleRequest Fact) : Option CenteredBinding := do
   let [one, repeated] := difference.args | none
   if repeated != input then none else pure ()
   if request.program.operationKey? one != some oneOp then none else pure ()
-  pure { anchor := request.action.node, input, complement, one }
+  pure { anchor := request.action.node, input }
 
 def centeredProposal? (request : RuleRequest Fact)
     (binding : CenteredBinding) : Option InstantiationRequest := do
@@ -431,7 +429,6 @@ def centeredProposal? (request : RuleRequest Fact)
   if input.domain != signature.output then none else pure ()
   pure
     { key := centeredFamilyKey
-      triggers := [binding.anchor, binding.input, binding.complement, binding.one]
       nodes :=
         [{ domain := signature.output
            op := operation

--- a/HexInterval/Experiment/DyadicRules.lean
+++ b/HexInterval/Experiment/DyadicRules.lean
@@ -184,15 +184,15 @@ def centeredSplit : Registration :=
     watches := [.argument 0]
     writes := [] }
 
-/-- A discovery rule for products.  It reads no interval facts: its semantic
-dependency is the immutable nested expression shape. -/
+/-- A discovery rule for products. It reads no interval facts and inspects
+only its anchor's immutable argument sub-DAG plus the operation table, so an
+unrelated program extension is not a dependency. -/
 def centeredInstantiate : Registration :=
   { key := centeredInstantiateKey
     head := mulOp
     kind := .instantiate
     watches := []
-    writes := []
-    watchesProgram := true }
+    writes := [] }
 
 /-! ## Registry configuration and result conversion -/
 
@@ -227,6 +227,18 @@ def centeredFamilyKey : Nat := 1
 
 def Config.precisionAt (config : Config) (effort : Nat) : Precision :=
   config.reciprocalBasePrecision + Int.ofNat effort
+
+def precisionAllowed (limit : EndpointLimit) (precision : Precision) : Bool :=
+  let magnitude := precision.natAbs
+  magnitude ≤ limit.maxEndpointHeight &&
+    EndpointCost.natBits magnitude ≤ limit.maxEndpointHeight
+
+/-- Effort raises precision monotonically, so the greatest absolute precision
+over the configured effort interval occurs at one of its endpoints. -/
+def Config.reciprocalPrecisionsAllowed (config : Config) : Bool :=
+  precisionAllowed config.endpointLimit config.reciprocalBasePrecision &&
+    precisionAllowed config.endpointLimit
+      (config.precisionAt config.maxReciprocalEffort)
 
 def successCost (arithmeticWork proofNodes : Nat) : CostObservation :=
   { arithmeticWork, estimatedProofNodes := proofNodes }
@@ -400,12 +412,6 @@ structure CenteredBinding where
   complement : NodeId
   one : NodeId
 
-def operationWithKey? (view : ProgramView) (key : OpKey) : Option OpId := do
-  for index in [0:view.operations.size] do
-    let operation <- view.operations[index]?
-    if operation.key == key then return { index }
-  none
-
 def centeredBinding? (request : RuleRequest Fact) : Option CenteredBinding := do
   if request.program.programVersion != request.action.programVersion then none else pure ()
   let product <- request.program.node? request.action.node
@@ -421,14 +427,11 @@ def centeredBinding? (request : RuleRequest Fact) : Option CenteredBinding := do
 def centeredProposal? (request : RuleRequest Fact)
     (binding : CenteredBinding) : Option InstantiationRequest := do
   let input <- request.program.node? binding.input
-  let operation <- operationWithKey? request.program centeredOp
-  let signature <- request.program.operation? operation
+  let (operation, signature) <- request.program.findOp? centeredOp
   if input.domain != signature.output then none else pure ()
   pure
     { key := centeredFamilyKey
       triggers := [binding.anchor, binding.input, binding.complement, binding.one]
-      /- This legacy package hint is deliberately not an admission input. -/
-      claimedGeneration := 1
       nodes :=
         [{ domain := signature.output
            op := operation
@@ -468,6 +471,7 @@ def arithmeticPackage (config : Config) (real : DomainId) : Package Fact :=
         Handler.stateless reciprocalBackward (invokeReciprocalBackward config)]
     acceptsLimits := fun _ limits =>
       config.maxReciprocalEffort ≤ limits.maxEffort &&
+        config.reciprocalPrecisionsAllowed &&
         2 ≤ limits.maxObservationValue && 60 ≤ limits.maxDiagnosticValue &&
         1 ≤ limits.maxOutcomeCandidates &&
         (config.maxReciprocalEffort == 0 || 1 ≤ limits.maxOutcomeSuggestions) }

--- a/HexInterval/Experiment/DyadicRules.lean
+++ b/HexInterval/Experiment/DyadicRules.lean
@@ -406,9 +406,6 @@ def operationWithKey? (view : ProgramView) (key : OpKey) : Option OpId := do
     if operation.key == key then return { index }
   none
 
-def findProgramNode? (view : ProgramView) (target : Node) : Option NodeId :=
-  Propagator.findNodeFrom 0 view.nodes.toList target
-
 def centeredBinding? (request : RuleRequest Fact) : Option CenteredBinding := do
   if request.program.programVersion != request.action.programVersion then none else pure ()
   let product <- request.program.node? request.action.node
@@ -421,30 +418,17 @@ def centeredBinding? (request : RuleRequest Fact) : Option CenteredBinding := do
   if request.program.operationKey? one != some oneOp then none else pure ()
   pure { anchor := request.action.node, input, complement, one }
 
-/-- Match the engine's authoritative generation calculation for this concrete
-proposal: invocation substitution, existing proposal references, and a CSE hit
-if the centered node already exists. -/
-def centeredGeneration? (request : RuleRequest Fact) (binding : CenteredBinding)
-    (centered : Node) : Option Nat := do
-  let cse := findProgramNode? request.program centered
-  let references := dedupList
-    (request.action.node :: request.action.inputs.map (fun input => input.node) ++
-      [binding.input] ++ cse.toList)
-  let generations <- references.mapM request.program.generation?
-  pure (generations.foldl Nat.max 0 + 1)
-
 def centeredProposal? (request : RuleRequest Fact)
     (binding : CenteredBinding) : Option InstantiationRequest := do
   let input <- request.program.node? binding.input
   let operation <- operationWithKey? request.program centeredOp
   let signature <- request.program.operation? operation
   if input.domain != signature.output then none else pure ()
-  let centered : Node := { domain := signature.output, op := operation, args := [binding.input] }
-  let generation <- centeredGeneration? request binding centered
   pure
     { key := centeredFamilyKey
       triggers := [binding.anchor, binding.input, binding.complement, binding.one]
-      claimedGeneration := generation
+      /- This legacy package hint is deliberately not an admission input. -/
+      claimedGeneration := 1
       nodes :=
         [{ domain := signature.output
            op := operation

--- a/HexInterval/Experiment/PackageRegistry.lean
+++ b/HexInterval/Experiment/PackageRegistry.lean
@@ -92,6 +92,19 @@ structure Registry (Fact : Type) where
   registrations : Array Registration
   routes : Array Route
 
+/- Stable opaque diagnostic codes for failures before a package callback is
+entered. -/
+namespace DispatchCode
+
+def missingRoute : Nat := 240
+def missingRegistration : Nat := 241
+def missingPackage : Nat := 242
+def missingHandler : Nat := 243
+def registryMismatch : Nat := 244
+def requestMismatch : Nat := 245
+
+end DispatchCode
+
 /-- Failure while flattening independently supplied packages. -/
 inductive RegistryError where
   | duplicateOperation (key : OpKey)
@@ -213,7 +226,8 @@ def acceptsProgram (registry : Registry Fact) (program : Program) : Bool :=
 engine resource envelope. -/
 def acceptsLimits (registry : Registry Fact) (program : Program)
     (limits : Limits) : Bool :=
-  registry.packages.all fun package => package.acceptsLimits program limits
+  DispatchCode.requestMismatch ≤ limits.maxDiagnosticValue &&
+    registry.packages.all fun package => package.acceptsLimits program limits
 
 end Registry
 
@@ -249,19 +263,6 @@ def accepts (registration : Registration) (request : RuleRequest Fact) : Bool :=
           request.action.inputs == seen
 
 end Registration
-
-/- Stable opaque diagnostic codes for failures before a package callback is
-entered. -/
-namespace DispatchCode
-
-def missingRoute : Nat := 240
-def missingRegistration : Nat := 241
-def missingPackage : Nat := 242
-def missingHandler : Nat := 243
-def registryMismatch : Nat := 244
-def requestMismatch : Nat := 245
-
-end DispatchCode
 
 namespace Registry
 

--- a/HexInterval/Experiment/PackageRegistry.lean
+++ b/HexInterval/Experiment/PackageRegistry.lean
@@ -1,0 +1,301 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Experiment.Propagator
+
+@[expose] public section
+
+/-!
+# Extensible propagator packages
+
+This module assembles independently defined function packages without adding
+function semantics to the interval engine.  A package existentially owns one
+private cache type shared by all of its handlers.  The compiled registry
+flattens only operation signatures and registrations for the engine and keeps
+an opaque route back to the selected package callback.
+
+The registry itself is the arbitrary cache threaded by `Propagator.drive` or
+the external policy driver.  Updating a package cache cannot alter its stable
+operations, registrations, callbacks, routes, or start checks.  Package caches
+are performance state only: for the same request and logical budget, cache
+contents must not change the callback's observable outcome.  Semantic state
+instead needs an explicit versioned dependency and wakeup protocol.  Immutable
+proof payloads must eventually be frozen in a separate per-run arena before
+their identifiers enter engine provenance.
+-/
+
+namespace Hex.Interval.Experiment.Propagator
+
+/-- The callback shape shared by the FIFO and policy-controlled drivers. -/
+abbrev Invoke (Fact Cache : Type) :=
+  Cache -> RuleRequest Fact -> Outcome Fact × Cache
+
+/-- One registration and the only callback allowed to interpret its key. -/
+structure Handler (Fact Cache : Type) where
+  registration : Registration
+  invoke : Invoke Fact Cache
+
+namespace Handler
+
+/-- Lift a cache-independent callback into any package cache. -/
+def readOnly (registration : Registration)
+    (invoke : RuleRequest Fact -> Outcome Fact) : Handler Fact Cache :=
+  { registration
+    invoke := fun cache request => (invoke request, cache) }
+
+/-- A cache-independent handler for a package whose cache is `Unit`. -/
+def stateless (registration : Registration)
+    (invoke : RuleRequest Fact -> Outcome Fact) : Handler Fact Unit :=
+  readOnly registration invoke
+
+end Handler
+
+/-- An independently upgradeable collection of operations and handlers.
+
+All handlers in one package share `Cache`; different packages in the same
+registry may choose unrelated cache types.  `operations` contains signatures
+introduced by this package, while `requiredOperations` records exact
+signatures supplied elsewhere but interpreted by its matchers.  A handler may
+target such an external operation; final head validation remains the engine's
+responsibility once the complete program is available.  `acceptsLimits` is a
+package-owned configuration preflight, not a soundness boundary: every reply
+is still checked against the engine limits. -/
+structure Package (Fact : Type) where
+  Cache : Type
+  cache : Cache
+  operations : Array Operation := #[]
+  requiredOperations : Array Operation := #[]
+  handlers : Array (Handler Fact Cache)
+  acceptsLimits : Program -> Limits -> Bool := fun _ _ => true
+  /-- Non-semantic routing telemetry used to check that only the selected
+  package snapshot changes. -/
+  invocations : Nat := 0
+
+/-- Compact dispatch address into an existential package and its homogeneous
+handler table. -/
+structure Route where
+  package : Nat
+  handler : Nat
+  deriving DecidableEq, Repr
+
+/-- One compiled, stateful registry snapshot.  The three flattened arrays are
+immutable after assembly; invocation updates only one existential package's
+cache and non-semantic invocation counter. -/
+structure Registry (Fact : Type) where
+  packages : Array (Package Fact)
+  operations : Array Operation
+  registrations : Array Registration
+  routes : Array Route
+
+/-- Failure while flattening independently supplied packages. -/
+inductive RegistryError where
+  | duplicateOperation (key : OpKey)
+  | duplicateRule (key : RuleKey)
+  | undeclaredHead (rule : RuleKey) (head : OpKey)
+  | resourceLimit (resource : Resource)
+  deriving DecidableEq, Repr
+
+namespace Registry
+
+def addOperations : List Operation -> Array Operation ->
+    Except RegistryError (Array Operation)
+  | [], operations => pure operations
+  | operation :: rest, operations =>
+      if operations.any (fun existing => existing.key == operation.key) then
+        throw (.duplicateOperation operation.key)
+      else
+        addOperations rest (operations.push operation)
+
+def declaresOperation (operations required : Array Operation) (key : OpKey) : Bool :=
+  operations.any (fun operation => operation.key == key) ||
+    required.any (fun operation => operation.key == key)
+
+def validateHandlerHeads (operations required : Array Operation) :
+    List (Handler Fact Cache) -> Except RegistryError Unit
+  | [] => pure ()
+  | handler :: handlers =>
+      if declaresOperation operations required handler.registration.head then
+        validateHandlerHeads operations required handlers
+      else
+        throw (.undeclaredHead handler.registration.key handler.registration.head)
+
+def addHandlers (packageIndex : Nat) : Nat -> List (Handler Fact Cache) ->
+    Array Registration -> Array Route ->
+      Except RegistryError (Array Registration × Array Route)
+  | _, [], registrations, routes => pure (registrations, routes)
+  | handlerIndex, handler :: rest, registrations, routes =>
+      if registrations.any
+          (fun existing => existing.key == handler.registration.key) then
+        throw (.duplicateRule handler.registration.key)
+      else
+        addHandlers packageIndex (handlerIndex + 1) rest
+          (registrations.push handler.registration)
+          (routes.push { package := packageIndex, handler := handlerIndex })
+
+def flatten : Nat -> List (Package Fact) -> Array Operation ->
+    Array Registration -> Array Route ->
+      Except RegistryError (Array Operation × Array Registration × Array Route)
+  | _, [], operations, registrations, routes =>
+      pure (operations, registrations, routes)
+  | packageIndex, package :: rest, operations, registrations, routes => do
+      validateHandlerHeads package.operations package.requiredOperations
+        package.handlers.toList
+      let operations <- addOperations package.operations.toList operations
+      let (registrations, routes) <-
+        addHandlers packageIndex 0 package.handlers.toList registrations routes
+      flatten (packageIndex + 1) rest operations registrations routes
+
+def preflight (limits : Limits) (packages : Array (Package Fact)) :
+    Except RegistryError Unit := do
+  if limits.maxOperations + limits.maxRules < packages.size then
+    throw (.resourceLimit .registryEntries)
+  let mut operationCount := 0
+  let mut ruleCount := 0
+  let mut metadataCount := 0
+  for package in packages do
+    operationCount := operationCount + package.operations.size
+    ruleCount := ruleCount + package.handlers.size
+    metadataCount := metadataCount + package.operations.size +
+      package.requiredOperations.size + package.handlers.size
+    if limits.maxOperations < operationCount then
+      throw (.resourceLimit .operations)
+    if limits.maxRules < ruleCount then
+      throw (.resourceLimit .rules)
+    if limits.maxOperations + limits.maxRules < metadataCount then
+      throw (.resourceLimit .registryEntries)
+    if package.operations.any
+        (fun operation => !listWithin limits.maxArity operation.inputs) ||
+        package.requiredOperations.any
+          (fun operation => !listWithin limits.maxArity operation.inputs) ||
+        package.handlers.any (fun handler =>
+          !listWithin (limits.maxArity + 1) handler.registration.watches ||
+            !listWithin (limits.maxArity + 1) handler.registration.writes) then
+      throw (.resourceLimit .arity)
+
+/-- Resource-preflight package metadata before duplicate scans or flattened
+array allocation.  The aggregate metadata cap also bounds external signature
+requirements and empty-package churn.  Assembly order is package-major and
+then handler-major; exact operation and rule keys are unique in the snapshot. -/
+def buildWithin (limits : Limits) (packages : Array (Package Fact)) :
+    Except RegistryError (Registry Fact) :=
+  match preflight limits packages with
+  | .error error => .error error
+  | .ok () =>
+      match flatten 0 packages.toList #[] #[] #[] with
+      | .error error => .error error
+      | .ok (operations, registrations, routes) =>
+          .ok { packages, operations, registrations, routes }
+
+/-- Resolve a contributed signature by stable key.  The returned value carries
+no `OpId`: compact identifiers belong to the final frontend program, whose
+operation order may differ from package assembly order. -/
+def operation? (registry : Registry Fact) (key : OpKey) : Option Operation :=
+  registry.operations.toList.find? fun operation => operation.key == key
+
+def operationAccepted (program : Program) (expected : Operation) : Bool :=
+  (program.operationWithKey? expected.key).any fun actual =>
+    actual.inputs == expected.inputs && actual.output == expected.output
+
+/-- A frontend may add operations of its own, but every package-owned key must
+retain the exact domain signature under which its handlers were assembled.
+External signatures explicitly required by a package are checked as well. -/
+def acceptsProgram (registry : Registry Fact) (program : Program) : Bool :=
+  registry.operations.all (operationAccepted program) &&
+    registry.packages.all fun package =>
+      package.requiredOperations.all (operationAccepted program)
+
+/-- Run every package-owned configuration preflight over the final program and
+engine resource envelope. -/
+def acceptsLimits (registry : Registry Fact) (program : Program)
+    (limits : Limits) : Bool :=
+  registry.packages.all fun package => package.acceptsLimits program limits
+
+end Registry
+
+namespace Registration
+
+/-- Exact equality for immutable registration metadata. -/
+def same (left right : Registration) : Bool :=
+  left.key == right.key && left.head == right.head && left.kind == right.kind &&
+    left.watches == right.watches && left.writes == right.writes &&
+      left.watchesProgram == right.watchesProgram &&
+      left.initialEffort == right.initialEffort
+
+/-- Check that a routed handler sees the structural request projection
+described by its immutable registration.  Engine-produced requests satisfy
+this by construction; checking it here catches registry drift and malformed
+direct test requests before a cache update.  Authentication of serials, fact
+values, versions, and pending-state ownership remains the engine's job. -/
+def accepts (registration : Registration) (request : RuleRequest Fact) : Bool :=
+  if request.program.programVersion != request.action.programVersion then
+    false
+  else
+    match request.program.node? request.action.node with
+    | none => false
+    | some anchor =>
+        let inputNodes := request.inputs.map (fun input => input.node)
+        let seen := request.inputs.map fun input =>
+          { node := input.node, version := input.version : SeenVersion }
+        registration.key == request.action.key &&
+          registration.kind == request.action.kind &&
+          request.program.operationKey? request.action.node == some registration.head &&
+          resolveSlots? request.action.node anchor registration.watches == some inputNodes &&
+          resolveSlots? request.action.node anchor registration.writes == some request.writes &&
+          request.action.inputs == seen
+
+end Registration
+
+/- Stable opaque diagnostic codes for failures before a package callback is
+entered. -/
+namespace DispatchCode
+
+def missingRoute : Nat := 240
+def missingRegistration : Nat := 241
+def missingPackage : Nat := 242
+def missingHandler : Nat := 243
+def registryMismatch : Nat := 244
+def requestMismatch : Nat := 245
+
+end DispatchCode
+
+namespace Registry
+
+/-- Route one engine-owned rule identifier to its package callback.  Dispatch
+uses compact validated indices; it never branches on the semantic operation
+or rule key.  Only the selected package cache is replaced. -/
+def invoke (registry : Registry Fact) (request : RuleRequest Fact) :
+    Outcome Fact × Registry Fact :=
+  match registry.routes[request.action.rule.index]? with
+  | none => (.failed DispatchCode.missingRoute, registry)
+  | some route =>
+      match registry.registrations[request.action.rule.index]? with
+      | none => (.failed DispatchCode.missingRegistration, registry)
+      | some registration =>
+          match registry.packages[route.package]? with
+          | none => (.failed DispatchCode.missingPackage, registry)
+          | some package =>
+              match package.handlers[route.handler]? with
+              | none => (.failed DispatchCode.missingHandler, registry)
+              | some handler =>
+                  if !registration.same handler.registration then
+                    (.failed DispatchCode.registryMismatch, registry)
+                  else if !handler.registration.accepts request then
+                    (.failed DispatchCode.requestMismatch, registry)
+                  else
+                    let (outcome, cache) := handler.invoke package.cache request
+                    let package :=
+                      { package with
+                        cache := cache
+                        invocations := package.invocations + 1 }
+                    (outcome,
+                      { registry with
+                        packages := registry.packages.set! route.package package })
+
+end Registry
+
+end Hex.Interval.Experiment.Propagator

--- a/HexInterval/Experiment/Policy.lean
+++ b/HexInterval/Experiment/Policy.lean
@@ -788,12 +788,14 @@ def emittedSuggestions (before after : Nat) : Array OfferId := Id.run do
     emitted := emitted.push (.suggestion { index := before + offset })
   return emitted
 
-/-- Detect narrowing-capable suggestions which the engine's bounded retained
-prefix will discard.  This must run against the pre-reply engine because the
-dropped suffix is intentionally absent from the accepted snapshot. -/
+/-- Detect narrowing-capable suggestions which exact engine classification
+will discard. This must run against the pre-reply engine because dropped work
+is intentionally absent from the accepted snapshot. -/
 def droppedAffectsClosure (state : Engine Fact) : Outcome Fact -> Bool
   | .success _ suggestions _ =>
-      (state.droppedSuggestions suggestions).any Suggestion.affectsClosure
+      match state.suggestionPlan suggestions with
+      | .ready plan => plan.dropped.any Suggestion.affectsClosure
+      | .malformed => false
   | .noChange _ | .inapplicable | .resourceLimit _ | .failed _ => false
 
 inductive SubmitResult (Fact : Type) where

--- a/HexInterval/Experiment/Policy.lean
+++ b/HexInterval/Experiment/Policy.lean
@@ -277,8 +277,7 @@ def State.suggestionKey? (state : State Fact) (suggestionId : SuggestionId) : Op
       else none
   | .instantiate request =>
       let generation <- state.engine.instantiationGeneration? retained
-      if request.claimedGeneration != generation then none
-      else some (.instantiate source (.ofRequest request generation))
+      some (.instantiate source (.ofRequest request generation))
   | .split request => do
       let version <- clock.splitVersion
       let current <- state.engine.versions[request.node.index]?

--- a/HexInterval/Experiment/Policy.lean
+++ b/HexInterval/Experiment/Policy.lean
@@ -87,7 +87,6 @@ structure ProposedEqualityKey where
 /-- Payload-erased structural identity of an instantiation request. -/
 structure InstantiationSemanticKey where
   family : Nat
-  triggers : List NodeId
   generation : Nat
   nodes : List ProposedNodeKey
   equalities : List ProposedEqualityKey
@@ -96,7 +95,6 @@ structure InstantiationSemanticKey where
 def InstantiationSemanticKey.ofRequest
     (request : InstantiationRequest) (generation : Nat) : InstantiationSemanticKey :=
   { family := request.key
-    triggers := request.triggers
     generation
     nodes := request.nodes.map fun node =>
       { domain := node.domain, op := node.op, args := node.args }

--- a/HexInterval/Experiment/Policy.lean
+++ b/HexInterval/Experiment/Policy.lean
@@ -780,6 +780,7 @@ structure RuleObservation (Fact : Type) where
   changes : Array (FactDelta Fact)
   contradiction : Bool
   cost : CostObservation
+  suggestionPlan : SuggestionPlan
   emittedSuggestions : Array OfferId
 
 def emittedSuggestions (before after : Nat) : Array OfferId := Id.run do
@@ -787,16 +788,6 @@ def emittedSuggestions (before after : Nat) : Array OfferId := Id.run do
   for offset in [0:after - before] do
     emitted := emitted.push (.suggestion { index := before + offset })
   return emitted
-
-/-- Detect narrowing-capable suggestions which exact engine classification
-will discard. This must run against the pre-reply engine because dropped work
-is intentionally absent from the accepted snapshot. -/
-def droppedAffectsClosure (state : Engine Fact) : Outcome Fact -> Bool
-  | .success _ suggestions _ =>
-      match state.suggestionPlan suggestions with
-      | .ready plan => plan.dropped.any Suggestion.affectsClosure
-      | .malformed => false
-  | .noChange _ | .inapplicable | .resourceLimit _ | .failed _ => false
 
 inductive SubmitResult (Fact : Type) where
   | accepted (observation : RuleObservation Fact) (state : State Fact)
@@ -828,18 +819,19 @@ opaque State.submit (state : State Fact) (reply : Reply Fact) : SubmitResult Fac
       | some application =>
           let before := state.engine
           match before.submit reply with
-          | .accepted engine =>
+          | .accepted plan engine =>
               let observation : RuleObservation Fact :=
                 { invocation := invocationOfAction state.scope action
                   outcome := outcomeTag reply.outcome
                   changes := deltasFor before engine application.writes
                   contradiction := engine.contradictory && !before.contradictory
                   cost := outcomeCost reply.outcome
+                  suggestionPlan := plan
                   emittedSuggestions :=
                     emittedSuggestions before.suggestions.size engine.suggestions.size }
               let next := advanceState state engine
               let incomplete :=
-                droppedAffectsClosure before reply.outcome ||
+                plan.affectsClosure ||
                   match reply.outcome with
                   | .resourceLimit _ | .failed _ => true
                   | .success _ _ _ | .noChange _ | .inapplicable => false

--- a/HexInterval/Experiment/PolicyDriver.lean
+++ b/HexInterval/Experiment/PolicyDriver.lean
@@ -28,7 +28,9 @@ creation.
 
 namespace Hex.Interval.Experiment.Propagator.Policy.Driver
 
-/-! # External policy protocol -/
+universe u
+
+/-! ## External policy protocol -/
 
 /-- One external policy decision.  Policy-private state has an arbitrary Lean
 type and remains outside the trusted engine. -/
@@ -79,7 +81,7 @@ structure Controller (Fact PolicyState : Type) where
   update : PolicyState -> Event Fact -> PolicyState
   choose : PolicyState -> View Fact -> Step PolicyState
 
-/-! # Driver result -/
+/-! ## Driver result -/
 
 inductive UnknownReason
   | policyStop (liveOffers : Nat)
@@ -102,8 +104,9 @@ inductive Stop (Fact : Type)
   | driverFuel
 
 /-- A run returns both kinds of arbitrary external state and the exact ordered
-event stream delivered to the policy. -/
-structure Result (Fact Cache PolicyState : Type) where
+event stream delivered to the policy.  The registry cache may live above
+`Type` when it existentially packages independently typed rule caches. -/
+structure Result (Fact : Type) (Cache : Type u) (PolicyState : Type) where
   state : State Fact
   policy : PolicyKey
   cache : Cache
@@ -116,7 +119,8 @@ def emit (controller : Controller Fact PolicyState) (event : Event Fact)
     PolicyState × Array (Event Fact) :=
   (controller.update policyState event, events.push event)
 
-def finish (controller : Controller Fact PolicyState) (event : Event Fact)
+def finish {Cache : Type u}
+    (controller : Controller Fact PolicyState) (event : Event Fact)
     (stop : Stop Fact) (state : State Fact) (cache : Cache)
     (policyState : PolicyState) (events : Array (Event Fact)) :
     Result Fact Cache PolicyState :=
@@ -142,13 +146,13 @@ def dismissalCauses (before : State Fact) (selection : Selection)
 def invocationOfRequest (scope : ScopeId) (request : RuleRequest Fact) : InvocationKey :=
   invocationOfAction scope request.action
 
-/-! # Ordered execution -/
+/-! ## Ordered execution -/
 
 /-- Internal fuelled loop.  The only action passed to the registry comes from
 {name}`Hex.Interval.Experiment.Propagator.Policy.State.select`; the driver
 merely echoes it through
 {name}`Hex.Interval.Experiment.Propagator.Action.reply`. -/
-def driveFrom (controller : Controller Fact PolicyState)
+def driveFrom {Cache : Type u} (controller : Controller Fact PolicyState)
     (invoke : Cache -> RuleRequest Fact -> Outcome Fact × Cache) :
     Nat -> State Fact -> Cache -> PolicyState -> Array (Event Fact) ->
       Result Fact Cache PolicyState
@@ -326,7 +330,7 @@ def driveFrom (controller : Controller Fact PolicyState)
 
 /-- Run an external policy and registry from one policy-controlled engine
 snapshot. -/
-def drive (controller : Controller Fact PolicyState)
+def drive {Cache : Type u} (controller : Controller Fact PolicyState)
     (invoke : Cache -> RuleRequest Fact -> Outcome Fact × Cache)
     (fuel : Nat) (state : State Fact) (cache : Cache)
     (policyState : PolicyState) : Result Fact Cache PolicyState :=

--- a/HexInterval/Experiment/PolicyFrontier.lean
+++ b/HexInterval/Experiment/PolicyFrontier.lean
@@ -167,6 +167,7 @@ def engineLimits (workload : Workload) : Experiment.Propagator.Limits :=
     maxProposalItems := 0
     maxInstances := 0
     maxGeneration := 0
+    maxNodeDepth := nodeCount workload
     maxEqualities := 0
     splitEndpointLimit :=
       { maxEndpointHeight := 1, maxAlignmentShift := 0 } }

--- a/HexInterval/Experiment/PolicyFrontier.lean
+++ b/HexInterval/Experiment/PolicyFrontier.lean
@@ -402,7 +402,7 @@ def retainedSemanticItems (retained : RetainedSuggestion) : Nat :=
     match retained.suggestion with
     | .retry _ | .split _ => 0
     | .instantiate request =>
-        request.triggers.length + request.nodes.length + request.equalities.length +
+        request.nodes.length + request.equalities.length +
           (request.nodes.foldl (fun count node => count + node.args.length) 0)
 
 def offerSemanticItems (state : Policy.State Fact) : OfferId -> Nat

--- a/HexInterval/Experiment/PolicyFrontier.lean
+++ b/HexInterval/Experiment/PolicyFrontier.lean
@@ -161,6 +161,7 @@ def engineLimits (workload : Workload) : Experiment.Propagator.Limits :=
     maxRetainedSuggestions := retainedCount workload
     maxEffort := 1
     maxObservationValue := 1
+    maxDiagnosticValue := 1
     maxOutcomeCandidates := Nat.max workload.roots 1
     maxOutcomeSuggestions := Nat.max workload.churn 1
     maxProposalItems := 0

--- a/HexInterval/Experiment/Propagator.lean
+++ b/HexInterval/Experiment/Propagator.lean
@@ -22,7 +22,10 @@ A companion registry may keep caches of any Lean type.  It receives a
 `RuleRequest` containing a bounded immutable structural view and exactly the
 declared fact reads and writes, then replies with an `Outcome` bound to that
 action.  Candidate facts are intersected by an engine-owned `FactDomain`;
-function-specific code never enters the scheduler.
+function-specific code never enters the scheduler. Candidates remain
+semantically untrusted: intersection can preserve consistency and monotonicity,
+but only successful replay of their opaque proof payloads establishes
+soundness.
 
 This experimental module is separate from the supported `HexInterval` API.
 Selecting a
@@ -118,6 +121,27 @@ def nodesCheckFrom (program : Program) : Nat -> List Node -> Bool
 and SSA topology. -/
 def check (program : Program) : Bool :=
   uniqueOpKeys program.operations.toList && nodesCheckFrom program 0 program.nodes.toList
+
+/-- Structural expression depth, with nullary nodes at depth zero. -/
+def nodeDepth? (depths : Array Nat) (arguments : List NodeId) : Option Nat := do
+  if arguments.isEmpty then
+    pure 0
+  else
+    let mut greatest := 0
+    for argument in arguments do
+      let depth <- depths[argument.index]?
+      greatest := Nat.max greatest depth
+    pure (greatest + 1)
+
+/-- Reconstruct the structural depth of every node in a validated SSA
+program.  This measure is independent of theorem-instantiation generation. -/
+def depths? (program : Program) : Option (Array Nat) := do
+  let mut depths := #[]
+  for index in [0:program.nodes.size] do
+    let node <- program.nodes[index]?
+    let depth <- nodeDepth? depths node.args
+    depths := depths.push depth
+  pure depths
 
 end Program
 
@@ -387,12 +411,22 @@ structure ProgramView where
   operations : Array Operation
   nodes : Array Node
   generations : Array Nat
+  depths : Array Nat
 
 namespace ProgramView
 
 /-- Exact optional operation lookup in this immutable snapshot. -/
 def operation? (view : ProgramView) (operation : OpId) : Option Operation :=
   view.operations[operation.index]?
+
+/-- Resolve a stable operation key to this snapshot's compact identifier and
+exact signature. Package callbacks must not assume a particular operation-table
+order. -/
+def findOp? (view : ProgramView) (key : OpKey) : Option (OpId × Operation) := do
+  for index in [0:view.operations.size] do
+    let operation <- view.operations[index]?
+    if operation.key == key then return ({ index }, operation)
+  none
 
 /-- Exact optional node lookup in this immutable snapshot. -/
 def node? (view : ProgramView) (node : NodeId) : Option Node :=
@@ -401,6 +435,10 @@ def node? (view : ProgramView) (node : NodeId) : Option Node :=
 /-- Exact optional instantiation-generation lookup. -/
 def generation? (view : ProgramView) (node : NodeId) : Option Nat :=
   view.generations[node.index]?
+
+/-- Exact optional structural-depth lookup. -/
+def depth? (view : ProgramView) (node : NodeId) : Option Nat :=
+  view.depths[node.index]?
 
 /-- Resolve a node's opaque semantic operation key without interpreting it. -/
 def operationKey? (view : ProgramView) (node : NodeId) : Option OpKey := do
@@ -432,7 +470,9 @@ structure PayloadId where
   index : Nat
   deriving DecidableEq, Repr
 
-/-- One proposed fact about an existing expression node. -/
+/-- One semantically untrusted proposed fact about an existing expression
+node. Its payload must later replay to a checked theorem; merely intersecting
+the fact into engine state does not prove it sound. -/
 structure Candidate (Fact : Type) where
   node : NodeId
   fact : Fact
@@ -466,10 +506,9 @@ structure ProposedEquality where
 recomputes generations and assigns concrete node identifiers. -/
 structure InstantiationRequest where
   key : Nat
+  /-- Replay-facing matcher metadata. It is bounded but is not authoritative
+  theorem dependency data and does not partition engine or policy identity. -/
   triggers : List NodeId
-  /-- Legacy package-side estimate retained for diagnostics.  Admission never
-  trusts this value: generation is recomputed from engine-owned dependencies. -/
-  claimedGeneration : Nat
   nodes : List ProposedNode
   equalities : List ProposedEquality
   payload : PayloadId
@@ -575,7 +614,9 @@ inductive NarrowResult (Fact : Type) where
   | malformed (code : Nat)
   | resourceLimit (budget : Nat)
 
-/-- The only fact-domain behavior needed by propagation scheduling. -/
+/-- The only fact-domain behavior needed by propagation scheduling.
+`narrow` enforces the fact representation's intersection discipline; it does
+not authenticate the semantic claim carried by a candidate. -/
 structure FactDomain (Fact : Type) where
   top : DomainId -> Fact
   narrow : DomainId -> Fact -> Fact -> NarrowResult Fact
@@ -606,6 +647,7 @@ inductive Resource where
   | outcomeSuggestions
   | instances
   | generation
+  | nodeDepth
   | equalities
   deriving DecidableEq, Repr
 
@@ -628,6 +670,7 @@ structure Limits where
   maxProposalItems : Nat
   maxInstances : Nat
   maxGeneration : Nat
+  maxNodeDepth : Nat
   maxEqualities : Nat
   splitEndpointLimit : EndpointLimit
   deriving DecidableEq, Repr
@@ -738,6 +781,7 @@ structure Engine (Fact : Type) where
   facts : Array Fact
   versions : Array Nat
   generations : Array Nat
+  depths : Array Nat
   queue : Array WorkItem
   queueHead : Nat
   queued : Array Bool
@@ -806,6 +850,9 @@ def preflightStart (program : Program) (rules : Array Registration)
     throw .wrongFactCount
   if !program.check then
     throw .invalidProgram
+  let some depths := program.depths? | throw .invalidProgram
+  if depths.any (fun depth => limits.maxNodeDepth < depth) then
+    throw (.resourceLimit .nodeDepth)
   if !registrationsCheck program rules then
     throw .invalidRegistrations
 
@@ -814,6 +861,7 @@ node, ordinarily the domain top refined by source hypotheses. -/
 def Engine.start (factDomain : FactDomain Fact) (program : Program) (rules : Array Registration)
     (facts : Array Fact) (limits : Limits) : Except StartError (Engine Fact) := do
   preflightStart program rules facts.size limits
+  let some depths := program.depths? | throw .invalidProgram
   let applications <-
     match compileApplicationsWithin limits.maxApplications program rules with
     | .ok applications => pure applications
@@ -833,6 +881,7 @@ def Engine.start (factDomain : FactDomain Fact) (program : Program) (rules : Arr
       facts
       versions := Array.replicate facts.size 0
       generations := Array.replicate facts.size 0
+      depths
       queue := initialQueue applications.size
       queueHead := 0
       queued := Array.replicate applications.size true
@@ -862,7 +911,8 @@ def programView (state : Engine Fact) : ProgramView :=
   { programVersion := state.programVersion
     operations := state.program.operations
     nodes := state.program.nodes
-    generations := state.generations }
+    generations := state.generations
+    depths := state.depths }
 
 /-- Read the versions of exactly the watched nodes in registration order. -/
 def seenVersions? (state : Engine Fact) : List NodeId -> Option (List SeenVersion)
@@ -1034,6 +1084,7 @@ inductive ReplyError where
   | duplicateWrite
   | undeclaredWrite (node : NodeId)
   | missingFact (node : NodeId)
+  | malformedProposal
   | malformedFact (code : Nat)
   deriving DecidableEq, Repr
 
@@ -1105,6 +1156,107 @@ def suggestionEffortBounded (limit : Nat) : Suggestion -> Bool
 
 def suggestionsEffortBounded (limit : Nat) (suggestions : List Suggestion) : Bool :=
   suggestions.all (suggestionEffortBounded limit)
+
+/-! # Structural proposal validation -/
+
+namespace Node
+
+/-- Exact syntactic node equality used by the experiment's linear CSE table. -/
+def same (left right : Node) : Bool :=
+  left.domain == right.domain && left.op == right.op && left.args == right.args
+
+end Node
+
+/-- Linear reference CSE lookup.  The experiment measures this against indexed
+tables before selecting a production representation. -/
+def findNodeFrom : Nat -> List Node -> Node -> Option NodeId
+  | _, [], _ => none
+  | index, node :: nodes, target =>
+      if node.same target then some { index } else findNodeFrom (index + 1) nodes target
+
+def Program.findNode? (program : Program) (target : Node) : Option NodeId :=
+  findNodeFrom 0 program.nodes.toList target
+
+/-- Resolve a draft reference.  `existing` IDs are restricted to the immutable
+pre-proposal boundary; generated references use prior draft positions. -/
+def resolveRef? (baseSize : Nat) (resolved : List NodeId) : NodeRef -> Option NodeId
+  | .existing node => if node.index < baseSize then some node else none
+  | .proposed index => resolved[index]?
+
+def resolveRefs? (baseSize : Nat) (resolved : List NodeId)
+    (refs : List NodeRef) : Option (List NodeId) :=
+  refs.mapM (resolveRef? baseSize resolved)
+
+/-- Failure while resolving the structural part of an untrusted proposal. -/
+inductive DraftFault where
+  | badReferenceOrShape
+  | nodeDepth
+  deriving DecidableEq, Repr
+
+/-- Resolve draft nodes in order, validate each typed SSA instruction, and CSE
+against both old nodes and earlier new nodes.  Fresh nodes receive
+`1 + max(argument depths)` (nullaries have depth zero); a CSE hit preserves
+the engine-owned depth already stored for that node. -/
+def resolveDrafts (baseSize maxNodeDepth : Nat) :
+    Program -> Array Nat -> List NodeId -> List ProposedNode ->
+      Except DraftFault (Program × Array Nat × List NodeId)
+  | program, depths, resolved, [] => pure (program, depths, resolved)
+  | program, depths, resolved, draft :: drafts => do
+      let some args := resolveRefs? baseSize resolved draft.args
+        | throw .badReferenceOrShape
+      let candidate : Node := { domain := draft.domain, op := draft.op, args }
+      if !Program.nodeCheck program program.nodes.size candidate then
+        throw .badReferenceOrShape
+      let some candidateDepth := Program.nodeDepth? depths args
+        | throw .badReferenceOrShape
+      if maxNodeDepth < candidateDepth then
+        throw .nodeDepth
+      match program.findNode? candidate with
+      | some id =>
+          let some storedDepth := depths[id.index]? | throw .badReferenceOrShape
+          if storedDepth != candidateDepth then throw .badReferenceOrShape
+          resolveDrafts baseSize maxNodeDepth program depths (resolved ++ [id]) drafts
+      | none =>
+          let id : NodeId := { index := program.nodes.size }
+          resolveDrafts baseSize maxNodeDepth
+            { program with nodes := program.nodes.push candidate }
+            (depths.push candidateDepth) (resolved ++ [id]) drafts
+
+/-- Canonical endpoint set requested by an instantiation, before existing-edge
+deduplication.  This makes repeat selection detect the same instance even
+after its equality has entered the live edge table. -/
+def resolveRequestedPairs (baseSize : Nat) (resolved : List NodeId) (program : Program) :
+    List ProposedEquality -> Option (List EqualityPair)
+  | [] => some []
+  | proposal :: proposals => do
+      let left <- resolveRef? baseSize resolved proposal.left
+      let right <- resolveRef? baseSize resolved proposal.right
+      let leftNode <- program.node? left
+      let rightNode <- program.node? right
+      if left == right || leftNode.domain != rightNode.domain then none else pure ()
+      let rest <- resolveRequestedPairs baseSize resolved program proposals
+      let pair := equalityPair left right
+      some (if rest.contains pair then rest else insertEqualityPair pair rest)
+
+/-- Result of validating a proposal before it can enter retained policy state. -/
+inductive ProposalCheck where
+  | valid
+  | malformed
+  | resourceLimit (resource : Resource)
+
+/-- Perform the same shape, typed-reference, equality, and structural-depth
+checks used by admission, without mutating the live engine. -/
+def checkInstantiationProposal (program : Program) (depths : Array Nat)
+    (maxNodeDepth : Nat) (request : InstantiationRequest) : ProposalCheck :=
+  let baseSize := program.nodes.size
+  match resolveDrafts baseSize maxNodeDepth program depths [] request.nodes with
+  | .error .badReferenceOrShape => .malformed
+  | .error .nodeDepth => .resourceLimit .nodeDepth
+  | .ok (program, _, resolved) =>
+      if (resolveRequestedPairs baseSize resolved program request.equalities).isSome then
+        .valid
+      else
+        .malformed
 
 namespace Engine
 
@@ -1230,6 +1382,21 @@ def droppedSuggestions (state : Engine Fact)
     (suggestions : List Suggestion) : List Suggestion :=
   suggestions.drop state.suggestionRoom
 
+/-- Validate every instantiation in the exact prefix about to be retained.
+Malformed structural work must not enter policy state and later disappear as
+if it had merely become stale. -/
+def checkRetainedProposals (state : Engine Fact) :
+    List Suggestion -> ProposalCheck
+  | [] => .valid
+  | .retry _ :: suggestions | .split _ :: suggestions =>
+      checkRetainedProposals state suggestions
+  | .instantiate request :: suggestions =>
+      match checkInstantiationProposal state.program state.depths
+          state.limits.maxNodeDepth request with
+      | .valid => checkRetainedProposals state suggestions
+      | .malformed => .malformed
+      | .resourceLimit resource => .resourceLimit resource
+
 /-- Validate and atomically admit one rule reply.  Candidate facts are all
 installed before the union of affected dependencies is woken. -/
 def submit (state : Engine Fact) (reply : Reply Fact) : ReplyResult Fact :=
@@ -1267,26 +1434,30 @@ def submit (state : Engine Fact) (reply : Reply Fact) : ReplyResult Fact :=
                 | none =>
                     let retainedSuggestions := state.keptSuggestions suggestions
                     let droppedSuggestions := (state.droppedSuggestions suggestions).length
-                    let working : Engine Fact :=
-                      { base with
-                        suggestions := retainedSuggestions.foldl
-                          (fun retained suggestion => retained.push
-                            (state.retainSuggestion action suggestion))
-                          base.suggestions
-                        metrics :=
-                          { base.metrics with
-                            candidates := base.metrics.candidates + candidates.length
-                            droppedSuggestions :=
-                              base.metrics.droppedSuggestions + droppedSuggestions } }
-                    match installCandidates action working candidates with
-                    | .error (_, some budget, _) =>
-                        .factResourceLimit budget base
-                    | .error (_, _, some resource) => .resourceLimit resource base
-                    | .error (error, _, _) => .invalid error base
-                    | .ok (working, changed) =>
-                        match working.wakeNodes changed with
-                        | .error resource => .resourceLimit resource base
-                        | .ok next => .accepted next
+                    match state.checkRetainedProposals retainedSuggestions with
+                    | .malformed => .invalid .malformedProposal base
+                    | .resourceLimit resource => .resourceLimit resource base
+                    | .valid =>
+                        let working : Engine Fact :=
+                          { base with
+                            suggestions := retainedSuggestions.foldl
+                              (fun retained suggestion => retained.push
+                                (state.retainSuggestion action suggestion))
+                              base.suggestions
+                            metrics :=
+                              { base.metrics with
+                                candidates := base.metrics.candidates + candidates.length
+                                droppedSuggestions :=
+                                  base.metrics.droppedSuggestions + droppedSuggestions } }
+                        match installCandidates action working candidates with
+                        | .error (_, some budget, _) =>
+                            .factResourceLimit budget base
+                        | .error (_, _, some resource) => .resourceLimit resource base
+                        | .error (error, _, _) => .invalid error base
+                        | .ok (working, changed) =>
+                            match working.wakeNodes changed with
+                            | .error resource => .resourceLimit resource base
+                            | .ok next => .accepted next
 
 def transportUpdate (target source : NodeId) (targetVersion sourceVersion : Nat) :
     NarrowResult Fact -> Except EqualityFactError (Option (TransportUpdate Fact))
@@ -1464,67 +1635,6 @@ inductive AdmissionResult (Fact : Type) where
   | invalid (error : AdmissionError) (state : Engine Fact)
   | resourceLimit (resource : Resource) (state : Engine Fact)
 
-namespace Node
-
-/-- Exact syntactic node equality used by the experiment's linear CSE table. -/
-def same (left right : Node) : Bool :=
-  left.domain == right.domain && left.op == right.op && left.args == right.args
-
-end Node
-
-/-- Linear reference CSE lookup.  The experiment measures this against indexed
-tables before selecting a production representation. -/
-def findNodeFrom : Nat -> List Node -> Node -> Option NodeId
-  | _, [], _ => none
-  | index, node :: nodes, target =>
-      if node.same target then some { index } else findNodeFrom (index + 1) nodes target
-
-def Program.findNode? (program : Program) (target : Node) : Option NodeId :=
-  findNodeFrom 0 program.nodes.toList target
-
-/-- Resolve a draft reference.  `existing` IDs are restricted to the immutable
-pre-proposal boundary; generated references use prior draft positions. -/
-def resolveRef? (baseSize : Nat) (resolved : List NodeId) : NodeRef -> Option NodeId
-  | .existing node => if node.index < baseSize then some node else none
-  | .proposed index => resolved[index]?
-
-def resolveRefs? (baseSize : Nat) (resolved : List NodeId)
-    (refs : List NodeRef) : Option (List NodeId) :=
-  refs.mapM (resolveRef? baseSize resolved)
-
-/-- Canonical endpoint set requested by an instantiation, before existing-edge
-deduplication.  This makes repeat selection detect the same instance even
-after its equality has entered the live edge table. -/
-def resolveRequestedPairs (baseSize : Nat) (resolved : List NodeId) (program : Program) :
-    List ProposedEquality -> Option (List EqualityPair)
-  | [] => some []
-  | proposal :: proposals => do
-      let left <- resolveRef? baseSize resolved proposal.left
-      let right <- resolveRef? baseSize resolved proposal.right
-      let leftNode <- program.node? left
-      let rightNode <- program.node? right
-      if left == right || leftNode.domain != rightNode.domain then none else pure ()
-      let rest <- resolveRequestedPairs baseSize resolved program proposals
-      let pair := equalityPair left right
-      some (if rest.contains pair then rest else insertEqualityPair pair rest)
-
-/-- Resolve draft nodes in order, validate each typed SSA instruction, and CSE
-against both old nodes and earlier new nodes. -/
-def resolveDrafts (baseSize : Nat) :
-    Program -> List NodeId -> List ProposedNode -> Option (Program × List NodeId)
-  | program, resolved, [] => some (program, resolved)
-  | program, resolved, draft :: drafts => do
-      let args <- resolveRefs? baseSize resolved draft.args
-      let candidate : Node := { domain := draft.domain, op := draft.op, args }
-      if !Program.nodeCheck program program.nodes.size candidate then
-        none
-      else
-        let id := program.findNode? candidate |>.getD { index := program.nodes.size }
-        let program :=
-          if id.index < program.nodes.size then program
-          else { program with nodes := program.nodes.push candidate }
-        resolveDrafts baseSize program (resolved ++ [id]) drafts
-
 /-- Existing references named directly by one draft reference list. -/
 def existingRefs (refs : List NodeRef) : List NodeId :=
   refs.foldr (fun ref nodes => match ref with
@@ -1555,14 +1665,13 @@ def inferredGeneration? (generations : Array Nat)
     greatest := Nat.max greatest generation
   some (greatest + 1)
 
-/-- Recompute the generation advertised to policy from current engine-owned
-structure.  The package's legacy hint is deliberately not trusted. -/
+/-- Recompute theorem-instantiation generation for a structurally validated
+retained proposal.  Reply admission already checked the full draft shape, so
+policy view construction need only recheck freshness and provenance. -/
 def Engine.instantiationGeneration? (state : Engine Fact)
     (retained : RetainedSuggestion) : Option Nat := do
   if !state.actionFresh retained.action then none else pure ()
   let .instantiate request := retained.suggestion | none
-  let baseSize := state.program.nodes.size
-  let _ <- resolveDrafts baseSize state.program [] request.nodes
   inferredGeneration? state.generations retained.action request
 
 /-- Treat equality endpoints as unordered for structural deduplication. -/
@@ -1677,9 +1786,11 @@ def admitRetained (state : Engine Fact)
           .invalid (.staleSuggestion retained.action.programVersion state.programVersion) state
         else
           let baseSize := state.program.nodes.size
-          match resolveDrafts baseSize state.program [] request.nodes with
-          | none => .invalid .badReferenceOrShape state
-          | some (program, resolved) =>
+          match resolveDrafts baseSize state.limits.maxNodeDepth state.program state.depths
+              [] request.nodes with
+          | .error .badReferenceOrShape => .invalid .badReferenceOrShape state
+          | .error .nodeDepth => .resourceLimit .nodeDepth state
+          | .ok (program, depths, resolved) =>
               let equalityPairs? :=
                 resolveRequestedPairs baseSize resolved program request.equalities
               if equalityPairs?.isNone then
@@ -1754,6 +1865,7 @@ def admitRetained (state : Engine Fact)
                                               Array.replicate addedNodes 0
                                             generations := state.generations ++
                                               Array.replicate addedNodes generation
+                                            depths
                                             queued
                                             equalityQueued
                                             instances := instanceKey :: state.instances

--- a/HexInterval/Experiment/Propagator.lean
+++ b/HexInterval/Experiment/Propagator.lean
@@ -506,9 +506,6 @@ structure ProposedEquality where
 recomputes generations and assigns concrete node identifiers. -/
 structure InstantiationRequest where
   key : Nat
-  /-- Replay-facing matcher metadata. It is bounded but is not authoritative
-  theorem dependency data and does not partition engine or policy identity. -/
-  triggers : List NodeId
   nodes : List ProposedNode
   equalities : List ProposedEquality
   payload : PayloadId
@@ -1130,9 +1127,7 @@ def existingRefBounded (nodeCount : Nat) : NodeRef -> Bool
   | .proposed _ => true
 
 def proposalBounded (nodeCount limit : Nat) (request : InstantiationRequest) : Bool :=
-  listWithin limit request.triggers && listWithin limit request.nodes &&
-    listWithin limit request.equalities &&
-    request.triggers.all (fun node => node.index < nodeCount) &&
+  listWithin limit request.nodes && listWithin limit request.equalities &&
     request.nodes.all (fun node => listWithin limit node.args &&
       node.args.all (existingRefBounded nodeCount)) &&
     request.equalities.all (fun edge =>
@@ -1245,18 +1240,23 @@ inductive ProposalCheck where
   | resourceLimit (resource : Resource)
 
 /-- Perform the same shape, typed-reference, equality, and structural-depth
-checks used by admission, without mutating the live engine. -/
+checks used by admission, without mutating the live engine. Structural
+validation deliberately runs to completion before the depth classification:
+a malformed proposal cannot disguise itself as a recoverable depth loss. -/
 def checkInstantiationProposal (program : Program) (depths : Array Nat)
     (maxNodeDepth : Nat) (request : InstantiationRequest) : ProposalCheck :=
   let baseSize := program.nodes.size
-  match resolveDrafts baseSize maxNodeDepth program depths [] request.nodes with
+  let validationDepth := depths.foldl Nat.max 0 + request.nodes.length
+  match resolveDrafts baseSize validationDepth program depths [] request.nodes with
   | .error .badReferenceOrShape => .malformed
-  | .error .nodeDepth => .resourceLimit .nodeDepth
-  | .ok (program, _, resolved) =>
-      if (resolveRequestedPairs baseSize resolved program request.equalities).isSome then
-        .valid
-      else
+  | .error .nodeDepth => .malformed
+  | .ok (program, depths, resolved) =>
+      if (resolveRequestedPairs baseSize resolved program request.equalities).isNone then
         .malformed
+      else if depths.any (fun depth => maxNodeDepth < depth) then
+        .resourceLimit .nodeDepth
+      else
+        .valid
 
 namespace Engine
 
@@ -1366,36 +1366,57 @@ def installCandidates (action : Action) :
           candidate.node :: changed
       pure (next, changed)
 
-/-- Remaining capacity in the engine-owned retained-suggestion prefix. -/
+/-- Remaining capacity in the engine-owned retained-suggestion array. -/
 def suggestionRoom (state : Engine Fact) : Nat :=
   state.limits.maxRetainedSuggestions - state.suggestions.size
 
-/-- The exact suggestion prefix which `submit` will retain. Policy layers use
-this helper rather than duplicating the retention arithmetic when deciding
-whether discarded work affects completeness. -/
-def keptSuggestions (state : Engine Fact)
-    (suggestions : List Suggestion) : List Suggestion :=
-  suggestions.take state.suggestionRoom
+/-- Exact result of validating and capacity-filtering one reply's suggestions.
+`kept` retains source order. `dropped` contains both capacity overflow and
+individually unaffordable structural proposals, also in source order. -/
+structure SuggestionPlan where
+  kept : List Suggestion := []
+  dropped : List Suggestion := []
 
-/-- The exact suggestion suffix which `submit` will discard. -/
-def droppedSuggestions (state : Engine Fact)
-    (suggestions : List Suggestion) : List Suggestion :=
-  suggestions.drop state.suggestionRoom
+/-- A malformed suggestion which had room to enter policy state invalidates
+the whole reply. Resource-limited structural suggestions are instead
+recoverable losses recorded in `SuggestionPlan.dropped`. -/
+inductive SuggestionCheck where
+  | ready (plan : SuggestionPlan)
+  | malformed
 
-/-- Validate every instantiation in the exact prefix about to be retained.
-Malformed structural work must not enter policy state and later disappear as
-if it had merely become stale. -/
-def checkRetainedProposals (state : Engine Fact) :
-    List Suggestion -> ProposalCheck
-  | [] => .valid
-  | .retry _ :: suggestions | .split _ :: suggestions =>
-      checkRetainedProposals state suggestions
-  | .instantiate request :: suggestions =>
-      match checkInstantiationProposal state.program state.depths
-          state.limits.maxNodeDepth request with
-      | .valid => checkRetainedProposals state suggestions
+/-- Classify the exact suggestions which `submit` can retain. An unaffordable
+instantiation does not consume retained capacity, so later affordable advice
+from the same atomic reply can survive. Once capacity is exhausted, the
+remaining suffix is dropped without structural validation, preserving the
+existing rule that only work selected for retention can invalidate a reply. -/
+def classifySuggestions (state : Engine Fact) :
+    Nat -> List Suggestion -> SuggestionCheck
+  | _, [] => .ready {}
+  | 0, suggestions => .ready { dropped := suggestions }
+  | room + 1, suggestion :: suggestions =>
+      let checked :=
+        match suggestion with
+        | .retry _ | .split _ => ProposalCheck.valid
+        | .instantiate request =>
+            checkInstantiationProposal state.program state.depths
+              state.limits.maxNodeDepth request
+      match checked with
       | .malformed => .malformed
-      | .resourceLimit resource => .resourceLimit resource
+      | .valid =>
+          match classifySuggestions state room suggestions with
+          | .malformed => .malformed
+          | .ready plan => .ready { plan with kept := suggestion :: plan.kept }
+      | .resourceLimit _ =>
+          match classifySuggestions state (room + 1) suggestions with
+          | .malformed => .malformed
+          | .ready plan => .ready { plan with dropped := suggestion :: plan.dropped }
+
+/-- Apply the live retained-suggestion capacity to one already surface-bounded
+reply. Engine admission and policy completeness accounting both use this exact
+classification. -/
+def suggestionPlan (state : Engine Fact)
+    (suggestions : List Suggestion) : SuggestionCheck :=
+  classifySuggestions state state.suggestionRoom suggestions
 
 /-- Validate and atomically admit one rule reply.  Candidate facts are all
 installed before the union of affected dependencies is woken. -/
@@ -1432,15 +1453,12 @@ def submit (state : Engine Fact) (reply : Reply Fact) : ReplyResult Fact :=
                 match candidatesAuthorized application.writes candidates with
                 | some error => .invalid error base
                 | none =>
-                    let retainedSuggestions := state.keptSuggestions suggestions
-                    let droppedSuggestions := (state.droppedSuggestions suggestions).length
-                    match state.checkRetainedProposals retainedSuggestions with
+                    match state.suggestionPlan suggestions with
                     | .malformed => .invalid .malformedProposal base
-                    | .resourceLimit resource => .resourceLimit resource base
-                    | .valid =>
+                    | .ready plan =>
                         let working : Engine Fact :=
                           { base with
-                            suggestions := retainedSuggestions.foldl
+                            suggestions := plan.kept.foldl
                               (fun retained suggestion => retained.push
                                 (state.retainSuggestion action suggestion))
                               base.suggestions
@@ -1448,7 +1466,7 @@ def submit (state : Engine Fact) (reply : Reply Fact) : ReplyResult Fact :=
                               { base.metrics with
                                 candidates := base.metrics.candidates + candidates.length
                                 droppedSuggestions :=
-                                  base.metrics.droppedSuggestions + droppedSuggestions } }
+                                  base.metrics.droppedSuggestions + plan.dropped.length } }
                         match installCandidates action working candidates with
                         | .error (_, some budget, _) =>
                             .factResourceLimit budget base
@@ -1646,9 +1664,7 @@ def requestExistingRefs (request : InstantiationRequest) : List NodeId :=
     request.equalities.flatMap (fun edge => existingRefs [edge.left, edge.right])
 
 /-- Canonical engine-owned substitution of an invocation: its anchor followed
-by every declared fact dependency, with the first occurrence retained.  The
-registry's `InstantiationRequest.triggers` field is replay data and cannot
-weaken either generation accounting or structural duplicate detection. -/
+by every declared fact dependency, with the first occurrence retained. -/
 def actionSubstitution (action : Action) : List NodeId :=
   dedupList (action.node :: action.inputs.map (fun input => input.node))
 

--- a/HexInterval/Experiment/Propagator.lean
+++ b/HexInterval/Experiment/Propagator.lean
@@ -179,6 +179,10 @@ structure Registration where
   kind : ActionKind
   watches : List Slot
   writes : List Slot
+  /-- Re-run existing applications after any append-only program extension.
+  This is the coarse first trigger for rules whose result depends on shape
+  outside their anchor's immutable argument subgraph. -/
+  watchesProgram : Bool := false
   initialEffort : Nat := 0
   deriving Repr
 
@@ -217,6 +221,16 @@ def opKeyExists (program : Program) (key : OpKey) : Bool :=
 
 def Program.operationWithKey? (program : Program) (key : OpKey) : Option Operation :=
   program.operations.toList.find? fun operation => operation.key == key
+
+/-- Resolve both the signature and the compact identifier assigned by this
+particular final program.  Package-local operation order is not authoritative
+for frontend nodes. -/
+def Program.operationEntry? (program : Program) (key : OpKey) :
+    Option (OpId × Operation) := do
+  for index in [0:program.operations.size] do
+    let operation <- program.operations[index]?
+    if operation.key == key then return ({ index }, operation)
+  none
 
 def Slot.validFor (operation : Operation) : Slot -> Bool
   | .result => true
@@ -526,11 +540,13 @@ inductive Outcome (Fact : Type) where
   | resourceLimit (budget : Nat)
   | failed (code : Nat)
 
-def Outcome.observationBounded (limit : Nat) : Outcome Fact -> Bool
-  | .success _ _ cost | .noChange cost => cost.bounded limit
+/-- Bound performed-work observations separately from negative diagnostic
+encodings.  A `resourceLimit` number is not charged as work, but it still needs
+an independent representation cap before entering retained policy events. -/
+def Outcome.observationBounded (costLimit diagnosticLimit : Nat) : Outcome Fact -> Bool
+  | .success _ _ cost | .noChange cost => cost.bounded costLimit
+  | .resourceLimit diagnostic | .failed diagnostic => diagnostic <= diagnosticLimit
   | .inapplicable => true
-  | .resourceLimit budget => budget <= limit
-  | .failed _ => true
 
 /-- Registry response bound to the exact outstanding invocation. -/
 structure Reply (Fact : Type) where
@@ -580,6 +596,8 @@ inductive Resource where
   | applications
   | queueEntries
   | actions
+  | effort
+  | registryEntries
   | acceptedFacts
   | retainedSuggestions
   | outcomeCandidates
@@ -602,6 +620,7 @@ structure Limits where
   maxRetainedSuggestions : Nat
   maxEffort : Nat
   maxObservationValue : Nat
+  maxDiagnosticValue : Nat
   maxOutcomeCandidates : Nat
   maxOutcomeSuggestions : Nat
   maxProposalItems : Nat
@@ -764,27 +783,35 @@ def initialQueue (applicationCount : Nat) : Array WorkItem := Id.run do
     queue := queue.push (.application { index })
   queue
 
-/-- Validate and compile an engine.  The caller supplies one initial fact per
-node, ordinarily the domain top refined by source hypotheses. -/
-def Engine.start (factDomain : FactDomain Fact) (program : Program) (rules : Array Registration)
-    (facts : Array Fact) (limits : Limits) : Except StartError (Engine Fact) := do
+/-- Resource-first validation shared by checked frontends and `Engine.start`.
+Size caps precede every traversal of untrusted program or registry metadata. -/
+def preflightStart (program : Program) (rules : Array Registration)
+    (factCount : Nat) (limits : Limits) : Except StartError Unit := do
   if limits.maxOperations < program.operations.size then
     throw (.resourceLimit .operations)
   if limits.maxNodes < program.nodes.size then
     throw (.resourceLimit .nodes)
   if limits.maxRules < rules.size then
     throw (.resourceLimit .rules)
+  if rules.any (fun rule => limits.maxEffort < rule.initialEffort) then
+    throw (.resourceLimit .effort)
   if program.operations.any (fun operation => !listWithin limits.maxArity operation.inputs) ||
       program.nodes.any (fun node => !listWithin limits.maxArity node.args) ||
       rules.any (fun rule => !listWithin (limits.maxArity + 1) rule.watches ||
         !listWithin (limits.maxArity + 1) rule.writes) then
     throw (.resourceLimit .arity)
-  if facts.size != program.nodes.size then
+  if factCount != program.nodes.size then
     throw .wrongFactCount
   if !program.check then
     throw .invalidProgram
   if !registrationsCheck program rules then
     throw .invalidRegistrations
+
+/-- Validate and compile an engine.  The caller supplies one initial fact per
+node, ordinarily the domain top refined by source hypotheses. -/
+def Engine.start (factDomain : FactDomain Fact) (program : Program) (rules : Array Registration)
+    (facts : Array Fact) (limits : Limits) : Except StartError (Engine Fact) := do
+  preflightStart program rules facts.size limits
   let applications <-
     match compileApplicationsWithin limits.maxApplications program rules with
     | .ok applications => pure applications
@@ -862,6 +889,7 @@ def actionFresh (state : Engine Fact) (action : Action) : Bool :=
   | some application, some rule, some current =>
       application.rule == action.rule && application.node == action.node &&
         application.kind == action.kind && rule.key == action.key &&
+        (!rule.watchesProgram || action.programVersion == state.programVersion) &&
         action.inputs.map (fun input => input.node) == application.watches &&
         current == action.inputs
   | _, _, _ => false
@@ -1033,6 +1061,7 @@ inductive EqualityFault where
   | missingEquality
   | domainMismatch
   | missingState
+  | oversizedDiagnostic
   | malformedFact (code : Nat)
   deriving DecidableEq, Repr
 
@@ -1163,8 +1192,16 @@ def installCandidates (action : Action) :
       let next <-
         match state.factDomain.narrow target.domain current candidate.fact with
         | .noChange => pure state
-        | .malformed code => throw (.malformedFact code, none, none)
-        | .resourceLimit budget => throw (.malformedFact 0, some budget, none)
+        | .malformed code =>
+            if code <= state.limits.maxDiagnosticValue then
+              throw (.malformedFact code, none, none)
+            else
+              throw (.oversizedObservation, none, none)
+        | .resourceLimit budget =>
+            if budget <= state.limits.maxDiagnosticValue then
+              throw (.malformedFact 0, some budget, none)
+            else
+              throw (.oversizedObservation, none, none)
         | .improved fact => installImprovement action candidate fact false state
         | .contradiction fact => installImprovement action candidate fact true state
       let (next, changed) <- installCandidates action next candidates
@@ -1200,7 +1237,8 @@ def submit (state : Engine Fact) (reply : Reply Fact) : ReplyResult Fact :=
       if reply.serial != action.serial || reply.programVersion != action.programVersion ||
           reply.application != action.application then
         .invalid .mismatchedAction state
-      else if !reply.outcome.observationBounded state.limits.maxObservationValue then
+      else if !reply.outcome.observationBounded state.limits.maxObservationValue
+          state.limits.maxDiagnosticValue then
         .invalid .oversizedObservation state.finishReply
       else
       match reply.outcome with
@@ -1309,13 +1347,29 @@ def contractEquality (state : Engine Fact) (equalityId : EqualityId) :
           else
             match transportUpdate equality.left equality.right leftVersion rightVersion
                 (state.factDomain.narrow leftNode.domain leftFact rightFact) with
-            | .error (.malformed code) => .invalid (.malformedFact code) 1 state
-            | .error (.resourceLimit budget) => .factResourceLimit budget 1 state
+            | .error (.malformed code) =>
+                if code <= state.limits.maxDiagnosticValue then
+                  .invalid (.malformedFact code) 1 state
+                else
+                  .invalid .oversizedDiagnostic 1 state
+            | .error (.resourceLimit budget) =>
+                if budget <= state.limits.maxDiagnosticValue then
+                  .factResourceLimit budget 1 state
+                else
+                  .invalid .oversizedDiagnostic 1 state
             | .ok left =>
                 match transportUpdate equality.right equality.left rightVersion leftVersion
                     (state.factDomain.narrow leftNode.domain rightFact leftFact) with
-                | .error (.malformed code) => .invalid (.malformedFact code) 2 state
-                | .error (.resourceLimit budget) => .factResourceLimit budget 2 state
+                | .error (.malformed code) =>
+                    if code <= state.limits.maxDiagnosticValue then
+                      .invalid (.malformedFact code) 2 state
+                    else
+                      .invalid .oversizedDiagnostic 2 state
+                | .error (.resourceLimit budget) =>
+                    if budget <= state.limits.maxDiagnosticValue then
+                      .factResourceLimit budget 2 state
+                    else
+                      .invalid .oversizedDiagnostic 2 state
                 | .ok right =>
                     let updates := [left, right].filterMap id
                     if state.limits.maxAcceptedFacts < state.history.size + updates.length then
@@ -1333,6 +1387,8 @@ end Engine
 
 /-! # External registry driver -/
 
+universe u
+
 /-- Why a bounded request/reply run stopped. -/
 inductive RunStop where
   | saturated
@@ -1344,8 +1400,10 @@ inductive RunStop where
   | driverFuel
   deriving DecidableEq, Repr
 
-/-- A run returns both solver state and the registry's arbitrary private cache. -/
-structure RunResult (Fact Cache : Type) where
+/-- A run returns both solver state and the registry's arbitrary private cache.
+The cache may itself existentially package `Type`-valued rule caches, so its
+universe is independent of the engine's fact universe. -/
+structure RunResult (Fact : Type) (Cache : Type u) where
   state : Engine Fact
   cache : Cache
   stop : RunStop
@@ -1353,7 +1411,8 @@ structure RunResult (Fact Cache : Type) where
 /-- Execute the request/reply protocol with a registry-owned cache.  `invoke`
 is the only place where operation or rule keys acquire function-specific
 meaning. -/
-def drive (invoke : Cache -> RuleRequest Fact -> Outcome Fact × Cache) :
+def drive {Cache : Type u}
+    (invoke : Cache -> RuleRequest Fact -> Outcome Fact × Cache) :
     Nat -> Engine Fact -> Cache -> RunResult Fact Cache
   | 0, state, cache => { state, cache, stop := .driverFuel }
   | fuel + 1, state, cache =>
@@ -1563,6 +1622,24 @@ def enqueueNewApplications (oldCount newCount : Nat) (state : Engine Fact) :
   (List.range newCount).foldlM
     (fun state offset => state.enqueue (.application { index := oldCount + offset })) state
 
+/-- Existing applications which explicitly declared a dependency on the whole
+program and are not already dirty.  Program extension is their versioned
+wakeup source, analogous to a changed watched fact for ordinary rules. -/
+def dormantProgramWatchers? (state : Engine Fact) : Option (List ApplicationId) := do
+  let mut watchers := []
+  for index in [0:state.applications.size] do
+    let application <- state.applications[index]?
+    let registration <- state.rules[application.rule.index]?
+    let queued <- state.queued[index]?
+    if registration.watchesProgram && !queued then
+      watchers := { index } :: watchers
+  pure watchers.reverse
+
+def enqueueApplications (applications : List ApplicationId) (state : Engine Fact) :
+    Except Resource (Engine Fact) :=
+  applications.foldlM
+    (fun state application => state.enqueue (.application application)) state
+
 /-- Queue every newly admitted equality contractor. -/
 def enqueueNewEqualities (oldCount newCount : Nat) (state : Engine Fact) :
     Except Resource (Engine Fact) :=
@@ -1646,12 +1723,16 @@ def admitRetained (state : Engine Fact)
                                 if !applicationsPrefix state.applications applications then
                                   .invalid .invalidCompiledProgram state
                                 else
-                                  let addedApplications :=
-                                    applications.size - state.applications.size
-                                  if state.limits.maxQueueEntries <
-                                      state.queue.size + addedApplications + equalities.length then
-                                    .resourceLimit .queueEntries state
-                                  else
+                                  match dormantProgramWatchers? state with
+                                  | none => .invalid .invalidCompiledProgram state
+                                  | some programWatchers =>
+                                    let addedApplications :=
+                                      applications.size - state.applications.size
+                                    if state.limits.maxQueueEntries <
+                                        state.queue.size + addedApplications + equalities.length +
+                                          programWatchers.length then
+                                      .resourceLimit .queueEntries state
+                                    else
                                     let allEqualities := state.equalities ++ equalities.toArray
                                     match buildWatchers program.nodes.size applications
                                         allEqualities with
@@ -1704,7 +1785,10 @@ def admitRetained (state : Engine Fact)
                                             match enqueueNewApplications state.applications.size
                                                 addedApplications prospective with
                                             | .error resource => .resourceLimit resource state
-                                            | .ok next => .admitted generated next
+                                            | .ok prospective =>
+                                                match enqueueApplications programWatchers prospective with
+                                                | .error resource => .resourceLimit resource state
+                                                | .ok next => .admitted generated next
 
 /-- Select one proposal retained in this concrete engine snapshot.  This
 experiment keeps `Engine` inspectable for benchmarks, so callers can still

--- a/HexInterval/Experiment/Propagator.lean
+++ b/HexInterval/Experiment/Propagator.lean
@@ -405,7 +405,12 @@ The explicit version lets registries key structural caches by the exact
 append-only snapshot.  Reply validation remains bound to the engine-owned
 `Action`, while retained instantiations recheck action freshness and resolve
 their complete structural effect against the current program.  Observing this
-view grants no mutation authority. -/
+view grants no mutation authority.
+
+A matcher may follow structure determined by its action anchor. Any additional
+side node which affects a proposed theorem instance must be named either by a
+declared fact input or by an explicit `existing` proposal reference.
+Generation accounting does not track arbitrary calls to `ProgramView.node?`. -/
 structure ProgramView where
   programVersion : Nat
   operations : Array Operation
@@ -542,6 +547,47 @@ contraction in the current branch. -/
 def Suggestion.affectsClosure : Suggestion -> Bool
   | .retry _ | .instantiate _ => true
   | .split _ => false
+
+/-- Why a bounded reply suggestion did not enter retained policy state. -/
+inductive SuggestionDrop where
+  | capacity (suggestion : Suggestion)
+  | depth (suggestion : Suggestion)
+
+namespace SuggestionDrop
+
+def suggestion : SuggestionDrop -> Suggestion
+  | .capacity suggestion | .depth suggestion => suggestion
+
+def affectsClosure (drop : SuggestionDrop) : Bool :=
+  drop.suggestion.affectsClosure
+
+end SuggestionDrop
+
+/-- Exact result of validating and capacity-filtering one reply's suggestions.
+Both lists retain source order. Every dropped suggestion records whether
+retained capacity or structural depth excluded it. -/
+structure SuggestionPlan where
+  kept : List Suggestion := []
+  dropped : List SuggestionDrop := []
+
+namespace SuggestionPlan
+
+def capacityDrops (plan : SuggestionPlan) : Nat :=
+  plan.dropped.foldl (fun count drop =>
+    match drop with
+    | .capacity _ => count + 1
+    | .depth _ => count) 0
+
+def depthDrops (plan : SuggestionPlan) : Nat :=
+  plan.dropped.foldl (fun count drop =>
+    match drop with
+    | .capacity _ => count
+    | .depth _ => count + 1) 0
+
+def affectsClosure (plan : SuggestionPlan) : Bool :=
+  plan.dropped.any SuggestionDrop.affectsClosure
+
+end SuggestionPlan
 
 /-- A policy candidate paired with engine-owned invocation provenance.  Split
 proposals retain the target version at proposal time; later policy adoption
@@ -689,7 +735,12 @@ structure Metrics where
   ruleFailures : Nat := 0
   admittedInstances : Nat := 0
   duplicateInstances : Nat := 0
+  /-- Total suggestions omitted from retained policy state. -/
   droppedSuggestions : Nat := 0
+  /-- Suggestions omitted because the retained array was full. -/
+  capacityDrops : Nat := 0
+  /-- Structurally valid instantiations omitted by `maxNodeDepth`. -/
+  depthDrops : Nat := 0
   generatedNodes : Nat := 0
   generatedEqualities : Nat := 0
   equalityRuns : Nat := 0
@@ -1087,7 +1138,7 @@ inductive ReplyError where
 
 /-- Result of atomically admitting one reply. -/
 inductive ReplyResult (Fact : Type) where
-  | accepted (state : Engine Fact)
+  | accepted (plan : SuggestionPlan) (state : Engine Fact)
   | invalid (error : ReplyError) (state : Engine Fact)
   | resourceLimit (resource : Resource) (state : Engine Fact)
   | factResourceLimit (budget : Nat) (state : Engine Fact)
@@ -1185,14 +1236,15 @@ def resolveRefs? (baseSize : Nat) (resolved : List NodeId)
 /-- Failure while resolving the structural part of an untrusted proposal. -/
 inductive DraftFault where
   | badReferenceOrShape
-  | nodeDepth
   deriving DecidableEq, Repr
 
 /-- Resolve draft nodes in order, validate each typed SSA instruction, and CSE
 against both old nodes and earlier new nodes.  Fresh nodes receive
 `1 + max(argument depths)` (nullaries have depth zero); a CSE hit preserves
-the engine-owned depth already stored for that node. -/
-def resolveDrafts (baseSize maxNodeDepth : Nat) :
+the engine-owned depth already stored for that node. This resolver is
+deliberately uncapped: callers first validate the complete untrusted shape,
+then separately classify only freshly appended depths. -/
+def resolveDrafts (baseSize : Nat) :
     Program -> Array Nat -> List NodeId -> List ProposedNode ->
       Except DraftFault (Program × Array Nat × List NodeId)
   | program, depths, resolved, [] => pure (program, depths, resolved)
@@ -1204,18 +1256,22 @@ def resolveDrafts (baseSize maxNodeDepth : Nat) :
         throw .badReferenceOrShape
       let some candidateDepth := Program.nodeDepth? depths args
         | throw .badReferenceOrShape
-      if maxNodeDepth < candidateDepth then
-        throw .nodeDepth
       match program.findNode? candidate with
       | some id =>
           let some storedDepth := depths[id.index]? | throw .badReferenceOrShape
           if storedDepth != candidateDepth then throw .badReferenceOrShape
-          resolveDrafts baseSize maxNodeDepth program depths (resolved ++ [id]) drafts
+          resolveDrafts baseSize program depths (resolved ++ [id]) drafts
       | none =>
           let id : NodeId := { index := program.nodes.size }
-          resolveDrafts baseSize maxNodeDepth
+          resolveDrafts baseSize
             { program with nodes := program.nodes.push candidate }
             (depths.push candidateDepth) (resolved ++ [id]) drafts
+
+/-- Whether every freshly appended node respects the structural-depth cap.
+Existing nodes were checked when their program snapshot was created and are
+not reclassified as losses of the current proposal. -/
+def appendedDepthsWithin (baseSize maxNodeDepth : Nat) (depths : Array Nat) : Bool :=
+  (depths.toList.drop baseSize).all fun depth => depth <= maxNodeDepth
 
 /-- Canonical endpoint set requested by an instantiation, before existing-edge
 deduplication.  This makes repeat selection detect the same instance even
@@ -1237,7 +1293,7 @@ def resolveRequestedPairs (baseSize : Nat) (resolved : List NodeId) (program : P
 inductive ProposalCheck where
   | valid
   | malformed
-  | resourceLimit (resource : Resource)
+  | tooDeep
 
 /-- Perform the same shape, typed-reference, equality, and structural-depth
 checks used by admission, without mutating the live engine. Structural
@@ -1246,15 +1302,13 @@ a malformed proposal cannot disguise itself as a recoverable depth loss. -/
 def checkInstantiationProposal (program : Program) (depths : Array Nat)
     (maxNodeDepth : Nat) (request : InstantiationRequest) : ProposalCheck :=
   let baseSize := program.nodes.size
-  let validationDepth := depths.foldl Nat.max 0 + request.nodes.length
-  match resolveDrafts baseSize validationDepth program depths [] request.nodes with
+  match resolveDrafts baseSize program depths [] request.nodes with
   | .error .badReferenceOrShape => .malformed
-  | .error .nodeDepth => .malformed
   | .ok (program, depths, resolved) =>
       if (resolveRequestedPairs baseSize resolved program request.equalities).isNone then
         .malformed
-      else if depths.any (fun depth => maxNodeDepth < depth) then
-        .resourceLimit .nodeDepth
+      else if !appendedDepthsWithin baseSize maxNodeDepth depths then
+        .tooDeep
       else
         .valid
 
@@ -1370,16 +1424,9 @@ def installCandidates (action : Action) :
 def suggestionRoom (state : Engine Fact) : Nat :=
   state.limits.maxRetainedSuggestions - state.suggestions.size
 
-/-- Exact result of validating and capacity-filtering one reply's suggestions.
-`kept` retains source order. `dropped` contains both capacity overflow and
-individually unaffordable structural proposals, also in source order. -/
-structure SuggestionPlan where
-  kept : List Suggestion := []
-  dropped : List Suggestion := []
-
 /-- A malformed suggestion which had room to enter policy state invalidates
-the whole reply. Resource-limited structural suggestions are instead
-recoverable losses recorded in `SuggestionPlan.dropped`. -/
+the whole reply. Depth-limited structural suggestions are instead recoverable
+losses recorded in `SuggestionPlan.dropped`. -/
 inductive SuggestionCheck where
   | ready (plan : SuggestionPlan)
   | malformed
@@ -1392,7 +1439,8 @@ existing rule that only work selected for retention can invalidate a reply. -/
 def classifySuggestions (state : Engine Fact) :
     Nat -> List Suggestion -> SuggestionCheck
   | _, [] => .ready {}
-  | 0, suggestions => .ready { dropped := suggestions }
+  | 0, suggestions =>
+      .ready { dropped := suggestions.map SuggestionDrop.capacity }
   | room + 1, suggestion :: suggestions =>
       let checked :=
         match suggestion with
@@ -1406,10 +1454,11 @@ def classifySuggestions (state : Engine Fact) :
           match classifySuggestions state room suggestions with
           | .malformed => .malformed
           | .ready plan => .ready { plan with kept := suggestion :: plan.kept }
-      | .resourceLimit _ =>
+      | .tooDeep =>
           match classifySuggestions state (room + 1) suggestions with
           | .malformed => .malformed
-          | .ready plan => .ready { plan with dropped := suggestion :: plan.dropped }
+          | .ready plan =>
+              .ready { plan with dropped := .depth suggestion :: plan.dropped }
 
 /-- Apply the live retained-suggestion capacity to one already surface-bounded
 reply. Engine admission and policy completeness accounting both use this exact
@@ -1433,7 +1482,7 @@ def submit (state : Engine Fact) (reply : Reply Fact) : ReplyResult Fact :=
       else
       match reply.outcome with
       | .noChange _ | .inapplicable | .resourceLimit _ | .failed _ =>
-          .accepted (state.outcomeNegative reply.outcome)
+          .accepted {} (state.outcomeNegative reply.outcome)
       | .success candidates suggestions _ =>
           let base := state.finishReply
           if !listWithin state.limits.maxOutcomeCandidates candidates then
@@ -1466,7 +1515,11 @@ def submit (state : Engine Fact) (reply : Reply Fact) : ReplyResult Fact :=
                               { base.metrics with
                                 candidates := base.metrics.candidates + candidates.length
                                 droppedSuggestions :=
-                                  base.metrics.droppedSuggestions + plan.dropped.length } }
+                                  base.metrics.droppedSuggestions + plan.dropped.length
+                                capacityDrops :=
+                                  base.metrics.capacityDrops + plan.capacityDrops
+                                depthDrops :=
+                                  base.metrics.depthDrops + plan.depthDrops } }
                         match installCandidates action working candidates with
                         | .error (_, some budget, _) =>
                             .factResourceLimit budget base
@@ -1475,7 +1528,7 @@ def submit (state : Engine Fact) (reply : Reply Fact) : ReplyResult Fact :=
                         | .ok (working, changed) =>
                             match working.wakeNodes changed with
                             | .error resource => .resourceLimit resource base
-                            | .ok next => .accepted next
+                            | .ok next => .accepted plan next
 
 def transportUpdate (target source : NodeId) (targetVersion sourceVersion : Nat) :
     NarrowResult Fact -> Except EqualityFactError (Option (TransportUpdate Fact))
@@ -1580,7 +1633,10 @@ end Engine
 
 universe u
 
-/-- Why a bounded request/reply run stopped. -/
+/-- Why a bounded request/reply run stopped. `saturated` means only that the
+raw engine queue is empty: this driver neither selects retained suggestions
+nor carries policy completeness, so it cannot certify a proof-search fixed
+point. -/
 inductive RunStop where
   | saturated
   | contradiction
@@ -1611,7 +1667,7 @@ def drive {Cache : Type u}
       | .request request awaiting =>
           let (outcome, cache) := invoke cache request
           match awaiting.submit (request.action.reply outcome) with
-          | .accepted next => drive invoke fuel next cache
+          | .accepted _ next => drive invoke fuel next cache
           | .invalid error next => { state := next, cache, stop := .invalidReply error }
           | .resourceLimit resource next =>
               { state := next, cache, stop := .engineResource resource }
@@ -1802,15 +1858,15 @@ def admitRetained (state : Engine Fact)
           .invalid (.staleSuggestion retained.action.programVersion state.programVersion) state
         else
           let baseSize := state.program.nodes.size
-          match resolveDrafts baseSize state.limits.maxNodeDepth state.program state.depths
-              [] request.nodes with
+          match resolveDrafts baseSize state.program state.depths [] request.nodes with
           | .error .badReferenceOrShape => .invalid .badReferenceOrShape state
-          | .error .nodeDepth => .resourceLimit .nodeDepth state
           | .ok (program, depths, resolved) =>
               let equalityPairs? :=
                 resolveRequestedPairs baseSize resolved program request.equalities
               if equalityPairs?.isNone then
                 .invalid .invalidEquality state
+              else if !appendedDepthsWithin baseSize state.limits.maxNodeDepth depths then
+                .resourceLimit .nodeDepth state
               else
               let substitution := actionSubstitution retained.action
               let instanceKey : InstanceKey :=

--- a/HexInterval/Experiment/Propagator.lean
+++ b/HexInterval/Experiment/Propagator.lean
@@ -467,6 +467,8 @@ recomputes generations and assigns concrete node identifiers. -/
 structure InstantiationRequest where
   key : Nat
   triggers : List NodeId
+  /-- Legacy package-side estimate retained for diagnostics.  Admission never
+  trusts this value: generation is recomputed from engine-owned dependencies. -/
   claimedGeneration : Nat
   nodes : List ProposedNode
   equalities : List ProposedEquality
@@ -1451,7 +1453,6 @@ inductive AdmissionError where
   | staleSuggestion (proposed current : Nat)
   | oversizedProposal
   | badReferenceOrShape
-  | generationMismatch (claimed actual : Nat)
   | invalidEquality
   | invalidCompiledProgram
   deriving DecidableEq, Repr
@@ -1541,12 +1542,13 @@ weaken either generation accounting or structural duplicate detection. -/
 def actionSubstitution (action : Action) : List NodeId :=
   dedupList (action.node :: action.inputs.map (fun input => input.node))
 
-/-- Recompute instantiation depth from the authoritative invocation, every old
-node named by the proposal, and every old node reached through a CSE hit. -/
-def inferredGeneration? (generations : Array Nat) (baseSize : Nat)
-    (action : Action) (request : InstantiationRequest) (resolved : List NodeId) : Option Nat := do
-  let references := actionSubstitution action ++ requestExistingRefs request ++
-    resolved.filter (fun node => node.index < baseSize)
+/-- Recompute logical instantiation depth from the authoritative invocation and
+every explicitly existing node named by the proposal.  Proposed nodes are
+outputs of this instance, so whether one happens to CSE-hit an already
+materialized node cannot turn it into a new proof dependency. -/
+def inferredGeneration? (generations : Array Nat)
+    (action : Action) (request : InstantiationRequest) : Option Nat := do
+  let references := actionSubstitution action ++ requestExistingRefs request
   let mut greatest := 0
   for node in references do
     let generation <- generations[node.index]?
@@ -1554,14 +1556,14 @@ def inferredGeneration? (generations : Array Nat) (baseSize : Nat)
   some (greatest + 1)
 
 /-- Recompute the generation advertised to policy from current engine-owned
-structure.  The rule's claimed generation is deliberately not trusted. -/
+structure.  The package's legacy hint is deliberately not trusted. -/
 def Engine.instantiationGeneration? (state : Engine Fact)
     (retained : RetainedSuggestion) : Option Nat := do
   if !state.actionFresh retained.action then none else pure ()
   let .instantiate request := retained.suggestion | none
   let baseSize := state.program.nodes.size
-  let (_, resolved) <- resolveDrafts baseSize state.program [] request.nodes
-  inferredGeneration? state.generations baseSize retained.action request resolved
+  let _ <- resolveDrafts baseSize state.program [] request.nodes
+  inferredGeneration? state.generations retained.action request
 
 /-- Treat equality endpoints as unordered for structural deduplication. -/
 def EqualityEdge.sameEndpoints (edge : EqualityEdge) (left right : NodeId) : Bool :=
@@ -1692,14 +1694,11 @@ def admitRetained (state : Engine Fact)
               if state.instances.contains instanceKey then
                 duplicateInstance state
               else
-                match inferredGeneration? state.generations baseSize retained.action request resolved with
+                match inferredGeneration? state.generations retained.action request with
                 | none => .invalid .badReferenceOrShape state
                 | some generation =>
-                    if request.claimedGeneration != generation then
-                      .invalid (.generationMismatch request.claimedGeneration generation) state
-                    else
-                      match resolveEqualities baseSize generation retained.action program resolved
-                          state.equalities request.equalities with
+                    match resolveEqualities baseSize generation retained.action program resolved
+                        state.equalities request.equalities with
                       | none => .invalid .invalidEquality state
                       | some (equalityIds, equalities) =>
                           let addedNodes := program.nodes.size - baseSize

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -581,6 +581,10 @@ inspection does not become a hidden fact dependency.
 `ProgramView.findOp?` resolves a stable `OpKey` to this snapshot's local
 `OpId` and exact signature; package assembly order is never authoritative for
 frontend node identifiers.
+`ProgramView.depth?` exposes the engine-owned structural depth as advisory
+matcher data, so a package may avoid proposing an alternate which is already
+obviously too deep. It is not admission authority: the engine recomputes the
+complete proposed suffix against its current depth table.
 Anchor-local inspection adds no wakeup beyond the declared fact slots; a rule
 which reads the whole view declares `watchesProgram`, making program extension
 an explicit dependency.
@@ -656,19 +660,26 @@ ordinary interval facts. Typical uses include:
 
 An instantiation proposal is retained under the selected action's versioned
 `RuleKey`; its own `key : Nat` is only an untrusted family label for replay and
-is not canonical authority. The proposal also contains replay-facing trigger
-data, new SSA instructions, and equality or derived-fact recipes. The engine
-derives the canonical substitution from the selected action's anchor and
-declared input facts; a registry-provided trigger list cannot weaken resource
-accounting or change structural instance identity.
+is not canonical authority. The proposal contains new SSA instructions,
+equality or derived-fact recipes, and their opaque replay payloads. The engine
+derives the canonical substitution from the selected action's anchor,
+declared input facts, and existing nodes explicitly referenced by those
+instructions and recipes.
 
-Before any instantiation enters retained policy state, reply admission resolves
-its references, checks operation arities and domains, topological order, scope
-visibility, equality endpoints, and structural depth, and applies the same CSE
-rule used by final admission. A malformed request returns the named
-`ReplyError.malformedProposal`; a depth overrun returns the engine-owned
-`Resource.nodeDepth`. Neither is retained and neither may later disappear as a
-false “stale” policy event. Full admission revalidates against the current
+For every suggestion which still has retained capacity, reply admission
+resolves its references, checks operation arities and domains, topological
+order, scope visibility, equality endpoints, and structural depth, and applies
+the same CSE rule used by final admission. A malformed request returns the
+named `ReplyError.malformedProposal` and invalidates the whole reply before
+candidate facts or suggestions commit. A structurally valid request whose new
+nodes exceed `maxNodeDepth` is instead an individually recoverable loss: it is
+dropped and counted, does not consume retained capacity, and later affordable
+suggestions in the same reply remain eligible. The engine and policy wrapper
+use one exact classification of the kept and dropped lists; losing an
+instantiation marks policy completeness false, so the filtered reply cannot
+manufacture saturation. Once retained capacity is exhausted, the remaining
+suffix is dropped without structural validation, as it cannot enter live
+state. Full admission revalidates a selected proposal against the current
 append-only program before atomically updating consumer and rule indexes and
 retaining opaque recipe identifiers. Policy view construction consequently
 checks freshness and engine-owned generation without repeating draft
@@ -683,11 +694,7 @@ theorem instance or per generated product; that choice remains open below. In
 either case, a new expression is not trusted merely because a trigger matched.
 
 The authoritative references are the action substitution and old nodes named
-explicitly as existing inputs by proposed drafts or equalities. The proposal's
-`triggers` list remains replay-facing data and contributes neither to the
-engine `InstanceKey` nor to payload-erased policy identity. Allowing an
-untrusted trigger ordering or superset to partition otherwise identical offers
-would make scheduling depend on non-semantic package metadata. A proposed node
+explicitly as existing inputs by proposed drafts or equalities. A proposed node
 remains an output of the theorem instance when it CSE-hits an already
 materialized node: storage reuse cannot manufacture a proof dependency. Thus
 the same append-stable proposal has the same logical generation before and
@@ -738,7 +745,9 @@ caps this measure independently of `maxGeneration`. This distinction is
 essential for whole-program matchers: a matcher can repeatedly propose
 `g(anchor)`, `g(previous)`, and an ever longer CSE-hit prefix while every
 theorem instance remains generation one. The growing-tower canary admits the
-prefix through depth three and rejects the depth-four reply before retention.
+prefix through depth three, then drops the depth-four proposal without
+aborting the rest of its reply; policy accounting records that lost
+instantiation as incomplete.
 
 The general experiment activates proposed equality edges as indexed,
 replayable search contractors: improving either endpoint wakes transport in
@@ -1149,12 +1158,14 @@ not cached as mathematical inapplicability; a `failed` code is an opaque
 diagnostic identifier rather than a cost magnitude. Rules do not promise that
 greater effort always gives a tighter answer. The solver intersects every
 result with existing facts, measures the actual improvement, and learns from
-that observation. Retained suggestions are advisory: when their cumulative
-storage cap is full, the engine retains the bounded prefix, records how many
-were dropped, and still commits independently valid candidate facts. Before
-that suffix disappears, the policy wrapper checks its variants: dropping a
-retry or instantiation marks propagation incomplete, while dropping only
-split advice preserves fixed-point completeness.
+that observation. Retained suggestions are advisory: the engine computes one
+bounded kept/dropped classification, records how many were dropped, and still
+commits independently valid candidate facts. Capacity overflow drops the
+remaining suffix; an individually depth-limited instantiation is filtered
+without consuming capacity, allowing later affordable advice to survive.
+Before dropped work disappears, the policy wrapper checks its variants:
+dropping a retry or instantiation marks propagation incomplete, while dropping
+only split advice preserves fixed-point completeness.
 
 The base `Program` is static after validation. Generic cheap alternates may be
 present before search, and `rewrite` only changes which form in the current
@@ -2146,8 +2157,11 @@ typical, boundary, and adversarial inputs. In particular it includes:
   structural depths are identical in either order;
 - a genuine `watchesProgram` matcher which proposes an increasingly long
   generation-one tower: two extensions CSE-hit their old prefixes, while the
-  depth-four reply is rejected before retention by an exact
-  `maxNodeDepth = 3` cap;
+  depth-four proposal is dropped under an exact `maxNodeDepth = 3` cap without
+  aborting unrelated rule processing;
+- one mixed reply in which a candidate fact, an affordable instantiation, and
+  a later retry survive an over-depth instantiation between them; the loss is
+  counted and policy completeness becomes false;
 - reply-boundary rejection of malformed structural/equality proposals, with no
   retained offer that can later be silently tombstoned;
 - an end-to-end concrete registry run in which `x * (1 - x)` first receives
@@ -2182,8 +2196,8 @@ typical, boundary, and adversarial inputs. In particular it includes:
 - program-extension validation that rejects bad topology, duplicate canonical
   keys, invisible branch-local nodes, invalid equality endpoints, and an
   instantiation beyond each generation budget;
-- deterministic deduplication of two triggers proposing the same expression
-  and equality edge in different orders;
+- deterministic deduplication of two rules proposing the same expression and
+  equality edge in different orders;
 - two successive opaque instantiations which add absent expressions, activate
   their registered propagators, recompute generations one and two, and leave
   the previous snapshot intact at each one-step-short limit;

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -585,6 +585,13 @@ frontend node identifiers.
 matcher data, so a package may avoid proposing an alternate which is already
 obviously too deep. It is not admission authority: the engine recomputes the
 complete proposed suffix against its current depth table.
+Structural inspection is restricted by a provenance contract. A matcher may
+follow nodes determined by its action anchor. Every additional side node which
+affects the theorem instance must be present either as a declared fact input
+or as an explicit `existing` reference in the proposal. Those are the two
+places engine-owned generation accounting can see it; merely calling
+`ProgramView.node?` on an arbitrary identifier does not make that node a
+generation dependency.
 Anchor-local inspection adds no wakeup beyond the declared fact slots; a rule
 which reads the whole view declares `watchesProgram`, making program extension
 an explicit dependency.
@@ -666,20 +673,24 @@ derives the canonical substitution from the selected action's anchor,
 declared input facts, and existing nodes explicitly referenced by those
 instructions and recipes.
 
-For every suggestion which still has retained capacity, reply admission
-resolves its references, checks operation arities and domains, topological
-order, scope visibility, equality endpoints, and structural depth, and applies
-the same CSE rule used by final admission. A malformed request returns the
-named `ReplyError.malformedProposal` and invalidates the whole reply before
-candidate facts or suggestions commit. A structurally valid request whose new
-nodes exceed `maxNodeDepth` is instead an individually recoverable loss: it is
-dropped and counted, does not consume retained capacity, and later affordable
-suggestions in the same reply remain eligible. The engine and policy wrapper
-use one exact classification of the kept and dropped lists; losing an
-instantiation marks policy completeness false, so the filtered reply cannot
-manufacture saturation. Once retained capacity is exhausted, the remaining
-suffix is dropped without structural validation, as it cannot enter live
-state. Full admission revalidates a selected proposal against the current
+For every suggestion which still has retained capacity, reply admission first
+resolves its complete uncapped draft, checks operation arities and domains,
+topological order, scope visibility and equality endpoints, and applies the
+same CSE rule used by final admission. Only after that full structural check
+does it compare `maxNodeDepth` with the freshly appended depth suffix; existing
+program depths were validated when their snapshot was created. A malformed
+request returns the named `ReplyError.malformedProposal` and invalidates the
+whole reply before candidate facts or suggestions commit. A structurally valid
+request whose new nodes exceed `maxNodeDepth` is instead an individually
+recoverable loss: it is dropped and counted, does not consume retained
+capacity, and later affordable suggestions in the same reply remain eligible.
+The engine returns one exact kept/drop-reason plan with the accepted state.
+`RuleObservation` preserves that same plan, and policy reads it directly
+rather than rerunning structural validation. Losing an instantiation marks
+policy completeness false, so the filtered reply cannot manufacture
+saturation. Once retained capacity is exhausted, the remaining suffix is
+dropped without structural validation, as it cannot enter live state. Full
+admission revalidates a selected proposal against the current
 append-only program before atomically updating consumer and rule indexes and
 retaining opaque recipe identifiers. Policy view construction consequently
 checks freshness and engine-owned generation without repeating draft
@@ -746,8 +757,10 @@ essential for whole-program matchers: a matcher can repeatedly propose
 `g(anchor)`, `g(previous)`, and an ever longer CSE-hit prefix while every
 theorem instance remains generation one. The growing-tower canary admits the
 prefix through depth three, then drops the depth-four proposal without
-aborting the rest of its reply; policy accounting records that lost
-instantiation as incomplete.
+aborting the rest of its reply. Its raw `drive` result is queue-saturated,
+which deliberately says nothing about retained suggestions or propagation
+completeness. A separate policy canary consumes the exact engine-issued drop
+plan and records the lost instantiation as incomplete.
 
 The general experiment activates proposed equality edges as indexed,
 replayable search contractors: improving either endpoint wakes transport in
@@ -760,6 +773,13 @@ retry, instantiation selection, and subdivision explicit state transitions
 over the same generic application protocol. Neither limitation is a reason to
 specialize the scheduler to rational operations or to bake function semantics
 into it.
+
+The raw `Propagator.drive` helper is only a bounded request/reply and equality
+worklist harness. Its `RunStop.saturated` constructor means that this queue is
+empty; the helper neither selects retained suggestions nor carries the policy
+incomplete bit. Only `Policy.State` and its driver may turn an empty frontier
+into proof-search saturation, and they return `unknown` when any
+closure-affecting suggestion was dropped or dismissed.
 
 ### Equality activation
 
@@ -1159,13 +1179,15 @@ diagnostic identifier rather than a cost magnitude. Rules do not promise that
 greater effort always gives a tighter answer. The solver intersects every
 result with existing facts, measures the actual improvement, and learns from
 that observation. Retained suggestions are advisory: the engine computes one
-bounded kept/dropped classification, records how many were dropped, and still
-commits independently valid candidate facts. Capacity overflow drops the
-remaining suffix; an individually depth-limited instantiation is filtered
-without consuming capacity, allowing later affordable advice to survive.
-Before dropped work disappears, the policy wrapper checks its variants:
-dropping a retry or instantiation marks propagation incomplete, while dropping
-only split advice preserves fixed-point completeness.
+bounded kept/drop-reason classification and still commits independently valid
+candidate facts. Metrics record the total omitted suggestions and separate
+capacity and structural-depth counts; the two category counts sum to the
+total. Capacity overflow drops the remaining suffix; an individually
+depth-limited instantiation is filtered without consuming capacity, allowing
+later affordable advice to survive. The exact plan accompanies the accepted
+reply into the policy observation. Dropping a retry or instantiation marks
+propagation incomplete, while dropping only split advice preserves
+fixed-point completeness.
 
 The base `Program` is static after validation. Generic cheap alternates may be
 present before search, and `rewrite` only changes which form in the current
@@ -1335,6 +1357,8 @@ structure RuleObservation (Fact : Type) where
   changes       : Array (FactDelta Fact)
   contradiction : Bool
   cost          : CostObservation
+  suggestionPlan      : SuggestionPlan
+  emittedSuggestions : Array OfferId
 
 inductive EqualityOutcome
   | noChange
@@ -2158,10 +2182,15 @@ typical, boundary, and adversarial inputs. In particular it includes:
 - a genuine `watchesProgram` matcher which proposes an increasingly long
   generation-one tower: two extensions CSE-hit their old prefixes, while the
   depth-four proposal is dropped under an exact `maxNodeDepth = 3` cap without
-  aborting unrelated rule processing;
+  aborting unrelated rule processing; the raw driver reports queue saturation,
+  not policy completeness;
 - one mixed reply in which a candidate fact, an affordable instantiation, and
   a later retry survive an over-depth instantiation between them; the loss is
   counted and policy completeness becomes false;
+- exact-capacity replies showing that an over-depth proposal does not consume
+  the sole retained slot, while a malformed instantiation already in the
+  capacity suffix is intentionally dropped without validation and marks
+  policy incomplete rather than invalidating the useful prefix;
 - reply-boundary rejection of malformed structural/equality proposals, with no
   retained offer that can later be silently tombstoned;
 - an end-to-end concrete registry run in which `x * (1 - x)` first receives

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -1,12 +1,14 @@
 # hex-interval (exact interval data and budgeted propagation search, Mathlib-free)
 
 `hex-interval` is the Mathlib-free computational library for interval
-arithmetic. It represents exact dyadic bounds, maintains the bounds of a
-shared expression program, schedules propagation and refinement actions, and
-records the successful search as a compact derivation trace. It does not
-interpret a program as a real-valued function and it does not construct Lean
-proof terms. Those tasks belong to
-[hex-interval-mathlib](../../SPEC/Libraries/hex-interval-mathlib.md).
+arithmetic. Its generic engine treats domains, operations, and facts as
+opaque: it maintains a shared expression program, schedules propagation and
+refinement actions, and records successful search steps. Mathlib-free function
+packages may associate stable opaque keys with callbacks that compute
+candidate interval facts, but those candidates remain untrusted search data.
+Only [hex-interval-mathlib](../../SPEC/Libraries/hex-interval-mathlib.md)
+interprets the keys as real-valued functions, reconstructs each retained step
+from a soundness theorem, and constructs Lean proof terms.
 
 The library is intended to support a standalone `interval` tactic. Integration
 with `grind` is not part of this development. The scheduler and rule protocol
@@ -60,6 +62,19 @@ worklist, and bounded extension mechanism, exercised with opaque operation
 keys. Dyadic, rational, elementary-function, and Mathlib theorem backends plug
 into that framework; backend-specific replay experiments do not block or
 define the scheduler architecture.
+
+The active implementation gate is to harden and compare the first complete
+arbitrary-function vertical: independently assembled forward and backward
+propagators, function-owned retries and split suggestions, structural
+instantiation, equality transport, and external policy choice must all run
+through the same engine protocol. The centered-product and reciprocal canaries
+are evidence for that interface, not a reason to declare it final.
+Exact-rational planning, projection, replay, and optimization remain deferred
+while package assembly, cache ownership, payload freezing, structural
+matching, and policy traces are still being tested; no registry, scheduler,
+instantiation, or policy interface may depend on the eventual rational
+representation. The checked dyadic interval domain is sufficient as the
+endpoint substrate for these framework experiments.
 
 “Compiled search” means ordinary elaboration-time Lean execution of the
 untrusted planner. It does not authorize `precompileModules := true`; the Lake
@@ -234,11 +249,18 @@ That check uses exact endpoint arithmetic: exact dyadic arithmetic in the
 initial candidate, or the selected exact comparison if the working-endpoint
 experiment adopts rationals.
 
-### Exact rational source facts
+### Non-dyadic source facts (deferred backend candidate)
 
-Lean goals often contain rational constants such as `1 / 3`, which are not
-dyadic. The frontend retains each such hypothesis as an exact source fact. At
-working precision `p`, it asks this library for an outward dyadic projection:
+Some exact representation of non-dyadic source cuts will eventually be needed
+because goal constants need not be dyadic. The table-and-outward-projection
+design below is one deferred backend candidate, not an active framework
+dependency or a frozen representation choice. It is not implemented further
+until the arbitrary-function package, replay, and policy boundaries above have
+stabilized under experiment.
+
+In this candidate, Lean goals containing rational constants such as `1 / 3`
+retain each such hypothesis as an exact source fact. At working precision `p`,
+the frontend asks this library for an outward dyadic projection:
 
 - a rational lower bound is rounded down;
 - a rational upper bound is rounded up;
@@ -296,9 +318,10 @@ measure compiled certificate production, interning, serialization, bounded
 decoding, table validation, and replay; they do not compare verifier-only work
 with end-to-end normalization as though the workloads were equal.
 
-The immediate rational vertical first projects the centered certificate to the
-endpoint-erased structural skeleton below and requires exact skeleton equality
-for every Dyadic/rational comparison. Its phase boundary is:
+When this backend layer resumes, its first vertical projects the centered
+certificate to the endpoint-erased structural skeleton below and requires
+exact skeleton equality for every Dyadic/rational comparison. Its phase
+boundary is:
 
 ```text
 load structural skeleton
@@ -535,20 +558,24 @@ operation, node, arity, and generation limits. Thus an external shape rule can
 follow a product argument to a nested difference, compare opaque operation
 keys, recover the repeated `NodeId`, and compute the claimed generation for a
 proposal. It still receives facts only for its registration's declared watch
-slots. Structural inspection does not become a hidden fact dependency and
-does not affect wakeups.
+slots. Structural inspection does not become a hidden fact dependency.
+Anchor-local inspection adds no wakeup beyond the declared fact slots; a rule
+which reads the whole view declares `watchesProgram`, making program extension
+an explicit dependency.
 
 `ProgramView.programVersion` equals the engine-owned version in the action for
 that invocation. An append-only extension creates subsequent requests with
-the new arrays and version, but does not by itself invalidate an earlier
-instantiation proposal: if its concrete application and all declared fact
-versions remain fresh, admission resolves its references, CSE hits, types,
-equalities, and generation again against the current validated program. A
-meaning-changing application replacement or watched-fact change still makes
-the action stale. Policy selections made against a current snapshot retain
-their separate exact program-version guard. The external registry assigns
-meaning to keys such as product, difference, or a distinguished constant. The
-engine supplies only exact lookups and never embeds those meanings.
+the new arrays and version. An anchor-local proposal may remain fresh when its
+concrete application and declared fact versions are unchanged; admission still
+resolves references, CSE hits, types, equalities, and generation against the
+current validated program. A `watchesProgram` action instead requires the exact
+program version: extension stales its old proposal and requeues the existing
+application to obtain a fresh view. A meaning-changing application replacement
+or watched-fact change also makes an action stale. Policy selections made
+against a current snapshot retain their separate exact program-version guard.
+The external registry assigns meaning to keys such as product, difference, or
+a distinguished constant. The engine supplies only exact lookups and never
+embeds those meanings.
 
 This full bounded view is the smallest flexible candidate currently exercised,
 not a frozen production interface. A compiled shape-pattern registration could
@@ -559,6 +586,19 @@ snapshot and anchor. Experiments should compare these against the view on
 large shared DAGs and after repeated extensions. Any replacement must retain
 the same separation: unrestricted validated structure is acceptable, but
 facts and their versions remain available only through explicit watch slots.
+
+The first concrete acceptance vertical uses two deliberately different
+examples. For `z = 2*y`, the forward rule is initially inapplicable on the
+one-sided-unbounded `y`, while the singleton-factor backward rule contracts
+`z ∈ (2,6]` to `y ∈ (1,3]` and wakes the forward rule again. For
+`x * (1 - x)` with `x ∈ [0,1]`, ordinary compositional propagation gives only
+`[0,1]`; a fact-free structural rule recognizes the repeated node and proposes
+`1/4 - (x - 1/2)^2`. Admission structurally validates the new node and
+equality endpoints and retains an opaque payload for later semantic replay.
+The alternate callback returns the candidate `[0,1/4]`, and the engine's
+equality contractor narrows the original product to that fact. The identity
+itself remains an obligation for the companion checker; neither semantic
+pattern is built into the engine.
 
 The caller supplies nullary nodes for free variables and named constants.
 Unknown free variables begin with the whole interval. Hypotheses add source
@@ -592,7 +632,9 @@ ordinary interval facts. Typical uses include:
 - instantiating a monotonicity theorem by adding product or difference nodes
   that were absent from the original goal.
 
-An instantiation proposal contains a versioned rule key, replay-facing trigger
+An instantiation proposal is retained under the selected action's versioned
+`RuleKey`; its own `key : Nat` is only an untrusted family label for replay and
+is not canonical authority. The proposal also contains replay-facing trigger
 data, new SSA instructions, equality or derived-fact recipes, and an untrusted
 claimed generation. The engine derives the canonical substitution from the
 selected action's anchor and declared input facts; a registry-provided trigger
@@ -602,11 +644,30 @@ visibility, and every referenced input; recomputes generation from the
 engine-owned action provenance and generated dependencies,
 rejecting a mismatch or over-budget descendant; deduplicates expressions by
 the same canonical CSE key as the base program; updates consumer and rule
-indexes; and freezes the proof recipe for replay. Base nodes have generation
-zero. The production representation may record generation per theorem
+indexes; and retains an opaque recipe identifier. Production must freeze every
+referenced recipe value before replay. Base nodes have generation zero. The
+production representation may record generation per theorem
 instance or per generated product; that choice remains open below. In either
 case, a new expression is not trusted merely because a trigger matched or
 labeled itself generation zero.
+
+The role of `claimedGeneration` remains an explicit experiment. The current
+canary requires the registry's exact prediction to equal the engine's
+recomputation, which catches stale or incomplete proposal logic but forces
+each shape rule to mirror part of admission. Alternatives are an advisory
+claim retained only for replay diagnostics, a checked lower/upper bound, or an
+engine-exported computation over `ProgramView` shared by proposal and
+admission. The production interface must choose one after CSE-hit and
+post-extension tests; exact prediction by every package is not frozen merely
+because the first centered rule can compute it.
+
+In the current centered canary, `centeredGeneration?` deliberately mirrors the
+engine's `inferredGeneration?`: the authoritative references are the action
+substitution, old nodes referenced by proposed drafts or equalities, and old
+nodes reached by CSE. The proposal's `triggers` list is replay-facing data and
+does not contribute to generation. Both policy offer construction and
+admission recompute the value against the current append-only program, so a
+package's exact claim remains a checked canary rather than authority.
 
 The current centered-product D2 vertical is deliberately narrower than this
 general recurrence. Its `Center.inferredGeneration` only recognizes one
@@ -862,6 +923,39 @@ must not recursively decide which algorithm computes an expression's bound.
 The registry may contain several rules for one head symbol, and the policy may
 try or combine all of them.
 
+A registry snapshot is assembled from independently upgradeable function
+packages. The current canary chooses an ordered `Array (Package Fact)`. Each
+package existentially owns one private `Cache` shared by its handlers and
+contributes owned operation signatures, exact external signatures required by
+its matchers, `(Registration, callback)` pairs, and a package-owned limit
+preflight. A handler head must be declared as owned or required.
+`Registry.buildWithin` bounds package and metadata counts plus arities before
+flattening, builds a `Route` from each compact `RuleId` back to its package and
+handler, and rejects undeclared heads and duplicate `OpKey`s or `RuleKey`s.
+Program size and arity are bounded before exact signature lookup. The checked
+start then validates every owned and required signature against the final
+frontend program, runs each package's configuration preflight, and starts the
+engine with the registry's exact flattened registration array.
+
+`Registry.invoke` cross-checks the flattened registration, routed handler
+metadata, and structural projection of an engine-produced request before
+entering the callback, then replaces only the selected package's cache. The
+engine still authenticates the pending serial, application, fact values, and
+versions; direct registry invocation is not an authentication boundary.
+
+The current package type does not yet carry replay schemas. A production
+checked assembly API should return operation metadata, registrations, callback
+routes, configuration validation, and payload-freezing/replay schemas as one
+coherent snapshot. Whether that snapshot retains existential packages,
+compiles one dispatch function, supports hot replacement, or uses another
+lookup structure remains experimental. The present experiment exposes its
+constructors and returns a separable engine/registry pair, so its checked start
+is a conformance canary rather than the final encapsulation boundary. A
+production session should prevent accidentally pairing an engine with an
+unrelated registry; a different callback implementation under the same
+versioned rule schema remains valid only when its retained payloads replay
+under that schema.
+
 The explicit registration and validation boundary is fixed. Discovery and
 scheduling above it remain empirical: one arm uses an incremental registry
 worklist to share facts and retain state, while a second traverses the same
@@ -870,17 +964,42 @@ Neither arm uses recursive typeclass search or bypasses rule validation. The
 benchmark compares these discovery styles rather than preselecting one for
 every structural goal; a hybrid may use the structural loop as one action.
 
-Rule-private caches can have arbitrary Lean types. For that reason the
-Mathlib-free library does not store them in a heterogeneous array. It exposes
-a request-and-reply state machine. Binding first expands relative ports into
-concrete applications, and a registry request exposes exactly the declared
-read facts and write targets. It does not provide an unrestricted fact getter:
-a hidden read would be absent from the dependency index and could miss a
-required wakeup.
+Rule-private caches can have arbitrary Lean types. The engine stores none of
+them. In the current canary, heterogeneous caches are existentially hidden
+inside the registry's `Array (Package Fact)`, and the resulting
+`Registry Fact : Type 1` is threaded as the single external cache through
+either the FIFO or policy driver. Handlers in one package share that package's
+cache; handlers in different packages may use unrelated types. This first
+scope-free run has one registry cache for the whole run. Before branching is
+implemented, production must choose branch ownership or explicit
+`ScopeId`/semantic cache keys and test cross-branch reuse separately.
+
+Cache contents are a performance optimization, not a hidden mathematical
+dependency. For the same request and logical budget, a memoization hit and
+miss must produce the same observable outcome. If package state can change
+applicability or a candidate fact, that state needs an explicit versioned
+dependency and wakeup rule; silently sharing it between handlers would make
+fixed points depend on schedule.
+
+Binding still expands relative ports into concrete applications, and every
+registry request exposes exactly the declared read facts and write targets. It
+provides no unrestricted fact getter: a hidden fact read would be absent from
+the dependency index and could miss a required wakeup.
+
+A registration whose matcher depends on the whole `ProgramView` sets
+`watchesProgram`. Every append-only extension then stales its old action and
+requeues all existing applications of that registration. This coarse trigger
+is the first grind-like instantiation mechanism: a matcher that was previously
+inapplicable can observe expressions introduced by another package. Ordinary
+anchor-local registrations remain append-stable. Compiled structural patterns
+or more selective operation-key triggers remain alternatives to compare once
+the behavior is established.
 
 1. The solver produces an `Action` naming a program snapshot, concrete rule
    application, anchor, declared input fact versions, effort, and action kind.
-2. The companion registry executes the rule and owns its cache.
+2. The external function-package registry executes the routed callback and
+   owns its private cache; the Mathlib companion is responsible for semantic
+   replay, not hot-loop dispatch.
 3. The registry returns an `Outcome` containing candidate facts, alternatives,
    suggestions, cost observations, and an opaque proof recipe identifier.
 4. A reply echoes the request serial, snapshot, and application. A delayed or
@@ -890,9 +1009,11 @@ required wakeup.
    state. It then commits the whole improving batch and wakes the deduplicated
    union of affected applications once. A malformed later candidate or a
    one-step-short fact or queue budget commits none of the batch.
-6. When a fact is accepted, the registry freezes every value needed for replay
-   into an immutable per-run payload arena. The `PayloadId` in the trace points
-   into this arena, never into a mutable or evictable rule cache.
+6. In the production replay protocol, every value needed to justify an
+   accepted fact is frozen into an immutable per-run payload arena, and the
+   retained `PayloadId` points there rather than into a mutable cache. The
+   current canary has only stable recipe identifiers; it does not yet implement
+   this arena, so it is not evidence that payload freezing is solved.
 7. The solver records the snapshot, concrete application, anchor, action kind,
    effort, input versions, target's preceding fact version, target, and frozen
    payload in provenance. The preceding target fact is an explicit dependency
@@ -914,6 +1035,28 @@ such as declared arithmetic work, visited certificate entries, generated
 nodes, or estimated proof nodes. Actual runtime reductions, allocations, and
 wall time are telemetry only: compiler and backend changes can alter them, so
 they cannot influence a reproducible action choice.
+
+A `resourceLimit` diagnostic reports work refused and is not itself a claim
+that this work was performed. The executable protocol therefore checks
+successful and fixed-point `CostObservation` fields against
+`maxObservationValue`, while `resourceLimit` and `failed` identifiers use the
+separate `maxDiagnosticValue`. Negative outcomes contribute no logical cost.
+Fact-domain malformed and resource identifiers cross the same diagnostic cap
+before they can enter reply or equality events.
+The dyadic canary maps its typed preflight failures to small fixed category
+codes rather than copying an arbitrary work magnitude into policy history.
+Whether negative outcomes should also carry a bounded logical cost remains
+open: omitting that cost simplifies the protocol, while including it lets
+policy learning account for unsuccessful probes. Until measured, a registry
+must label its successful cost model as a versioned declared estimate rather
+than present placeholder weights as exact operation counts.
+
+The current recipe and family identifiers are not yet arena indices with a
+checked cardinality bound. `PayloadId.index`, instantiation family labels,
+equality payloads, and custom split-reason numbers therefore remain an explicit
+representation gap. The production payload arena must bound allocation and
+identifier encoding before any of these values enter retained provenance; the
+presence of small named constants in the canary does not solve that problem.
 
 ### Action kinds
 
@@ -948,6 +1091,13 @@ forward/backward contraction, BC-style searches for repeated occurrences,
 targeted shaving, interval Newton, and a global split. Which strength to apply
 is empirical and may depend on occurrence counts, derivative influence,
 observed contraction, and proof cost.
+
+Whether `ActionKind` is only a policy/provenance label or also constrains the
+constructors a callback may return remains open. The current experiment allows,
+for example, an instantiation suggestion from any successfully routed handler;
+a binding design would instead reject a mismatch at reply admission. This must
+be settled together with multi-purpose handlers rather than inferred from the
+first registration names.
 
 An `Outcome` may be `noChange`, `inapplicable`, `resourceLimit`, or `failed`
 without affecting soundness. `resourceLimit` names the exhausted budget and is
@@ -1196,15 +1346,17 @@ structure Policy (Fact : Type) where
 ```
 
 The policy state, like rule-private caches, may have an arbitrary Lean type and
-is owned by the external driver. `Policy.State.select` rechecks the decision serial,
-scope, program version, offer identifier, complete canonical key, eligibility,
-and budgets. It alone freezes current input versions and creates a registry
-`Action`, runs an engine equality contractor, admits a selected instance, or
-emits a resource-checked `SplitPlan`.
-The later scope/branch layer validates domain-specific interiority and creates
-complementary child assumptions. A stale, fabricated, or transplanted
-selection changes no facts, program, frontier membership, or pending action;
-it may consume one bounded decision step and append an audit disposition.
+is owned by the external driver. `Policy.State.select` rechecks the decision
+serial, scope, program version, offer identifier, complete canonical key,
+eligibility, and budgets. It alone freezes current input versions and creates
+a registry `Action`, runs an engine equality contractor, admits a selected
+instance, or emits an endpoint-resource-checked `SplitPlan`. The current driver
+stops and returns that plan; it does not create branches or establish that the
+point is interior. A future scope/branch layer must validate domain-specific
+interiority and construct complementary child assumptions. A stale,
+fabricated, or transplanted selection changes no facts, program, frontier
+membership, or pending action; it may consume one bounded decision step and
+append an audit disposition.
 
 Dirty concrete applications create or refresh invocation offers. Any
 structurally accepted bounded rule report may create engine-indexed retry,
@@ -1218,15 +1370,18 @@ A selected retry prepares a fresh action carrying the bounded effort override;
 it does not mutate the compiled application's registration baseline, so later
 append-only program validation still compares an immutable application prefix.
 
-Each completed selection produces an engine-owned observation: outcome class,
-changed target versions, contradiction status, emitted offer identifiers,
-declared logical work, visited entries, estimated proof nodes, and exact
-resource result. Exact before/after facts may be passed ephemerally in the
-transition event; the engine retains only bounded summaries and trace
-references unless the separately charged observation-byte budget permits
-more. Width reduction and other domain-specific benefits are not inferred by
-the generic scheduler; bounded exact feature extractors may be provided by the
-fact domain or registry and influence search only.
+Each completed rule selection produces an engine-owned observation containing
+the outcome class, actual admitted fact deltas, contradiction status, emitted
+offer identifiers, and the bounded declared `CostObservation` for successful
+or fixed-point reports. Rule-declared refusal and failure identifiers remain
+separately bounded diagnostics, while engine-owned `Resource` stops and
+fact-domain resource identifiers use distinct typed events. The current
+experiment retains exact `FactDelta Fact` values in its event array and has no
+observation-byte budget; that is useful conformance evidence, not a settled
+production storage choice. A later experiment must compare ephemeral exact
+deltas with retained bounded features and explicitly charge any exact values
+kept for policy history. Width reduction and other domain-specific benefits
+are not inferred by the generic scheduler.
 
 The concrete `RuleObservation` shown above records actual admitted deltas
 rather than a rule's claimed gain. Other `PolicyEvent` constructors distinguish
@@ -1241,9 +1396,10 @@ justify silently omitting it.
 observations, instance admission, split preparation, offer additions and
 tombstones, rejected choices, and engine resource stops. `OfferView.summary`
 is merely the current bounded aggregate derived from earlier events, not a
-second observation channel. Every reply-supplied cost and feature integer is
-preflighted against value, count, and encoded-byte caps before it can enter
-policy scoring.
+second observation channel. Successful and fixed-point cost components are
+checked against `maxObservationValue`; candidate, suggestion, and proposal
+counts have separate structural caps, and negative identifiers have their own
+diagnostic cap. The current event protocol has no general encoded-byte cap.
 
 It may be cleaner to normalize the registry result as one bounded `RuleReport`
 containing an outcome tag, candidate list, suggestion list, and cost. That
@@ -1345,12 +1501,15 @@ weak or stale retry. Whether some failure reasons can be proved redundant and
 discarded without that penalty remains an open policy question.
 
 Freshness is offer-specific. An invocation or retry compares the concrete
-application and relevant current input versions. Instantiation initially uses
-the conservative exact program snapshot and then repeats all structural
+application and relevant current input versions. An anchor-local rule remains
+fresh across an unrelated append-only extension. A `watchesProgram` rule also
+requires the exact program version: extension stales its old offer and requeues
+the application against the new snapshot. Instantiation repeats all structural
 admission checks. A split compares its scope, target fact version, and endpoint
-interiority; an unrelated append-only program extension need not stale it.
-Proactive invalidation is an optimization, so selection always rechecks these
-conditions.
+resource bound; an unrelated append-only program extension need not stale it.
+Domain-specific interiority belongs to the later scope/branch validator which
+constructs the complementary children. Proactive invalidation is an
+optimization, so selection always rechecks the conditions it owns.
 
 Policy decisions, retained decision notes, effort, and live frontier size have
 independent deterministic limits. Even a rejected stale selection consumes a
@@ -1358,15 +1517,18 @@ decision step, preventing a faulty policy from looping for free. A rule defines
 the meaning of its own bounded effort ladder: pieces, Taylor degree, reduction
 precision, or another function-specific choice. Different incomparable
 methods remain separate registrations rather than pretending their effort
-numbers share a scale. The engine also bounds every reply-provided effort,
-outcome code, resource report, and `CostObservation` component before it can
-enter policy state. These bounds limit representation size; they do not assign
-cross-rule semantic meaning to an effort or cost number.
+numbers share a scale. The engine bounds action and retry effort, every
+structural suggestion, each `CostObservation` component, and negative
+diagnostic identifiers before they can enter policy state. These independent
+bounds limit representation size; they do not assign cross-rule semantic
+meaning to an effort, diagnostic, or cost number. Payload-arena identifiers
+remain the explicit unfinished exception described above.
 
-The engine bounds every choice attempt and every value it supplies, but it
-cannot force an arbitrary external callback to terminate. Shipped policies are
-structurally fuelled and audited; nontermination of a malicious policy or rule
-registry is outside theorem soundness and produces no proof.
+The engine bounds every choice attempt and the structural, cost, effort, and
+diagnostic values enumerated above, but it cannot force an arbitrary external
+callback to terminate. Shipped policies are structurally fuelled and audited;
+nontermination of a malicious policy or rule registry is outside theorem
+soundness and produces no proof.
 
 Every attempted choice has a bounded audit entry containing the decision
 serial, versioned policy key, expected semantic offer key, bounded note, and
@@ -1397,7 +1559,21 @@ The policy experiment proceeds in replaceable increments:
 4. return exact fact deltas, logical costs, and frontier changes from reply
    admission;
 5. add the external policy driver and compare scan, staged, replay, and
-   versioned-priority implementations on identical semantic offers.
+   versioned-priority implementations on identical semantic offers;
+6. run that unchanged driver over concrete function packages, including a
+   retryable enclosure, a structure-triggered alternate form, equality
+   contraction, and a function-owned split landmark.
+
+The concrete package canary reaches step 6 with the unchanged external driver.
+One deterministic schedule selects subtraction and multiplication propagation,
+the structure matcher, instantiation admission, the centered function's split
+handler and forward propagator, equality contraction, reciprocal propagation,
+a precision retry, and finally the centered function's split suggestion. It
+adds the centered node at generation one, narrows both representations to
+`[0,1/4]`, improves the enclosure of `1/3` at effort one, and returns a prepared
+plan at `x = 1/2` while the effort-two retry remains live. No branch is
+executed, so this is evidence for policy routing and freshness, not for scope
+creation or split interiority.
 
 Once policy control begins, the wrapper is the sole scheduling authority for
 that state: callers use its `view`, `select`, `submit`, equality, and admission
@@ -1832,9 +2008,11 @@ states.
 - Total search is bounded by the configured action, leaf, endpoint-height, and
   payload budgets.
 
-Individual propagators declare their own arithmetic complexity and cache
-behavior in the Mathlib companion. The solver does not hide that cost inside
-a scheduler bound.
+Individual Mathlib-free propagator packages declare their logical cost model
+and cache behavior at the external registry boundary. The Mathlib companion
+supplies the soundness theorems and replay interpretation for retained
+payloads. The generic scheduler neither interprets those semantics nor hides
+their declared cost inside a scheduler bound.
 
 ## File organization
 
@@ -1892,12 +2070,30 @@ typical, boundary, and adversarial inputs. In particular it includes:
 - an atomic multi-output outcome, repeated-operand watcher deduplication,
   projected-input enforcement, and rejection of an undeclared write or a
   mismatched delayed reply without state mutation;
-- an opaque shape rule which distinguishes `x * (one - x)` from products with
-  a reversed difference or a different repeated input, proposes the exact
-  existing node identifiers while receiving no fact inputs, repeats the match
-  on a newly appended DAG suffix, and admits both the still-fresh pre-extension
-  proposal and the new proposal after revalidation with their exact assigned
-  node identifiers and generations;
+- package-major registry assembly with two handlers sharing a `Nat` cache,
+  independently appended packages using `List Nat` and `Bool` caches, exact
+  route and final-program signature checks, external required signatures,
+  duplicate operation/rule-key and undeclared-head rejection, cache-preserving
+  rejection of wrong routes, and a `Type 1` registry threaded through both
+  drivers;
+- an anchor-local opaque shape rule which distinguishes `x * (one - x)` from
+  products with a reversed difference or a different repeated input, proposes
+  the exact existing node identifiers while receiving no fact inputs, repeats
+  the match on a newly appended DAG suffix, and admits both the append-stable
+  pre-extension proposal and the new proposal after revalidation with their
+  exact assigned node identifiers and generations;
+- an end-to-end concrete registry run in which `x * (1 - x)` first receives
+  the dependency-losing hull `[0,1]`, structural instantiation adds the
+  centered node and an opaque-payload equality, the alternate callback returns
+  `[0,1/4]`, and equality transport narrows the original expression to the same
+  fact; its whole-program matcher rejects the old proposal as stale and runs
+  again on the extended snapshot, while `z = 2*y` shows a backward contraction
+  waking an initially inapplicable forward rule;
+- the same concrete registry under the external policy driver, selecting
+  propagation, structural matching, instantiation, equality, reciprocal retry,
+  and a function-owned split in a checked event order; it returns an
+  endpoint-resource-checked plan at `1/2`, leaves the next retry offer live,
+  and performs no branch/interiority step;
 - undirected equality transport, including incomparable endpoint facts that
   improve both sides atomically, equality chains, reactivation after a later
   function improvement, and an original expression transferring its bound to
@@ -1907,9 +2103,11 @@ typical, boundary, and adversarial inputs. In particular it includes:
 - deterministic action choice for a fixed `balancedV1` configuration;
 - two policies over the same opaque `f` and dynamically introduced `g`: one
   retries `f` before instantiation and one instantiates first. They must reach
-  the same final facts and checked split plan while recording different exact
-  rule-call counts; replay of either semantic offer log is exact, and a stale
-  effort or exhausted decision budget stops without state mutation;
+  the same final facts and endpoint-resource-checked prepared split plan (with
+  branch creation and interiority left to the scope layer) while recording
+  different exact rule-call counts; replay of either semantic offer log is
+  exact, and a stale effort or exhausted decision budget stops without state
+  mutation;
 - derivation slicing that removes failed probes and unused facts;
 - branch validation that rejects sibling fact references and mutable or
   dangling payloads;

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -556,9 +556,10 @@ SSA node table, and per-node instantiation generations. It contains no facts.
 The engine constructs it only from a validated state already covered by the
 operation, node, arity, and generation limits. Thus an external shape rule can
 follow a product argument to a nested difference, compare opaque operation
-keys, recover the repeated `NodeId`, and compute the claimed generation for a
-proposal. It still receives facts only for its registration's declared watch
-slots. Structural inspection does not become a hidden fact dependency.
+keys, recover the repeated `NodeId`, and construct a proposal without
+duplicating the engine's generation calculation. It still receives facts only
+for its registration's declared watch slots. Structural inspection does not
+become a hidden fact dependency.
 Anchor-local inspection adds no wakeup beyond the declared fact slots; a rule
 which reads the whole view declares `watchesProgram`, making program extension
 an explicit dependency.
@@ -636,38 +637,41 @@ An instantiation proposal is retained under the selected action's versioned
 `RuleKey`; its own `key : Nat` is only an untrusted family label for replay and
 is not canonical authority. The proposal also contains replay-facing trigger
 data, new SSA instructions, equality or derived-fact recipes, and an untrusted
-claimed generation. The engine derives the canonical substitution from the
-selected action's anchor and declared input facts; a registry-provided trigger
-list cannot weaken generation accounting or change structural identity.
+legacy generation hint. The engine derives the canonical substitution from
+the selected action's anchor and declared input facts; a registry-provided
+trigger list or generation hint cannot weaken generation accounting or change
+structural identity.
 Acceptance validates operation arities and domains, topological order, scope
 visibility, and every referenced input; recomputes generation from the
-engine-owned action provenance and generated dependencies,
-rejecting a mismatch or over-budget descendant; deduplicates expressions by
-the same canonical CSE key as the base program; updates consumer and rule
-indexes; and retains an opaque recipe identifier. Production must freeze every
-referenced recipe value before replay. Base nodes have generation zero. The
-production representation may record generation per theorem
+engine-owned action provenance and genuine input dependencies, using that
+value—not the package hint—for the generation cap; deduplicates expressions
+by the same canonical CSE key as the base program; updates consumer and rule
+indexes; and retains an opaque recipe identifier. Production must freeze
+every referenced recipe value before replay. Base nodes have generation zero.
+The production representation may record generation per theorem
 instance or per generated product; that choice remains open below. In either
 case, a new expression is not trusted merely because a trigger matched or
 labeled itself generation zero.
 
-The role of `claimedGeneration` remains an explicit experiment. The current
-canary requires the registry's exact prediction to equal the engine's
-recomputation, which catches stale or incomplete proposal logic but forces
-each shape rule to mirror part of admission. Alternatives are an advisory
-claim retained only for replay diagnostics, a checked lower/upper bound, or an
-engine-exported computation over `ProgramView` shared by proposal and
-admission. The production interface must choose one after CSE-hit and
-post-extension tests; exact prediction by every package is not frozen merely
-because the first centered rule can compute it.
+The CSE-order experiment resolves the role of `claimedGeneration`: it is not
+an admission field. Requiring equality makes a valid retained proposal depend
+on whether another policy choice materialized one of its outputs first; a
+lower-bound comparison catches no safety-relevant lie, because the engine must
+recompute the value anyway. The production request should omit the field. The
+current canary retains it only as legacy diagnostic data and deliberately
+ignores it in both policy offer construction and admission. Policy sees the
+engine-computed generation in the semantic offer key, and the accepted
+instance records that same value for replay.
 
-In the current centered canary, `centeredGeneration?` deliberately mirrors the
-engine's `inferredGeneration?`: the authoritative references are the action
-substitution, old nodes referenced by proposed drafts or equalities, and old
-nodes reached by CSE. The proposal's `triggers` list is replay-facing data and
-does not contribute to generation. Both policy offer construction and
-admission recompute the value against the current append-only program, so a
-package's exact claim remains a checked canary rather than authority.
+The authoritative references are the action substitution and old nodes named
+explicitly as existing inputs by proposed drafts or equalities. The proposal's
+`triggers` list remains replay-facing data and does not contribute. A proposed
+node remains an output of the theorem instance when it CSE-hits an already
+materialized node: storage reuse cannot manufacture a proof dependency. Thus
+the same append-stable proposal has the same logical generation before and
+after an unrelated CSE-producing extension. The centered package no longer
+mirrors the admission algorithm; its retained legacy hint is ignored while
+policy and admission independently recompute the authoritative value.
 
 The current centered-product D2 vertical is deliberately narrower than this
 general recurrence. Its `Center.inferredGeneration` only recognizes one
@@ -700,11 +704,14 @@ encapsulation and would obstruct ordinary-kernel theorems about admission.
 
 One atomic theorem instantiation initially assigns a single instantiation
 generation to all helper nodes it introduces: one plus the maximum generation
-of every old node referenced by the authoritative action substitution, draft,
-equality output, or CSE result. This measures theorem-instantiation depth
-rather than expression-tree depth. Per-product generation remains a possible
-refinement, but neither a false trigger list nor a draft's ordering may let a
-deeper theorem instance pass a shallower limit.
+of every node in the authoritative action substitution or explicitly named as
+an existing input by a draft or equality. Proposed products are outputs, even
+when CSE reuses their storage, so selection order cannot raise their logical
+generation or change success at an exact generation cap. This measures
+theorem-instantiation depth rather than expression-tree depth. Per-product or
+multiple-provenance generation remains a possible refinement, but neither a
+false trigger list nor a package hint may let a deeper action pass a shallower
+limit.
 
 The general experiment activates proposed equality edges as indexed,
 replayable search contractors: improving either endpoint wakes transport in
@@ -991,9 +998,10 @@ A registration whose matcher depends on the whole `ProgramView` sets
 requeues all existing applications of that registration. This coarse trigger
 is the first grind-like instantiation mechanism: a matcher that was previously
 inapplicable can observe expressions introduced by another package. Ordinary
-anchor-local registrations remain append-stable. Compiled structural patterns
-or more selective operation-key triggers remain alternatives to compare once
-the behavior is established.
+anchor-local registrations remain append-stable; they do not acquire a global
+dependency merely because engine-owned admission may CSE one of their outputs.
+Compiled structural patterns or more selective operation-key triggers remain
+alternatives to compare once the behavior is established.
 
 1. The solver produces an `Action` naming a program snapshot, concrete rule
    application, anchor, declared input fact versions, effort, and action kind.
@@ -2082,6 +2090,11 @@ typical, boundary, and adversarial inputs. In particular it includes:
   the match on a newly appended DAG suffix, and admits both the append-stable
   pre-extension proposal and the new proposal after revalidation with their
   exact assigned node identifiers and generations;
+- two append-stable rules which propose the same absent product and distinct
+  equality outputs in either selection order: the first materializes the
+  product, the second CSE-hits it, both remain generation one under an exact
+  generation-one cap, and deliberately wrong package hints affect neither the
+  policy offer nor admission;
 - an end-to-end concrete registry run in which `x * (1 - x)` first receives
   the dependency-losing hull `[0,1]`, structural instantiation adds the
   centered node and an opaque-payload equality, the alternate callback returns

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -69,12 +69,20 @@ propagators, function-owned retries and split suggestions, structural
 instantiation, equality transport, and external policy choice must all run
 through the same engine protocol. The centered-product and reciprocal canaries
 are evidence for that interface, not a reason to declare it final.
-Exact-rational planning, projection, replay, and optimization remain deferred
-while package assembly, cache ownership, payload freezing, structural
-matching, and policy traces are still being tested; no registry, scheduler,
-instantiation, or policy interface may depend on the eventual rational
-representation. The checked dyadic interval domain is sufficient as the
-endpoint substrate for these framework experiments.
+Before another rational-backend milestone, at least one non-polynomial
+function package must complete semantic replay through this same path,
+including any retained instantiation and equality evidence, and produce an
+ordinary theorem about the caller's target. A compiled search fixture or
+`#guard` is not completion of that gate. Sine is the first candidate because
+it exercises the existing research experiment, but the exact function and
+certificate shape remain open to evidence from implementation.
+
+Exact-rational planning, projection, replay, and optimization therefore remain
+deferred while package assembly, cache ownership, payload freezing, structural
+matching, policy traces, and non-polynomial replay are still being tested; no
+registry, scheduler, instantiation, or policy interface may depend on the
+eventual rational representation. The checked dyadic interval domain is
+sufficient as the endpoint substrate for these framework experiments.
 
 “Compiled search” means ordinary elaboration-time Lean execution of the
 untrusted planner. It does not authorize `precompileModules := true`; the Lake
@@ -448,6 +456,15 @@ whole-interval hull. A rule can request a split at zero before using a tighter
 sign-specific result. A later `IntervalSet` with at most two components is an
 isolated extension, not a reason to complicate every initial operation.
 
+This paragraph is the target contract, not a description of the current
+component canary. `Experiment.DyadicInterval.reciprocal` currently returns
+`inapplicable` for singleton zero, a closed zero endpoint, or a sign-crossing
+input; it implements only the sign-separated cases (including an open zero
+endpoint mapping to an unbounded side). The concrete package has an executable
+across-zero regression for that behavior. Implementing the connected hull of
+Lean's total inverse, or selecting an interval-set result, is an explicit
+experimental gap before reciprocal can claim the target contract above.
+
 Grid-tightness remains an acceptance target, not an assumed consequence of
 core's API. Core currently proves the one-sided `roundDown_le` and
 `le_roundUp` lemmas but leaves the corresponding optimality characterizations
@@ -552,14 +569,18 @@ cross-node applications without changing the scheduler protocol.
 
 The current arbitrary-propagator experiment gives each request a bounded,
 immutable `ProgramView` containing the exact program version, operation table,
-SSA node table, and per-node instantiation generations. It contains no facts.
+SSA node table, per-node theorem-instantiation generations, and per-node
+structural expression depths. It contains no facts.
 The engine constructs it only from a validated state already covered by the
-operation, node, arity, and generation limits. Thus an external shape rule can
-follow a product argument to a nested difference, compare opaque operation
-keys, recover the repeated `NodeId`, and construct a proposal without
-duplicating the engine's generation calculation. It still receives facts only
-for its registration's declared watch slots. Structural inspection does not
-become a hidden fact dependency.
+operation, node, arity, generation, and structural-depth limits. Thus an
+external shape rule can follow a product argument to a nested difference,
+compare opaque operation keys, recover the repeated `NodeId`, and construct a
+proposal without duplicating either engine-owned depth calculation. It still
+receives facts only for its registration's declared watch slots. Structural
+inspection does not become a hidden fact dependency.
+`ProgramView.findOp?` resolves a stable `OpKey` to this snapshot's local
+`OpId` and exact signature; package assembly order is never authoritative for
+frontend node identifiers.
 Anchor-local inspection adds no wakeup beyond the declared fact slots; a rule
 which reads the whole view declares `watchesProgram`, making program extension
 an explicit dependency.
@@ -636,42 +657,41 @@ ordinary interval facts. Typical uses include:
 An instantiation proposal is retained under the selected action's versioned
 `RuleKey`; its own `key : Nat` is only an untrusted family label for replay and
 is not canonical authority. The proposal also contains replay-facing trigger
-data, new SSA instructions, equality or derived-fact recipes, and an untrusted
-legacy generation hint. The engine derives the canonical substitution from
-the selected action's anchor and declared input facts; a registry-provided
-trigger list or generation hint cannot weaken generation accounting or change
-structural identity.
-Acceptance validates operation arities and domains, topological order, scope
-visibility, and every referenced input; recomputes generation from the
-engine-owned action provenance and genuine input dependencies, using that
-value—not the package hint—for the generation cap; deduplicates expressions
-by the same canonical CSE key as the base program; updates consumer and rule
-indexes; and retains an opaque recipe identifier. Production must freeze
-every referenced recipe value before replay. Base nodes have generation zero.
-The production representation may record generation per theorem
-instance or per generated product; that choice remains open below. In either
-case, a new expression is not trusted merely because a trigger matched or
-labeled itself generation zero.
+data, new SSA instructions, and equality or derived-fact recipes. The engine
+derives the canonical substitution from the selected action's anchor and
+declared input facts; a registry-provided trigger list cannot weaken resource
+accounting or change structural instance identity.
 
-The CSE-order experiment resolves the role of `claimedGeneration`: it is not
-an admission field. Requiring equality makes a valid retained proposal depend
-on whether another policy choice materialized one of its outputs first; a
-lower-bound comparison catches no safety-relevant lie, because the engine must
-recompute the value anyway. The production request should omit the field. The
-current canary retains it only as legacy diagnostic data and deliberately
-ignores it in both policy offer construction and admission. Policy sees the
+Before any instantiation enters retained policy state, reply admission resolves
+its references, checks operation arities and domains, topological order, scope
+visibility, equality endpoints, and structural depth, and applies the same CSE
+rule used by final admission. A malformed request returns the named
+`ReplyError.malformedProposal`; a depth overrun returns the engine-owned
+`Resource.nodeDepth`. Neither is retained and neither may later disappear as a
+false “stale” policy event. Full admission revalidates against the current
+append-only program before atomically updating consumer and rule indexes and
+retaining opaque recipe identifiers. Policy view construction consequently
+checks freshness and engine-owned generation without repeating draft
+resolution.
+
+The request has no package-claimed generation field. Policy sees the
 engine-computed generation in the semantic offer key, and the accepted
-instance records that same value for replay.
+instance records that same value for replay. Production must freeze every
+referenced recipe value before replay. Base nodes have theorem-instantiation
+generation zero. The production representation may record generation per
+theorem instance or per generated product; that choice remains open below. In
+either case, a new expression is not trusted merely because a trigger matched.
 
 The authoritative references are the action substitution and old nodes named
 explicitly as existing inputs by proposed drafts or equalities. The proposal's
-`triggers` list remains replay-facing data and does not contribute. A proposed
-node remains an output of the theorem instance when it CSE-hits an already
+`triggers` list remains replay-facing data and contributes neither to the
+engine `InstanceKey` nor to payload-erased policy identity. Allowing an
+untrusted trigger ordering or superset to partition otherwise identical offers
+would make scheduling depend on non-semantic package metadata. A proposed node
+remains an output of the theorem instance when it CSE-hits an already
 materialized node: storage reuse cannot manufacture a proof dependency. Thus
 the same append-stable proposal has the same logical generation before and
-after an unrelated CSE-producing extension. The centered package no longer
-mirrors the admission algorithm; its retained legacy hint is ignored while
-policy and admission independently recompute the authoritative value.
+after an unrelated CSE-producing extension.
 
 The current centered-product D2 vertical is deliberately narrower than this
 general recurrence. Its `Center.inferredGeneration` only recognizes one
@@ -689,11 +709,11 @@ proposed nodes, assigned an engine-recomputed generation, and committed
 atomically with rebuilt rule and watcher indexes. Its two-step canary adds
 `g (f x)` and then `h (g (f x))`; newly registered rules run through the
 ordinary request/reply path, producing generations one and two. Exact node,
-generation, application, queue, instance, equality, and proposal-list limits
-are independent, and failure retains the preceding snapshot. The current hot
-storage uses linear reference CSE and rebuilds indexes after an extension;
-that validates the state transition but does not select the production CSE or
-incremental-index representation.
+generation, structural-depth, application, queue, instance, equality, and
+proposal-list limits are independent, and failure retains the preceding
+snapshot. The current hot storage uses linear reference CSE and rebuilds
+indexes after an extension; that validates the state transition but does not
+select the production CSE or incremental-index representation.
 
 For inspection and mutation-cost experiments this provisional `Engine` is an
 exposed record. Consequently, its raw module does not enforce an authority
@@ -709,9 +729,16 @@ an existing input by a draft or equality. Proposed products are outputs, even
 when CSE reuses their storage, so selection order cannot raise their logical
 generation or change success at an exact generation cap. This measures
 theorem-instantiation depth rather than expression-tree depth. Per-product or
-multiple-provenance generation remains a possible refinement, but neither a
-false trigger list nor a package hint may let a deeper action pass a shallower
-limit.
+multiple-provenance generation remains a possible refinement.
+
+Structural expression depth is a separate engine invariant: nullary nodes have
+depth zero; every fresh non-nullary node has one plus the maximum depth of its
+resolved arguments; a CSE hit keeps the already stored depth. `maxNodeDepth`
+caps this measure independently of `maxGeneration`. This distinction is
+essential for whole-program matchers: a matcher can repeatedly propose
+`g(anchor)`, `g(previous)`, and an ever longer CSE-hit prefix while every
+theorem instance remains generation one. The growing-tower canary admits the
+prefix through depth three and rejects the depth-four reply before retention.
 
 The general experiment activates proposed equality edges as indexed,
 replayable search contractors: improving either endpoint wakes transport in
@@ -846,15 +873,15 @@ Whether scheduler fuel should count abstract logical references or concrete
 storage steps remains empirical, but a certificate-supplied cost is never
 trusted.
 
-Generation is explicitly budgeted by new nodes, new equality edges, rule
-applications, depth, and retained payload bytes. A canonical key consisting
-of the rule, substitution, scope, and generated expression prevents duplicate
-instances. Candidate traversal and insertion order are deterministic. If a
-branch-local fact triggers a semantically branch-independent expression, the
-node may be shared globally while the resulting fact and conditional equality
-remain branch-scoped. Whether the first implementation uses that scheme or
-branch-local extensions is an experiment; identifiers and replay must make
-the choice explicit.
+Instantiation is explicitly budgeted by new nodes, new equality edges, rule
+applications, theorem-generation, structural node depth, and retained payload
+bytes. A canonical key consisting of the rule, substitution, scope, and
+generated expression prevents duplicate instances. Candidate traversal and
+insertion order are deterministic. If a branch-local fact triggers a
+semantically branch-independent expression, the node may be shared globally
+while the resulting fact and conditional equality remain branch-scoped.
+Whether the first implementation uses that scheme or branch-local extensions
+is an experiment; identifiers and replay must make the choice explicit.
 
 The initial feasibility comparison has three arms:
 
@@ -942,7 +969,13 @@ handler, and rejects undeclared heads and duplicate `OpKey`s or `RuleKey`s.
 Program size and arity are bounded before exact signature lookup. The checked
 start then validates every owned and required signature against the final
 frontend program, runs each package's configuration preflight, and starts the
-engine with the registry's exact flattened registration array.
+engine with the registry's exact flattened registration array. Registry-owned
+dispatch diagnostics impose their own `maxDiagnosticValue` floor even when
+every callback package would accept a smaller value. The concrete reciprocal
+package additionally checks both endpoints of its configured effort-to-
+precision ladder against its arithmetic endpoint-height limit; otherwise a
+configuration known in advance to exceed the backend limit is rejected at
+start rather than advertised as compatible.
 
 `Registry.invoke` cross-checks the flattened registration, routed handler
 metadata, and structural projection of an engine-produced request before
@@ -1016,7 +1049,10 @@ alternatives to compare once the behavior is established.
    declared writes and computes all intersections against the pre-outcome
    state. It then commits the whole improving batch and wakes the deduplicated
    union of affected applications once. A malformed later candidate or a
-   one-step-short fact or queue budget commits none of the batch.
+   one-step-short fact or queue budget commits none of the batch. Interval
+   intersection enforces representation consistency and monotone narrowing;
+   it does not establish the semantic soundness of an untrusted candidate.
+   Only companion replay of the retained payload can do that.
 6. In the production replay protocol, every value needed to justify an
    accepted fact is frozen into an immutable per-run payload arena, and the
    retained `PayloadId` points there rather than into a mutable cache. The
@@ -1203,8 +1239,9 @@ does not construct an `Action`: action serials, program snapshots, concrete
 applications, and input versions are engine-owned authority. The engine owns a
 bounded frontier of offers and the policy returns only the stable identity and
 canonical key of one offer it observed. In the sketch below,
-`InstantiationSemanticKey` is the payload-erased canonical family, trigger,
-proposed-operation/reference graph, and unordered equality-pair key;
+`InstantiationSemanticKey` is the payload-erased canonical family,
+engine-computed generation, proposed-operation/reference graph, and unordered
+equality-pair key. Replay-facing trigger metadata is deliberately absent;
 `PolicyFeature` is a bounded exact integer key/value; and frontier events are
 engine-issued additions, refreshes, tombstones, and observations:
 
@@ -1512,12 +1549,15 @@ Freshness is offer-specific. An invocation or retry compares the concrete
 application and relevant current input versions. An anchor-local rule remains
 fresh across an unrelated append-only extension. A `watchesProgram` rule also
 requires the exact program version: extension stales its old offer and requeues
-the application against the new snapshot. Instantiation repeats all structural
-admission checks. A split compares its scope, target fact version, and endpoint
-resource bound; an unrelated append-only program extension need not stale it.
-Domain-specific interiority belongs to the later scope/branch validator which
-constructs the complementary children. Proactive invalidation is an
-optimization, so selection always rechecks the conditions it owns.
+the application against the new snapshot. Instantiation shape is validated
+before retention; offer construction rechecks freshness and authoritative
+generation without resolving the draft again, and selection repeats full
+admission against the current append-only program. A split compares its scope,
+target fact version, and endpoint resource bound; an unrelated append-only
+program extension need not stale it. Domain-specific interiority belongs to
+the later scope/branch validator which constructs the complementary children.
+Proactive invalidation is an optimization, so selection always rechecks the
+conditions it owns.
 
 Policy decisions, retained decision notes, effort, and live frontier size have
 independent deterministic limits. Even a rejected stale selection consumes a
@@ -1704,6 +1744,15 @@ A symbolic or irrational landmark cannot be a global cut in this first
 format. Its rule instead proposes a nearby dyadic guard backed by a certified
 enclosure, or handles a symbolic partition entirely inside its local proof
 payload.
+
+The concrete `Dyadic` split point and `EndpointLimit` in the current generic
+experiment are a deliberate real-domain-v1 seam, not a claim that every future
+domain or branch policy must use dyadic cuts. Keeping that seam concrete lets
+the arbitrary real-function vertical proceed without prematurely choosing
+between a cut-type parameter, a domain-owned split interface, and an opaque
+landmark decoded by the branch layer. That choice remains open and must be
+revisited before stabilizing a multi-domain API; it does not require changing
+the function-package, instantiation, or replay protocols now.
 
 A split on term `t` adds `t ≤ m` to the left child and `m < t` to the right
 child. This complementary form preserves strictness, avoids a duplicate
@@ -2091,17 +2140,23 @@ typical, boundary, and adversarial inputs. In particular it includes:
   pre-extension proposal and the new proposal after revalidation with their
   exact assigned node identifiers and generations;
 - two append-stable rules which propose the same absent product and distinct
-  equality outputs in either selection order: the first materializes the
-  product, the second CSE-hits it, both remain generation one under an exact
-  generation-one cap, and deliberately wrong package hints affect neither the
-  policy offer nor admission;
+  equality outputs in either selection order: the first materializes a
+  depth-three tower, the second CSE-hits the entire prefix, both remain
+  theorem-generation one under an exact generation-one cap, and the stored
+  structural depths are identical in either order;
+- a genuine `watchesProgram` matcher which proposes an increasingly long
+  generation-one tower: two extensions CSE-hit their old prefixes, while the
+  depth-four reply is rejected before retention by an exact
+  `maxNodeDepth = 3` cap;
+- reply-boundary rejection of malformed structural/equality proposals, with no
+  retained offer that can later be silently tombstoned;
 - an end-to-end concrete registry run in which `x * (1 - x)` first receives
   the dependency-losing hull `[0,1]`, structural instantiation adds the
   centered node and an opaque-payload equality, the alternate callback returns
   `[0,1/4]`, and equality transport narrows the original expression to the same
-  fact; its whole-program matcher rejects the old proposal as stale and runs
-  again on the extended snapshot, while `z = 2*y` shows a backward contraction
-  waking an initially inapplicable forward rule;
+  fact; its anchor-local proposal remains append-stable and does not consume
+  closure budget by rerunning after its own extension, while `z = 2*y` shows a
+  backward contraction waking an initially inapplicable forward rule;
 - the same concrete registry under the external policy driver, selecting
   propagation, structural matching, instantiation, equality, reciprocal retry,
   and a function-owned split in a checked event order; it returns an

--- a/bench/HexInterval/IntervalSchedulerSpike.lean
+++ b/bench/HexInterval/IntervalSchedulerSpike.lean
@@ -115,6 +115,7 @@ def generousLimits (trees depth : Nat) : Limits :=
     maxProposalItems := 0
     maxInstances := 0
     maxGeneration := 0
+    maxNodeDepth := nodeCount
     maxEqualities := 0
     splitEndpointLimit := { maxEndpointHeight := 64, maxAlignmentShift := 64 } }
 

--- a/bench/HexInterval/IntervalSchedulerSpike.lean
+++ b/bench/HexInterval/IntervalSchedulerSpike.lean
@@ -109,6 +109,7 @@ def generousLimits (trees depth : Nat) : Limits :=
     maxRetainedSuggestions := 0
     maxEffort := 0
     maxObservationValue := 1
+    maxDiagnosticValue := 1
     maxOutcomeCandidates := 1
     maxOutcomeSuggestions := 0
     maxProposalItems := 0

--- a/conformance/HexInterval/DyadicIntervalConformance.lean
+++ b/conformance/HexInterval/DyadicIntervalConformance.lean
@@ -502,6 +502,7 @@ private def engineLimits : Limits :=
     maxRetainedSuggestions := 0
     maxEffort := 4
     maxObservationValue := 16
+    maxDiagnosticValue := 16
     maxOutcomeCandidates := 2
     maxOutcomeSuggestions := 0
     maxProposalItems := 2

--- a/conformance/HexInterval/DyadicIntervalConformance.lean
+++ b/conformance/HexInterval/DyadicIntervalConformance.lean
@@ -508,6 +508,7 @@ private def engineLimits : Limits :=
     maxProposalItems := 2
     maxInstances := 0
     maxGeneration := 0
+    maxNodeDepth := 16
     maxEqualities := 0
     splitEndpointLimit := endpointLimit }
 

--- a/conformance/HexInterval/DyadicRulesConformance.lean
+++ b/conformance/HexInterval/DyadicRulesConformance.lean
@@ -54,6 +54,7 @@ def limits : Experiment.Propagator.Limits :=
     maxProposalItems := 16
     maxInstances := 8
     maxGeneration := 4
+    maxNodeDepth := 16
     maxEqualities := 8
     splitEndpointLimit := endpointLimit }
 
@@ -188,6 +189,80 @@ def centeredProgram : Program :=
         instruction 2 [node 1, node 0],
         instruction 3 [node 0, node 2]] }
 
+/-! The compact operation table is frontend-owned. Put `source` before the
+package-owned centered operation and materialize the centered node already, so
+the matcher must resolve its stable key to index seven and CSE-hit node four. -/
+
+def keyedOperations : Array Operation :=
+  ((arithmeticOperations real).push
+    { key := sourceOp, inputs := [], output := real }).push
+      { key := centeredOp, inputs := [real], output := real }
+
+def keyedProgram : Program :=
+  { operations := keyedOperations
+    nodes :=
+      #[instruction 6,
+        instruction 0,
+        instruction 2 [node 1, node 0],
+        instruction 3 [node 0, node 2],
+        instruction 7 [node 0]] }
+
+def keyedView : ProgramView :=
+  { programVersion := 0
+    operations := keyedProgram.operations
+    nodes := keyedProgram.nodes
+    generations := #[0, 0, 0, 0, 0]
+    depths := #[0, 0, 1, 2, 1] }
+
+def keyedRequest : RuleRequest Fact :=
+  { action :=
+      { serial := 0
+        programVersion := 0
+        application := { index := 0 }
+        rule := { index := 0 }
+        key := centeredInstantiateKey
+        node := node 3
+        kind := .instantiate
+        effort := 0
+        inputs := [] }
+    program := keyedView
+    inputs := []
+    writes := [] }
+
+def keyedProposal? : Option InstantiationRequest :=
+  centeredBinding? keyedRequest >>= centeredProposal? keyedRequest
+
+#guard keyedProgram.check
+
+-- Stable keys resolve to the compact identifier assigned by this particular
+-- frontend snapshot; an absent key does not acquire a fallback meaning.
+#guard
+  match keyedView.findOp? centeredOp with
+  | some (operation, signature) =>
+      operation.index == 7 && signature.key == centeredOp
+  | none => false
+
+#guard
+  (keyedView.findOp? { name := "real.absent-from-keyed-view" }).isNone
+
+-- The package uses the resolved identifier in its draft. Structural admission
+-- therefore recognizes the already materialized centered node instead of
+-- appending a duplicate whose operation index came from package-local order.
+#guard
+  match keyedProposal? with
+  | some proposal =>
+      match proposal.nodes with
+      | [draft] =>
+          draft.op.index == 7 &&
+            match resolveDrafts keyedProgram.nodes.size limits.maxNodeDepth
+                keyedProgram keyedView.depths [] proposal.nodes with
+            | .ok (resolvedProgram, depths, resolved) =>
+                resolvedProgram.nodes.size == keyedProgram.nodes.size &&
+                  depths == keyedView.depths && resolved == [node 4]
+            | .error _ => false
+      | _ => false
+  | none => false
+
 def centeredStart? : Option (Engine Fact × ConcreteRegistry) :=
   match DyadicRules.start config real centeredProgram
       #[finite 0 false 1 false,
@@ -244,22 +319,21 @@ def falseOneRun? : Option (RunResult Fact ConcreteRegistry) := do
 #guard centeredAt half quarter
 #guard centeredAt 1 0
 
--- The old whole-program match is stale after extension, and admission has
--- requeued the structural application so it can observe the new snapshot.
+-- The anchor-local match remains fresh after its own append-only extension.
+-- Selecting it again is a structural duplicate, and the matcher is not
+-- spuriously requeued as a whole-program dependency.
 #guard
   match centeredAdmitted? with
   | some (state, _) =>
       match state.admitInstantiation (suggestion 0) with
-      | .invalid (.staleSuggestion 0 1) unchanged =>
+      | .duplicate unchanged =>
           unchanged.programVersion == 1 &&
-            unchanged.queue.toList.any fun work =>
-              match work with
-              | .application applicationId =>
-                  (unchanged.applications[applicationId.index]?).any fun application =>
-                    (unchanged.rules[application.rule.index]?).any fun registration =>
-                      registration.key == centeredInstantiateKey &&
-                        (unchanged.queued[applicationId.index]?).getD false
-              | .equality _ => false
+            unchanged.applications.toList.zipIdx.all fun (application, index) =>
+              match unchanged.rules[application.rule.index]? with
+              | some registration =>
+                  registration.key != centeredInstantiateKey ||
+                    unchanged.queued[index]? == some false
+              | none => false
       | _ => false
   | none => false
 
@@ -334,16 +408,15 @@ def badSignatureProgram : Program :=
               match retained.suggestion with
               | .instantiate request =>
                   request.triggers == [node 3, node 0, node 2, node 1] &&
-                    request.claimedGeneration == 1 && request.nodes.length == 1 &&
-                    request.equalities.length == 1
+                    request.nodes.length == 1 && request.equalities.length == 1
               | _ => false
         | none => false
   | none => false
 
 -- Admission creates the opaque centered node and equality.  Its arbitrary
 -- callback returns `[0,1/4]`; equality transport then improves the original
--- product to the same fact.  The whole-program matcher also runs on the new
--- snapshot rather than silently remaining dormant.
+-- product to the same fact. The anchor-local matcher emits no duplicate
+-- post-extension suggestion.
 #guard
   match centeredFinal? with
   | some result =>
@@ -354,9 +427,13 @@ def badSignatureProgram : Program :=
           (.bounds (.finite 0 false) (.finite quarter false)) &&
         exactFact result.state 4
           (.bounds (.finite 0 false) (.finite quarter false)) &&
+        result.state.suggestions.size == 2 &&
         result.state.suggestions.toList.any (fun retained =>
           retained.action.key == centeredInstantiateKey &&
-            retained.action.programVersion == 1) &&
+            retained.action.programVersion == 0) &&
+        result.state.suggestions.toList.all (fun retained =>
+          retained.action.key != centeredInstantiateKey ||
+            retained.action.programVersion == 0) &&
         match result.state.program.node? (node 4), result.state.equalities[0]? with
         | some centered, some equality =>
             centered.args == [node 0] &&
@@ -544,6 +621,22 @@ def reciprocalStart? : Option (Engine Fact × ConcreteRegistry) :=
   | .ok state => some state
   | .error _ => none
 
+-- Both endpoints of the configured effort range must fit the arithmetic
+-- endpoint budget before the package is accepted.
+#guard
+  match DyadicRules.start
+      { config with reciprocalBasePrecision := 129 }
+      real reciprocalProgram #[finite 3 false 3 false, whole] limits with
+  | .error .incompatibleLimits => true
+  | _ => false
+
+#guard
+  match DyadicRules.start
+      { config with reciprocalBasePrecision := 126, maxReciprocalEffort := 4 }
+      real reciprocalProgram #[finite 3 false 3 false, whole] limits with
+  | .error .incompatibleLimits => true
+  | _ => false
+
 def reciprocalFirstRequest? : Option (RuleRequest Fact × ConcreteRegistry) := do
   let (state, registry) <- reciprocalStart?
   match state.poll with
@@ -563,6 +656,25 @@ def reciprocalFirstRequest? : Option (RuleRequest Fact × ConcreteRegistry) := d
       | _ => false
   | none => false
 
+def reciprocalAcrossZeroRequest? : Option (RuleRequest Fact × ConcreteRegistry) := do
+  let (state, registry) <- match DyadicRules.start config real reciprocalProgram
+      #[finite (-1) false 1 false, whole] limits with
+    | .ok state => some state
+    | .error _ => none
+  match state.poll with
+  | .request request _ => some (request, registry)
+  | _ => none
+
+-- This first component backend intentionally does not yet implement the
+-- connected hull of Lean's total inverse across zero.
+#guard
+  match reciprocalAcrossZeroRequest? with
+  | some (request, registry) =>
+      match (registry.invoke request).1 with
+      | .inapplicable => true
+      | _ => false
+  | none => false
+
 def bogusRequest : RuleRequest Fact :=
   { action :=
       { serial := 0
@@ -578,7 +690,8 @@ def bogusRequest : RuleRequest Fact :=
       { programVersion := 0
         operations := #[]
         nodes := #[]
-        generations := #[] }
+        generations := #[]
+        depths := #[] }
     inputs := []
     writes := [] }
 

--- a/conformance/HexInterval/DyadicRulesConformance.lean
+++ b/conformance/HexInterval/DyadicRulesConformance.lean
@@ -1,0 +1,303 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexInterval.Experiment.DyadicRules
+
+/-!
+End-to-end conformance for concrete arbitrary-function propagators.  These
+fixtures run the generic worklist; they do not call interval operations in
+place of the registry when checking the final facts.
+-/
+
+namespace Hex.Interval.DyadicRulesConformance
+
+open Experiment Propagator
+open DyadicRules
+
+def d (value : Int) : Dyadic := Dyadic.ofInt value
+
+def real : DomainId := { index := 0 }
+def sourceOp : OpKey := { name := "real.source" }
+
+def endpointLimit : EndpointLimit where
+  maxEndpointHeight := 128
+  maxAlignmentShift := 64
+
+def config : Config :=
+  { endpointLimit
+    reciprocalBasePrecision := 2
+    maxReciprocalEffort := 4 }
+
+def registry : Registry := { config }
+
+def limits : Experiment.Propagator.Limits :=
+  { maxOperations := 16
+    maxNodes := 32
+    maxRules := 16
+    maxArity := 4
+    maxApplications := 64
+    maxQueueEntries := 256
+    maxActions := 128
+    maxAcceptedFacts := 128
+    maxRetainedSuggestions := 32
+    maxEffort := 8
+    maxObservationValue := 256
+    maxOutcomeCandidates := 4
+    maxOutcomeSuggestions := 4
+    maxProposalItems := 16
+    maxInstances := 8
+    maxGeneration := 4
+    maxEqualities := 8
+    splitEndpointLimit := endpointLimit }
+
+def allOperations : Array Operation :=
+  operations real |>.push { key := sourceOp, inputs := [], output := real }
+
+def instruction (operation : Nat) (args : List NodeId := []) : Node :=
+  { domain := real, op := { index := operation }, args }
+
+def node (index : Nat) : NodeId := { index }
+def suggestion (index : Nat) : SuggestionId := { index }
+
+def finite (lower : Int) (lowerStrict : Bool)
+    (upper : Int) (upperStrict : Bool) : Raw :=
+  .bounds (.finite (d lower) lowerStrict) (.finite (d upper) upperStrict)
+
+def whole : Raw := .bounds .unbounded .unbounded
+
+def exactFact (state : Engine Fact) (index : Nat) (expected : Raw) : Bool :=
+  (state.facts[index]?).any fun fact => fact.view == expected
+
+/-! ## Exact backward singleton multiplication -/
+
+/-- Nodes are `2`, `y`, and `z = 2*y`.  The output and input cuts deliberately
+mix strict and closed endpoints. -/
+def scaleProgram : Program :=
+  { operations := allOperations
+    nodes :=
+      #[instruction 7,
+        instruction 7,
+        instruction 3 [node 0, node 1]] }
+
+def scaleStart? : Option (Engine Fact) :=
+  match DyadicInterval.start endpointLimit scaleProgram registrations
+      #[finite 2 false 2 false,
+        .bounds (.finite 0 true) .unbounded,
+        finite 2 true 6 false]
+      limits with
+  | .ok state => some state
+  | .error _ => none
+
+def scaleFinal? : Option (RunResult Fact Unit) := do
+  let state <- scaleStart?
+  pure (drive registry.invokeWithCache 32 state ())
+
+#guard scaleProgram.check
+#guard registrationsCheck scaleProgram registrations
+
+-- The unbounded forward image is honestly inapplicable.  The exact singleton
+-- backward contractor nevertheless derives `(1,3]`, then the now-finite
+-- forward rule confirms the existing `(2,6]` output.
+#guard
+  match scaleFinal? with
+  | some result =>
+      result.stop == .saturated && result.state.metrics.requests == 6 &&
+        result.state.metrics.improvements == 1 &&
+        result.state.metrics.ruleInapplicable == 4 &&
+        exactFact result.state 0 (finite 2 false 2 false) &&
+        exactFact result.state 1 (finite 1 true 3 false) &&
+        exactFact result.state 2 (finite 2 true 6 false)
+  | none => false
+
+/-! ## Mixed forward/backward cycles -/
+
+/-- Three disconnected components exercise negation backward, subtraction
+backward-left, and an open square image in one worklist. -/
+def cycleProgram : Program :=
+  { operations := allOperations
+    nodes :=
+      #[instruction 7,
+        instruction 1 [node 0],
+        instruction 7,
+        instruction 7,
+        instruction 2 [node 3, node 2],
+        instruction 7,
+        instruction 4 [node 5]] }
+
+def cycleStart? : Option (Engine Fact) :=
+  match DyadicInterval.start endpointLimit cycleProgram registrations
+      #[whole,
+        finite 1 false 2 false,
+        finite 1 false 2 false,
+        whole,
+        finite 3 false 4 false,
+        finite (-1) true 1 true,
+        whole]
+      limits with
+  | .ok state => some state
+  | .error _ => none
+
+def cycleFinal? : Option (RunResult Fact Unit) := do
+  let state <- cycleStart?
+  pure (drive registry.invokeWithCache 48 state ())
+
+#guard cycleProgram.check
+#guard registrationsCheck cycleProgram registrations
+
+#guard
+  match cycleFinal? with
+  | some result =>
+      result.stop == .saturated && !result.state.contradictory &&
+        exactFact result.state 0 (finite (-2) false (-1) false) &&
+        exactFact result.state 1 (finite 1 false 2 false) &&
+        exactFact result.state 2 (finite 1 false 2 false) &&
+        exactFact result.state 3 (finite 4 false 6 false) &&
+        exactFact result.state 4 (finite 3 false 4 false) &&
+        exactFact result.state 5 (finite (-1) true 1 true) &&
+        exactFact result.state 6 (finite 0 false 1 true)
+  | none => false
+
+/-! ## Dependency loss and centered instantiation -/
+
+/-- `x`, `1`, `1-x`, and `x*(1-x)`. -/
+def centeredProgram : Program :=
+  { operations := allOperations
+    nodes :=
+      #[instruction 7,
+        instruction 0,
+        instruction 2 [node 1, node 0],
+        instruction 3 [node 0, node 2]] }
+
+def centeredStart? : Option (Engine Fact) :=
+  match DyadicInterval.start endpointLimit centeredProgram registrations
+      #[finite 0 false 1 false,
+        finite 1 false 1 false,
+        whole,
+        whole]
+      limits with
+  | .ok state => some state
+  | .error _ => none
+
+def centeredInitial? : Option (RunResult Fact Unit) := do
+  let state <- centeredStart?
+  pure (drive registry.invokeWithCache 32 state ())
+
+def centeredFinal? : Option (RunResult Fact Unit) := do
+  let initial <- centeredInitial?
+  match initial.state.admitInstantiation (suggestion 0) with
+  | .admitted [centered] state =>
+      if centered == node 4 then
+        some (drive registry.invokeWithCache 32 state ())
+      else
+        none
+  | _ => none
+
+#guard centeredProgram.check
+#guard registrationsCheck centeredProgram registrations
+
+-- Ordinary interval evaluation loses the dependency between the two
+-- occurrences of `x` and obtains only `[0,1]`.  The shape rule has no fact
+-- inputs, but retains an engine-indexed proposal for the alternate form.
+#guard
+  match centeredInitial? with
+  | some result =>
+      result.stop == .saturated && result.state.programVersion == 0 &&
+        result.state.suggestions.size == 1 &&
+        exactFact result.state 2 (finite 0 false 1 false) &&
+        exactFact result.state 3 (finite 0 false 1 false) &&
+        match result.state.suggestions[0]? with
+        | some retained =>
+            retained.action.key == centeredInstantiateKey &&
+              retained.action.inputs.isEmpty &&
+              match retained.suggestion with
+              | .instantiate request =>
+                  request.triggers == [node 3, node 0, node 2, node 1] &&
+                    request.claimedGeneration == 1 && request.nodes.length == 1 &&
+                    request.equalities.length == 1
+              | _ => false
+        | none => false
+  | none => false
+
+-- Admission creates the opaque centered node and equality.  Its arbitrary
+-- propagator proves `[0,1/4]`; equality transport then improves the original
+-- product to the same fact.
+#guard
+  match centeredFinal? with
+  | some result =>
+      result.stop == .saturated && result.state.programVersion == 1 &&
+        result.state.program.nodes.size == 5 && result.state.equalities.size == 1 &&
+        result.state.generations[4]? == some 1 &&
+        exactFact result.state 3
+          (.bounds (.finite 0 false) (.finite quarter false)) &&
+        exactFact result.state 4
+          (.bounds (.finite 0 false) (.finite quarter false)) &&
+        match result.state.program.node? (node 4), result.state.equalities[0]? with
+        | some centered, some equality =>
+            centered.args == [node 0] &&
+              (result.state.program.operation? centered.op).any
+                (fun operation => operation.key == centeredOp) &&
+              equality.left == node 3 && equality.right == node 4
+        | _, _ => false
+  | none => false
+
+/-! ## Retry and malformed dispatch boundaries -/
+
+def reciprocalProgram : Program :=
+  { operations := allOperations
+    nodes := #[instruction 7, instruction 5 [node 0]] }
+
+def reciprocalStart? : Option (Engine Fact) :=
+  match DyadicInterval.start endpointLimit reciprocalProgram registrations
+      #[finite 3 false 3 false, whole] limits with
+  | .ok state => some state
+  | .error _ => none
+
+def reciprocalFirstRequest? : Option (RuleRequest Fact) := do
+  let state <- reciprocalStart?
+  match state.poll with
+  | .request request _ => some request
+  | _ => none
+
+-- Precision two encloses `1/3` by open quarter-grid endpoints and emits the
+-- next effort as an advisory retry.
+#guard
+  match reciprocalFirstRequest? with
+  | some request =>
+      match registry.invoke request with
+      | .success [candidate] [.retry 1] _ =>
+          candidate.node == node 1 &&
+            candidate.fact.view ==
+              .bounds (.finite quarter true) (.finite half true)
+      | _ => false
+  | none => false
+
+def bogusRequest : RuleRequest Fact :=
+  { action :=
+      { serial := 0
+        programVersion := 0
+        application := { index := 0 }
+        rule := { index := 0 }
+        key := { name := "unknown.rule" }
+        node := node 0
+        kind := .forward
+        effort := 0
+        inputs := [] }
+    program :=
+      { programVersion := 0
+        operations := #[]
+        nodes := #[]
+        generations := #[] }
+    inputs := []
+    writes := [] }
+
+-- A callback outside the versioned registry cannot manufacture a candidate;
+-- unknown dispatch is a diagnostic failure with no writes.
+#guard
+  match registry.invoke bogusRequest with
+  | .failed 255 => true
+  | _ => false
+
+end Hex.Interval.DyadicRulesConformance

--- a/conformance/HexInterval/DyadicRulesConformance.lean
+++ b/conformance/HexInterval/DyadicRulesConformance.lean
@@ -407,8 +407,7 @@ def badSignatureProgram : Program :=
               retained.action.inputs.isEmpty &&
               match retained.suggestion with
               | .instantiate request =>
-                  request.triggers == [node 3, node 0, node 2, node 1] &&
-                    request.nodes.length == 1 && request.equalities.length == 1
+                  request.nodes.length == 1 && request.equalities.length == 1
               | _ => false
         | none => false
   | none => false

--- a/conformance/HexInterval/DyadicRulesConformance.lean
+++ b/conformance/HexInterval/DyadicRulesConformance.lean
@@ -254,8 +254,8 @@ def keyedProposal? : Option InstantiationRequest :=
       match proposal.nodes with
       | [draft] =>
           draft.op.index == 7 &&
-            match resolveDrafts keyedProgram.nodes.size limits.maxNodeDepth
-                keyedProgram keyedView.depths [] proposal.nodes with
+            match resolveDrafts keyedProgram.nodes.size keyedProgram
+                keyedView.depths [] proposal.nodes with
             | .ok (resolvedProgram, depths, resolved) =>
                 resolvedProgram.nodes.size == keyedProgram.nodes.size &&
                   depths == keyedView.depths && resolved == [node 4]

--- a/conformance/HexInterval/DyadicRulesConformance.lean
+++ b/conformance/HexInterval/DyadicRulesConformance.lean
@@ -5,6 +5,7 @@ Authors: Kim Morrison
 -/
 
 import HexInterval.Experiment.DyadicRules
+import HexInterval.Experiment.PolicyDriver
 
 /-!
 End-to-end conformance for concrete arbitrary-function propagators.  These
@@ -31,7 +32,7 @@ def config : Config :=
     reciprocalBasePrecision := 2
     maxReciprocalEffort := 4 }
 
-def registry : Registry := { config }
+abbrev ConcreteRegistry := Propagator.Registry Fact
 
 def limits : Experiment.Propagator.Limits :=
   { maxOperations := 16
@@ -45,6 +46,7 @@ def limits : Experiment.Propagator.Limits :=
     maxRetainedSuggestions := 32
     maxEffort := 8
     maxObservationValue := 256
+    maxDiagnosticValue := 256
     maxOutcomeCandidates := 4
     maxOutcomeSuggestions := 4
     maxProposalItems := 16
@@ -53,8 +55,16 @@ def limits : Experiment.Propagator.Limits :=
     maxEqualities := 8
     splitEndpointLimit := endpointLimit }
 
+def registry? : Option ConcreteRegistry :=
+  match buildRegistry config real limits with
+  | .ok registry => some registry
+  | .error _ => none
+
 def allOperations : Array Operation :=
-  operations real |>.push { key := sourceOp, inputs := [], output := real }
+  match registry? with
+  | some registry =>
+      registry.operations.push { key := sourceOp, inputs := [], output := real }
+  | none => #[]
 
 def instruction (operation : Nat) (args : List NodeId := []) : Node :=
   { domain := real, op := { index := operation }, args }
@@ -71,6 +81,11 @@ def whole : Raw := .bounds .unbounded .unbounded
 def exactFact (state : Engine Fact) (index : Nat) (expected : Raw) : Bool :=
   (state.facts[index]?).any fun fact => fact.view == expected
 
+def registryChecks (program : Program) : Bool :=
+  match registry? with
+  | some registry => registrationsCheck program registry.registrations
+  | none => false
+
 /-! ## Exact backward singleton multiplication -/
 
 /-- Nodes are `2`, `y`, and `z = 2*y`.  The output and input cuts deliberately
@@ -82,8 +97,8 @@ def scaleProgram : Program :=
         instruction 7,
         instruction 3 [node 0, node 1]] }
 
-def scaleStart? : Option (Engine Fact) :=
-  match DyadicInterval.start endpointLimit scaleProgram registrations
+def scaleStart? : Option (Engine Fact × ConcreteRegistry) :=
+  match DyadicRules.start config real scaleProgram
       #[finite 2 false 2 false,
         .bounds (.finite 0 true) .unbounded,
         finite 2 true 6 false]
@@ -91,12 +106,12 @@ def scaleStart? : Option (Engine Fact) :=
   | .ok state => some state
   | .error _ => none
 
-def scaleFinal? : Option (RunResult Fact Unit) := do
-  let state <- scaleStart?
-  pure (drive registry.invokeWithCache 32 state ())
+def scaleFinal? : Option (RunResult Fact ConcreteRegistry) := do
+  let (state, registry) <- scaleStart?
+  pure (drive Propagator.Registry.invoke 32 state registry)
 
 #guard scaleProgram.check
-#guard registrationsCheck scaleProgram registrations
+#guard registryChecks scaleProgram
 
 -- The unbounded forward image is honestly inapplicable.  The exact singleton
 -- backward contractor nevertheless derives `(1,3]`, then the now-finite
@@ -127,8 +142,8 @@ def cycleProgram : Program :=
         instruction 7,
         instruction 4 [node 5]] }
 
-def cycleStart? : Option (Engine Fact) :=
-  match DyadicInterval.start endpointLimit cycleProgram registrations
+def cycleStart? : Option (Engine Fact × ConcreteRegistry) :=
+  match DyadicRules.start config real cycleProgram
       #[whole,
         finite 1 false 2 false,
         finite 1 false 2 false,
@@ -140,12 +155,12 @@ def cycleStart? : Option (Engine Fact) :=
   | .ok state => some state
   | .error _ => none
 
-def cycleFinal? : Option (RunResult Fact Unit) := do
-  let state <- cycleStart?
-  pure (drive registry.invokeWithCache 48 state ())
+def cycleFinal? : Option (RunResult Fact ConcreteRegistry) := do
+  let (state, registry) <- cycleStart?
+  pure (drive Propagator.Registry.invoke 48 state registry)
 
 #guard cycleProgram.check
-#guard registrationsCheck cycleProgram registrations
+#guard registryChecks cycleProgram
 
 #guard
   match cycleFinal? with
@@ -171,8 +186,8 @@ def centeredProgram : Program :=
         instruction 2 [node 1, node 0],
         instruction 3 [node 0, node 2]] }
 
-def centeredStart? : Option (Engine Fact) :=
-  match DyadicInterval.start endpointLimit centeredProgram registrations
+def centeredStart? : Option (Engine Fact × ConcreteRegistry) :=
+  match DyadicRules.start config real centeredProgram
       #[finite 0 false 1 false,
         finite 1 false 1 false,
         whole,
@@ -181,22 +196,124 @@ def centeredStart? : Option (Engine Fact) :=
   | .ok state => some state
   | .error _ => none
 
-def centeredInitial? : Option (RunResult Fact Unit) := do
-  let state <- centeredStart?
-  pure (drive registry.invokeWithCache 32 state ())
+def centeredAt (input expected : Dyadic) : Bool :=
+  match DyadicInterval.closed endpointLimit input input with
+  | .ready fact =>
+      match centeredImage endpointLimit fact with
+      | .ready image =>
+          image.view ==
+            .bounds (.finite expected false) (.finite expected false)
+      | .inapplicable | .resourceLimit _ => false
+  | .inapplicable | .resourceLimit _ => false
 
-def centeredFinal? : Option (RunResult Fact Unit) := do
+def centeredInitial? : Option (RunResult Fact ConcreteRegistry) := do
+  let (state, registry) <- centeredStart?
+  pure (drive Propagator.Registry.invoke 32 state registry)
+
+def centeredAdmitted? : Option (Engine Fact × ConcreteRegistry) := do
   let initial <- centeredInitial?
   match initial.state.admitInstantiation (suggestion 0) with
   | .admitted [centered] state =>
       if centered == node 4 then
-        some (drive registry.invokeWithCache 32 state ())
+        some (state, initial.cache)
       else
         none
   | _ => none
 
+def centeredFinal? : Option (RunResult Fact ConcreteRegistry) := do
+  let (state, registry) <- centeredAdmitted?
+  pure (drive Propagator.Registry.invoke 32 state registry)
+
+def falseOneRun? : Option (RunResult Fact ConcreteRegistry) := do
+  let (state, registry) <-
+    match DyadicRules.start config real centeredProgram
+        #[finite 0 false 1 false,
+          finite 5 false 5 false,
+          whole,
+          whole]
+        limits with
+    | .ok state => some state
+    | .error _ => none
+  pure (drive Propagator.Registry.invoke 8 state registry)
+
 #guard centeredProgram.check
-#guard registrationsCheck centeredProgram registrations
+#guard registryChecks centeredProgram
+#guard centeredAt 0 0
+#guard centeredAt half quarter
+#guard centeredAt 1 0
+
+-- The old whole-program match is stale after extension, and admission has
+-- requeued the structural application so it can observe the new snapshot.
+#guard
+  match centeredAdmitted? with
+  | some (state, _) =>
+      match state.admitInstantiation (suggestion 0) with
+      | .invalid (.staleSuggestion 0 1) unchanged =>
+          unchanged.programVersion == 1 &&
+            unchanged.queue.toList.any fun work =>
+              match work with
+              | .application applicationId =>
+                  (unchanged.applications[applicationId.index]?).any fun application =>
+                    (unchanged.rules[application.rule.index]?).any fun registration =>
+                      registration.key == centeredInstantiateKey &&
+                        (unchanged.queued[applicationId.index]?).getD false
+              | .equality _ => false
+      | _ => false
+  | none => false
+
+def lowEffortLimits : Experiment.Propagator.Limits :=
+  { limits with maxEffort := 3 }
+
+def lowDiagnosticLimits : Experiment.Propagator.Limits :=
+  { limits with maxDiagnosticValue := 70 }
+
+def noCandidateLimits : Experiment.Propagator.Limits :=
+  { limits with maxOutcomeCandidates := 0 }
+
+def noSuggestionLimits : Experiment.Propagator.Limits :=
+  { limits with maxOutcomeSuggestions := 0 }
+
+def shortProposalLimits : Experiment.Propagator.Limits :=
+  { limits with maxProposalItems := 3 }
+
+def tinySplitLimits : Experiment.Propagator.Limits :=
+  { limits with
+    splitEndpointLimit := { maxEndpointHeight := 0, maxAlignmentShift := 0 } }
+
+def rejectsPackageLimits (candidateLimits : Experiment.Propagator.Limits) : Bool :=
+  match DyadicRules.start config real centeredProgram
+      #[finite 0 false 1 false, finite 1 false 1 false, whole, whole]
+      candidateLimits with
+  | .error .incompatibleLimits => true
+  | _ => false
+
+def badSignatureProgram : Program :=
+  { centeredProgram with
+    operations := centeredProgram.operations.set! 6
+      { key := centeredOp, inputs := [real, real], output := real } }
+
+#guard rejectsPackageLimits lowEffortLimits
+#guard rejectsPackageLimits lowDiagnosticLimits
+#guard rejectsPackageLimits noCandidateLimits
+#guard rejectsPackageLimits noSuggestionLimits
+#guard rejectsPackageLimits shortProposalLimits
+#guard rejectsPackageLimits tinySplitLimits
+
+#guard badSignatureProgram.check
+#guard
+  match DyadicRules.start config real badSignatureProgram
+      #[finite 0 false 1 false, finite 1 false 1 false, whole, whole]
+      limits with
+  | .error .operationMismatch => true
+  | _ => false
+
+-- The distinguished nullary operation carries its own semantics.  A caller
+-- cannot seed a node named `real.one` with `{5}` and let the structural
+-- identity matcher treat it as one.
+#guard
+  match falseOneRun? with
+  | some result => result.stop == .contradiction && result.state.contradictory
+  | none => false
 
 -- Ordinary interval evaluation loses the dependency between the two
 -- occurrences of `x` and obtains only `[0,1]`.  The shape rule has no fact
@@ -222,8 +339,9 @@ def centeredFinal? : Option (RunResult Fact Unit) := do
   | none => false
 
 -- Admission creates the opaque centered node and equality.  Its arbitrary
--- propagator proves `[0,1/4]`; equality transport then improves the original
--- product to the same fact.
+-- callback returns `[0,1/4]`; equality transport then improves the original
+-- product to the same fact.  The whole-program matcher also runs on the new
+-- snapshot rather than silently remaining dormant.
 #guard
   match centeredFinal? with
   | some result =>
@@ -234,6 +352,9 @@ def centeredFinal? : Option (RunResult Fact Unit) := do
           (.bounds (.finite 0 false) (.finite quarter false)) &&
         exactFact result.state 4
           (.bounds (.finite 0 false) (.finite quarter false)) &&
+        result.state.suggestions.toList.any (fun retained =>
+          retained.action.key == centeredInstantiateKey &&
+            retained.action.programVersion == 1) &&
         match result.state.program.node? (node 4), result.state.equalities[0]? with
         | some centered, some equality =>
             centered.args == [node 0] &&
@@ -243,30 +364,196 @@ def centeredFinal? : Option (RunResult Fact Unit) := do
         | _, _ => false
   | none => false
 
+/-! ## External policy over concrete function offers -/
+
+def policyLimits : Propagator.Policy.Limits :=
+  { maxDecisions := 128
+    maxTraversal := 16384
+    maxLiveOffers := 512 }
+
+inductive ConcreteCommand
+  | invoke (key : RuleKey)
+  | instantiate (key : RuleKey)
+  | retry (key : RuleKey) (effort : Nat)
+  | equality
+  | split (key : RuleKey)
+
+def commandMatches (command : ConcreteCommand)
+    (offer : Propagator.Policy.OfferView) : Bool :=
+  match command, offer.key with
+  | .invoke key, .invoke source => source.rule == key
+  | .instantiate key, .instantiate source _ => source.rule == key
+  | .retry key effort, .retry source offeredEffort =>
+      source.rule == key && offeredEffort == effort
+  | .equality, .equality _ => true
+  | .split key, .split source _ _ _ => source.rule == key
+  | _, _ => false
+
+def concreteChoose (commands : List ConcreteCommand)
+    (view : Propagator.Policy.View Fact) :
+    Propagator.Policy.Driver.Step (List ConcreteCommand) :=
+  match commands with
+  | [] => .stop []
+  | command :: rest =>
+      match view.offers.toList.find? (commandMatches command) with
+      | none => .stop rest
+      | some offer =>
+      .select
+        { scope := view.scope
+          serial := view.serial
+          programVersion := view.programVersion
+          id := offer.id
+          expected := offer.key }
+        rest
+
+def concreteController :
+    Propagator.Policy.Driver.Controller Fact (List ConcreteCommand) where
+  key := { name := "dyadic-rules.script", version := 0 }
+  update state _ := state
+  choose := concreteChoose
+
+def combinedProgram : Program :=
+  { operations := allOperations
+    nodes :=
+      #[instruction 7,
+        instruction 0,
+        instruction 2 [node 1, node 0],
+        instruction 3 [node 0, node 2],
+        instruction 7,
+        instruction 5 [node 4]] }
+
+def combinedStart? : Option (Engine Fact × ConcreteRegistry) :=
+  match DyadicRules.start config real combinedProgram
+      #[finite 0 false 1 false,
+        finite 1 false 1 false,
+        whole,
+        whole,
+        finite 3 false 3 false,
+        whole]
+      limits with
+  | .ok state => some state
+  | .error _ => none
+
+def concreteCommands : List ConcreteCommand :=
+  [.invoke subForwardKey,
+    .invoke mulForwardKey,
+    .invoke centeredInstantiateKey,
+    .instantiate centeredInstantiateKey,
+    .invoke centeredSplitKey,
+    .invoke centeredForwardKey,
+    .equality,
+    .invoke reciprocalForwardKey,
+    .retry reciprocalForwardKey 1,
+    .split centeredSplitKey]
+
+def combinedPolicyRun? : Option
+    (Propagator.Policy.Driver.Result Fact ConcreteRegistry
+      (List ConcreteCommand)) := do
+  let (engine, registry) <- combinedStart?
+  let state := Propagator.Policy.State.start engine policyLimits
+  pure (Propagator.Policy.Driver.drive concreteController Propagator.Registry.invoke
+    32 state registry concreteCommands)
+
+def exactConcreteEvents
+    (events : Array (Propagator.Policy.Driver.Event Fact)) : Bool :=
+  match events.toList with
+  | [.rule _ subObservation,
+      .rule _ mulObservation,
+      .rule _ instantiateObservation,
+      .instance _ (.admitted [fresh]),
+      .rule _ splitObservation,
+      .rule _ centeredObservation,
+      .equality _ equalityObservation,
+      .rule _ reciprocalObservation,
+      .rule _ retryObservation,
+      .splitPrepared _ plan] =>
+      subObservation.invocation.rule == subForwardKey &&
+        mulObservation.invocation.rule == mulForwardKey &&
+        instantiateObservation.invocation.rule == centeredInstantiateKey &&
+        fresh == node 6 && splitObservation.invocation.rule == centeredSplitKey &&
+        centeredObservation.invocation.rule == centeredForwardKey &&
+        equalityObservation.outcome == .improved &&
+        reciprocalObservation.invocation.rule == reciprocalForwardKey &&
+        reciprocalObservation.invocation.effort == 0 &&
+        retryObservation.invocation.rule == reciprocalForwardKey &&
+        retryObservation.invocation.effort == 1 &&
+        plan.node == node 0 && plan.version == 0
+  | _ => false
+
+#guard combinedProgram.check
+#guard registryChecks combinedProgram
+
+-- A single external schedule chooses propagation, instantiation, equality,
+-- one precision retry, and finally a function-owned split.  The split offer
+-- survives unrelated improvements, and retry effort two remains live when the
+-- policy deliberately chooses subdivision.  No branch is executed here.
+#guard
+  match combinedPolicyRun? with
+  | some result =>
+      result.policyState.isEmpty && result.events.size == 10 &&
+        exactConcreteEvents result.events &&
+        result.state.metrics.decisions == 10 &&
+        result.state.metrics.selectedInvocations == 6 &&
+        result.state.metrics.selectedRetries == 1 &&
+        result.state.metrics.selectedInstances == 1 &&
+        result.state.metrics.selectedSplits == 1 &&
+        result.state.metrics.selectedEqualities == 1 &&
+        result.state.engine.programVersion == 1 &&
+        result.state.engine.program.nodes.size == 7 &&
+        result.state.engine.applications.size == 12 &&
+        result.state.engine.equalities.size == 1 &&
+        result.state.engine.metrics.requests == 7 &&
+        result.state.engine.metrics.replies == 7 &&
+        result.state.engine.metrics.candidates == 5 &&
+        result.state.engine.metrics.improvements == 6 &&
+        result.state.engine.metrics.equalityRuns == 1 &&
+        result.state.engine.metrics.equalityImprovements == 1 &&
+        result.state.engine.versions.toList == [0, 0, 1, 2, 0, 2, 1] &&
+        exactFact result.state.engine 3
+          (.bounds (.finite 0 false) (.finite quarter false)) &&
+        exactFact result.state.engine 5
+          (.bounds (.finite quarter true)
+            (.finite (Dyadic.ofIntWithPrec 3 3) true)) &&
+        exactFact result.state.engine 6
+          (.bounds (.finite 0 false) (.finite quarter false)) &&
+        (match result.state.offer? (.suggestion (suggestion 3)) with
+         | some { key := .retry source 2, .. } =>
+             source.rule == reciprocalForwardKey &&
+               match result.stop with
+               | .split plan =>
+                   plan.node == node 0 && plan.version == 0 && plan.point == half &&
+                     plan.reason == .criticalPoint &&
+                     plan.origin.key == centeredSplitKey &&
+                     plan.source.rule == centeredSplitKey &&
+                     plan.fact.view == finite 0 false 1 false
+               | _ => false
+         | _ => false)
+  | none => false
+
 /-! ## Retry and malformed dispatch boundaries -/
 
 def reciprocalProgram : Program :=
   { operations := allOperations
     nodes := #[instruction 7, instruction 5 [node 0]] }
 
-def reciprocalStart? : Option (Engine Fact) :=
-  match DyadicInterval.start endpointLimit reciprocalProgram registrations
+def reciprocalStart? : Option (Engine Fact × ConcreteRegistry) :=
+  match DyadicRules.start config real reciprocalProgram
       #[finite 3 false 3 false, whole] limits with
   | .ok state => some state
   | .error _ => none
 
-def reciprocalFirstRequest? : Option (RuleRequest Fact) := do
-  let state <- reciprocalStart?
+def reciprocalFirstRequest? : Option (RuleRequest Fact × ConcreteRegistry) := do
+  let (state, registry) <- reciprocalStart?
   match state.poll with
-  | .request request _ => some request
+  | .request request _ => some (request, registry)
   | _ => none
 
 -- Precision two encloses `1/3` by open quarter-grid endpoints and emits the
 -- next effort as an advisory retry.
 #guard
   match reciprocalFirstRequest? with
-  | some request =>
-      match registry.invoke request with
+  | some (request, registry) =>
+      match (registry.invoke request).1 with
       | .success [candidate] [.retry 1] _ =>
           candidate.node == node 1 &&
             candidate.fact.view ==
@@ -296,8 +583,11 @@ def bogusRequest : RuleRequest Fact :=
 -- A callback outside the versioned registry cannot manufacture a candidate;
 -- unknown dispatch is a diagnostic failure with no writes.
 #guard
-  match registry.invoke bogusRequest with
-  | .failed 255 => true
-  | _ => false
+  match registry? with
+  | some registry =>
+      match (registry.invoke bogusRequest).1 with
+      | .failed code => code == DispatchCode.requestMismatch
+      | _ => false
+  | none => false
 
 end Hex.Interval.DyadicRulesConformance

--- a/conformance/HexInterval/DyadicRulesConformance.lean
+++ b/conformance/HexInterval/DyadicRulesConformance.lean
@@ -8,6 +8,8 @@ import HexInterval.Experiment.DyadicRules
 import HexInterval.Experiment.PolicyDriver
 
 /-!
+# Arbitrary-function package conformance
+
 End-to-end conformance for concrete arbitrary-function propagators.  These
 fixtures run the generic worklist; they do not call interval operations in
 place of the registry when checking the final facts.

--- a/conformance/HexInterval/PackageRegistryConformance.lean
+++ b/conformance/HexInterval/PackageRegistryConformance.lean
@@ -192,7 +192,8 @@ def view : ProgramView :=
   { programVersion := 0
     operations := program.operations
     nodes := program.nodes
-    generations := #[0, 0, 0, 0] }
+    generations := #[0, 0, 0, 0]
+    depths := #[0, 1, 1, 1] }
 
 def unaryRequest (rule application : Nat) (key : RuleKey) (anchor : NodeId)
     (kind : ActionKind) (writes : List NodeId) : RuleRequest Nat :=
@@ -248,6 +249,7 @@ def limits : Limits :=
     maxProposalItems := 4
     maxInstances := 2
     maxGeneration := 2
+    maxNodeDepth := 16
     maxEqualities := 2
     splitEndpointLimit :=
       { maxEndpointHeight := 16
@@ -307,6 +309,17 @@ def policyDriverTypecheck {PolicyState : Type}
   match registry? with
   | some registry => !registry.acceptsLimits program lowDiagnosticLimits
   | none => false
+
+-- Registry-owned dispatch failures have a diagnostic floor independent of
+-- every package's callback-specific preflight.
+#guard
+  match Registry.buildWithin limits #[sharedPackage] with
+  | .ok registry =>
+      !registry.acceptsLimits program
+          { limits with maxDiagnosticValue := DispatchCode.requestMismatch - 1 } &&
+        registry.acceptsLimits program
+          { limits with maxDiagnosticValue := DispatchCode.requestMismatch }
+  | .error _ => false
 
 #guard
   match Registry.buildWithin shortRuleLimits

--- a/conformance/HexInterval/PackageRegistryConformance.lean
+++ b/conformance/HexInterval/PackageRegistryConformance.lean
@@ -1,0 +1,443 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexInterval.Experiment.PackageRegistry
+import HexInterval.Experiment.PolicyDriver
+
+/-!
+Focused conformance for independently composable propagator packages.  The
+fixtures deliberately combine unrelated private cache types, multiple rules
+for one head, a package appended without central dispatch changes, malformed
+requests, and an oversized resource refusal.
+-/
+
+namespace Hex.Interval.PackageRegistryConformance
+
+open Experiment.Propagator
+
+def real : DomainId := { index := 0 }
+def other : DomainId := { index := 1 }
+
+def sourceOp : OpKey := { name := "package-test.source" }
+def sharedOp : OpKey := { name := "package-test.shared" }
+def thirdOp : OpKey := { name := "package-test.third-party" }
+def limitedOp : OpKey := { name := "package-test.resource" }
+def externalOp : OpKey := { name := "package-test.frontend-owned" }
+
+def tickKey : RuleKey := { name := "package-test.shared.tick" }
+def observeKey : RuleKey := { name := "package-test.shared.observe" }
+def thirdKey : RuleKey := { name := "package-test.third-party.forward" }
+def limitedKey : RuleKey := { name := "package-test.resource.refuse" }
+def externalKey : RuleKey := { name := "package-test.frontend-owned.observe" }
+
+def sourceOperation : Operation := { key := sourceOp, inputs := [], output := real }
+def sharedOperation : Operation := { key := sharedOp, inputs := [real], output := real }
+def thirdOperation : Operation := { key := thirdOp, inputs := [real], output := real }
+def limitedOperation : Operation := { key := limitedOp, inputs := [real], output := real }
+def externalOperation : Operation := { key := externalOp, inputs := [real], output := real }
+
+def tickRegistration : Registration :=
+  { key := tickKey
+    head := sharedOp
+    kind := .improve
+    watches := [.argument 0]
+    writes := [] }
+
+def observeRegistration : Registration :=
+  { key := observeKey
+    head := sharedOp
+    kind := .forward
+    watches := [.argument 0]
+    writes := [.result] }
+
+def thirdRegistration : Registration :=
+  { key := thirdKey
+    head := thirdOp
+    kind := .forward
+    watches := [.argument 0]
+    writes := [.result] }
+
+def limitedRegistration : Registration :=
+  { key := limitedKey
+    head := limitedOp
+    kind := .improve
+    watches := [.argument 0]
+    writes := [] }
+
+def externalRegistration : Registration :=
+  { key := externalKey
+    head := externalOp
+    kind := .improve
+    watches := [.argument 0]
+    writes := [] }
+
+def tickInvoke (cache : Nat) (_request : RuleRequest Nat) : Outcome Nat × Nat :=
+  (.noChange { arithmeticWork := 1 }, cache + 1)
+
+def observeInvoke (cache : Nat) (request : RuleRequest Nat) : Outcome Nat × Nat :=
+  match request.writes with
+  | [target] =>
+      (.success [{ node := target, fact := 1, payload := { index := 1 } }]
+        [] { arithmeticWork := 1 }, cache + 10)
+  | _ => (.failed 32, cache)
+
+/-- A separately appended package owns a `List Nat` cache.  Its mathematical
+outcome is deliberately independent of that performance cache. -/
+def thirdInvoke (cache : List Nat) (request : RuleRequest Nat) :
+    Outcome Nat × List Nat :=
+  match request.writes with
+  | [target] =>
+      (.success
+        [{ node := target, fact := 2, payload := { index := 2 } }]
+        [] { arithmeticWork := 1 }, request.action.node.index :: cache)
+  | _ => (.failed 33, cache)
+
+def limitedInvoke (_cache : Bool) (_request : RuleRequest Nat) : Outcome Nat × Bool :=
+  (.resourceLimit 1000000, true)
+
+def sharedPackage : Package Nat :=
+  { Cache := Nat
+    cache := 0
+    operations := #[sourceOperation, sharedOperation]
+    handlers :=
+      #[{ registration := tickRegistration, invoke := tickInvoke },
+        { registration := observeRegistration, invoke := observeInvoke }] }
+
+def thirdPackage : Package Nat :=
+  { Cache := List Nat
+    cache := []
+    operations := #[thirdOperation]
+    requiredOperations := #[sourceOperation]
+    handlers := #[{ registration := thirdRegistration, invoke := thirdInvoke }] }
+
+def limitedPackage : Package Nat :=
+  { Cache := Bool
+    cache := false
+    operations := #[limitedOperation]
+    handlers := #[{ registration := limitedRegistration, invoke := limitedInvoke }]
+    acceptsLimits := fun _ limits =>
+      8 ≤ limits.maxObservationValue && 1000000 ≤ limits.maxDiagnosticValue }
+
+/-- A package may attach a handler to a signature supplied only by the final
+frontend program, but it must declare the exact dependency. -/
+def externalPackage : Package Nat :=
+  { Cache := Unit
+    cache := ()
+    requiredOperations := #[externalOperation]
+    handlers :=
+      #[Handler.stateless externalRegistration (fun _ => .noChange {})] }
+
+def duplicateRulePackage : Package Nat :=
+  { Cache := Unit
+    cache := ()
+    requiredOperations := #[sharedOperation]
+    handlers := #[Handler.stateless tickRegistration (fun _ => .inapplicable)] }
+
+def undeclaredHeadPackage : Package Nat :=
+  { Cache := Unit
+    cache := ()
+    handlers := #[Handler.stateless tickRegistration (fun _ => .inapplicable)] }
+
+def duplicateOperationPackage : Package Nat :=
+  { Cache := Unit
+    cache := ()
+    operations := #[sharedOperation]
+    handlers := #[] }
+
+def instruction (operation : Nat) (args : List NodeId := []) : Node :=
+  { domain := real, op := { index := operation }, args }
+
+def node (index : Nat) : NodeId := { index }
+
+def program : Program :=
+  { operations := #[sourceOperation, sharedOperation, thirdOperation, limitedOperation]
+    nodes :=
+      #[instruction 0,
+        instruction 1 [node 0],
+        instruction 2 [node 0],
+        instruction 3 [node 0]] }
+
+def mismatchedProgram : Program :=
+  { operations :=
+      #[sourceOperation,
+        { sharedOperation with output := other },
+        thirdOperation,
+        limitedOperation]
+    nodes := #[] }
+
+def reorderedProgram : Program :=
+  { operations := #[sourceOperation, thirdOperation, sharedOperation, limitedOperation]
+    nodes :=
+      #[instruction 0,
+        instruction 2 [node 0],
+        instruction 1 [node 0],
+        instruction 3 [node 0]] }
+
+def externalProgram : Program :=
+  { operations := #[sourceOperation, externalOperation]
+    nodes := #[instruction 0, instruction 1 [node 0]] }
+
+def mismatchedExternalProgram : Program :=
+  { operations :=
+      #[sourceOperation, { externalOperation with inputs := [other] }]
+    nodes := #[] }
+
+def missingExternalProgram : Program :=
+  { operations := #[sourceOperation], nodes := #[] }
+
+def view : ProgramView :=
+  { programVersion := 0
+    operations := program.operations
+    nodes := program.nodes
+    generations := #[0, 0, 0, 0] }
+
+def unaryRequest (rule application : Nat) (key : RuleKey) (anchor : NodeId)
+    (kind : ActionKind) (writes : List NodeId) : RuleRequest Nat :=
+  { action :=
+      { serial := application
+        programVersion := 0
+        application := { index := application }
+        rule := { index := rule }
+        key
+        node := anchor
+        kind
+        effort := 0
+        inputs := [{ node := node 0, version := 0 }] }
+    program := view
+    inputs := [{ node := node 0, fact := 0, version := 0 }]
+    writes }
+
+def tickRequest : RuleRequest Nat :=
+  unaryRequest 0 0 tickKey (node 1) .improve []
+
+def observeRequest : RuleRequest Nat :=
+  unaryRequest 1 1 observeKey (node 1) .forward [node 1]
+
+def thirdRequest : RuleRequest Nat :=
+  unaryRequest 2 2 thirdKey (node 2) .forward [node 2]
+
+def wrongKeyRequest : RuleRequest Nat :=
+  { tickRequest with action := { tickRequest.action with key := observeKey } }
+
+def missingRouteRequest : RuleRequest Nat :=
+  { tickRequest with action := { tickRequest.action with rule := { index := 99 } } }
+
+def factDomain : FactDomain Nat where
+  top _ := 0
+  narrow _ current candidate :=
+    if current < candidate then .improved candidate else .noChange
+
+def limits : Limits :=
+  { maxOperations := 8
+    maxNodes := 8
+    maxRules := 8
+    maxArity := 2
+    maxApplications := 8
+    maxQueueEntries := 16
+    maxActions := 16
+    maxAcceptedFacts := 8
+    maxRetainedSuggestions := 4
+    maxEffort := 4
+    maxObservationValue := 8
+    maxDiagnosticValue := 1000000
+    maxOutcomeCandidates := 2
+    maxOutcomeSuggestions := 2
+    maxProposalItems := 4
+    maxInstances := 2
+    maxGeneration := 2
+    maxEqualities := 2
+    splitEndpointLimit :=
+      { maxEndpointHeight := 16
+        maxAlignmentShift := 8 } }
+
+def registry? : Option (Registry Nat) :=
+  match Registry.buildWithin limits #[sharedPackage, thirdPackage, limitedPackage] with
+  | .ok registry => some registry
+  | .error _ => none
+
+def externalRegistry? : Option (Registry Nat) :=
+  match Registry.buildWithin limits #[externalPackage] with
+  | .ok registry => some registry
+  | .error _ => none
+
+def lowDiagnosticLimits : Limits :=
+  { limits with maxDiagnosticValue := 999999 }
+
+def shortRuleLimits : Limits :=
+  { limits with maxRules := 3 }
+
+def shortOperationLimits : Limits :=
+  { limits with maxOperations := 3 }
+
+def shortMetadataLimits : Limits :=
+  { limits with maxOperations := 4, maxRules := 4 }
+
+def nullaryLimits : Limits :=
+  { limits with maxArity := 0 }
+
+def run? : Option (RunResult Nat (Registry Nat)) :=
+  match registry? with
+  | none => none
+  | some registry =>
+      if !registry.acceptsProgram program || !registry.acceptsLimits program limits then none
+      else
+        match Engine.start factDomain program registry.registrations #[0, 0, 0, 0] limits with
+        | .error _ => none
+        | .ok state => some (drive Registry.invoke 12 state registry)
+
+/-- Type-level conformance that the policy driver accepts the same
+`Type 1` registry value as its private cache. -/
+def policyDriverTypecheck {PolicyState : Type}
+    (controller : Policy.Driver.Controller Nat PolicyState) (fuel : Nat)
+    (state : Policy.State Nat) (registry : Registry Nat) (policyState : PolicyState) :
+    Policy.Driver.Result Nat (Registry Nat) PolicyState :=
+  Policy.Driver.drive controller Registry.invoke fuel state registry policyState
+
+#guard program.check
+#guard mismatchedProgram.check
+#guard reorderedProgram.check
+#guard externalProgram.check
+#guard mismatchedExternalProgram.check
+#guard missingExternalProgram.check
+
+#guard
+  match registry? with
+  | some registry => !registry.acceptsLimits program lowDiagnosticLimits
+  | none => false
+
+#guard
+  match Registry.buildWithin shortRuleLimits
+      #[sharedPackage, thirdPackage, limitedPackage] with
+  | .error (.resourceLimit .rules) => true
+  | _ => false
+
+#guard
+  match Registry.buildWithin shortOperationLimits
+      #[sharedPackage, thirdPackage, limitedPackage] with
+  | .error (.resourceLimit .operations) => true
+  | _ => false
+
+#guard
+  match Registry.buildWithin shortMetadataLimits
+      #[sharedPackage, thirdPackage, limitedPackage] with
+  | .error (.resourceLimit .registryEntries) => true
+  | _ => false
+
+#guard
+  match Registry.buildWithin nullaryLimits
+      #[sharedPackage, thirdPackage, limitedPackage] with
+  | .error (.resourceLimit .arity) => true
+  | _ => false
+
+-- Package-major flattening preserves two distinct handlers for one head and
+-- appends unrelated cache types without a central semantic dispatch edit.
+#guard
+  match registry? with
+  | none => false
+  | some registry =>
+      registry.operations.size == 4 && registry.registrations.size == 4 &&
+        registry.acceptsProgram program && registry.acceptsLimits program limits &&
+        registry.acceptsProgram reorderedProgram &&
+        !registry.acceptsProgram mismatchedProgram &&
+        registry.routes ==
+          #[{ package := 0, handler := 0 }, { package := 0, handler := 1 },
+            { package := 1, handler := 0 }, { package := 2, handler := 0 }] &&
+        (registry.operation? thirdOp).any fun operation => operation.key == thirdOp &&
+        (reorderedProgram.operationEntry? thirdOp).any fun entry =>
+          entry.1 == { index := 1 } && entry.2.key == thirdOp
+
+#guard
+  match externalRegistry? with
+  | some registry =>
+      registry.operations.isEmpty && registry.acceptsProgram externalProgram &&
+        !registry.acceptsProgram mismatchedExternalProgram &&
+        !registry.acceptsProgram missingExternalProgram
+  | none => false
+
+-- Exact duplicate semantic keys are rejected across package boundaries.
+#guard
+  match Registry.buildWithin limits #[sharedPackage, duplicateRulePackage] with
+  | .error (.duplicateRule key) => key == tickKey
+  | _ => false
+
+#guard
+  match Registry.buildWithin limits #[sharedPackage, duplicateOperationPackage] with
+  | .error (.duplicateOperation key) => key == sharedOp
+  | _ => false
+
+#guard
+  match Registry.buildWithin limits #[undeclaredHeadPackage] with
+  | .error (.undeclaredHead rule head) => rule == tickKey && head == sharedOp
+  | _ => false
+
+-- Two handlers route through one package while an appended third-party
+-- handler routes through another.  Their mathematical outcomes stay
+-- cache-transparent; package invocation telemetry exposes isolation.
+#guard
+  match registry? with
+  | none => false
+  | some registry =>
+      let (first, registry) := registry.invoke tickRequest
+      let (second, registry) := registry.invoke observeRequest
+      let (third, registry) := registry.invoke thirdRequest
+      let (fourth, registry) := registry.invoke thirdRequest
+      match first, second, third, fourth with
+      | .noChange _, .success [observed] [] _,
+          .success [initialThird] [] _, .success [cachedThird] [] _ =>
+          observed.fact == 1 && initialThird.fact == 2 && cachedThird.fact == 2 &&
+            registry.packages.map (fun package => package.invocations) == #[2, 2, 0]
+      | _, _, _, _ => false
+
+-- A valid route with the wrong stable key and an out-of-range RuleId both
+-- fail before entering a callback.  Only the two later valid calls increment
+-- package invocation telemetry.
+#guard
+  match registry? with
+  | none => false
+  | some registry =>
+      let (wrong, registry) := registry.invoke wrongKeyRequest
+      let (missing, registry) := registry.invoke missingRouteRequest
+      let (tick, registry) := registry.invoke tickRequest
+      let (observed, registry) := registry.invoke observeRequest
+      match wrong, missing, tick, observed with
+      | .failed wrongCode, .failed missingCode, .noChange _, .success [candidate] [] _ =>
+          wrongCode == DispatchCode.requestMismatch &&
+            missingCode == DispatchCode.missingRoute && candidate.fact == 1 &&
+            registry.packages.map (fun package => package.invocations) == #[2, 0, 0]
+      | _, _, _, _ => false
+
+-- A corrupted static route is diagnosed before its unrelated handler can run.
+#guard
+  match registry? with
+  | none => false
+  | some registry =>
+      let corrupted :=
+        { registry with
+          routes := registry.routes.set! 0 { package := 1, handler := 0 } }
+      match (corrupted.invoke tickRequest).1 with
+      | .failed code => code == DispatchCode.registryMismatch
+      | _ => false
+
+-- The million-unit number reports work refused before execution; it is not a
+-- claimed cost observation, but it is checked by the separate diagnostic cap.
+-- The engine accepts the boundary value, rejects one above it, and reaches a
+-- genuine fixed point for the package accepted by start preflight.
+#guard (Outcome.resourceLimit (Fact := Nat) 1000000).observationBounded 8 1000000
+#guard !(Outcome.resourceLimit (Fact := Nat) 1000001).observationBounded 8 1000000
+
+#guard
+  match run? with
+  | none => false
+  | some result =>
+      result.stop == .saturated && result.state.pending.isNone &&
+        result.state.facts == #[0, 1, 2, 0] &&
+        result.state.metrics.requests == 4 && result.state.metrics.replies == 4 &&
+        result.state.metrics.improvements == 2 &&
+        result.state.metrics.ruleNoChange == 1 &&
+        result.state.metrics.ruleResourceLimits == 1 &&
+        result.state.metrics.ruleFailures == 0
+
+end Hex.Interval.PackageRegistryConformance

--- a/conformance/HexInterval/PolicyConformance.lean
+++ b/conformance/HexInterval/PolicyConformance.lean
@@ -140,7 +140,6 @@ def proposedG : ProposedNode :=
 
 def instantiateG (request : RuleRequest Rank) : InstantiationRequest :=
   { key := 31
-    triggers := [request.action.node]
     nodes := [proposedG]
     equalities :=
       [{ left := .existing request.action.node
@@ -650,18 +649,9 @@ def proposedGAt (input : NodeId) : ProposedNode :=
 
 def instantiateAt (family : Nat) (input : NodeId) : InstantiationRequest :=
   { key := family
-    triggers := [input]
     nodes := [proposedGAt input]
     equalities := []
     payload := { index := family } }
-
--- Replay-facing trigger metadata cannot partition payload-erased policy
--- identity for the same source invocation and structural proposal.
-#guard
-  let first := instantiateAt 101 (node 0)
-  let second := { first with triggers := [node 1, node 0] }
-  InstantiationSemanticKey.ofRequest first 1 ==
-    InstantiationSemanticKey.ofRequest second 1
 
 def twoInstances (request : RuleRequest Rank) : Outcome Rank :=
   .success [candidate request 1]
@@ -698,7 +688,6 @@ def emptyInstance (request : RuleRequest Rank) : Outcome Rank :=
   .success [candidate request 1]
     [.instantiate
       { key := 107
-        triggers := [request.action.node]
         nodes := []
         equalities := []
         payload := { index := 109 } }]
@@ -719,10 +708,9 @@ def emptyInstance (request : RuleRequest Rank) : Outcome Rank :=
       | _ => false
 
 def selfEqualityInstance (request : RuleRequest Rank) : Outcome Rank :=
-  .success []
+  .success [candidate request 3]
     [.instantiate
       { key := 127
-        triggers := [request.action.node]
         nodes := []
         equalities :=
           [{ left := .existing (node 0)
@@ -752,6 +740,37 @@ def overflowSplit (_ : RuleRequest Rank) : Outcome Rank :=
   .success []
     [.split { node := node 0, point := 0, reason := .midpoint }] {}
 
+def overdepthG (request : RuleRequest Rank) : InstantiationRequest :=
+  { key := 139
+    nodes :=
+      [{ domain := real
+         op := { index := 2 }
+         args := [.existing request.action.node] }]
+    equalities := []
+    payload := { index := 149 } }
+
+def mixedDepth (request : RuleRequest Rank) : Outcome Rank :=
+  .success [candidate request 2]
+    [.instantiate (instantiateG request),
+      .instantiate (overdepthG request),
+      .retry 1] {}
+
+def overdepthMalformed (request : RuleRequest Rank) : Outcome Rank :=
+  .success [candidate request 3]
+    [.instantiate
+      { overdepthG request with
+        equalities :=
+          [{ left := .existing (node 0)
+             right := .existing (node 0)
+             payload := { index := 151 } }] }]
+    {}
+
+def overdepthMalformedResult? : Option (SubmitResult Rank) := do
+  let limits := { engineLimits with maxNodeDepth := 1 }
+  let state <- initialWithLimits? limits policyLimits
+  let (request, state) <- request? state (.application (application 0))
+  some (state.submit (request.action.reply (overdepthMalformed request)))
+
 def startWithWeakRetry? : Option (State Rank) := do
   let engine <- match Engine.start rankDomain program #[fRule, gRule] #[0, 0] engineLimits with
     | .ok engine => some engine
@@ -777,8 +796,43 @@ def startWithWeakRetry? : Option (State Rank) := do
 #guard
   match selfEqualityResult? with
   | some (.invalid .malformedProposal state) =>
-      state.incomplete && state.engine.suggestions.isEmpty
+      state.incomplete && state.engine.facts.toList == [0, 0] &&
+        state.engine.history.isEmpty && state.engine.suggestions.isEmpty
   | _ => false
+
+-- Structural validation outranks recoverable depth filtering: a bad equality
+-- after an over-depth draft still invalidates the whole reply atomically.
+#guard
+  match overdepthMalformedResult? with
+  | some (.invalid .malformedProposal state) =>
+      state.incomplete && state.engine.facts.toList == [0, 0] &&
+        state.engine.history.isEmpty && state.engine.suggestions.isEmpty &&
+        state.engine.metrics.droppedSuggestions == 0
+  | _ => false
+
+-- A depth-limited instantiation is a recoverable loss local to that
+-- suggestion. The useful candidate commits, the valid instantiation and later
+-- retry keep their source order, the dropped proposal is counted, and policy
+-- cannot report a false fixed point.
+#guard
+  match observedWith? { engineLimits with maxNodeDepth := 1 } mixedDepth with
+  | some (observation, state) =>
+      observation.outcome == .success &&
+        oneChange observation.changes (node 1) 0 2 0 1 &&
+        observation.emittedSuggestions.toList ==
+          [.suggestion (suggestion 0), .suggestion (suggestion 1)] &&
+        state.engine.facts.toList == [0, 2] &&
+        state.engine.history.size == 1 &&
+        state.engine.metrics.candidates == 1 &&
+        state.engine.metrics.droppedSuggestions == 1 &&
+        state.engine.suggestions.size == 2 && state.incomplete &&
+        match state.engine.suggestions[0]?, state.engine.suggestions[1]? with
+        | some first, some second =>
+            match first.suggestion, second.suggestion with
+            | .instantiate request, .retry effort => request.key == 31 && effort == 1
+            | _, _ => false
+        | _, _ => false
+  | none => false
 
 -- A retry which fails its variant-specific freshness guard is tombstoned, but
 -- its disappearance cannot be mistaken for successful propagation.

--- a/conformance/HexInterval/PolicyConformance.lean
+++ b/conformance/HexInterval/PolicyConformance.lean
@@ -87,6 +87,7 @@ def engineLimits : Experiment.Propagator.Limits :=
     maxProposalItems := 8
     maxInstances := 8
     maxGeneration := 4
+    maxNodeDepth := 16
     maxEqualities := 8
     splitEndpointLimit :=
       { maxEndpointHeight := 32, maxAlignmentShift := 16 } }
@@ -140,7 +141,6 @@ def proposedG : ProposedNode :=
 def instantiateG (request : RuleRequest Rank) : InstantiationRequest :=
   { key := 31
     triggers := [request.action.node]
-    claimedGeneration := 1
     nodes := [proposedG]
     equalities :=
       [{ left := .existing request.action.node
@@ -651,10 +651,17 @@ def proposedGAt (input : NodeId) : ProposedNode :=
 def instantiateAt (family : Nat) (input : NodeId) : InstantiationRequest :=
   { key := family
     triggers := [input]
-    claimedGeneration := 1
     nodes := [proposedGAt input]
     equalities := []
     payload := { index := family } }
+
+-- Replay-facing trigger metadata cannot partition payload-erased policy
+-- identity for the same source invocation and structural proposal.
+#guard
+  let first := instantiateAt 101 (node 0)
+  let second := { first with triggers := [node 1, node 0] }
+  InstantiationSemanticKey.ofRequest first 1 ==
+    InstantiationSemanticKey.ofRequest second 1
 
 def twoInstances (request : RuleRequest Rank) : Outcome Rank :=
   .success [candidate request 1]
@@ -692,7 +699,6 @@ def emptyInstance (request : RuleRequest Rank) : Outcome Rank :=
     [.instantiate
       { key := 107
         triggers := [request.action.node]
-        claimedGeneration := 1
         nodes := []
         equalities := []
         payload := { index := 109 } }]
@@ -712,16 +718,11 @@ def emptyInstance (request : RuleRequest Rank) : Outcome Rank :=
             next.engine.metrics.duplicateInstances == 1
       | _ => false
 
-def falseHint (request : RuleRequest Rank) : Outcome Rank :=
-  let proposal := { instantiateAt 113 (node 0) with claimedGeneration := 99 }
-  .success [candidate request 1] [.instantiate proposal] {}
-
 def selfEqualityInstance (request : RuleRequest Rank) : Outcome Rank :=
   .success []
     [.instantiate
       { key := 127
         triggers := [request.action.node]
-        claimedGeneration := 1
         nodes := []
         equalities :=
           [{ left := .existing (node 0)
@@ -729,6 +730,11 @@ def selfEqualityInstance (request : RuleRequest Rank) : Outcome Rank :=
              payload := { index := 131 } }]
         payload := { index := 137 } }]
     {}
+
+def selfEqualityResult? : Option (SubmitResult Rank) := do
+  let state <- initialWithLimits? engineLimits policyLimits
+  let (request, state) <- request? state (.application (application 0))
+  some (state.submit (request.action.reply (selfEqualityInstance request)))
 
 def weakRetry (_ : RuleRequest Rank) : Outcome Rank :=
   .success [] [.retry 0] {}
@@ -757,8 +763,7 @@ def startWithWeakRetry? : Option (State Rank) := do
       | _ => none
   | _ => none
 
--- The policy key exposes the engine-computed generation.  A disagreeing
--- package hint cannot hide otherwise valid work or control admission.
+-- The policy key exposes the engine-computed theorem-instantiation generation.
 #guard
   match afterInitial? with
   | some state =>
@@ -767,33 +772,13 @@ def startWithWeakRetry? : Option (State Rank) := do
       | _ => false
   | none => false
 
+-- Malformed structural work is rejected by reply admission and never enters
+-- retained policy state.
 #guard
-  match afterReplyWith? engineLimits falseHint with
-  | some state =>
-      match state.offer? (.suggestion (suggestion 0)) with
-      | some { key := .instantiate _ semantic, .. } =>
-          semantic.generation == 1 &&
-            match selectOffer state (.suggestion (suggestion 0)) with
-            | .completed (.instanceAdmitted [fresh]) next =>
-                fresh == node 2 && next.engine.generations[2]? == some 1
-            | _ => false
-      | _ => false
-  | none => false
-
--- A structurally advertised instantiation may still fail a later admission
--- check. Consuming that rejected proposal leaves the current propagation
--- closure incomplete.
-#guard
-  match afterReplyWith? engineLimits selfEqualityInstance with
-  | none => false
-  | some state =>
-      !state.incomplete &&
-        match selectOffer state (.suggestion (suggestion 0)) with
-        | .completed (.instanceRejected .invalidEquality) next =>
-            next.incomplete &&
-              (next.view).toOption.any fun pair =>
-                pair.1.offers.isEmpty && pair.1.incomplete
-        | _ => false
+  match selfEqualityResult? with
+  | some (.invalid .malformedProposal state) =>
+      state.incomplete && state.engine.suggestions.isEmpty
+  | _ => false
 
 -- A retry which fails its variant-specific freshness guard is tombstoned, but
 -- its disappearance cannot be mistaken for successful propagation.

--- a/conformance/HexInterval/PolicyConformance.lean
+++ b/conformance/HexInterval/PolicyConformance.lean
@@ -218,6 +218,8 @@ def exactInitialObservation (observation : RuleObservation Rank) : Bool :=
     observation.invocation.inputs == [{ node := node 0, version := 0 }] &&
     observation.outcome == .success && oneChange observation.changes (node 1) 0 1 0 1 &&
     !observation.contradiction && exactCost observation.cost 3 5 7 &&
+    observation.suggestionPlan.kept.length == 3 &&
+    observation.suggestionPlan.dropped.isEmpty &&
     observation.emittedSuggestions.toList ==
       [.suggestion (suggestion 0), .suggestion (suggestion 1), .suggestion (suggestion 2)]
 
@@ -227,6 +229,8 @@ def exactRetryObservation (observation : RuleObservation Rank) (changed : Bool) 
     (if changed then oneChange observation.changes (node 1) 1 4 1 2
       else noChanges observation.changes) &&
     !observation.contradiction && exactCost observation.cost 11 13 17 &&
+    observation.suggestionPlan.kept.isEmpty &&
+    observation.suggestionPlan.dropped.isEmpty &&
     observation.emittedSuggestions.isEmpty
 
 def exactGObservation (observation : RuleObservation Rank) (before : Nat) : Bool :=
@@ -236,6 +240,8 @@ def exactGObservation (observation : RuleObservation Rank) (before : Nat) : Bool
         (if before == 0 then 0 else 1) (if before == 0 then 1 else 2)
       else noChanges observation.changes) &&
     !observation.contradiction && exactCost observation.cost 19 23 29 &&
+    observation.suggestionPlan.kept.isEmpty &&
+    observation.suggestionPlan.dropped.isEmpty &&
     observation.emittedSuggestions.isEmpty
 
 def exactEqualityObservation (observation : EqualityObservation Rank)
@@ -541,7 +547,7 @@ def retainedEngineWith? (limits : Experiment.Propagator.Limits) : Option (Engine
   match engine.poll with
   | .request request awaiting =>
       match awaiting.submit (request.action.reply (invoke request)) with
-      | .accepted next => some next
+      | .accepted _ next => some next
       | _ => none
   | _ => none
 
@@ -707,17 +713,18 @@ def emptyInstance (request : RuleRequest Rank) : Outcome Rank :=
             next.engine.metrics.duplicateInstances == 1
       | _ => false
 
+def selfEqualityRequest (_request : RuleRequest Rank) : InstantiationRequest :=
+  { key := 127
+    nodes := []
+    equalities :=
+      [{ left := .existing (node 0)
+         right := .existing (node 0)
+         payload := { index := 131 } }]
+    payload := { index := 137 } }
+
 def selfEqualityInstance (request : RuleRequest Rank) : Outcome Rank :=
   .success [candidate request 3]
-    [.instantiate
-      { key := 127
-        nodes := []
-        equalities :=
-          [{ left := .existing (node 0)
-             right := .existing (node 0)
-             payload := { index := 131 } }]
-        payload := { index := 137 } }]
-    {}
+    [.instantiate (selfEqualityRequest request)] {}
 
 def selfEqualityResult? : Option (SubmitResult Rank) := do
   let state <- initialWithLimits? engineLimits policyLimits
@@ -755,6 +762,15 @@ def mixedDepth (request : RuleRequest Rank) : Outcome Rank :=
       .instantiate (overdepthG request),
       .retry 1] {}
 
+def depthThenRetry (request : RuleRequest Rank) : Outcome Rank :=
+  .success [candidate request 2]
+    [.instantiate (overdepthG request), .retry 1] {}
+
+def malformedSuffix (request : RuleRequest Rank) : Outcome Rank :=
+  .success [candidate request 2]
+    [.split { node := node 0, point := 0, reason := .midpoint },
+      .instantiate (selfEqualityRequest request)] {}
+
 def overdepthMalformed (request : RuleRequest Rank) : Outcome Rank :=
   .success [candidate request 3]
     [.instantiate
@@ -778,7 +794,7 @@ def startWithWeakRetry? : Option (State Rank) := do
   match engine.poll with
   | .request request awaiting =>
       match awaiting.submit (request.action.reply (weakRetry request)) with
-      | .accepted next => some (State.start next policyLimits)
+      | .accepted _ next => some (State.start next policyLimits)
       | _ => none
   | _ => none
 
@@ -807,7 +823,8 @@ def startWithWeakRetry? : Option (State Rank) := do
   | some (.invalid .malformedProposal state) =>
       state.incomplete && state.engine.facts.toList == [0, 0] &&
         state.engine.history.isEmpty && state.engine.suggestions.isEmpty &&
-        state.engine.metrics.droppedSuggestions == 0
+        state.engine.metrics.droppedSuggestions == 0 &&
+        state.engine.metrics.capacityDrops == 0 && state.engine.metrics.depthDrops == 0
   | _ => false
 
 -- A depth-limited instantiation is a recoverable loss local to that
@@ -825,12 +842,61 @@ def startWithWeakRetry? : Option (State Rank) := do
         state.engine.history.size == 1 &&
         state.engine.metrics.candidates == 1 &&
         state.engine.metrics.droppedSuggestions == 1 &&
+        state.engine.metrics.capacityDrops == 0 &&
+        state.engine.metrics.depthDrops == 1 &&
         state.engine.suggestions.size == 2 && state.incomplete &&
+        (match observation.suggestionPlan.kept, observation.suggestionPlan.dropped with
+        | [.instantiate kept, .retry effort], [.depth (.instantiate dropped)] =>
+            kept.key == 31 && dropped.key == 139 && effort == 1
+        | _, _ => false) &&
         match state.engine.suggestions[0]?, state.engine.suggestions[1]? with
         | some first, some second =>
             match first.suggestion, second.suggestion with
             | .instantiate request, .retry effort => request.key == 31 && effort == 1
             | _, _ => false
+        | _, _ => false
+  | none => false
+
+-- Depth filtering does not consume the sole retained-suggestion slot. The
+-- later retry is kept, and the exact engine plan reaches the policy
+-- observation without structural revalidation.
+#guard
+  match observedWith?
+      { engineLimits with maxNodeDepth := 1, maxRetainedSuggestions := 1 }
+      depthThenRetry with
+  | some (observation, state) =>
+      observation.outcome == .success &&
+        oneChange observation.changes (node 1) 0 2 0 1 &&
+        observation.emittedSuggestions.toList == [.suggestion (suggestion 0)] &&
+        state.engine.facts.toList == [0, 2] &&
+        state.engine.metrics.droppedSuggestions == 1 &&
+        state.engine.metrics.capacityDrops == 0 &&
+        state.engine.metrics.depthDrops == 1 &&
+        state.engine.suggestions.size == 1 && state.incomplete &&
+        match observation.suggestionPlan.kept, observation.suggestionPlan.dropped with
+        | [.retry effort], [.depth (.instantiate dropped)] =>
+            effort == 1 && dropped.key == 139
+        | _, _ => false
+  | none => false
+
+-- Suggestions beyond exact capacity never become retained work and therefore
+-- are not structurally validated. This malformed suffix is classified as a
+-- capacity loss, its useful sibling candidate commits, and losing the
+-- instantiation marks policy incomplete instead of invalidating the reply.
+#guard
+  match observedWith?
+      { engineLimits with maxRetainedSuggestions := 1 } malformedSuffix with
+  | some (observation, state) =>
+      observation.outcome == .success &&
+        oneChange observation.changes (node 1) 0 2 0 1 &&
+        observation.emittedSuggestions.toList == [.suggestion (suggestion 0)] &&
+        state.engine.facts.toList == [0, 2] &&
+        state.engine.metrics.droppedSuggestions == 1 &&
+        state.engine.metrics.capacityDrops == 1 &&
+        state.engine.metrics.depthDrops == 0 &&
+        state.engine.suggestions.size == 1 && state.incomplete &&
+        match observation.suggestionPlan.kept, observation.suggestionPlan.dropped with
+        | [.split _], [.capacity (.instantiate dropped)] => dropped.key == 127
         | _, _ => false
   | none => false
 
@@ -866,7 +932,9 @@ def startWithWeakRetry? : Option (State Rank) := do
       observation.outcome == .success &&
         observation.emittedSuggestions.toList == [.suggestion (suggestion 0)] &&
         state.engine.suggestions.size == 1 &&
-        state.engine.metrics.droppedSuggestions == 1 && state.incomplete &&
+        state.engine.metrics.droppedSuggestions == 1 &&
+        state.engine.metrics.capacityDrops == 1 &&
+        state.engine.metrics.depthDrops == 0 && state.incomplete &&
         match state.engine.suggestions[0]? with
         | some retained =>
             match retained.suggestion with
@@ -884,7 +952,9 @@ def startWithWeakRetry? : Option (State Rank) := do
       observation.outcome == .success &&
         observation.emittedSuggestions.toList == [.suggestion (suggestion 0)] &&
         state.engine.suggestions.size == 1 &&
-        state.engine.metrics.droppedSuggestions == 1 && state.incomplete
+        state.engine.metrics.droppedSuggestions == 1 &&
+        state.engine.metrics.capacityDrops == 1 &&
+        state.engine.metrics.depthDrops == 0 && state.incomplete
   | none => false
 
 -- Dropping only optional split advice does not make propagation incomplete.
@@ -894,7 +964,9 @@ def startWithWeakRetry? : Option (State Rank) := do
   | some (observation, state) =>
       observation.outcome == .success && observation.emittedSuggestions.isEmpty &&
         state.engine.suggestions.isEmpty &&
-        state.engine.metrics.droppedSuggestions == 1 && !state.incomplete &&
+        state.engine.metrics.droppedSuggestions == 1 &&
+        state.engine.metrics.capacityDrops == 1 &&
+        state.engine.metrics.depthDrops == 0 && !state.incomplete &&
         (state.view).toOption.any fun pair =>
           pair.1.offers.isEmpty && !pair.1.incomplete
   | none => false

--- a/conformance/HexInterval/PolicyConformance.lean
+++ b/conformance/HexInterval/PolicyConformance.lean
@@ -81,6 +81,7 @@ def engineLimits : Experiment.Propagator.Limits :=
     maxRetainedSuggestions := 16
     maxEffort := 4
     maxObservationValue := 64
+    maxDiagnosticValue := 128
     maxOutcomeCandidates := 8
     maxOutcomeSuggestions := 8
     maxProposalItems := 8

--- a/conformance/HexInterval/PolicyConformance.lean
+++ b/conformance/HexInterval/PolicyConformance.lean
@@ -712,7 +712,7 @@ def emptyInstance (request : RuleRequest Rank) : Outcome Rank :=
             next.engine.metrics.duplicateInstances == 1
       | _ => false
 
-def wrongGeneration (request : RuleRequest Rank) : Outcome Rank :=
+def falseHint (request : RuleRequest Rank) : Outcome Rank :=
   let proposal := { instantiateAt 113 (node 0) with claimedGeneration := 99 }
   .success [candidate request 1] [.instantiate proposal] {}
 
@@ -757,8 +757,8 @@ def startWithWeakRetry? : Option (State Rank) := do
       | _ => none
   | _ => none
 
--- The policy key exposes the engine-computed generation, and a proposal whose
--- untrusted claim disagrees is never advertised as selectable work.
+-- The policy key exposes the engine-computed generation.  A disagreeing
+-- package hint cannot hide otherwise valid work or control admission.
 #guard
   match afterInitial? with
   | some state =>
@@ -768,12 +768,16 @@ def startWithWeakRetry? : Option (State Rank) := do
   | none => false
 
 #guard
-  match afterReplyWith? engineLimits wrongGeneration with
+  match afterReplyWith? engineLimits falseHint with
   | some state =>
-      state.engine.suggestions.size == 1 && state.incomplete &&
-        (state.offer? (.suggestion (suggestion 0))).isNone &&
-        (state.view).toOption.any fun pair =>
-          pair.1.offers.isEmpty && pair.1.incomplete
+      match state.offer? (.suggestion (suggestion 0)) with
+      | some { key := .instantiate _ semantic, .. } =>
+          semantic.generation == 1 &&
+            match selectOffer state (.suggestion (suggestion 0)) with
+            | .completed (.instanceAdmitted [fresh]) next =>
+                fresh == node 2 && next.engine.generations[2]? == some 1
+            | _ => false
+      | _ => false
   | none => false
 
 -- A structurally advertised instantiation may still fail a later admission

--- a/conformance/HexInterval/PolicyDriverConformance.lean
+++ b/conformance/HexInterval/PolicyDriverConformance.lean
@@ -142,8 +142,7 @@ def exactInstanceSelection (selection : Selection) (serial programVersion : Nat)
     match selection.expected with
     | .instantiate source request =>
         source == expectedSource &&
-          request.family == 31 && request.triggers == [node 1] &&
-          request.generation == 1 &&
+          request.family == 31 && request.generation == 1 &&
           request.nodes ==
             [{ domain := real
                op := { index := 2 }

--- a/conformance/HexInterval/PropagatorConformance.lean
+++ b/conformance/HexInterval/PropagatorConformance.lean
@@ -410,7 +410,92 @@ def dynamicFinal? : Option (RunResult Rank (List String) × SuggestionId) := do
       | _ => false
   | none => false
 
-/-! # Two successive shape triggers exercise general generation recurrence -/
+/-! ## CSE does not create a proof dependency -/
+
+def cseAnchorKey : RuleKey := { name := "shape.cse-anchor" }
+def cseSourceKey : RuleKey := { name := "shape.cse-source" }
+
+def cseRule (key : RuleKey) : Registration :=
+  { key
+    head := unaryOp
+    kind := .instantiate
+    watches := [.argument 0]
+    writes := [] }
+
+def cseProposal (request : RuleRequest Rank) (left : NodeId) :
+    InstantiationRequest :=
+  { key := left.index
+    triggers := [request.action.node, left]
+    /- Deliberately wrong: this package hint is not admission authority. -/
+    claimedGeneration := 0
+    nodes := [proposedGenerated request.action.node]
+    equalities :=
+      [{ left := .existing left
+         right := .proposed 0
+         payload := { index := left.index } }]
+    payload := { index := left.index } }
+
+def cseInvoke (calls : Nat) (request : RuleRequest Rank) :
+    Outcome Rank × Nat :=
+  if request.action.key == cseAnchorKey then
+    (.success [] [.instantiate (cseProposal request request.action.node)] {}, calls + 1)
+  else if request.action.key == cseSourceKey then
+    (.success [] [.instantiate (cseProposal request (node 0))] {}, calls + 1)
+  else
+    (.failed 10, calls + 1)
+
+def cseInitial? : Option (RunResult Rank Nat) := do
+  let program : Program :=
+    { operations := dynamicOperations, nodes := #[sourceNode, unaryNode 0] }
+  let state <- start? program #[cseRule cseAnchorKey, cseRule cseSourceKey]
+    #[4, 0] { generous with maxGeneration := 1 }
+  pure (drive cseInvoke 8 state 0)
+
+def cseOrder? (first second : SuggestionId) : Option (Engine Rank) := do
+  let initial <- cseInitial?
+  let firstRetained <- initial.state.suggestions[first.index]?
+  let secondRetained <- initial.state.suggestions[second.index]?
+  if initial.state.instantiationGeneration? firstRetained != some 1 ||
+      initial.state.instantiationGeneration? secondRetained != some 1 then
+    none
+  else
+    match initial.state.admitInstantiation first with
+    | .admitted [fresh] state =>
+        if fresh != node 2 then none else
+        let retained := state.suggestions[second.index]?
+        match retained with
+        | none => none
+        | some retained =>
+            if !state.actionFresh retained.action ||
+                state.instantiationGeneration? retained != some 1 then
+              none
+            else
+              match state.admitInstantiation second with
+              | .admitted [] final => some final
+              | _ => none
+    | _ => none
+
+def exactCseState (state : Engine Rank) : Bool :=
+  state.programVersion == 2 && state.program.nodes.size == 3 &&
+    state.generations.toList == [0, 0, 1] &&
+    state.equalities.size == 2 && state.instances.length == 2 &&
+    state.instanceHistory.size == 2 &&
+    state.instanceHistory.toList.all (fun event => event.generation == 1) &&
+    state.equalities.toList.all (fun edge => edge.generation == 1) &&
+    state.equalities.toList.any (fun edge => edge.sameEndpoints (node 0) (node 2)) &&
+    state.equalities.toList.any (fun edge => edge.sameEndpoints (node 1) (node 2))
+
+-- Either proposal may materialize `generated(anchor)` first.  The second
+-- append-stable proposal then CSE-hits that output but remains generation one,
+-- so both equalities are admitted under the exact generation-one cap.
+#guard
+  match cseOrder? (suggestion 0) (suggestion 1),
+      cseOrder? (suggestion 1) (suggestion 0) with
+  | some anchorFirst, some sourceFirst =>
+      exactCseState anchorFirst && exactCseState sourceFirst
+  | _, _ => false
+
+/-! ## Two successive shape triggers exercise general generation recurrence -/
 
 def nextOp : OpKey := { name := "opaque.next-generation" }
 def nextCopyKey : RuleKey := { name := "opaque.next.copy" }
@@ -511,9 +596,10 @@ def ladderFinal? : Option (RunResult Rank (List String)) := do
       | _ => false
   | none => false
 
--- A registry cannot launder a generation-one invocation back to generation
--- one by omitting its anchor from the untrusted trigger list and mentioning
--- only a shallow node in the draft.
+-- A registry claim cannot launder a generation-one invocation back to
+-- generation one.  The engine ignores the claim and derives generation two
+-- from the action anchor even when the trigger list and draft mention only a
+-- shallow node.
 #guard
   match ladderAfterFirst? with
   | some first =>
@@ -530,9 +616,12 @@ def ladderFinal? : Option (RunResult Rank (List String)) := do
               { action := retained.action
                 suggestion := .instantiate proposal
                 splitVersion := none } with
-          | .invalid (.generationMismatch 1 2) state =>
-              state.programVersion == 1 && state.program.nodes.size == 3 &&
-                state.generations.toList == [0, 0, 1]
+          | .admitted [fresh] state =>
+              fresh == node 3 && state.programVersion == 2 &&
+                state.generations.toList == [0, 0, 1, 2] &&
+                match state.instanceHistory[1]? with
+                | some event => event.generation == 2
+                | none => false
           | _ => false
       | none => false
   | none => false

--- a/conformance/HexInterval/PropagatorConformance.lean
+++ b/conformance/HexInterval/PropagatorConformance.lean
@@ -67,6 +67,7 @@ def generous : Limits :=
     maxProposalItems := 16
     maxInstances := 16
     maxGeneration := 4
+    maxNodeDepth := 32
     maxEqualities := 16
     splitEndpointLimit :=
       { maxEndpointHeight := 128, maxAlignmentShift := 64 } }
@@ -106,6 +107,14 @@ def start? (program : Program) (rules : Array Registration) (facts : Array Rank)
 def chainProgram : Program :=
   { operations
     nodes := #[sourceNode, unaryNode 0, unaryNode 1, unaryNode 2, unaryNode 3] }
+
+-- Initial SSA structure is covered by the same structural-depth invariant as
+-- later instantiation products.
+#guard
+  match Engine.start rankDomain chainProgram #[copyRule]
+      #[4, 0, 0, 0, 0] { generous with maxNodeDepth := 3 } with
+  | .error (.resourceLimit .nodeDepth) => true
+  | _ => false
 
 def chainResult? : Option (RunResult Rank (List Nat)) := do
   let state <- start? chainProgram #[copyRule] #[4, 0, 0, 0, 0]
@@ -290,7 +299,6 @@ def instantiateInvoke (calls : Nat) (request : RuleRequest Rank) :
   let proposal : InstantiationRequest :=
     { key := 7
       triggers := [request.action.node]
-      claimedGeneration := 1
       nodes := [proposedUnary request.action.node]
       equalities := []
       payload := { index := 11 } }
@@ -329,11 +337,9 @@ def proposedGenerated (input : NodeId) : ProposedNode :=
     op := { index := 2 }
     args := [.existing input] }
 
-def dynamicProposal (request : RuleRequest Rank) (generation : Nat := 1) :
-    InstantiationRequest :=
+def dynamicProposal (request : RuleRequest Rank) : InstantiationRequest :=
   { key := 19
     triggers := [request.action.node]
-    claimedGeneration := generation
     nodes := [proposedGenerated request.action.node]
     equalities := []
     payload := { index := 23 } }
@@ -426,12 +432,14 @@ def cseProposal (request : RuleRequest Rank) (left : NodeId) :
     InstantiationRequest :=
   { key := left.index
     triggers := [request.action.node, left]
-    /- Deliberately wrong: this package hint is not admission authority. -/
-    claimedGeneration := 0
-    nodes := [proposedGenerated request.action.node]
+    nodes :=
+      [proposedGenerated request.action.node,
+        { domain := real
+          op := { index := 2 }
+          args := [.proposed 0] }]
     equalities :=
       [{ left := .existing left
-         right := .proposed 0
+         right := .proposed 1
          payload := { index := left.index } }]
     payload := { index := left.index } }
 
@@ -448,7 +456,7 @@ def cseInitial? : Option (RunResult Rank Nat) := do
   let program : Program :=
     { operations := dynamicOperations, nodes := #[sourceNode, unaryNode 0] }
   let state <- start? program #[cseRule cseAnchorKey, cseRule cseSourceKey]
-    #[4, 0] { generous with maxGeneration := 1 }
+    #[4, 0] { generous with maxGeneration := 1, maxNodeDepth := 3 }
   pure (drive cseInvoke 8 state 0)
 
 def cseOrder? (first second : SuggestionId) : Option (Engine Rank) := do
@@ -460,8 +468,8 @@ def cseOrder? (first second : SuggestionId) : Option (Engine Rank) := do
     none
   else
     match initial.state.admitInstantiation first with
-    | .admitted [fresh] state =>
-        if fresh != node 2 then none else
+    | .admitted [firstFresh, secondFresh] state =>
+        if firstFresh != node 2 || secondFresh != node 3 then none else
         let retained := state.suggestions[second.index]?
         match retained with
         | none => none
@@ -476,24 +484,86 @@ def cseOrder? (first second : SuggestionId) : Option (Engine Rank) := do
     | _ => none
 
 def exactCseState (state : Engine Rank) : Bool :=
-  state.programVersion == 2 && state.program.nodes.size == 3 &&
-    state.generations.toList == [0, 0, 1] &&
+  state.programVersion == 2 && state.program.nodes.size == 4 &&
+    state.generations.toList == [0, 0, 1, 1] &&
+    state.depths.toList == [0, 1, 2, 3] &&
     state.equalities.size == 2 && state.instances.length == 2 &&
     state.instanceHistory.size == 2 &&
     state.instanceHistory.toList.all (fun event => event.generation == 1) &&
     state.equalities.toList.all (fun edge => edge.generation == 1) &&
-    state.equalities.toList.any (fun edge => edge.sameEndpoints (node 0) (node 2)) &&
-    state.equalities.toList.any (fun edge => edge.sameEndpoints (node 1) (node 2))
+    state.equalities.toList.any (fun edge => edge.sameEndpoints (node 0) (node 3)) &&
+    state.equalities.toList.any (fun edge => edge.sameEndpoints (node 1) (node 3))
 
--- Either proposal may materialize `generated(anchor)` first.  The second
--- append-stable proposal then CSE-hits that output but remains generation one,
--- so both equalities are admitted under the exact generation-one cap.
+-- Either proposal may materialize a depth-three tower first. The second
+-- append-stable proposal CSE-hits the entire prefix: its stored depths remain
+-- unchanged while theorem-instantiation generation remains one.
 #guard
   match cseOrder? (suggestion 0) (suggestion 1),
       cseOrder? (suggestion 1) (suggestion 0) with
   | some anchorFirst, some sourceFirst =>
       exactCseState anchorFirst && exactCseState sourceFirst
   | _, _ => false
+
+/-! ## A program watcher cannot grow an unbounded generation-one tower -/
+
+def towerKey : RuleKey := { name := "shape.program-tower" }
+
+def towerRule : Registration :=
+  { key := towerKey
+    head := unaryOp
+    kind := .instantiate
+    watches := []
+    writes := []
+    watchesProgram := true }
+
+def towerDrafts (anchor : NodeId) (count : Nat) : List ProposedNode :=
+  (List.range count).map fun index =>
+    { domain := real
+      op := { index := 2 }
+      args :=
+        [if index == 0 then .existing anchor else .proposed (index - 1)] }
+
+def towerInvoke (calls : Nat) (request : RuleRequest Rank) : Outcome Rank × Nat :=
+  let proposal : InstantiationRequest :=
+    { key := 43
+      triggers := [request.action.node]
+      nodes := towerDrafts request.action.node (request.program.nodes.size - 1)
+      equalities := []
+      payload := { index := 47 } }
+  (.success [] [.instantiate proposal] {}, calls + 1)
+
+def towerFinal? : Option (RunResult Rank Nat) := do
+  let program : Program :=
+    { operations := dynamicOperations, nodes := #[sourceNode, unaryNode 0] }
+  let state <- start? program #[towerRule] #[4, 0]
+    { generous with maxGeneration := 1, maxNodeDepth := 3 }
+  let first := drive towerInvoke 4 state 0
+  if first.stop != .saturated then none else pure ()
+  let state <- match first.state.admitInstantiation (suggestion 0) with
+    | .admitted [fresh] state => if fresh == node 2 then some state else none
+    | _ => none
+  let second := drive towerInvoke 4 state first.cache
+  if second.stop != .saturated then none else pure ()
+  let state <- match second.state.admitInstantiation (suggestion 1) with
+    | .admitted [fresh] state => if fresh == node 3 then some state else none
+    | _ => none
+  pure (drive towerInvoke 4 state second.cache)
+
+-- Each fresh request CSE-hits the materialized prefix and asks for one more
+-- node. All instances remain theorem-generation one, but the third reply is
+-- rejected before retention because its last node would have depth four.
+#guard
+  match towerFinal? with
+  | some result =>
+      result.stop == .engineResource .nodeDepth &&
+        result.state.program.nodes.size == 4 &&
+        result.state.generations.toList == [0, 0, 1, 1] &&
+        result.state.depths.toList == [0, 1, 2, 3] &&
+        result.state.instances.length == 2 &&
+        result.state.suggestions.size == 2 &&
+        result.state.metrics.requests == 3 &&
+        result.state.metrics.generatedNodes == 2
+  | none => false
 
 /-! ## Two successive shape triggers exercise general generation recurrence -/
 
@@ -525,11 +595,10 @@ def proposedNext (input : NodeId) : ProposedNode :=
 
 def ladderProposal (request : RuleRequest Rank) : InstantiationRequest :=
   if request.action.key == instantiateKey then
-    dynamicProposal request 1
+    dynamicProposal request
   else
     { key := 29
       triggers := [request.action.node]
-      claimedGeneration := 2
       nodes := [proposedNext request.action.node]
       equalities := []
       payload := { index := 31 } }
@@ -608,7 +677,6 @@ def ladderFinal? : Option (RunResult Rank (List String)) := do
           let proposal : InstantiationRequest :=
             { key := 97
               triggers := []
-              claimedGeneration := 1
               nodes := [proposedNext (node 0)]
               equalities := []
               payload := { index := 101 } }
@@ -656,7 +724,6 @@ def batchInvoke (calls : Nat) (request : RuleRequest Rank) : Outcome Rank × Nat
   let proposal : InstantiationRequest :=
     { key := 37
       triggers := [request.action.node]
-      claimedGeneration := 1
       nodes :=
         [proposedGeneratedRef (.existing request.action.node),
           proposedGeneratedRef (.existing request.action.node),
@@ -723,7 +790,6 @@ def pairEqualityInvoke (calls : Nat) (request : RuleRequest PairRank) :
   let proposal : InstantiationRequest :=
     { key := 47
       triggers := [request.action.node]
-      claimedGeneration := 1
       nodes := []
       equalities :=
         [{ left := .existing (node 0)
@@ -760,7 +826,6 @@ def pairReuseAdmitted? : Option (Engine PairRank) := do
   let proposal : InstantiationRequest :=
     { key := 103
       triggers := []
-      claimedGeneration := 1
       nodes := [proposedUnary (node 1)]
       equalities :=
         [{ left := .existing (node 1)
@@ -820,7 +885,6 @@ def pairReuseAdmitted? : Option (Engine PairRank) := do
           let proposal : InstantiationRequest :=
             { key := 113
               triggers := []
-              claimedGeneration := 1
               nodes := []
               equalities :=
                 [{ left := .existing (node 0)
@@ -931,7 +995,6 @@ def alternateEqualityRule : Registration :=
 def alternateEqualityProposal (request : RuleRequest Rank) : InstantiationRequest :=
   { key := 61
     triggers := [request.action.node]
-    claimedGeneration := 1
     nodes :=
       [proposedGeneratedRef (.existing request.action.node),
         proposedNextRef (.proposed 0)]
@@ -1152,7 +1215,6 @@ def firstRequestWith? (domain : FactDomain Rank) :
       let proposal : InstantiationRequest :=
         { key := 73
           triggers := List.replicate (generous.maxProposalItems + 1) (node 0)
-          claimedGeneration := 1
           nodes := []
           equalities := []
           payload := { index := 79 } }

--- a/conformance/HexInterval/PropagatorConformance.lean
+++ b/conformance/HexInterval/PropagatorConformance.lean
@@ -298,7 +298,6 @@ def instantiateInvoke (calls : Nat) (request : RuleRequest Rank) :
     Outcome Rank × Nat :=
   let proposal : InstantiationRequest :=
     { key := 7
-      triggers := [request.action.node]
       nodes := [proposedUnary request.action.node]
       equalities := []
       payload := { index := 11 } }
@@ -339,7 +338,6 @@ def proposedGenerated (input : NodeId) : ProposedNode :=
 
 def dynamicProposal (request : RuleRequest Rank) : InstantiationRequest :=
   { key := 19
-    triggers := [request.action.node]
     nodes := [proposedGenerated request.action.node]
     equalities := []
     payload := { index := 23 } }
@@ -431,7 +429,6 @@ def cseRule (key : RuleKey) : Registration :=
 def cseProposal (request : RuleRequest Rank) (left : NodeId) :
     InstantiationRequest :=
   { key := left.index
-    triggers := [request.action.node, left]
     nodes :=
       [proposedGenerated request.action.node,
         { domain := real
@@ -526,7 +523,6 @@ def towerDrafts (anchor : NodeId) (count : Nat) : List ProposedNode :=
 def towerInvoke (calls : Nat) (request : RuleRequest Rank) : Outcome Rank × Nat :=
   let proposal : InstantiationRequest :=
     { key := 43
-      triggers := [request.action.node]
       nodes := towerDrafts request.action.node (request.program.nodes.size - 1)
       equalities := []
       payload := { index := 47 } }
@@ -551,16 +547,18 @@ def towerFinal? : Option (RunResult Rank Nat) := do
 
 -- Each fresh request CSE-hits the materialized prefix and asks for one more
 -- node. All instances remain theorem-generation one, but the third reply is
--- rejected before retention because its last node would have depth four.
+-- accepted with its individually unaffordable proposal dropped because its
+-- last node would have depth four. Unrelated rule processing can continue.
 #guard
   match towerFinal? with
   | some result =>
-      result.stop == .engineResource .nodeDepth &&
+      result.stop == .saturated &&
         result.state.program.nodes.size == 4 &&
         result.state.generations.toList == [0, 0, 1, 1] &&
         result.state.depths.toList == [0, 1, 2, 3] &&
         result.state.instances.length == 2 &&
         result.state.suggestions.size == 2 &&
+        result.state.metrics.droppedSuggestions == 1 &&
         result.state.metrics.requests == 3 &&
         result.state.metrics.generatedNodes == 2
   | none => false
@@ -598,7 +596,6 @@ def ladderProposal (request : RuleRequest Rank) : InstantiationRequest :=
     dynamicProposal request
   else
     { key := 29
-      triggers := [request.action.node]
       nodes := [proposedNext request.action.node]
       equalities := []
       payload := { index := 31 } }
@@ -665,10 +662,9 @@ def ladderFinal? : Option (RunResult Rank (List String)) := do
       | _ => false
   | none => false
 
--- A registry claim cannot launder a generation-one invocation back to
--- generation one.  The engine ignores the claim and derives generation two
--- from the action anchor even when the trigger list and draft mention only a
--- shallow node.
+-- Replacing a retained proposal with a shallow draft cannot launder a
+-- generation-one invocation back to generation one. The engine derives
+-- generation two from the authoritative action anchor.
 #guard
   match ladderAfterFirst? with
   | some first =>
@@ -676,7 +672,6 @@ def ladderFinal? : Option (RunResult Rank (List String)) := do
       | some retained =>
           let proposal : InstantiationRequest :=
             { key := 97
-              triggers := []
               nodes := [proposedNext (node 0)]
               equalities := []
               payload := { index := 101 } }
@@ -723,7 +718,6 @@ def batchEquality (anchor : NodeId) : ProposedEquality :=
 def batchInvoke (calls : Nat) (request : RuleRequest Rank) : Outcome Rank × Nat :=
   let proposal : InstantiationRequest :=
     { key := 37
-      triggers := [request.action.node]
       nodes :=
         [proposedGeneratedRef (.existing request.action.node),
           proposedGeneratedRef (.existing request.action.node),
@@ -785,11 +779,10 @@ def pairEqualityRule : Registration :=
     watches := [.result]
     writes := [] }
 
-def pairEqualityInvoke (calls : Nat) (request : RuleRequest PairRank) :
+def pairEqualityInvoke (calls : Nat) (_request : RuleRequest PairRank) :
     Outcome PairRank × Nat :=
   let proposal : InstantiationRequest :=
     { key := 47
-      triggers := [request.action.node]
       nodes := []
       equalities :=
         [{ left := .existing (node 0)
@@ -825,7 +818,6 @@ def pairReuseAdmitted? : Option (Engine PairRank) := do
   let retained <- state.suggestions[0]?
   let proposal : InstantiationRequest :=
     { key := 103
-      triggers := []
       nodes := [proposedUnary (node 1)]
       equalities :=
         [{ left := .existing (node 1)
@@ -884,7 +876,6 @@ def pairReuseAdmitted? : Option (Engine PairRank) := do
       | some retained =>
           let proposal : InstantiationRequest :=
             { key := 113
-              triggers := []
               nodes := []
               equalities :=
                 [{ left := .existing (node 0)
@@ -994,7 +985,6 @@ def alternateEqualityRule : Registration :=
 
 def alternateEqualityProposal (request : RuleRequest Rank) : InstantiationRequest :=
   { key := 61
-    triggers := [request.action.node]
     nodes :=
       [proposedGeneratedRef (.existing request.action.node),
         proposedNextRef (.proposed 0)]
@@ -1207,15 +1197,16 @@ def firstRequestWith? (domain : FactDomain Rank) :
       | _ => false
   | none => false
 
--- Trigger cardinality and every trigger reference are part of the proposal's
--- own boundedness predicate, including callers which invoke it directly.
+-- Proposed-node cardinality is part of the proposal's own boundedness
+-- predicate, including callers which invoke it directly.
 #guard
   match firstChainRequest? with
   | some (request, awaiting) =>
       let proposal : InstantiationRequest :=
         { key := 73
-          triggers := List.replicate (generous.maxProposalItems + 1) (node 0)
-          nodes := []
+          nodes :=
+            List.replicate (generous.maxProposalItems + 1)
+              { domain := real, op := { index := 1 }, args := [.existing (node 0)] }
           equalities := []
           payload := { index := 79 } }
       match awaiting.submit (request.action.reply

--- a/conformance/HexInterval/PropagatorConformance.lean
+++ b/conformance/HexInterval/PropagatorConformance.lean
@@ -116,6 +116,16 @@ def chainProgram : Program :=
   | .error (.resourceLimit .nodeDepth) => true
   | _ => false
 
+def emptyProposal : InstantiationRequest :=
+  { key := 3, nodes := [], equalities := [], payload := { index := 5 } }
+
+-- Proposal depth classification examines only nodes appended by that
+-- proposal. Existing depths belong to the already validated snapshot.
+#guard
+  match checkInstantiationProposal chainProgram #[0, 1, 2, 3, 4] 0 emptyProposal with
+  | .valid => true
+  | .malformed | .tooDeep => false
+
 def chainResult? : Option (RunResult Rank (List Nat)) := do
   let state <- start? chainProgram #[copyRule] #[4, 0, 0, 0, 0]
   pure (drive copyInvoke 16 state [])
@@ -548,7 +558,9 @@ def towerFinal? : Option (RunResult Rank Nat) := do
 -- Each fresh request CSE-hits the materialized prefix and asks for one more
 -- node. All instances remain theorem-generation one, but the third reply is
 -- accepted with its individually unaffordable proposal dropped because its
--- last node would have depth four. Unrelated rule processing can continue.
+-- last node would have depth four. The raw driver then reports only queue
+-- saturation; retained or dropped suggestions make no policy-completeness
+-- claim here.
 #guard
   match towerFinal? with
   | some result =>
@@ -559,6 +571,8 @@ def towerFinal? : Option (RunResult Rank Nat) := do
         result.state.instances.length == 2 &&
         result.state.suggestions.size == 2 &&
         result.state.metrics.droppedSuggestions == 1 &&
+        result.state.metrics.capacityDrops == 0 &&
+        result.state.metrics.depthDrops == 1 &&
         result.state.metrics.requests == 3 &&
         result.state.metrics.generatedNodes == 2
   | none => false
@@ -1140,9 +1154,10 @@ def firstRequestWith? (domain : FactDomain Rank) :
       | .request request awaiting =>
           match awaiting.submit (request.action.reply
               (.success [candidate request 4] [.retry 1] {})) with
-          | .accepted state =>
+          | .accepted _ state =>
               state.facts.toList == [4, 4, 0, 0, 0] && state.history.size == 1 &&
                 state.suggestions.isEmpty && state.metrics.droppedSuggestions == 1 &&
+                state.metrics.capacityDrops == 1 && state.metrics.depthDrops == 0 &&
                 state.metrics.candidates == 1
           | _ => false
       | _ => false
@@ -1155,7 +1170,7 @@ def firstRequestWith? (domain : FactDomain Rank) :
   | some (request, awaiting) =>
       match awaiting.submit (request.action.reply
           (.failed (generous.maxObservationValue + 1))) with
-      | .accepted state =>
+      | .accepted _ state =>
           state.pending.isNone && state.metrics.ruleFailures == 1 && state.history.isEmpty
       | _ => false
   | none => false

--- a/conformance/HexInterval/PropagatorConformance.lean
+++ b/conformance/HexInterval/PropagatorConformance.lean
@@ -61,6 +61,7 @@ def generous : Limits :=
     maxRetainedSuggestions := 16
     maxEffort := 16
     maxObservationValue := 1024
+    maxDiagnosticValue := 2048
     maxOutcomeCandidates := 8
     maxOutcomeSuggestions := 8
     maxProposalItems := 16
@@ -111,6 +112,14 @@ def chainResult? : Option (RunResult Rank (List Nat)) := do
   pure (drive copyInvoke 16 state [])
 
 #guard chainProgram.check
+
+-- A registration cannot begin above the engine's effort envelope.
+#guard
+  match Engine.start rankDomain chainProgram
+      #[{ copyRule with initialEffort := generous.maxEffort + 1 }]
+      #[4, 0, 0, 0, 0] generous with
+  | .error (.resourceLimit .effort) => true
+  | _ => false
 
 #guard
   match chainResult? with
@@ -913,6 +922,24 @@ def firstChainRequest? : Option (RuleRequest Rank × Engine Rank) := do
   | .request request awaiting => some (request, awaiting)
   | _ => none
 
+def oversizedMalformedDomain : FactDomain Rank where
+  top _ := 0
+  narrow _ _ _ := .malformed (generous.maxDiagnosticValue + 1)
+
+def oversizedResourceDomain : FactDomain Rank where
+  top _ := 0
+  narrow _ _ _ := .resourceLimit (generous.maxDiagnosticValue + 1)
+
+def firstRequestWith? (domain : FactDomain Rank) :
+    Option (RuleRequest Rank × Engine Rank) := do
+  let initial <-
+    match Engine.start domain chainProgram #[copyRule] #[4, 0, 0, 0, 0] generous with
+    | .ok state => some state
+    | .error _ => none
+  match initial.poll with
+  | .request request awaiting => some (request, awaiting)
+  | _ => none
+
 -- Append-only recompilation must preserve every existing concrete
 -- application exactly, not merely preserve the old array length.
 #guard
@@ -924,6 +951,28 @@ def firstChainRequest? : Option (RuleRequest Rank × Engine Rank) := do
             !applicationsPrefix state.applications
               (state.applications.set! 0 { first with effort := first.effort + 1 })
       | none => false
+  | none => false
+
+-- Fact-domain diagnostics cross the same independent representation cap as
+-- callback diagnostics before they can enter driver or policy events.
+#guard
+  match firstRequestWith? oversizedMalformedDomain with
+  | some (request, awaiting) =>
+      match awaiting.submit (request.action.reply
+          (.success [candidate request 4] [] {})) with
+      | .invalid .oversizedObservation state =>
+          state.pending.isNone && state.history.isEmpty
+      | _ => false
+  | none => false
+
+#guard
+  match firstRequestWith? oversizedResourceDomain with
+  | some (request, awaiting) =>
+      match awaiting.submit (request.action.reply
+          (.success [candidate request 4] [] {})) with
+      | .invalid .oversizedObservation state =>
+          state.pending.isNone && state.history.isEmpty
+      | _ => false
   | none => false
 
 -- Reply-provided policy telemetry is checked before it can enter retained
@@ -958,7 +1007,7 @@ def firstChainRequest? : Option (RuleRequest Rank × Engine Rank) := do
   | none => false
 
 -- A failure code is an opaque diagnostic identifier, not a logical cost
--- magnitude governed by the observation-value budget.
+-- magnitude governed by the performed-work budget.  It has its own cap.
 #guard
   match firstChainRequest? with
   | some (request, awaiting) =>
@@ -966,6 +1015,16 @@ def firstChainRequest? : Option (RuleRequest Rank × Engine Rank) := do
           (.failed (generous.maxObservationValue + 1))) with
       | .accepted state =>
           state.pending.isNone && state.metrics.ruleFailures == 1 && state.history.isEmpty
+      | _ => false
+  | none => false
+
+#guard
+  match firstChainRequest? with
+  | some (request, awaiting) =>
+      match awaiting.submit (request.action.reply
+          (.failed (generous.maxDiagnosticValue + 1))) with
+      | .invalid .oversizedObservation state =>
+          state.pending.isNone && state.metrics.ruleFailures == 0 && state.history.isEmpty
       | _ => false
   | none => false
 

--- a/conformance/HexInterval/StructureViewConformance.lean
+++ b/conformance/HexInterval/StructureViewConformance.lean
@@ -82,6 +82,7 @@ def limits : Limits :=
     maxRetainedSuggestions := 16
     maxEffort := 8
     maxObservationValue := 128
+    maxDiagnosticValue := 128
     maxOutcomeCandidates := 4
     maxOutcomeSuggestions := 4
     maxProposalItems := 8

--- a/conformance/HexInterval/StructureViewConformance.lean
+++ b/conformance/HexInterval/StructureViewConformance.lean
@@ -110,8 +110,6 @@ def centeredRule : Registration :=
 structure Binding where
   anchor : NodeId
   input : NodeId
-  complement : NodeId
-  one : NodeId
   deriving DecidableEq, Repr
 
 /-- Registry-owned interpretation of the opaque nested shape. -/
@@ -128,14 +126,12 @@ def centeredBinding? (request : RuleRequest Fact) : Option Binding := do
   if repeated != input then none else pure ()
   let oneKey <- request.program.operationKey? one
   if oneKey != oneOp then none else pure ()
-  pure { anchor := request.action.node, input, complement, one }
+  pure { anchor := request.action.node, input }
 
 def centeredProposal? (_request : RuleRequest Fact) (binding : Binding) :
     Option InstantiationRequest := do
-  let triggers := [binding.anchor, binding.input, binding.complement, binding.one]
   pure
     { key := 101
-      triggers
       nodes :=
         [{ domain
            op := { index := 6 }
@@ -157,7 +153,6 @@ def appendProposal? (request : RuleRequest Fact) : Option InstantiationRequest :
   if request.program.operationKey? one != some oneOp then none else pure ()
   pure
     { key := 109
-      triggers := [request.action.node, input, one]
       nodes :=
         [{ domain
            op := { index := 4 }
@@ -220,13 +215,12 @@ def afterAppend? : Option (RunResult Fact (List Visit)) := do
   | _ => none
 
 def exactCenteredSuggestion (state : Engine Fact) (index version : Nat)
-    (anchor input complement one : NodeId) : Bool :=
+    (anchor input : NodeId) : Bool :=
   match state.suggestions[index]? with
   | some { action, suggestion := .instantiate request, .. } =>
       action.key == centeredKey && action.programVersion == version &&
         action.node == anchor && action.inputs.isEmpty &&
         request.key == 101 &&
-        request.triggers == [anchor, input, complement, one] &&
         match request.nodes, request.equalities with
         | [product], [equality] =>
             product.domain == domain && product.op == { index := 6 } &&
@@ -252,7 +246,7 @@ def exactCenteredSuggestion (state : Engine Fact) (index version : Nat)
              declaredFacts := 0, input := none, anchorGeneration := some 0 },
            { programVersion := 0, actionVersion := 0, anchor := node 8,
              declaredFacts := 0, input := none, anchorGeneration := some 0 }] &&
-        exactCenteredSuggestion result.state 1 0 (node 5) (node 0) (node 4) (node 2)
+        exactCenteredSuggestion result.state 1 0 (node 5) (node 0)
   | none => false
 
 -- Appending two nodes recompiles one new `mul` application.  Its request sees
@@ -267,7 +261,7 @@ def exactCenteredSuggestion (state : Engine Fact) (index version : Nat)
           some
             { programVersion := 1, actionVersion := 1, anchor := node 10,
               declaredFacts := 0, input := some (node 1), anchorGeneration := some 1 } &&
-        exactCenteredSuggestion result.state 2 1 (node 10) (node 1) (node 9) (node 2)
+        exactCenteredSuggestion result.state 2 1 (node 10) (node 1)
   | none => false
 
 -- Append-only growth does not stale an otherwise fresh action.  Both the old

--- a/conformance/HexInterval/StructureViewConformance.lean
+++ b/conformance/HexInterval/StructureViewConformance.lean
@@ -88,6 +88,7 @@ def limits : Limits :=
     maxProposalItems := 8
     maxInstances := 8
     maxGeneration := 4
+    maxNodeDepth := 16
     maxEqualities := 8
     splitEndpointLimit :=
       { maxEndpointHeight := 32, maxAlignmentShift := 16 } }
@@ -129,18 +130,12 @@ def centeredBinding? (request : RuleRequest Fact) : Option Binding := do
   if oneKey != oneOp then none else pure ()
   pure { anchor := request.action.node, input, complement, one }
 
-def nextGeneration? (view : ProgramView) (nodes : List NodeId) : Option Nat := do
-  let generations <- nodes.mapM view.generation?
-  pure (generations.foldl Nat.max 0 + 1)
-
-def centeredProposal? (request : RuleRequest Fact) (binding : Binding) :
+def centeredProposal? (_request : RuleRequest Fact) (binding : Binding) :
     Option InstantiationRequest := do
   let triggers := [binding.anchor, binding.input, binding.complement, binding.one]
-  let generation <- nextGeneration? request.program triggers
   pure
     { key := 101
       triggers
-      claimedGeneration := generation
       nodes :=
         [{ domain
            op := { index := 6 }
@@ -163,7 +158,6 @@ def appendProposal? (request : RuleRequest Fact) : Option InstantiationRequest :
   pure
     { key := 109
       triggers := [request.action.node, input, one]
-      claimedGeneration := 1
       nodes :=
         [{ domain
            op := { index := 4 }
@@ -226,14 +220,13 @@ def afterAppend? : Option (RunResult Fact (List Visit)) := do
   | _ => none
 
 def exactCenteredSuggestion (state : Engine Fact) (index version : Nat)
-    (anchor input complement one : NodeId) (generation : Nat) : Bool :=
+    (anchor input complement one : NodeId) : Bool :=
   match state.suggestions[index]? with
   | some { action, suggestion := .instantiate request, .. } =>
       action.key == centeredKey && action.programVersion == version &&
         action.node == anchor && action.inputs.isEmpty &&
         request.key == 101 &&
         request.triggers == [anchor, input, complement, one] &&
-        request.claimedGeneration == generation &&
         match request.nodes, request.equalities with
         | [product], [equality] =>
             product.domain == domain && product.op == { index := 6 } &&
@@ -259,7 +252,7 @@ def exactCenteredSuggestion (state : Engine Fact) (index version : Nat)
              declaredFacts := 0, input := none, anchorGeneration := some 0 },
            { programVersion := 0, actionVersion := 0, anchor := node 8,
              declaredFacts := 0, input := none, anchorGeneration := some 0 }] &&
-        exactCenteredSuggestion result.state 1 0 (node 5) (node 0) (node 4) (node 2) 1
+        exactCenteredSuggestion result.state 1 0 (node 5) (node 0) (node 4) (node 2)
   | none => false
 
 -- Appending two nodes recompiles one new `mul` application.  Its request sees
@@ -274,7 +267,7 @@ def exactCenteredSuggestion (state : Engine Fact) (index version : Nat)
           some
             { programVersion := 1, actionVersion := 1, anchor := node 10,
               declaredFacts := 0, input := some (node 1), anchorGeneration := some 1 } &&
-        exactCenteredSuggestion result.state 2 1 (node 10) (node 1) (node 9) (node 2) 2
+        exactCenteredSuggestion result.state 2 1 (node 10) (node 1) (node 9) (node 2)
   | none => false
 
 -- Append-only growth does not stale an otherwise fresh action.  Both the old

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -231,6 +231,7 @@ lean_lib HexIntervalExperiment where
     `HexInterval.Experiment.Scale, `HexInterval.Experiment.Propagator,
     `HexInterval.Experiment.Policy, `HexInterval.Experiment.PolicyFrontier,
     `HexInterval.Experiment.PolicyDriver,
+    `HexInterval.Experiment.PackageRegistry,
     `HexInterval.Experiment.DyadicInterval,
     `HexInterval.Experiment.DyadicRules]
 
@@ -299,7 +300,7 @@ lean_lib HexRCFProofProbeScientific where
 -- `*_emit_fixtures` exes below, carrying `srcDir := "conformance"`.
 lean_lib HexConformance where
   srcDir := "conformance"
-  globs := #[`HexArith.Conformance, `HexArith.CrossCheck, `HexBerlekamp.Conformance, `HexBerlekampZassenhaus.Conformance, `HexBerlekampZassenhaus.CrossCheck, `HexConway.Conformance, `HexGF2.Conformance, `HexGF2.CrossCheck, `HexGF2.FastCheck, `HexGFq.Conformance, `HexGFq.CrossCheck, `HexGFqField.Conformance, `HexGFqRing.Conformance, `HexGramSchmidt.Conformance, `HexHensel.Conformance, `HexHensel.CrossCheck, `HexInterval.Conformance, `HexInterval.CenterConformance, `HexInterval.ScaleConformance, `HexInterval.PropagatorConformance, `HexInterval.StructureViewConformance, `HexInterval.PolicyConformance, `HexInterval.PolicyFrontierConformance, `HexInterval.PolicyDriverConformance, `HexInterval.DyadicIntervalConformance, `HexInterval.DyadicRulesConformance, `HexLLL.Conformance, `HexMatrix.Conformance, `HexRowReduce.Conformance, `HexDeterminant.Conformance, `HexBareiss.Conformance, `HexModArith.Conformance, `HexModArith.FastCheck, `HexNumberField.Conformance, `HexNumberFieldTower.Conformance, `HexPoly.Conformance, `HexPolyFp.Conformance, `HexPolyZ.Conformance, `HexRCF.Conformance, `HexRealRoots.Conformance, `HexRealRootsMathlib.Conformance, `HexResultant.Conformance, `HexRoots.Conformance].map Glob.one
+  globs := #[`HexArith.Conformance, `HexArith.CrossCheck, `HexBerlekamp.Conformance, `HexBerlekampZassenhaus.Conformance, `HexBerlekampZassenhaus.CrossCheck, `HexConway.Conformance, `HexGF2.Conformance, `HexGF2.CrossCheck, `HexGF2.FastCheck, `HexGFq.Conformance, `HexGFq.CrossCheck, `HexGFqField.Conformance, `HexGFqRing.Conformance, `HexGramSchmidt.Conformance, `HexHensel.Conformance, `HexHensel.CrossCheck, `HexInterval.Conformance, `HexInterval.CenterConformance, `HexInterval.ScaleConformance, `HexInterval.PropagatorConformance, `HexInterval.StructureViewConformance, `HexInterval.PolicyConformance, `HexInterval.PolicyFrontierConformance, `HexInterval.PolicyDriverConformance, `HexInterval.PackageRegistryConformance, `HexInterval.DyadicIntervalConformance, `HexInterval.DyadicRulesConformance, `HexLLL.Conformance, `HexMatrix.Conformance, `HexRowReduce.Conformance, `HexDeterminant.Conformance, `HexBareiss.Conformance, `HexModArith.Conformance, `HexModArith.FastCheck, `HexNumberField.Conformance, `HexNumberFieldTower.Conformance, `HexPoly.Conformance, `HexPolyFp.Conformance, `HexPolyZ.Conformance, `HexRCF.Conformance, `HexRealRoots.Conformance, `HexRealRootsMathlib.Conformance, `HexResultant.Conformance, `HexRoots.Conformance].map Glob.one
 
 -- Public umbrellas intentionally contain only the supported API. Executable
 -- examples and regression tests are compiled through this separate target so

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -231,7 +231,8 @@ lean_lib HexIntervalExperiment where
     `HexInterval.Experiment.Scale, `HexInterval.Experiment.Propagator,
     `HexInterval.Experiment.Policy, `HexInterval.Experiment.PolicyFrontier,
     `HexInterval.Experiment.PolicyDriver,
-    `HexInterval.Experiment.DyadicInterval]
+    `HexInterval.Experiment.DyadicInterval,
+    `HexInterval.Experiment.DyadicRules]
 
 lean_lib HexIntervalMathlibExperiment where
   globs := #[`HexIntervalMathlib.Experiment.Center]
@@ -298,7 +299,7 @@ lean_lib HexRCFProofProbeScientific where
 -- `*_emit_fixtures` exes below, carrying `srcDir := "conformance"`.
 lean_lib HexConformance where
   srcDir := "conformance"
-  globs := #[`HexArith.Conformance, `HexArith.CrossCheck, `HexBerlekamp.Conformance, `HexBerlekampZassenhaus.Conformance, `HexBerlekampZassenhaus.CrossCheck, `HexConway.Conformance, `HexGF2.Conformance, `HexGF2.CrossCheck, `HexGF2.FastCheck, `HexGFq.Conformance, `HexGFq.CrossCheck, `HexGFqField.Conformance, `HexGFqRing.Conformance, `HexGramSchmidt.Conformance, `HexHensel.Conformance, `HexHensel.CrossCheck, `HexInterval.Conformance, `HexInterval.CenterConformance, `HexInterval.ScaleConformance, `HexInterval.PropagatorConformance, `HexInterval.StructureViewConformance, `HexInterval.PolicyConformance, `HexInterval.PolicyFrontierConformance, `HexInterval.PolicyDriverConformance, `HexInterval.DyadicIntervalConformance, `HexLLL.Conformance, `HexMatrix.Conformance, `HexRowReduce.Conformance, `HexDeterminant.Conformance, `HexBareiss.Conformance, `HexModArith.Conformance, `HexModArith.FastCheck, `HexNumberField.Conformance, `HexNumberFieldTower.Conformance, `HexPoly.Conformance, `HexPolyFp.Conformance, `HexPolyZ.Conformance, `HexRCF.Conformance, `HexRealRoots.Conformance, `HexRealRootsMathlib.Conformance, `HexResultant.Conformance, `HexRoots.Conformance].map Glob.one
+  globs := #[`HexArith.Conformance, `HexArith.CrossCheck, `HexBerlekamp.Conformance, `HexBerlekampZassenhaus.Conformance, `HexBerlekampZassenhaus.CrossCheck, `HexConway.Conformance, `HexGF2.Conformance, `HexGF2.CrossCheck, `HexGF2.FastCheck, `HexGFq.Conformance, `HexGFq.CrossCheck, `HexGFqField.Conformance, `HexGFqRing.Conformance, `HexGramSchmidt.Conformance, `HexHensel.Conformance, `HexHensel.CrossCheck, `HexInterval.Conformance, `HexInterval.CenterConformance, `HexInterval.ScaleConformance, `HexInterval.PropagatorConformance, `HexInterval.StructureViewConformance, `HexInterval.PolicyConformance, `HexInterval.PolicyFrontierConformance, `HexInterval.PolicyDriverConformance, `HexInterval.DyadicIntervalConformance, `HexInterval.DyadicRulesConformance, `HexLLL.Conformance, `HexMatrix.Conformance, `HexRowReduce.Conformance, `HexDeterminant.Conformance, `HexBareiss.Conformance, `HexModArith.Conformance, `HexModArith.FastCheck, `HexNumberField.Conformance, `HexNumberFieldTower.Conformance, `HexPoly.Conformance, `HexPolyFp.Conformance, `HexPolyZ.Conformance, `HexRCF.Conformance, `HexRealRoots.Conformance, `HexRealRootsMathlib.Conformance, `HexResultant.Conformance, `HexRoots.Conformance].map Glob.one
 
 -- Public umbrellas intentionally contain only the supported API. Executable
 -- examples and regression tests are compiled through this separate target so

--- a/progress/20260727T144045Z.md
+++ b/progress/20260727T144045Z.md
@@ -1,0 +1,32 @@
+# Arbitrary-function rule vertical
+
+## Accomplished
+
+- Added a concrete registry of opaque forward, backward, and instantiation
+  callbacks over checked open/closed/unbounded interval facts.
+- Exercised exact backward scaling, mixed propagation cycles, and
+  precision-indexed reciprocal retries through the generic worklist.
+- Added the arbitrary propagator for `x ↦ 1/4 - (x - 1/2)^2` and a structural
+  trigger which recognizes `x * (1 - x)`, proposes the alternate node, and
+  connects both expressions by an equality.
+- Demonstrated the complete dependency-recovery path: naive evaluation gives
+  `[0,1]`, instantiation adds the alternate expression, its function-specific
+  propagator gives `[0,1/4]`, and equality transport improves the original.
+- Rebuilt the rule module and focused conformance target successfully.
+
+## Current frontier
+
+The generic engine now runs function-owned propagators and can let expression
+shape trigger new nodes.  The next experiment should make this registry easier
+to extend with independent function packages and put its decisions under the
+external policy driver, rather than adding more endpoint arithmetic.
+
+## Next step
+
+Import the completed resource-preflight audit fixes, open the focused PR, then
+exercise retry, instantiation, and subdivision choices through the policy
+boundary on these concrete function rules.
+
+## Blockers
+
+None.

--- a/progress/20260727T153930Z.md
+++ b/progress/20260727T153930Z.md
@@ -1,0 +1,43 @@
+# Arbitrary-function package and instantiation framework
+
+## Accomplished
+
+- Replaced the concrete semantic dispatch chain with independently assembled
+  function packages. Packages own heterogeneous performance caches, declare
+  owned and externally required operation signatures, contribute registrations
+  and callbacks together, and run package-specific start preflights.
+- Added resource-first package assembly, exact final-program signature checks,
+  duplicate and undeclared-head rejection, registry-local routing, and separate
+  bounds for performed-work observations and callback/fact-domain diagnostic
+  identifiers.
+- Added an explicit whole-program structural dependency. Append-only expression
+  extension now stales old structural offers and requeues existing matchers, so
+  one package can react to expressions introduced by another package.
+- Exercised one policy-controlled run over `x * (1 - x)` and reciprocal:
+  propagation, structural instantiation, equality contraction, a precision
+  retry, and a function-owned split are selected in one exact event trace.
+- Corrected the SPEC to keep proof replay, payload freezing, branch creation,
+  split interiority, cache semantics, and package/session encapsulation open.
+  Exact-rational backend work is explicitly deferred from the framework path.
+- Built the complete monorepo successfully (9,497 jobs), as well as the focused
+  integration suite; touched Lean modules contain no `native_decide`, `axiom`,
+  or `sorry`.
+
+## Current frontier
+
+The search framework now supports arbitrary function callbacks and grind-like
+expression-network growth without embedding function semantics in the engine.
+Callbacks still return untrusted candidates and small recipe identifiers: the
+immutable payload arena and Mathlib replay that turn retained steps into Lean
+proof terms are not implemented by this canary.
+
+## Next step
+
+Freeze and replay one accepted function-package payload end to end, while
+testing an opaque engine/registry session boundary and the first scope layer
+which validates split interiority and creates complementary branches.
+
+## Blockers
+
+None for the current framework PR. Payload storage/replay and branching are
+deliberately the next experiments, not hidden assumptions of this one.

--- a/progress/20260728T051419Z.md
+++ b/progress/20260728T051419Z.md
@@ -1,0 +1,32 @@
+# CSE-invariant instantiation generation
+
+## Accomplished
+
+- Made instantiation generation depend on the engine-owned action substitution
+  and explicit existing proposal references, rather than on CSE-resolved
+  outputs.
+- Made the package-provided generation field diagnostic-only in both policy
+  offers and admission; the engine-computed value controls limits and replay
+  provenance.
+- Added both proposal orders under an exact generation-one cap. In each order,
+  the second rule CSE-reuses the first rule's product and still admits its
+  distinct equality at generation one.
+- Updated the SPEC and concrete centered package so function packages no
+  longer mirror admission's generation calculation.
+- Built the interval umbrella and focused propagator, policy, structure-view,
+  package-registry, policy-driver, and concrete dyadic conformance modules.
+
+## Current frontier
+
+`claimedGeneration` remains in the experimental request only to avoid a broad
+constructor migration in this PR. It has no admission or policy authority and
+the SPEC says the production request should omit it.
+
+## Next step
+
+Review the uncommitted diff with the rest of the #8984 stack, then commit it
+with the framework changes before continuing the payload-freezing layer.
+
+## Blockers
+
+None.

--- a/progress/20260729T052540Z.md
+++ b/progress/20260729T052540Z.md
@@ -1,0 +1,33 @@
+# Arbitrary-propagator stack rebuild
+
+## Accomplished
+
+- Rebuilt PR #8984 on the current concrete-fact prerequisite using only its
+  three framework commits: arbitrary-function canaries, composable packages,
+  and CSE-invariant instantiation generation.
+- Dropped embedded copies of the already-merged structural-view and policy
+  work while preserving the current policy completeness invariants.
+- Kept the policy driver universe-polymorphic so an existential package
+  registry can be threaded as external state.
+- Preserved all current Lake and conformance targets while adding only the
+  package and arbitrary-function modules.
+- Updated the conformance module title for the current documentation checker.
+- Verified the conformance target matrix and rebuilt the package registry,
+  concrete arbitrary propagators, policy/propagator/package conformance, and
+  `HexIntervalExperiment` successfully.
+
+## Current frontier
+
+The framework PR now contains only work that is genuinely new relative to its
+prerequisites. It provides the centered-expression instantiation canary but
+not yet the sealed proof-payload session or semantic replay, which remain in
+the stacked PRs.
+
+## Next step
+
+Force-update PR #8984 to this clean stack, obtain a fresh independent review,
+and rebase the proof-session stack after the prerequisite PRs merge.
+
+## Blockers
+
+None.

--- a/progress/20260729T060253Z.md
+++ b/progress/20260729T060253Z.md
@@ -1,0 +1,47 @@
+# Arbitrary-function framework hardening
+
+## Accomplished
+
+- Added a stable operation-key lookup to the generic program view, and changed
+  the centered-function package to use the frontend program's actual operation
+  identifier instead of assuming package order.
+- Separated two different notions of depth:
+  theorem-instantiation generation remains unchanged by CSE, while every
+  expression node now has an engine-computed structural depth with its own
+  `maxNodeDepth` limit.
+- Rejected malformed or over-depth expression proposals when a rule reply is
+  admitted, before they can become policy offers. Policy views no longer
+  rebuild proposed programs merely to display an offer.
+- Removed the unused package-supplied generation estimate and excluded
+  replay-only trigger metadata from policy identity.
+- Added executable checks for deep CSE in either selection order, a genuine
+  whole-program matcher trying to grow a generation-one expression tower,
+  malformed equality rejection, stable operation lookup, initial-program
+  depth, and trigger-independent policy identity.
+- Removed an unnecessary whole-program dependency from the centered matcher,
+  documented that candidate intersection is not a soundness proof, checked
+  reciprocal precision configuration up front, made the current
+  reciprocal-at-zero gap explicit, and enforced the registry's own diagnostic
+  limit.
+- Updated the SPEC to keep rational-backend work behind a non-polynomial
+  semantic replay milestone and to leave the real-domain split representation
+  as an explicit open seam.
+
+## Current frontier
+
+PR #8984 now exercises the arbitrary-function framework against the main
+correctness failures identified in independent review. The generic scheduler
+still knows no arithmetic operations. The remaining major milestone is a
+non-polynomial package whose retained payloads replay to an ordinary Lean
+theorem; the current compiled canaries are not claimed as that proof.
+
+## Next step
+
+Push this commit to PR #8984 and ask the independent reviewer to check the
+updated structural-depth, reply-validation, and program-watcher design. Then
+continue the semantic replay work without adding another rational-only
+milestone.
+
+## Blockers
+
+None.

--- a/progress/20260729T060708Z.md
+++ b/progress/20260729T060708Z.md
@@ -1,0 +1,25 @@
+# Arbitrary-propagator prerequisite merge
+
+## Accomplished
+
+- Confirmed PR #8977 passed its complete CI run and merged into `main`.
+- Rebasing PR #8984's five arbitrary-propagator commits onto the resulting
+  `origin/main` required no conflict resolution.
+- Rechecked the conformance target matrix and the branch diff, then rebuilt
+  `HexIntervalExperiment` and the dyadic, package, policy, propagator, and
+  structure conformance targets successfully.
+
+## Current frontier
+
+PR #8984 is now directly based on `main`; its diff contains only the
+arbitrary-function package, instantiation, scheduling, and associated SPEC and
+conformance work.
+
+## Next step
+
+Publish the rebased branch and retarget PR #8984 to `main`, leaving it open for
+independent review and CI.
+
+## Blockers
+
+None.

--- a/progress/20260729T063445Z.md
+++ b/progress/20260729T063445Z.md
@@ -1,0 +1,33 @@
+# Recoverable structural-depth limits
+
+## Accomplished
+
+- Changed reply admission so one valid but over-depth instantiation is dropped
+  without losing candidate facts or affordable suggestions from the same
+  reply.
+- Made engine admission and policy completeness use one exact kept/dropped
+  suggestion classification. Dropped instantiations are counted and prevent a
+  false fixed-point result.
+- Kept malformed proposals atomic, including malformed equality data following
+  an over-depth draft.
+- Removed the unused `InstantiationRequest.triggers` field and its downstream
+  accounting, constructors, and tests.
+- Documented structural depth as advisory package-visible data and updated the
+  SPEC and conformance canaries for the new behavior.
+- Rebuilt the interval experiments, focused conformance targets, benchmark
+  executables, and the complete `HexConformance` target successfully.
+
+## Current frontier
+
+PR #8984 now treats package-local depth exhaustion as a recoverable search
+loss instead of a whole-run failure, while preserving atomic rejection at the
+untrusted reply boundary.
+
+## Next step
+
+Push the branch, update the PR description, and obtain an independent review
+of the revised classification before merging.
+
+## Blockers
+
+None.

--- a/progress/20260729T065742Z.md
+++ b/progress/20260729T065742Z.md
@@ -1,0 +1,34 @@
+# Exact suggestion admission plans
+
+## Accomplished
+
+- Replaced sentinel-based proposal validation with an uncapped structural
+  resolver followed by a depth check over only newly appended nodes.
+- Narrowed the recoverable proposal result to structural depth specifically.
+- Carried the engine's exact kept/drop-reason plan through accepted replies and
+  policy observations, removing duplicate structural validation in policy.
+- Split omitted-suggestion metrics into capacity and depth counts while
+  retaining the total count.
+- Added exact-capacity tests: a depth-limited proposal leaves the sole slot for
+  later advice, while a malformed suggestion already beyond capacity is
+  intentionally dropped and makes policy incomplete without rejecting useful
+  work.
+- Documented the raw driver as queue-only, policy as completeness authority,
+  and the structural provenance contract for side-node inspection.
+- Rebuilt the complete conformance target and both interval spike executables
+  successfully.
+
+## Current frontier
+
+PR #8984 now has one authoritative suggestion-admission result from the
+untrusted engine boundary through policy observation and completeness
+accounting.
+
+## Next step
+
+Publish the hardened commit, refresh the PR description, and inspect the new CI
+run while the independent review monitor continues.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Purpose

Establish the framework for arbitrary function propagators, including grind-like expression instantiation, without teaching the generic engine any function semantics.

## What this establishes

- independently upgradeable packages own operation signatures, registrations, callbacks, replay identifiers, private performance caches, and start preflight;
- stable operation-key lookup resolves the actual frontend `OpId`, so package assembly order is never authoritative;
- engine-issued rule actions route back to packages without a central function switch;
- rules may explicitly watch append-only program growth and introduce auxiliary expressions plus equality edges;
- engine-owned theorem-instantiation generation is CSE-invariant, while separate per-node structural depth and `maxNodeDepth` bound expression towers;
- proposal resolution validates the complete uncapped structure first, then classifies depth using only nodes appended by that proposal;
- one engine-issued `SuggestionPlan` records every kept suggestion and every capacity/depth drop in source order, travels through the accepted reply into `RuleObservation`, and is the sole policy-completeness authority;
- a structurally valid over-depth instantiation is dropped and counted without consuming retained capacity, so candidate facts and later affordable suggestions from the same reply still commit;
- malformed, ill-typed, and invalid-equality instantiations still invalidate the whole reply atomically, including malformed content following an over-depth draft;
- malformed suggestions already beyond exact retained capacity are intentionally dropped without structural validation; losing such an instantiation still makes policy incomplete;
- total dropped-suggestion metrics are split into exact capacity and depth counts;
- the unused package-supplied trigger metadata is gone; authoritative substitution comes from the selected action and explicit existing-node references;
- matchers may follow anchor-determined structure, while every additional side-node dependency must be a declared fact input or an explicit existing proposal reference;
- forward/backward propagation, instantiation, equality contraction, retry, dismissal, and split preparation are all external policy choices;
- open, closed, empty, and one-sided-unbounded facts remain behind the same generic fact-domain boundary;
- exact-rational backend work remains deferred until a non-polynomial package replays to an ordinary theorem.

## Decisive canaries

For `x ∈ [0,1]`, ordinary compositional propagation gives only `x * (1 - x) ∈ [0,1]`. A separately installed package recognizes that shape, proposes `1/4 - (x - 1/2)^2`, and supplies an equality recipe. Its propagator returns `[0,1/4]`, and the generic equality contractor transfers that bound to the original product.

A genuine whole-program watcher repeatedly proposes a longer `g` tower. Old prefixes CSE-hit and every instance remains theorem-generation one. Under `maxNodeDepth = 3`, the depth-four proposal is dropped without aborting unrelated processing. The raw driver reports only queue saturation; policy is the completeness authority.

Exact-capacity policy canaries exercise both sides of admission. With one slot, an over-depth proposal leaves the slot for a later retry. With the same one-slot cap, a retained split puts a malformed instantiation in the capacity suffix: the useful candidate and split commit, the suffix is recorded as a capacity loss without validation, and policy becomes incomplete instead of rejecting the reply.

A second arithmetic canary starts with one-sided-unbounded `y`: `z = 2*y` is initially inapplicable, backward propagation contracts `z ∈ (2,6]` to `y ∈ (1,3]`, and that improvement wakes forward propagation.

## Trust boundary

Callbacks and their candidate intervals are untrusted search producers. Engine-owned intersection maintains representation consistency and monotone narrowing; it does not prove semantic soundness. The engine also owns projected reads/writes, freshness, bounded expression admission, equality transport, exact suggestion classification, and policy offers. Immutable payload freezing and semantic theorem replay are deliberately implemented in the next stacked PRs, not claimed here. Package caches remain performance-only; semantic package state requires an explicit versioned dependency and wakeup protocol.

## Open points kept explicit

The current dyadic split type is a real-domain-v1 seam, not a frozen multi-domain interface. The current reciprocal component is deliberately inapplicable across zero and does not yet implement the SPEC target hull for Lean total inverse. Both remain experiments, as do compiled structural patterns and more selective program-growth triggers.

## Stack

Stacked only on #8977. Structural views and the external policy driver are already merged; their commits are no longer duplicated here.

## Verification

- `python3 scripts/conformance_targets.py --check`
- `lake build HexConformance`
- focused package-registry, arbitrary-rule, propagator, policy, structural-view, and policy-driver conformance targets
- `lake build HexIntervalExperiment`
- `lake build hex_interval_scheduler_spike hex_interval_policy_frontier_spike`
- `git diff --check`
- no added `native_decide`, `axiom`, or `sorry`