### PR TITLE
refactor(rcf): extract Mathlib-free isolation checks

### DIFF
--- a/HexRCF.lean
+++ b/HexRCF.lean
@@ -22,6 +22,7 @@ public import HexRCF.Separation
 public import HexRCF.SeparationTests
 public import HexRCF.Cells
 public import HexRCF.CellsTests
+public import HexRCF.CommonRootCheck
 public import HexRCF.CommonRoot
 public import HexRCF.CommonRootTests
 public import HexRCF.SignMatrix

--- a/HexRCF.lean
+++ b/HexRCF.lean
@@ -16,6 +16,7 @@ public import HexRCF.SturmBuilderTests
 public import HexRCF.CarrierCheck
 public import HexRCF.Carrier
 public import HexRCF.CarrierTests
+public import HexRCF.IsolationCheck
 public import HexRCF.Isolations
 public import HexRCF.IsolationsTests
 public import HexRCF.Separation

--- a/HexRCF.lean
+++ b/HexRCF.lean
@@ -9,6 +9,7 @@ module
 public import HexRCF.Syntax
 public import HexRCF.Language
 public import HexRCF.LanguageTests
+public import HexRCF.SturmCheck
 public import HexRCF.SturmReplay
 public import HexRCF.SturmBuilder
 public import HexRCF.SturmBuilderTests

--- a/HexRCF.lean
+++ b/HexRCF.lean
@@ -13,6 +13,7 @@ public import HexRCF.SturmCheck
 public import HexRCF.SturmReplay
 public import HexRCF.SturmBuilder
 public import HexRCF.SturmBuilderTests
+public import HexRCF.CarrierCheck
 public import HexRCF.Carrier
 public import HexRCF.CarrierTests
 public import HexRCF.Isolations

--- a/HexRCF/Builder.lean
+++ b/HexRCF/Builder.lean
@@ -6,7 +6,7 @@ Authors: Kim Morrison
 
 module
 
-public import HexRCF.Carrier
+public import HexRCF.CarrierCheck
 public import HexRCF.CommonRoot
 public import HexRCF.SignMatrix
 public import HexRCF.SturmBuilder

--- a/HexRCF/Builder.lean
+++ b/HexRCF/Builder.lean
@@ -7,7 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexRCF.CarrierCheck
-public import HexRCF.CommonRoot
+public import HexRCF.CommonRootCheck
 public import HexRCF.SignMatrix
 public import HexRCF.SturmBuilder
 

--- a/HexRCF/Carrier.lean
+++ b/HexRCF/Carrier.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexRCF.CarrierCheck
 public import HexRCF.Language
 public import HexRCF.SturmReplay
 public import HexRealRootsMathlib.SquareFreeCore
@@ -13,115 +14,18 @@ public import HexRealRootsMathlib.SquareFreeCore
 public section
 
 /-!
-# Certified square-free carriers for reflected RCF sentences
+# Real-root semantics of certified RCF carriers
 
-The carrier checker recomputes the nonconstant atom polynomials and their
-product from the reflected sentence.  A certificate supplies a proposed
-square-free carrier, two factor witnesses, two nonzero integer scales, and a
-multiplication-only Sturm replay for the carrier.  Checking uses only exact
-polynomial arithmetic, differentiation, coefficient equality, and the replay
-checker.
+The Mathlib-free certificate and checker live in `HexRCF.CarrierCheck`. The
+theorems in this file prove that an accepted carrier is squarefree and has
+exactly the roots of the sentence's nonconstant atom polynomials.
 -/
 
 namespace Hex.RCF
 
 open HexRealRootsMathlib Polynomial
 
-/-- Check that every polynomial in a literal list has positive degree. -/
-@[expose]
-def checkPosDegrees : List ZPoly → Bool
-  | [] => true
-  | p :: ps => decide (0 < p.degree?.getD 0) && checkPosDegrees ps
-
-/-- Multiplication-checkable witnesses that a polynomial is a square-free
-carrier for the atom product of a sentence. -/
-structure CarrierCert where
-  /-- Proposed square-free carrier `P`. -/
-  carrier : ZPoly
-  /-- Repeated-factor witness `R`. -/
-  repeated : ZPoly
-  /-- Derivative quotient witness `S`. -/
-  derivPart : ZPoly
-  /-- Nonzero scale `k` in `Q = scale k (P * R)`. -/
-  factorScale : Int
-  /-- Nonzero scale `d` in `scale d Q' = R * S`. -/
-  derivScale : Int
-  /-- Generalized Sturm replay proving the carrier squarefree. -/
-  replay : SturmReplay
-
 namespace CarrierCert
-
-/-- Executable carrier validation.  The atom product is recomputed from the
-sentence and is never supplied by the certificate. -/
-@[expose]
-def check (s : Sentence) (cert : CarrierCert) : Bool :=
-  let q := s.product
-  -- `Sentence.polys` filters by this predicate; retaining the explicit walk
-  -- makes the certificate contract visible at its trust boundary.
-  checkPosDegrees s.polys &&
-  decide (0 < q.degree?.getD 0) &&
-  !cert.repeated.isZero &&
-  decide (cert.factorScale ≠ 0) &&
-  decide (cert.derivScale ≠ 0) &&
-  DensePoly.beqCoeffs q
-    (DensePoly.scale cert.factorScale (cert.carrier * cert.repeated)) &&
-  DensePoly.beqCoeffs (DensePoly.scale cert.derivScale (DensePoly.derivative q))
-    (cert.repeated * cert.derivPart) &&
-  cert.replay.check cert.carrier
-
-/-- Proposition-level facts recovered from the Boolean carrier checker. -/
-@[expose]
-def Valid (s : Sentence) (cert : CarrierCert) : Prop :=
-  let q := s.product
-  (∀ p ∈ s.polys, 0 < p.degree?.getD 0) ∧
-  0 < q.degree?.getD 0 ∧
-  cert.repeated ≠ 0 ∧
-  cert.factorScale ≠ 0 ∧
-  cert.derivScale ≠ 0 ∧
-  q = DensePoly.scale cert.factorScale (cert.carrier * cert.repeated) ∧
-  DensePoly.scale cert.derivScale (DensePoly.derivative q) =
-    cert.repeated * cert.derivPart ∧
-  cert.replay.check cert.carrier = true
-
-/-- A successful positive-degree walk proves its proposition-level form. -/
-theorem checkPosDegrees_sound {ps : List ZPoly} (h : checkPosDegrees ps = true) :
-    ∀ p ∈ ps, 0 < p.degree?.getD 0 := by
-  induction ps with
-  | nil => simp
-  | cons p ps ih =>
-      simp only [checkPosDegrees, Bool.and_eq_true, decide_eq_true_eq] at h
-      intro q hq
-      simp only [List.mem_cons] at hq
-      rcases hq with rfl | hq
-      · exact h.1
-      · exact ih h.2 q hq
-
-/-- Soundness of the executable carrier checker. -/
-theorem check_sound {s : Sentence} {cert : CarrierCert}
-    (h : cert.check s = true) : cert.Valid s := by
-  simp only [check, Bool.and_eq_true, decide_eq_true_eq] at h
-  obtain ⟨⟨⟨⟨⟨⟨⟨hdegrees, hqdeg⟩, hr0⟩, hk0⟩, hd0⟩, hfactor⟩,
-    hderiv⟩, hreplay⟩ := h
-  refine ⟨checkPosDegrees_sound hdegrees, hqdeg, ?_, hk0, hd0, ?_, ?_, hreplay⟩
-  · simp only [Bool.not_eq_true'] at hr0
-    have hr := (DensePoly.isZero_eq_false_iff cert.repeated).mp hr0
-    intro hzero
-    rw [hzero] at hr
-    simp at hr
-  · exact DensePoly.eq_of_beqCoeffs hfactor
-  · exact DensePoly.eq_of_beqCoeffs hderiv
-
-/-- The carrier replay component recovered from the combined checker. -/
-theorem replay_of_check {s : Sentence} {cert : CarrierCert}
-    (h : cert.check s = true) : cert.replay.check cert.carrier = true :=
-  (check_sound h).2.2.2.2.2.2.2
-
-/-- An accepted carrier certificate has a nonzero carrier polynomial. -/
-theorem carrier_ne_zero {s : Sentence} {cert : CarrierCert}
-    (h : cert.check s = true) : cert.carrier ≠ 0 := by
-  obtain ⟨_hdegrees, _hqdeg, _hr0, _hk0, _hd0, _hfactor, _hderiv, hreplay⟩ :=
-    check_sound h
-  exact SturmReplay.head_ne_zero hreplay
 
 /-- An accepted carrier is squarefree after casting to real coefficients. -/
 theorem squarefree {s : Sentence} {cert : CarrierCert}
@@ -130,17 +34,6 @@ theorem squarefree {s : Sentence} {cert : CarrierCert}
     obtain ⟨_hdegrees, _hqdeg, _hr0, _hk0, _hd0, _hfactor, _hderiv, hreplay⟩ :=
       check_sound h
     exact SturmReplay.squarefree_of_check hreplay
-
-/-- A positive literal degree implies a nonzero executable polynomial. -/
-private theorem ne_zero_of_degree_pos {p : ZPoly} (h : 0 < p.degree?.getD 0) : p ≠ 0 := by
-  intro hp
-  subst p
-  simp [DensePoly.degree?] at h
-
-/-- The recomputed atom product is nonzero for an accepted certificate. -/
-theorem product_ne_zero {s : Sentence} {cert : CarrierCert}
-    (h : cert.check s = true) : s.product ≠ 0 :=
-  ne_zero_of_degree_pos (check_sound h).2.1
 
 /-- Exact scalar-and-factor identities imply that the proposed factor and the
 original polynomial have the same real roots. -/

--- a/HexRCF/CarrierCheck.lean
+++ b/HexRCF/CarrierCheck.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.Syntax
+public import HexRCF.SturmCheck
+
+public section
+
+/-!
+# Multiplication-checkable RCF carriers
+
+The carrier checker recomputes the nonconstant atom polynomials and their
+product from the reflected sentence. A certificate supplies a proposed
+square-free carrier, two factor witnesses, two nonzero integer scales, and a
+multiplication-only Sturm replay for the carrier. Checking uses only exact
+polynomial arithmetic, differentiation, coefficient equality, and the replay
+checker. Real-polynomial consequences live in `HexRCF.Carrier`.
+-/
+
+namespace Hex.RCF
+
+/-- Check that every polynomial in a literal list has positive degree. -/
+@[expose]
+def checkPosDegrees : List ZPoly → Bool
+  | [] => true
+  | p :: ps => decide (0 < p.degree?.getD 0) && checkPosDegrees ps
+
+/-- Multiplication-checkable witnesses that a polynomial is a square-free
+carrier for the atom product of a sentence. -/
+structure CarrierCert where
+  /-- Proposed square-free carrier `P`. -/
+  carrier : ZPoly
+  /-- Repeated-factor witness `R`. -/
+  repeated : ZPoly
+  /-- Derivative quotient witness `S`. -/
+  derivPart : ZPoly
+  /-- Nonzero scale `k` in `Q = scale k (P * R)`. -/
+  factorScale : Int
+  /-- Nonzero scale `d` in `scale d Q' = R * S`. -/
+  derivScale : Int
+  /-- Generalized Sturm replay proving the carrier squarefree. -/
+  replay : SturmReplay
+
+namespace CarrierCert
+
+/-- Executable carrier validation. The atom product is recomputed from the
+sentence and is never supplied by the certificate. -/
+@[expose]
+def check (s : Sentence) (cert : CarrierCert) : Bool :=
+  let q := s.product
+  -- `Sentence.polys` filters by this predicate; retaining the explicit walk
+  -- makes the certificate contract visible at its trust boundary.
+  checkPosDegrees s.polys &&
+  decide (0 < q.degree?.getD 0) &&
+  !cert.repeated.isZero &&
+  decide (cert.factorScale ≠ 0) &&
+  decide (cert.derivScale ≠ 0) &&
+  DensePoly.beqCoeffs q
+    (DensePoly.scale cert.factorScale (cert.carrier * cert.repeated)) &&
+  DensePoly.beqCoeffs (DensePoly.scale cert.derivScale (DensePoly.derivative q))
+    (cert.repeated * cert.derivPart) &&
+  cert.replay.check cert.carrier
+
+/-- Proposition-level facts recovered from the Boolean carrier checker. -/
+@[expose]
+def Valid (s : Sentence) (cert : CarrierCert) : Prop :=
+  let q := s.product
+  (∀ p ∈ s.polys, 0 < p.degree?.getD 0) ∧
+  0 < q.degree?.getD 0 ∧
+  cert.repeated ≠ 0 ∧
+  cert.factorScale ≠ 0 ∧
+  cert.derivScale ≠ 0 ∧
+  q = DensePoly.scale cert.factorScale (cert.carrier * cert.repeated) ∧
+  DensePoly.scale cert.derivScale (DensePoly.derivative q) =
+    cert.repeated * cert.derivPart ∧
+  cert.replay.check cert.carrier = true
+
+/-- A successful positive-degree walk proves its proposition-level form. -/
+theorem checkPosDegrees_sound {ps : List ZPoly} (h : checkPosDegrees ps = true) :
+    ∀ p ∈ ps, 0 < p.degree?.getD 0 := by
+  induction ps with
+  | nil => simp
+  | cons p ps ih =>
+      simp only [checkPosDegrees, Bool.and_eq_true, decide_eq_true_eq] at h
+      intro q hq
+      simp only [List.mem_cons] at hq
+      rcases hq with rfl | hq
+      · exact h.1
+      · exact ih h.2 q hq
+
+/-- Soundness of the executable carrier checker. -/
+theorem check_sound {s : Sentence} {cert : CarrierCert}
+    (h : cert.check s = true) : cert.Valid s := by
+  simp only [check, Bool.and_eq_true, decide_eq_true_eq] at h
+  obtain ⟨⟨⟨⟨⟨⟨⟨hdegrees, hqdeg⟩, hr0⟩, hk0⟩, hd0⟩, hfactor⟩,
+    hderiv⟩, hreplay⟩ := h
+  refine ⟨checkPosDegrees_sound hdegrees, hqdeg, ?_, hk0, hd0, ?_, ?_, hreplay⟩
+  · simp only [Bool.not_eq_true'] at hr0
+    have hr := (DensePoly.isZero_eq_false_iff cert.repeated).mp hr0
+    intro hzero
+    rw [hzero] at hr
+    simp at hr
+  · exact DensePoly.eq_of_beqCoeffs hfactor
+  · exact DensePoly.eq_of_beqCoeffs hderiv
+
+/-- The carrier replay component recovered from the combined checker. -/
+theorem replay_of_check {s : Sentence} {cert : CarrierCert}
+    (h : cert.check s = true) : cert.replay.check cert.carrier = true :=
+  (check_sound h).2.2.2.2.2.2.2
+
+/-- An accepted carrier certificate has a nonzero carrier polynomial. -/
+theorem carrier_ne_zero {s : Sentence} {cert : CarrierCert}
+    (h : cert.check s = true) : cert.carrier ≠ 0 := by
+  obtain ⟨_hdegrees, _hqdeg, _hr0, _hk0, _hd0, _hfactor, _hderiv, hreplay⟩ :=
+    check_sound h
+  exact SturmReplay.head_ne_zero hreplay
+
+/-- A positive literal degree implies a nonzero executable polynomial. -/
+private theorem ne_zero_of_degree_pos {p : ZPoly}
+    (h : 0 < p.degree?.getD 0) : p ≠ 0 := by
+  intro hp
+  subst p
+  simp [DensePoly.degree?] at h
+
+/-- The recomputed atom product is nonzero for an accepted certificate. -/
+theorem product_ne_zero {s : Sentence} {cert : CarrierCert}
+    (h : cert.check s = true) : s.product ≠ 0 :=
+  ne_zero_of_degree_pos (check_sound h).2.1
+
+end CarrierCert
+
+end Hex.RCF

--- a/HexRCF/CommonRoot.lean
+++ b/HexRCF/CommonRoot.lean
@@ -6,124 +6,25 @@ Authors: Kim Morrison
 
 module
 
+public import HexRCF.CommonRootCheck
 public import HexRCF.Cells
 
 public section
 
 /-!
-# Certified common roots for RCF sign matrices
+# Real-root semantics of certified common roots
 
-A common-root package is checked once for each distinct nonconstant atom
-polynomial.  Its multiplication identities prove that a supplied polynomial
-has exactly the common real roots of the atom and the square-free carrier.  A
-nonconstant common-root polynomial also carries one generalized Sturm replay,
-which is then shared by every carrier root cell.
+The Mathlib-free package and checker live in `HexRCF.CommonRootCheck`. The
+theorems in this file prove that an accepted package has exactly the common
+real roots of the atom and square-free carrier, and connect its cached replay
+query to semantic root cells.
 -/
 
 namespace Hex.RCF
 
 open HexRealRootsMathlib Polynomial
 
-/-- Multiplication-checkable witnesses for the common roots of an atom and a
-carrier polynomial.  The atom and carrier themselves are external checker
-inputs, so certificate data cannot silently substitute different polynomials.
--/
-structure CommonRootCert where
-  /-- Proposed common-root polynomial. -/
-  gcd : ZPoly
-  /-- Quotient witnessing that the common-root polynomial divides the atom. -/
-  atomFactor : ZPoly
-  /-- Quotient witnessing that the common-root polynomial divides the carrier. -/
-  carrierFactor : ZPoly
-  /-- Atom coefficient in the scaled Bezout identity. -/
-  atomCoeff : ZPoly
-  /-- Carrier coefficient in the scaled Bezout identity. -/
-  carrierCoeff : ZPoly
-  /-- Nonzero integer scale in the Bezout identity. -/
-  scale : Int
-  /-- Cached replay for a nonconstant common-root polynomial.  A nonzero
-  constant common-root polynomial uses `none`. -/
-  replay : Option SturmReplay
-
 namespace CommonRootCert
-
-/-- Validate the constant/nonconstant replay branch. -/
-@[expose]
-def checkReplay (cert : CommonRootCert) : Bool :=
-  match cert.replay with
-  | none => decide (cert.gcd.size = 1)
-  | some replay =>
-      -- The replay checker already implies this degree bound.  Keeping the
-      -- guard makes the constant/nonconstant trust boundary explicit.
-      decide (0 < cert.gcd.degree?.getD 0) && replay.check cert.gcd
-
-/-- Proposition-level replay facts recovered from `checkReplay`. -/
-@[expose]
-def ReplayValid (cert : CommonRootCert) : Prop :=
-  match cert.replay with
-  | none => cert.gcd.size = 1
-  | some replay =>
-      0 < cert.gcd.degree?.getD 0 ∧ replay.check cert.gcd = true
-
-/-- Check the divisibility and scaled Bezout identities against the external
-atom and carrier polynomials. -/
-@[expose]
-def check (atom carrier : ZPoly) (cert : CommonRootCert) : Bool :=
-  decide (cert.scale ≠ 0) &&
-  DensePoly.beqCoeffs atom (cert.gcd * cert.atomFactor) &&
-  DensePoly.beqCoeffs carrier (cert.gcd * cert.carrierFactor) &&
-  DensePoly.beqCoeffs
-    (cert.atomCoeff * atom + cert.carrierCoeff * carrier)
-    (DensePoly.scale cert.scale cert.gcd) &&
-  cert.checkReplay
-
-/-- Proposition-level facts recovered from the common-root checker. -/
-@[expose]
-def Valid (atom carrier : ZPoly) (cert : CommonRootCert) : Prop :=
-  cert.scale ≠ 0 ∧
-  atom = cert.gcd * cert.atomFactor ∧
-  carrier = cert.gcd * cert.carrierFactor ∧
-  cert.atomCoeff * atom + cert.carrierCoeff * carrier =
-    DensePoly.scale cert.scale cert.gcd ∧
-  cert.ReplayValid
-
-/-- Soundness of the constant/nonconstant replay branch. -/
-theorem checkReplay_sound {cert : CommonRootCert}
-    (h : cert.checkReplay = true) : cert.ReplayValid := by
-  cases hreplay : cert.replay with
-  | none => simpa [checkReplay, ReplayValid, hreplay] using h
-  | some replay => simpa [checkReplay, ReplayValid, hreplay] using h
-
-/-- Soundness of the executable common-root checker. -/
-theorem check_sound {atom carrier : ZPoly} {cert : CommonRootCert}
-    (h : cert.check atom carrier = true) : cert.Valid atom carrier := by
-  simp only [check, Bool.and_eq_true, decide_eq_true_eq] at h
-  obtain ⟨⟨⟨⟨hscale, hatom⟩, hcarrier⟩, hbezout⟩, hreplay⟩ := h
-  exact ⟨hscale, DensePoly.eq_of_beqCoeffs hatom,
-    DensePoly.eq_of_beqCoeffs hcarrier,
-    DensePoly.eq_of_beqCoeffs hbezout, checkReplay_sound hreplay⟩
-
-/-- A checked common-root polynomial is nonzero in both certificate branches. -/
-theorem gcd_ne_zero {atom carrier : ZPoly} {cert : CommonRootCert}
-    (h : cert.check atom carrier = true) : cert.gcd ≠ 0 := by
-  have hvalid := (check_sound h).2.2.2.2
-  cases hreplay : cert.replay with
-  | none =>
-      simp only [ReplayValid, hreplay] at hvalid
-      intro hzero
-      rw [hzero] at hvalid
-      simp at hvalid
-  | some replay =>
-      simp only [ReplayValid, hreplay] at hvalid
-      exact SturmReplay.head_ne_zero hvalid.2
-
-/-- Recover the checked replay in the nonconstant certificate branch. -/
-theorem replay_of_check {atom carrier : ZPoly} {cert : CommonRootCert}
-    {replay : SturmReplay} (h : cert.check atom carrier = true)
-    (hreplay : cert.replay = some replay) : replay.check cert.gcd = true := by
-  have hvalid := (check_sound h).2.2.2.2
-  simp only [ReplayValid, hreplay] at hvalid
-  exact hvalid.2
 
 /-- A checked common-root polynomial has exactly the common real roots of the
 atom and carrier. -/
@@ -173,16 +74,6 @@ theorem noRoot_of_constant {atom carrier : ZPoly} {cert : CommonRootCert}
   obtain ⟨u, hu, hunitEq⟩ := Polynomial.isUnit_iff.mp hunit
   rw [← hunitEq, Polynomial.IsRoot, Polynomial.eval_C] at hroot
   exact hu.ne_zero hroot
-
-/-- Decide whether the cached common-root polynomial has a root in an
-interval.  The constant branch is root-free; the nonconstant branch reads its
-shared generalized Sturm replay.  Its semantic guarantee applies when the
-interval comes from a checked carrier isolation. -/
-@[expose]
-def hasRoot (cert : CommonRootCert) (I : DyadicInterval) : Bool :=
-  match cert.replay with
-  | none => false
-  | some replay => decide (replay.count I = 1)
 
 /-- A cached nonconstant replay counts one common root in a carrier isolation
 exactly when the atom vanishes at its supplied carrier root. -/

--- a/HexRCF/CommonRootCheck.lean
+++ b/HexRCF/CommonRootCheck.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.SturmCheck
+
+public section
+
+/-!
+# Multiplication-checkable common roots
+
+A common-root package is checked once for each distinct nonconstant atom
+polynomial. Its exact identities witness divisibility by a supplied common-root
+polynomial and a scaled Bezout relation. A nonconstant common-root polynomial
+also carries one generalized Sturm replay, shared by every carrier root cell.
+Real-root and cell semantics live in `HexRCF.CommonRoot`.
+-/
+
+namespace Hex.RCF
+
+/-- Multiplication-checkable witnesses for the common roots of an atom and a
+carrier polynomial. The atom and carrier themselves are external checker
+inputs, so certificate data cannot silently substitute different polynomials.
+-/
+structure CommonRootCert where
+  /-- Proposed common-root polynomial. -/
+  gcd : ZPoly
+  /-- Quotient witnessing that the common-root polynomial divides the atom. -/
+  atomFactor : ZPoly
+  /-- Quotient witnessing that the common-root polynomial divides the carrier. -/
+  carrierFactor : ZPoly
+  /-- Atom coefficient in the scaled Bezout identity. -/
+  atomCoeff : ZPoly
+  /-- Carrier coefficient in the scaled Bezout identity. -/
+  carrierCoeff : ZPoly
+  /-- Nonzero integer scale in the Bezout identity. -/
+  scale : Int
+  /-- Cached replay for a nonconstant common-root polynomial. A nonzero
+  constant common-root polynomial uses `none`. -/
+  replay : Option SturmReplay
+
+namespace CommonRootCert
+
+/-- Validate the constant/nonconstant replay branch. -/
+@[expose]
+def checkReplay (cert : CommonRootCert) : Bool :=
+  match cert.replay with
+  | none => decide (cert.gcd.size = 1)
+  | some replay =>
+      -- The replay checker already implies this degree bound. Keeping the
+      -- guard makes the constant/nonconstant trust boundary explicit.
+      decide (0 < cert.gcd.degree?.getD 0) && replay.check cert.gcd
+
+/-- Proposition-level replay facts recovered from `checkReplay`. -/
+@[expose]
+def ReplayValid (cert : CommonRootCert) : Prop :=
+  match cert.replay with
+  | none => cert.gcd.size = 1
+  | some replay =>
+      0 < cert.gcd.degree?.getD 0 ∧ replay.check cert.gcd = true
+
+/-- Check the divisibility and scaled Bezout identities against the external
+atom and carrier polynomials. -/
+@[expose]
+def check (atom carrier : ZPoly) (cert : CommonRootCert) : Bool :=
+  decide (cert.scale ≠ 0) &&
+  DensePoly.beqCoeffs atom (cert.gcd * cert.atomFactor) &&
+  DensePoly.beqCoeffs carrier (cert.gcd * cert.carrierFactor) &&
+  DensePoly.beqCoeffs
+    (cert.atomCoeff * atom + cert.carrierCoeff * carrier)
+    (DensePoly.scale cert.scale cert.gcd) &&
+  cert.checkReplay
+
+/-- Proposition-level facts recovered from the common-root checker. -/
+@[expose]
+def Valid (atom carrier : ZPoly) (cert : CommonRootCert) : Prop :=
+  cert.scale ≠ 0 ∧
+  atom = cert.gcd * cert.atomFactor ∧
+  carrier = cert.gcd * cert.carrierFactor ∧
+  cert.atomCoeff * atom + cert.carrierCoeff * carrier =
+    DensePoly.scale cert.scale cert.gcd ∧
+  cert.ReplayValid
+
+/-- Soundness of the constant/nonconstant replay branch. -/
+theorem checkReplay_sound {cert : CommonRootCert}
+    (h : cert.checkReplay = true) : cert.ReplayValid := by
+  cases hreplay : cert.replay with
+  | none => simpa [checkReplay, ReplayValid, hreplay] using h
+  | some replay => simpa [checkReplay, ReplayValid, hreplay] using h
+
+/-- Soundness of the executable common-root checker. -/
+theorem check_sound {atom carrier : ZPoly} {cert : CommonRootCert}
+    (h : cert.check atom carrier = true) : cert.Valid atom carrier := by
+  simp only [check, Bool.and_eq_true, decide_eq_true_eq] at h
+  obtain ⟨⟨⟨⟨hscale, hatom⟩, hcarrier⟩, hbezout⟩, hreplay⟩ := h
+  exact ⟨hscale, DensePoly.eq_of_beqCoeffs hatom,
+    DensePoly.eq_of_beqCoeffs hcarrier,
+    DensePoly.eq_of_beqCoeffs hbezout, checkReplay_sound hreplay⟩
+
+/-- A checked common-root polynomial is nonzero in both certificate branches. -/
+theorem gcd_ne_zero {atom carrier : ZPoly} {cert : CommonRootCert}
+    (h : cert.check atom carrier = true) : cert.gcd ≠ 0 := by
+  have hvalid := (check_sound h).2.2.2.2
+  cases hreplay : cert.replay with
+  | none =>
+      simp only [ReplayValid, hreplay] at hvalid
+      intro hzero
+      rw [hzero] at hvalid
+      simp at hvalid
+  | some replay =>
+      simp only [ReplayValid, hreplay] at hvalid
+      exact SturmReplay.head_ne_zero hvalid.2
+
+/-- Recover the checked replay in the nonconstant certificate branch. -/
+theorem replay_of_check {atom carrier : ZPoly} {cert : CommonRootCert}
+    {replay : SturmReplay} (h : cert.check atom carrier = true)
+    (hreplay : cert.replay = some replay) : replay.check cert.gcd = true := by
+  have hvalid := (check_sound h).2.2.2.2
+  simp only [ReplayValid, hreplay] at hvalid
+  exact hvalid.2
+
+/-- Decide whether the cached common-root polynomial has a root in an
+interval. The constant branch is root-free; the nonconstant branch reads its
+shared generalized Sturm replay. -/
+@[expose]
+def hasRoot (cert : CommonRootCert) (I : DyadicInterval) : Bool :=
+  match cert.replay with
+  | none => false
+  | some replay => decide (replay.count I = 1)
+
+end CommonRootCert
+
+end Hex.RCF

--- a/HexRCF/IsolationCheck.lean
+++ b/HexRCF/IsolationCheck.lean
@@ -1,0 +1,131 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.SturmCheck
+
+public section
+
+/-!
+# Generalized literal isolation checks
+
+An isolation certificate stores only raw dyadic intervals. Its Boolean checker
+reads root counts from an independently validated `SturmReplay`, checks one
+root per interval, adjacent ordering, and completeness. Mathlib-facing literal
+isolation and real-root semantics live in `HexRCF.Isolations`.
+-/
+
+namespace Hex.RCF
+
+/-- Raw intervals proposed as an ordered, complete isolation of the roots of
+the head polynomial of a generalized Sturm replay. -/
+structure IsolationCert where
+  /-- Proposed half-open root intervals in ascending order. -/
+  intervals : Array DyadicInterval
+
+namespace IsolationCert
+
+/-- Check that every supplied interval has literal replay count one. -/
+@[expose]
+def checkCounts (replay : SturmReplay) (cert : IsolationCert) : Bool :=
+  (List.range cert.intervals.size).all fun i =>
+    if h : i < cert.intervals.size then
+      decide (replay.count (cert.intervals[i]'h) = 1)
+    else false
+
+/-- Check the emitted order in linear time using only adjacent pairs. This is
+intentionally non-strict for half-open isolations; strict gaps are checked by
+the later cell-separation certificate. -/
+@[expose]
+def checkOrder (cert : IsolationCert) : Bool :=
+  (List.range (cert.intervals.size - 1)).all fun i =>
+    if h : i + 1 < cert.intervals.size then
+      decide ((cert.intervals[i]'(by omega)).upper ≤
+        (cert.intervals[i + 1]'h).lower)
+    else false
+
+/-- Validate literal interval counts, ordering, and total completeness. Replay
+validation is a separate premise so an outer checker need not reduce it twice. -/
+@[expose]
+def check (replay : SturmReplay) (cert : IsolationCert) : Bool :=
+  cert.checkCounts replay && cert.checkOrder &&
+    decide (replay.total = (cert.intervals.size : Int))
+
+/-- Every interval accepted by the count walk has literal count one. -/
+theorem count_one_of_check {replay : SturmReplay} {cert : IsolationCert}
+    (h : cert.checkCounts replay = true) (i : Fin cert.intervals.size) :
+    replay.count cert.intervals[i] = 1 := by
+  have hmem : i.val ∈ List.range cert.intervals.size := List.mem_range.mpr i.isLt
+  have hcount := (List.all_eq_true.mp h) i.val hmem
+  simp only [i.isLt, dif_pos] at hcount
+  exact of_decide_eq_true hcount
+
+/-- Each adjacent interval pair accepted by the order walk is separated in the
+non-strict half-open sense. -/
+theorem adjacent_of_check {cert : IsolationCert} (h : cert.checkOrder = true)
+    (i : Nat) (hi : i + 1 < cert.intervals.size) :
+    (cert.intervals[i]'(by omega)).upper ≤
+      (cert.intervals[i + 1]'hi).lower := by
+  have hmem : i ∈ List.range (cert.intervals.size - 1) := List.mem_range.mpr (by omega)
+  have hstep := (List.all_eq_true.mp h) i hmem
+  simp only [hi, dif_pos] at hstep
+  exact of_decide_eq_true hstep
+
+/-- `Dyadic` version of `le_of_lt`, derived from the core total order API. -/
+private theorem dyadic_le_of_lt {a b : Dyadic} (h : a < b) : a ≤ b := by
+  rcases Dyadic.le_total a b with hle | hle
+  · exact hle
+  · exact absurd h (Dyadic.not_le.mpr hle)
+
+/-- Adjacent ordering implies the all-pairs ordering used by the semantic
+literal-isolation layer. -/
+theorem ordered_of_check {cert : IsolationCert} (h : cert.checkOrder = true) :
+    ∀ i j : Fin cert.intervals.size, i < j →
+      cert.intervals[i].upper ≤ cert.intervals[j].lower := by
+  have aux : ∀ (j : Nat) (hj : j < cert.intervals.size) (i : Nat) (_hij : i < j),
+      (cert.intervals[i]'(by omega)).upper ≤ (cert.intervals[j]'hj).lower := by
+    intro j
+    induction j with
+    | zero => intro _ i hij; omega
+    | succ j ih =>
+        intro hj i hij
+        rcases Nat.lt_or_ge i j with hlt | hge
+        · have hjlt : j < cert.intervals.size := by omega
+          have step1 := ih hjlt i hlt
+          have step2 : (cert.intervals[j]'hjlt).lower ≤
+              (cert.intervals[j]'hjlt).upper :=
+            dyadic_le_of_lt (cert.intervals[j]'hjlt).lt
+          have step3 := adjacent_of_check h j (by omega)
+          exact Dyadic.le_trans step1 (Dyadic.le_trans step2 step3)
+        · have hij' : i = j := by omega
+          subst hij'
+          exact adjacent_of_check h i (by omega)
+  intro i j hij
+  exact aux j.val j.isLt i.val hij
+
+/-- The completeness equality recovered from the Boolean isolation checker. -/
+theorem complete_of_check {replay : SturmReplay} {cert : IsolationCert}
+    (h : cert.check replay = true) :
+    replay.total = (cert.intervals.size : Int) := by
+  simp only [check, Bool.and_eq_true, decide_eq_true_eq] at h
+  exact h.2
+
+/-- The count component recovered from the combined checker. -/
+theorem counts_of_check {replay : SturmReplay} {cert : IsolationCert}
+    (h : cert.check replay = true) : cert.checkCounts replay = true := by
+  simp only [check, Bool.and_eq_true] at h
+  exact h.1.1
+
+/-- The order component recovered from the combined checker. -/
+theorem order_of_check {replay : SturmReplay} {cert : IsolationCert}
+    (h : cert.check replay = true) : cert.checkOrder = true := by
+  simp only [check, Bool.and_eq_true] at h
+  exact h.1.2
+
+end IsolationCert
+
+end Hex.RCF

--- a/HexRCF/Isolations.lean
+++ b/HexRCF/Isolations.lean
@@ -6,130 +6,26 @@ Authors: Kim Morrison
 
 module
 
+public import HexRCF.IsolationCheck
 public import HexRCF.SturmReplay
 public import HexRealRootsMathlib.LiteralIsolations
 
 public section
 
 /-!
-# Generalized literal isolations for RCF replay certificates
+# Semantics of generalized literal isolations
 
-An isolation certificate stores only raw dyadic intervals.  Its Boolean
-checker reads root counts from an independently validated `SturmReplay`, checks
-one root per interval, adjacent ordering, and completeness.  Soundness packages
-the raw intervals into `LiteralIsolations` and applies the generic semantic
-isolation theorem; it never identifies the replay with the executable
-pseudo-remainder chain.
+The Mathlib-free certificate and checker live in `HexRCF.IsolationCheck`.
+Soundness packages accepted raw intervals into `LiteralIsolations` and applies
+the generic semantic isolation theorem; it never identifies the replay with
+the executable pseudo-remainder chain.
 -/
 
 namespace Hex.RCF
 
 open HexRealRootsMathlib
 
-/-- Raw intervals proposed as an ordered, complete isolation of the roots of
-the head polynomial of a generalized Sturm replay. -/
-structure IsolationCert where
-  /-- Proposed half-open root intervals in ascending order. -/
-  intervals : Array DyadicInterval
-
 namespace IsolationCert
-
-/-- Check that every supplied interval has literal replay count one. -/
-@[expose]
-def checkCounts (replay : SturmReplay) (cert : IsolationCert) : Bool :=
-  (List.range cert.intervals.size).all fun i =>
-    if h : i < cert.intervals.size then
-      decide (replay.count (cert.intervals[i]'h) = 1)
-    else false
-
-/-- Check the emitted order in linear time using only adjacent pairs.  This is
-intentionally non-strict for half-open isolations; strict gaps are checked by
-the later cell-separation certificate. -/
-@[expose]
-def checkOrder (cert : IsolationCert) : Bool :=
-  (List.range (cert.intervals.size - 1)).all fun i =>
-    if h : i + 1 < cert.intervals.size then
-      decide ((cert.intervals[i]'(by omega)).upper ≤
-        (cert.intervals[i + 1]'h).lower)
-    else false
-
-/-- Validate literal interval counts, ordering, and total completeness.  Replay
-validation is a separate premise so an outer checker need not reduce it twice. -/
-@[expose]
-def check (replay : SturmReplay) (cert : IsolationCert) : Bool :=
-  cert.checkCounts replay && cert.checkOrder &&
-    decide (replay.total = (cert.intervals.size : Int))
-
-/-- Every interval accepted by the count walk has literal count one. -/
-theorem count_one_of_check {replay : SturmReplay} {cert : IsolationCert}
-    (h : cert.checkCounts replay = true) (i : Fin cert.intervals.size) :
-    replay.count cert.intervals[i] = 1 := by
-  have hmem : i.val ∈ List.range cert.intervals.size := List.mem_range.mpr i.isLt
-  have hcount := (List.all_eq_true.mp h) i.val hmem
-  simp only [i.isLt, dif_pos] at hcount
-  exact of_decide_eq_true hcount
-
-/-- Each adjacent interval pair accepted by the order walk is separated in the
-non-strict half-open sense. -/
-theorem adjacent_of_check {cert : IsolationCert} (h : cert.checkOrder = true)
-    (i : Nat) (hi : i + 1 < cert.intervals.size) :
-    (cert.intervals[i]'(by omega)).upper ≤
-      (cert.intervals[i + 1]'hi).lower := by
-  have hmem : i ∈ List.range (cert.intervals.size - 1) := List.mem_range.mpr (by omega)
-  have hstep := (List.all_eq_true.mp h) i hmem
-  simp only [hi, dif_pos] at hstep
-  exact of_decide_eq_true hstep
-
-/-- `Dyadic` version of `le_of_lt`, derived from the core total order API. -/
-private theorem dyadic_le_of_lt {a b : Dyadic} (h : a < b) : a ≤ b := by
-  rcases Dyadic.le_total a b with hle | hle
-  · exact hle
-  · exact absurd h (Dyadic.not_le.mpr hle)
-
-/-- Adjacent ordering implies the all-pairs ordering used by
-`LiteralIsolations`. -/
-theorem ordered_of_check {cert : IsolationCert} (h : cert.checkOrder = true) :
-    ∀ i j : Fin cert.intervals.size, i < j →
-      cert.intervals[i].upper ≤ cert.intervals[j].lower := by
-  have aux : ∀ (j : Nat) (hj : j < cert.intervals.size) (i : Nat) (_hij : i < j),
-      (cert.intervals[i]'(by omega)).upper ≤ (cert.intervals[j]'hj).lower := by
-    intro j
-    induction j with
-    | zero => intro _ i hij; omega
-    | succ j ih =>
-        intro hj i hij
-        rcases Nat.lt_or_ge i j with hlt | hge
-        · have hjlt : j < cert.intervals.size := by omega
-          have step1 := ih hjlt i hlt
-          have step2 : (cert.intervals[j]'hjlt).lower ≤
-              (cert.intervals[j]'hjlt).upper :=
-            dyadic_le_of_lt (cert.intervals[j]'hjlt).lt
-          have step3 := adjacent_of_check h j (by omega)
-          exact Dyadic.le_trans step1 (Dyadic.le_trans step2 step3)
-        · have hij' : i = j := by omega
-          subst hij'
-          exact adjacent_of_check h i (by omega)
-  intro i j hij
-  exact aux j.val j.isLt i.val hij
-
-/-- The completeness equality recovered from the Boolean isolation checker. -/
-theorem complete_of_check {replay : SturmReplay} {cert : IsolationCert}
-    (h : cert.check replay = true) :
-    replay.total = (cert.intervals.size : Int) := by
-  simp only [check, Bool.and_eq_true, decide_eq_true_eq] at h
-  exact h.2
-
-/-- The count component recovered from the combined checker. -/
-theorem counts_of_check {replay : SturmReplay} {cert : IsolationCert}
-    (h : cert.check replay = true) : cert.checkCounts replay = true := by
-  simp only [check, Bool.and_eq_true] at h
-  exact h.1.1
-
-/-- The order component recovered from the combined checker. -/
-theorem order_of_check {replay : SturmReplay} {cert : IsolationCert}
-    (h : cert.check replay = true) : cert.checkOrder = true := by
-  simp only [check, Bool.and_eq_true] at h
-  exact h.1.2
 
 /-- Package an accepted raw certificate into the generic literal-isolation
 interface. -/

--- a/HexRCF/SturmBuilder.lean
+++ b/HexRCF/SturmBuilder.lean
@@ -6,7 +6,7 @@ Authors: Kim Morrison
 
 module
 
-public import HexRCF.SturmReplay
+public import HexRCF.SturmCheck
 public import HexRealRoots.Chain
 public import HexPolyZ.Core
 

--- a/HexRCF/SturmBuilderTests.lean
+++ b/HexRCF/SturmBuilderTests.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexRCF.SturmBuilder
+public import HexRCF.SturmReplay
 import all HexRCF.SturmBuilder
 
 public section

--- a/HexRCF/SturmCheck.lean
+++ b/HexRCF/SturmCheck.lean
@@ -1,0 +1,164 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRealRoots.Var
+
+public section
+
+/-!
+# Multiplication-only Sturm replay checks
+
+An RCF certificate supplies a literal integer-polynomial chain together with
+positive three-term recurrence scales. The executable checker in this file
+uses only coefficient equality, integer arithmetic, and linear walks over the
+literal arrays. The Mathlib-facing soundness theorems live in
+`HexRCF.SturmReplay`.
+-/
+
+namespace Hex.RCF
+
+/-- One positive three-term recurrence in a generalized Sturm replay. -/
+structure SturmStep where
+  /-- Positive scale on the polynomial two positions before the new term. -/
+  leftScale : Int
+  /-- Quotient multiplying the preceding polynomial. -/
+  quotient : ZPoly
+  /-- Positive scale on the new polynomial. -/
+  rightScale : Int
+
+/-- A literal generalized Sturm chain and its multiplication-only replay. -/
+structure SturmReplay where
+  /-- The chain `[f, s₁, …, sₙ]`. -/
+  chain : Array ZPoly
+  /-- Positive integer `δ` satisfying `f' = δ s₁`. -/
+  derivScale : Int
+  /-- The three-term identities for consecutive chain triples. -/
+  steps : Array SturmStep
+
+namespace SturmReplay
+
+/-- Boolean validation of a supplied positive three-term identity. -/
+@[expose]
+def checkStep (a b c : ZPoly) (step : SturmStep) : Bool :=
+  decide (0 < step.leftScale) &&
+  decide (0 < step.rightScale) &&
+  DensePoly.beqCoeffs (DensePoly.scale step.leftScale a)
+    (step.quotient * b - DensePoly.scale step.rightScale c)
+
+/-- Validate recurrence steps and the terminal nonzero constant. -/
+@[expose]
+def checkSteps : ZPoly → ZPoly → List ZPoly → List SturmStep → Bool
+  | _, b, [], [] => decide (b.size = 1)
+  | a, b, c :: rest, step :: steps =>
+      checkStep a b c step && checkSteps b c rest steps
+  | _, _, _, _ => false
+
+/-- Every literal polynomial in a chain is nonzero. -/
+@[expose]
+def checkNonzero : List ZPoly → Bool
+  | [] => true
+  | p :: rest => !p.isZero && checkNonzero rest
+
+/-- Consecutive literal chain degrees strictly decrease. -/
+@[expose]
+def checkDegrees : List ZPoly → Bool
+  | a :: b :: rest =>
+      decide (b.degree?.getD 0 < a.degree?.getD 0) && checkDegrees (b :: rest)
+  | _ => true
+
+/-- Executable generalized Sturm replay checker.
+
+All polynomial comparisons use `DensePoly.beqCoeffs`, avoiding structural
+array equality during kernel reduction. Nonzero checking before strict degree
+descent makes `degree?.getD 0` unambiguous and implies that an accepted head
+has positive degree. Degree descent is retained as an explicit certificate
+invariant even though the abstract `IsSturmChain` consequence does not need
+it. -/
+@[expose]
+def check (f : ZPoly) (cert : SturmReplay) : Bool :=
+  match cert.chain.toList with
+  | a :: s₁ :: rest =>
+      decide (2 ≤ cert.chain.size) &&
+      DensePoly.beqCoeffs a f &&
+      checkNonzero (a :: s₁ :: rest) &&
+      checkDegrees (a :: s₁ :: rest) &&
+      decide (cert.steps.size + 2 = cert.chain.size) &&
+      decide (0 < cert.derivScale) &&
+      DensePoly.beqCoeffs (DensePoly.derivative f)
+        (DensePoly.scale cert.derivScale s₁) &&
+      checkSteps a s₁ rest cert.steps.toList
+  | _ => false
+
+/-- Literal Sturm variation drop across the dyadic interval
+`(I.lower, I.upper]`. -/
+@[expose]
+def count (cert : SturmReplay) (I : DyadicInterval) : Int :=
+  (Hex.sturmVarAt cert.chain I.lower : Int) - Hex.sturmVarAt cert.chain I.upper
+
+/-- Literal Sturm variation drop from negative to positive infinity. -/
+@[expose]
+def total (cert : SturmReplay) : Int :=
+  (Hex.sturmVarNegInf cert.chain : Int) - Hex.sturmVarPosInf cert.chain
+
+/-- Proposition-level adjacent degree descent mirrored by `checkDegrees`. -/
+@[expose]
+def DegreesDescend : List ZPoly → Prop
+  | a :: b :: rest =>
+      b.degree?.getD 0 < a.degree?.getD 0 ∧ DegreesDescend (b :: rest)
+  | _ => True
+
+/-- A successful nonzero walk proves every chain entry nonzero. -/
+theorem checkNonzero_sound {chain : List ZPoly}
+    (h : checkNonzero chain = true) : ∀ q ∈ chain, q ≠ 0 := by
+  induction chain with
+  | nil => simp
+  | cons p rest ih =>
+      simp only [checkNonzero, Bool.and_eq_true, Bool.not_eq_true'] at h
+      obtain ⟨hp, hrest⟩ := h
+      have hp0 : p ≠ 0 := by
+        have hpos := (DensePoly.isZero_eq_false_iff p).mp hp
+        intro hzero
+        subst p
+        simp at hpos
+      intro q hq
+      simp only [List.mem_cons] at hq
+      rcases hq with rfl | hq
+      · exact hp0
+      · exact ih hrest q hq
+
+/-- A successful degree walk proves proposition-level adjacent descent. -/
+theorem checkDegrees_sound {chain : List ZPoly}
+    (h : checkDegrees chain = true) : DegreesDescend chain := by
+  induction chain with
+  | nil => trivial
+  | cons a rest ih =>
+      cases rest with
+      | nil => trivial
+      | cons b rest =>
+          simp only [checkDegrees, Bool.and_eq_true, decide_eq_true_eq] at h
+          exact ⟨h.1, ih h.2⟩
+
+/-- The head of an accepted replay is nonzero. -/
+theorem head_ne_zero {f : ZPoly} {cert : SturmReplay}
+    (h : cert.check f = true) : f ≠ 0 := by
+  unfold check at h
+  match hm : cert.chain.toList with
+  | [] => rw [hm] at h; simp at h
+  | [_] => rw [hm] at h; simp at h
+  | a :: s₁ :: rest =>
+      rw [hm] at h
+      simp only [Bool.and_eq_true] at h
+      obtain ⟨⟨⟨⟨⟨⟨⟨_hsize, hhead⟩, hnz⟩, _hdegrees⟩, _hcount⟩,
+        _hderivPos⟩, _hderiv⟩, _hsteps⟩ := h
+      have ha : a = f := DensePoly.eq_of_beqCoeffs hhead
+      subst a
+      exact checkNonzero_sound hnz f (by simp)
+
+end SturmReplay
+
+end Hex.RCF

--- a/HexRCF/SturmReplay.lean
+++ b/HexRCF/SturmReplay.lean
@@ -6,112 +6,22 @@ Authors: Kim Morrison
 
 module
 
+public import HexRCF.SturmCheck
 public import HexRealRootsMathlib.LiteralChain
 
 public section
 
 /-!
-# Multiplication-only Sturm replay certificates
+# Soundness of multiplication-only Sturm replay certificates
 
-An RCF certificate supplies a literal integer-polynomial chain together with
-positive three-term recurrence scales. The executable checker in this file
-uses only coefficient equality, integer arithmetic, and linear walks over the
-literal arrays. Its soundness theorem packages the accepted data as
+The Mathlib-free data and executable checker live in `HexRCF.SturmCheck`.
+The theorems in this file package accepted data as
 `HexRealRootsMathlib.ZReplay`, ready for the literal Sturm count theorems.
 -/
 
 namespace Hex.RCF
 
-/-- One positive three-term recurrence in a generalized Sturm replay. -/
-structure SturmStep where
-  /-- Positive scale on the polynomial two positions before the new term. -/
-  leftScale : Int
-  /-- Quotient multiplying the preceding polynomial. -/
-  quotient : ZPoly
-  /-- Positive scale on the new polynomial. -/
-  rightScale : Int
-
-/-- A literal generalized Sturm chain and its multiplication-only replay. -/
-structure SturmReplay where
-  /-- The chain `[f, s₁, …, sₙ]`. -/
-  chain : Array ZPoly
-  /-- Positive integer `δ` satisfying `f' = δ s₁`. -/
-  derivScale : Int
-  /-- The three-term identities for consecutive chain triples. -/
-  steps : Array SturmStep
-
 namespace SturmReplay
-
-/-- Boolean validation of a supplied positive three-term identity. -/
-@[expose]
-def checkStep (a b c : ZPoly) (step : SturmStep) : Bool :=
-  decide (0 < step.leftScale) &&
-  decide (0 < step.rightScale) &&
-  DensePoly.beqCoeffs (DensePoly.scale step.leftScale a)
-    (step.quotient * b - DensePoly.scale step.rightScale c)
-
-/-- Validate recurrence steps and the terminal nonzero constant. Its recursive
-shape matches `HexRealRootsMathlib.ZReplay`. -/
-@[expose]
-def checkSteps : ZPoly → ZPoly → List ZPoly → List SturmStep → Bool
-  | _, b, [], [] => decide (b.size = 1)
-  | a, b, c :: rest, step :: steps =>
-      checkStep a b c step && checkSteps b c rest steps
-  | _, _, _, _ => false
-
-/-- Every literal polynomial in a chain is nonzero. -/
-@[expose]
-def checkNonzero : List ZPoly → Bool
-  | [] => true
-  | p :: rest => !p.isZero && checkNonzero rest
-
-/-- Consecutive literal chain degrees strictly decrease. -/
-@[expose]
-def checkDegrees : List ZPoly → Bool
-  | a :: b :: rest =>
-      decide (b.degree?.getD 0 < a.degree?.getD 0) && checkDegrees (b :: rest)
-  | _ => true
-
-/-- Executable generalized Sturm replay checker.
-
-All polynomial comparisons use `DensePoly.beqCoeffs`, avoiding structural
-array equality during kernel reduction. Nonzero checking before strict degree
-descent makes `degree?.getD 0` unambiguous and implies that an accepted head
-has positive degree. Degree descent is retained as an explicit certificate
-invariant even though the abstract `IsSturmChain` consequence does not need
-it. -/
-@[expose]
-def check (f : ZPoly) (cert : SturmReplay) : Bool :=
-  match cert.chain.toList with
-  | a :: s₁ :: rest =>
-      decide (2 ≤ cert.chain.size) &&
-      DensePoly.beqCoeffs a f &&
-      checkNonzero (a :: s₁ :: rest) &&
-      checkDegrees (a :: s₁ :: rest) &&
-      decide (cert.steps.size + 2 = cert.chain.size) &&
-      decide (0 < cert.derivScale) &&
-      DensePoly.beqCoeffs (DensePoly.derivative f)
-        (DensePoly.scale cert.derivScale s₁) &&
-      checkSteps a s₁ rest cert.steps.toList
-  | _ => false
-
-/-- Literal Sturm variation drop across the dyadic interval
-`(I.lower, I.upper]`. -/
-@[expose]
-def count (cert : SturmReplay) (I : DyadicInterval) : Int :=
-  (Hex.sturmVarAt cert.chain I.lower : Int) - Hex.sturmVarAt cert.chain I.upper
-
-/-- Literal Sturm variation drop from negative to positive infinity. -/
-@[expose]
-def total (cert : SturmReplay) : Int :=
-  (Hex.sturmVarNegInf cert.chain : Int) - Hex.sturmVarPosInf cert.chain
-
-/-- Proposition-level adjacent degree descent mirrored by `checkDegrees`. -/
-@[expose]
-def DegreesDescend : List ZPoly → Prop
-  | a :: b :: rest =>
-      b.degree?.getD 0 < a.degree?.getD 0 ∧ DegreesDescend (b :: rest)
-  | _ => True
 
 /-- Kernel-facing consequences of an accepted generalized Sturm replay. The
 existential form keeps this a proposition while exposing the literal list
@@ -126,37 +36,6 @@ def Valid (f : ZPoly) (cert : SturmReplay) : Prop :=
             0 < cert.derivScale ∧
               DensePoly.derivative f = DensePoly.scale cert.derivScale s₁ ∧
                 cert.steps.size + 2 = cert.chain.size
-
-/-- A successful nonzero walk proves every chain entry nonzero. -/
-theorem checkNonzero_sound {chain : List ZPoly}
-    (h : checkNonzero chain = true) : ∀ q ∈ chain, q ≠ 0 := by
-  induction chain with
-  | nil => simp
-  | cons p rest ih =>
-      simp only [checkNonzero, Bool.and_eq_true, Bool.not_eq_true'] at h
-      obtain ⟨hp, hrest⟩ := h
-      have hp0 : p ≠ 0 := by
-        have hpos := (DensePoly.isZero_eq_false_iff p).mp hp
-        intro hzero
-        subst p
-        simp at hpos
-      intro q hq
-      simp only [List.mem_cons] at hq
-      rcases hq with rfl | hq
-      · exact hp0
-      · exact ih hrest q hq
-
-/-- A successful degree walk proves proposition-level adjacent descent. -/
-theorem checkDegrees_sound {chain : List ZPoly}
-    (h : checkDegrees chain = true) : DegreesDescend chain := by
-  induction chain with
-  | nil => trivial
-  | cons a rest ih =>
-      cases rest with
-      | nil => trivial
-      | cons b rest =>
-          simp only [checkDegrees, Bool.and_eq_true, decide_eq_true_eq] at h
-          exact ⟨h.1, ih h.2⟩
 
 /-- A successful identity check supplies the existential recurrence expected
 by `HexRealRootsMathlib.ZReplay`. -/
@@ -203,13 +82,6 @@ theorem check_sound {f : ZPoly} {cert : SturmReplay}
       · exact checkNonzero_sound hnz
       · exact checkDegrees_sound hdegrees
       · exact DensePoly.eq_of_beqCoeffs hderiv
-
-/-- The head of an accepted replay is nonzero. -/
-theorem head_ne_zero {f : ZPoly} {cert : SturmReplay}
-    (h : cert.check f = true) : f ≠ 0 := by
-  obtain ⟨s₁, rest, _hchain, _hrep, hnz, _hdegrees, _hpos, _hderiv, _hcount⟩ :=
-    check_sound h
-  exact hnz f (by simp)
 
 /-- An accepted replay is a Sturm chain after casting its literal entries to
 real polynomials. -/

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -585,8 +585,10 @@ free to change.
   their structural polynomial traversals; `HexRCF/Language.lean`: real-valued
   `toProp` semantics;
   `HexRCF/LanguageTests.lean`: executable language-semantics tests.
-- `HexRCF/SturmReplay.lean`: generalized multiplication-only chain
-  replay and literal root counts.
+- `HexRCF/SturmCheck.lean`: Mathlib-free generalized multiplication-only
+  replay data, executable validation, and literal root counts;
+  `HexRCF/SturmReplay.lean`: Mathlib-facing replay soundness and root-count
+  correspondence.
 - `HexRCF/SturmBuilder.lean`: compiled pseudo-remainder instrumentation that
   emits replay witnesses and retains only checker-approved candidates;
   `HexRCF/SturmBuilderTests.lean`: valid, malformed, nonprimitive, and

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -593,8 +593,9 @@ free to change.
   emits replay witnesses and retains only checker-approved candidates;
   `HexRCF/SturmBuilderTests.lean`: valid, malformed, nonprimitive, and
   nonsquarefree regressions.
-- `HexRCF/Carrier.lean`: deterministic nonconstant-atom collection, the
-  multiplication-checkable carrier certificate, and root-set soundness;
+- `HexRCF/CarrierCheck.lean`: Mathlib-free multiplication-checkable carrier
+  certificates and Boolean validation; `HexRCF/Carrier.lean`: squarefreeness
+  and root-set soundness;
   `HexRCF/CarrierTests.lean`: constant filtering, genuine repeated-factor,
   dropped-root, and other tampered-carrier regressions.
 - `HexRCF/Isolations.lean`: the raw generalized isolation checker and its

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -625,10 +625,11 @@ free to change.
   `HexRCF/CellsTests.lean`: enumeration,
   zero/singleton/multiple-root samples, endpoint equality/order guards,
   relevance tables, and malformed lower/upper claim regressions.
-- `HexRCF/CommonRoot.lean`: multiplication-checkable common-root packages,
-  constant/nonconstant replay branches, exact common-root semantics, and
-  cached root-cell queries; `HexRCF/CommonRootTests.lean`: shared-factor,
-  coprime, equal-polynomial, and tampered-evidence regressions.
+- `HexRCF/CommonRootCheck.lean`: Mathlib-free multiplication-checkable
+  common-root packages, replay branches, and cached interval queries;
+  `HexRCF/CommonRoot.lean`: exact common-root and root-cell semantics;
+  `HexRCF/CommonRootTests.lean`: shared-factor, coprime, equal-polynomial, and
+  tampered-evidence regressions.
 - `HexRCF/SignMatrix.lean`: three-way exact signs, coefficient-equality
   atom deduplication and common-package alignment, guarded open-cell
   evaluation, the `gⱼ` root-cell computation, and full Boolean reflection;

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -598,9 +598,11 @@ free to change.
   and root-set soundness;
   `HexRCF/CarrierTests.lean`: constant filtering, genuine repeated-factor,
   dropped-root, and other tampered-carrier regressions.
-- `HexRCF/Isolations.lean`: the raw generalized isolation checker and its
-  bridge to literal isolation semantics; `HexRCF/IsolationsTests.lean`:
-  count, order, completeness, and no-real-root regressions.
+- `HexRCF/IsolationCheck.lean`: Mathlib-free raw generalized isolation data,
+  checks, and ordering/count consequences; `HexRCF/Isolations.lean`: the
+  bridge to literal isolation and real-root semantics;
+  `HexRCF/IsolationsTests.lean`: count, order, completeness, and no-real-root
+  regressions.
 - `HexRCF/Certificate.lean`: strict option folds, the four `Certificate`
   branches, three-valued replay, and `check`; `HexRCF/CertificateTests.lean`:
   all quantifiers, empty/reversed domains, constants, zero/single/multiple-root

--- a/progress/20260727T151952Z_rcf-sturm-check.md
+++ b/progress/20260727T151952Z_rcf-sturm-check.md
@@ -1,0 +1,36 @@
+# Mathlib-free RCF Sturm replay checks
+
+## Accomplished
+
+- Added `HexRCF.SturmCheck`, containing the generalized replay data,
+  executable validation, literal root counts, pure degree/nonzero consequences,
+  and the accepted-head nonzero theorem.
+- Reduced `HexRCF.SturmReplay` to the Mathlib-facing replay, Sturm-chain,
+  squarefreeness, and root-count correspondence layer while preserving every
+  existing qualified declaration name through a public import.
+- Made the compiled `SturmBuilder` consume `SturmCheck` directly. Its semantic
+  tests now import `SturmReplay` explicitly instead of relying on the old
+  transitive dependency.
+- Updated the HexRCF umbrella and SPEC file map.
+- Verified full HexRCF builds and mechanically checked that the repository-local
+  closures of `HexRCF.SturmCheck` and `HexRCF.SturmBuilder` contain neither
+  `Mathlib.*` nor `HexRealRootsMathlib.*`. DAG, Phase-4, release-manifest,
+  trust-surface, copyright, diff, and banned-token checks pass. An independent
+  Sol review returned GO.
+
+## Current frontier
+
+Issue #8987 is implemented on a branch stacked above the syntax-seam PR #8983.
+The extraction exposes the first nontrivial executable RCF certificate builder
+with a genuinely Mathlib-free import closure.
+
+## Next step
+
+Publish the stacked PR, then split the carrier certificate data and Boolean
+checker from its real-root semantic proofs so compiled carrier construction can
+depend on the pure syntax and replay-check modules.
+
+## Blockers
+
+None for this extraction. The parent syntax PR is still completing CI, so this
+PR should remain stacked until #8983 merges and can then be rebased onto main.

--- a/progress/20260727T152625Z_rcf-carrier-check.md
+++ b/progress/20260727T152625Z_rcf-carrier-check.md
@@ -1,0 +1,36 @@
+# Mathlib-free RCF carrier checks
+
+## Accomplished
+
+- Added `HexRCF.CarrierCheck`, containing the carrier certificate data,
+  Boolean validation, proposition-level checker consequences, and the pure
+  carrier/product nonzero theorems.
+- Reduced `HexRCF.Carrier` to real-polynomial squarefreeness and root-set
+  semantics while preserving all qualified declaration names through a public
+  import.
+- Narrowed `HexRCF.Builder`'s direct carrier dependency to `CarrierCheck`;
+  its remaining Mathlib closure comes through the still-combined common-root
+  and sign-matrix layers.
+- Updated the HexRCF umbrella and SPEC file map.
+- Verified targeted and full HexRCF builds and mechanically checked the
+  31-module `HexRCF.CarrierCheck` closure contains neither `Mathlib.*` nor
+  `HexRealRootsMathlib.*`. DAG, Phase-4, release-manifest, trust-surface,
+  copyright, diff, and banned-token checks pass. An independent Sol review
+  returned GO.
+
+## Current frontier
+
+Issue #8990 is implemented on a branch stacked above the Sturm-check PR #8988.
+The pure syntax, replay checker/builder, and carrier checker now form a
+source-compatible Mathlib-free certificate prefix.
+
+## Next step
+
+Publish the stacked PR, then extract common-root certificate validation and
+its cached interval query from `HexRCF.CommonRoot` so compiled arithmetic
+preparation can depend on another pure checker seam.
+
+## Blockers
+
+None for this extraction. The branch remains stacked until #8988 and its
+syntax parent #8983 merge; it can then be rebased and retargeted to main.

--- a/progress/20260727T153139Z_rcf-common-root-check.md
+++ b/progress/20260727T153139Z_rcf-common-root-check.md
@@ -1,0 +1,36 @@
+# Mathlib-free RCF common-root checks
+
+## Accomplished
+
+- Added `HexRCF.CommonRootCheck`, containing common-root certificate data,
+  replay/divisibility/Bezout validation, proposition-level checker
+  consequences, nonzero and replay recovery, and the executable cached
+  interval query.
+- Reduced `HexRCF.CommonRoot` to real-root, isolation, and root-cell semantics
+  while preserving all qualified declaration names through a public import.
+- Narrowed `HexRCF.Builder`'s direct common-root dependency to
+  `CommonRootCheck`; its remaining Mathlib closure comes through the
+  still-combined sign-matrix layer.
+- Updated the HexRCF umbrella and SPEC file map.
+- Verified targeted consumers and the full HexRCF build and mechanically
+  checked the 30-module `HexRCF.CommonRootCheck` closure contains neither
+  `Mathlib.*` nor `HexRealRootsMathlib.*`. DAG, Phase-4, release-manifest,
+  trust-surface, copyright, diff, and banned-token checks pass. An independent
+  Sol review returned GO.
+
+## Current frontier
+
+Issue #8993 is implemented on a branch stacked above the carrier-check PR
+#8991. Syntax, replay, carrier, and common-root validation now have explicit
+Mathlib-free module boundaries.
+
+## Next step
+
+Publish the stacked PR, then extract the raw isolation certificate checks and
+their pure ordering/count consequences from `HexRCF.Isolations` as the next
+dependency needed by a pure sign-matrix/certificate replay path.
+
+## Blockers
+
+None for this extraction. The branch remains stacked until the syntax, Sturm,
+and carrier parents merge; it can then be rebased and retargeted to main.

--- a/progress/20260727T153638Z_rcf-isolation-check.md
+++ b/progress/20260727T153638Z_rcf-isolation-check.md
@@ -1,0 +1,36 @@
+# Mathlib-free RCF isolation checks
+
+## Accomplished
+
+- Added `HexRCF.IsolationCheck`, containing raw isolation certificate data,
+  count/order/completeness validation, and the pure adjacent/all-pairs ordering
+  and checker-projection theorems.
+- Reduced `HexRCF.Isolations` to literal-isolation packaging and real-root
+  semantics while preserving all qualified declaration names through a public
+  import.
+- Audited direct consumers: `Separation` and `IsolationsTests` both genuinely
+  use retained semantic declarations, so their imports remain unchanged.
+- Updated the HexRCF umbrella and SPEC file map.
+- Verified focused consumers and the full HexRCF build and mechanically checked
+  the 30-module `HexRCF.IsolationCheck` closure contains neither `Mathlib.*`
+  nor `HexRealRootsMathlib.*`. DAG, Phase-4, release-manifest, trust-surface,
+  copyright, diff, and banned-token checks pass. An independent Sol review
+  returned GO.
+
+## Current frontier
+
+Issue #8995 is implemented on a branch stacked above the common-root-check PR
+#8994. The raw isolation checker is now available to the compiled-core path
+without importing literal real-root semantics.
+
+## Next step
+
+Publish the stacked PR, then split strict-gap checks, endpoint classification,
+and separation builders from their real-root proofs in `HexRCF.Separation`.
+That pure seam is required before executable cell and sign-matrix layers can
+drop their Mathlib dependency.
+
+## Blockers
+
+None for this extraction. The branch remains stacked until its parent chain
+merges; it can then be rebased and retargeted to main.


### PR DESCRIPTION
## Summary

- extract raw isolation certificate data, count/order/completeness checks, and pure consequences into `HexRCF.IsolationCheck`
- retain literal-isolation packaging and real-root semantics in `HexRCF.Isolations` while preserving existing qualified names
- keep semantic consumer imports explicit

Stacked on #8994. Closes #8995. Contributes to #8973.

## Verification

- `lake build HexRCF.IsolationCheck HexRCF.Isolations HexRCF.Separation HexRCF.Cells`
- `lake build HexRCF`
- repository-local import-closure audit: `HexRCF.IsolationCheck` spans 30 modules and contains no `Mathlib.*` or `HexRealRootsMathlib.*` imports
- DAG, Phase-4, release-manifest, published trust-surface, copyright, diff, and banned-token checks
- independent Sol review: GO