### PR TITLE
refactor(rcf): extract Mathlib-free cell checks

### DIFF
--- a/HexRCF.lean
+++ b/HexRCF.lean
@@ -22,6 +22,7 @@ public import HexRCF.IsolationsTests
 public import HexRCF.SeparationCheck
 public import HexRCF.Separation
 public import HexRCF.SeparationTests
+public import HexRCF.CellsCheck
 public import HexRCF.Cells
 public import HexRCF.CellsTests
 public import HexRCF.CommonRootCheck

--- a/HexRCF/Cells.lean
+++ b/HexRCF/Cells.lean
@@ -6,76 +6,23 @@ Authors: Kim Morrison
 
 module
 
+public import HexRCF.CellsCheck
 public import HexRCF.Separation
 
 public section
 
 /-!
-# Cells cut out by strictly isolated carrier roots
+# Semantics of cells cut out by strictly isolated carrier roots
 
-An array of `n` strictly ordered carrier roots cuts the real line into `n`
-root cells and `n + 1` open cells.  Open cut `0` is the left tail, cut `n`
-is the right tail, and an interior cut is the gap between its predecessor and
-successor roots.  For `n = 0`, the sole open cell is all of `ℝ`.
-
-The executable layer stores only indices and exact dyadic sample points.  A
-noncomputable `RootModel` packages the semantic roots justified by the replay
-and isolation checkers.
+The Mathlib-free cell data, exact samples, endpoint-comparison checks, and
+bounded-domain relevance table live in `HexRCF.CellsCheck`. A noncomputable
+`RootModel` packages the semantic roots justified by the replay and isolation
+checkers, and the theorems here interpret every executable cell over `ℝ`.
 -/
 
 namespace Hex.RCF
 
 open HexRealRootsMathlib
-
-/-- A root cell or one of the open cuts around `n` ordered roots. -/
-inductive Cell (n : Nat) where
-  /-- Open cell at a cut between roots, including both tails. -/
-  | open (cut : Fin (n + 1))
-  /-- Singleton cell at an isolated root. -/
-  | root (i : Fin n)
-  deriving DecidableEq, Repr
-
-namespace Cell
-
-/-- Alternating position of a cell in the left-to-right decomposition. -/
-@[expose]
-def rank : Cell n → Nat
-  | .open cut => 2 * cut.val
-  | .root i => 2 * i.val + 1
-
-/-- Every rank is a valid index into a `2 * n + 1` cell vector. -/
-theorem rank_lt (c : Cell n) : c.rank < 2 * n + 1 := by
-  cases c with
-  | «open» cut => simp [rank]; omega
-  | root i => simp [rank]
-
-/-- Deterministic left-to-right enumeration of all `2 * n + 1` cells. -/
-@[expose]
-def all (n : Nat) : Array (Cell n) :=
-  (((List.finRange n).flatMap fun i =>
-      [Cell.open i.castSucc, Cell.root i]) ++
-    [Cell.open (Fin.last n)]).toArray
-
-@[simp] theorem size_all (n : Nat) : (all n).size = 2 * n + 1 := by
-  simp [all]
-  omega
-
-/-- Every size-correct cell occurs in the executable enumeration. -/
-theorem mem_all (c : Cell n) : c ∈ all n := by
-  cases c with
-  | root i =>
-      simp [all]
-  | «open» cut =>
-      by_cases hlast : cut.val = n
-      · have hcut : cut = Fin.last n := Fin.ext (by simpa [Fin.last] using hlast)
-        subst cut
-        simp [all]
-      · let i : Fin n := ⟨cut.val, by omega⟩
-        have hcut : i.castSucc = cut := Fin.ext rfl
-        simp [all]
-        exact Or.inl ⟨i, hcut.symm⟩
-
-end Cell
 
 /-- The semantic roots named by a checked isolation array. -/
 structure RootModel (f : ZPoly) (cert : IsolationCert) where
@@ -114,12 +61,6 @@ theorem rootAt_unique {f : ZPoly} {replay : SturmReplay}
   (Classical.choose_spec (exists_unique_root_of_check hreplay hcert i)).2 x
     ⟨hx, hmem⟩
 
-/-- Strict validation exposes its strict-gap component. -/
-theorem gaps_of_checkStrict {replay : SturmReplay} {cert : IsolationCert}
-    (h : cert.checkStrict replay = true) : cert.checkGaps = true := by
-  simp only [checkStrict, Bool.and_eq_true] at h
-  exact h.2
-
 /-- Package all semantic consequences of an accepted strict isolation array. -/
 noncomputable def rootModel {f : ZPoly} {replay : SturmReplay}
     (cert : IsolationCert) (hreplay : replay.check f = true)
@@ -142,31 +83,6 @@ noncomputable def rootModel {f : ZPoly} {replay : SturmReplay}
       apply huniq j
       rw [← hj]
       exact (rootAt_spec cert hreplay (check_of_checkStrict hstrict) j).2
-
-/-- Exact dyadic sample for an open cut. -/
-@[expose]
-def openPoint (cert : IsolationCert) :
-    Fin (cert.intervals.size + 1) → Dyadic
-  | cut =>
-      if hzero : cert.intervals.size = 0 then 0
-      else if hleft : cut.val = 0 then
-        (cert.intervals[0]'(by omega)).lower + Dyadic.ofInt (-1)
-      else if hright : cut.val = cert.intervals.size then
-        (cert.intervals[cert.intervals.size - 1]'(by omega)).upper + Dyadic.ofInt 1
-      else
-        ((cert.intervals[cut.val - 1]'(by omega)).upper +
-          (cert.intervals[cut.val]'(by omega)).lower) >>> (1 : Int)
-
-/-- Open cells carry exact dyadic samples; root cells are represented by their
-certified isolation instead. -/
-@[expose]
-def sample? (cert : IsolationCert) : Cell cert.intervals.size → Option Dyadic
-  | .open cut => some (cert.openPoint cut)
-  | .root _ => none
-
-@[simp] theorem sample?_open (cert : IsolationCert)
-    (cut : Fin (cert.intervals.size + 1)) :
-    cert.sample? (.open cut) = some (cert.openPoint cut) := rfl
 
 end IsolationCert
 
@@ -562,27 +478,7 @@ theorem root_eq_of_mem_leftSpan
 
 end RootModel
 
-/-- Claimed carrier-root comparisons against the lower and upper endpoints of
-a bounded domain. -/
-structure IocCmps (n : Nat) where
-  /-- Each root's order relative to the excluded lower endpoint. -/
-  lower : Vector Separation.RootCmp n
-  /-- Each root's order relative to the included upper endpoint. -/
-  upper : Vector Separation.RootCmp n
-  deriving Repr
-
 namespace IocCmps
-
-/-- Recompute every claimed endpoint comparison. This validates comparison
-data only; the bounded-domain layer separately checks `a < b`. -/
-@[expose]
-def check (f : ZPoly) (replay : SturmReplay) (cert : IsolationCert)
-    (a b : Dyadic) (cmps : IocCmps cert.intervals.size) : Bool :=
-  (List.range cert.intervals.size).all fun i =>
-    if hi : i < cert.intervals.size then
-      Separation.checkCmp f replay cert.intervals[i] a cmps.lower[i] &&
-        Separation.checkCmp f replay cert.intervals[i] b cmps.upper[i]
-    else false
 
 /-- A checked comparison vector has its claimed meaning against the chosen
 semantic roots. -/
@@ -619,27 +515,6 @@ theorem holds_of_check {f : ZPoly} {replay : SturmReplay}
 end IocCmps
 
 namespace Cell
-
-/-- Executable bounded-domain relevance test for a cell. The surrounding
-certificate first checks `a < b`; this core assumes that nonempty-domain
-hypothesis. -/
-@[expose]
-def meetsIoc (cmps : IocCmps n) : Cell n → Bool
-  | .root i => cmps.lower[i] == .gt && cmps.upper[i] != .gt
-  | .open cut =>
-      if hzero : n = 0 then true
-      else if hleft : cut.val = 0 then
-        cmps.lower[0] == .gt
-      else if hright : cut.val = n then
-        cmps.upper[n - 1] == .lt
-      else
-        cmps.upper[cut.val - 1] == .lt && cmps.lower[cut.val] == .gt
-
-/-- Guard the nonempty-domain relevance table against equal or reversed
-endpoints. -/
-@[expose]
-def meetsIocOn (a b : Dyadic) (cmps : IocCmps n) (c : Cell n) : Bool :=
-  decide (a < b) && meetsIoc cmps c
 
 private theorem eq_gt_iff {cmp : Separation.RootCmp} {root endpoint : ℝ}
     (h : cmp.Holds root endpoint) :

--- a/HexRCF/CellsCheck.lean
+++ b/HexRCF/CellsCheck.lean
@@ -1,0 +1,154 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+import Init.Data.List.Lemmas
+import Init.Data.List.Nat.Sum
+public import HexRCF.SeparationCheck
+
+public section
+
+/-!
+# Executable cells and bounded-domain checks
+
+An array of `n` strictly ordered carrier roots cuts the real line into `n`
+root cells and `n + 1` open cells. This module stores only indices, exact
+dyadic sample points, claimed endpoint comparisons, and Boolean relevance
+checks. The semantic roots and real-cell interpretation live in `HexRCF.Cells`.
+-/
+
+namespace Hex.RCF
+
+/-- A root cell or one of the open cuts around `n` ordered roots. -/
+inductive Cell (n : Nat) where
+  /-- Open cell at a cut between roots, including both tails. -/
+  | open (cut : Fin (n + 1))
+  /-- Singleton cell at an isolated root. -/
+  | root (i : Fin n)
+  deriving DecidableEq, Repr
+
+namespace Cell
+
+/-- Alternating position of a cell in the left-to-right decomposition. -/
+@[expose]
+def rank : Cell n → Nat
+  | .open cut => 2 * cut.val
+  | .root i => 2 * i.val + 1
+
+/-- Every rank is a valid index into a `2 * n + 1` cell vector. -/
+theorem rank_lt (c : Cell n) : c.rank < 2 * n + 1 := by
+  cases c with
+  | «open» cut => simp [rank]; omega
+  | root i => simp [rank]
+
+/-- Deterministic left-to-right enumeration of all `2 * n + 1` cells. -/
+@[expose]
+def all (n : Nat) : Array (Cell n) :=
+  (((List.finRange n).flatMap fun i =>
+      [Cell.open i.castSucc, Cell.root i]) ++
+    [Cell.open (Fin.last n)]).toArray
+
+@[simp] theorem size_all (n : Nat) : (all n).size = 2 * n + 1 := by
+  simp [all, List.map_const']
+  omega
+
+/-- Every size-correct cell occurs in the executable enumeration. -/
+theorem mem_all (c : Cell n) : c ∈ all n := by
+  cases c with
+  | root i =>
+      simp [all]
+  | «open» cut =>
+      by_cases hlast : cut.val = n
+      · have hcut : cut = Fin.last n := Fin.ext (by simpa [Fin.last] using hlast)
+        subst cut
+        simp [all]
+      · let i : Fin n := ⟨cut.val, by omega⟩
+        have hcut : i.castSucc = cut := Fin.ext rfl
+        simp [all]
+        exact Or.inl ⟨i, hcut.symm⟩
+
+end Cell
+
+namespace IsolationCert
+
+/-- Exact dyadic sample for an open cut. -/
+@[expose]
+def openPoint (cert : IsolationCert) :
+    Fin (cert.intervals.size + 1) → Dyadic
+  | cut =>
+      if hzero : cert.intervals.size = 0 then 0
+      else if hleft : cut.val = 0 then
+        (cert.intervals[0]'(by omega)).lower + Dyadic.ofInt (-1)
+      else if hright : cut.val = cert.intervals.size then
+        (cert.intervals[cert.intervals.size - 1]'(by omega)).upper + Dyadic.ofInt 1
+      else
+        ((cert.intervals[cut.val - 1]'(by omega)).upper +
+          (cert.intervals[cut.val]'(by omega)).lower) >>> (1 : Int)
+
+/-- Open cells carry exact dyadic samples; root cells are represented by their
+certified isolation instead. -/
+@[expose]
+def sample? (cert : IsolationCert) : Cell cert.intervals.size → Option Dyadic
+  | .open cut => some (cert.openPoint cut)
+  | .root _ => none
+
+@[simp] theorem sample?_open (cert : IsolationCert)
+    (cut : Fin (cert.intervals.size + 1)) :
+    cert.sample? (.open cut) = some (cert.openPoint cut) := rfl
+
+end IsolationCert
+
+/-- Claimed carrier-root comparisons against the lower and upper endpoints of
+a bounded domain. -/
+structure IocCmps (n : Nat) where
+  /-- Each root's order relative to the excluded lower endpoint. -/
+  lower : Vector Separation.RootCmp n
+  /-- Each root's order relative to the included upper endpoint. -/
+  upper : Vector Separation.RootCmp n
+  deriving Repr
+
+namespace IocCmps
+
+/-- Recompute every claimed endpoint comparison. This validates comparison
+data only; the bounded-domain layer separately checks `a < b`. -/
+@[expose]
+def check (f : ZPoly) (replay : SturmReplay) (cert : IsolationCert)
+    (a b : Dyadic) (cmps : IocCmps cert.intervals.size) : Bool :=
+  (List.range cert.intervals.size).all fun i =>
+    if hi : i < cert.intervals.size then
+      Separation.checkCmp f replay cert.intervals[i] a cmps.lower[i] &&
+        Separation.checkCmp f replay cert.intervals[i] b cmps.upper[i]
+    else false
+
+end IocCmps
+
+namespace Cell
+
+/-- Executable bounded-domain relevance test for a cell. The surrounding
+certificate first checks `a < b`; this core assumes that nonempty-domain
+hypothesis. -/
+@[expose]
+def meetsIoc (cmps : IocCmps n) : Cell n → Bool
+  | .root i => cmps.lower[i] == .gt && cmps.upper[i] != .gt
+  | .open cut =>
+      if hzero : n = 0 then true
+      else if hleft : cut.val = 0 then
+        cmps.lower[0] == .gt
+      else if hright : cut.val = n then
+        cmps.upper[n - 1] == .lt
+      else
+        cmps.upper[cut.val - 1] == .lt && cmps.lower[cut.val] == .gt
+
+/-- Guard the nonempty-domain relevance table against equal or reversed
+endpoints. -/
+@[expose]
+def meetsIocOn (a b : Dyadic) (cmps : IocCmps n) (c : Cell n) : Bool :=
+  decide (a < b) && meetsIoc cmps c
+
+end Cell
+
+end Hex.RCF

--- a/HexRCF/SeparationCheck.lean
+++ b/HexRCF/SeparationCheck.lean
@@ -47,6 +47,12 @@ theorem check_of_checkStrict {replay : SturmReplay} {cert : IsolationCert}
   simp only [checkStrict, Bool.and_eq_true] at h
   exact h.1
 
+/-- Strict validation exposes its strict-gap component. -/
+theorem gaps_of_checkStrict {replay : SturmReplay} {cert : IsolationCert}
+    (h : cert.checkStrict replay = true) : cert.checkGaps = true := by
+  simp only [checkStrict, Bool.and_eq_true] at h
+  exact h.2
+
 /-- Every adjacent pair accepted by the strict-gap walk is strictly separated. -/
 theorem gap_of_check {cert : IsolationCert} (h : cert.checkGaps = true)
     (i : Nat) (hi : i + 1 < cert.intervals.size) :

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -622,9 +622,10 @@ free to change.
   `HexRCF/Separation.lean`: real-root ordering and classifier semantics;
   `HexRCF/SeparationTests.lean`: midpoint ownership, close-root, scan,
   malformed-input, and endpoint regressions.
-- `HexRCF/Cells.lean`: size-indexed executable cells, checked root models,
-  semantic partition, exact samples, canonical left-root spans,
-  endpoint-comparison vectors, and exact `Ioc` intersection;
+- `HexRCF/CellsCheck.lean`: Mathlib-free size-indexed cells, exact dyadic
+  samples, endpoint-comparison checks, and bounded-domain relevance;
+  `HexRCF/Cells.lean`: checked root models, semantic partition, canonical
+  left-root spans, and exact `Ioc` intersection;
   `HexRCF/CellsTests.lean`: enumeration,
   zero/singleton/multiple-root samples, endpoint equality/order guards,
   relevance tables, and malformed lower/upper claim regressions.

--- a/progress/20260727T155044Z_rcf-cells-check.md
+++ b/progress/20260727T155044Z_rcf-cells-check.md
@@ -1,0 +1,35 @@
+# Mathlib-free RCF cell checks
+
+## Accomplished
+
+- Added `HexRCF.CellsCheck`, containing size-indexed cell data and enumeration,
+  exact dyadic samples, endpoint-comparison vectors and validation, and
+  bounded-domain relevance checks.
+- Reduced `HexRCF.Cells` to root models and real-cell semantics while
+  preserving the existing public declaration names through imports.
+- Moved the pure strict-gap projection theorem into `HexRCF.SeparationCheck`.
+- Replaced a hidden Mathlib simplification dependency in `Cell.size_all` with
+  explicit core list lemmas.
+- Updated the HexRCF umbrella and SPEC file map.
+- Verified focused consumers and the full HexRCF build. Mechanically checked
+  that the 35-module `HexRCF.CellsCheck` closure contains neither `Mathlib.*`
+  nor `HexRealRootsMathlib.*`; DAG, Phase-4, release-manifest, trust-surface,
+  copyright, diff, and banned-token checks pass. An independent Sol review
+  returned GO.
+
+## Current frontier
+
+Issue #9000 is implemented on a branch stacked above the separation-check PR
+#8999. Executable cell enumeration, sampling, endpoint comparison, and
+bounded-domain relevance now have an explicit Mathlib-free boundary.
+
+## Next step
+
+Publish the stacked PR, then extract sign values, sign-entry lookup, and the
+sign-matrix certificate replay into a Mathlib-free `HexRCF.SignMatrixCheck`
+layer while retaining real-sign semantics in `HexRCF.SignMatrix`.
+
+## Blockers
+
+None for this extraction. The branch remains stacked until its parent chain
+merges; it can then be rebased and retargeted to main.


### PR DESCRIPTION
Closes #9000.

Contributes to #8973 by separating executable cell enumeration, exact dyadic sampling, endpoint comparison validation, and bounded-domain relevance from real-root semantics.

Validation:
- `lake build HexRCF.CellsCheck`
- `lake build HexRCF.Cells HexRCF.SignMatrix HexRCF.Certificate`
- `lake build HexRCF`
- 35-module closure contains no `Mathlib.*` or `HexRealRootsMathlib.*`
- DAG, Phase-4, release-manifest, trust-surface, copyright, diff, and banned-token checks pass
- independent Sol review: GO