### PR TITLE
refactor(rcf): extract Mathlib-free common-root checks

### DIFF
--- a/HexRCF.lean
+++ b/HexRCF.lean
@@ -22,6 +22,7 @@ public import HexRCF.Separation
 public import HexRCF.SeparationTests
 public import HexRCF.Cells
 public import HexRCF.CellsTests
+public import HexRCF.CommonRootCheck
 public import HexRCF.CommonRoot
 public import HexRCF.CommonRootTests
 public import HexRCF.SignMatrix

--- a/HexRCF/Builder.lean
+++ b/HexRCF/Builder.lean
@@ -7,7 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexRCF.CarrierCheck
-public import HexRCF.CommonRoot
+public import HexRCF.CommonRootCheck
 public import HexRCF.SignMatrix
 public import HexRCF.SturmBuilder
 

--- a/HexRCF/CommonRoot.lean
+++ b/HexRCF/CommonRoot.lean
@@ -6,124 +6,25 @@ Authors: Kim Morrison
 
 module
 
+public import HexRCF.CommonRootCheck
 public import HexRCF.Cells
 
 public section
 
 /-!
-# Certified common roots for RCF sign matrices
+# Real-root semantics of certified common roots
 
-A common-root package is checked once for each distinct nonconstant atom
-polynomial.  Its multiplication identities prove that a supplied polynomial
-has exactly the common real roots of the atom and the square-free carrier.  A
-nonconstant common-root polynomial also carries one generalized Sturm replay,
-which is then shared by every carrier root cell.
+The Mathlib-free package and checker live in `HexRCF.CommonRootCheck`. The
+theorems in this file prove that an accepted package has exactly the common
+real roots of the atom and square-free carrier, and connect its cached replay
+query to semantic root cells.
 -/
 
 namespace Hex.RCF
 
 open HexRealRootsMathlib Polynomial
 
-/-- Multiplication-checkable witnesses for the common roots of an atom and a
-carrier polynomial.  The atom and carrier themselves are external checker
-inputs, so certificate data cannot silently substitute different polynomials.
--/
-structure CommonRootCert where
-  /-- Proposed common-root polynomial. -/
-  gcd : ZPoly
-  /-- Quotient witnessing that the common-root polynomial divides the atom. -/
-  atomFactor : ZPoly
-  /-- Quotient witnessing that the common-root polynomial divides the carrier. -/
-  carrierFactor : ZPoly
-  /-- Atom coefficient in the scaled Bezout identity. -/
-  atomCoeff : ZPoly
-  /-- Carrier coefficient in the scaled Bezout identity. -/
-  carrierCoeff : ZPoly
-  /-- Nonzero integer scale in the Bezout identity. -/
-  scale : Int
-  /-- Cached replay for a nonconstant common-root polynomial.  A nonzero
-  constant common-root polynomial uses `none`. -/
-  replay : Option SturmReplay
-
 namespace CommonRootCert
-
-/-- Validate the constant/nonconstant replay branch. -/
-@[expose]
-def checkReplay (cert : CommonRootCert) : Bool :=
-  match cert.replay with
-  | none => decide (cert.gcd.size = 1)
-  | some replay =>
-      -- The replay checker already implies this degree bound.  Keeping the
-      -- guard makes the constant/nonconstant trust boundary explicit.
-      decide (0 < cert.gcd.degree?.getD 0) && replay.check cert.gcd
-
-/-- Proposition-level replay facts recovered from `checkReplay`. -/
-@[expose]
-def ReplayValid (cert : CommonRootCert) : Prop :=
-  match cert.replay with
-  | none => cert.gcd.size = 1
-  | some replay =>
-      0 < cert.gcd.degree?.getD 0 ∧ replay.check cert.gcd = true
-
-/-- Check the divisibility and scaled Bezout identities against the external
-atom and carrier polynomials. -/
-@[expose]
-def check (atom carrier : ZPoly) (cert : CommonRootCert) : Bool :=
-  decide (cert.scale ≠ 0) &&
-  DensePoly.beqCoeffs atom (cert.gcd * cert.atomFactor) &&
-  DensePoly.beqCoeffs carrier (cert.gcd * cert.carrierFactor) &&
-  DensePoly.beqCoeffs
-    (cert.atomCoeff * atom + cert.carrierCoeff * carrier)
-    (DensePoly.scale cert.scale cert.gcd) &&
-  cert.checkReplay
-
-/-- Proposition-level facts recovered from the common-root checker. -/
-@[expose]
-def Valid (atom carrier : ZPoly) (cert : CommonRootCert) : Prop :=
-  cert.scale ≠ 0 ∧
-  atom = cert.gcd * cert.atomFactor ∧
-  carrier = cert.gcd * cert.carrierFactor ∧
-  cert.atomCoeff * atom + cert.carrierCoeff * carrier =
-    DensePoly.scale cert.scale cert.gcd ∧
-  cert.ReplayValid
-
-/-- Soundness of the constant/nonconstant replay branch. -/
-theorem checkReplay_sound {cert : CommonRootCert}
-    (h : cert.checkReplay = true) : cert.ReplayValid := by
-  cases hreplay : cert.replay with
-  | none => simpa [checkReplay, ReplayValid, hreplay] using h
-  | some replay => simpa [checkReplay, ReplayValid, hreplay] using h
-
-/-- Soundness of the executable common-root checker. -/
-theorem check_sound {atom carrier : ZPoly} {cert : CommonRootCert}
-    (h : cert.check atom carrier = true) : cert.Valid atom carrier := by
-  simp only [check, Bool.and_eq_true, decide_eq_true_eq] at h
-  obtain ⟨⟨⟨⟨hscale, hatom⟩, hcarrier⟩, hbezout⟩, hreplay⟩ := h
-  exact ⟨hscale, DensePoly.eq_of_beqCoeffs hatom,
-    DensePoly.eq_of_beqCoeffs hcarrier,
-    DensePoly.eq_of_beqCoeffs hbezout, checkReplay_sound hreplay⟩
-
-/-- A checked common-root polynomial is nonzero in both certificate branches. -/
-theorem gcd_ne_zero {atom carrier : ZPoly} {cert : CommonRootCert}
-    (h : cert.check atom carrier = true) : cert.gcd ≠ 0 := by
-  have hvalid := (check_sound h).2.2.2.2
-  cases hreplay : cert.replay with
-  | none =>
-      simp only [ReplayValid, hreplay] at hvalid
-      intro hzero
-      rw [hzero] at hvalid
-      simp at hvalid
-  | some replay =>
-      simp only [ReplayValid, hreplay] at hvalid
-      exact SturmReplay.head_ne_zero hvalid.2
-
-/-- Recover the checked replay in the nonconstant certificate branch. -/
-theorem replay_of_check {atom carrier : ZPoly} {cert : CommonRootCert}
-    {replay : SturmReplay} (h : cert.check atom carrier = true)
-    (hreplay : cert.replay = some replay) : replay.check cert.gcd = true := by
-  have hvalid := (check_sound h).2.2.2.2
-  simp only [ReplayValid, hreplay] at hvalid
-  exact hvalid.2
 
 /-- A checked common-root polynomial has exactly the common real roots of the
 atom and carrier. -/
@@ -173,16 +74,6 @@ theorem noRoot_of_constant {atom carrier : ZPoly} {cert : CommonRootCert}
   obtain ⟨u, hu, hunitEq⟩ := Polynomial.isUnit_iff.mp hunit
   rw [← hunitEq, Polynomial.IsRoot, Polynomial.eval_C] at hroot
   exact hu.ne_zero hroot
-
-/-- Decide whether the cached common-root polynomial has a root in an
-interval.  The constant branch is root-free; the nonconstant branch reads its
-shared generalized Sturm replay.  Its semantic guarantee applies when the
-interval comes from a checked carrier isolation. -/
-@[expose]
-def hasRoot (cert : CommonRootCert) (I : DyadicInterval) : Bool :=
-  match cert.replay with
-  | none => false
-  | some replay => decide (replay.count I = 1)
 
 /-- A cached nonconstant replay counts one common root in a carrier isolation
 exactly when the atom vanishes at its supplied carrier root. -/

--- a/HexRCF/CommonRootCheck.lean
+++ b/HexRCF/CommonRootCheck.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.SturmCheck
+
+public section
+
+/-!
+# Multiplication-checkable common roots
+
+A common-root package is checked once for each distinct nonconstant atom
+polynomial. Its exact identities witness divisibility by a supplied common-root
+polynomial and a scaled Bezout relation. A nonconstant common-root polynomial
+also carries one generalized Sturm replay, shared by every carrier root cell.
+Real-root and cell semantics live in `HexRCF.CommonRoot`.
+-/
+
+namespace Hex.RCF
+
+/-- Multiplication-checkable witnesses for the common roots of an atom and a
+carrier polynomial. The atom and carrier themselves are external checker
+inputs, so certificate data cannot silently substitute different polynomials.
+-/
+structure CommonRootCert where
+  /-- Proposed common-root polynomial. -/
+  gcd : ZPoly
+  /-- Quotient witnessing that the common-root polynomial divides the atom. -/
+  atomFactor : ZPoly
+  /-- Quotient witnessing that the common-root polynomial divides the carrier. -/
+  carrierFactor : ZPoly
+  /-- Atom coefficient in the scaled Bezout identity. -/
+  atomCoeff : ZPoly
+  /-- Carrier coefficient in the scaled Bezout identity. -/
+  carrierCoeff : ZPoly
+  /-- Nonzero integer scale in the Bezout identity. -/
+  scale : Int
+  /-- Cached replay for a nonconstant common-root polynomial. A nonzero
+  constant common-root polynomial uses `none`. -/
+  replay : Option SturmReplay
+
+namespace CommonRootCert
+
+/-- Validate the constant/nonconstant replay branch. -/
+@[expose]
+def checkReplay (cert : CommonRootCert) : Bool :=
+  match cert.replay with
+  | none => decide (cert.gcd.size = 1)
+  | some replay =>
+      -- The replay checker already implies this degree bound. Keeping the
+      -- guard makes the constant/nonconstant trust boundary explicit.
+      decide (0 < cert.gcd.degree?.getD 0) && replay.check cert.gcd
+
+/-- Proposition-level replay facts recovered from `checkReplay`. -/
+@[expose]
+def ReplayValid (cert : CommonRootCert) : Prop :=
+  match cert.replay with
+  | none => cert.gcd.size = 1
+  | some replay =>
+      0 < cert.gcd.degree?.getD 0 ∧ replay.check cert.gcd = true
+
+/-- Check the divisibility and scaled Bezout identities against the external
+atom and carrier polynomials. -/
+@[expose]
+def check (atom carrier : ZPoly) (cert : CommonRootCert) : Bool :=
+  decide (cert.scale ≠ 0) &&
+  DensePoly.beqCoeffs atom (cert.gcd * cert.atomFactor) &&
+  DensePoly.beqCoeffs carrier (cert.gcd * cert.carrierFactor) &&
+  DensePoly.beqCoeffs
+    (cert.atomCoeff * atom + cert.carrierCoeff * carrier)
+    (DensePoly.scale cert.scale cert.gcd) &&
+  cert.checkReplay
+
+/-- Proposition-level facts recovered from the common-root checker. -/
+@[expose]
+def Valid (atom carrier : ZPoly) (cert : CommonRootCert) : Prop :=
+  cert.scale ≠ 0 ∧
+  atom = cert.gcd * cert.atomFactor ∧
+  carrier = cert.gcd * cert.carrierFactor ∧
+  cert.atomCoeff * atom + cert.carrierCoeff * carrier =
+    DensePoly.scale cert.scale cert.gcd ∧
+  cert.ReplayValid
+
+/-- Soundness of the constant/nonconstant replay branch. -/
+theorem checkReplay_sound {cert : CommonRootCert}
+    (h : cert.checkReplay = true) : cert.ReplayValid := by
+  cases hreplay : cert.replay with
+  | none => simpa [checkReplay, ReplayValid, hreplay] using h
+  | some replay => simpa [checkReplay, ReplayValid, hreplay] using h
+
+/-- Soundness of the executable common-root checker. -/
+theorem check_sound {atom carrier : ZPoly} {cert : CommonRootCert}
+    (h : cert.check atom carrier = true) : cert.Valid atom carrier := by
+  simp only [check, Bool.and_eq_true, decide_eq_true_eq] at h
+  obtain ⟨⟨⟨⟨hscale, hatom⟩, hcarrier⟩, hbezout⟩, hreplay⟩ := h
+  exact ⟨hscale, DensePoly.eq_of_beqCoeffs hatom,
+    DensePoly.eq_of_beqCoeffs hcarrier,
+    DensePoly.eq_of_beqCoeffs hbezout, checkReplay_sound hreplay⟩
+
+/-- A checked common-root polynomial is nonzero in both certificate branches. -/
+theorem gcd_ne_zero {atom carrier : ZPoly} {cert : CommonRootCert}
+    (h : cert.check atom carrier = true) : cert.gcd ≠ 0 := by
+  have hvalid := (check_sound h).2.2.2.2
+  cases hreplay : cert.replay with
+  | none =>
+      simp only [ReplayValid, hreplay] at hvalid
+      intro hzero
+      rw [hzero] at hvalid
+      simp at hvalid
+  | some replay =>
+      simp only [ReplayValid, hreplay] at hvalid
+      exact SturmReplay.head_ne_zero hvalid.2
+
+/-- Recover the checked replay in the nonconstant certificate branch. -/
+theorem replay_of_check {atom carrier : ZPoly} {cert : CommonRootCert}
+    {replay : SturmReplay} (h : cert.check atom carrier = true)
+    (hreplay : cert.replay = some replay) : replay.check cert.gcd = true := by
+  have hvalid := (check_sound h).2.2.2.2
+  simp only [ReplayValid, hreplay] at hvalid
+  exact hvalid.2
+
+/-- Decide whether the cached common-root polynomial has a root in an
+interval. The constant branch is root-free; the nonconstant branch reads its
+shared generalized Sturm replay. -/
+@[expose]
+def hasRoot (cert : CommonRootCert) (I : DyadicInterval) : Bool :=
+  match cert.replay with
+  | none => false
+  | some replay => decide (replay.count I = 1)
+
+end CommonRootCert
+
+end Hex.RCF

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -625,10 +625,11 @@ free to change.
   `HexRCF/CellsTests.lean`: enumeration,
   zero/singleton/multiple-root samples, endpoint equality/order guards,
   relevance tables, and malformed lower/upper claim regressions.
-- `HexRCF/CommonRoot.lean`: multiplication-checkable common-root packages,
-  constant/nonconstant replay branches, exact common-root semantics, and
-  cached root-cell queries; `HexRCF/CommonRootTests.lean`: shared-factor,
-  coprime, equal-polynomial, and tampered-evidence regressions.
+- `HexRCF/CommonRootCheck.lean`: Mathlib-free multiplication-checkable
+  common-root packages, replay branches, and cached interval queries;
+  `HexRCF/CommonRoot.lean`: exact common-root and root-cell semantics;
+  `HexRCF/CommonRootTests.lean`: shared-factor, coprime, equal-polynomial, and
+  tampered-evidence regressions.
 - `HexRCF/SignMatrix.lean`: three-way exact signs, coefficient-equality
   atom deduplication and common-package alignment, guarded open-cell
   evaluation, the `gⱼ` root-cell computation, and full Boolean reflection;

--- a/progress/20260727T153139Z_rcf-common-root-check.md
+++ b/progress/20260727T153139Z_rcf-common-root-check.md
@@ -1,0 +1,36 @@
+# Mathlib-free RCF common-root checks
+
+## Accomplished
+
+- Added `HexRCF.CommonRootCheck`, containing common-root certificate data,
+  replay/divisibility/Bezout validation, proposition-level checker
+  consequences, nonzero and replay recovery, and the executable cached
+  interval query.
+- Reduced `HexRCF.CommonRoot` to real-root, isolation, and root-cell semantics
+  while preserving all qualified declaration names through a public import.
+- Narrowed `HexRCF.Builder`'s direct common-root dependency to
+  `CommonRootCheck`; its remaining Mathlib closure comes through the
+  still-combined sign-matrix layer.
+- Updated the HexRCF umbrella and SPEC file map.
+- Verified targeted consumers and the full HexRCF build and mechanically
+  checked the 30-module `HexRCF.CommonRootCheck` closure contains neither
+  `Mathlib.*` nor `HexRealRootsMathlib.*`. DAG, Phase-4, release-manifest,
+  trust-surface, copyright, diff, and banned-token checks pass. An independent
+  Sol review returned GO.
+
+## Current frontier
+
+Issue #8993 is implemented on a branch stacked above the carrier-check PR
+#8991. Syntax, replay, carrier, and common-root validation now have explicit
+Mathlib-free module boundaries.
+
+## Next step
+
+Publish the stacked PR, then extract the raw isolation certificate checks and
+their pure ordering/count consequences from `HexRCF.Isolations` as the next
+dependency needed by a pure sign-matrix/certificate replay path.
+
+## Blockers
+
+None for this extraction. The branch remains stacked until the syntax, Sturm,
+and carrier parents merge; it can then be rebased and retargeted to main.


### PR DESCRIPTION
## Summary

- extract common-root certificate data, multiplication checks, pure checker consequences, and cached interval query into `HexRCF.CommonRootCheck`
- retain real-root/isolation/cell semantics in `HexRCF.CommonRoot` while preserving existing qualified names
- narrow `HexRCF.Builder` to a direct `CommonRootCheck` dependency

Stacked on #8991. Closes #8993. Contributes to #8973.

## Verification

- `lake build HexRCF.CommonRootCheck HexRCF.CommonRoot HexRCF.Builder`
- `lake build HexRCF`
- repository-local import-closure audit: `HexRCF.CommonRootCheck` spans 30 modules and contains no `Mathlib.*` or `HexRealRootsMathlib.*` imports
- DAG, Phase-4, release-manifest, published trust-surface, copyright, diff, and banned-token checks
- independent Sol review: GO