### PR TITLE
prove(number-field-tower): validate recursive inversion

### DIFF
--- a/HexNumberFieldTower/Arithmetic.lean
+++ b/HexNumberFieldTower/Arithmetic.lean
@@ -193,6 +193,16 @@ def inv {T : NumberTower} (a : Elem T) : Elem T :=
 
 instance {T : NumberTower} : Inv (Elem T) := ⟨inv⟩
 
+/-- Recursive inversion exposes its fixed-width extended-gcd coordinates. -/
+@[simp]
+theorem coeffs_inv {T : NumberTower} (a : Elem T) :
+    coeffs a⁻¹ = Arithmetic.invCoords T.levels.toList (coeffs a) := by
+  change coeffs (inv a) = _
+  unfold inv
+  rw [coeffs_ofCoeffs]
+  apply normalizeCoeffs_eq_self
+  simp [dim]
+
 /-- Tower division. -/
 @[expose]
 def div {T : NumberTower} (a b : Elem T) : Elem T :=

--- a/HexNumberFieldTower/RawArithmetic.lean
+++ b/HexNumberFieldTower/RawArithmetic.lean
@@ -399,9 +399,26 @@ instance (levels : List Level) : Mul (Coeff levels) :=
   ⟨fun a b =>
     ⟨mulCoords levels a.data b.data, mulCoords_size levels a.data b.data⟩⟩
 
+/-- View one top-level coordinate array as a polynomial over canonical lower
+tower coefficients. -/
+@[expose]
+def Coeff.value (level : Level) (lower : List Level) (a : Array Rat) :
+    DensePoly (Coeff lower) :=
+  DensePoly.ofCoeffs <| ((List.range level.degree).map fun i =>
+    Coeff.ofData lower (block a i (levelsDim lower))).toArray
+
+/-- The monic defining relation as a polynomial over canonical lower-tower
+coefficients. -/
+@[expose]
+def Coeff.relation (level : Level) (lower : List Level) :
+    DensePoly (Coeff lower) :=
+  DensePoly.ofCoeffs <| ((List.range level.degree).map fun i =>
+    Coeff.ofData lower (level.defining.getD i #[])).toArray.push 1
+
 /-- Recursive inverse coordinates. The zero convention is inherited at every
 level; defensive nonconstant/zero gcd branches are unreachable for certified
 level lists. -/
+@[expose]
 def invCoords : (levels : List Level) → Array Rat → Array Rat
   | [], a => #[if a.getD 0 0 = 0 then 0 else (a.getD 0 0)⁻¹]
   | level :: lower, a =>
@@ -413,12 +430,8 @@ def invCoords : (levels : List Level) → Array Rat → Array Rat
         letI : Inv (Coeff lower) :=
           ⟨fun x => Coeff.ofData lower (invCoords lower x.data)⟩
         letI : Div (Coeff lower) := ⟨fun x y => x * y⁻¹⟩
-        let value : DensePoly (Coeff lower) :=
-          DensePoly.ofCoeffs <| ((List.range d).map fun i =>
-            Coeff.ofData lower (block a i lowerDim)).toArray
-        let defining : DensePoly (Coeff lower) :=
-          DensePoly.ofCoeffs <| ((List.range d).map fun i =>
-            Coeff.ofData lower (level.defining.getD i #[])).toArray.push 1
+        let value := Coeff.value level lower a
+        let defining := Coeff.relation level lower
         let result := DensePoly.xgcdLeft value defining
         if result.gcd.size = 1 then
           let c := result.gcd.leadingCoeff
@@ -426,7 +439,7 @@ def invCoords : (levels : List Level) → Array Rat → Array Rat
             Hex.panicWith (Array.replicate (d * lowerDim) 0)
               "NumberTower.inv: zero constant gcd"
           else
-            let normalized := DensePoly.scale c⁻¹ result.left
+            let normalized := DensePoly.scale c⁻¹ result.left % defining
             flattenBlocks d lowerDim <| ((List.range d).map fun i =>
               (normalized.coeff i).data).toArray
         else

--- a/HexNumberFieldTowerMathlib/Arithmetic.lean
+++ b/HexNumberFieldTowerMathlib/Arithmetic.lean
@@ -790,6 +790,7 @@ def coeffZPow {levels : List Level} (a : Arithmetic.Coeff levels) :
   | .negSucc n => (coeffPow a (n + 1))⁻¹
 
 /-- Canonical coefficients at one level list have unique complex denotation. -/
+@[expose]
 def DenoteInjective (levels : List Level) : Prop :=
   Function.Injective (coeffDenote levels)
 
@@ -797,7 +798,7 @@ def DenoteInjective (levels : List Level) : Prop :=
 once recursive inversion is known to preserve complex denotation. Auxiliary
 casts, scalar actions, and powers are chosen through rational coordinate
 scaling and the existing executable operations. -/
-@[implicit_reducible]
+@[expose, reducible]
 noncomputable def coeffField (levels : List Level) (hvalid : LevelsValid levels)
     (hinjective : DenoteInjective levels)
     (hinv : ∀ a : Arithmetic.Coeff levels,
@@ -823,7 +824,7 @@ noncomputable def coeffField (levels : List Level) (hvalid : LevelsValid levels)
     ⟨fun q => coeffSmul levels (q : Rat) 1⟩
   letI : RatCast (Arithmetic.Coeff levels) :=
     ⟨fun q => coeffSmul levels q 1⟩
-  apply hinjective.field (coeffDenote levels)
+  apply Function.Injective.field (coeffDenote levels) hinjective
   · exact coeffDenote_zero levels
   · exact coeffDenote_one levels hvalid
   · exact coeffDenote_add levels
@@ -881,6 +882,40 @@ noncomputable def coeffField (levels : List Level) (hvalid : LevelsValid levels)
     rw [coeffDenote_smul, coeffDenote_one levels hvalid]
     simp
 
+/-- Canonical coefficient denotation bundled as a ring homomorphism for the
+transferred executable field. -/
+@[expose]
+noncomputable def coeffHom (levels : List Level) (hvalid : LevelsValid levels)
+    (hinjective : DenoteInjective levels)
+    (hinv : ∀ a : Arithmetic.Coeff levels,
+      coeffDenote levels a⁻¹ = (coeffDenote levels a)⁻¹) :
+    letI : Field (Arithmetic.Coeff levels) :=
+      coeffField levels hvalid hinjective hinv
+    Arithmetic.Coeff levels →+* ℂ := by
+  letI : Field (Arithmetic.Coeff levels) :=
+    coeffField levels hvalid hinjective hinv
+  exact
+    { toFun := coeffDenote levels
+      map_zero' := by
+        change denote levels
+          (Arithmetic.fixedCoeffs (levelsDim levels) #[]) = 0
+        exact denote_zero levels
+      map_one' := by
+        change denote levels
+          (Arithmetic.fixedCoeffs (levelsDim levels) #[1]) = 1
+        exact denote_one levels hvalid
+      map_add' := by
+        intro a b
+        change denote levels
+            (Arithmetic.addCoords (levelsDim levels) a.data b.data) =
+          denote levels a.data + denote levels b.data
+        exact denote_add levels a.data b.data
+      map_mul' := by
+        intro a b
+        change denote levels (Arithmetic.mulCoords levels a.data b.data) =
+          denote levels a.data * denote levels b.data
+        exact denote_mul levels hvalid a.data b.data }
+
 private theorem fixedCoeffs_eq_self (levels : List Level)
     (a : Arithmetic.Coeff levels) :
     Arithmetic.fixedCoeffs (levelsDim levels) a.data = a.data := by
@@ -888,6 +923,581 @@ private theorem fixedCoeffs_eq_self (levels : List Level)
   · simp [Arithmetic.fixedCoeffs, a.size_eq]
   · intro i hi₁ hi₂
     simp [Arithmetic.fixedCoeffs, Array.getD, hi₂]
+
+private theorem coeff_eq_of_data_eq {levels : List Level}
+    {a b : Arithmetic.Coeff levels} (h : a.data = b.data) : a = b := by
+  cases a with
+  | mk ad ha =>
+      cases b with
+      | mk bd hb =>
+          simp only at h
+          cases h
+          rfl
+
+/-- Evaluate a prescribed coefficient range of an executable dense polynomial
+through lower-tower denotation. -/
+@[expose]
+noncomputable def denseEval (lower : List Level) (x : ℂ) (degree : Nat)
+    (f : DensePoly (Arithmetic.Coeff lower)) : ℂ :=
+  ∑ i ∈ Finset.range degree, coeffDenote lower (f.coeff i) * x ^ i
+
+/-- Evaluation of executable dense polynomials after transferring the lawful
+lower-tower field structure. -/
+@[expose]
+noncomputable def denseMap (lower : List Level) (x : ℂ)
+    (hvalid : LevelsValid lower) (hinjective : DenoteInjective lower)
+    (hinv : ∀ a : Arithmetic.Coeff lower,
+      coeffDenote lower a⁻¹ = (coeffDenote lower a)⁻¹) :
+    letI : Field (Arithmetic.Coeff lower) :=
+      coeffField lower hvalid hinjective hinv
+    DensePoly (Arithmetic.Coeff lower) → ℂ := by
+  letI : Field (Arithmetic.Coeff lower) :=
+    coeffField lower hvalid hinjective hinv
+  exact fun f => (HexPolyMathlib.toPolynomial f).eval₂
+    (coeffHom lower hvalid hinjective hinv) x
+
+/-- Ring-hom evaluation agrees with the prescribed coefficient sum whenever
+the polynomial has degree below that range. -/
+theorem denseMap_eq_denseEval (lower : List Level) (x : ℂ)
+    (hvalid : LevelsValid lower) (hinjective : DenoteInjective lower)
+    (hinv : ∀ a : Arithmetic.Coeff lower,
+      coeffDenote lower a⁻¹ = (coeffDenote lower a)⁻¹)
+    (degree : Nat) (f : DensePoly (Arithmetic.Coeff lower))
+    (hdegree : f.degree?.getD 0 < degree) :
+    letI : Field (Arithmetic.Coeff lower) :=
+      coeffField lower hvalid hinjective hinv
+    denseMap lower x hvalid hinjective hinv f =
+      denseEval lower x degree f := by
+  letI : Field (Arithmetic.Coeff lower) :=
+    coeffField lower hvalid hinjective hinv
+  rw [denseMap,
+    Polynomial.eval₂_eq_sum_range'
+      (coeffHom lower hvalid hinjective hinv)
+      (by simpa using hdegree) x,
+    denseEval]
+  simp [coeffHom, HexPolyMathlib.coeff_toPolynomial]
+
+/-- Dense evaluation preserves multiplication. -/
+theorem denseMap_mul (lower : List Level) (x : ℂ)
+    (hvalid : LevelsValid lower) (hinjective : DenoteInjective lower)
+    (hinv : ∀ a : Arithmetic.Coeff lower,
+      coeffDenote lower a⁻¹ = (coeffDenote lower a)⁻¹)
+    (f g : DensePoly (Arithmetic.Coeff lower)) :
+    letI : Field (Arithmetic.Coeff lower) :=
+      coeffField lower hvalid hinjective hinv
+    denseMap lower x hvalid hinjective hinv (f * g) =
+      denseMap lower x hvalid hinjective hinv f *
+        denseMap lower x hvalid hinjective hinv g := by
+  letI : Field (Arithmetic.Coeff lower) :=
+    coeffField lower hvalid hinjective hinv
+  simp [denseMap, HexPolyMathlib.toPolynomial_mul, Polynomial.eval₂_mul]
+
+/-- Dense evaluation preserves addition. -/
+theorem denseMap_add (lower : List Level) (x : ℂ)
+    (hvalid : LevelsValid lower) (hinjective : DenoteInjective lower)
+    (hinv : ∀ a : Arithmetic.Coeff lower,
+      coeffDenote lower a⁻¹ = (coeffDenote lower a)⁻¹)
+    (f g : DensePoly (Arithmetic.Coeff lower)) :
+    letI : Field (Arithmetic.Coeff lower) :=
+      coeffField lower hvalid hinjective hinv
+    denseMap lower x hvalid hinjective hinv (f + g) =
+      denseMap lower x hvalid hinjective hinv f +
+        denseMap lower x hvalid hinjective hinv g := by
+  letI : Field (Arithmetic.Coeff lower) :=
+    coeffField lower hvalid hinjective hinv
+  simp [denseMap, HexPolyMathlib.toPolynomial_add, Polynomial.eval₂_add]
+
+/-- Dense evaluation sends coefficient scaling to scalar multiplication. -/
+theorem denseMap_scale (lower : List Level) (x : ℂ)
+    (hvalid : LevelsValid lower) (hinjective : DenoteInjective lower)
+    (hinv : ∀ a : Arithmetic.Coeff lower,
+      coeffDenote lower a⁻¹ = (coeffDenote lower a)⁻¹)
+    (c : Arithmetic.Coeff lower)
+    (f : DensePoly (Arithmetic.Coeff lower)) :
+    letI : Field (Arithmetic.Coeff lower) :=
+      coeffField lower hvalid hinjective hinv
+    denseMap lower x hvalid hinjective hinv (DensePoly.scale c f) =
+      coeffDenote lower c * denseMap lower x hvalid hinjective hinv f := by
+  letI : Field (Arithmetic.Coeff lower) :=
+    coeffField lower hvalid hinjective hinv
+  simp [denseMap, HexPolyMathlib.toPolynomial_scale, Polynomial.eval₂_mul,
+    coeffHom]
+
+/-- Dense evaluation of a constant is lower-tower denotation. -/
+theorem denseMap_C (lower : List Level) (x : ℂ)
+    (hvalid : LevelsValid lower) (hinjective : DenoteInjective lower)
+    (hinv : ∀ a : Arithmetic.Coeff lower,
+      coeffDenote lower a⁻¹ = (coeffDenote lower a)⁻¹)
+    (c : Arithmetic.Coeff lower) :
+    letI : Field (Arithmetic.Coeff lower) :=
+      coeffField lower hvalid hinjective hinv
+    denseMap lower x hvalid hinjective hinv (DensePoly.C c) =
+      coeffDenote lower c := by
+  letI : Field (Arithmetic.Coeff lower) :=
+    coeffField lower hvalid hinjective hinv
+  simp [denseMap, coeffHom]
+
+/-- Dense evaluation sends zero to zero. -/
+theorem denseMap_zero (lower : List Level) (x : ℂ)
+    (hvalid : LevelsValid lower) (hinjective : DenoteInjective lower)
+    (hinv : ∀ a : Arithmetic.Coeff lower,
+      coeffDenote lower a⁻¹ = (coeffDenote lower a)⁻¹) :
+    letI : Field (Arithmetic.Coeff lower) :=
+      coeffField lower hvalid hinjective hinv
+    denseMap lower x hvalid hinjective hinv 0 = 0 := by
+  letI : Field (Arithmetic.Coeff lower) :=
+    coeffField lower hvalid hinjective hinv
+  simp [denseMap]
+
+private theorem toPolynomial_dvd {R : Type*} [CommSemiring R] [DecidableEq R]
+    {f g : DensePoly R} : f ∣ g →
+      HexPolyMathlib.toPolynomial f ∣ HexPolyMathlib.toPolynomial g := by
+  rintro ⟨q, rfl⟩
+  exact ⟨HexPolyMathlib.toPolynomial q, by simp⟩
+
+private theorem toPolynomial_ne_zero {R : Type*} [CommRing R] [DecidableEq R]
+    {f : DensePoly R} (hf : f ≠ 0) : HexPolyMathlib.toPolynomial f ≠ 0 := by
+  intro hzero
+  apply hf
+  calc
+    f = HexPolyMathlib.ofPolynomial (HexPolyMathlib.toPolynomial f) :=
+      (HexPolyMathlib.ofPolynomial_toPolynomial f).symm
+    _ = 0 := by rw [hzero, HexPolyMathlib.ofPolynomial_zero]
+
+private theorem eq_C_leadingCoeff_of_size_one {R : Type*} [Zero R]
+    [DecidableEq R] (f : DensePoly R) (hsize : f.size = 1) :
+    f = DensePoly.C f.leadingCoeff := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [DensePoly.coeff_C]
+  by_cases hn : n = 0
+  · subst n
+    rw [DensePoly.leadingCoeff_eq_coeff_last f (by omega), hsize]
+    rfl
+  · rw [if_neg hn]
+    exact DensePoly.coeff_eq_zero_of_size_le f (by omega)
+
+/-- The first prescribed coefficient range of a dense polynomial, exposed as
+lower-tower coordinate blocks. -/
+@[expose]
+def denseBlocks (degree : Nat) {lower : List Level}
+    (f : DensePoly (Arithmetic.Coeff lower)) : Array (Array Rat) :=
+  (Vector.ofFn fun i : Fin degree => (f.coeff i).data).toArray
+
+/-- Embed a lower-coefficient dense polynomial as one canonical coefficient at
+the extended level. -/
+@[expose]
+def liftDense (level : Level) (lower : List Level)
+    (f : DensePoly (Arithmetic.Coeff lower)) :
+    Arithmetic.Coeff (level :: lower) :=
+  ⟨Arithmetic.flattenBlocks level.degree (levelsDim lower)
+      (denseBlocks level.degree f), by simp [levelsDim]⟩
+
+/-- Dense-polynomial coefficient embedding denotes its finite evaluation. -/
+theorem coeffDenote_liftDense (level : Level) (lower : List Level)
+    (f : DensePoly (Arithmetic.Coeff lower)) :
+    coeffDenote (level :: lower) (liftDense level lower f) =
+      denseEval lower level.root.toComplex level.degree f := by
+  rw [coeffDenote, liftDense, denote_flatten, denseEval]
+  apply Finset.sum_congr rfl
+  intro i hi
+  have hi' : i < level.degree := Finset.mem_range.mp hi
+  simp [denseBlocks, coeffDenote, Array.getD, hi']
+
+/-- Flattening an explicit range of dense coefficients denotes the prescribed
+finite dense evaluation. -/
+theorem denote_flatten_dense (level : Level) (lower : List Level)
+    (f : DensePoly (Arithmetic.Coeff lower)) :
+    denote (level :: lower)
+        (Arithmetic.flattenBlocks level.degree (levelsDim lower)
+          (((List.range level.degree).map fun i => (f.coeff i).data).toArray)) =
+      denseEval lower level.root.toComplex level.degree f := by
+  rw [denote_flatten, denseEval]
+  apply Finset.sum_congr rfl
+  intro i hi
+  have hi' : i < level.degree := Finset.mem_range.mp hi
+  simp [coeffDenote, Array.getD, hi']
+
+/-- Injective extended-level denotation rules out every nonzero vanishing
+dense polynomial below the defining degree. -/
+theorem dense_eq_zero_of_eval (level : Level) (lower : List Level)
+    (hinjective : DenoteInjective (level :: lower))
+    (f : DensePoly (Arithmetic.Coeff lower))
+    (hdegree : f.degree?.getD 0 < level.degree)
+    (heval : denseEval lower level.root.toComplex level.degree f = 0) :
+    f = 0 := by
+  have hlift : liftDense level lower f = liftDense level lower 0 := by
+    apply hinjective
+    rw [coeffDenote_liftDense, coeffDenote_liftDense, heval]
+    simp [denseEval, coeffDenote_zero]
+  apply DensePoly.ext_coeff
+  intro n
+  by_cases hn : n < level.degree
+  · have hblock := congrArg
+      (fun c : Arithmetic.Coeff (level :: lower) =>
+        Arithmetic.block c.data n (levelsDim lower)) hlift
+    simp only [liftDense] at hblock
+    rw [Arithmetic.block_flatten level.degree (levelsDim lower) n
+        (denseBlocks level.degree f) hn,
+      Arithmetic.block_flatten level.degree (levelsDim lower) n
+        (denseBlocks level.degree 0) hn] at hblock
+    have hf : (denseBlocks level.degree f).getD n #[] =
+        (f.coeff n).data := by
+      simp [denseBlocks, Array.getD, hn]
+    have hz : (denseBlocks level.degree
+        (0 : DensePoly (Arithmetic.Coeff lower))).getD n #[] =
+        ((0 : DensePoly (Arithmetic.Coeff lower)).coeff n).data := by
+      simp [denseBlocks, Array.getD, hn]
+    rw [hf, hz, fixedCoeffs_eq_self lower (f.coeff n),
+      fixedCoeffs_eq_self lower
+        ((0 : DensePoly (Arithmetic.Coeff lower)).coeff n)] at hblock
+    exact coeff_eq_of_data_eq hblock
+  · rw [DensePoly.coeff_zero]
+    apply DensePoly.coeff_eq_zero_of_size_le
+    by_cases hf : f.size = 0
+    · omega
+    · have hdeg : f.degree?.getD 0 = f.size - 1 := by
+        simp [DensePoly.degree?, hf]
+      rw [hdeg] at hdegree
+      omega
+
+/-- The inversion input polynomial evaluates to the denotation of its top-level
+coordinate array. -/
+theorem denseEval_value (level : Level) (lower : List Level) (a : Array Rat) :
+    denseEval lower level.root.toComplex level.degree
+        (Arithmetic.Coeff.value level lower a) =
+      denote (level :: lower) a := by
+  rw [denseEval, denote_cons]
+  apply Finset.sum_congr rfl
+  intro i hi
+  have hi' : i < level.degree := Finset.mem_range.mp hi
+  congr 1
+  simp [Arithmetic.Coeff.value, Arithmetic.Coeff.ofData,
+    coeffDenote, Array.getD, hi', denote_fixed]
+
+/-- The executable monic level relation evaluates to zero at the stored root. -/
+theorem denseEval_relation (level : Level) (lower : List Level)
+    (hvalid : LevelsValid (level :: lower)) :
+    denseEval lower level.root.toComplex (level.degree + 1)
+        (Arithmetic.Coeff.relation level lower) = 0 := by
+  rw [denseEval, Finset.sum_range_succ]
+  have hbelow : ∀ j < level.degree,
+      (Arithmetic.Coeff.relation level lower).coeff j =
+        Arithmetic.Coeff.ofData lower (level.defining.getD j #[]) := by
+    intro j hj
+    rw [Arithmetic.Coeff.relation, DensePoly.coeff_ofCoeffs]
+    have hj' : j <
+        (((List.range level.degree).map fun i =>
+          Arithmetic.Coeff.ofData lower
+            (level.defining.getD i #[])).toArray).size := by
+      simpa using hj
+    rw [Array.getD_eq_getD_getElem?, Array.getElem?_push_lt hj']
+    simp [Array.getD_eq_getD_getElem?]
+  have htop : (Arithmetic.Coeff.relation level lower).coeff level.degree = 1 := by
+    simp [Arithmetic.Coeff.relation, Array.getD]
+  have hsum :
+      (∑ j ∈ Finset.range level.degree,
+          coeffDenote lower
+              ((Arithmetic.Coeff.relation level lower).coeff j) *
+            level.root.toComplex ^ j) =
+        ∑ j ∈ Finset.range level.degree,
+          denote lower (level.defining.getD j #[]) *
+            level.root.toComplex ^ j := by
+    apply Finset.sum_congr rfl
+    intro j hj
+    rw [hbelow j (Finset.mem_range.mp hj)]
+    simp [Arithmetic.Coeff.ofData, coeffDenote, denote_fixed]
+  rw [hsum]
+  rw [htop, coeffDenote_one lower hvalid.2.2]
+  simpa using relation_sum level lower hvalid
+
+/-- The inversion input polynomial lies strictly below the current defining
+degree. -/
+theorem value_degree_lt (level : Level) (lower : List Level) (a : Array Rat)
+    (hdegree : 0 < level.degree) :
+    (Arithmetic.Coeff.value level lower a).degree?.getD 0 < level.degree := by
+  have hsize : (Arithmetic.Coeff.value level lower a).size ≤ level.degree :=
+    (DensePoly.size_ofCoeffs_le _).trans (by
+      simp)
+  by_cases hzero : (Arithmetic.Coeff.value level lower a).size = 0
+  · simp [DensePoly.degree?, hzero, hdegree]
+  · rw [DensePoly.degree?_eq_some_of_pos_size _ (Nat.pos_of_ne_zero hzero),
+      Option.getD_some]
+    omega
+
+/-- The executable relation retains its monic top coefficient and therefore
+has exactly defining degree plus one stored coefficients. -/
+theorem relation_size (level : Level) (lower : List Level)
+    (hvalid : LevelsValid (level :: lower)) :
+    (Arithmetic.Coeff.relation level lower).size = level.degree + 1 := by
+  have hle : (Arithmetic.Coeff.relation level lower).size ≤
+      level.degree + 1 := (DensePoly.size_ofCoeffs_le _).trans (by
+    simp)
+  have htop : (Arithmetic.Coeff.relation level lower).coeff level.degree = 1 := by
+    simp [Arithmetic.Coeff.relation, Array.getD]
+  have hone : (1 : Arithmetic.Coeff lower) ≠ 0 := by
+    intro h
+    have hmap := congrArg (coeffDenote lower) h
+    rw [coeffDenote_one lower hvalid.2.2, coeffDenote_zero lower] at hmap
+    exact one_ne_zero hmap
+  have hnle : ¬ (Arithmetic.Coeff.relation level lower).size ≤
+      level.degree := by
+    intro hsize
+    exact hone (htop.symm.trans
+      (DensePoly.coeff_eq_zero_of_size_le _ hsize))
+  omega
+
+/-- The executable relation has its advertised defaulted degree. -/
+theorem relation_degree (level : Level) (lower : List Level)
+    (hvalid : LevelsValid (level :: lower)) :
+    (Arithmetic.Coeff.relation level lower).degree?.getD 0 = level.degree := by
+  rw [DensePoly.degree?_eq_some_of_pos_size _ (by
+      rw [relation_size level lower hvalid]
+      omega), Option.getD_some, relation_size level lower hvalid]
+  omega
+
+/-- For a nonzero input, the executable one-sided extended gcd with the
+defining relation returns a nonzero constant gcd. -/
+theorem xgcdLeft_size_one (level : Level) (lower : List Level)
+    (hvalid : LevelsValid (level :: lower))
+    (hinjective : DenoteInjective (level :: lower))
+    (hlowerInjective : DenoteInjective lower)
+    (hinv : ∀ b : Arithmetic.Coeff lower,
+      coeffDenote lower b⁻¹ = (coeffDenote lower b)⁻¹)
+    (a : Array Rat) (ha : denote (level :: lower) a ≠ 0) :
+    letI : Field (Arithmetic.Coeff lower) :=
+      coeffField lower hvalid.2.2 hlowerInjective hinv
+    (DensePoly.xgcdLeft (Arithmetic.Coeff.value level lower a)
+      (Arithmetic.Coeff.relation level lower)).gcd.size = 1 := by
+  letI : Field (Arithmetic.Coeff lower) :=
+    coeffField lower hvalid.2.2 hlowerInjective hinv
+  let value := Arithmetic.Coeff.value level lower a
+  let relation := Arithmetic.Coeff.relation level lower
+  let result := DensePoly.xgcdLeft value relation
+  let gcd := result.gcd
+  change gcd.size = 1
+  have hvalueDegree : value.degree?.getD 0 < level.degree :=
+    value_degree_lt level lower a hvalid.1.1
+  have hrelationDegree : relation.degree?.getD 0 = level.degree :=
+    relation_degree level lower hvalid
+  have hvalueMap : denseMap lower level.root.toComplex hvalid.2.2
+      hlowerInjective hinv value = denote (level :: lower) a := by
+    rw [denseMap_eq_denseEval lower level.root.toComplex hvalid.2.2
+      hlowerInjective hinv level.degree value hvalueDegree]
+    exact denseEval_value level lower a
+  have hrelationMap : denseMap lower level.root.toComplex hvalid.2.2
+      hlowerInjective hinv relation = 0 := by
+    rw [denseMap_eq_denseEval lower level.root.toComplex hvalid.2.2
+      hlowerInjective hinv (level.degree + 1) relation (by omega)]
+    exact denseEval_relation level lower hvalid
+  have hvalueNe : value ≠ 0 := by
+    intro hzero
+    apply ha
+    rw [← hvalueMap, hzero,
+      denseMap_zero lower level.root.toComplex hvalid.2.2
+        hlowerInjective hinv]
+  have hrelationNe : relation ≠ 0 := by
+    intro hzero
+    have hsize := relation_size level lower hvalid
+    change relation.size = level.degree + 1 at hsize
+    rw [hzero, DensePoly.size_zero] at hsize
+    omega
+  have hgcdDvdValue : gcd ∣ value := by
+    change result.gcd ∣ value
+    rw [DensePoly.xgcdLeft_gcd_eq_xgcd, DensePoly.xgcd_gcd_eq_gcd]
+    exact DensePoly.gcd_dvd_left value relation
+  have hgcdDvdRelation : gcd ∣ relation := by
+    change result.gcd ∣ relation
+    rw [DensePoly.xgcdLeft_gcd_eq_xgcd, DensePoly.xgcd_gcd_eq_gcd]
+    exact DensePoly.gcd_dvd_right value relation
+  have hgcdNe : gcd ≠ 0 := by
+    intro hzero
+    rcases hgcdDvdValue with ⟨q, hq⟩
+    apply hvalueNe
+    rw [hq, hzero]
+    exact DensePoly.zero_mul q
+  have hgcdDegree : gcd.degree?.getD 0 < level.degree := by
+    have hpolyValue : HexPolyMathlib.toPolynomial value ≠ 0 :=
+      toPolynomial_ne_zero hvalueNe
+    have hle := Polynomial.natDegree_le_of_dvd
+      (toPolynomial_dvd hgcdDvdValue) hpolyValue
+    rw [HexPolyMathlib.natDegree_toPolynomial,
+      HexPolyMathlib.natDegree_toPolynomial] at hle
+    exact hle.trans_lt hvalueDegree
+  have hgcdMapNe : denseMap lower level.root.toComplex hvalid.2.2
+      hlowerInjective hinv gcd ≠ 0 := by
+    intro hmap
+    apply hgcdNe
+    apply dense_eq_zero_of_eval level lower hinjective gcd hgcdDegree
+    rw [← denseMap_eq_denseEval lower level.root.toComplex hvalid.2.2
+      hlowerInjective hinv level.degree gcd hgcdDegree]
+    exact hmap
+  rcases hgcdDvdRelation with ⟨factor, hfactor⟩
+  have hfactorNe : factor ≠ 0 := by
+    intro hzero
+    apply hrelationNe
+    rw [hfactor, hzero]
+    rw [DensePoly.mul_comm_poly gcd 0]
+    exact DensePoly.zero_mul gcd
+  have hgcdDegreeZero : gcd.degree?.getD 0 = 0 := by
+    apply Nat.eq_zero_of_not_pos
+    intro hgcdPos
+    have hfactorDegree : factor.degree?.getD 0 < level.degree := by
+      have hgcdPolyNe : HexPolyMathlib.toPolynomial gcd ≠ 0 :=
+        toPolynomial_ne_zero hgcdNe
+      have hfactorPolyNe : HexPolyMathlib.toPolynomial factor ≠ 0 :=
+        toPolynomial_ne_zero hfactorNe
+      have hsum : level.degree =
+          gcd.degree?.getD 0 + factor.degree?.getD 0 := by
+        calc
+          level.degree = (HexPolyMathlib.toPolynomial relation).natDegree := by
+            simpa using hrelationDegree.symm
+          _ = (HexPolyMathlib.toPolynomial (gcd * factor)).natDegree := by
+            rw [← hfactor]
+          _ = (HexPolyMathlib.toPolynomial gcd *
+                HexPolyMathlib.toPolynomial factor).natDegree := by
+            rw [HexPolyMathlib.toPolynomial_mul]
+          _ = (HexPolyMathlib.toPolynomial gcd).natDegree +
+                (HexPolyMathlib.toPolynomial factor).natDegree := by
+            rw [Polynomial.natDegree_mul hgcdPolyNe hfactorPolyNe]
+          _ = gcd.degree?.getD 0 + factor.degree?.getD 0 := by
+            rw [HexPolyMathlib.natDegree_toPolynomial,
+              HexPolyMathlib.natDegree_toPolynomial]
+      omega
+    have hfactorMap : denseMap lower level.root.toComplex hvalid.2.2
+        hlowerInjective hinv factor = 0 := by
+      have hproduct :
+          denseMap lower level.root.toComplex hvalid.2.2 hlowerInjective hinv gcd *
+              denseMap lower level.root.toComplex hvalid.2.2 hlowerInjective hinv factor = 0 := by
+        rw [← denseMap_mul lower level.root.toComplex hvalid.2.2
+          hlowerInjective hinv gcd factor, ← hfactor]
+        exact hrelationMap
+      exact (mul_eq_zero.mp hproduct).resolve_left hgcdMapNe
+    apply hfactorNe
+    apply dense_eq_zero_of_eval level lower hinjective factor hfactorDegree
+    rw [← denseMap_eq_denseEval lower level.root.toComplex hvalid.2.2
+      hlowerInjective hinv level.degree factor hfactorDegree]
+    exact hfactorMap
+  have hgcdSizePos : 0 < gcd.size := by
+    by_contra hpos
+    apply hgcdNe
+    apply DensePoly.ext_coeff
+    intro n
+    rw [DensePoly.coeff_zero]
+    exact DensePoly.coeff_eq_zero_of_size_le gcd (by omega)
+  rw [DensePoly.degree?_eq_some_of_pos_size gcd hgcdSizePos,
+    Option.getD_some] at hgcdDegreeZero
+  omega
+
+/-- The normalized extended-gcd coefficient used by executable inversion
+denotes the reciprocal of a nonzero top-level coordinate array. -/
+theorem denote_xgcd_inverse (level : Level) (lower : List Level)
+    (hvalid : LevelsValid (level :: lower))
+    (hinjective : DenoteInjective (level :: lower))
+    (hlowerInjective : DenoteInjective lower)
+    (hinv : ∀ b : Arithmetic.Coeff lower,
+      coeffDenote lower b⁻¹ = (coeffDenote lower b)⁻¹)
+    (a : Array Rat) (ha : denote (level :: lower) a ≠ 0) :
+    letI : Field (Arithmetic.Coeff lower) :=
+      coeffField lower hvalid.2.2 hlowerInjective hinv
+    let value := Arithmetic.Coeff.value level lower a
+    let relation := Arithmetic.Coeff.relation level lower
+    let result := DensePoly.xgcdLeft value relation
+    let c := result.gcd.leadingCoeff
+    let normalized := DensePoly.scale c⁻¹ result.left % relation
+    denote (level :: lower)
+        (Arithmetic.flattenBlocks level.degree (levelsDim lower)
+          (((List.range level.degree).map fun i =>
+            (normalized.coeff i).data).toArray)) =
+      (denote (level :: lower) a)⁻¹ := by
+  letI : Field (Arithmetic.Coeff lower) :=
+    coeffField lower hvalid.2.2 hlowerInjective hinv
+  let value := Arithmetic.Coeff.value level lower a
+  let relation := Arithmetic.Coeff.relation level lower
+  let result := DensePoly.xgcdLeft value relation
+  let c := result.gcd.leadingCoeff
+  let scaled := DensePoly.scale c⁻¹ result.left
+  change denote (level :: lower)
+      (Arithmetic.flattenBlocks level.degree (levelsDim lower)
+        (((List.range level.degree).map fun i =>
+          ((scaled % relation).coeff i).data).toArray)) = _
+  have hvalueDegree : value.degree?.getD 0 < level.degree :=
+    value_degree_lt level lower a hvalid.1.1
+  have hrelationDegree : relation.degree?.getD 0 = level.degree :=
+    relation_degree level lower hvalid
+  have hvalueMap : denseMap lower level.root.toComplex hvalid.2.2
+      hlowerInjective hinv value = denote (level :: lower) a := by
+    rw [denseMap_eq_denseEval lower level.root.toComplex hvalid.2.2
+      hlowerInjective hinv level.degree value hvalueDegree]
+    exact denseEval_value level lower a
+  have hrelationMap : denseMap lower level.root.toComplex hvalid.2.2
+      hlowerInjective hinv relation = 0 := by
+    rw [denseMap_eq_denseEval lower level.root.toComplex hvalid.2.2
+      hlowerInjective hinv (level.degree + 1) relation (by omega)]
+    exact denseEval_relation level lower hvalid
+  have hgcdSize : result.gcd.size = 1 := by
+    exact xgcdLeft_size_one level lower hvalid hinjective hlowerInjective
+      hinv a ha
+  have hcNe : c ≠ 0 := by
+    exact DensePoly.leadingCoeff_ne_zero_of_pos_size result.gcd
+      (by rw [hgcdSize]; exact Nat.zero_lt_one)
+  have hgcdC : result.gcd = DensePoly.C c :=
+    eq_C_leadingCoeff_of_size_one result.gcd hgcdSize
+  have hbezout :
+      result.left * value +
+          (DensePoly.xgcd value relation).right * relation = result.gcd := by
+    have h := DensePoly.xgcd_bezout value relation
+    dsimp only at h
+    rw [← DensePoly.xgcdLeft_left_eq_xgcd value relation,
+      ← DensePoly.xgcdLeft_gcd_eq_xgcd value relation] at h
+    exact h
+  have hmapBezout := congrArg
+    (denseMap lower level.root.toComplex hvalid.2.2 hlowerInjective hinv)
+    hbezout
+  rw [denseMap_add, denseMap_mul, denseMap_mul, hrelationMap, mul_zero,
+    add_zero, hgcdC, denseMap_C] at hmapBezout
+  have hcMapNe : coeffDenote lower c ≠ 0 := by
+    intro hmap
+    apply hcNe
+    apply hlowerInjective
+    rw [hmap, coeffDenote_zero]
+  have hscaledMap : denseMap lower level.root.toComplex hvalid.2.2
+      hlowerInjective hinv scaled =
+      (coeffDenote lower c)⁻¹ *
+        denseMap lower level.root.toComplex hvalid.2.2
+          hlowerInjective hinv result.left := by
+    rw [denseMap_scale]
+    exact congrArg (· * denseMap lower level.root.toComplex hvalid.2.2
+      hlowerInjective hinv result.left) (hinv c)
+  have hnormalizedMap : denseMap lower level.root.toComplex hvalid.2.2
+      hlowerInjective hinv (scaled % relation) =
+      denseMap lower level.root.toComplex hvalid.2.2
+        hlowerInjective hinv scaled := by
+    have hdivision := EuclideanDomain.mod_add_div
+      (HexPolyMathlib.toPolynomial scaled)
+      (HexPolyMathlib.toPolynomial relation)
+    have hmapDivision := congrArg
+      (Polynomial.eval₂ (coeffHom lower hvalid.2.2 hlowerInjective hinv)
+        level.root.toComplex) hdivision
+    rw [Polynomial.eval₂_add, Polynomial.eval₂_mul] at hmapDivision
+    have hrelationPolynomial :
+        (HexPolyMathlib.toPolynomial relation).eval₂
+            (coeffHom lower hvalid.2.2 hlowerInjective hinv)
+            level.root.toComplex = 0 := hrelationMap
+    rw [hrelationPolynomial, zero_mul, add_zero] at hmapDivision
+    rw [denseMap, HexPolyMathlib.toPolynomial_mod, denseMap]
+    exact hmapDivision
+  have hnormalizedDegree : (scaled % relation).degree?.getD 0 < level.degree := by
+    rw [← hrelationDegree]
+    exact DensePoly.mod_degree_lt_of_pos_degree scaled relation (by
+      rw [hrelationDegree]
+      exact hvalid.1.1)
+  rw [denote_flatten_dense, ← denseMap_eq_denseEval lower
+    level.root.toComplex hvalid.2.2 hlowerInjective hinv level.degree
+    (scaled % relation) hnormalizedDegree, hnormalizedMap, hscaledMap]
+  apply (mul_eq_one_iff_eq_inv₀ ha).mp
+  rw [mul_assoc, ← hvalueMap, hmapBezout]
+  exact inv_mul_cancel₀ hcMapNe
 
 /-- A lower-tower coefficient embedded as the constant coefficient of one
 extension level. -/
@@ -947,6 +1557,106 @@ theorem DenoteInjective.tail (level : Level) (lower : List Level)
           simp only at hblock
           cases hblock
           rfl
+
+/-- The executable fixed-width all-zero test is equivalent to semantic zero
+when canonical coefficient denotation is injective. -/
+theorem fixed_all_zero_iff (levels : List Level)
+    (hinjective : DenoteInjective levels) (a : Array Rat) :
+    (Arithmetic.fixedCoeffs (levelsDim levels) a).all (fun q => q = 0) = true ↔
+      denote levels a = 0 := by
+  constructor
+  · intro hall
+    rw [← denote_fixed levels a]
+    have hdata : Arithmetic.fixedCoeffs (levelsDim levels) a =
+        Arithmetic.fixedCoeffs (levelsDim levels) #[] := by
+      apply Array.ext
+      · simp [Arithmetic.fixedCoeffs]
+      · intro i hi₁ hi₂
+        have hi := (Array.all_eq_true.mp hall) i hi₁
+        simpa [Arithmetic.fixedCoeffs, Array.getD] using hi
+    rw [hdata, denote_zero]
+  · intro hdenote
+    have hcoeff : Arithmetic.Coeff.ofData levels a = 0 := by
+      apply hinjective
+      change denote levels (Arithmetic.fixedCoeffs (levelsDim levels) a) =
+        coeffDenote levels 0
+      rw [denote_fixed, hdenote, coeffDenote_zero]
+    have hdata := congrArg Arithmetic.Coeff.data hcoeff
+    change Arithmetic.fixedCoeffs (levelsDim levels) a =
+      Arithmetic.fixedCoeffs (levelsDim levels) #[] at hdata
+    rw [Array.all_eq_true]
+    intro i hi
+    have hentry := congrArg (fun data : Array Rat => data.getD i 0) hdata
+    have hiBound : i < levelsDim levels := by
+      simpa [Arithmetic.fixedCoeffs] using hi
+    simpa [Arithmetic.fixedCoeffs, Array.getD, hiBound] using hentry
+
+/-- Recursive extended-gcd coordinates denote complex inversion at every
+validated tower depth, including the executable `0⁻¹ = 0` convention. -/
+theorem denote_invCoords (levels : List Level) (hvalid : LevelsValid levels)
+    (hinjective : DenoteInjective levels) (a : Array Rat) :
+    denote levels (Arithmetic.invCoords levels a) = (denote levels a)⁻¹ := by
+  induction levels generalizing a with
+  | nil =>
+      rw [show Arithmetic.invCoords [] a =
+        #[if a.getD 0 0 = 0 then 0 else (a.getD 0 0)⁻¹] from rfl]
+      simp only [denote]
+      by_cases h : a[0]?.getD 0 = 0 <;> simp [h]
+  | cons level lower ih =>
+      have hlowerInjective : DenoteInjective lower :=
+        DenoteInjective.tail level lower hvalid.1.1 hinjective
+      have hlowerInv : ∀ b : Arithmetic.Coeff lower,
+          coeffDenote lower b⁻¹ = (coeffDenote lower b)⁻¹ := by
+        intro b
+        change denote lower
+            (Arithmetic.fixedCoeffs (levelsDim lower)
+              (Arithmetic.invCoords lower b.data)) =
+          (denote lower b.data)⁻¹
+        rw [denote_fixed]
+        exact ih hvalid.2.2 hlowerInjective b.data
+      letI : Field (Arithmetic.Coeff lower) :=
+        coeffField lower hvalid.2.2 hlowerInjective hlowerInv
+      let zeroTest :=
+        (Arithmetic.fixedCoeffs
+          (level.degree * levelsDim lower) a).all (fun q => q = 0)
+      by_cases hzero : zeroTest = true
+      · have hdenote : denote (level :: lower) a = 0 :=
+          (fixed_all_zero_iff (level :: lower) hinjective a).mp (by
+            simpa [zeroTest, levelsDim] using hzero)
+        have hrep : Array.replicate (level.degree * levelsDim lower) 0 =
+            Arithmetic.fixedCoeffs (levelsDim (level :: lower)) #[] := by
+          apply Array.ext
+          · simp [levelsDim, Arithmetic.fixedCoeffs]
+          · intro i hi₁ hi₂
+            simp [Arithmetic.fixedCoeffs, Array.getD]
+        rw [Arithmetic.invCoords]
+        rw [show (Arithmetic.fixedCoeffs
+            (level.degree * levelsDim lower) a).all (fun q => q = 0) = true by
+          simpa [zeroTest] using hzero]
+        simp only [if_true]
+        rw [hrep, denote_zero, hdenote]
+        simp
+      · have ha : denote (level :: lower) a ≠ 0 := by
+          intro hdenote
+          apply hzero
+          simpa [zeroTest, levelsDim] using
+            (fixed_all_zero_iff (level :: lower) hinjective a).mpr hdenote
+        have hgcdSize := xgcdLeft_size_one level lower hvalid hinjective
+          hlowerInjective hlowerInv a ha
+        let value := Arithmetic.Coeff.value level lower a
+        let relation := Arithmetic.Coeff.relation level lower
+        let result := DensePoly.xgcdLeft value relation
+        have hcNe : result.gcd.leadingCoeff ≠ 0 := by
+          exact DensePoly.leadingCoeff_ne_zero_of_pos_size result.gcd
+            (by rw [hgcdSize]; exact Nat.zero_lt_one)
+        rw [Arithmetic.invCoords]
+        rw [show (Arithmetic.fixedCoeffs
+            (level.degree * levelsDim lower) a).all (fun q => q = 0) = false by
+          exact Bool.eq_false_of_not_eq_true hzero]
+        simp only [Bool.false_eq_true, if_false]
+        rw [if_pos hgcdSize, if_neg hcNe]
+        exact denote_xgcd_inverse level lower hvalid hinjective
+          hlowerInjective hlowerInv a ha
 
 end LevelSemantics
 
@@ -1020,7 +1730,10 @@ theorem map_mul (T : NumberTower) (a b : Elem T) :
 the executable convention `0⁻¹ = 0`. -/
 theorem map_inv (T : NumberTower) (a : Elem T) :
     T.toComplex a⁻¹ = (T.toComplex a)⁻¹ := by
-  sorry
+  rw [LevelSemantics.toComplex_eq_denote T a⁻¹,
+    LevelSemantics.toComplex_eq_denote T a, coeffs_inv]
+  exact LevelSemantics.denote_invCoords T.levels.toList T.valid
+    (coeffDenote_injective T) (coeffs a)
 
 /-- Tower division computes complex division. -/
 theorem map_div (T : NumberTower) (a b : Elem T) :

--- a/progress/20260727T163418Z_number-tower-inverse-denotation.md
+++ b/progress/20260727T163418Z_number-tower-inverse-denotation.md
@@ -1,0 +1,36 @@
+# Accomplished
+
+- Canonicalized recursive xgcd inverses modulo the defining relation so the
+  returned coordinate array always represents the reduced inverse polynomial.
+- Added executable views of a top-level value and its monic defining relation
+  as dense polynomials over canonical lower-tower coefficients.
+- Proved the dense-polynomial evaluation and coefficient-mapping bridges needed
+  to transport executable Euclidean division, gcd, and Bezout identities to
+  complex evaluation at the stored root.
+- Proved that a nonzero tower value has constant xgcd with its defining
+  relation, then proved the normalized left Bezout coefficient denotes its
+  complex reciprocal.
+- Closed recursive inverse denotation at every validated tower depth, including
+  the executable `0⁻¹ = 0` branch, and discharged the public `map_inv` theorem.
+- Added `coeffs_inv`, exposing the exact fixed-width inverse coordinates used by
+  the public element operation.
+- Completed `lake build` (9,515 jobs), `lake exe
+  hexnumberfieldtower_bench verify` (19 benchmarks), diff/banned-declaration
+  checks, and the copyright, file-size, dependency-DAG, and Phase 4 checks.
+
+# Current frontier
+
+All executable tower arithmetic operations now have complex correspondence
+theorems, including multiplication, inversion, division, and rational scaling.
+The public element type still lacks the assembled law-bearing field interface.
+
+# Next step
+
+Transfer a `Field (Elem T)` structure through the injective complex denotation
+using the proved map laws, and bundle the canonical embedding as the appropriate
+Mathlib homomorphism without changing the executable operations.
+
+# Blockers
+
+None. Independent second-opinion review will continue asynchronously while the
+next stacked milestone is developed.


### PR DESCRIPTION
## Summary

- canonicalize executable xgcd inverses modulo each defining relation and expose their dense coefficient-polynomial inputs
- prove evaluation, Euclidean, gcd, and Bezout bridges over the recursively transferred lower-coefficient field
- prove recursive inverse denotation at every validated tower depth and close the public `map_inv` correspondence theorem

## Validation

- `lake build` (9,515 jobs)
- `lake exe hexnumberfieldtower_bench verify` (19 benchmarks)
- copyright, file-size, dependency-DAG, Phase 4, diff, and banned-declaration checks