### PR TITLE
fix(bench): derive proof-probe owners from metadata

### DIFF
--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -604,9 +604,10 @@ hard invariants:
    `Hex*Mathlib.*` modules are not what this rule forbids — but per
    invariant (1) above, no bench imports them either.
 
-There is one narrow, non-computational exception. A build-only library may
-place Mathlib proof-elaboration or kernel-replay probes under
-`bench/HexFooMathlib/`. Such a probe measures a fresh module build from an
+There is one narrow, non-computational exception. A library declared
+`mathlib: true` in `libraries.yml` may place Mathlib proof-elaboration or
+kernel-replay probes under `bench/HexFoo/`, where `HexFoo` is the exact
+manifest library name. Such a probe measures a fresh module build from an
 external harness; it is not a `lean-bench` registration. It must not import
 `LeanBench`, use `setup_benchmark` or `setup_fixed_benchmark`, define `main`,
 perform an in-process timing loop, or serve as the root of any `lean_exe`.
@@ -616,23 +617,24 @@ computational benches and everything in their import closures remain
 Mathlib-free.
 
 Both invariants are enforced by
-`scripts/ci/check_benches_mathlib_free.sh`, invoked from the `build`
+`scripts/ci/check_benches_mathlib_free.py`, invoked from the `build`
 job in `ci.yml`. The script:
 
-- Globs `lakefile.lean` for `lean_exe *_bench where root := ...` to
-  enumerate bench exe roots (handles top-level roots like
-  `HexGF2Bench` as well as `Hex*/Bench` modules).
-- Walks each root's transitive `import` graph (Lean syntax allows
-  `import` only at file start, so a simple `^import ` line scan up
-  to the first non-import/non-comment line is sound).
+- Parses `lakefile.lean` for each benchmark executable's literal `root` and
+  effective `srcDir`, failing closed on missing roots or computed source
+  directories.
+- Walks each root's transitive `import` graph through repository and configured
+  package source roots, recognizing module headers, `prelude`, import
+  visibility/meta modifiers, and `import all`.
 - Fails on the first reachable `Mathlib.*` import, printing the
   offending bench root and the full chain (e.g.
   `HexPolyMathlib.Bench → HexPolyMathlib.Euclid → Mathlib.Algebra.Polynomial.FieldDivision`).
 - Globs `Hex*Mathlib/Bench.lean` and `Hex*Mathlib/Bench/` and fails
   if any such path exists.
-- Checks `bench/Hex*Mathlib/` proof-probe trees for `LeanBench` imports,
-  benchmark registrations, `main`, in-process clocks, or an executable rooted
-  at a probe module.
+- Derives proof-probe owner directories from libraries declared `mathlib: true`
+  in `libraries.yml`, then checks their `bench/<Library>/` trees for `LeanBench`
+  imports, benchmark registrations, `main`, in-process clocks, or an executable
+  rooted at a probe module.
 
 A computational bench that needs Mathlib is a category error, not an oversight
 to work around: either it is measuring through Mathlib (slow and missing the

--- a/progress/20260727T150045Z_proof-probe-owners.md
+++ b/progress/20260727T150045Z_proof-probe-owners.md
@@ -1,0 +1,35 @@
+# Metadata-driven proof-probe owners
+
+## Accomplished
+
+- Opened #8985 to replace the proof-probe directory suffix heuristic with the
+  canonical `libraries.yml` `mathlib: true` ownership declaration.
+- Updated the benchmark lint to recognize `bench/HexRCF/` and every other
+  exact manifest-declared Mathlib owner while leaving Mathlib-free libraries
+  outside the exception.
+- Added strict duplicate-library and duplicate-field prechecks before the
+  shared manifest parser, classified both lexical and physically resolved
+  probe paths to close `..` and symlink aliases, and retained the existing
+  suffix-based prohibition on proof-only bridge bench surfaces.
+- Hardened probe scans for attributed registrations, attributed or modified
+  `def`/`opaque`/`abbrev` main declarations, escaped/root main names, and
+  qualified or unqualified monotonic clocks after comment stripping.
+- Updated the benchmarking SPEC to describe metadata-based owners and the
+  current root/import traversal.
+- Expanded the lint suite from 11 to 20 tests. Unit tests, the real 21-exe /
+  3-probe traversal, DAG, Python compilation, and diff checks pass.
+
+## Current frontier
+
+The policy can now safely admit future build-only `bench/HexRCF/` tactic probes
+without relying on a false `Mathlib` name suffix or leaving them unlinted.
+
+## Next step
+
+Rebase this slice and the existing #8980/#8983 child branches onto the newly
+merged conformance parent on `main`, then publish #8985 as its own focused PR.
+
+## Blockers
+
+None for this slice. The policy change does not itself authorize a probe or
+advance HexRCF Phase 4; #8973 still governs that evidence contract.

--- a/scripts/ci/check_benches_mathlib_free.py
+++ b/scripts/ci/check_benches_mathlib_free.py
@@ -14,7 +14,8 @@ The computational-benchmark invariants are:
      `import`, may name a `Mathlib.*` module.
 
 A narrow exception permits build-only proof-elaboration probes below
-`bench/Hex*Mathlib/`.  Such files may import Mathlib, but may not import
+`bench/HexFoo/` when `libraries.yml` declares `HexFoo.mathlib: true`. Such
+files may import Mathlib, but may not import
 LeanBench, register a benchmark, define `main`, time work in-process, or
 serve as a `lean_exe` root.
 
@@ -28,11 +29,18 @@ Stdlib only; runs from the repository root regardless of cwd.
 from __future__ import annotations
 
 import functools
+import os
 import re
 import sys
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+from scripts.libgraph import _strip_comment as _strip_manifest_comment  # noqa: E402
+from scripts.libgraph import load_libraries  # noqa: E402
 
 
 # Module name -> file path: `A.B.C` ↔ `A/B/C.lean` relative to repo root.
@@ -318,21 +326,73 @@ def _find_mathlib_bridge_bench_paths(repo_root: Path) -> list[Path]:
     return out
 
 
-def _is_mathlib_probe_path(path: Path, repo_root: Path) -> bool:
-    """Whether `path` lies below `bench/Hex*Mathlib/`."""
-    try:
-        rel = path.relative_to(repo_root / "bench")
-    except ValueError:
-        return False
-    return (
-        len(rel.parts) >= 2
-        and rel.parts[0].startswith("Hex")
-        and rel.parts[0].endswith("Mathlib")
+_MANIFEST_LIBRARY_RE = re.compile(r"^ {2}(\S(?:.*\S)?):\s*$")
+_MANIFEST_FIELD_RE = re.compile(r"^ {4}(\S[^:]*):")
+
+
+def _check_manifest_uniqueness(path: Path) -> None:
+    """Reject duplicate library entries or fields before YAML-like parsing."""
+    seen_libraries: set[str] = set()
+    seen_fields: set[str] = set()
+    current: str | None = None
+    libraries_headers = 0
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = _strip_manifest_comment(raw).rstrip()
+        if line == "libraries:":
+            libraries_headers += 1
+            current = None
+            continue
+        library = _MANIFEST_LIBRARY_RE.match(line)
+        if library:
+            current = library.group(1)
+            if current in seen_libraries:
+                raise ValueError(f"{path}: duplicate library entry {current}")
+            seen_libraries.add(current)
+            seen_fields = set()
+            continue
+        field = _MANIFEST_FIELD_RE.match(line)
+        if current is not None and field:
+            name = field.group(1).strip()
+            if name in seen_fields:
+                raise ValueError(f"{path}: duplicate {current}.{name} field")
+            seen_fields.add(name)
+    if libraries_headers != 1:
+        raise ValueError(
+            f"{path}: expected exactly one libraries: header, got {libraries_headers}"
+        )
+
+
+def _mathlib_probe_owners(repo_root: Path) -> set[str]:
+    """Return the manifest-declared owners admitted to the probe carveout."""
+    manifest = repo_root / "libraries.yml"
+    _check_manifest_uniqueness(manifest)
+    libraries = load_libraries(manifest)
+    return {name for name, info in libraries.items() if info.mathlib}
+
+
+def _is_mathlib_probe_path(path: Path, repo_root: Path,
+                           owners: set[str]) -> bool:
+    """Whether `path` lies below a manifest-declared Mathlib probe owner."""
+    def has_owner(candidate: Path, bench_root: Path) -> bool:
+        try:
+            rel = candidate.relative_to(bench_root)
+        except ValueError:
+            return False
+        return len(rel.parts) >= 2 and rel.parts[0] in owners
+
+    # Lexical normalization keeps an owner symlink pointing outward covered;
+    # physical normalization catches a source-root alias pointing inward.
+    lexical = Path(os.path.abspath(path))
+    lexical_bench = Path(os.path.abspath(repo_root / "bench"))
+    physical = path.resolve()
+    physical_bench = (repo_root / "bench").resolve()
+    return has_owner(lexical, lexical_bench) or has_owner(
+        physical, physical_bench
     )
 
 
-def _find_mathlib_probe_files(repo_root: Path) -> list[Path]:
-    """Find Lean proof probes admitted by the narrow Mathlib carveout."""
+def _find_mathlib_probe_files(repo_root: Path, owners: set[str]) -> list[Path]:
+    """Find Lean proof probes admitted by the manifest-based carveout."""
     bench_root = repo_root / "bench"
     if not bench_root.is_dir():
         return []
@@ -340,7 +400,7 @@ def _find_mathlib_probe_files(repo_root: Path) -> list[Path]:
     for entry in sorted(bench_root.iterdir()):
         if not entry.is_dir():
             continue
-        if not (entry.name.startswith("Hex") and entry.name.endswith("Mathlib")):
+        if entry.name not in owners:
             continue
         out.extend(sorted(entry.rglob("*.lean")))
     return out
@@ -358,35 +418,46 @@ _PROBE_FORBIDDEN = (
     (
         "registers a LeanBench benchmark",
         re.compile(
-            r"^\s*setup_(?:fixed_)?benchmark\b",
+            rf"^\s*{_ATTR_PREFIX}(?:(?:public|private|meta)\s+)*"
+            r"setup_(?:fixed_)?benchmark\b",
             re.MULTILINE,
         ),
     ),
     (
         "defines main",
         re.compile(
-            r"^\s*(?:public\s+)?(?:unsafe\s+)?def\s+main\b",
+            rf"^\s*{_ATTR_PREFIX}"
+            r"(?:(?:public|private|protected|noncomputable|partial|unsafe|meta)\s+)*"
+            r"(?:def|opaque|abbrev)\s+"
+            r"(?:main(?![\w'.!?])|«main»(?![\w'.!?])|"
+            r"_root_\.(?:main(?![\w'.!?])|«main»(?![\w'.!?])))",
             re.MULTILINE,
         ),
     ),
     (
         "uses an in-process monotonic clock",
-        re.compile(r"\bIO\.mono(?:Nanos|Ms)Now\b"),
+        re.compile(
+            r"(?<![\w.])(?:_root_\.)?(?:IO\.)?"
+            r"(?:mono(?:Nanos|Ms)Now|«mono(?:Nanos|Ms)Now»)(?![\w'.])"
+        ),
     ),
 )
 
 
 def _probe_violations(path: Path) -> list[str]:
     """Return forbidden computational-benchmark features used by one probe."""
-    text = path.read_text()
+    text = _without_comments(path.read_text())
     return [description for description, pattern in _PROBE_FORBIDDEN
             if pattern.search(text)]
 
 
-def _probe_root_path(target: _ExeTarget, repo_root: Path) -> Path | None:
+def _probe_root_path(target: _ExeTarget, repo_root: Path,
+                     owners: set[str]) -> Path | None:
     """Resolve a module when its source is an admitted Mathlib probe file."""
     candidate = target.root_path(repo_root)
-    if candidate.is_file() and _is_mathlib_probe_path(candidate, repo_root):
+    if candidate.is_file() and _is_mathlib_probe_path(
+        candidate, repo_root, owners
+    ):
         return candidate
     return None
 
@@ -408,7 +479,7 @@ def _missing_exe_root_failures(
 
 
 def main() -> int:
-    repo_root = Path(__file__).resolve().parents[2]
+    repo_root = REPO_ROOT
     lakefile = repo_root / "lakefile.lean"
     if not lakefile.is_file():
         print(f"FATAL: lakefile.lean not found at {lakefile}",
@@ -430,6 +501,7 @@ def main() -> int:
     try:
         exe_targets = _parse_exe_targets(lakefile)
         _configured_source_roots(repo_root)
+        probe_owners = _mathlib_probe_owners(repo_root)
     except (OSError, ValueError, tomllib.TOMLDecodeError) as exc:
         print(f"FATAL: cannot resolve Lake module roots: {exc}", file=sys.stderr)
         return 2
@@ -448,7 +520,7 @@ def main() -> int:
 
     # The build-only proof-probe carveout is intentionally not an executable
     # or a second computational benchmark harness.
-    probe_files = _find_mathlib_probe_files(repo_root)
+    probe_files = _find_mathlib_probe_files(repo_root, probe_owners)
     for probe in probe_files:
         for violation in _probe_violations(probe):
             failures.append(
@@ -457,7 +529,7 @@ def main() -> int:
                 f"timed; see SPEC/benchmarking.md §Mathlib-free benches."
             )
     for exe, target in sorted(exe_targets.items()):
-        probe = _probe_root_path(target, repo_root)
+        probe = _probe_root_path(target, repo_root, probe_owners)
         if probe is not None:
             failures.append(
                 f"  FORBIDDEN: executable `{exe}` is rooted at Mathlib proof "
@@ -486,8 +558,8 @@ def main() -> int:
         print(
             "\nFix: keep executable computational benches Mathlib-free. "
             "A Mathlib proof-elaboration probe may instead be a build-only "
-            "module under bench/Hex*Mathlib/, with timing performed by an "
-            "external harness.",
+            "module under bench/<Library>/ when libraries.yml declares that "
+            "owner mathlib: true, with timing performed by an external harness.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/ci/test_check_benches_mathlib_free.py
+++ b/scripts/ci/test_check_benches_mathlib_free.py
@@ -29,6 +29,10 @@ class BenchLintTests(unittest.TestCase):
         self.assertEqual(list(targets), ["sample_bench"])
         return targets["sample_bench"]
 
+    def manifest(self, root: Path, entries: str) -> set[str]:
+        self.write(root, "libraries.yml", "libraries:\n" + entries)
+        return lint._mathlib_probe_owners(root)
+
     def test_src_dir_and_module_import_modifiers_reach_mathlib(self) -> None:
         for import_line in (
             "public import Mathlib.Data.Nat.Basic",
@@ -161,6 +165,266 @@ class BenchLintTests(unittest.TestCase):
             path = root / "Probe.lean"
             path.write_text("module\npublic meta import LeanBench\n")
             self.assertIn("imports LeanBench", lint._probe_violations(path))
+
+    def test_manifest_declares_non_suffix_probe_owner(self) -> None:
+        tmp, root = self.make_repo()
+        with tmp:
+            owners = self.manifest(
+                root,
+                "  HexRCF:\n"
+                "    deps: []\n"
+                "    mathlib: true\n"
+                "    done_through: 3\n"
+                "    status: active\n"
+                "  HexCore:\n"
+                "    deps: []\n"
+                "    mathlib: false\n"
+                "    done_through: 3\n"
+                "    status: active\n",
+            )
+            self.assertEqual(owners, {"HexRCF"})
+            self.write(root, "bench/HexRCF/Import.lean", "import LeanBench\n")
+            self.write(
+                root,
+                "bench/HexRCF/Register.lean",
+                "@[implemented_by ignored] private setup_fixed_benchmark sample := 1\n",
+            )
+            self.write(
+                root, "bench/HexRCF/Main.lean", "noncomputable def main := pure ()\n"
+            )
+            self.write(
+                root, "bench/HexRCF/Clock.lean", "#check IO.monoNanosNow\n"
+            )
+            probes = lint._find_mathlib_probe_files(root, owners)
+            self.assertEqual(len(probes), 4)
+            violations = {
+                violation
+                for probe in probes
+                for violation in lint._probe_violations(probe)
+            }
+            self.assertEqual(
+                violations,
+                {
+                    "imports LeanBench",
+                    "registers a LeanBench benchmark",
+                    "defines main",
+                    "uses an in-process monotonic clock",
+                },
+            )
+
+    def test_mathlib_false_owner_does_not_gain_probe_exception(self) -> None:
+        tmp, root = self.make_repo()
+        with tmp:
+            owners = self.manifest(
+                root,
+                "  HexCore:\n"
+                "    deps: []\n"
+                "    mathlib: false\n"
+                "    done_through: 3\n"
+                "    status: active\n",
+            )
+            self.write(root, "bench/HexCore/Probe.lean", "import Mathlib\n")
+            probe = root / "bench/HexCore/Probe.lean"
+            self.assertFalse(lint._is_mathlib_probe_path(probe, root, owners))
+            self.assertEqual(lint._find_mathlib_probe_files(root, owners), [])
+
+    def test_manifest_owned_probe_cannot_root_executable(self) -> None:
+        tmp, root = self.make_repo()
+        with tmp:
+            owners = self.manifest(
+                root,
+                "  HexRCF:\n"
+                "    deps: []\n"
+                "    mathlib: true\n"
+                "    done_through: 3\n"
+                "    status: active\n",
+            )
+            target = self.target(
+                root,
+                "lean_exe sample_bench where\n"
+                "  srcDir := \"bench\"\n"
+                "  root := `HexRCF.Probe\n",
+            )
+            self.write(root, "bench/HexRCF/Probe.lean", "import Mathlib\n")
+            self.assertEqual(
+                lint._probe_root_path(target, root, owners),
+                root / "bench/HexRCF/Probe.lean",
+            )
+
+    def test_malformed_manifest_fails_closed(self) -> None:
+        tmp, root = self.make_repo()
+        with tmp:
+            self.write(
+                root,
+                "libraries.yml",
+                "libraries:\n"
+                "  HexRCF:\n"
+                "    deps: []\n"
+                "    mathlib: perhaps\n"
+                "    done_through: 3\n"
+                "    status: active\n",
+            )
+            with self.assertRaises(ValueError):
+                lint._mathlib_probe_owners(root)
+
+    def test_duplicate_manifest_ownership_fails_closed(self) -> None:
+        duplicate_library = (
+            "  HexRCF:\n"
+            "    deps: []\n"
+            "    mathlib: true\n"
+            "    done_through: 3\n"
+            "    status: active\n"
+            "  HexRCF:\n"
+            "    deps: []\n"
+            "    mathlib: false\n"
+            "    done_through: 3\n"
+            "    status: active\n"
+        )
+        duplicate_field = (
+            "  HexRCF:\n"
+            "    deps: []\n"
+            "    mathlib: true\n"
+            "    mathlib: false\n"
+            "    done_through: 3\n"
+            "    status: active\n"
+        )
+        for entries, message in (
+            (duplicate_library, "duplicate library entry HexRCF"),
+            (duplicate_field, "duplicate HexRCF.mathlib field"),
+            (
+                duplicate_library.replace("HexRCF", "Hex-RCF"),
+                "duplicate library entry Hex-RCF",
+            ),
+        ):
+            with self.subTest(message=message):
+                tmp, root = self.make_repo()
+                with tmp:
+                    with self.assertRaisesRegex(ValueError, message):
+                        self.manifest(root, entries)
+
+    def test_probe_root_path_normalizes_src_dir(self) -> None:
+        tmp, root = self.make_repo()
+        with tmp:
+            owners = self.manifest(
+                root,
+                "  HexRCF:\n"
+                "    deps: []\n"
+                "    mathlib: true\n"
+                "    done_through: 3\n"
+                "    status: active\n"
+                "  HexCore:\n"
+                "    deps: []\n"
+                "    mathlib: false\n"
+                "    done_through: 3\n"
+                "    status: active\n",
+            )
+            (root / "bench/Other").mkdir(parents=True)
+            target = self.target(
+                root,
+                "lean_exe sample_bench where\n"
+                "  srcDir := \"bench/Other/..\"\n"
+                "  root := `HexRCF.Probe\n",
+            )
+            self.write(root, "bench/HexRCF/Probe.lean", "import Mathlib\n")
+            self.assertIsNotNone(lint._probe_root_path(target, root, owners))
+
+            (root / "bench/HexRCF").mkdir(parents=True, exist_ok=True)
+            target = self.target(
+                root,
+                "lean_exe sample_bench where\n"
+                "  srcDir := \"bench/HexRCF/..\"\n"
+                "  root := `HexCore.Probe\n",
+            )
+            self.write(root, "bench/HexCore/Probe.lean", "import Mathlib\n")
+            self.assertIsNone(lint._probe_root_path(target, root, owners))
+
+    def test_probe_root_path_preserves_symlink_owner(self) -> None:
+        tmp, root = self.make_repo()
+        with tmp:
+            owners = self.manifest(
+                root,
+                "  HexRCF:\n"
+                "    deps: []\n"
+                "    mathlib: true\n"
+                "    done_through: 3\n"
+                "    status: active\n",
+            )
+            self.write(root, "Physical/Probe.lean", "import Mathlib\n")
+            (root / "bench").mkdir()
+            (root / "bench/HexRCF").symlink_to(root / "Physical", target_is_directory=True)
+            target = self.target(
+                root,
+                "lean_exe sample_bench where\n"
+                "  srcDir := \"bench\"\n"
+                "  root := `HexRCF.Probe\n",
+            )
+            self.assertEqual(
+                lint._find_mathlib_probe_files(root, owners),
+                [root / "bench/HexRCF/Probe.lean"],
+            )
+            self.assertIsNotNone(lint._probe_root_path(target, root, owners))
+
+    def test_probe_root_path_follows_alias_into_owner(self) -> None:
+        tmp, root = self.make_repo()
+        with tmp:
+            owners = self.manifest(
+                root,
+                "  HexRCF:\n"
+                "    deps: []\n"
+                "    mathlib: true\n"
+                "    done_through: 3\n"
+                "    status: active\n",
+            )
+            self.write(root, "bench/HexRCF/Probe.lean", "import Mathlib\n")
+            (root / "Alias").symlink_to(
+                root / "bench/HexRCF", target_is_directory=True
+            )
+            target = self.target(
+                root,
+                "lean_exe sample_bench where\n"
+                "  srcDir := \"Alias\"\n"
+                "  root := `Probe\n",
+            )
+            self.assertIsNotNone(lint._probe_root_path(target, root, owners))
+
+    def test_probe_main_and_unqualified_clock_variants_are_forbidden(self) -> None:
+        main_variants = (
+            "@[inline] def main : IO Unit := pure ()\n",
+            "partial def main : IO Unit := main\n",
+            "opaque main : IO Unit\n",
+            "abbrev main := IO Unit\n",
+            "def «main» : IO Unit := pure ()\n",
+            "def _root_.main : IO Unit := pure ()\n",
+            "def _root_.«main» : IO Unit := pure ()\n",
+        )
+        tmp, root = self.make_repo()
+        with tmp:
+            for index, source in enumerate(main_variants):
+                with self.subTest(source=source.strip()):
+                    path = root / f"Main{index}.lean"
+                    path.write_text(source, encoding="utf-8")
+                    self.assertIn("defines main", lint._probe_violations(path))
+            clock = root / "Clock.lean"
+            clock.write_text("open IO\n#check monoNanosNow\n", encoding="utf-8")
+            self.assertIn(
+                "uses an in-process monotonic clock",
+                lint._probe_violations(clock),
+            )
+            escaped_clock = root / "EscapedClock.lean"
+            escaped_clock.write_text(
+                "#check IO.«monoNanosNow»\n#check _root_.IO.monoNanosNow\n",
+                encoding="utf-8",
+            )
+            self.assertIn(
+                "uses an in-process monotonic clock",
+                lint._probe_violations(escaped_clock),
+            )
+            helper = root / "Helper.lean"
+            helper.write_text(
+                "def main' := 1\ndef main! := 1\ndef main? := 1\n",
+                encoding="utf-8",
+            )
+            self.assertNotIn("defines main", lint._probe_violations(helper))
 
     def test_clean_src_dir_closure(self) -> None:
         tmp, root = self.make_repo()


### PR DESCRIPTION
Closes #8985.

The build-only proof-probe carveout now derives exact owner directories from `libraries.yml` entries with `mathlib: true`, so `bench/HexRCF/` is covered without inventing a `Mathlib` suffix and Mathlib-free owners do not gain the exception. The conventional `Hex*Mathlib/Bench` and `*mathlib*_bench` bans remain unchanged.

The lint fails closed on duplicate/ambiguous manifest ownership, normalizes both lexical and physical paths to close `..` and symlink aliases, rejects executable roots at admitted probes, and recognizes attributed registrations, exact modified/escaped/root `main` declarations, and qualified/unqualified monotonic clocks. The SPEC now states the metadata-based location rule.

Verification: 20 unit tests; real traversal of 21 benchmark executables and 3 current proof probes; DAG, Phase-4, release-manifest, trust-surface, Python compilation, and diff checks. Independent Sol review: GO.