### PR TITLE
prove(number-field-tower): establish multiplicative evaluation

### DIFF
--- a/HexNumberFieldTower/Arithmetic.lean
+++ b/HexNumberFieldTower/Arithmetic.lean
@@ -175,6 +175,17 @@ def mul {T : NumberTower} (a b : Elem T) : Elem T :=
 
 instance {T : NumberTower} : Mul (Elem T) := ⟨mul⟩
 
+/-- Multiplication exposes its fixed-width recursively reduced coordinates. -/
+@[simp]
+theorem coeffs_mul {T : NumberTower} (a b : Elem T) :
+    coeffs (a * b) =
+      Arithmetic.mulCoords T.levels.toList (coeffs a) (coeffs b) := by
+  change coeffs (mul a b) = _
+  unfold mul
+  rw [coeffs_ofCoeffs]
+  apply normalizeCoeffs_eq_self
+  simp [dim]
+
 /-- Recursive extended-gcd inversion, totalized by `0⁻¹ = 0`. -/
 @[expose]
 def inv {T : NumberTower} (a : Elem T) : Elem T :=

--- a/HexNumberFieldTower/RawArithmetic.lean
+++ b/HexNumberFieldTower/RawArithmetic.lean
@@ -19,6 +19,16 @@ arithmetic is a thin dependent wrapper defined later.
 -/
 namespace Hex.NumberTower.Arithmetic
 
+private theorem foldl_array_size {α β : Type} (indices : List β)
+    (step : Array α → β → Array α) (initial : Array α)
+    (hstep : ∀ work index, (step work index).size = work.size) :
+    (indices.foldl step initial).size = initial.size := by
+  induction indices generalizing initial with
+  | nil => rfl
+  | cons index indices ih =>
+      simp only [List.foldl_cons]
+      rw [ih, hstep]
+
 /-- Fixed-width rational coordinates, padding with zero and truncating excess
 entries. -/
 @[expose]
@@ -40,10 +50,67 @@ def subCoords (n : Nat) (a b : Array Rat) : Array Rat :=
 def negCoords (n : Nat) (a : Array Rat) : Array Rat :=
   (Vector.ofFn fun i : Fin n => -a.getD i.val 0).toArray
 
+/-- Adding back the subtrahend recovers the fixed-width minuend. -/
+theorem add_subCoords (n : Nat) (a b : Array Rat) :
+    addCoords n (subCoords n a b) b = fixedCoeffs n a := by
+  apply Array.ext
+  · simp [addCoords, subCoords, fixedCoeffs]
+  · intro i hi₁ hi₂
+    simp [addCoords, subCoords, fixedCoeffs, Array.getD,
+      Rat.sub_add_cancel]
+
 /-- One mixed-radix block. -/
 @[expose]
 def block (a : Array Rat) (index width : Nat) : Array Rat :=
   (Vector.ofFn fun i : Fin width => a.getD (index * width + i.val) 0).toArray
+
+/-- A block of fixed-width coordinates is the fixed-width source block. -/
+theorem block_fixed (count width index : Nat) (a : Array Rat)
+    (hindex : index < count) :
+    block (fixedCoeffs (count * width) a) index width =
+      fixedCoeffs width (block a index width) := by
+  apply Array.ext
+  · simp [block, fixedCoeffs]
+  · intro i hi₁ hi₂
+    have hi : i < width := by
+      simpa [fixedCoeffs] using hi₂
+    have hglobal : index * width + i < count * width := by
+      calc
+        index * width + i < index * width + width :=
+          Nat.add_lt_add_left hi _
+        _ = (index + 1) * width := by simp [Nat.add_mul]
+        _ ≤ count * width :=
+          Nat.mul_le_mul_right width (Nat.succ_le_of_lt hindex)
+    simp [block, fixedCoeffs, Array.getD, hglobal]
+
+/-- The only nonzero block of the fixed-width coordinate one is its constant
+block. -/
+theorem block_one (count width index : Nat) (hindex : index < count) :
+    block (fixedCoeffs (count * width) #[1]) index width =
+      if index = 0 then fixedCoeffs width #[1]
+      else fixedCoeffs width #[] := by
+  by_cases hindex0 : index = 0
+  · subst index
+    apply Array.ext
+    · simp [block, fixedCoeffs]
+    · intro i hi₁ hi₂
+      have hi : i < width := by
+        simpa [fixedCoeffs] using hi₂
+      have htotal : 0 < count * width :=
+        Nat.mul_pos hindex (Nat.zero_lt_of_lt hi)
+      rcases i with _ | i
+      · simp [block, fixedCoeffs, Array.getD, Nat.ne_of_gt htotal]
+      · simp [block, fixedCoeffs, Array.getD]
+  · simp only [if_neg hindex0]
+    apply Array.ext
+    · simp [block, fixedCoeffs]
+    · intro i hi₁ hi₂
+      have hi : i < width := by
+        simpa [fixedCoeffs] using hi₂
+      have hwidth : 0 < width := Nat.zero_lt_of_lt hi
+      have hmul : 0 < index * width :=
+        Nat.mul_pos (Nat.pos_of_ne_zero hindex0) hwidth
+      simp [block, fixedCoeffs, Array.getD, Nat.ne_of_gt hmul]
 
 /-- A block of fixed-width coordinate addition is the sum of the blocks. -/
 theorem block_add (count width index : Nat) (a b : Array Rat)
@@ -73,6 +140,165 @@ def flattenBlocks (count width : Nat) (blocks : Array (Array Rat)) : Array Rat :
     (Vector.ofFn fun i : Fin (count * width) =>
       (blocks.getD (i.val / width) #[]).getD (i.val % width) 0).toArray
 
+/-- Flattening fixed-width blocks always produces the requested total width. -/
+@[simp]
+theorem flattenBlocks_size (count width : Nat) (blocks : Array (Array Rat)) :
+    (flattenBlocks count width blocks).size = count * width := by
+  by_cases hwidth : width = 0
+  · simp [flattenBlocks, hwidth]
+  · simp [flattenBlocks, hwidth]
+
+/-- Reading an in-range block after flattening recovers that source block at
+the fixed lower width. -/
+theorem block_flatten (count width index : Nat)
+    (blocks : Array (Array Rat)) (hindex : index < count) :
+    block (flattenBlocks count width blocks) index width =
+      fixedCoeffs width (blocks.getD index #[]) := by
+  by_cases hwidth : width = 0
+  · subst width
+    simp [block, flattenBlocks, fixedCoeffs]
+  · apply Array.ext
+    · simp [block, fixedCoeffs]
+    · intro i hi₁ hi₂
+      have hi : i < width := by
+        simpa [fixedCoeffs] using hi₂
+      have hglobal : index * width + i < count * width := by
+        calc
+          index * width + i < index * width + width :=
+            Nat.add_lt_add_left hi _
+          _ = (index + 1) * width := by simp [Nat.add_mul]
+          _ ≤ count * width :=
+            Nat.mul_le_mul_right width (Nat.succ_le_of_lt hindex)
+      have hdiv : (index * width + i) / width = index := by
+        calc
+          _ = (width * index + i) / width := by
+            rw [Nat.mul_comm index width]
+          _ = index + i / width :=
+            Nat.mul_add_div (Nat.pos_of_ne_zero hwidth) index i
+          _ = index := by simp [Nat.div_eq_of_lt hi]
+      have himod : i % width = i := Nat.mod_eq_of_lt hi
+      simp [block, flattenBlocks, fixedCoeffs, Array.getD, hwidth, hglobal,
+        hdiv, himod]
+
+/-- Add one row of schoolbook block products to a convolution workspace. -/
+@[expose]
+def convolveRow (degree width i : Nat)
+    (multiply : Array Rat → Array Rat → Array Rat)
+    (a b : Array Rat) (work : Array (Array Rat)) : Array (Array Rat) :=
+  let zeroBlock : Array Rat := Array.replicate width 0
+  (List.range degree).foldl
+    (fun work j =>
+      let product := multiply (block a i width) (block b j width)
+      let k := i + j
+      work.set! k (addCoords width (work.getD k zeroBlock) product))
+    work
+
+@[simp]
+theorem convolveRow_size (degree width i : Nat)
+    (multiply : Array Rat → Array Rat → Array Rat)
+    (a b : Array Rat) (work : Array (Array Rat)) :
+    (convolveRow degree width i multiply a b work).size = work.size := by
+  unfold convolveRow
+  apply foldl_array_size
+  intro inner j
+  simp
+
+/-- Schoolbook convolution of fixed-width coefficient blocks. -/
+@[expose]
+def convolve (degree width : Nat)
+    (multiply : Array Rat → Array Rat → Array Rat)
+    (a b : Array Rat) : Array (Array Rat) :=
+  let zeroBlock : Array Rat := Array.replicate width 0
+  let work := Array.replicate (2 * degree - 1) zeroBlock
+  (List.range degree).foldl
+    (fun work i => convolveRow degree width i multiply a b work)
+    work
+
+/-- Convolution allocates exactly the coefficient range of a product of two
+polynomials of degree below `degree`. -/
+@[simp]
+theorem convolve_size (degree width : Nat)
+    (multiply : Array Rat → Array Rat → Array Rat)
+    (a b : Array Rat) :
+    (convolve degree width multiply a b).size = 2 * degree - 1 := by
+  unfold convolve
+  rw [foldl_array_size]
+  · simp
+  · intro work i
+    simp
+
+/-- Apply all lower-coefficient corrections for eliminating the coefficient
+at `k` with a monic relation. -/
+@[expose]
+def reduceCoeffs (degree width k : Nat) (defining : Array (Array Rat))
+    (multiply : Array Rat → Array Rat → Array Rat)
+    (work : Array (Array Rat)) : Array (Array Rat) :=
+  let zeroBlock : Array Rat := Array.replicate width 0
+  let high := work.getD k zeroBlock
+  (List.range degree).foldl
+    (fun work j =>
+      let relation := defining.getD j zeroBlock
+      let correction := multiply high relation
+      let target := k - degree + j
+      work.set! target
+        (subCoords width (work.getD target zeroBlock) correction))
+    work
+
+@[simp]
+theorem reduceCoeffs_size (degree width k : Nat)
+    (defining : Array (Array Rat))
+    (multiply : Array Rat → Array Rat → Array Rat)
+    (work : Array (Array Rat)) :
+    (reduceCoeffs degree width k defining multiply work).size = work.size := by
+  unfold reduceCoeffs
+  apply foldl_array_size
+  intro inner j
+  simp
+
+/-- Eliminate the coefficient at `k`, then discard it. -/
+@[expose]
+def reduceAt (degree width k : Nat) (defining : Array (Array Rat))
+    (multiply : Array Rat → Array Rat → Array Rat)
+    (work : Array (Array Rat)) : Array (Array Rat) :=
+  (reduceCoeffs degree width k defining multiply work).take k
+
+/-- One descending reduction step removes exactly its top coefficient. -/
+@[simp]
+theorem reduceAt_size (degree width k : Nat)
+    (defining : Array (Array Rat))
+    (multiply : Array Rat → Array Rat → Array Rat)
+    (work : Array (Array Rat)) (hsize : work.size = k + 1) :
+    (reduceAt degree width k defining multiply work).size = k := by
+  simp [reduceAt, hsize]
+
+/-- Descending monic reduction of all coefficients at or above `degree`. -/
+@[expose]
+def reduce (degree width : Nat) (defining : Array (Array Rat))
+    (multiply : Array Rat → Array Rat → Array Rat) :
+    Nat → Array (Array Rat) → Array (Array Rat)
+  | 0, work => work.take degree
+  | fuel + 1, work =>
+      reduce degree width defining multiply fuel
+        (reduceAt degree width (degree + fuel) defining multiply work)
+
+/-- Descending reduction consumes its whole high-coefficient fuel. -/
+@[simp]
+theorem reduce_size (degree width fuel : Nat)
+    (defining : Array (Array Rat))
+    (multiply : Array Rat → Array Rat → Array Rat)
+    (work : Array (Array Rat)) (hsize : work.size = degree + fuel) :
+    (reduce degree width defining multiply fuel work).size = degree := by
+  induction fuel generalizing work with
+  | zero => simp [reduce, hsize]
+  | succ fuel ih =>
+      have hstep :
+          (reduceAt degree width (degree + fuel) defining multiply work).size =
+            degree + fuel := by
+        apply reduceAt_size
+        omega
+      simpa [reduce] using
+        ih (reduceAt degree width (degree + fuel) defining multiply work) hstep
+
 /-- Recursive mixed-radix multiplication on top-first raw level data. -/
 @[expose]
 def mulCoords : (levels : List Level) → Array Rat → Array Rat → Array Rat
@@ -83,31 +309,22 @@ def mulCoords : (levels : List Level) → Array Rat → Array Rat → Array Rat
       if d = 0 then
         #[]
       else
-        let zeroBlock : Array Rat := Array.replicate lowerDim 0
-        let work := Array.replicate (2 * d - 1) zeroBlock
-        let convolved := (List.range d).foldl
-          (fun work i => (List.range d).foldl
-            (fun work j =>
-              let product := mulCoords lower
-                (block a i lowerDim) (block b j lowerDim)
-              let k := i + j
-              work.set! k (addCoords lowerDim work[k]! product))
-            work)
-          work
-        let reduced := (List.range (d - 1)).foldl
-          (fun work offset =>
-            let k := 2 * d - 2 - offset
-            let high := work[k]!
-            (List.range d).foldl
-              (fun work j =>
-                let relation := level.defining.getD j zeroBlock
-                let correction := mulCoords lower high relation
-                let target := k - d + j
-                work.set! target
-                  (subCoords lowerDim work[target]! correction))
-              work)
-          convolved
-        flattenBlocks d lowerDim (reduced.take d)
+        let convolved := convolve d lowerDim (mulCoords lower) a b
+        let reduced := reduce d lowerDim level.defining (mulCoords lower)
+          (d - 1) convolved
+        flattenBlocks d lowerDim reduced
+
+/-- Recursive multiplication returns exactly one mixed-radix coordinate
+vector. -/
+@[simp]
+theorem mulCoords_size (levels : List Level) (a b : Array Rat) :
+    (mulCoords levels a b).size = levelsDim levels := by
+  induction levels generalizing a b with
+  | nil => simp [mulCoords, levelsDim]
+  | cons level lower ih =>
+      by_cases hdegree : level.degree = 0
+      · simp [mulCoords, levelsDim, hdegree]
+      · simp [mulCoords, levelsDim, hdegree]
 
 /-- Dynamically indexed tower coefficient used internally when an algorithm
 recurses through runtime level data rather than a dependent `NumberTower`.

--- a/HexNumberFieldTowerMathlib/Arithmetic.lean
+++ b/HexNumberFieldTowerMathlib/Arithmetic.lean
@@ -21,6 +21,649 @@ operation.
 
 namespace Hex.NumberTower
 
+namespace LevelSemantics
+
+private theorem horner_eq_sum (x : ℂ) (coefficients : List ℂ) :
+    coefficients.reverse.foldl
+        (fun value coefficient => value * x + coefficient) 0 =
+      ∑ i ∈ Finset.range coefficients.length,
+        coefficients.getD i 0 * x ^ i := by
+  induction coefficients with
+  | nil => simp
+  | cons coefficient coefficients ih =>
+      rw [List.reverse_cons, List.foldl_append, ih]
+      simp only [List.foldl_cons, List.foldl_nil, List.length_cons]
+      rw [Finset.sum_range_succ']
+      simp only [List.getD_cons_zero, pow_zero, mul_one,
+        List.getD_cons_succ, pow_succ]
+      rw [Finset.sum_mul]
+      calc
+        _ = coefficient + ∑ i ∈ Finset.range coefficients.length,
+              coefficients.getD i 0 * x ^ i * x := add_comm _ _
+        _ = coefficient + ∑ i ∈ Finset.range coefficients.length,
+              x * x ^ i * coefficients.getD i 0 := by
+            apply congrArg (coefficient + ·)
+            apply Finset.sum_congr rfl
+            intro i hi
+            ring
+        _ = (∑ i ∈ Finset.range coefficients.length,
+              x * x ^ i * coefficients.getD i 0) + coefficient := add_comm _ _
+        _ = (∑ i ∈ Finset.range coefficients.length,
+              coefficients.getD i 0 * (x ^ i * x)) + coefficient := by
+            apply congrArg (· + coefficient)
+            apply Finset.sum_congr rfl
+            intro i hi
+            ring
+
+/-- Recursive Horner denotation is the finite power sum of its top-level
+coefficient blocks. -/
+theorem denote_cons (level : Level) (lower : List Level) (data : Array Rat) :
+    denote (level :: lower) data =
+      ∑ i ∈ Finset.range level.degree,
+        denote lower (Arithmetic.block data i (levelsDim lower)) *
+          level.root.toComplex ^ i := by
+  rw [denote]
+  let coefficients := (List.range level.degree).map fun i =>
+    denote lower (Arithmetic.block data i (levelsDim lower))
+  rw [horner_eq_sum]
+  simp only [List.length_map, List.length_range]
+  apply Finset.sum_congr rfl
+  intro i hi
+  have hi' : i < level.degree := Finset.mem_range.mp hi
+  simp [hi']
+
+/-- Evaluate an array of lower-tower coefficient blocks as a power sum. -/
+@[expose]
+noncomputable def evalBlocks (lower : List Level) (x : ℂ)
+    (blocks : Array (Array Rat)) : ℂ :=
+  ∑ i ∈ Finset.range blocks.size,
+    denote lower (blocks.getD i #[]) * x ^ i
+
+/-- Evaluate a prescribed initial range of lower-tower coefficient blocks. -/
+@[expose]
+noncomputable def evalUpTo (lower : List Level) (x : ℂ) (count : Nat)
+    (blocks : Array (Array Rat)) : ℂ :=
+  ∑ i ∈ Finset.range count,
+    denote lower (blocks.getD i #[]) * x ^ i
+
+private theorem getD_set! (blocks : Array (Array Rat)) (k i : Nat)
+    (value default : Array Rat) (hk : k < blocks.size) :
+    (blocks.set! k value).getD i default =
+      if k = i then value else blocks.getD i default := by
+  by_cases hki : k = i
+  · subst i
+    simp [Array.getD_eq_getD_getElem?, Array.set!_eq_setIfInBounds, hk]
+  · simp [Array.getD_eq_getD_getElem?, Array.set!_eq_setIfInBounds, hki]
+
+/-- Updating one in-bounds block changes its power-sum value by exactly the
+corresponding monomial delta. -/
+theorem evalBlocks_set (lower : List Level) (x : ℂ)
+    (blocks : Array (Array Rat)) (k : Nat) (value : Array Rat)
+    (hk : k < blocks.size) :
+    evalBlocks lower x (blocks.set! k value) =
+      evalBlocks lower x blocks +
+        (denote lower value - denote lower (blocks.getD k #[])) * x ^ k := by
+  unfold evalBlocks
+  rw [Array.size_set!]
+  let indices := Finset.range blocks.size
+  have hmem : k ∈ indices := Finset.mem_range.mpr hk
+  calc
+    _ = (∑ i ∈ indices.erase k,
+          denote lower ((blocks.set! k value).getD i #[]) * x ^ i) +
+        denote lower ((blocks.set! k value).getD k #[]) * x ^ k := by
+          exact (Finset.sum_erase_add _ _ hmem).symm
+    _ = (∑ i ∈ indices.erase k,
+          denote lower (blocks.getD i #[]) * x ^ i) +
+        denote lower value * x ^ k := by
+          congr 1
+          · apply Finset.sum_congr rfl
+            intro i hi
+            have hki : k ≠ i := by
+              exact fun h => (Finset.mem_erase.mp hi).1 h.symm
+            rw [getD_set! blocks k i value #[] hk]
+            simp [hki]
+          · rw [getD_set! blocks k k value #[] hk]
+            simp
+    _ = (∑ i ∈ indices,
+          denote lower (blocks.getD i #[]) * x ^ i) +
+        (denote lower value - denote lower (blocks.getD k #[])) * x ^ k := by
+          rw [← Finset.sum_erase_add _ _ hmem]
+          ring
+
+/-- Updating one block inside the evaluated range changes its value by the
+corresponding monomial delta. -/
+theorem evalUpTo_set (lower : List Level) (x : ℂ) (count : Nat)
+    (blocks : Array (Array Rat)) (k : Nat) (value : Array Rat)
+    (hcount : k < count) (hsize : k < blocks.size) :
+    evalUpTo lower x count (blocks.set! k value) =
+      evalUpTo lower x count blocks +
+        (denote lower value - denote lower (blocks.getD k #[])) * x ^ k := by
+  unfold evalUpTo
+  let indices := Finset.range count
+  have hmem : k ∈ indices := Finset.mem_range.mpr hcount
+  calc
+    _ = (∑ i ∈ indices.erase k,
+          denote lower ((blocks.set! k value).getD i #[]) * x ^ i) +
+        denote lower ((blocks.set! k value).getD k #[]) * x ^ k := by
+          exact (Finset.sum_erase_add _ _ hmem).symm
+    _ = (∑ i ∈ indices.erase k,
+          denote lower (blocks.getD i #[]) * x ^ i) +
+        denote lower value * x ^ k := by
+          congr 1
+          · apply Finset.sum_congr rfl
+            intro i hi
+            have hki : k ≠ i := by
+              exact fun h => (Finset.mem_erase.mp hi).1 h.symm
+            rw [getD_set! blocks k i value #[] hsize]
+            simp [hki]
+          · rw [getD_set! blocks k k value #[] hsize]
+            simp
+    _ = (∑ i ∈ indices,
+          denote lower (blocks.getD i #[]) * x ^ i) +
+        (denote lower value - denote lower (blocks.getD k #[])) * x ^ k := by
+          rw [← Finset.sum_erase_add _ _ hmem]
+          ring
+
+/-- Truncation above the evaluated range does not alter its power sum. -/
+theorem evalUpTo_take (lower : List Level) (x : ℂ) (count cutoff : Nat)
+    (blocks : Array (Array Rat)) (hcount : count ≤ cutoff) :
+    evalUpTo lower x count (blocks.take cutoff) =
+      evalUpTo lower x count blocks := by
+  unfold evalUpTo
+  apply Finset.sum_congr rfl
+  intro i hi
+  have hi' : i < cutoff := lt_of_lt_of_le (Finset.mem_range.mp hi) hcount
+  congr 2
+  rw [← Array.shrink_eq_take]
+  by_cases hsize : i < blocks.size
+  · simp [Array.getD_eq_getD_getElem?, hi', hsize]
+  · simp [Array.getD_eq_getD_getElem?, hi', hsize]
+
+private theorem fold_eval {ι : Type} (lower : List Level) (x : ℂ)
+    (count size : Nat) (indices : List ι)
+    (step : Array (Array Rat) → ι → Array (Array Rat))
+    (term : ι → ℂ) (initial : Array (Array Rat))
+    (hinitial : initial.size = size)
+    (hstep : ∀ work index, index ∈ indices → work.size = size →
+      (step work index).size = size ∧
+        evalUpTo lower x count (step work index) =
+          evalUpTo lower x count work + term index) :
+    evalUpTo lower x count (indices.foldl step initial) =
+        evalUpTo lower x count initial + (indices.map term).sum ∧
+      (indices.foldl step initial).size = size := by
+  induction indices generalizing initial with
+  | nil => simp [hinitial]
+  | cons index indices ih =>
+      have hnext := hstep initial index (by simp) hinitial
+      have htail := ih (step initial index) hnext.1 (by
+        intro work tailIndex hmem hwork
+        exact hstep work tailIndex (by simp [hmem]) hwork)
+      constructor
+      · simp only [List.foldl_cons, List.map_cons, List.sum_cons]
+        rw [htail.1, hnext.2]
+        ring
+      · simpa only [List.foldl_cons] using htail.2
+
+private theorem list_sum_range (count : Nat) (term : Nat → ℂ) :
+    ((List.range count).map term).sum =
+      ∑ i ∈ Finset.range count, term i := by
+  induction count with
+  | zero => simp
+  | succ count ih =>
+      rw [List.range_succ, List.map_append, List.sum_append,
+        Finset.sum_range_succ, ih]
+      simp
+
+private theorem convolveRow_eval (lower : List Level) (x : ℂ)
+    (degree i : Nat) (a b : Array Rat)
+    (multiply : Array Rat → Array Rat → Array Rat)
+    (work : Array (Array Rat)) (hdegree : 0 < degree)
+    (hi : i < degree) (hsize : work.size = 2 * degree - 1)
+    (hmul : ∀ u v, denote lower (multiply u v) =
+      denote lower u * denote lower v) :
+    evalUpTo lower x (2 * degree - 1)
+        (Arithmetic.convolveRow degree (levelsDim lower) i multiply a b work) =
+      evalUpTo lower x (2 * degree - 1) work +
+        ((List.range degree).map fun j =>
+          denote lower (Arithmetic.block a i (levelsDim lower)) *
+            denote lower (Arithmetic.block b j (levelsDim lower)) *
+              x ^ (i + j)).sum := by
+  unfold Arithmetic.convolveRow
+  refine (fold_eval lower x (2 * degree - 1) (2 * degree - 1)
+    (List.range degree) _ _ work hsize ?_).1
+  intro current j hjmem hcurrent
+  have hj : j < degree := List.mem_range.mp hjmem
+  have hindex : i + j < 2 * degree - 1 := by omega
+  have hbound : i + j < current.size := by omega
+  constructor
+  · simp [hcurrent]
+  · rw [evalUpTo_set lower x (2 * degree - 1) current (i + j)
+        (Arithmetic.addCoords (levelsDim lower)
+          (current.getD (i + j) (Array.replicate (levelsDim lower) 0))
+          (multiply (Arithmetic.block a i (levelsDim lower))
+            (Arithmetic.block b j (levelsDim lower)))) hindex hbound]
+    rw [denote_add, hmul]
+    have hold :
+        denote lower
+            (current.getD (i + j) (Array.replicate (levelsDim lower) 0)) =
+          denote lower (current.getD (i + j) #[]) := by
+      simp [Array.getD, hbound]
+    rw [hold]
+    ring
+
+/-- Flattening a top-level block array preserves its finite power sum through
+the requested extension degree. -/
+theorem denote_flatten (level : Level) (lower : List Level)
+    (blocks : Array (Array Rat)) :
+    denote (level :: lower)
+        (Arithmetic.flattenBlocks level.degree (levelsDim lower) blocks) =
+      ∑ i ∈ Finset.range level.degree,
+        denote lower (blocks.getD i #[]) * level.root.toComplex ^ i := by
+  rw [denote_cons]
+  apply Finset.sum_congr rfl
+  intro i hi
+  rw [Arithmetic.block_flatten level.degree (levelsDim lower) i blocks
+    (Finset.mem_range.mp hi), denote_fixed]
+
+/-- The polynomial view of raw blocks evaluates to their finite power sum. -/
+theorem polynomial_eval (lower : List Level) (blocks : Array (Array Rat))
+    (x : ℂ) :
+    (polynomial lower blocks).eval x = evalBlocks lower x blocks := by
+  rw [polynomial, Polynomial.eval_finsetSum]
+  simp [evalBlocks, Polynomial.eval_monomial]
+
+private theorem denote_empty (levels : List Level) : denote levels #[] = 0 := by
+  induction levels with
+  | nil => simp [denote, Array.getD]
+  | cons level lower ih =>
+      rw [denote_cons]
+      apply Finset.sum_eq_zero
+      intro i hi
+      have hblock : Arithmetic.block #[] i (levelsDim lower) =
+          Arithmetic.fixedCoeffs (levelsDim lower) #[] := by
+        apply Array.ext
+        · simp [Arithmetic.block, Arithmetic.fixedCoeffs]
+        · intro j hj₁ hj₂
+          simp [Arithmetic.block, Arithmetic.fixedCoeffs, Array.getD]
+      rw [hblock, denote_fixed, ih]
+      simp
+
+/-- The canonical all-zero block denotes zero at every tower depth. -/
+theorem denote_zero (levels : List Level) :
+    denote levels (Arithmetic.fixedCoeffs (levelsDim levels) #[]) = 0 := by
+  rw [denote_fixed]
+  exact denote_empty levels
+
+private theorem denote_replicate_zero (levels : List Level) :
+    denote levels (Array.replicate (levelsDim levels) 0) = 0 := by
+  rw [← denote_zero levels]
+  congr 1
+  apply Array.ext
+  · simp [Arithmetic.fixedCoeffs]
+  · intro i hi₁ hi₂
+    simp [Arithmetic.fixedCoeffs]
+
+private theorem evalUpTo_replicate_zero (lower : List Level) (x : ℂ)
+    (count : Nat) :
+    evalUpTo lower x count
+        (Array.replicate count
+          (Array.replicate (levelsDim lower) 0)) = 0 := by
+  unfold evalUpTo
+  apply Finset.sum_eq_zero
+  intro i hi
+  have hi' : i < count := Finset.mem_range.mp hi
+  simp [Array.getD, hi', denote_replicate_zero]
+
+private theorem convolve_eval (lower : List Level) (x : ℂ)
+    (degree : Nat) (a b : Array Rat)
+    (multiply : Array Rat → Array Rat → Array Rat)
+    (hdegree : 0 < degree)
+    (hmul : ∀ u v, denote lower (multiply u v) =
+      denote lower u * denote lower v) :
+    evalUpTo lower x (2 * degree - 1)
+        (Arithmetic.convolve degree (levelsDim lower) multiply a b) =
+      ∑ i ∈ Finset.range degree,
+        ∑ j ∈ Finset.range degree,
+          denote lower (Arithmetic.block a i (levelsDim lower)) *
+            denote lower (Arithmetic.block b j (levelsDim lower)) *
+              x ^ (i + j) := by
+  let initial : Array (Array Rat) := Array.replicate (2 * degree - 1)
+    (Array.replicate (levelsDim lower) 0)
+  let term := fun i => ((List.range degree).map fun j =>
+    denote lower (Arithmetic.block a i (levelsDim lower)) *
+      denote lower (Arithmetic.block b j (levelsDim lower)) *
+        x ^ (i + j)).sum
+  have hfold := fold_eval lower x (2 * degree - 1) (2 * degree - 1)
+    (List.range degree)
+    (fun work i => Arithmetic.convolveRow degree (levelsDim lower) i
+      multiply a b work) term initial (by simp [initial]) (by
+        intro work i hi hsize
+        constructor
+        · simp [hsize]
+        · exact convolveRow_eval lower x degree i a b multiply work hdegree
+            (List.mem_range.mp hi) hsize hmul)
+  have hlist :
+      evalUpTo lower x (2 * degree - 1)
+          (Arithmetic.convolve degree (levelsDim lower) multiply a b) =
+        ((List.range degree).map term).sum := by
+    simpa [Arithmetic.convolve, initial, term,
+      evalUpTo_replicate_zero] using hfold.1
+  calc
+    _ = ((List.range degree).map term).sum := hlist
+    _ = ∑ i ∈ Finset.range degree, term i :=
+      list_sum_range degree term
+    _ = ∑ i ∈ Finset.range degree,
+          ∑ j ∈ Finset.range degree,
+            denote lower (Arithmetic.block a i (levelsDim lower)) *
+              denote lower (Arithmetic.block b j (levelsDim lower)) *
+                x ^ (i + j) := by
+      apply Finset.sum_congr rfl
+      intro i hi
+      exact list_sum_range degree fun j =>
+        denote lower (Arithmetic.block a i (levelsDim lower)) *
+          denote lower (Arithmetic.block b j (levelsDim lower)) *
+            x ^ (i + j)
+
+private theorem convolve_mul (lower : List Level) (x : ℂ)
+    (degree : Nat) (a b : Array Rat)
+    (multiply : Array Rat → Array Rat → Array Rat)
+    (hdegree : 0 < degree)
+    (hmul : ∀ u v, denote lower (multiply u v) =
+      denote lower u * denote lower v) :
+    evalUpTo lower x (2 * degree - 1)
+        (Arithmetic.convolve degree (levelsDim lower) multiply a b) =
+      (∑ i ∈ Finset.range degree,
+          denote lower (Arithmetic.block a i (levelsDim lower)) * x ^ i) *
+        ∑ j ∈ Finset.range degree,
+          denote lower (Arithmetic.block b j (levelsDim lower)) * x ^ j := by
+  rw [convolve_eval lower x degree a b multiply hdegree hmul,
+    Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro i hi
+  rw [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro j hj
+  rw [pow_add]
+  ring
+
+private theorem reduceCoeffs_eval (lower : List Level) (x : ℂ)
+    (degree k : Nat) (defining : Array (Array Rat))
+    (multiply : Array Rat → Array Rat → Array Rat)
+    (work : Array (Array Rat))
+    (hdk : degree ≤ k) (hsize : work.size = k + 1)
+    (hmul : ∀ u v, denote lower (multiply u v) =
+      denote lower u * denote lower v) :
+    let zeroBlock : Array Rat := Array.replicate (levelsDim lower) 0
+    let high := work.getD k zeroBlock
+    evalUpTo lower x k
+        (Arithmetic.reduceCoeffs degree (levelsDim lower) k defining
+          multiply work) =
+      evalUpTo lower x k work +
+        ∑ j ∈ Finset.range degree,
+          -(denote lower high * denote lower (defining.getD j zeroBlock) *
+            x ^ (k - degree + j)) := by
+  let zeroBlock : Array Rat := Array.replicate (levelsDim lower) 0
+  let high := work.getD k zeroBlock
+  let term := fun j =>
+    -(denote lower high * denote lower (defining.getD j zeroBlock) *
+      x ^ (k - degree + j))
+  have hfold := fold_eval lower x k (k + 1) (List.range degree)
+    (fun current j =>
+      current.set! (k - degree + j)
+        (Arithmetic.subCoords (levelsDim lower)
+          (current.getD (k - degree + j) zeroBlock)
+          (multiply high (defining.getD j zeroBlock))))
+    term work hsize (by
+      intro current j hjmem hcurrent
+      have hj : j < degree := List.mem_range.mp hjmem
+      have hindex : k - degree + j < k := by omega
+      have hbound : k - degree + j < current.size := by omega
+      constructor
+      · simp [hcurrent]
+      · rw [evalUpTo_set lower x k current (k - degree + j)
+            (Arithmetic.subCoords (levelsDim lower)
+              (current.getD (k - degree + j) zeroBlock)
+              (multiply high (defining.getD j zeroBlock))) hindex hbound]
+        rw [denote_sub, hmul]
+        have hold :
+            denote lower
+                (current.getD (k - degree + j) zeroBlock) =
+              denote lower (current.getD (k - degree + j) #[]) := by
+          simp [Array.getD, hbound]
+        rw [hold]
+        ring)
+  have hlist :
+      evalUpTo lower x k
+          (Arithmetic.reduceCoeffs degree (levelsDim lower) k defining
+            multiply work) =
+        evalUpTo lower x k work + ((List.range degree).map term).sum := by
+    simpa [Arithmetic.reduceCoeffs, zeroBlock, high, term] using hfold.1
+  calc
+    _ = evalUpTo lower x k work + ((List.range degree).map term).sum := hlist
+    _ = evalUpTo lower x k work +
+          ∑ j ∈ Finset.range degree, term j := by
+      rw [list_sum_range]
+    _ = evalUpTo lower x k work +
+          ∑ j ∈ Finset.range degree,
+            -(denote lower high *
+              denote lower (defining.getD j zeroBlock) *
+                x ^ (k - degree + j)) := rfl
+
+/-- The canonical constant-one block denotes one for every valid lower
+tower. -/
+theorem denote_one (levels : List Level) (hvalid : LevelsValid levels) :
+    denote levels (Arithmetic.fixedCoeffs (levelsDim levels) #[1]) = 1 := by
+  induction levels with
+  | nil => simp [denote, Arithmetic.fixedCoeffs, levelsDim, Array.getD]
+  | cons level lower ih =>
+      rw [denote_cons]
+      simp only [levelsDim]
+      calc
+        _ = denote lower (Arithmetic.block
+              (Arithmetic.fixedCoeffs
+                (level.degree * levelsDim lower) #[1]) 0
+              (levelsDim lower)) *
+            level.root.toComplex ^ 0 := by
+              apply Finset.sum_eq_single 0
+              · intro i hi hi0
+                rw [Arithmetic.block_one level.degree (levelsDim lower) i
+                  (Finset.mem_range.mp hi)]
+                simp [hi0, denote_zero]
+              · intro hnot
+                exact (hnot (Finset.mem_range.mpr hvalid.1.1)).elim
+        _ = denote lower
+              (Arithmetic.fixedCoeffs (levelsDim lower) #[1]) *
+            level.root.toComplex ^ 0 := by
+              rw [Arithmetic.block_one level.degree (levelsDim lower) 0
+                hvalid.1.1]
+              simp
+        _ = 1 := by rw [ih hvalid.2.2]; simp
+
+/-- The stored monic relation is the vanishing power sum used by descending
+coordinate reduction. -/
+theorem relation_sum (level : Level) (lower : List Level)
+    (hvalid : LevelsValid (level :: lower)) :
+    (∑ j ∈ Finset.range level.degree,
+        denote lower (level.defining.getD j #[]) *
+          level.root.toComplex ^ j) +
+      level.root.toComplex ^ level.degree = 0 := by
+  let one := Arithmetic.fixedCoeffs (levelsDim lower) #[1]
+  have hbelow (j : Nat) (hj : j < level.degree) :
+      (level.defining.push one).getD j #[] = level.defining.getD j #[] := by
+    have hj' : j < level.defining.size := by
+      simpa [hvalid.1.2.1] using hj
+    simp [Array.getD_eq_getD_getElem?, Array.getElem?_push_lt, hj']
+  have htop :
+      (level.defining.push one).getD level.degree #[] = one := by
+    rw [← hvalid.1.2.1]
+    simp [Array.getD_eq_getD_getElem?]
+  have h := level_relation_vanishes level lower hvalid
+  rw [polynomial_eval] at h
+  simp only [evalBlocks, Level.polynomial, Array.size_push,
+    hvalid.1.2.1, Finset.sum_range_succ] at h
+  have hsum :
+      (∑ j ∈ Finset.range level.degree,
+          denote lower ((level.defining.push one).getD j #[]) *
+            level.root.toComplex ^ j) =
+        ∑ j ∈ Finset.range level.degree,
+          denote lower (level.defining.getD j #[]) *
+            level.root.toComplex ^ j := by
+    apply Finset.sum_congr rfl
+    intro j hj
+    rw [hbelow j (Finset.mem_range.mp hj)]
+  rw [hsum, htop, denote_one lower hvalid.2.2, one_mul] at h
+  exact h
+
+private theorem reduceAt_eval (level : Level) (lower : List Level)
+    (k : Nat) (multiply : Array Rat → Array Rat → Array Rat)
+    (work : Array (Array Rat)) (hvalid : LevelsValid (level :: lower))
+    (hdk : level.degree ≤ k) (hsize : work.size = k + 1)
+    (hmul : ∀ u v, denote lower (multiply u v) =
+      denote lower u * denote lower v) :
+    evalUpTo lower level.root.toComplex k
+        (Arithmetic.reduceAt level.degree (levelsDim lower) k
+          level.defining multiply work) =
+      evalUpTo lower level.root.toComplex (k + 1) work := by
+  let zeroBlock : Array Rat := Array.replicate (levelsDim lower) 0
+  let high := work.getD k zeroBlock
+  have hdefault (j : Nat) (hj : j < level.degree) :
+      level.defining.getD j zeroBlock = level.defining.getD j #[] := by
+    have hj' : j < level.defining.size := by
+      simpa [hvalid.1.2.1] using hj
+    simp [Array.getD, hj']
+  have hrelation :
+      (∑ j ∈ Finset.range level.degree,
+          denote lower (level.defining.getD j zeroBlock) *
+            level.root.toComplex ^ j) +
+        level.root.toComplex ^ level.degree = 0 := by
+    have hsum :
+        (∑ j ∈ Finset.range level.degree,
+            denote lower (level.defining.getD j zeroBlock) *
+              level.root.toComplex ^ j) =
+          ∑ j ∈ Finset.range level.degree,
+            denote lower (level.defining.getD j #[]) *
+              level.root.toComplex ^ j := by
+      apply Finset.sum_congr rfl
+      intro j hj
+      rw [hdefault j (Finset.mem_range.mp hj)]
+    rw [hsum]
+    exact relation_sum level lower hvalid
+  have hrelation' :
+      (∑ j ∈ Finset.range level.degree,
+          denote lower (level.defining.getD j zeroBlock) *
+            level.root.toComplex ^ j) =
+        -level.root.toComplex ^ level.degree := by
+    linear_combination hrelation
+  have hcorrection :
+      (∑ j ∈ Finset.range level.degree,
+          -(denote lower high *
+            denote lower (level.defining.getD j zeroBlock) *
+              level.root.toComplex ^ (k - level.degree + j))) =
+        denote lower high * level.root.toComplex ^ k := by
+    calc
+      _ = -(∑ j ∈ Finset.range level.degree,
+            denote lower high *
+              denote lower (level.defining.getD j zeroBlock) *
+                level.root.toComplex ^ (k - level.degree + j)) := by
+              rw [Finset.sum_neg_distrib]
+      _ = -(denote lower high * level.root.toComplex ^ (k - level.degree) *
+            ∑ j ∈ Finset.range level.degree,
+              denote lower (level.defining.getD j zeroBlock) *
+                level.root.toComplex ^ j) := by
+              congr 1
+              rw [Finset.mul_sum]
+              apply Finset.sum_congr rfl
+              intro j hj
+              rw [pow_add]
+              ring
+      _ = denote lower high * level.root.toComplex ^ (k - level.degree) *
+            level.root.toComplex ^ level.degree := by
+              rw [hrelation']
+              ring
+      _ = denote lower high * level.root.toComplex ^ k := by
+              rw [mul_assoc, ← pow_add]
+              congr 2
+              omega
+  have heval_succ :
+      evalUpTo lower level.root.toComplex (k + 1) work =
+        evalUpTo lower level.root.toComplex k work +
+          denote lower high * level.root.toComplex ^ k := by
+    have hk : k < work.size := by omega
+    unfold evalUpTo
+    rw [Finset.sum_range_succ]
+    simp [high, Array.getD, hk]
+  rw [Arithmetic.reduceAt,
+    evalUpTo_take lower level.root.toComplex k k _ (Nat.le_refl k),
+    reduceCoeffs_eval lower level.root.toComplex level.degree k
+      level.defining multiply work hdk hsize hmul,
+    hcorrection, heval_succ]
+
+/-- Descending reduction preserves evaluation at the current algebraic root. -/
+private theorem reduce_eval (level : Level) (lower : List Level)
+    (fuel : Nat) (multiply : Array Rat → Array Rat → Array Rat)
+    (work : Array (Array Rat)) (hvalid : LevelsValid (level :: lower))
+    (hsize : work.size = level.degree + fuel)
+    (hmul : ∀ u v, denote lower (multiply u v) =
+      denote lower u * denote lower v) :
+    evalUpTo lower level.root.toComplex level.degree
+        (Arithmetic.reduce level.degree (levelsDim lower) level.defining
+          multiply fuel work) =
+      evalUpTo lower level.root.toComplex (level.degree + fuel) work := by
+  induction fuel generalizing work with
+  | zero =>
+      simp only [Arithmetic.reduce]
+      simpa using
+        evalUpTo_take lower level.root.toComplex level.degree level.degree
+          work (Nat.le_refl level.degree)
+  | succ fuel ih =>
+      let next :=
+        Arithmetic.reduceAt level.degree (levelsDim lower)
+          (level.degree + fuel) level.defining multiply work
+      have hnext : next.size = level.degree + fuel := by
+        apply Arithmetic.reduceAt_size
+        omega
+      simp only [Arithmetic.reduce]
+      rw [ih next hnext]
+      simpa [next, Nat.add_assoc] using
+        reduceAt_eval level lower (level.degree + fuel) multiply work hvalid
+          (Nat.le_add_right level.degree fuel) (by omega) hmul
+
+/-- Recursive convolution and monic reduction denote complex
+multiplication. -/
+theorem denote_mul (levels : List Level) (hvalid : LevelsValid levels)
+    (a b : Array Rat) :
+    denote levels (Arithmetic.mulCoords levels a b) =
+      denote levels a * denote levels b := by
+  induction levels generalizing a b with
+  | nil =>
+      by_cases ha : 0 < a.size <;> by_cases hb : 0 < b.size <;>
+        simp [Arithmetic.mulCoords, denote, Array.getD, ha, hb]
+  | cons level lower ih =>
+      have hdegree : 0 < level.degree := hvalid.1.1
+      have hlower : LevelsValid lower := hvalid.2.2
+      have hmul : ∀ u v, denote lower (Arithmetic.mulCoords lower u v) =
+          denote lower u * denote lower v := fun u v => ih hlower u v
+      simp only [Arithmetic.mulCoords]
+      rw [if_neg (Nat.ne_of_gt hdegree)]
+      rw [denote_flatten]
+      change evalUpTo lower level.root.toComplex level.degree
+          (Arithmetic.reduce level.degree (levelsDim lower) level.defining
+            (Arithmetic.mulCoords lower) (level.degree - 1)
+            (Arithmetic.convolve level.degree (levelsDim lower)
+              (Arithmetic.mulCoords lower) a b)) =
+        denote (level :: lower) a * denote (level :: lower) b
+      rw [reduce_eval level lower (level.degree - 1)
+        (Arithmetic.mulCoords lower)
+        (Arithmetic.convolve level.degree (levelsDim lower)
+          (Arithmetic.mulCoords lower) a b) hvalid (by simp; omega) hmul]
+      rw [show level.degree + (level.degree - 1) =
+          2 * level.degree - 1 by omega]
+      rw [convolve_mul lower level.root.toComplex level.degree a b
+        (Arithmetic.mulCoords lower) hdegree hmul]
+      rw [denote_cons, denote_cons]
+
+end LevelSemantics
+
 /-- Executable zero denotes complex zero. -/
 theorem map_zero (T : NumberTower) :
     T.toComplex (0 : Elem T) = 0 := by
@@ -58,7 +701,10 @@ theorem map_sub (T : NumberTower) (a b : Elem T) :
 /-- Recursive reduced multiplication computes complex multiplication. -/
 theorem map_mul (T : NumberTower) (a b : Elem T) :
     T.toComplex (a * b) = T.toComplex a * T.toComplex b := by
-  sorry
+  rw [LevelSemantics.toComplex_eq_denote T (a * b),
+    LevelSemantics.toComplex_eq_denote T a,
+    LevelSemantics.toComplex_eq_denote T b, coeffs_mul]
+  exact LevelSemantics.denote_mul T.levels.toList T.valid (coeffs a) (coeffs b)
 
 /-- Recursive extended-gcd inversion computes complex inversion, including
 the executable convention `0⁻¹ = 0`. -/

--- a/HexNumberFieldTowerMathlib/Basic.lean
+++ b/HexNumberFieldTowerMathlib/Basic.lean
@@ -133,6 +133,31 @@ theorem denote_add (levels : List Level) (a b : Array Rat) :
           (fun i => denote lower (Arithmetic.block a i (levelsDim lower)))
           (fun i => denote lower (Arithmetic.block b i (levelsDim lower))) 0 0
 
+/-- Direct tower denotation only observes the canonical mixed-radix width. -/
+theorem denote_fixed (levels : List Level) (data : Array Rat) :
+    denote levels (Arithmetic.fixedCoeffs (levelsDim levels) data) =
+      denote levels data := by
+  induction levels generalizing data with
+  | nil =>
+      simp [denote, Arithmetic.fixedCoeffs, levelsDim, Array.getD]
+  | cons level lower ih =>
+      simp only [denote, levelsDim]
+      congr 1
+      apply congrArg List.reverse
+      apply List.map_congr_left
+      intro i hi
+      rw [Arithmetic.block_fixed level.degree (levelsDim lower) i data
+        (List.mem_range.mp hi), ih]
+
+/-- Direct tower denotation is subtractive on fixed-width coordinates. -/
+theorem denote_sub (levels : List Level) (a b : Array Rat) :
+    denote levels (Arithmetic.subCoords (levelsDim levels) a b) =
+      denote levels a - denote levels b := by
+  have h := denote_add levels
+    (Arithmetic.subCoords (levelsDim levels) a b) b
+  rw [Arithmetic.add_subCoords, denote_fixed] at h
+  exact eq_sub_of_add_eq h.symm
+
 private theorem foldlM_sound (x : AlgebraicRoot)
     (coefficients : List AlgebraicRoot) (acc : AlgebraicRoot)
     {out : AlgebraicRoot}
@@ -257,19 +282,12 @@ theorem toComplex_eq_denote (T : NumberTower) (a : Elem T) :
   | some root =>
       rw [NumberTower.toComplex_eq T a h, evalCoords_sound _ _ h]
 
-/-- Interpret raw lower-tower coordinates through their selected complex
-embedding. Validity makes the fallback unreachable. -/
-@[expose]
-noncomputable def toComplex (lower : List Level) (a : Array Rat) : ℂ :=
-  (RawEvaluation.evalCoords? lower a).map AlgebraicRoot.toComplex |>.getD 0
-
 /-- Interpret a raw polynomial over a lower tower in `Polynomial ℂ`. -/
 @[expose]
 noncomputable def polynomial (lower : List Level)
     (f : Array (Array Rat)) : Polynomial ℂ :=
-  f.foldr
-    (fun a value => Polynomial.C (toComplex lower a) +
-      Polynomial.X * value) 0
+  ∑ i ∈ Finset.range f.size,
+    Polynomial.monomial i (denote lower (f.getD i #[]))
 
 end LevelSemantics
 

--- a/progress/20260727T152017Z_number-tower-multiplicative-evaluation.md
+++ b/progress/20260727T152017Z_number-tower-multiplicative-evaluation.md
@@ -1,0 +1,34 @@
+# Number-tower multiplicative evaluation
+
+## Accomplished
+
+- Refactored recursive raw multiplication into named convolution and
+  structurally recursive monic-reduction helpers with fixed-size theorems.
+- Proved the direct complex denotation of block convolution and every
+  descending reduction step, then composed those invariants across the full
+  reducer.
+- Proved recursive raw multiplication denotes complex multiplication and used
+  it to retire the public `map_mul` placeholder.
+- Built `HexNumberFieldTowerMathlib`, `HexManual`, the tower conformance target,
+  and the tower benchmark executable; all 19 fixed benchmarks pass with their
+  committed checksums.
+- Passed the DAG, Phase-4, copyright, status, diff, and banned-declaration
+  checks.
+
+## Current frontier
+
+- Zero, addition, negation, subtraction, multiplication, division's
+  multiplicative step, and zero recognition now have proved complex semantics.
+- Recursive inversion and rational scalar multiplication remain the primitive
+  field-operation correspondence obligations.
+
+## Next step
+
+- Open this milestone as a draft PR stacked on `NumberFieldTowerRawAdd`.
+- On the next branch, prove the recursive extended-gcd inversion invariant and
+  close `map_inv`; continue review monitoring independently.
+
+## Blockers
+
+- Claude second-opinion capacity remains unavailable until the provider quota
+  reset; implementation and GitHub CI continue independently.


### PR DESCRIPTION
## Summary

- refactor raw tower multiplication into proof-friendly convolution and structurally recursive monic reduction helpers
- prove convolution, reduction, flattening, and recursive multiplication preserve the selected complex denotation
- close `NumberTower.map_mul` without axioms or new sorries

Stacked on #8981.

## Verification

- `lake build HexNumberFieldTowerMathlib`
- `lake build HexManual`
- `lake build HexNumberFieldTower.Conformance`
- `lake build hexnumberfieldtower_bench`
- `lake exe hexnumberfieldtower_bench verify` (19/19)
- DAG, Phase-4, copyright, status, diff, and banned-declaration checks