### PR TITLE
refactor(rcf): extract Mathlib-free separation checks

### DIFF
--- a/HexRCF.lean
+++ b/HexRCF.lean
@@ -19,6 +19,7 @@ public import HexRCF.CarrierTests
 public import HexRCF.IsolationCheck
 public import HexRCF.Isolations
 public import HexRCF.IsolationsTests
+public import HexRCF.SeparationCheck
 public import HexRCF.Separation
 public import HexRCF.SeparationTests
 public import HexRCF.Cells

--- a/HexRCF/Separation.lean
+++ b/HexRCF/Separation.lean
@@ -6,18 +6,17 @@ Authors: Kim Morrison
 
 module
 
+public import HexRCF.SeparationCheck
 public import HexRCF.Isolations
-public import HexRealRoots.Prec
 
 public section
 
 /-!
-# Strict separation and endpoint order for RCF cells
+# Semantics of strict separation and endpoint order
 
-The untrusted builder in this module bisects touching generalized isolations
-with counts from a cached `SturmReplay`.  Its output is retained only when a
-small checker revalidates all isolation facts and the emitted strict gaps.  The
-kernel checker never evaluates separation bounds or runs refinement.
+The Mathlib-free strict-gap checker, endpoint classifier, and refinement
+builders live in `HexRCF.SeparationCheck`. The theorems in this file connect
+their accepted dyadic data to the corresponding real-root order.
 -/
 
 namespace Hex.RCF
@@ -25,64 +24,6 @@ namespace Hex.RCF
 open HexRealRootsMathlib
 
 namespace IsolationCert
-
-/-- Check strict gaps between every adjacent pair of emitted intervals. -/
-@[expose]
-def checkGaps (cert : IsolationCert) : Bool :=
-  (List.range (cert.intervals.size - 1)).all fun i =>
-    if h : i + 1 < cert.intervals.size then
-      decide ((cert.intervals[i]'(by omega)).upper <
-        (cert.intervals[i + 1]'h).lower)
-    else false
-
-/-- Validate generalized isolation and strict adjacent separation. -/
-@[expose]
-def checkStrict (replay : SturmReplay) (cert : IsolationCert) : Bool :=
-  cert.check replay && cert.checkGaps
-
-/-- Recover the underlying generalized isolation check. -/
-theorem check_of_checkStrict {replay : SturmReplay} {cert : IsolationCert}
-    (h : cert.checkStrict replay = true) : cert.check replay = true := by
-  simp only [checkStrict, Bool.and_eq_true] at h
-  exact h.1
-
-/-- Every adjacent pair accepted by the strict-gap walk is strictly separated. -/
-theorem gap_of_check {cert : IsolationCert} (h : cert.checkGaps = true)
-    (i : Nat) (hi : i + 1 < cert.intervals.size) :
-    (cert.intervals[i]'(by omega)).upper <
-      (cert.intervals[i + 1]'hi).lower := by
-  have hmem : i ∈ List.range (cert.intervals.size - 1) := List.mem_range.mpr (by omega)
-  have hstep := (List.all_eq_true.mp h) i hmem
-  simp only [hi, dif_pos] at hstep
-  exact of_decide_eq_true hstep
-
-/-- Transitivity for the core dyadic strict order. -/
-private theorem dlt_trans {a b c : Dyadic} (hab : a < b) (hbc : b < c) : a < c := by
-  rw [← Dyadic.toRat_lt_toRat_iff] at hab hbc ⊢
-  exact lt_trans hab hbc
-
-/-- Strict adjacent gaps imply strict separation for every earlier/later pair. -/
-theorem gaps_of_check {cert : IsolationCert} (h : cert.checkGaps = true) :
-    ∀ i j : Fin cert.intervals.size, i < j →
-      cert.intervals[i].upper < cert.intervals[j].lower := by
-  have aux : ∀ (j : Nat) (hj : j < cert.intervals.size) (i : Nat) (_hij : i < j),
-      (cert.intervals[i]'(by omega)).upper < (cert.intervals[j]'hj).lower := by
-    intro j
-    induction j with
-    | zero => intro _ i hij; omega
-    | succ j ih =>
-        intro hj i hij
-        rcases Nat.lt_or_ge i j with hlt | hge
-        · have hjlt : j < cert.intervals.size := by omega
-          have step1 := ih hjlt i hlt
-          have step2 := (cert.intervals[j]'hjlt).lt
-          have step3 := gap_of_check h j (by omega)
-          exact dlt_trans (dlt_trans step1 step2) step3
-        · have hij' : i = j := by omega
-          subst hij'
-          exact gap_of_check h i (by omega)
-  intro i j hij
-  exact aux j.val j.isLt i.val hij
 
 /-- Strictly separated intervals contain roots in the corresponding strict
 order. -/
@@ -98,16 +39,6 @@ end IsolationCert
 
 namespace Separation
 
-/-- The order of an isolated real root relative to an exact dyadic endpoint. -/
-inductive RootCmp where
-  /-- The isolated root is strictly below the endpoint. -/
-  | lt
-  /-- The isolated root equals the endpoint. -/
-  | eq
-  /-- The endpoint is strictly below the isolated root. -/
-  | gt
-  deriving DecidableEq, Repr
-
 namespace RootCmp
 
 /-- Semantic interpretation of an endpoint comparison. -/
@@ -118,30 +49,6 @@ def Holds : RootCmp → ℝ → ℝ → Prop
   | .gt, root, endpoint => endpoint < root
 
 end RootCmp
-
-/-- Classify one isolated root against an exact dyadic endpoint.  In the
-interior case, the literal replay count on the prefix interval determines the
-side, with exact polynomial evaluation resolving equality. -/
-@[expose]
-def classify? (f : ZPoly) (replay : SturmReplay)
-    (I : DyadicInterval) (endpoint : Dyadic) : Option RootCmp :=
-  if hleft : endpoint ≤ I.lower then some .gt
-  else if _hright : I.upper < endpoint then some .lt
-  else
-    -- Core's names are the converses of the usual Mathlib convention:
-    -- `Dyadic.not_lt` turns `¬e ≤ l` into `l < e`.
-    let initial := DyadicInterval.mk I.lower endpoint (Dyadic.not_lt.mp hleft)
-    if replay.count initial = 0 then some .gt
-    else if replay.count initial = 1 then
-      if Hex.dyadicSign (f.evalDyadic endpoint) = 0 then some .eq else some .lt
-    else none
-
-/-- Recompute and check a claimed endpoint comparison.  Sound use additionally
-requires the outer certificate to establish `replay.check f`. -/
-@[expose]
-def checkCmp (f : ZPoly) (replay : SturmReplay) (I : DyadicInterval)
-    (endpoint : Dyadic) (claim : RootCmp) : Bool :=
-  decide (classify? f replay I endpoint = some claim)
 
 /-- Every successful endpoint classification has the stated order against the
 unique root in the accepted isolation. -/
@@ -313,93 +220,6 @@ theorem checkCmp_sound {f : ZPoly} {replay : SturmReplay}
       claim.Holds root (Dyadic.toReal endpoint) := by
   apply classify_sound hreplay hcert i endpoint
   exact of_decide_eq_true hclaim
-
-/-- Bisect one raw interval and retain a count-one half.  The midpoint
-variation is shared between the two candidate counts. -/
-def refine1? (replay : SturmReplay) (I : DyadicInterval) : Option DyadicInterval :=
-  let m := I.midpoint
-  if hl : I.lower < m then
-    let left := DyadicInterval.mk I.lower m hl
-    let vlo := sturmVarAt replay.chain I.lower
-    let vm := sturmVarAt replay.chain m
-    if vlo - vm = 1 then some left
-    else if hr : m < I.upper then
-      let right := DyadicInterval.mk m I.upper hr
-      let vhi := sturmVarAt replay.chain I.upper
-      if vm - vhi = 1 then some right else none
-    else none
-  else none
-
-/-- Separate a pair with an explicit structural fuel budget. -/
-def refinePairWith? (replay : SturmReplay) :
-    Nat → DyadicInterval → DyadicInterval →
-      Option (DyadicInterval × DyadicInterval)
-  | fuel, left, right =>
-      if left.upper < right.lower then some (left, right)
-      else if left.upper ≤ right.lower then
-        match fuel with
-        | 0 => none
-        | fuel + 1 => do
-            let left' ← refine1? replay left
-            let right' ← refine1? replay right
-            refinePairWith? replay fuel left' right'
-      else none
-
-/-- Refine both members of a touching pair until they have a strict gap or the
-structural fuel is exhausted.  Genuine overlaps and malformed count data are
-rejected. -/
-def refinePair? (p : ZPoly) (replay : SturmReplay)
-    (left right : DyadicInterval) : Option (DyadicInterval × DyadicInterval) :=
-  let fuel := max
-    ((Hex.ceilLog2Dyadic left.width + Hex.sepPrec p).toNat + 1)
-    ((Hex.ceilLog2Dyadic right.width + Hex.sepPrec p).toNat + 1)
-  refinePairWith? replay fuel left right
-
-/-- Continue a left-to-right separation scan from its current interval. -/
-def separateFrom? (p : ZPoly) (replay : SturmReplay)
-    (previous : DyadicInterval) :
-    List DyadicInterval → Option (List DyadicInterval)
-  | [] => some [previous]
-  | next :: rest =>
-      if previous.upper < next.lower then do
-        let tail ← separateFrom? p replay next rest
-        pure (previous :: tail)
-      else do
-        let pair ← refinePair? p replay previous next
-        let tail ← separateFrom? p replay pair.2 rest
-        pure (pair.1 :: tail)
-
-/-- Left-to-right separation scan.  Refining a later interval only shrinks it,
-so honest input preserves every strict gap already emitted. -/
-def separateList? (p : ZPoly) (replay : SturmReplay) :
-    List DyadicInterval → Option (List DyadicInterval)
-  | [] => some []
-  | first :: rest => separateFrom? p replay first rest
-
-/-- Run untrusted strict separation and retain only checker-approved output.
-The caller pairs `p` with a replay checked against it; a mismatch can only
-choose inadequate fuel and make this builder return `none`, because the output
-checker reads counts solely from `replay`. -/
-def separate? (p : ZPoly) (replay : SturmReplay)
-    (cert : IsolationCert) : Option IsolationCert :=
-  match separateList? p replay cert.intervals.toList with
-  | none => none
-  | some intervals =>
-      let out : IsolationCert := ⟨intervals.toArray⟩
-      if out.checkStrict replay then some out else none
-
-/-- The public builder never returns an unchecked strict isolation array. -/
-theorem check_of_separate_eq_some {p : ZPoly} {replay : SturmReplay}
-    {input output : IsolationCert} (h : separate? p replay input = some output) :
-    output.checkStrict replay = true := by
-  unfold separate? at h
-  split at h <;> rename_i hlist
-  · simp at h
-  · dsimp only at h
-    split at h <;> rename_i hc
-    · cases Option.some.inj h
-      exact hc
-    · simp at h
 
 end Separation
 

--- a/HexRCF/SeparationCheck.lean
+++ b/HexRCF/SeparationCheck.lean
@@ -1,0 +1,215 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.IsolationCheck
+public import HexRealRoots.Prec
+import Init.Data.Order.Lemmas
+
+public section
+
+/-!
+# Strict separation and endpoint checks for RCF cells
+
+The untrusted builders in this module bisect touching generalized isolations
+with counts from a cached `SturmReplay`. Their output is retained only when a
+small checker revalidates all isolation facts and emitted strict gaps. Endpoint
+classification likewise uses exact dyadic comparison, literal replay counts,
+and exact polynomial evaluation. Real-root semantics live in
+`HexRCF.Separation`.
+-/
+
+namespace Hex.RCF
+
+namespace IsolationCert
+
+/-- Check strict gaps between every adjacent pair of emitted intervals. -/
+@[expose]
+def checkGaps (cert : IsolationCert) : Bool :=
+  (List.range (cert.intervals.size - 1)).all fun i =>
+    if h : i + 1 < cert.intervals.size then
+      decide ((cert.intervals[i]'(by omega)).upper <
+        (cert.intervals[i + 1]'h).lower)
+    else false
+
+/-- Validate generalized isolation and strict adjacent separation. -/
+@[expose]
+def checkStrict (replay : SturmReplay) (cert : IsolationCert) : Bool :=
+  cert.check replay && cert.checkGaps
+
+/-- Recover the underlying generalized isolation check. -/
+theorem check_of_checkStrict {replay : SturmReplay} {cert : IsolationCert}
+    (h : cert.checkStrict replay = true) : cert.check replay = true := by
+  simp only [checkStrict, Bool.and_eq_true] at h
+  exact h.1
+
+/-- Every adjacent pair accepted by the strict-gap walk is strictly separated. -/
+theorem gap_of_check {cert : IsolationCert} (h : cert.checkGaps = true)
+    (i : Nat) (hi : i + 1 < cert.intervals.size) :
+    (cert.intervals[i]'(by omega)).upper <
+      (cert.intervals[i + 1]'hi).lower := by
+  have hmem : i ∈ List.range (cert.intervals.size - 1) := List.mem_range.mpr (by omega)
+  have hstep := (List.all_eq_true.mp h) i hmem
+  simp only [hi, dif_pos] at hstep
+  exact of_decide_eq_true hstep
+
+/-- Transitivity for the core dyadic strict order. -/
+private theorem dlt_trans {a b c : Dyadic} (hab : a < b) (hbc : b < c) : a < c := by
+  rw [← Dyadic.toRat_lt_toRat_iff] at hab hbc ⊢
+  exact Std.lt_trans hab hbc
+
+/-- Strict adjacent gaps imply strict separation for every earlier/later pair. -/
+theorem gaps_of_check {cert : IsolationCert} (h : cert.checkGaps = true) :
+    ∀ i j : Fin cert.intervals.size, i < j →
+      cert.intervals[i].upper < cert.intervals[j].lower := by
+  have aux : ∀ (j : Nat) (hj : j < cert.intervals.size) (i : Nat) (_hij : i < j),
+      (cert.intervals[i]'(by omega)).upper < (cert.intervals[j]'hj).lower := by
+    intro j
+    induction j with
+    | zero => intro _ i hij; omega
+    | succ j ih =>
+        intro hj i hij
+        rcases Nat.lt_or_ge i j with hlt | hge
+        · have hjlt : j < cert.intervals.size := by omega
+          have step1 := ih hjlt i hlt
+          have step2 := (cert.intervals[j]'hjlt).lt
+          have step3 := gap_of_check h j (by omega)
+          exact dlt_trans (dlt_trans step1 step2) step3
+        · have hij' : i = j := by omega
+          subst hij'
+          exact gap_of_check h i (by omega)
+  intro i j hij
+  exact aux j.val j.isLt i.val hij
+
+end IsolationCert
+
+namespace Separation
+
+/-- The order of an isolated real root relative to an exact dyadic endpoint. -/
+inductive RootCmp where
+  /-- The isolated root is strictly below the endpoint. -/
+  | lt
+  /-- The isolated root equals the endpoint. -/
+  | eq
+  /-- The endpoint is strictly below the isolated root. -/
+  | gt
+  deriving DecidableEq, Repr
+
+/-- Classify one isolated root against an exact dyadic endpoint. In the
+interior case, the literal replay count on the prefix interval determines the
+side, with exact polynomial evaluation resolving equality. -/
+@[expose]
+def classify? (f : ZPoly) (replay : SturmReplay)
+    (I : DyadicInterval) (endpoint : Dyadic) : Option RootCmp :=
+  if hleft : endpoint ≤ I.lower then some .gt
+  else if _hright : I.upper < endpoint then some .lt
+  else
+    -- Core's names are the converses of the usual Mathlib convention:
+    -- `Dyadic.not_lt` turns `¬e ≤ l` into `l < e`.
+    let initial := DyadicInterval.mk I.lower endpoint (Dyadic.not_lt.mp hleft)
+    if replay.count initial = 0 then some .gt
+    else if replay.count initial = 1 then
+      if Hex.dyadicSign (f.evalDyadic endpoint) = 0 then some .eq else some .lt
+    else none
+
+/-- Recompute and check a claimed endpoint comparison. Sound use additionally
+requires the outer certificate to establish `replay.check f`. -/
+@[expose]
+def checkCmp (f : ZPoly) (replay : SturmReplay) (I : DyadicInterval)
+    (endpoint : Dyadic) (claim : RootCmp) : Bool :=
+  decide (classify? f replay I endpoint = some claim)
+
+/-- Bisect one raw interval and retain a count-one half. The midpoint variation
+is shared between the two candidate counts. -/
+def refine1? (replay : SturmReplay) (I : DyadicInterval) : Option DyadicInterval :=
+  let m := I.midpoint
+  if hl : I.lower < m then
+    let left := DyadicInterval.mk I.lower m hl
+    let vlo := sturmVarAt replay.chain I.lower
+    let vm := sturmVarAt replay.chain m
+    if vlo - vm = 1 then some left
+    else if hr : m < I.upper then
+      let right := DyadicInterval.mk m I.upper hr
+      let vhi := sturmVarAt replay.chain I.upper
+      if vm - vhi = 1 then some right else none
+    else none
+  else none
+
+/-- Separate a pair with an explicit structural fuel budget. -/
+def refinePairWith? (replay : SturmReplay) :
+    Nat → DyadicInterval → DyadicInterval →
+      Option (DyadicInterval × DyadicInterval)
+  | fuel, left, right =>
+      if left.upper < right.lower then some (left, right)
+      else if left.upper ≤ right.lower then
+        match fuel with
+        | 0 => none
+        | fuel + 1 => do
+            let left' ← refine1? replay left
+            let right' ← refine1? replay right
+            refinePairWith? replay fuel left' right'
+      else none
+
+/-- Refine both members of a touching pair until they have a strict gap or the
+structural fuel is exhausted. Genuine overlaps and malformed count data are
+rejected. -/
+def refinePair? (p : ZPoly) (replay : SturmReplay)
+    (left right : DyadicInterval) : Option (DyadicInterval × DyadicInterval) :=
+  let fuel := max
+    ((Hex.ceilLog2Dyadic left.width + Hex.sepPrec p).toNat + 1)
+    ((Hex.ceilLog2Dyadic right.width + Hex.sepPrec p).toNat + 1)
+  refinePairWith? replay fuel left right
+
+/-- Continue a left-to-right separation scan from its current interval. -/
+def separateFrom? (p : ZPoly) (replay : SturmReplay)
+    (previous : DyadicInterval) :
+    List DyadicInterval → Option (List DyadicInterval)
+  | [] => some [previous]
+  | next :: rest =>
+      if previous.upper < next.lower then do
+        let tail ← separateFrom? p replay next rest
+        pure (previous :: tail)
+      else do
+        let pair ← refinePair? p replay previous next
+        let tail ← separateFrom? p replay pair.2 rest
+        pure (pair.1 :: tail)
+
+/-- Left-to-right separation scan. Refining a later interval only shrinks it,
+so honest input preserves every strict gap already emitted. -/
+def separateList? (p : ZPoly) (replay : SturmReplay) :
+    List DyadicInterval → Option (List DyadicInterval)
+  | [] => some []
+  | first :: rest => separateFrom? p replay first rest
+
+/-- Run untrusted strict separation and retain only checker-approved output.
+The caller pairs `p` with a replay checked against it; a mismatch can only
+choose inadequate fuel and make this builder return `none`, because the output
+checker reads counts solely from `replay`. -/
+def separate? (p : ZPoly) (replay : SturmReplay)
+    (cert : IsolationCert) : Option IsolationCert :=
+  match separateList? p replay cert.intervals.toList with
+  | none => none
+  | some intervals =>
+      let out : IsolationCert := ⟨intervals.toArray⟩
+      if out.checkStrict replay then some out else none
+
+/-- The public builder never returns an unchecked strict isolation array. -/
+theorem check_of_separate_eq_some {p : ZPoly} {replay : SturmReplay}
+    {input output : IsolationCert} (h : separate? p replay input = some output) :
+    output.checkStrict replay = true := by
+  unfold separate? at h
+  split at h <;> rename_i hlist
+  · simp at h
+  · dsimp only at h
+    split at h <;> rename_i hc
+    · cases Option.some.inj h
+      exact hc
+    · simp at h
+
+end Separation
+
+end Hex.RCF

--- a/HexRCF/SeparationTests.lean
+++ b/HexRCF/SeparationTests.lean
@@ -18,6 +18,7 @@ public meta import HexRealRoots.Var
 public meta import HexRealRoots.Prec
 public meta import HexPolyZ.Mignotte
 import all HexRCF.Separation
+import all HexRCF.SeparationCheck
 import all HexRCF.SturmBuilder
 import all Init.Data.Array.DecidableEq
 import all HexRealRoots.Basic

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -617,8 +617,9 @@ free to change.
   `HexRCF/DecisionTests.lean`: all four certificate branches and quantifiers,
   half-open endpoint ownership, multiple/repeated/shared roots, helper failure,
   and output-check regressions.
-- `HexRCF/Separation.lean`: replay-based strict-separation refinement,
-  strict-gap checking, and endpoint classification for bounded sentences;
+- `HexRCF/SeparationCheck.lean`: Mathlib-free strict-gap checks, endpoint
+  classification, and replay-based separation refinement;
+  `HexRCF/Separation.lean`: real-root ordering and classifier semantics;
   `HexRCF/SeparationTests.lean`: midpoint ownership, close-root, scan,
   malformed-input, and endpoint regressions.
 - `HexRCF/Cells.lean`: size-indexed executable cells, checked root models,

--- a/progress/20260727T154419Z_rcf-separation-check.md
+++ b/progress/20260727T154419Z_rcf-separation-check.md
@@ -1,0 +1,38 @@
+# Mathlib-free RCF separation checks
+
+## Accomplished
+
+- Added `HexRCF.SeparationCheck`, containing strict-gap validation and pure
+  dyadic consequences, endpoint comparison data and executable classification,
+  replay-based interval refinement/separation builders, and output-retention
+  soundness.
+- Reduced `HexRCF.Separation` to `RootCmp.Holds` and real-root ordering and
+  endpoint-classifier semantics while preserving all public declaration names.
+- Replaced the proof-only Mathlib order helper with the core
+  `Init.Data.Order.Lemmas` / `Std.lt_trans` operation.
+- Made `SeparationTests` import all of the checker module explicitly so kernel
+  reduction sees the moved non-exposed builder bodies.
+- Updated the HexRCF umbrella and SPEC file map.
+- Verified focused consumers and the full HexRCF build and mechanically checked
+  the 33-module `HexRCF.SeparationCheck` closure contains neither `Mathlib.*`
+  nor `HexRealRootsMathlib.*`. DAG, Phase-4, release-manifest, trust-surface,
+  copyright, diff, and banned-token checks pass. An independent Sol review
+  returned GO.
+
+## Current frontier
+
+Issue #8997 is implemented on a branch stacked above the isolation-check PR
+#8996. Strict isolation and endpoint comparison computation now have an
+explicit Mathlib-free boundary.
+
+## Next step
+
+Publish the stacked PR, then separate executable cell data/sampling and bounded
+domain comparison checks from the `RootModel` and real-cell semantics in
+`HexRCF.Cells`. That module boundary will unblock a pure sign-matrix replay
+layer.
+
+## Blockers
+
+None for this extraction. The branch remains stacked until its parent chain
+merges; it can then be rebased and retargeted to main.


### PR DESCRIPTION
## Summary

- extract strict-gap checks, endpoint classifier, refinement/separation builders, and pure retention facts into `HexRCF.SeparationCheck`
- retain real-root ordering and classifier semantics in `HexRCF.Separation` while preserving public names
- make reduction tests explicitly import all moved builder bodies

Stacked on #8996. Closes #8997. Contributes to #8973.

## Verification

- `lake build HexRCF.SeparationCheck` (84 jobs)
- `lake build HexRCF.Separation HexRCF.Cells HexRCF.Decision`
- `lake build HexRCF.SeparationTests`
- `lake build HexRCF`
- repository-local import-closure audit: `HexRCF.SeparationCheck` spans 33 modules and contains no `Mathlib.*` or `HexRealRootsMathlib.*` imports
- DAG, Phase-4, release-manifest, published trust-surface, copyright, diff, and banned-token checks
- independent Sol review: GO