### PR TITLE
refactor(rcf): extract Mathlib-free carrier checks

### DIFF
--- a/HexRCF.lean
+++ b/HexRCF.lean
@@ -13,6 +13,7 @@ public import HexRCF.SturmCheck
 public import HexRCF.SturmReplay
 public import HexRCF.SturmBuilder
 public import HexRCF.SturmBuilderTests
+public import HexRCF.CarrierCheck
 public import HexRCF.Carrier
 public import HexRCF.CarrierTests
 public import HexRCF.Isolations

--- a/HexRCF/Builder.lean
+++ b/HexRCF/Builder.lean
@@ -6,7 +6,7 @@ Authors: Kim Morrison
 
 module
 
-public import HexRCF.Carrier
+public import HexRCF.CarrierCheck
 public import HexRCF.CommonRoot
 public import HexRCF.SignMatrix
 public import HexRCF.SturmBuilder

--- a/HexRCF/Carrier.lean
+++ b/HexRCF/Carrier.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexRCF.CarrierCheck
 public import HexRCF.Language
 public import HexRCF.SturmReplay
 public import HexRealRootsMathlib.SquareFreeCore
@@ -13,115 +14,18 @@ public import HexRealRootsMathlib.SquareFreeCore
 public section
 
 /-!
-# Certified square-free carriers for reflected RCF sentences
+# Real-root semantics of certified RCF carriers
 
-The carrier checker recomputes the nonconstant atom polynomials and their
-product from the reflected sentence.  A certificate supplies a proposed
-square-free carrier, two factor witnesses, two nonzero integer scales, and a
-multiplication-only Sturm replay for the carrier.  Checking uses only exact
-polynomial arithmetic, differentiation, coefficient equality, and the replay
-checker.
+The Mathlib-free certificate and checker live in `HexRCF.CarrierCheck`. The
+theorems in this file prove that an accepted carrier is squarefree and has
+exactly the roots of the sentence's nonconstant atom polynomials.
 -/
 
 namespace Hex.RCF
 
 open HexRealRootsMathlib Polynomial
 
-/-- Check that every polynomial in a literal list has positive degree. -/
-@[expose]
-def checkPosDegrees : List ZPoly → Bool
-  | [] => true
-  | p :: ps => decide (0 < p.degree?.getD 0) && checkPosDegrees ps
-
-/-- Multiplication-checkable witnesses that a polynomial is a square-free
-carrier for the atom product of a sentence. -/
-structure CarrierCert where
-  /-- Proposed square-free carrier `P`. -/
-  carrier : ZPoly
-  /-- Repeated-factor witness `R`. -/
-  repeated : ZPoly
-  /-- Derivative quotient witness `S`. -/
-  derivPart : ZPoly
-  /-- Nonzero scale `k` in `Q = scale k (P * R)`. -/
-  factorScale : Int
-  /-- Nonzero scale `d` in `scale d Q' = R * S`. -/
-  derivScale : Int
-  /-- Generalized Sturm replay proving the carrier squarefree. -/
-  replay : SturmReplay
-
 namespace CarrierCert
-
-/-- Executable carrier validation.  The atom product is recomputed from the
-sentence and is never supplied by the certificate. -/
-@[expose]
-def check (s : Sentence) (cert : CarrierCert) : Bool :=
-  let q := s.product
-  -- `Sentence.polys` filters by this predicate; retaining the explicit walk
-  -- makes the certificate contract visible at its trust boundary.
-  checkPosDegrees s.polys &&
-  decide (0 < q.degree?.getD 0) &&
-  !cert.repeated.isZero &&
-  decide (cert.factorScale ≠ 0) &&
-  decide (cert.derivScale ≠ 0) &&
-  DensePoly.beqCoeffs q
-    (DensePoly.scale cert.factorScale (cert.carrier * cert.repeated)) &&
-  DensePoly.beqCoeffs (DensePoly.scale cert.derivScale (DensePoly.derivative q))
-    (cert.repeated * cert.derivPart) &&
-  cert.replay.check cert.carrier
-
-/-- Proposition-level facts recovered from the Boolean carrier checker. -/
-@[expose]
-def Valid (s : Sentence) (cert : CarrierCert) : Prop :=
-  let q := s.product
-  (∀ p ∈ s.polys, 0 < p.degree?.getD 0) ∧
-  0 < q.degree?.getD 0 ∧
-  cert.repeated ≠ 0 ∧
-  cert.factorScale ≠ 0 ∧
-  cert.derivScale ≠ 0 ∧
-  q = DensePoly.scale cert.factorScale (cert.carrier * cert.repeated) ∧
-  DensePoly.scale cert.derivScale (DensePoly.derivative q) =
-    cert.repeated * cert.derivPart ∧
-  cert.replay.check cert.carrier = true
-
-/-- A successful positive-degree walk proves its proposition-level form. -/
-theorem checkPosDegrees_sound {ps : List ZPoly} (h : checkPosDegrees ps = true) :
-    ∀ p ∈ ps, 0 < p.degree?.getD 0 := by
-  induction ps with
-  | nil => simp
-  | cons p ps ih =>
-      simp only [checkPosDegrees, Bool.and_eq_true, decide_eq_true_eq] at h
-      intro q hq
-      simp only [List.mem_cons] at hq
-      rcases hq with rfl | hq
-      · exact h.1
-      · exact ih h.2 q hq
-
-/-- Soundness of the executable carrier checker. -/
-theorem check_sound {s : Sentence} {cert : CarrierCert}
-    (h : cert.check s = true) : cert.Valid s := by
-  simp only [check, Bool.and_eq_true, decide_eq_true_eq] at h
-  obtain ⟨⟨⟨⟨⟨⟨⟨hdegrees, hqdeg⟩, hr0⟩, hk0⟩, hd0⟩, hfactor⟩,
-    hderiv⟩, hreplay⟩ := h
-  refine ⟨checkPosDegrees_sound hdegrees, hqdeg, ?_, hk0, hd0, ?_, ?_, hreplay⟩
-  · simp only [Bool.not_eq_true'] at hr0
-    have hr := (DensePoly.isZero_eq_false_iff cert.repeated).mp hr0
-    intro hzero
-    rw [hzero] at hr
-    simp at hr
-  · exact DensePoly.eq_of_beqCoeffs hfactor
-  · exact DensePoly.eq_of_beqCoeffs hderiv
-
-/-- The carrier replay component recovered from the combined checker. -/
-theorem replay_of_check {s : Sentence} {cert : CarrierCert}
-    (h : cert.check s = true) : cert.replay.check cert.carrier = true :=
-  (check_sound h).2.2.2.2.2.2.2
-
-/-- An accepted carrier certificate has a nonzero carrier polynomial. -/
-theorem carrier_ne_zero {s : Sentence} {cert : CarrierCert}
-    (h : cert.check s = true) : cert.carrier ≠ 0 := by
-  obtain ⟨_hdegrees, _hqdeg, _hr0, _hk0, _hd0, _hfactor, _hderiv, hreplay⟩ :=
-    check_sound h
-  exact SturmReplay.head_ne_zero hreplay
 
 /-- An accepted carrier is squarefree after casting to real coefficients. -/
 theorem squarefree {s : Sentence} {cert : CarrierCert}
@@ -130,17 +34,6 @@ theorem squarefree {s : Sentence} {cert : CarrierCert}
     obtain ⟨_hdegrees, _hqdeg, _hr0, _hk0, _hd0, _hfactor, _hderiv, hreplay⟩ :=
       check_sound h
     exact SturmReplay.squarefree_of_check hreplay
-
-/-- A positive literal degree implies a nonzero executable polynomial. -/
-private theorem ne_zero_of_degree_pos {p : ZPoly} (h : 0 < p.degree?.getD 0) : p ≠ 0 := by
-  intro hp
-  subst p
-  simp [DensePoly.degree?] at h
-
-/-- The recomputed atom product is nonzero for an accepted certificate. -/
-theorem product_ne_zero {s : Sentence} {cert : CarrierCert}
-    (h : cert.check s = true) : s.product ≠ 0 :=
-  ne_zero_of_degree_pos (check_sound h).2.1
 
 /-- Exact scalar-and-factor identities imply that the proposed factor and the
 original polynomial have the same real roots. -/

--- a/HexRCF/CarrierCheck.lean
+++ b/HexRCF/CarrierCheck.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.Syntax
+public import HexRCF.SturmCheck
+
+public section
+
+/-!
+# Multiplication-checkable RCF carriers
+
+The carrier checker recomputes the nonconstant atom polynomials and their
+product from the reflected sentence. A certificate supplies a proposed
+square-free carrier, two factor witnesses, two nonzero integer scales, and a
+multiplication-only Sturm replay for the carrier. Checking uses only exact
+polynomial arithmetic, differentiation, coefficient equality, and the replay
+checker. Real-polynomial consequences live in `HexRCF.Carrier`.
+-/
+
+namespace Hex.RCF
+
+/-- Check that every polynomial in a literal list has positive degree. -/
+@[expose]
+def checkPosDegrees : List ZPoly → Bool
+  | [] => true
+  | p :: ps => decide (0 < p.degree?.getD 0) && checkPosDegrees ps
+
+/-- Multiplication-checkable witnesses that a polynomial is a square-free
+carrier for the atom product of a sentence. -/
+structure CarrierCert where
+  /-- Proposed square-free carrier `P`. -/
+  carrier : ZPoly
+  /-- Repeated-factor witness `R`. -/
+  repeated : ZPoly
+  /-- Derivative quotient witness `S`. -/
+  derivPart : ZPoly
+  /-- Nonzero scale `k` in `Q = scale k (P * R)`. -/
+  factorScale : Int
+  /-- Nonzero scale `d` in `scale d Q' = R * S`. -/
+  derivScale : Int
+  /-- Generalized Sturm replay proving the carrier squarefree. -/
+  replay : SturmReplay
+
+namespace CarrierCert
+
+/-- Executable carrier validation. The atom product is recomputed from the
+sentence and is never supplied by the certificate. -/
+@[expose]
+def check (s : Sentence) (cert : CarrierCert) : Bool :=
+  let q := s.product
+  -- `Sentence.polys` filters by this predicate; retaining the explicit walk
+  -- makes the certificate contract visible at its trust boundary.
+  checkPosDegrees s.polys &&
+  decide (0 < q.degree?.getD 0) &&
+  !cert.repeated.isZero &&
+  decide (cert.factorScale ≠ 0) &&
+  decide (cert.derivScale ≠ 0) &&
+  DensePoly.beqCoeffs q
+    (DensePoly.scale cert.factorScale (cert.carrier * cert.repeated)) &&
+  DensePoly.beqCoeffs (DensePoly.scale cert.derivScale (DensePoly.derivative q))
+    (cert.repeated * cert.derivPart) &&
+  cert.replay.check cert.carrier
+
+/-- Proposition-level facts recovered from the Boolean carrier checker. -/
+@[expose]
+def Valid (s : Sentence) (cert : CarrierCert) : Prop :=
+  let q := s.product
+  (∀ p ∈ s.polys, 0 < p.degree?.getD 0) ∧
+  0 < q.degree?.getD 0 ∧
+  cert.repeated ≠ 0 ∧
+  cert.factorScale ≠ 0 ∧
+  cert.derivScale ≠ 0 ∧
+  q = DensePoly.scale cert.factorScale (cert.carrier * cert.repeated) ∧
+  DensePoly.scale cert.derivScale (DensePoly.derivative q) =
+    cert.repeated * cert.derivPart ∧
+  cert.replay.check cert.carrier = true
+
+/-- A successful positive-degree walk proves its proposition-level form. -/
+theorem checkPosDegrees_sound {ps : List ZPoly} (h : checkPosDegrees ps = true) :
+    ∀ p ∈ ps, 0 < p.degree?.getD 0 := by
+  induction ps with
+  | nil => simp
+  | cons p ps ih =>
+      simp only [checkPosDegrees, Bool.and_eq_true, decide_eq_true_eq] at h
+      intro q hq
+      simp only [List.mem_cons] at hq
+      rcases hq with rfl | hq
+      · exact h.1
+      · exact ih h.2 q hq
+
+/-- Soundness of the executable carrier checker. -/
+theorem check_sound {s : Sentence} {cert : CarrierCert}
+    (h : cert.check s = true) : cert.Valid s := by
+  simp only [check, Bool.and_eq_true, decide_eq_true_eq] at h
+  obtain ⟨⟨⟨⟨⟨⟨⟨hdegrees, hqdeg⟩, hr0⟩, hk0⟩, hd0⟩, hfactor⟩,
+    hderiv⟩, hreplay⟩ := h
+  refine ⟨checkPosDegrees_sound hdegrees, hqdeg, ?_, hk0, hd0, ?_, ?_, hreplay⟩
+  · simp only [Bool.not_eq_true'] at hr0
+    have hr := (DensePoly.isZero_eq_false_iff cert.repeated).mp hr0
+    intro hzero
+    rw [hzero] at hr
+    simp at hr
+  · exact DensePoly.eq_of_beqCoeffs hfactor
+  · exact DensePoly.eq_of_beqCoeffs hderiv
+
+/-- The carrier replay component recovered from the combined checker. -/
+theorem replay_of_check {s : Sentence} {cert : CarrierCert}
+    (h : cert.check s = true) : cert.replay.check cert.carrier = true :=
+  (check_sound h).2.2.2.2.2.2.2
+
+/-- An accepted carrier certificate has a nonzero carrier polynomial. -/
+theorem carrier_ne_zero {s : Sentence} {cert : CarrierCert}
+    (h : cert.check s = true) : cert.carrier ≠ 0 := by
+  obtain ⟨_hdegrees, _hqdeg, _hr0, _hk0, _hd0, _hfactor, _hderiv, hreplay⟩ :=
+    check_sound h
+  exact SturmReplay.head_ne_zero hreplay
+
+/-- A positive literal degree implies a nonzero executable polynomial. -/
+private theorem ne_zero_of_degree_pos {p : ZPoly}
+    (h : 0 < p.degree?.getD 0) : p ≠ 0 := by
+  intro hp
+  subst p
+  simp [DensePoly.degree?] at h
+
+/-- The recomputed atom product is nonzero for an accepted certificate. -/
+theorem product_ne_zero {s : Sentence} {cert : CarrierCert}
+    (h : cert.check s = true) : s.product ≠ 0 :=
+  ne_zero_of_degree_pos (check_sound h).2.1
+
+end CarrierCert
+
+end Hex.RCF

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -593,8 +593,9 @@ free to change.
   emits replay witnesses and retains only checker-approved candidates;
   `HexRCF/SturmBuilderTests.lean`: valid, malformed, nonprimitive, and
   nonsquarefree regressions.
-- `HexRCF/Carrier.lean`: deterministic nonconstant-atom collection, the
-  multiplication-checkable carrier certificate, and root-set soundness;
+- `HexRCF/CarrierCheck.lean`: Mathlib-free multiplication-checkable carrier
+  certificates and Boolean validation; `HexRCF/Carrier.lean`: squarefreeness
+  and root-set soundness;
   `HexRCF/CarrierTests.lean`: constant filtering, genuine repeated-factor,
   dropped-root, and other tampered-carrier regressions.
 - `HexRCF/Isolations.lean`: the raw generalized isolation checker and its

--- a/progress/20260727T152625Z_rcf-carrier-check.md
+++ b/progress/20260727T152625Z_rcf-carrier-check.md
@@ -1,0 +1,36 @@
+# Mathlib-free RCF carrier checks
+
+## Accomplished
+
+- Added `HexRCF.CarrierCheck`, containing the carrier certificate data,
+  Boolean validation, proposition-level checker consequences, and the pure
+  carrier/product nonzero theorems.
+- Reduced `HexRCF.Carrier` to real-polynomial squarefreeness and root-set
+  semantics while preserving all qualified declaration names through a public
+  import.
+- Narrowed `HexRCF.Builder`'s direct carrier dependency to `CarrierCheck`;
+  its remaining Mathlib closure comes through the still-combined common-root
+  and sign-matrix layers.
+- Updated the HexRCF umbrella and SPEC file map.
+- Verified targeted and full HexRCF builds and mechanically checked the
+  31-module `HexRCF.CarrierCheck` closure contains neither `Mathlib.*` nor
+  `HexRealRootsMathlib.*`. DAG, Phase-4, release-manifest, trust-surface,
+  copyright, diff, and banned-token checks pass. An independent Sol review
+  returned GO.
+
+## Current frontier
+
+Issue #8990 is implemented on a branch stacked above the Sturm-check PR #8988.
+The pure syntax, replay checker/builder, and carrier checker now form a
+source-compatible Mathlib-free certificate prefix.
+
+## Next step
+
+Publish the stacked PR, then extract common-root certificate validation and
+its cached interval query from `HexRCF.CommonRoot` so compiled arithmetic
+preparation can depend on another pure checker seam.
+
+## Blockers
+
+None for this extraction. The branch remains stacked until #8988 and its
+syntax parent #8983 merge; it can then be rebased and retargeted to main.


### PR DESCRIPTION
## Summary

- extract carrier certificate data, Boolean validation, and pure nonzero consequences into `HexRCF.CarrierCheck`
- retain squarefreeness and real-root correspondence in `HexRCF.Carrier` while preserving existing qualified names
- narrow `HexRCF.Builder` to a direct `CarrierCheck` dependency

Stacked on #8988. Closes #8990. Contributes to #8973.

## Verification

- `lake build HexRCF.CarrierCheck HexRCF.Carrier`
- `lake build HexRCF.Builder`
- `lake build HexRCF`
- repository-local import-closure audit: `HexRCF.CarrierCheck` spans 31 modules and contains no `Mathlib.*` or `HexRealRootsMathlib.*` imports
- DAG, Phase-4, release-manifest, published trust-surface, copyright, diff, and banned-token checks
- independent Sol review: GO