### PR TITLE
prove(number-field-tower): establish scalar evaluation

### DIFF
--- a/HexNumberFieldTower/Arithmetic.lean
+++ b/HexNumberFieldTower/Arithmetic.lean
@@ -207,6 +207,16 @@ def smul {T : NumberTower} (q : Rat) (a : Elem T) : Elem T :=
 
 instance {T : NumberTower} : SMul Rat (Elem T) := ⟨smul⟩
 
+/-- Rational scalar multiplication exposes coordinatewise multiplication. -/
+@[simp]
+theorem coeffs_smul {T : NumberTower} (q : Rat) (a : Elem T) :
+    coeffs (q • a) = (coeffs a).map fun c => q * c := by
+  change coeffs (smul q a) = _
+  unfold smul
+  rw [coeffs_ofCoeffs]
+  apply normalizeCoeffs_eq_self
+  simp
+
 /-- Dense univariate polynomials over a fixed tower. -/
 abbrev Poly (T : NumberTower) := DensePoly (Elem T)
 

--- a/HexNumberFieldTowerMathlib/Arithmetic.lean
+++ b/HexNumberFieldTowerMathlib/Arithmetic.lean
@@ -23,6 +23,15 @@ namespace Hex.NumberTower
 
 namespace LevelSemantics
 
+private theorem block_map_mul (q : Rat) (data : Array Rat)
+    (index width : Nat) :
+    Arithmetic.block (data.map fun c => q * c) index width =
+      (Arithmetic.block data index width).map fun c => q * c := by
+  apply Array.ext
+  · simp [Arithmetic.block]
+  · intro i hi₁ hi₂
+    simp [Arithmetic.block, Array.getD]
+
 private theorem horner_eq_sum (x : ℂ) (coefficients : List ℂ) :
     coefficients.reverse.foldl
         (fun value coefficient => value * x + coefficient) 0 =
@@ -71,6 +80,21 @@ theorem denote_cons (level : Level) (lower : List Level) (data : Array Rat) :
   intro i hi
   have hi' : i < level.degree := Finset.mem_range.mp hi
   simp [hi']
+
+/-- Coordinatewise rational scaling commutes with direct tower denotation. -/
+theorem denote_smul (levels : List Level) (q : Rat) (data : Array Rat) :
+    denote levels (data.map fun c => q * c) =
+      (q : ℂ) * denote levels data := by
+  induction levels generalizing data with
+  | nil =>
+      by_cases hdata : 0 < data.size <;>
+        simp [denote, Array.getD, hdata]
+  | cons level lower ih =>
+      rw [denote_cons, denote_cons, Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro i hi
+      rw [block_map_mul, ih]
+      ring
 
 /-- Evaluate an array of lower-tower coefficient blocks as a power sum. -/
 @[expose]
@@ -722,7 +746,9 @@ theorem map_div (T : NumberTower) (a b : Elem T) :
 /-- The executable rational scalar action is semantic scalar multiplication. -/
 theorem map_smul (T : NumberTower) (q : Rat) (a : Elem T) :
     T.toComplex (q • a) = (q : ℂ) * T.toComplex a := by
-  sorry
+  rw [LevelSemantics.toComplex_eq_denote T (q • a),
+    LevelSemantics.toComplex_eq_denote T a, coeffs_smul,
+    LevelSemantics.denote_smul]
 
 /-- The Boolean zero test recognizes exactly semantic zero. -/
 theorem isZero_iff (T : NumberTower) (a : Elem T) :

--- a/progress/20260727T152642Z_number-tower-scalar-evaluation.md
+++ b/progress/20260727T152642Z_number-tower-scalar-evaluation.md
@@ -1,0 +1,30 @@
+# Number-tower scalar evaluation
+
+## Accomplished
+
+- Exposed the exact coordinate array produced by rational scalar
+  multiplication.
+- Proved coordinatewise rational scaling commutes with mixed-radix block
+  extraction and direct complex tower denotation.
+- Retired the public `map_smul` placeholder.
+- Built `HexNumberFieldTowerMathlib` and `HexManual` and passed the DAG,
+  Phase-4, copyright, diff, and banned-declaration checks.
+
+## Current frontier
+
+- `map_inv` is the only remaining primitive arithmetic correspondence
+  placeholder in `HexNumberFieldTowerMathlib.Arithmetic`.
+- Its executable xgcd proof needs a semantic division/Bezout bridge for
+  canonical lower-tower coefficients; the existing later factor bridge imports
+  arithmetic and therefore cannot be imported back without a cycle.
+
+## Next step
+
+- Open this milestone as a draft PR stacked on `NumberFieldTowerRawMul`.
+- Isolate the minimal canonical-coefficient division invariant below the factor
+  layer, then use it to prove the xgcd result is the selected inverse.
+
+## Blockers
+
+- Claude second-opinion capacity remains unavailable until the provider quota
+  reset; implementation and GitHub CI continue independently.


### PR DESCRIPTION
## Summary

- expose the coordinate array produced by rational scalar multiplication
- prove coordinatewise rational scaling commutes with mixed-radix denotation
- close NumberTower.map_smul without axioms or new sorries

Stacked on #8989.

## Verification

- lake build HexNumberFieldTowerMathlib HexManual
- DAG, Phase-4, copyright, diff, and banned-declaration checks