### PR TITLE
refactor(rcf): extract Mathlib-free Sturm checks

### DIFF
--- a/HexRCF.lean
+++ b/HexRCF.lean
@@ -9,6 +9,7 @@ module
 public import HexRCF.Syntax
 public import HexRCF.Language
 public import HexRCF.LanguageTests
+public import HexRCF.SturmCheck
 public import HexRCF.SturmReplay
 public import HexRCF.SturmBuilder
 public import HexRCF.SturmBuilderTests

--- a/HexRCF/SturmBuilder.lean
+++ b/HexRCF/SturmBuilder.lean
@@ -6,7 +6,7 @@ Authors: Kim Morrison
 
 module
 
-public import HexRCF.SturmReplay
+public import HexRCF.SturmCheck
 public import HexRealRoots.Chain
 public import HexPolyZ.Core
 

--- a/HexRCF/SturmBuilderTests.lean
+++ b/HexRCF/SturmBuilderTests.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexRCF.SturmBuilder
+public import HexRCF.SturmReplay
 import all HexRCF.SturmBuilder
 
 public section

--- a/HexRCF/SturmCheck.lean
+++ b/HexRCF/SturmCheck.lean
@@ -1,0 +1,164 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRealRoots.Var
+
+public section
+
+/-!
+# Multiplication-only Sturm replay checks
+
+An RCF certificate supplies a literal integer-polynomial chain together with
+positive three-term recurrence scales. The executable checker in this file
+uses only coefficient equality, integer arithmetic, and linear walks over the
+literal arrays. The Mathlib-facing soundness theorems live in
+`HexRCF.SturmReplay`.
+-/
+
+namespace Hex.RCF
+
+/-- One positive three-term recurrence in a generalized Sturm replay. -/
+structure SturmStep where
+  /-- Positive scale on the polynomial two positions before the new term. -/
+  leftScale : Int
+  /-- Quotient multiplying the preceding polynomial. -/
+  quotient : ZPoly
+  /-- Positive scale on the new polynomial. -/
+  rightScale : Int
+
+/-- A literal generalized Sturm chain and its multiplication-only replay. -/
+structure SturmReplay where
+  /-- The chain `[f, s₁, …, sₙ]`. -/
+  chain : Array ZPoly
+  /-- Positive integer `δ` satisfying `f' = δ s₁`. -/
+  derivScale : Int
+  /-- The three-term identities for consecutive chain triples. -/
+  steps : Array SturmStep
+
+namespace SturmReplay
+
+/-- Boolean validation of a supplied positive three-term identity. -/
+@[expose]
+def checkStep (a b c : ZPoly) (step : SturmStep) : Bool :=
+  decide (0 < step.leftScale) &&
+  decide (0 < step.rightScale) &&
+  DensePoly.beqCoeffs (DensePoly.scale step.leftScale a)
+    (step.quotient * b - DensePoly.scale step.rightScale c)
+
+/-- Validate recurrence steps and the terminal nonzero constant. -/
+@[expose]
+def checkSteps : ZPoly → ZPoly → List ZPoly → List SturmStep → Bool
+  | _, b, [], [] => decide (b.size = 1)
+  | a, b, c :: rest, step :: steps =>
+      checkStep a b c step && checkSteps b c rest steps
+  | _, _, _, _ => false
+
+/-- Every literal polynomial in a chain is nonzero. -/
+@[expose]
+def checkNonzero : List ZPoly → Bool
+  | [] => true
+  | p :: rest => !p.isZero && checkNonzero rest
+
+/-- Consecutive literal chain degrees strictly decrease. -/
+@[expose]
+def checkDegrees : List ZPoly → Bool
+  | a :: b :: rest =>
+      decide (b.degree?.getD 0 < a.degree?.getD 0) && checkDegrees (b :: rest)
+  | _ => true
+
+/-- Executable generalized Sturm replay checker.
+
+All polynomial comparisons use `DensePoly.beqCoeffs`, avoiding structural
+array equality during kernel reduction. Nonzero checking before strict degree
+descent makes `degree?.getD 0` unambiguous and implies that an accepted head
+has positive degree. Degree descent is retained as an explicit certificate
+invariant even though the abstract `IsSturmChain` consequence does not need
+it. -/
+@[expose]
+def check (f : ZPoly) (cert : SturmReplay) : Bool :=
+  match cert.chain.toList with
+  | a :: s₁ :: rest =>
+      decide (2 ≤ cert.chain.size) &&
+      DensePoly.beqCoeffs a f &&
+      checkNonzero (a :: s₁ :: rest) &&
+      checkDegrees (a :: s₁ :: rest) &&
+      decide (cert.steps.size + 2 = cert.chain.size) &&
+      decide (0 < cert.derivScale) &&
+      DensePoly.beqCoeffs (DensePoly.derivative f)
+        (DensePoly.scale cert.derivScale s₁) &&
+      checkSteps a s₁ rest cert.steps.toList
+  | _ => false
+
+/-- Literal Sturm variation drop across the dyadic interval
+`(I.lower, I.upper]`. -/
+@[expose]
+def count (cert : SturmReplay) (I : DyadicInterval) : Int :=
+  (Hex.sturmVarAt cert.chain I.lower : Int) - Hex.sturmVarAt cert.chain I.upper
+
+/-- Literal Sturm variation drop from negative to positive infinity. -/
+@[expose]
+def total (cert : SturmReplay) : Int :=
+  (Hex.sturmVarNegInf cert.chain : Int) - Hex.sturmVarPosInf cert.chain
+
+/-- Proposition-level adjacent degree descent mirrored by `checkDegrees`. -/
+@[expose]
+def DegreesDescend : List ZPoly → Prop
+  | a :: b :: rest =>
+      b.degree?.getD 0 < a.degree?.getD 0 ∧ DegreesDescend (b :: rest)
+  | _ => True
+
+/-- A successful nonzero walk proves every chain entry nonzero. -/
+theorem checkNonzero_sound {chain : List ZPoly}
+    (h : checkNonzero chain = true) : ∀ q ∈ chain, q ≠ 0 := by
+  induction chain with
+  | nil => simp
+  | cons p rest ih =>
+      simp only [checkNonzero, Bool.and_eq_true, Bool.not_eq_true'] at h
+      obtain ⟨hp, hrest⟩ := h
+      have hp0 : p ≠ 0 := by
+        have hpos := (DensePoly.isZero_eq_false_iff p).mp hp
+        intro hzero
+        subst p
+        simp at hpos
+      intro q hq
+      simp only [List.mem_cons] at hq
+      rcases hq with rfl | hq
+      · exact hp0
+      · exact ih hrest q hq
+
+/-- A successful degree walk proves proposition-level adjacent descent. -/
+theorem checkDegrees_sound {chain : List ZPoly}
+    (h : checkDegrees chain = true) : DegreesDescend chain := by
+  induction chain with
+  | nil => trivial
+  | cons a rest ih =>
+      cases rest with
+      | nil => trivial
+      | cons b rest =>
+          simp only [checkDegrees, Bool.and_eq_true, decide_eq_true_eq] at h
+          exact ⟨h.1, ih h.2⟩
+
+/-- The head of an accepted replay is nonzero. -/
+theorem head_ne_zero {f : ZPoly} {cert : SturmReplay}
+    (h : cert.check f = true) : f ≠ 0 := by
+  unfold check at h
+  match hm : cert.chain.toList with
+  | [] => rw [hm] at h; simp at h
+  | [_] => rw [hm] at h; simp at h
+  | a :: s₁ :: rest =>
+      rw [hm] at h
+      simp only [Bool.and_eq_true] at h
+      obtain ⟨⟨⟨⟨⟨⟨⟨_hsize, hhead⟩, hnz⟩, _hdegrees⟩, _hcount⟩,
+        _hderivPos⟩, _hderiv⟩, _hsteps⟩ := h
+      have ha : a = f := DensePoly.eq_of_beqCoeffs hhead
+      subst a
+      exact checkNonzero_sound hnz f (by simp)
+
+end SturmReplay
+
+end Hex.RCF

--- a/HexRCF/SturmReplay.lean
+++ b/HexRCF/SturmReplay.lean
@@ -6,112 +6,22 @@ Authors: Kim Morrison
 
 module
 
+public import HexRCF.SturmCheck
 public import HexRealRootsMathlib.LiteralChain
 
 public section
 
 /-!
-# Multiplication-only Sturm replay certificates
+# Soundness of multiplication-only Sturm replay certificates
 
-An RCF certificate supplies a literal integer-polynomial chain together with
-positive three-term recurrence scales. The executable checker in this file
-uses only coefficient equality, integer arithmetic, and linear walks over the
-literal arrays. Its soundness theorem packages the accepted data as
+The Mathlib-free data and executable checker live in `HexRCF.SturmCheck`.
+The theorems in this file package accepted data as
 `HexRealRootsMathlib.ZReplay`, ready for the literal Sturm count theorems.
 -/
 
 namespace Hex.RCF
 
-/-- One positive three-term recurrence in a generalized Sturm replay. -/
-structure SturmStep where
-  /-- Positive scale on the polynomial two positions before the new term. -/
-  leftScale : Int
-  /-- Quotient multiplying the preceding polynomial. -/
-  quotient : ZPoly
-  /-- Positive scale on the new polynomial. -/
-  rightScale : Int
-
-/-- A literal generalized Sturm chain and its multiplication-only replay. -/
-structure SturmReplay where
-  /-- The chain `[f, s₁, …, sₙ]`. -/
-  chain : Array ZPoly
-  /-- Positive integer `δ` satisfying `f' = δ s₁`. -/
-  derivScale : Int
-  /-- The three-term identities for consecutive chain triples. -/
-  steps : Array SturmStep
-
 namespace SturmReplay
-
-/-- Boolean validation of a supplied positive three-term identity. -/
-@[expose]
-def checkStep (a b c : ZPoly) (step : SturmStep) : Bool :=
-  decide (0 < step.leftScale) &&
-  decide (0 < step.rightScale) &&
-  DensePoly.beqCoeffs (DensePoly.scale step.leftScale a)
-    (step.quotient * b - DensePoly.scale step.rightScale c)
-
-/-- Validate recurrence steps and the terminal nonzero constant. Its recursive
-shape matches `HexRealRootsMathlib.ZReplay`. -/
-@[expose]
-def checkSteps : ZPoly → ZPoly → List ZPoly → List SturmStep → Bool
-  | _, b, [], [] => decide (b.size = 1)
-  | a, b, c :: rest, step :: steps =>
-      checkStep a b c step && checkSteps b c rest steps
-  | _, _, _, _ => false
-
-/-- Every literal polynomial in a chain is nonzero. -/
-@[expose]
-def checkNonzero : List ZPoly → Bool
-  | [] => true
-  | p :: rest => !p.isZero && checkNonzero rest
-
-/-- Consecutive literal chain degrees strictly decrease. -/
-@[expose]
-def checkDegrees : List ZPoly → Bool
-  | a :: b :: rest =>
-      decide (b.degree?.getD 0 < a.degree?.getD 0) && checkDegrees (b :: rest)
-  | _ => true
-
-/-- Executable generalized Sturm replay checker.
-
-All polynomial comparisons use `DensePoly.beqCoeffs`, avoiding structural
-array equality during kernel reduction. Nonzero checking before strict degree
-descent makes `degree?.getD 0` unambiguous and implies that an accepted head
-has positive degree. Degree descent is retained as an explicit certificate
-invariant even though the abstract `IsSturmChain` consequence does not need
-it. -/
-@[expose]
-def check (f : ZPoly) (cert : SturmReplay) : Bool :=
-  match cert.chain.toList with
-  | a :: s₁ :: rest =>
-      decide (2 ≤ cert.chain.size) &&
-      DensePoly.beqCoeffs a f &&
-      checkNonzero (a :: s₁ :: rest) &&
-      checkDegrees (a :: s₁ :: rest) &&
-      decide (cert.steps.size + 2 = cert.chain.size) &&
-      decide (0 < cert.derivScale) &&
-      DensePoly.beqCoeffs (DensePoly.derivative f)
-        (DensePoly.scale cert.derivScale s₁) &&
-      checkSteps a s₁ rest cert.steps.toList
-  | _ => false
-
-/-- Literal Sturm variation drop across the dyadic interval
-`(I.lower, I.upper]`. -/
-@[expose]
-def count (cert : SturmReplay) (I : DyadicInterval) : Int :=
-  (Hex.sturmVarAt cert.chain I.lower : Int) - Hex.sturmVarAt cert.chain I.upper
-
-/-- Literal Sturm variation drop from negative to positive infinity. -/
-@[expose]
-def total (cert : SturmReplay) : Int :=
-  (Hex.sturmVarNegInf cert.chain : Int) - Hex.sturmVarPosInf cert.chain
-
-/-- Proposition-level adjacent degree descent mirrored by `checkDegrees`. -/
-@[expose]
-def DegreesDescend : List ZPoly → Prop
-  | a :: b :: rest =>
-      b.degree?.getD 0 < a.degree?.getD 0 ∧ DegreesDescend (b :: rest)
-  | _ => True
 
 /-- Kernel-facing consequences of an accepted generalized Sturm replay. The
 existential form keeps this a proposition while exposing the literal list
@@ -126,37 +36,6 @@ def Valid (f : ZPoly) (cert : SturmReplay) : Prop :=
             0 < cert.derivScale ∧
               DensePoly.derivative f = DensePoly.scale cert.derivScale s₁ ∧
                 cert.steps.size + 2 = cert.chain.size
-
-/-- A successful nonzero walk proves every chain entry nonzero. -/
-theorem checkNonzero_sound {chain : List ZPoly}
-    (h : checkNonzero chain = true) : ∀ q ∈ chain, q ≠ 0 := by
-  induction chain with
-  | nil => simp
-  | cons p rest ih =>
-      simp only [checkNonzero, Bool.and_eq_true, Bool.not_eq_true'] at h
-      obtain ⟨hp, hrest⟩ := h
-      have hp0 : p ≠ 0 := by
-        have hpos := (DensePoly.isZero_eq_false_iff p).mp hp
-        intro hzero
-        subst p
-        simp at hpos
-      intro q hq
-      simp only [List.mem_cons] at hq
-      rcases hq with rfl | hq
-      · exact hp0
-      · exact ih hrest q hq
-
-/-- A successful degree walk proves proposition-level adjacent descent. -/
-theorem checkDegrees_sound {chain : List ZPoly}
-    (h : checkDegrees chain = true) : DegreesDescend chain := by
-  induction chain with
-  | nil => trivial
-  | cons a rest ih =>
-      cases rest with
-      | nil => trivial
-      | cons b rest =>
-          simp only [checkDegrees, Bool.and_eq_true, decide_eq_true_eq] at h
-          exact ⟨h.1, ih h.2⟩
 
 /-- A successful identity check supplies the existential recurrence expected
 by `HexRealRootsMathlib.ZReplay`. -/
@@ -203,13 +82,6 @@ theorem check_sound {f : ZPoly} {cert : SturmReplay}
       · exact checkNonzero_sound hnz
       · exact checkDegrees_sound hdegrees
       · exact DensePoly.eq_of_beqCoeffs hderiv
-
-/-- The head of an accepted replay is nonzero. -/
-theorem head_ne_zero {f : ZPoly} {cert : SturmReplay}
-    (h : cert.check f = true) : f ≠ 0 := by
-  obtain ⟨s₁, rest, _hchain, _hrep, hnz, _hdegrees, _hpos, _hderiv, _hcount⟩ :=
-    check_sound h
-  exact hnz f (by simp)
 
 /-- An accepted replay is a Sturm chain after casting its literal entries to
 real polynomials. -/

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -585,8 +585,10 @@ free to change.
   their structural polynomial traversals; `HexRCF/Language.lean`: real-valued
   `toProp` semantics;
   `HexRCF/LanguageTests.lean`: executable language-semantics tests.
-- `HexRCF/SturmReplay.lean`: generalized multiplication-only chain
-  replay and literal root counts.
+- `HexRCF/SturmCheck.lean`: Mathlib-free generalized multiplication-only
+  replay data, executable validation, and literal root counts;
+  `HexRCF/SturmReplay.lean`: Mathlib-facing replay soundness and root-count
+  correspondence.
 - `HexRCF/SturmBuilder.lean`: compiled pseudo-remainder instrumentation that
   emits replay witnesses and retains only checker-approved candidates;
   `HexRCF/SturmBuilderTests.lean`: valid, malformed, nonprimitive, and

--- a/progress/20260727T151952Z_rcf-sturm-check.md
+++ b/progress/20260727T151952Z_rcf-sturm-check.md
@@ -1,0 +1,36 @@
+# Mathlib-free RCF Sturm replay checks
+
+## Accomplished
+
+- Added `HexRCF.SturmCheck`, containing the generalized replay data,
+  executable validation, literal root counts, pure degree/nonzero consequences,
+  and the accepted-head nonzero theorem.
+- Reduced `HexRCF.SturmReplay` to the Mathlib-facing replay, Sturm-chain,
+  squarefreeness, and root-count correspondence layer while preserving every
+  existing qualified declaration name through a public import.
+- Made the compiled `SturmBuilder` consume `SturmCheck` directly. Its semantic
+  tests now import `SturmReplay` explicitly instead of relying on the old
+  transitive dependency.
+- Updated the HexRCF umbrella and SPEC file map.
+- Verified full HexRCF builds and mechanically checked that the repository-local
+  closures of `HexRCF.SturmCheck` and `HexRCF.SturmBuilder` contain neither
+  `Mathlib.*` nor `HexRealRootsMathlib.*`. DAG, Phase-4, release-manifest,
+  trust-surface, copyright, diff, and banned-token checks pass. An independent
+  Sol review returned GO.
+
+## Current frontier
+
+Issue #8987 is implemented on a branch stacked above the syntax-seam PR #8983.
+The extraction exposes the first nontrivial executable RCF certificate builder
+with a genuinely Mathlib-free import closure.
+
+## Next step
+
+Publish the stacked PR, then split the carrier certificate data and Boolean
+checker from its real-root semantic proofs so compiled carrier construction can
+depend on the pure syntax and replay-check modules.
+
+## Blockers
+
+None for this extraction. The parent syntax PR is still completing CI, so this
+PR should remain stacked until #8983 merges and can then be rebased onto main.


### PR DESCRIPTION
## Summary

- extract generalized Sturm replay data, executable checks, counts, and pure consequences into `HexRCF.SturmCheck`
- keep Mathlib-facing replay/sturm/root-count proofs in `HexRCF.SturmReplay` with all existing qualified names preserved
- make compiled `SturmBuilder` depend directly on the pure checker and make its semantic test import explicit

Stacked on #8983. Closes #8987. Contributes to #8973.

## Verification

- `lake build HexRCF.SturmCheck HexRCF.SturmReplay HexRCF.Carrier`
- `lake build HexRCF.SturmBuilderTests`
- `lake build HexRCF`
- repository-local import-closure audit: `HexRCF.SturmCheck` (29 modules) and `HexRCF.SturmBuilder` (30 modules) contain no `Mathlib.*` or `HexRealRootsMathlib.*` imports
- `python3 scripts/check_dag.py`
- `python3 scripts/check_phase4.py`
- release manifest, published trust surface, copyright, diff, and banned-token checks
- independent Sol review: GO