### PR TITLE
refactor(rcf): extract Mathlib-free sign-matrix replay

### DIFF
--- a/HexRCF.lean
+++ b/HexRCF.lean
@@ -28,6 +28,7 @@ public import HexRCF.CellsTests
 public import HexRCF.CommonRootCheck
 public import HexRCF.CommonRoot
 public import HexRCF.CommonRootTests
+public import HexRCF.SignMatrixCheck
 public import HexRCF.SignMatrix
 public import HexRCF.SignMatrixTests
 public import HexRCF.Builder

--- a/HexRCF/Builder.lean
+++ b/HexRCF/Builder.lean
@@ -8,7 +8,7 @@ module
 
 public import HexRCF.CarrierCheck
 public import HexRCF.CommonRootCheck
-public import HexRCF.SignMatrix
+public import HexRCF.SignMatrixCheck
 public import HexRCF.SturmBuilder
 
 public section

--- a/HexRCF/BuilderTests.lean
+++ b/HexRCF/BuilderTests.lean
@@ -10,7 +10,7 @@ public import HexRCF.Builder
 public meta import HexRCF.Builder
 public meta import HexRCF.Carrier
 public meta import HexRCF.CommonRoot
-public meta import HexRCF.SignMatrix
+public meta import HexRCF.SignMatrixCheck
 public meta import HexRCF.SturmBuilder
 
 public section

--- a/HexRCF/Certificate.lean
+++ b/HexRCF/Certificate.lean
@@ -6,7 +6,7 @@ Authors: Kim Morrison
 
 module
 
-public import HexRCF.SignMatrix
+public import HexRCF.SignMatrixCheck
 
 public section
 

--- a/HexRCF/SignMatrix.lean
+++ b/HexRCF/SignMatrix.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexRCF.SignMatrixCheck
 public import HexRCF.Carrier
 public import HexRCF.CommonRoot
 public import Mathlib.Topology.Instances.Sign
@@ -13,41 +14,19 @@ public import Mathlib.Topology.Instances.Sign
 public section
 
 /-!
-# Certified sign matrices for RCF cells
+# Semantics of certified sign matrices for RCF cells
 
-This file computes exact polynomial signs on the semantic cells cut out by a
-checked square-free carrier.  Open-cell signs come from exact dyadic Horner
-evaluation and preconnected root-free sign constancy. Root-cell zero tests use
-the cached common-root packages; nonzero root signs are transferred from an
-adjacent open cell. Formula evaluation is option-valued so missing or
-misaligned certificate data fails closed.
+The Mathlib-free checker and replay live in `HexRCF.SignMatrixCheck`. This file
+proves that its exact dyadic signs and cached common-root decisions agree with
+polynomial signs over the semantic cells cut out by a checked square-free
+carrier, and connects Boolean formula replay to reflected propositions.
 -/
 
 namespace Hex.RCF
 
 open HexRealRootsMathlib Polynomial
 
-/-- The three possible signs stored by an RCF sign matrix. -/
-inductive Sign where
-  | neg
-  | zero
-  | pos
-  deriving DecidableEq, Repr
-
 namespace Sign
-
-/-- Canonical integer representative used to connect signs to Mathlib's
-`SignType.sign`. -/
-@[expose]
-def toInt : Sign → Int
-  | .neg => -1
-  | .zero => 0
-  | .pos => 1
-
-/-- Collapse an arbitrary integer to its three-way sign. -/
-@[expose]
-def ofInt (value : Int) : Sign :=
-  if value < 0 then .neg else if 0 < value then .pos else .zero
 
 /-- Collapsing an integer preserves its mathematical sign. -/
 theorem ofInt_spec (value : Int) :
@@ -84,11 +63,6 @@ theorem sign_eval_eq_of_noRoot {p : Polynomial ℝ} {s : Set ℝ}
     exact continuousAt_sign_of_ne_zero (fun hzero => hnz z hz hzero)
   exact (hs.image _ hcont).subsingleton
     (Set.mem_image_of_mem _ hx) (Set.mem_image_of_mem _ hy)
-
-/-- Exact executable sign of an integer polynomial at a dyadic point. -/
-@[expose]
-def evalSign (p : ZPoly) (x : Dyadic) : Sign :=
-  Sign.ofInt (Hex.dyadicSign (p.evalDyadic x))
 
 /-- Exact dyadic Horner evaluation computes the sign of the corresponding
 real-polynomial evaluation. -/
@@ -237,163 +211,6 @@ theorem evalSign_ne_zero_of_not_root (p : ZPoly) (x : Dyadic)
     simpa [Sign.toInt] using hsign.symm
   exact hroot heval
 
-/-- Coefficient-equality membership test for literal polynomials. This avoids
-the derived array equality that does not kernel-reduce through modules. -/
-@[expose]
-def containsPoly (p : ZPoly) : List ZPoly → Bool
-  | [] => false
-  | q :: qs => DensePoly.beqCoeffs p q || containsPoly p qs
-
-theorem containsPoly_iff {p : ZPoly} {ps : List ZPoly} :
-    containsPoly p ps = true ↔ p ∈ ps := by
-  induction ps with
-  | nil => simp [containsPoly]
-  | cons q qs ih =>
-      simp [containsPoly, Bool.or_eq_true, DensePoly.beqCoeffs_iff_eq, ih]
-
-/-- The coefficient-equality membership test is false exactly on
-nonmembership. -/
-theorem containsPoly_eq_false_iff {p : ZPoly} {ps : List ZPoly} :
-    containsPoly p ps = false ↔ p ∉ ps := by
-  rw [Bool.eq_false_iff]
-  exact not_congr containsPoly_iff
-
-/-- First-occurrence-preserving duplicate removal with an explicit seen set. -/
-@[expose]
-def dedupPolysAux (seen : List ZPoly) : List ZPoly → List ZPoly
-  | [] => []
-  | p :: ps =>
-      if containsPoly p seen then dedupPolysAux seen ps
-      else p :: dedupPolysAux (p :: seen) ps
-
-/-- Deterministic first-occurrence-preserving duplicate removal using only
-coefficient equality. -/
-@[expose]
-def dedupPolys (ps : List ZPoly) : List ZPoly := dedupPolysAux [] ps
-
-theorem mem_dedupPolysAux {p : ZPoly} {seen ps : List ZPoly} :
-    p ∈ dedupPolysAux seen ps ↔ p ∈ ps ∧ p ∉ seen := by
-  classical
-  induction ps generalizing seen p with
-  | nil => simp [dedupPolysAux]
-  | cons q qs ih =>
-      simp only [dedupPolysAux]
-      split <;> rename_i hq
-      · have hqmem : q ∈ seen := containsPoly_iff.mp hq
-        simp only [ih, List.mem_cons]
-        by_cases hpq : p = q
-        · subst p
-          simp [hqmem]
-        · simp [hpq]
-      · have hqmem : q ∉ seen :=
-          containsPoly_eq_false_iff.mp (Bool.eq_false_of_not_eq_true hq)
-        simp only [List.mem_cons, ih]
-        by_cases hpq : p = q
-        · subst p
-          simp [hqmem]
-        · simp [hpq]
-
-theorem mem_dedupPolys {p : ZPoly} {ps : List ZPoly} :
-    p ∈ dedupPolys ps ↔ p ∈ ps := by
-  simp [dedupPolys, mem_dedupPolysAux]
-
-theorem dedupPolysAux_nodup (seen ps : List ZPoly) :
-    (dedupPolysAux seen ps).Nodup := by
-  induction ps generalizing seen with
-  | nil => simp [dedupPolysAux]
-  | cons p ps ih =>
-      simp only [dedupPolysAux]
-      split
-      · exact ih seen
-      · apply List.nodup_cons.mpr
-        exact ⟨by simp [mem_dedupPolysAux], ih (p :: seen)⟩
-
-theorem dedupPolys_nodup (ps : List ZPoly) : (dedupPolys ps).Nodup :=
-  dedupPolysAux_nodup [] ps
-
-/-- Pair a recomputed polynomial order with common-root packages and validate
-every package. Length mismatches and malformed packages are rejected. -/
-@[expose]
-def checkCommon (carrier : ZPoly) :
-    List ZPoly → List CommonRootCert → Bool
-  | [], [] => true
-  | p :: ps, common :: commons =>
-      common.check p carrier && checkCommon carrier ps commons
-  | _, _ => false
-
-/-- Positional lookup in an aligned common-root package list. -/
-@[expose]
-def findCommon? (p : ZPoly) :
-    List ZPoly → List CommonRootCert → Option CommonRootCert
-  | q :: qs, common :: commons =>
-      if DensePoly.beqCoeffs p q then some common
-      else findCommon? p qs commons
-  | _, _ => none
-
-/-- Checked alignment makes positional lookup total and validates the package
-against the requested external polynomial. -/
-theorem findCommon?_of_check {carrier p : ZPoly} {ps : List ZPoly}
-    {commons : List CommonRootCert} (hcheck : checkCommon carrier ps commons = true)
-    (hmem : p ∈ ps) :
-    ∃ common, findCommon? p ps commons = some common ∧
-      common.check p carrier = true := by
-  induction ps generalizing commons with
-  | nil => simp at hmem
-  | cons q qs ih =>
-      cases commons with
-      | nil => simp [checkCommon] at hcheck
-      | cons common commons =>
-          simp only [checkCommon, Bool.and_eq_true] at hcheck
-          rcases hcheck with ⟨hhead, htail⟩
-          by_cases hpq : p = q
-          · subst q
-            exact ⟨common, by simp [findCommon?, DensePoly.beqCoeffs_iff_eq], hhead⟩
-          · have htailMem : p ∈ qs := by
-              simpa [hpq] using hmem
-            obtain ⟨found, hfind, hfound⟩ := ih htail htailMem
-            refine ⟨found, ?_, hfound⟩
-            simp [findCommon?, DensePoly.beqCoeffs_iff_eq, hpq, hfind]
-
-/-- Common-root data carried by the sign-matrix layer.  No signs or formula
-truth values are trusted fields: both are recomputed exactly. -/
-structure SignMatrixCert where
-  commonRoots : List CommonRootCert
-
-/-- Exact sign on an open cell, rejecting the impossible zero result for a
-nonconstant atom of a valid carrier decomposition. -/
-@[expose]
-def openSign? (p : ZPoly) (isolations : IsolationCert)
-    (cut : Fin (isolations.intervals.size + 1)) : Option Sign :=
-  match evalSign p (isolations.openPoint cut) with
-  | .zero => none
-  | sign => some sign
-
-/-- Exact sign on a root cell from the cached common-root zero test, or from
-the canonical left open sample when the atom does not vanish. -/
-@[expose]
-def rootSign? (p : ZPoly) (common : CommonRootCert)
-    (isolations : IsolationCert) (i : Fin isolations.intervals.size) :
-    Option Sign :=
-  match common.hasRoot isolations.intervals[i] with
-  | true => some .zero
-  | false => openSign? p isolations i.castSucc
-
-theorem openSign?_eq_some {p : ZPoly} {isolations : IsolationCert}
-    {cut : Fin (isolations.intervals.size + 1)}
-    (hnonzero : evalSign p (isolations.openPoint cut) ≠ .zero) :
-    openSign? p isolations cut =
-      some (evalSign p (isolations.openPoint cut)) := by
-  cases hsign : evalSign p (isolations.openPoint cut) <;>
-    simp_all [openSign?]
-
-/-- Exact sign on an open cell, with constant polynomials evaluated once at
-zero and nonconstant polynomials guarded against an impossible zero sample. -/
-@[expose]
-def openCellSign? (p : ZPoly) (isolations : IsolationCert)
-    (cut : Fin (isolations.intervals.size + 1)) : Option Sign :=
-  if 0 < p.degree?.getD 0 then openSign? p isolations cut
-  else some (evalSign p 0)
-
 /-- The shared open-cell lookup is total and exact for every formula atom of a
 checked carrier, including constants. -/
 theorem openCellSign_spec {sentence : Sentence} {carrier : CarrierCert}
@@ -434,113 +251,7 @@ theorem openCellSign_spec {sentence : Sentence} {carrier : CarrierCert}
     rw [eval_eq_eval_zero_of_degree_nonpos p hdegree x]
     simpa using evalSign_spec p 0
 
-/-- One cached sign associated with its literal polynomial. -/
-structure SignEntry where
-  poly : ZPoly
-  sign : Sign
-
-/-- Coefficient-equality lookup in a cached sign row. -/
-@[expose]
-def findSign? (p : ZPoly) : List SignEntry → Option Sign
-  | [] => none
-  | entry :: entries =>
-      if DensePoly.beqCoeffs p entry.poly then some entry.sign
-      else findSign? p entries
-
-/-- Materialize a sign row once for each polynomial in a recomputed distinct
-order. Any missing sign fails the whole row. -/
-@[expose]
-def buildSigns? (signOf : ZPoly → Option Sign) :
-    List ZPoly → Option (List SignEntry)
-  | [] => some []
-  | p :: ps => do
-      let sign ← signOf p
-      let entries ← buildSigns? signOf ps
-      pure (⟨p, sign⟩ :: entries)
-
-/-- A row built from an option-valued environment returns exactly that
-environment on every polynomial included in the row order. -/
-theorem findSign?_of_build {signOf : ZPoly → Option Sign} {ps : List ZPoly}
-    {entries : List SignEntry} (hbuild : buildSigns? signOf ps = some entries)
-    {p : ZPoly} (hmem : p ∈ ps) : findSign? p entries = signOf p := by
-  induction ps generalizing entries with
-  | nil => simp at hmem
-  | cons q qs ih =>
-      cases hq : signOf q with
-      | none => simp [buildSigns?, hq] at hbuild
-      | some sign =>
-          cases hrest : buildSigns? signOf qs with
-          | none => simp [buildSigns?, hq, hrest] at hbuild
-          | some rest =>
-              have hentries : entries = ⟨q, sign⟩ :: rest := by
-                simpa [buildSigns?, hq, hrest] using hbuild.symm
-              subst entries
-              by_cases hpq : p = q
-              · subst q
-                simp [findSign?, DensePoly.beqCoeffs_iff_eq, hq]
-              · have htail : p ∈ qs := by simpa [hpq] using hmem
-                simp [findSign?, DensePoly.beqCoeffs_iff_eq, hpq,
-                  ih hrest htail]
-
-/-- A total option-valued environment builds a complete cached row. -/
-theorem buildSigns?_total {signOf : ZPoly → Option Sign} {ps : List ZPoly}
-    (htotal : ∀ p ∈ ps, ∃ sign, signOf p = some sign) :
-    ∃ entries, buildSigns? signOf ps = some entries := by
-  induction ps with
-  | nil => exact ⟨[], rfl⟩
-  | cons p ps ih =>
-      obtain ⟨sign, hsign⟩ := htotal p (by simp)
-      obtain ⟨entries, hentries⟩ := ih (by
-        intro q hq
-        exact htotal q (by simp [hq]))
-      exact ⟨⟨p, sign⟩ :: entries, by simp [buildSigns?, hsign, hentries]⟩
-
 namespace SignMatrixCert
-
-/-- Recompute the distinct nonconstant atom order and validate exact package
-alignment against the checked carrier. -/
-@[expose]
-def check (sentence : Sentence) (carrier : CarrierCert)
-    (cert : SignMatrixCert) : Bool :=
-  checkCommon carrier.carrier (dedupPolys sentence.polys) cert.commonRoots
-
-/-- Look up the package associated with one nonconstant atom. -/
-@[expose]
-def findCommon? (sentence : Sentence) (cert : SignMatrixCert)
-    (p : ZPoly) : Option CommonRootCert :=
-  Hex.RCF.findCommon? p (dedupPolys sentence.polys) cert.commonRoots
-
-/-- Every recomputed nonconstant atom has a checked package after successful
-alignment. -/
-theorem findCommon?_of_check {sentence : Sentence} {carrier : CarrierCert}
-    {cert : SignMatrixCert} (hcheck : cert.check sentence carrier = true)
-    {p : ZPoly} (hmem : p ∈ sentence.polys) :
-    ∃ common, cert.findCommon? sentence p = some common ∧
-      common.check p carrier.carrier = true := by
-  apply Hex.RCF.findCommon?_of_check hcheck
-  exact mem_dedupPolys.mpr hmem
-
-/-- Recompute one atom sign on one carrier cell using a precomputed distinct
-nonconstant order. Constants use evaluation at zero and consume no
-common-root package. -/
-@[expose]
-def signWith? (cert : SignMatrixCert) (commonPolys : List ZPoly)
-    (isolations : IsolationCert) (cell : Cell isolations.intervals.size)
-    (p : ZPoly) : Option Sign :=
-  match cell with
-  | .open cut => openCellSign? p isolations cut
-  | .root i =>
-      if 0 < p.degree?.getD 0 then do
-        let common ← Hex.RCF.findCommon? p commonPolys cert.commonRoots
-        rootSign? p common isolations i
-      else some (evalSign p 0)
-
-/-- Public atom-sign lookup, recomputing the deterministic package order. -/
-@[expose]
-def sign? (cert : SignMatrixCert) (sentence : Sentence)
-    (isolations : IsolationCert) (cell : Cell isolations.intervals.size)
-    (p : ZPoly) : Option Sign :=
-  cert.signWith? (dedupPolys sentence.polys) isolations cell p
 
 /-- A checked sign-matrix package returns a total exact sign for every atom on
 every semantic carrier cell when given the checker-derived package order. -/
@@ -664,17 +375,6 @@ end SignMatrixCert
 
 namespace Cmp
 
-/-- Evaluate a comparison from the sign of its left-hand side. -/
-@[expose]
-def evalSign (cmp : Cmp) (sign : Sign) : Bool :=
-  match cmp with
-  | .lt => sign == .neg
-  | .le => sign != .pos
-  | .eq => sign == .zero
-  | .ge => sign != .neg
-  | .gt => sign == .pos
-  | .ne => sign != .zero
-
 /-- Comparison evaluation depends only on the mathematical sign. -/
 theorem evalSign_iff {cmp : Cmp} {sign : Sign} {value : ℝ}
     (hsign : SignType.sign (((sign.toInt : Int) : ℝ)) = SignType.sign value) :
@@ -711,32 +411,6 @@ theorem Atom.toProp_iff_eval (a : Atom) (x : ℝ) :
   rfl
 
 namespace Formula
-
-/-- Evaluate a formula from an option-valued polynomial-sign environment.
-Every Boolean branch evaluates both children, so any missing sign fails closed.
--/
-@[expose]
-def evalSigns (signOf : ZPoly → Option Sign) : Formula → Option Bool
-  | .atom a => do
-      let sign ← signOf a.p
-      pure (a.cmp.evalSign sign)
-  | .tt => some true
-  | .ff => some false
-  | .not φ => do
-      let value ← φ.evalSigns signOf
-      pure (!value)
-  | .and φ ψ => do
-      let left ← φ.evalSigns signOf
-      let right ← ψ.evalSigns signOf
-      pure (left && right)
-  | .or φ ψ => do
-      let left ← φ.evalSigns signOf
-      let right ← ψ.evalSigns signOf
-      pure (left || right)
-  | .imp φ ψ => do
-      let left ← φ.evalSigns signOf
-      let right ← ψ.evalSigns signOf
-      pure (!left || right)
 
 /-- Formula evaluation returns a Boolean whose truth is exactly the semantic
 formula, provided every referenced polynomial lookup carries its exact sign.
@@ -819,12 +493,6 @@ theorem evalSigns_eq_true_iff {formula : Formula}
     have : value = true := hsound.mpr hprop
     simpa [this] using hvalue
 
-/-- Evaluate a formula whose atoms are all constant, without constructing a
-carrier decomposition. -/
-@[expose]
-def evalConstants? (formula : Formula) : Option Bool :=
-  formula.evalSigns fun p => some (Hex.RCF.evalSign p 0)
-
 /-- Constant-only formula evaluation is exact at every real point, including
 formulas containing the zero polynomial. -/
 theorem evalConstants_eq_true_iff {formula : Formula}
@@ -839,18 +507,6 @@ theorem evalConstants_eq_true_iff {formula : Formula}
 end Formula
 
 namespace SignMatrixCert
-
-/-- Recompute the formula truth value on one carrier cell after materializing
-one exact sign per distinct polynomial. Repeated atom occurrences reuse the
-cached row entry. -/
-@[expose]
-def evalCell? (cert : SignMatrixCert) (sentence : Sentence)
-    (isolations : IsolationCert) (cell : Cell isolations.intervals.size) :
-    Option Bool := do
-  let commonPolys := dedupPolys sentence.polys
-  let entries ← buildSigns? (cert.signWith? commonPolys isolations cell)
-    (dedupPolys sentence.formula.polys)
-  sentence.formula.evalSigns (findSign? · entries)
 
 /-- A checked package computes one Boolean valid uniformly throughout each
 semantic carrier cell. -/

--- a/HexRCF/SignMatrixCheck.lean
+++ b/HexRCF/SignMatrixCheck.lean
@@ -1,0 +1,391 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+import Init.Data.List.Lemmas
+public import HexRCF.CarrierCheck
+public import HexRCF.CellsCheck
+public import HexRCF.CommonRootCheck
+
+public section
+
+/-!
+# Executable sign-matrix replay
+
+This module computes exact polynomial signs from dyadic samples and checked
+common-root packages, caches one sign per distinct polynomial, and evaluates
+reflected formulas on carrier cells. It contains only exact data and Boolean
+or option-valued replay. The interpretation over real roots and semantic cells
+lives in `HexRCF.SignMatrix`.
+-/
+
+namespace Hex.RCF
+
+/-- The three possible signs stored by an RCF sign matrix. -/
+inductive Sign where
+  | neg
+  | zero
+  | pos
+  deriving DecidableEq, Repr
+
+namespace Sign
+
+/-- Canonical integer representative of a stored sign. -/
+@[expose]
+def toInt : Sign → Int
+  | .neg => -1
+  | .zero => 0
+  | .pos => 1
+
+/-- Collapse an arbitrary integer to its three-way sign. -/
+@[expose]
+def ofInt (value : Int) : Sign :=
+  if value < 0 then .neg else if 0 < value then .pos else .zero
+
+end Sign
+
+/-- Exact executable sign of an integer polynomial at a dyadic point. -/
+@[expose]
+def evalSign (p : ZPoly) (x : Dyadic) : Sign :=
+  Sign.ofInt (Hex.dyadicSign (p.evalDyadic x))
+
+/-- Coefficient-equality membership test for literal polynomials. This avoids
+the derived array equality that does not kernel-reduce through modules. -/
+@[expose]
+def containsPoly (p : ZPoly) : List ZPoly → Bool
+  | [] => false
+  | q :: qs => DensePoly.beqCoeffs p q || containsPoly p qs
+
+theorem containsPoly_iff {p : ZPoly} {ps : List ZPoly} :
+    containsPoly p ps = true ↔ p ∈ ps := by
+  induction ps with
+  | nil => simp [containsPoly]
+  | cons q qs ih =>
+      simp [containsPoly, Bool.or_eq_true, DensePoly.beqCoeffs_iff_eq, ih]
+
+/-- The coefficient-equality membership test is false exactly on
+nonmembership. -/
+theorem containsPoly_eq_false_iff {p : ZPoly} {ps : List ZPoly} :
+    containsPoly p ps = false ↔ p ∉ ps := by
+  rw [Bool.eq_false_iff]
+  exact not_congr containsPoly_iff
+
+/-- First-occurrence-preserving duplicate removal with an explicit seen set. -/
+@[expose]
+def dedupPolysAux (seen : List ZPoly) : List ZPoly → List ZPoly
+  | [] => []
+  | p :: ps =>
+      if containsPoly p seen then dedupPolysAux seen ps
+      else p :: dedupPolysAux (p :: seen) ps
+
+/-- Deterministic first-occurrence-preserving duplicate removal using only
+coefficient equality. -/
+@[expose]
+def dedupPolys (ps : List ZPoly) : List ZPoly := dedupPolysAux [] ps
+
+theorem mem_dedupPolysAux {p : ZPoly} {seen ps : List ZPoly} :
+    p ∈ dedupPolysAux seen ps ↔ p ∈ ps ∧ p ∉ seen := by
+  classical
+  induction ps generalizing seen p with
+  | nil => simp [dedupPolysAux]
+  | cons q qs ih =>
+      simp only [dedupPolysAux]
+      split <;> rename_i hq
+      · have hqmem : q ∈ seen := containsPoly_iff.mp hq
+        simp only [ih, List.mem_cons]
+        by_cases hpq : p = q
+        · subst p
+          simp [hqmem]
+        · simp [hpq]
+      · have hqmem : q ∉ seen := by
+          apply containsPoly_eq_false_iff.mp
+          cases h : containsPoly q seen <;> simp_all
+        simp only [List.mem_cons, ih]
+        by_cases hpq : p = q
+        · subst p
+          simp [hqmem]
+        · simp [hpq]
+
+theorem mem_dedupPolys {p : ZPoly} {ps : List ZPoly} :
+    p ∈ dedupPolys ps ↔ p ∈ ps := by
+  simp [dedupPolys, mem_dedupPolysAux]
+
+theorem dedupPolysAux_nodup (seen ps : List ZPoly) :
+    (dedupPolysAux seen ps).Nodup := by
+  induction ps generalizing seen with
+  | nil => simp [dedupPolysAux]
+  | cons p ps ih =>
+      simp only [dedupPolysAux]
+      split
+      · exact ih seen
+      · apply List.nodup_cons.mpr
+        exact ⟨by simp [mem_dedupPolysAux], ih (p :: seen)⟩
+
+theorem dedupPolys_nodup (ps : List ZPoly) : (dedupPolys ps).Nodup :=
+  dedupPolysAux_nodup [] ps
+
+/-- Pair a recomputed polynomial order with common-root packages and validate
+every package. Length mismatches and malformed packages are rejected. -/
+@[expose]
+def checkCommon (carrier : ZPoly) :
+    List ZPoly → List CommonRootCert → Bool
+  | [], [] => true
+  | p :: ps, common :: commons =>
+      common.check p carrier && checkCommon carrier ps commons
+  | _, _ => false
+
+/-- Positional lookup in an aligned common-root package list. -/
+@[expose]
+def findCommon? (p : ZPoly) :
+    List ZPoly → List CommonRootCert → Option CommonRootCert
+  | q :: qs, common :: commons =>
+      if DensePoly.beqCoeffs p q then some common
+      else findCommon? p qs commons
+  | _, _ => none
+
+/-- Checked alignment makes positional lookup total and validates the package
+against the requested external polynomial. -/
+theorem findCommon?_of_check {carrier p : ZPoly} {ps : List ZPoly}
+    {commons : List CommonRootCert} (hcheck : checkCommon carrier ps commons = true)
+    (hmem : p ∈ ps) :
+    ∃ common, findCommon? p ps commons = some common ∧
+      common.check p carrier = true := by
+  induction ps generalizing commons with
+  | nil => simp at hmem
+  | cons q qs ih =>
+      cases commons with
+      | nil => simp [checkCommon] at hcheck
+      | cons common commons =>
+          simp only [checkCommon, Bool.and_eq_true] at hcheck
+          rcases hcheck with ⟨hhead, htail⟩
+          by_cases hpq : p = q
+          · subst q
+            exact ⟨common, by simp [findCommon?, DensePoly.beqCoeffs_iff_eq], hhead⟩
+          · have htailMem : p ∈ qs := by
+              simpa [hpq] using hmem
+            obtain ⟨found, hfind, hfound⟩ := ih htail htailMem
+            refine ⟨found, ?_, hfound⟩
+            simp [findCommon?, DensePoly.beqCoeffs_iff_eq, hpq, hfind]
+
+/-- Common-root data carried by the sign-matrix layer. No signs or formula
+truth values are trusted fields: both are recomputed exactly. -/
+structure SignMatrixCert where
+  commonRoots : List CommonRootCert
+
+/-- Exact sign on an open cell, rejecting zero for a nonconstant atom of a
+valid carrier decomposition. -/
+@[expose]
+def openSign? (p : ZPoly) (isolations : IsolationCert)
+    (cut : Fin (isolations.intervals.size + 1)) : Option Sign :=
+  match evalSign p (isolations.openPoint cut) with
+  | .zero => none
+  | sign => some sign
+
+/-- Exact sign on a root cell from the cached common-root zero test, or from
+the canonical left open sample when the atom does not vanish. -/
+@[expose]
+def rootSign? (p : ZPoly) (common : CommonRootCert)
+    (isolations : IsolationCert) (i : Fin isolations.intervals.size) :
+    Option Sign :=
+  match common.hasRoot isolations.intervals[i] with
+  | true => some .zero
+  | false => openSign? p isolations i.castSucc
+
+theorem openSign?_eq_some {p : ZPoly} {isolations : IsolationCert}
+    {cut : Fin (isolations.intervals.size + 1)}
+    (hnonzero : evalSign p (isolations.openPoint cut) ≠ .zero) :
+    openSign? p isolations cut =
+      some (evalSign p (isolations.openPoint cut)) := by
+  cases hsign : evalSign p (isolations.openPoint cut) <;>
+    simp_all [openSign?]
+
+/-- Exact sign on an open cell, with constant polynomials evaluated once at
+zero and nonconstant polynomials guarded against an impossible zero sample. -/
+@[expose]
+def openCellSign? (p : ZPoly) (isolations : IsolationCert)
+    (cut : Fin (isolations.intervals.size + 1)) : Option Sign :=
+  if 0 < p.degree?.getD 0 then openSign? p isolations cut
+  else some (evalSign p 0)
+
+/-- One cached sign associated with its literal polynomial. -/
+structure SignEntry where
+  poly : ZPoly
+  sign : Sign
+
+/-- Coefficient-equality lookup in a cached sign row. -/
+@[expose]
+def findSign? (p : ZPoly) : List SignEntry → Option Sign
+  | [] => none
+  | entry :: entries =>
+      if DensePoly.beqCoeffs p entry.poly then some entry.sign
+      else findSign? p entries
+
+/-- Materialize a sign row once for each polynomial in a recomputed distinct
+order. Any missing sign fails the whole row. -/
+@[expose]
+def buildSigns? (signOf : ZPoly → Option Sign) :
+    List ZPoly → Option (List SignEntry)
+  | [] => some []
+  | p :: ps => do
+      let sign ← signOf p
+      let entries ← buildSigns? signOf ps
+      pure (⟨p, sign⟩ :: entries)
+
+/-- A row built from an option-valued environment returns exactly that
+environment on every polynomial included in the row order. -/
+theorem findSign?_of_build {signOf : ZPoly → Option Sign} {ps : List ZPoly}
+    {entries : List SignEntry} (hbuild : buildSigns? signOf ps = some entries)
+    {p : ZPoly} (hmem : p ∈ ps) : findSign? p entries = signOf p := by
+  induction ps generalizing entries with
+  | nil => simp at hmem
+  | cons q qs ih =>
+      cases hq : signOf q with
+      | none => simp [buildSigns?, hq] at hbuild
+      | some sign =>
+          cases hrest : buildSigns? signOf qs with
+          | none => simp [buildSigns?, hq, hrest] at hbuild
+          | some rest =>
+              have hentries : entries = ⟨q, sign⟩ :: rest := by
+                simpa [buildSigns?, hq, hrest] using hbuild.symm
+              subst entries
+              by_cases hpq : p = q
+              · subst q
+                simp [findSign?, DensePoly.beqCoeffs_iff_eq, hq]
+              · have htail : p ∈ qs := by simpa [hpq] using hmem
+                simp [findSign?, DensePoly.beqCoeffs_iff_eq, hpq,
+                  ih hrest htail]
+
+/-- A total option-valued environment builds a complete cached row. -/
+theorem buildSigns?_total {signOf : ZPoly → Option Sign} {ps : List ZPoly}
+    (htotal : ∀ p ∈ ps, ∃ sign, signOf p = some sign) :
+    ∃ entries, buildSigns? signOf ps = some entries := by
+  induction ps with
+  | nil => exact ⟨[], rfl⟩
+  | cons p ps ih =>
+      obtain ⟨sign, hsign⟩ := htotal p (by simp)
+      obtain ⟨entries, hentries⟩ := ih (by
+        intro q hq
+        exact htotal q (by simp [hq]))
+      exact ⟨⟨p, sign⟩ :: entries, by simp [buildSigns?, hsign, hentries]⟩
+
+namespace SignMatrixCert
+
+/-- Recompute the distinct nonconstant atom order and validate exact package
+alignment against the checked carrier. -/
+@[expose]
+def check (sentence : Sentence) (carrier : CarrierCert)
+    (cert : SignMatrixCert) : Bool :=
+  checkCommon carrier.carrier (dedupPolys sentence.polys) cert.commonRoots
+
+/-- Look up the package associated with one nonconstant atom. -/
+@[expose]
+def findCommon? (sentence : Sentence) (cert : SignMatrixCert)
+    (p : ZPoly) : Option CommonRootCert :=
+  Hex.RCF.findCommon? p (dedupPolys sentence.polys) cert.commonRoots
+
+/-- Every recomputed nonconstant atom has a checked package after successful
+alignment. -/
+theorem findCommon?_of_check {sentence : Sentence} {carrier : CarrierCert}
+    {cert : SignMatrixCert} (hcheck : cert.check sentence carrier = true)
+    {p : ZPoly} (hmem : p ∈ sentence.polys) :
+    ∃ common, cert.findCommon? sentence p = some common ∧
+      common.check p carrier.carrier = true := by
+  apply Hex.RCF.findCommon?_of_check hcheck
+  exact mem_dedupPolys.mpr hmem
+
+/-- Recompute one atom sign on one carrier cell using a precomputed distinct
+nonconstant order. Constants use evaluation at zero and consume no common-root
+package. -/
+@[expose]
+def signWith? (cert : SignMatrixCert) (commonPolys : List ZPoly)
+    (isolations : IsolationCert) (cell : Cell isolations.intervals.size)
+    (p : ZPoly) : Option Sign :=
+  match cell with
+  | .open cut => openCellSign? p isolations cut
+  | .root i =>
+      if 0 < p.degree?.getD 0 then do
+        let common ← Hex.RCF.findCommon? p commonPolys cert.commonRoots
+        rootSign? p common isolations i
+      else some (evalSign p 0)
+
+/-- Public atom-sign lookup, recomputing the deterministic package order. -/
+@[expose]
+def sign? (cert : SignMatrixCert) (sentence : Sentence)
+    (isolations : IsolationCert) (cell : Cell isolations.intervals.size)
+    (p : ZPoly) : Option Sign :=
+  cert.signWith? (dedupPolys sentence.polys) isolations cell p
+
+end SignMatrixCert
+
+namespace Cmp
+
+/-- Evaluate a comparison from the sign of its left-hand side. -/
+@[expose]
+def evalSign (cmp : Cmp) (sign : Sign) : Bool :=
+  match cmp with
+  | .lt => sign == .neg
+  | .le => sign != .pos
+  | .eq => sign == .zero
+  | .ge => sign != .neg
+  | .gt => sign == .pos
+  | .ne => sign != .zero
+
+end Cmp
+
+namespace Formula
+
+/-- Evaluate a formula from an option-valued polynomial-sign environment.
+Every Boolean branch evaluates both children, so any missing sign fails closed.
+-/
+@[expose]
+def evalSigns (signOf : ZPoly → Option Sign) : Formula → Option Bool
+  | .atom a => do
+      let sign ← signOf a.p
+      pure (a.cmp.evalSign sign)
+  | .tt => some true
+  | .ff => some false
+  | .not φ => do
+      let value ← φ.evalSigns signOf
+      pure (!value)
+  | .and φ ψ => do
+      let left ← φ.evalSigns signOf
+      let right ← ψ.evalSigns signOf
+      pure (left && right)
+  | .or φ ψ => do
+      let left ← φ.evalSigns signOf
+      let right ← ψ.evalSigns signOf
+      pure (left || right)
+  | .imp φ ψ => do
+      let left ← φ.evalSigns signOf
+      let right ← ψ.evalSigns signOf
+      pure (!left || right)
+
+/-- Evaluate a formula whose atoms are all constant, without constructing a
+carrier decomposition. -/
+@[expose]
+def evalConstants? (formula : Formula) : Option Bool :=
+  formula.evalSigns fun p => some (Hex.RCF.evalSign p 0)
+
+end Formula
+
+namespace SignMatrixCert
+
+/-- Recompute the formula truth value on one carrier cell after materializing
+one exact sign per distinct polynomial. Repeated atom occurrences reuse the
+cached row entry. -/
+@[expose]
+def evalCell? (cert : SignMatrixCert) (sentence : Sentence)
+    (isolations : IsolationCert) (cell : Cell isolations.intervals.size) :
+    Option Bool := do
+  let commonPolys := dedupPolys sentence.polys
+  let entries ← buildSigns? (cert.signWith? commonPolys isolations cell)
+    (dedupPolys sentence.formula.polys)
+  sentence.formula.evalSigns (findSign? · entries)
+
+end SignMatrixCert
+
+end Hex.RCF

--- a/HexRCF/Soundness.lean
+++ b/HexRCF/Soundness.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexRCF.Certificate
+public import HexRCF.SignMatrix
 
 public section
 

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -634,9 +634,11 @@ free to change.
   `HexRCF/CommonRoot.lean`: exact common-root and root-cell semantics;
   `HexRCF/CommonRootTests.lean`: shared-factor, coprime, equal-polynomial, and
   tampered-evidence regressions.
-- `HexRCF/SignMatrix.lean`: three-way exact signs, coefficient-equality
-  atom deduplication and common-package alignment, guarded open-cell
-  evaluation, the `gⱼ` root-cell computation, and full Boolean reflection;
+- `HexRCF/SignMatrixCheck.lean`: Mathlib-free three-way exact signs,
+  coefficient-equality atom deduplication and common-package alignment,
+  guarded open/root-cell evaluation, sign-row caching, and Boolean replay;
+  `HexRCF/SignMatrix.lean`: real-polynomial sign, root-cell, and full formula
+  reflection semantics;
   `HexRCF/SignMatrixTests.lean`: exhaustive comparisons/connectives,
   zero/singleton/multiple-root cells, shared roots, constants, deduplication,
   and malformed-alignment regressions.

--- a/progress/20260727T160001Z_rcf-sign-matrix-check.md
+++ b/progress/20260727T160001Z_rcf-sign-matrix-check.md
@@ -1,0 +1,40 @@
+# Mathlib-free RCF sign-matrix replay
+
+## Accomplished
+
+- Added `HexRCF.SignMatrixCheck`, containing exact sign data and dyadic
+  evaluation, coefficient-based polynomial deduplication, common-root package
+  alignment, open/root-cell sign lookup, sign-row caching, Boolean comparison
+  and formula evaluation, and per-cell certificate replay.
+- Reduced `HexRCF.SignMatrix` to real-polynomial, semantic-cell, and reflected
+  formula correctness theorems while preserving existing public names through
+  imports.
+- Replaced the hidden Mathlib-only `Bool.eq_false_of_not_eq_true` proof helper
+  with a core Boolean case proof and made the core list dependency explicit.
+- Rewired `Builder` and `Certificate` to `SignMatrixCheck`; `Soundness` now owns
+  the semantic `SignMatrix` import explicitly, and `BuilderTests` requests the
+  checker implementation in its meta import.
+- Updated the HexRCF umbrella and SPEC file map.
+- Verified focused consumers and the full HexRCF build. Mechanically checked
+  the 39-module `SignMatrixCheck`, 40-module `Certificate`, and 41-module
+  `Builder` closures contain neither `Mathlib.*` nor
+  `HexRealRootsMathlib.*`; DAG, Phase-4, release-manifest, trust-surface,
+  copyright, diff, and banned-token checks pass. An independent Sol review
+  verified all 56 declarations and 21 exposure annotations and returned GO.
+
+## Current frontier
+
+Issue #9003 is implemented on a branch stacked above the cell-check PR #9002.
+The complete kernel-facing certificate replay and its compiled witness builder
+now have mechanically verified Mathlib-free import closures.
+
+## Next step
+
+Publish the stacked PR, then use the new pure certificate boundary to finish
+the generic-vs-tactic Phase-4 evidence and promote the green extraction stack
+as each parent reaches `main`.
+
+## Blockers
+
+None for this extraction. The branch remains stacked until its parent chain
+merges; it can then be rebased and retargeted to main.


### PR DESCRIPTION
Closes #9003.

Contributes to #8973 by separating exact sign computation, sign-row caching, Boolean formula evaluation, and per-cell replay from real-polynomial and semantic-cell correctness proofs. `Builder` and the complete `Certificate` replay now import the pure layer directly.

Validation:
- `lake build HexRCF.SignMatrixCheck HexRCF.SignMatrix HexRCF.Certificate HexRCF.Builder HexRCF.Soundness`
- `lake build HexRCF`
- pure closures: SignMatrixCheck 39 modules, Certificate 40, Builder 41; none imports `Mathlib.*` or `HexRealRootsMathlib.*`
- DAG, Phase-4, release-manifest, trust-surface, copyright, diff, and banned-token checks pass
- independent Sol audit of all declarations/exposure annotations: GO