### PR TITLE
refactor(rcf): extract Mathlib-free compiled decision

### DIFF
--- a/HexRCF.lean
+++ b/HexRCF.lean
@@ -36,6 +36,7 @@ public import HexRCF.BuilderTests
 public import HexRCF.Certificate
 public import HexRCF.Soundness
 public import HexRCF.CertificateTests
+public import HexRCF.DecisionCheck
 public import HexRCF.Decision
 public import HexRCF.DecisionTests
 public import HexRCF.Reify

--- a/HexRCF/Decision.lean
+++ b/HexRCF/Decision.lean
@@ -6,181 +6,20 @@ Authors: Kim Morrison
 
 module
 
-public import HexRCF.Builder
+public import HexRCF.DecisionCheck
 public import HexRCF.Soundness
-public import HexRealRoots.Isolate
 
 public section
 
 /-!
-# Compiled RCF certificate assembly
+# Soundness of compiled RCF decisions
 
-This module runs root search, strict separation, endpoint classification, and
-arithmetic witness construction outside kernel replay. It retains a candidate
-only when the small certificate replay produces a well-formed verdict. A true
-verdict is checked once more before the public decision wrapper returns it.
+The Mathlib-free certificate construction and decision pipeline live in
+`HexRCF.DecisionCheck`. This module connects an accepted compiled verdict to
+the real-valued reflected sentence semantics.
 -/
 
 namespace Hex.RCF
-
-/-- Erase the proof fields tied to the executable Sturm chain, retaining only
-the raw intervals that the generalized replay checker will validate. -/
-private def rawIsolations {p : ZPoly} (roots : Hex.RealRootIsolations p) :
-    IsolationCert :=
-  ⟨roots.isolations.map (fun isolation => isolation.interval)⟩
-
-/-- Run executable isolation, validate the raw intervals against the carrier's
-literal replay, and refine touching intervals to strict separation. -/
-def buildIsolations? (carrier : CarrierCert) : Option IsolationCert :=
-  match Hex.isolate? carrier.carrier with
-  | none => none
-  | some roots =>
-      let raw := rawIsolations roots
-      if raw.check carrier.replay then
-        Separation.separate? carrier.carrier carrier.replay raw
-      else none
-
-/-- Every emitted isolation array passes the generalized strict checker. -/
-theorem check_buildIsolations {carrier : CarrierCert}
-    {isolations : IsolationCert}
-    (h : buildIsolations? carrier = some isolations) :
-    isolations.checkStrict carrier.replay = true := by
-  unfold buildIsolations? at h
-  split at h <;> rename_i hroots
-  · simp at h
-  · dsimp only at h
-    split at h
-    · exact Separation.check_of_separate_eq_some h
-    · simp at h
-
-/-- Classify every isolated carrier root against one exact endpoint. -/
-def buildRootCmps? (carrier : CarrierCert) (isolations : IsolationCert)
-    (endpoint : Dyadic) :
-    Option (Vector Separation.RootCmp isolations.intervals.size) :=
-  Vector.ofFnM fun i =>
-    Separation.classify? carrier.carrier carrier.replay
-      isolations.intervals[i] endpoint
-
-/-- Build both size-indexed endpoint-comparison vectors and retain them only
-after the endpoint checker accepts every position. -/
-def buildIocCmps? (carrier : CarrierCert) (isolations : IsolationCert)
-    (a b : Dyadic) : Option (IocCmps isolations.intervals.size) := do
-  let lower ← buildRootCmps? carrier isolations a
-  let upper ← buildRootCmps? carrier isolations b
-  let cmps : IocCmps isolations.intervals.size := { lower, upper }
-  if cmps.check carrier.carrier carrier.replay isolations a b then
-    some cmps
-  else none
-
-/-- Every emitted endpoint package passes its positional checker. -/
-theorem check_buildIocCmps {carrier : CarrierCert}
-    {isolations : IsolationCert} {a b : Dyadic}
-    {cmps : IocCmps isolations.intervals.size}
-    (h : buildIocCmps? carrier isolations a b = some cmps) :
-    cmps.check carrier.carrier carrier.replay isolations a b = true := by
-  unfold buildIocCmps? at h
-  obtain ⟨lower, _hlower, h⟩ := Option.bind_eq_some_iff.mp h
-  obtain ⟨upper, _hupper, h⟩ := Option.bind_eq_some_iff.mp h
-  dsimp only at h
-  split at h <;> rename_i hcheck
-  · cases Option.some.inj h
-    exact hcheck
-  · simp at h
-
-/-- Wrap the aligned common-root list as a sign-matrix certificate, retaining
-it only after the sign-matrix alignment checker accepts it. -/
-def buildSignMatrix? (s : Sentence) (carrier : CarrierCert) :
-    Option SignMatrixCert := do
-  let commons ← buildCommonRoots? s carrier.carrier
-  let cert : SignMatrixCert := { commonRoots := commons }
-  if cert.check s carrier then some cert else none
-
-/-- Every emitted sign-matrix package passes its alignment checker. -/
-theorem check_buildSignMatrix {s : Sentence} {carrier : CarrierCert}
-    {signs : SignMatrixCert}
-    (h : buildSignMatrix? s carrier = some signs) :
-    signs.check s carrier = true := by
-  unfold buildSignMatrix? at h
-  obtain ⟨commons, _hcommons, h⟩ := Option.bind_eq_some_iff.mp h
-  dsimp only at h
-  split at h <;> rename_i hcheck
-  · cases Option.some.inj h
-    exact hcheck
-  · simp at h
-
-/-- Assemble the constant or carrier decomposition for a domain already known
-not to be empty. Common-root work is skipped for root-free carriers. -/
-private def buildDecomposition? (s : Sentence) : Option Certificate :=
-  if s.polys.isEmpty then some .constants
-  else do
-    let carrier ← buildCarrier? s
-    let isolations ← buildIsolations? carrier
-    if isolations.intervals.isEmpty then
-      some (.noRoots { carrier, isolations })
-    else do
-      let signs ← buildSignMatrix? s carrier
-      match s with
-      | .forallReal _ | .existsReal _ =>
-          some (.cells { carrier, isolations, signs, iocCmps := none })
-      | .forallIoc a b _ | .existsIoc a b _ => do
-          let cmps ← buildIocCmps? carrier isolations a b
-          some (.cells { carrier, isolations, signs, iocCmps := some cmps })
-
-/-- Choose the empty-domain branch before performing any arithmetic work. -/
-private def buildCandidate? (s : Sentence) : Option Certificate :=
-  match s with
-  | .forallIoc a b _ | .existsIoc a b _ =>
-      if a < b then buildDecomposition? s else some .emptyIoc
-  | .forallReal _ | .existsReal _ => buildDecomposition? s
-
-/-- A compiled build result retains the certificate that produced its
-diagnostic or proof-producing verdict. -/
-structure BuildResult where
-  certificate : Certificate
-  verdict : Bool
-
-/-- Assemble a certificate and reject it if replay finds malformed evidence. -/
-def build? (s : Sentence) : Option BuildResult := do
-  let certificate ← buildCandidate? s
-  match certificate.replay? s with
-  | none => none
-  | some verdict => some { certificate, verdict }
-
-/-- A retained build result records exactly the certificate's replay verdict. -/
-theorem replay_build {s : Sentence} {result : BuildResult}
-    (h : build? s = some result) :
-    result.certificate.replay? s = some result.verdict := by
-  unfold build? at h
-  obtain ⟨certificate, _hcandidate, h⟩ := Option.bind_eq_some_iff.mp h
-  split at h <;> rename_i hreplay
-  · simp at h
-  · cases Option.some.inj h
-    exact hreplay
-
-/-- Compiled convenience decision. False is diagnostic; true is returned only
-after the kernel-facing Boolean checker accepts the retained certificate. -/
-def decide (s : Sentence) : Option Bool :=
-  match build? s with
-  | none => none
-  | some result =>
-      if result.verdict then
-        if result.certificate.check s then some true else none
-      else some false
-
-/-- A true compiled verdict exposes a certificate accepted by the checker. -/
-theorem decide_eq_some_true_imp_exists_cert {s : Sentence}
-    (h : decide s = some true) :
-    ∃ cert, Certificate.check s cert = true := by
-  unfold decide at h
-  split at h
-  · simp at h
-  · rename_i result hresult
-    split at h
-    · split at h
-      · rename_i hcheck
-        exact ⟨result.certificate, hcheck⟩
-      · simp at h
-    · simp at h
 
 /-- Every true compiled verdict proves the reflected sentence. -/
 theorem decide_sound (s : Sentence) (h : decide s = some true) : s.toProp := by

--- a/HexRCF/DecisionCheck.lean
+++ b/HexRCF/DecisionCheck.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRCF.Builder
+public import HexRCF.Certificate
+public import HexRealRoots.Isolate
+
+public section
+
+/-!
+# Compiled RCF certificate assembly and decision
+
+This Mathlib-free module runs root search, strict separation, endpoint
+classification, arithmetic witness construction, and exact certificate replay.
+It retains a candidate only when replay produces a well-formed verdict. The
+interpretation of an accepted true verdict lives in `HexRCF.Decision`.
+-/
+
+namespace Hex.RCF
+
+/-- Erase the proof fields tied to the executable Sturm chain, retaining only
+the raw intervals that the generalized replay checker will validate. -/
+private def rawIsolations {p : ZPoly} (roots : Hex.RealRootIsolations p) :
+    IsolationCert :=
+  ⟨roots.isolations.map (fun isolation => isolation.interval)⟩
+
+/-- Run executable isolation, validate the raw intervals against the carrier's
+literal replay, and refine touching intervals to strict separation. -/
+def buildIsolations? (carrier : CarrierCert) : Option IsolationCert :=
+  match Hex.isolate? carrier.carrier with
+  | none => none
+  | some roots =>
+      let raw := rawIsolations roots
+      if raw.check carrier.replay then
+        Separation.separate? carrier.carrier carrier.replay raw
+      else none
+
+/-- Every emitted isolation array passes the generalized strict checker. -/
+theorem check_buildIsolations {carrier : CarrierCert}
+    {isolations : IsolationCert}
+    (h : buildIsolations? carrier = some isolations) :
+    isolations.checkStrict carrier.replay = true := by
+  unfold buildIsolations? at h
+  split at h <;> rename_i hroots
+  · simp at h
+  · dsimp only at h
+    split at h
+    · exact Separation.check_of_separate_eq_some h
+    · simp at h
+
+/-- Classify every isolated carrier root against one exact endpoint. -/
+def buildRootCmps? (carrier : CarrierCert) (isolations : IsolationCert)
+    (endpoint : Dyadic) :
+    Option (Vector Separation.RootCmp isolations.intervals.size) :=
+  Vector.ofFnM fun i =>
+    Separation.classify? carrier.carrier carrier.replay
+      isolations.intervals[i] endpoint
+
+/-- Build both size-indexed endpoint-comparison vectors and retain them only
+after the endpoint checker accepts every position. -/
+def buildIocCmps? (carrier : CarrierCert) (isolations : IsolationCert)
+    (a b : Dyadic) : Option (IocCmps isolations.intervals.size) := do
+  let lower ← buildRootCmps? carrier isolations a
+  let upper ← buildRootCmps? carrier isolations b
+  let cmps : IocCmps isolations.intervals.size := { lower, upper }
+  if cmps.check carrier.carrier carrier.replay isolations a b then
+    some cmps
+  else none
+
+/-- Every emitted endpoint package passes its positional checker. -/
+theorem check_buildIocCmps {carrier : CarrierCert}
+    {isolations : IsolationCert} {a b : Dyadic}
+    {cmps : IocCmps isolations.intervals.size}
+    (h : buildIocCmps? carrier isolations a b = some cmps) :
+    cmps.check carrier.carrier carrier.replay isolations a b = true := by
+  unfold buildIocCmps? at h
+  obtain ⟨lower, _hlower, h⟩ := Option.bind_eq_some_iff.mp h
+  obtain ⟨upper, _hupper, h⟩ := Option.bind_eq_some_iff.mp h
+  dsimp only at h
+  split at h <;> rename_i hcheck
+  · cases Option.some.inj h
+    exact hcheck
+  · simp at h
+
+/-- Wrap the aligned common-root list as a sign-matrix certificate, retaining
+it only after the sign-matrix alignment checker accepts it. -/
+def buildSignMatrix? (s : Sentence) (carrier : CarrierCert) :
+    Option SignMatrixCert := do
+  let commons ← buildCommonRoots? s carrier.carrier
+  let cert : SignMatrixCert := { commonRoots := commons }
+  if cert.check s carrier then some cert else none
+
+/-- Every emitted sign-matrix package passes its alignment checker. -/
+theorem check_buildSignMatrix {s : Sentence} {carrier : CarrierCert}
+    {signs : SignMatrixCert}
+    (h : buildSignMatrix? s carrier = some signs) :
+    signs.check s carrier = true := by
+  unfold buildSignMatrix? at h
+  obtain ⟨commons, _hcommons, h⟩ := Option.bind_eq_some_iff.mp h
+  dsimp only at h
+  split at h <;> rename_i hcheck
+  · cases Option.some.inj h
+    exact hcheck
+  · simp at h
+
+/-- Assemble the constant or carrier decomposition for a domain already known
+not to be empty. Common-root work is skipped for root-free carriers. -/
+private def buildDecomposition? (s : Sentence) : Option Certificate :=
+  if s.polys.isEmpty then some .constants
+  else do
+    let carrier ← buildCarrier? s
+    let isolations ← buildIsolations? carrier
+    if isolations.intervals.isEmpty then
+      some (.noRoots { carrier, isolations })
+    else do
+      let signs ← buildSignMatrix? s carrier
+      match s with
+      | .forallReal _ | .existsReal _ =>
+          some (.cells { carrier, isolations, signs, iocCmps := none })
+      | .forallIoc a b _ | .existsIoc a b _ => do
+          let cmps ← buildIocCmps? carrier isolations a b
+          some (.cells { carrier, isolations, signs, iocCmps := some cmps })
+
+/-- Choose the empty-domain branch before performing any arithmetic work. -/
+private def buildCandidate? (s : Sentence) : Option Certificate :=
+  match s with
+  | .forallIoc a b _ | .existsIoc a b _ =>
+      if a < b then buildDecomposition? s else some .emptyIoc
+  | .forallReal _ | .existsReal _ => buildDecomposition? s
+
+/-- A compiled build result retains the certificate that produced its
+diagnostic or proof-producing verdict. -/
+structure BuildResult where
+  certificate : Certificate
+  verdict : Bool
+
+/-- Assemble a certificate and reject it if replay finds malformed evidence. -/
+def build? (s : Sentence) : Option BuildResult := do
+  let certificate ← buildCandidate? s
+  match certificate.replay? s with
+  | none => none
+  | some verdict => some { certificate, verdict }
+
+/-- A retained build result records exactly the certificate's replay verdict. -/
+theorem replay_build {s : Sentence} {result : BuildResult}
+    (h : build? s = some result) :
+    result.certificate.replay? s = some result.verdict := by
+  unfold build? at h
+  obtain ⟨certificate, _hcandidate, h⟩ := Option.bind_eq_some_iff.mp h
+  split at h <;> rename_i hreplay
+  · simp at h
+  · cases Option.some.inj h
+    exact hreplay
+
+/-- Compiled convenience decision. False is diagnostic; true is returned only
+after the kernel-facing Boolean checker accepts the retained certificate. -/
+def decide (s : Sentence) : Option Bool :=
+  match build? s with
+  | none => none
+  | some result =>
+      if result.verdict then
+        if result.certificate.check s then some true else none
+      else some false
+
+/-- A true compiled verdict exposes a certificate accepted by the checker. -/
+theorem decide_eq_some_true_imp_exists_cert {s : Sentence}
+    (h : decide s = some true) :
+    ∃ cert, Certificate.check s cert = true := by
+  unfold decide at h
+  split at h
+  · simp at h
+  · rename_i result hresult
+    split at h
+    · split at h
+      · rename_i hcheck
+        exact ⟨result.certificate, hcheck⟩
+      · simp at h
+    · simp at h
+
+end Hex.RCF

--- a/HexRCF/DecisionTests.lean
+++ b/HexRCF/DecisionTests.lean
@@ -7,7 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexRCF.Decision
-public meta import HexRCF.Decision
+public meta import HexRCF.DecisionCheck
 
 public section
 

--- a/HexRCF/Reify.lean
+++ b/HexRCF/Reify.lean
@@ -10,7 +10,7 @@ public import HexRCF.Soundness
 public import HexRealRootsMathlib.IsolateRoots
 public import Mathlib.Tactic.NormNum
 public import Mathlib.Tactic.Ring
-public meta import HexRCF.Decision
+public meta import HexRCF.DecisionCheck
 public meta import Mathlib.Lean.Elab.Tactic.Meta
 public meta import Qq
 public import Lean

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -611,9 +611,10 @@ free to change.
   compiled carrier and deduplicated, aligned common-root construction;
   `HexRCF/BuilderTests.lean`: signed-content, repeated-factor, rational-scale,
   common-root alignment, and failure regressions.
-- `HexRCF/Decision.lean`: compiled root isolation, strict separation, endpoint
-  classification, sign-matrix and certificate assembly, retained diagnostic
-  build results, and the public one-way-sound `decide` wrapper;
+- `HexRCF/DecisionCheck.lean`: Mathlib-free compiled root isolation, strict
+  separation, endpoint classification, sign-matrix and certificate assembly,
+  retained diagnostic build results, and `decide`;
+  `HexRCF/Decision.lean`: the public one-way soundness theorem;
   `HexRCF/DecisionTests.lean`: all four certificate branches and quantifiers,
   half-open endpoint ownership, multiple/repeated/shared roots, helper failure,
   and output-check regressions.

--- a/conformance/HexRCF/EmitFixtures.lean
+++ b/conformance/HexRCF/EmitFixtures.lean
@@ -5,7 +5,7 @@ Authors: Kim Morrison
 -/
 
 import Hex.Conformance.Emit
-import HexRCF.Decision
+import HexRCF.DecisionCheck
 
 /-!
 JSONL fixture emission for the independent HexRCF oracle.

--- a/progress/20260727T160458Z_rcf-decision-check.md
+++ b/progress/20260727T160458Z_rcf-decision-check.md
@@ -1,0 +1,39 @@
+# Mathlib-free compiled RCF decision
+
+## Accomplished
+
+- Added `HexRCF.DecisionCheck`, containing compiled real-root isolation,
+  strict separation, endpoint classification, sign-matrix and certificate
+  assembly, retained build results, replay validation, and `decide`.
+- Reduced `HexRCF.Decision` to `decide_sound`, the sole theorem interpreting
+  an accepted verdict in real-valued sentence semantics, while preserving the
+  existing public declaration surface through imports.
+- Rewired `Reify` and `DecisionTests` to request the pure decision module's
+  bodies explicitly for compiled/meta execution, and switched the shared
+  conformance fixture emitter to the pure decision import.
+- Updated the HexRCF umbrella and SPEC file map.
+- Verified focused decision, test, reification, and tactic targets and the full
+  HexRCF build. Mechanically checked the 47-module `DecisionCheck` closure
+  contains neither `Mathlib.*` nor `HexRealRootsMathlib.*`; the Certificate and
+  Builder closures remain pure. DAG, Phase-4, release-manifest, trust-surface,
+  copyright, diff, and banned-token checks pass. The standalone
+  `hexrcf_emit_fixtures` executable also builds through the pure closure. An
+  independent Sol review returned GO after auditing declarations, imports,
+  API preservation, and consumers.
+
+## Current frontier
+
+Issue #9006 is implemented on a branch stacked above the sign-matrix-check PR
+#9005. The complete compiled decision track required by directive #8973 now
+has a mechanically verified Mathlib-free import closure.
+
+## Next step
+
+Publish the stacked PR, then define controlled one-parameter LeanBench
+families over `DecisionCheck` separately from the fresh-module tactic probes,
+and reconcile the Phase-4 evidence contract around those two tracks.
+
+## Blockers
+
+None for this extraction. The branch remains stacked until its parent chain
+merges; it can then be rebased and retargeted to main.


### PR DESCRIPTION
Closes #9006.

Contributes the compiled-decision track required by #8973: root isolation, strict separation, endpoint classification, witness/certificate assembly, replay, and `decide` now live behind a 47-module Mathlib-free closure. Only `decide_sound` remains semantic. The shared fixture emitter now imports the pure decision path directly.

Validation:
- `lake build HexRCF.DecisionCheck HexRCF.Decision HexRCF.DecisionTests HexRCF.Reify HexRCF.Tactic`
- `lake build HexRCF`
- `lake build hexrcf_emit_fixtures`
- 47-module DecisionCheck closure contains no `Mathlib.*` or `HexRealRootsMathlib.*`
- DAG, Phase-4, release-manifest, trust-surface, copyright, diff, and banned-token checks pass
- independent Sol audit: GO