### PR TITLE
feat(phase4): define mixed tactic evidence tracks

### DIFF
--- a/PLAN/Phase4.md
+++ b/PLAN/Phase4.md
@@ -5,11 +5,12 @@
 `libraries.yml[d].done_through ≥ 4`.
 
 Phase 4 makes algorithmic complexity a first-class deliverable. By
-the end of Phase 4 every advertised operation in the library's API
+the end of Phase 4 every advertised compiled operation in the library's API
 has a textbook complexity model declared at its `setup_benchmark`
-registration, and a benchmark family whose verdict is *consistent
-with declared complexity*. An *inconclusive* verdict is not a Phase
-4 exit; it is a finding that triggers a rollback per
+registration and a benchmark family whose verdict is *consistent
+with declared complexity*; every advertised proof/tactic operation has the
+fresh-module evidence defined below. An *inconclusive* compiled verdict is not
+a Phase 4 exit; it is a finding that triggers a rollback per
 [Conventions.md §Rollback is a normal action](Conventions.md#rollback-is-a-normal-action)
 and a fix at the rolled-back phase.
 
@@ -18,19 +19,39 @@ verdict-as-bug-trigger doctrine, and the anti-patterns all live in
 [SPEC/benchmarking.md](../SPEC/benchmarking.md). Read it before
 opening Phase 4 issues.
 
+## Evidence tracks
+
+Phase 4 classifies each advertised operation by what is actually being
+measured. A library may have one track or both; its SPEC must assign every
+advertised operation to exactly one row.
+
+| Surface | Required evidence | Generic requirements replaced |
+| --- | --- | --- |
+| Mathlib-free compiled computation | An ordinary LeanBench executable, registrations with controlled one-parameter ladders and adjacent textbook cost derivations, `list`/`verify`, scientific verdicts, comparator coverage, and timed-region sampling profiles. | None. |
+| Elaboration, proof-search tactics, emitted proof terms, or kernel checking | Externally timed fresh-module builds below an explicit `libraries.yml` `proof_probes` root, with matched import baselines, rotated raw samples, compiler/proof artefacts, and the trust/provenance record in `SPEC/benchmarking.md`. | No LeanBench registration or executable, no `list`/`verify` entry for that surface, no complexity verdict, and no timed-region sampling profile. |
+
+A `mathlib: true` library with a separable compiled core is a **mixed**
+library, not a proof-only exception. Its compiled core obeys every ordinary
+LeanBench requirement, while its tactic/proof surface uses the second row.
+Fixed tactic-build budgets are acceptance cases, never substitutes for the
+compiled track's asymptotic ladders. The headline report keeps the two tracks
+separate and does not combine their times into a synthetic verdict.
+
 ## Deliverables
 
 For each library `HexFoo` advancing through Phase 4:
 
-1. **`HexFoo.Bench` exe** — rooted at `HexFoo/Bench.lean`, with
-   helper modules under `HexFoo/Bench/` when useful. It registers
-   every advertised operation in the library's SPEC API surface
+1. **`HexFoo.Bench` exe** — for every compiled-track operation, rooted at
+   `HexFoo/Bench.lean`, with helper modules under `HexFoo/Bench/` when useful.
+   It registers every compiled operation in the library's SPEC API surface
    with `setup_benchmark` (parametric) or
    `setup_fixed_benchmark` (canonical input). The complexity
    expression in each `setup_benchmark` is the *textbook*
-   complexity, not the observed one.
+   complexity, not the observed one. Proof-track operations instead have
+   named fresh-module probes and matched baselines under an explicit manifest
+   `proof_probes` directory; those probes are not registrations.
 
-2. **`lakefile.lean` exe entry**:
+2. **`lakefile.lean` exe entry** for a library with compiled-track targets:
 
    ```lean
    lean_exe hexfoo_bench where
@@ -41,11 +62,13 @@ For each library `HexFoo` advancing through Phase 4:
    `require` (per the snippet in
    [SPEC/benchmarking.md §Harness](../SPEC/benchmarking.md#harness-lean-bench)).
 
-3. **CI smoke step** invoking
+3. **CI smoke step** invoking, when the compiled track exists,
    `lake exe hexfoo_bench list && lake exe hexfoo_bench verify`.
    `verify` is the bitrot gate; it does not assert timing values.
    It may use reduced smoke settings, but may not weaken the
-   scientific settings used for real runs.
+   scientific settings used for real runs. Build-only proof probes extend the
+   existing build job with structural/reduced build checks; they never become
+   executable roots.
 
 4. **`compare` registrations** for any pair of alternative algorithms
    the library SPEC calls out (e.g. Barrett vs Montgomery, linear vs
@@ -68,20 +91,24 @@ For each library `HexFoo` advancing through Phase 4:
    [SPEC/benchmarking.md §External comparators](../SPEC/benchmarking.md#external-comparators)
    for the integration patterns.
 
-6. **Profile coverage** per
+6. **Profile coverage** for the compiled track per
    [SPEC/profiling.md §Coverage requirement](../SPEC/profiling.md#coverage-requirement):
    at least one representative case per `phase4.input_families`
    entry in `libraries.yml`, recorded in
    `reports/<lib>-performance.md §Profile`. Categorise leaf cost
    across {own code, GMP, allocation, Lean runtime}; rank inclusive
-   cost; explain the dominant entries.
+   cost; explain the dominant entries. Proof-track probes carry the external
+   build evidence required by `SPEC/benchmarking.md` instead of a timed-region
+   sampling profile.
 
 7. **Headline report** at `reports/<lib>-performance.md` per
    [SPEC/benchmarking.md §Headline reports](../SPEC/benchmarking.md#headline-reports).
    Five subsections: Bench targets, Verdicts, Comparator ratios,
    Profile, Concerns. Every numeric claim cites the bench case
    name, command line, seed/parameter, JSONL path, profile
-   location, and comparator source.
+   location, and comparator source. Mixed libraries split every subsection by
+   compiled versus proof/tactic evidence and state each proof-track replacement
+   explicitly.
 
 The PR description records, in one paragraph, any case where the
 declared complexity model differs from the canonical textbook
@@ -96,8 +123,9 @@ required.
   current code is `O(n³)`, declare `O(n²)`, run the benchmark, get
   the inconclusive verdict, file the issue, roll back. The
   benchmark's job is to reveal the gap, not to ratify it.
-- **Use one harness.** lean-bench is the inner harness; gaps go to
-  its issue tracker, not into a hex-local replacement.
+- **Use the assigned harness.** LeanBench is the sole compiled-code inner
+  harness. The external fresh-build runner is permitted only for proof-track
+  evidence and may not time compiled computation redundantly.
 - **Use stable case names.** The `setup_benchmark` declaration name
   is the case name; renaming a registration is a tracked change.
 - **Use fixed seeds and committed inputs.** Randomised inputs
@@ -118,16 +146,18 @@ required.
 
 For library `hex-foo`, Phase 4 is done when:
 
-- every operation listed in the library's SPEC API surface has a
-  `setup_benchmark` or `setup_fixed_benchmark` registration in the
-  `HexFoo.Bench` exe;
+- every operation listed in the library's SPEC API surface is assigned to a
+  track, every compiled-track operation has a `setup_benchmark` or
+  `setup_fixed_benchmark` registration in the `HexFoo.Bench` exe, and every
+  proof-track operation has the specified externally timed fresh-module probe;
 - every parametric registration declares a complexity model that
   matches the SPEC's textbook complexity for that operation;
 - every new or changed parametric registration has an adjacent
   cost-model derivation comment, and every PR that changes a
   `setup_benchmark` complexity declaration includes an independent
   cost-model derivation in the commit message that made the change;
-- `lake exe hexfoo_bench verify` succeeds under smoke settings, and
+- when a compiled track exists, `lake exe hexfoo_bench verify` succeeds under
+  smoke settings, and
   `lake exe hexfoo_bench run NAME` returns *consistent with declared
   complexity* for every parametric registration at its scientific
   settings;
@@ -152,7 +182,9 @@ For library `hex-foo`, Phase 4 is done when:
   cannot be separated;
 - a profile run per
   [SPEC/profiling.md §Coverage requirement](../SPEC/profiling.md#coverage-requirement)
-  is recorded in `reports/<lib>-performance.md §Profile`;
+  is recorded in `reports/<lib>-performance.md §Profile` for every compiled
+  input family; proof-track surfaces instead record the required fresh-build
+  samples and provenance;
 - the headline report at `reports/<lib>-performance.md` exists with
   the five mandated subsections and full artefact traceability;
 - the headline report's §Concerns subsection is empty. A library
@@ -161,7 +193,9 @@ For library `hex-foo`, Phase 4 is done when:
   The only resolution available to the orchestrator is to act on
   the HO issue tied to the Concern until the underlying problem is
   fixed and the Concern entry is removed from the report.
-- the CI smoke step (`list` + `verify`) runs on every PR.
+- the compiled-track CI smoke step (`list` + `verify`) and every declared
+  proof-probe structural/build smoke check run on every PR where their track
+  exists.
 
 If any of these fail, the right action is rollback per
 [Conventions.md](Conventions.md), not a SPEC-text edit weakening

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -651,12 +651,68 @@ free to change.
 - `conformance/HexRCF/{Conformance,EmitFixtures}.lean`: conformance
   in the shared sub-project.
 
-No bench target: bench targets must not import Mathlib
-([SPEC/benchmarking.md](../benchmarking.md)), and this library
-cannot avoid it. The time budgets below are validated through the
-Phase-4 timing harness. The Phase-3 `local` emitter exercises the same
-compiled decision workloads but is not an elaboration benchmark and does not
-run on each PR.
+## Phase-4 evidence tracks
+
+HexRCF is a mixed library. `HexRCF.DecisionCheck` contains the complete
+compiled search, certificate construction, replay, and `decide` path in a
+mechanically checked import closure containing neither `Mathlib.*` nor
+`HexRealRootsMathlib.*`. That track uses the ordinary Mathlib-free
+`bench/HexRCF/Bench.lean` LeanBench executable. `by rcf` reification, proof
+emission, and kernel checking remain Mathlib-facing and use build-only modules
+below the explicit `libraries.yml` root `bench/HexRCF/ProofProbe/`.
+
+The compiled track requires these stable parametric cases. Every ladder varies
+only the named parameter, and fixture generation stays outside the timed
+region. LeanBench's mandatory conformance hash is computed before its timer
+stops; each target therefore returns a result whose structural hash has no
+higher asymptotic order than the named operation, and each nonconstant hash
+walk is included in the adjacent derivation. The adjacent comments in the
+eventual registrations must repeat these derivations.
+
+| Case | Timed operation and controlled ladder | Declared textbook model |
+| --- | --- | --- |
+| `runDecisionCarrierDegree` | `decide` on one square-free product of `n` unit-separated linear factors; one atom and one Boolean node | `O(n⁴)` integer operations: `O(n)` active intervals over `O(n)` levels, each dominated by an `O(n²)` Möbius transform; other fixed-shape RCF phases are no worse on this family. |
+| `runDedupRepeated` | `dedupPolys` on `u` repetitions of one fixed-degree polynomial | `O(u)`: after the first entry the seen set has fixed size one. |
+| `runDedupDistinct` | `dedupPolys` on the first `u` entries of a committed fixed-degree, fixed-bit-width distinct-polynomial corpus | `O(u²)`: first-occurrence insertion scans a seen prefix of lengths `0 … u-1`; coefficient comparison cost is bounded by the corpus contract. |
+| `runCommonRoots` | a strict batch of public `buildCommonRoot?` calls on the first `m` atoms of each committed fixed-degree, fixed-bit-width case corpus against one fixed-degree carrier; coprime, shared-factor, and repeated-polynomial cases are separate subladders | `O(m)`: one bounded-size gcd, identity package, and checker call per atom; distinct-order deduplication is excluded here and measured by `runDedupDistinct`. |
+| `runSeparationDepth` | `Separation.separate?` at fixed carrier degree while coefficient height forces a dyadic close pair to depth `b` | There are `O(b)` exact-arithmetic operations, but their operands have `O(b)` bits. The wall-cost contract is `O(b M(b))`; the registration uses the quasi-linear multiplication proxy `b² ceilLog₂(b+1)` on a homogeneous multiprecision schedule, avoiding the immediate-`Int`/GMP seam. |
+| `runReplayCells` | `Certificate.replay?` on prebuilt accepted `.cells` certificates for a unit-separated degree-`k` carrier with one atom, varying its `k` roots and `2k+1` cells | Isolation validation and `k` root-cell `hasRoot` checks take `O(k³)` exact operations. For `Pₖ = ∏_{j≤k}(x-j)`, primitive-PRS operand height is `B(k) = O(k² log k)`, so the wall-cost contract is `O(k³ M(B(k)))`; the registration uses the quasi-linear proxy `k⁵ ceilLog₂(k+1)²` on one multiprecision regime. |
+| `runReplaySigns` | `Certificate.replay?` on prebuilt accepted `.cells` certificates with a fixed one-root carrier and `u` distinct fixed-width scalar multiples of its linear atom | `O(u²)` exact-arithmetic/list operations: sentence-product construction and the repeated-factor witness grow at most quadratically, while deduplication, aligned common-root lookup, sign-row construction, and formula lookup each scan prefixes of the `u` entries. |
+| `runReplayFormula` | `Certificate.replay?` on prebuilt accepted `.cells` certificates with carrier, cell count, and atom multiset fixed while appending `s` literal `.tt`/`.ff` nodes by one fixed tree recipe | `O(s)`: the arithmetic payload is fixed, while the formula/polynomial discovery traversals and the strict option-valued fold visit each added literal/connective node a bounded number of times. |
+
+The five manifest input-family dimensions map respectively to carrier
+degree/root count, distinct versus repeated occurrences, common-root package
+count, separation depth, and the three independent replay subladders (cells,
+distinct sign entries, and formula occurrences). The fixed
+quadratic/degree-10/degree-50 cases below do not participate in those
+complexity verdicts.
+
+The tactic track uses matched fresh-module variants for each fixed case:
+`Baseline` (identical imports), `Reify` (reify-only checksum), `Input`
+(reflected sentence literal), `Search` (the same input plus a meta checksum of
+compiled certificate construction, emitting no proof), `Literal` (input plus
+the pre-generated certificate), `Replay` (literal plus its kernel-checked
+theorem), and `Tactic` (the source goal closed by `rcf`). An external runner
+rotates fresh builds and reports raw paired deltas for reification, search,
+literal elaboration, replay, and the full tactic. `Search − Input` is
+phase-attribution evidence only; the matching LeanBench target supplies the
+scientific asymptotic verdict, and the report neither substitutes nor adds the
+two. The headline report records source hashes, commit/toolchain/host/load
+state, raw samples, artifact sizes, timeout cleanup, and the theorem's axiom
+set, and refuses release claims from a dirty or busy host.
+
+python-flint is an **informational** comparator for the compiled decision
+verdict on committed shared sentence families. It is not proof-producing, and
+no comparable proof-producing univariate RCF tactic is currently named; the
+tactic/elaboration track is therefore
+`no-comparable-surface-in-named-comparator` rather than assigned a fake ratio.
+The Phase-3 `local` emitter exercises related compiled workloads but is neither
+an elaboration benchmark nor Phase-4 asymptotic evidence.
+
+This contract and the pure-module extraction do not advance the phase marker.
+`HexRCF.done_through` remains `3` until every dependency, including
+HexRealRootsMathlib, has completed Phase 4 and both evidence tracks have their
+required structural wiring and scientific artifacts.
 
 ## Conformance fixtures
 
@@ -745,6 +801,12 @@ For typical goals (`m ≤ 5`, `deg ≤ 10`, small coefficients) the whole
 pipeline is dominated by elaboration overhead, not arithmetic.
 
 ## Time budgets (Phase 4 validation)
+
+These are fixed whole-tactic acceptance cases, measured as the preregistered
+paired `Tactic − Baseline` fresh-module delta on a clean, quiescent named host.
+Raw total wall times and every pair remain in the artifact. They are not
+one-parameter ladders, complexity verdicts, or substitutes for the compiled
+LeanBench cases above.
 
 - Quadratic goals, one atom: under 100 ms.
 - Degree ≤ 10, up to 3 atoms: under 1 second.

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -276,9 +276,10 @@ closure may import `LeanBench`, register a benchmark, define `main`, read an
 in-process clock, or contain a timing loop. A probe also cannot root any
 `lean_exe`. Their external runner must:
 
-- build a matched import baseline and each probe in isolated fresh build
-  directories, rotating baseline/probe order rather than measuring all
-  baselines first;
+- before each sample, remove only the measured module's generated artefacts
+  and run `lake build +<module>:olean`, keeping imported dependency artefacts
+  warm; build each matched reference/candidate pair adjacently, rotate pair
+  order, and alternate pair orientation between rounds;
 - retain every raw wall-time sample and paired delta, and identify the exact
   source hashes, repository commit, dirty-state decision, toolchain, command,
   host/CPU/OS, load state, and timeout/cleanup policy;

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -156,6 +156,14 @@ Both forms accept a `where { … }` clause to override fields of the
 per-benchmark config (`maxSecondsPerCall`, `repeats`, `paramCeiling`,
 slope tolerance, etc.); CLI flags layer on top.
 
+The parametric runner hashes every result before stopping its inner-loop timer.
+That hash is the conformance signal used by `compare`, not optional harness
+overhead. A target returning a growing structure must therefore include the
+structural hash walk in its adjacent cost derivation and ensure the walk has no
+higher asymptotic order than the operation being measured. Do not replace a
+structural result hash with a parameter-only digest merely to hide its cost;
+that would discard the conformance signal.
+
 Each benchmark therefore has two settings layers:
 
 - **scientific settings** — the canonical parameter domain or fixed
@@ -225,22 +233,74 @@ record `spawn_floor_nanos` and `signal_floor_multiplier`.
 ### What we don't measure
 
 `lean-bench` measures compiled-code execution. The following are
-**out of scope** for this contract; their performance is a separate
-concern:
+**out of scope** for LeanBench's compiled timing contract:
 
 - elaboration-time `decide` and `decide +kernel`,
 - `#eval` and `#eval!`,
 - kernel reduction (proof terms, `decide` after elaboration),
 - proof-search tactics inside `Bench.lean`.
 
-If a tactic's compile time matters, it's a Lean / tactic-author
-issue and goes to a different tracker.
+These are out of scope for **LeanBench**. When a library advertises a tactic or
+proof-producing API, Phase 4 covers that surface through the build-only
+fresh-module evidence below; it must not disguise elaboration or kernel time as
+compiled benchmark time.
 
 CPU profiling of compiled benchmark binaries is **in scope** and is
 a Phase-4 deliverable; see [profiling.md](profiling.md). A bench
 verdict of "consistent with declared complexity" only checks
 asymptotics; profiling is what attributes the constant factor and
 catches dominant costs that the registered targets do not measure.
+
+## Fresh-module proof evidence
+
+Elaboration, tactic execution, emitted proof terms, and ordinary kernel
+checking are measured only by an external runner building fresh Lean modules.
+The module sources live recursively below a directory listed in the owning
+`mathlib: true` library's `libraries.yml: proof_probes`. A path may reserve a
+not-yet-created directory for a stacked change, but when present it must be a
+directory below `bench/<Owner>/`, must resolve physically inside `bench/`, and
+must contain no symlinks. Reservations are staging-only: before a library may
+claim `done_through: 4`, each declared root must exist and contain at least one
+Lean source.
+Names such as `HexFooMathlib` and a library's `mathlib: true` flag grant no
+implicit directory-wide exception.
+
+For a mixed library, a proof-probe subtree may coexist with an ordinary
+Mathlib-free `bench/<Owner>/Bench.lean` executable. The exception is exact and
+component-aware: a declaration of `bench/HexFoo/ProofProbe` admits neither
+`bench/HexFoo/Bench.lean` nor `bench/HexFoo/ProofProbeExtra`. Every undeclared
+bench source whose transitive import closure reaches Mathlib is rejected.
+
+Neither a proof probe nor any repository-local source in its transitive import
+closure may import `LeanBench`, register a benchmark, define `main`, read an
+in-process clock, or contain a timing loop. A probe also cannot root any
+`lean_exe`. Their external runner must:
+
+- build a matched import baseline and each probe in isolated fresh build
+  directories, rotating baseline/probe order rather than measuring all
+  baselines first;
+- retain every raw wall-time sample and paired delta, and identify the exact
+  source hashes, repository commit, dirty-state decision, toolchain, command,
+  host/CPU/OS, load state, and timeout/cleanup policy;
+- record emitted artefact sizes and the axiom set of the accepted theorem;
+- refuse a release-quality verdict on a dirty tree, a busy shared host, a
+  timed-out build, or a provenance mismatch.
+
+Phase attribution uses matched module variants, not clocks embedded in the
+probe. A tactic library may use a baseline; a reify-only module; an input module
+containing the reflected sentence literal; a search module that runs compiled
+certificate construction from that input through a meta checksum but emits no
+proof; a literal module adding the pre-generated certificate; a replay module
+adding the kernel-checked theorem; and a full tactic module. The matched
+differences attribute reification, compiled search within the build, emitted
+literal elaboration, kernel replay, and whole-tactic cost.
+
+The search variant is phase-attribution evidence only: it gets no asymptotic
+verdict. The same Mathlib-free operation is also timed by LeanBench on a
+controlled ladder for its scientific complexity claim. The report links the
+two by input and source hash and never substitutes the fresh-build delta for
+the LeanBench verdict or adds both times together. Fixed tactic budgets apply
+to the predeclared paired fresh-build cases and are not asymptotic evidence.
 
 ## Within-Lean comparisons
 
@@ -604,17 +664,15 @@ hard invariants:
    `Hex*Mathlib.*` modules are not what this rule forbids — but per
    invariant (1) above, no bench imports them either.
 
-There is one narrow, non-computational exception. A library declared
-`mathlib: true` in `libraries.yml` may place Mathlib proof-elaboration or
-kernel-replay probes under `bench/HexFoo/`, where `HexFoo` is the exact
-manifest library name. Such a probe measures a fresh module build from an
-external harness; it is not a `lean-bench` registration. It must not import
-`LeanBench`, use `setup_benchmark` or `setup_fixed_benchmark`, define `main`,
-perform an in-process timing loop, or serve as the root of any `lean_exe`.
-This exception exists to compare proof encodings and elaboration/replay costs;
-it does not permit computational timing through Mathlib. All executable
-computational benches and everything in their import closures remain
-Mathlib-free.
+There is one narrow, non-computational exception. A `mathlib: true` library may
+declare recursive directory roots in `libraries.yml: proof_probes` for the
+fresh-module evidence specified above. No suffix or library flag grants an
+implicit exception, and files outside the exact declared roots remain ordinary
+Mathlib-free bench sources. A probe is not a LeanBench registration and must
+not import `LeanBench`, use `setup_benchmark` or `setup_fixed_benchmark`, define
+`main`, perform an in-process timing loop, or serve as the root of any
+`lean_exe`. This exception covers proof encodings and elaboration/replay costs;
+it does not permit computational timing through Mathlib.
 
 Both invariants are enforced by
 `scripts/ci/check_benches_mathlib_free.py`, invoked from the `build`
@@ -631,10 +689,11 @@ job in `ci.yml`. The script:
   `HexPolyMathlib.Bench → HexPolyMathlib.Euclid → Mathlib.Algebra.Polynomial.FieldDivision`).
 - Globs `Hex*Mathlib/Bench.lean` and `Hex*Mathlib/Bench/` and fails
   if any such path exists.
-- Derives proof-probe owner directories from libraries declared `mathlib: true`
-  in `libraries.yml`, then checks their `bench/<Library>/` trees for `LeanBench`
-  imports, benchmark registrations, `main`, in-process clocks, or an executable
-  rooted at a probe module.
+- Reads exact proof-probe roots from `libraries.yml`, validates their ownership
+  and physical containment, scans every probe for `LeanBench` imports,
+  benchmark registrations, `main`, in-process clocks, or an executable root,
+  and rejects every undeclared bench source whose transitive closure reaches
+  Mathlib.
 
 A computational bench that needs Mathlib is a category error, not an oversight
 to work around: either it is measuring through Mathlib (slow and missing the
@@ -646,7 +705,8 @@ build-only probe exception above.
 
 ## CI integration
 
-Every library at `done_through ≥ 4` ships a CI job that runs:
+Every library at `done_through ≥ 4` with a compiled track extends the existing
+CI job with:
 
 ```sh
 lake exe hexfoo_bench list
@@ -659,10 +719,14 @@ child exits cleanly, and verifies hashable benchmarks emit hashes.
 It does NOT assert timing values — the gate detects bitrot of the
 bench module itself, not regressions in the implementation.
 
+A proof-only track instead builds its reduced declared probes in that same
+single CI job and runs the structural lint. A mixed library does both. Proof
+probes never add a second job, matrix, executable, or `list`/`verify` command.
+
 The `Bench verify` step lives in `ci.yml`'s `build` ubuntu job (per
 [SPEC/CI.md §Job-count budget](CI.md)), one sequential block, no
-matrix. New libraries at `done_through ≥ 4` append their bench
-target to that block.
+matrix. New compiled tracks at `done_through ≥ 4` append their bench target to
+that block.
 
 ### Time budget
 
@@ -771,13 +835,17 @@ performance shape.
 
 The report contains five subsections:
 
-1. **Bench targets.** The registered bench targets and their
-   declared complexities, copied (not paraphrased) from the
-   `setup_benchmark` registration sites.
+1. **Bench targets.** The registered compiled targets and their declared
+   complexities, copied (not paraphrased) from the `setup_benchmark`
+   registration sites. A mixed/proof library also lists every fresh-module
+   probe, its matched baseline, and the generic requirements that probe
+   replaces.
 2. **Verdicts.** Each parametric registration's verdict at
    scientific settings ("consistent with declared complexity",
    "inconclusive", with the verdict text). Each fixed registration's
-   median per-call time and observed-hash agreement.
+   median per-call time and observed-hash agreement. Proof-track entries report
+   all raw rotated fresh-build samples and paired deltas, never a complexity
+   verdict.
 3. **Comparator ratios.** Each comparator named in the per-library
    SPEC ([§Comparator naming](#comparator-naming)) — `gating` and
    `informational` alike — with measured ratios across the full
@@ -856,14 +924,15 @@ The report contains five subsections:
      Plots disagreeing with the §"Comparator ratios" values are
      an audit-found issue.
 4. **Profile.** Per [profiling.md §Coverage requirement](profiling.md),
-   one representative case per `phase4.input_families`. Dominant
+   one representative compiled case per `phase4.input_families`. Dominant
    inclusive costs are named and explained, with leaf cost
    categorised across {own code, GMP, allocation, Lean runtime}.
    Any inclusive cost the author cannot attribute to a registered
    bench target is filed as an audit-found issue per
    [Conventions.md §Bench-found, conformance-found, and audit-found
    issues](../PLAN/Conventions.md#bench-found-conformance-found-and-audit-found-issues)
-   and linked from the next subsection.
+   and linked from the next subsection. Proof-track surfaces cite their
+   fresh-build artefacts and state that timed-region sampling does not apply.
 5. **Concerns.** Audit-found issues filed against this library
    that have not yet resolved. The library cannot **remain** at
    `done_through: 4` while any Concern is unresolved (see
@@ -873,12 +942,11 @@ The report contains five subsections:
 
 ### Artefact traceability
 
-Every numeric claim in a headline report is traceable: the report
-cites the exact bench case name, the command line that produced
-the number, the seed or parameter, the JSONL row path or hash,
-the profile artefact location, and the comparator's source. A
-narrative without traceable artefacts does not satisfy this
-requirement.
+Every numeric claim in a headline report is traceable: the report cites the
+exact bench/probe case name, command line, seed or parameter, JSONL row or raw
+fresh-build sample path/hash, applicable profile artefact location, source
+hash, host/toolchain/commit, and comparator source. A narrative without
+traceable artefacts does not satisfy this requirement.
 
 The `reports/<lib>-performance.md` file is overwrite-on-rerun:
 when the report is regenerated against a newer build, the previous

--- a/SPEC/profiling.md
+++ b/SPEC/profiling.md
@@ -6,6 +6,16 @@ benchmarking checks declared asymptotic complexity against observed
 scaling; profiling attributes the constant factor and surfaces
 dominant costs that the registered bench targets do not measure.
 
+This contract applies only to the Mathlib-free compiled evidence track.
+Fresh-module elaboration, tactic, emitted-proof, and kernel-checking probes have
+no LeanBench timed region and therefore no sampling-profile obligation. Their
+replacement is the raw rotated build evidence, compiler/proof artefacts, and
+provenance record in
+[benchmarking.md §Fresh-module proof evidence](benchmarking.md#fresh-module-proof-evidence).
+A mixed library profiles its compiled track and reports its proof track
+separately; it never samples the whole compiler process and labels that a
+timed-region profile.
+
 A bench verdict of "consistent with declared complexity" is
 asymptotic-only. A profile is what tells you whether the cost is
 landing where the algorithm says it should — or whether 90% of the
@@ -66,9 +76,11 @@ filtering postprocessor emits a diagnostics block per run; see
 
 ## Coverage requirement
 
-Profile **at least one representative case per
+Profile **at least one representative compiled case per
 `phase4.input_families` entry** in `libraries.yml` for the library
-being audited. Within the case-per-family minimum:
+being audited. Proof-track fixed build cases are declared separately in the
+per-library SPEC and do not create synthetic profile families. Within the
+case-per-family minimum:
 
 - Always profile the family that the per-library SPEC names as
   the downstream hot path. For HexLLL, that is the BZ

--- a/libraries.yml
+++ b/libraries.yml
@@ -49,6 +49,15 @@
 #                                 # per-library SPEC's narrative
 #       See SPEC/benchmarking.md §"Anti-patterns" entry on best-case
 #       inputs and SPEC/profiling.md §"Coverage requirement".
+# - proof_probes (optional): explicit repository-relative paths below
+#   bench/<Library>/ containing build-only Mathlib proof-elaboration or
+#   kernel-replay probes. Only mathlib: true libraries may declare these.
+#   Files elsewhere in the same bench/<Library>/ tree remain ordinary
+#   computational-bench sources and receive no proof-probe exception. A path
+#   may reserve a not-yet-created directory for a later stacked change; once
+#   present it must be a directory resolving physically inside bench/ and its
+#   subtree must contain no symlinks. A done_through: 4 library may not retain
+#   a missing or empty reservation.
 #
 # This file is the single source of truth for the library graph.
 # lakefile.lean entries are cross-checked against active libraries.yml
@@ -489,6 +498,7 @@ libraries:
     mathlib: true
     done_through: 0
     status: planned
+    proof_probes: [bench/HexIntervalMathlib]
   HexResultantMathlib:
     deps: [HexResultant, HexPolyMathlib]
     mathlib: true
@@ -528,8 +538,26 @@ libraries:
     mathlib: true
     done_through: 3
     status: active
+    proof_probes: [bench/HexRealRootsMathlib]
   HexRCF:
     deps: [HexRealRoots, HexRealRootsMathlib, HexPolyZ, HexPolyZMathlib]
     mathlib: true
     done_through: 3
     status: active
+    proof_probes: [bench/HexRCF/ProofProbe]
+    phase4:
+      comparators:
+        - tool: "python-flint univariate RCF verdict oracle"
+          class: informational
+          rationale: "python-flint supplies an independent exact/ball-arithmetic verdict on the committed shared sentence families, but it does not emit a proof term or exercise Lean certificate replay. Ratios orient the Mathlib-free compiled DecisionCheck track and are scheduled-only; they do not gate the proof-producing tactic surface. No comparable proof-producing univariate RCF tactic is named, so the tactic track is declared no-comparable-surface-in-named-comparator in the HexRCF SPEC."
+      input_families:
+        - name: carrier-degree-roots
+          description: One-atom square-free families varying carrier degree and real-root count while holding atom multiplicity, coefficient-height regime, and Boolean shape fixed.
+        - name: atom-multiplicity
+          description: Fixed-degree, fixed-bit-width committed-corpus families varying distinct nonconstant polynomials independently from repeated atom occurrences, with each ladder capped by the corpus and holding root geometry fixed.
+        - name: common-root-work
+          description: Fixed-carrier, fixed-degree, fixed-bit-width subladders varying only the number of public common-root builder calls, with separate committed corpora for coprime, shared-factor, and repeated-polynomial cases.
+        - name: separation-refinement
+          description: Fixed-degree isolation families varying adjacent-root gap and required dyadic refinement depth from already-strict to Mignotte-style clustered roots.
+        - name: certificate-replay-size
+          description: Three prebuilt accepted .cells-certificate subladders independently vary carrier cells, distinct scalar-multiple sign entries, and literal .tt/.ff formula occurrences under a fixed tree recipe while excluding compiled witness construction from every timed replay target.

--- a/progress/20260727T163536Z_rcf-phase4-contract.md
+++ b/progress/20260727T163536Z_rcf-phase4-contract.md
@@ -1,0 +1,43 @@
+# RCF two-track Phase-4 contract
+
+## Accomplished
+
+- Defined separate Phase-4 evidence tracks for Mathlib-free compiled
+  computation and Mathlib-facing elaboration, tactics, proof emission, and
+  kernel replay. The compiled track retains all LeanBench, scientific verdict,
+  comparator, and profiling requirements; the proof track uses externally
+  timed fresh-module builds with explicit replacement evidence.
+- Specified controlled HexRCF compiled ladders for carrier degree,
+  deduplication, common-root batches, separation depth, and three independent
+  prebuilt-certificate replay dimensions, with adjacent cost derivations.
+- Added explicit manifest-owned `proof_probes` roots and HexRCF Phase-4
+  comparator/input-family metadata while retaining `done_through: 3`.
+- Hardened the bench lint so the proof exception is exact and component-aware,
+  rejects malformed or overlapping roots and symlink escapes, scans forbidden
+  behavior through each probe's repository-local import closure, and rejects
+  missing or empty reservations once a library claims Phase 4.
+- Added adversarial regression coverage. All 27 lint tests, the real bench
+  lint, `lake build HexRCF`, DAG, Phase-4, release-manifest, trust-surface,
+  copyright, source-line-count, conformance-matrix, Python compilation, and
+  diff checks pass. An independent Sol architecture audit returned GO.
+
+## Current frontier
+
+Issue #9008 is implemented on a branch stacked above the Mathlib-free
+DecisionCheck extraction. This change establishes the structural contract and
+controlled families only; it deliberately records no scientific measurements
+and makes no Phase-4 completion claim.
+
+## Next step
+
+Publish the stacked contract PR, then implement `bench/HexRCF/Bench.lean` and
+the fresh-module `bench/HexRCF/ProofProbe/` variants against this contract.
+Rebase and promote the extraction PR chain one parent at a time as each parent
+lands.
+
+## Blockers
+
+Scientific proof/tactic timing remains gated on the HexRealRootsMathlib
+Phase-4 prerequisite and a clean, quiescent dedicated host. The structural
+contract itself has no blocker; its PR remains stacked until the extraction
+chain merges.

--- a/progress/20260728T003148Z_proof-probe-protocol.md
+++ b/progress/20260728T003148Z_proof-probe-protocol.md
@@ -1,0 +1,24 @@
+# Fresh-module proof-probe protocol correction
+
+## Accomplished
+
+- Corrected the Phase-4 proof-probe protocol to require exact invalidation and
+  rebuilding of each measured module while imported dependency artefacts stay
+  warm.
+- Required adjacent reference/candidate builds, rotated pair order, and
+  alternating pair orientation, matching the reusable runner implemented for
+  #8972 and avoiding measurement of the entire local import closure.
+
+## Current frontier
+
+- The Phase-4 contract now states the executable protocol that the shared
+  harness can enforce and that the original #8972 directive requires.
+
+## Next step
+
+- Restack the compiled HexRCF benchmark branch on this correction and use the
+  shared pair runner for the HexRCF proof-probe matrix.
+
+## Blockers
+
+- None.

--- a/scripts/ci/check_benches_mathlib_free.py
+++ b/scripts/ci/check_benches_mathlib_free.py
@@ -11,11 +11,13 @@ The computational-benchmark invariants are:
   2. No bench-exe root module (any module named by `lean_exe
      *_bench where root := `Module.Name`` in `lakefile.lean`), and
      no module transitively reachable from such a root via Lean
-     `import`, may name a `Mathlib.*` module.
+     `import`, may name a `Mathlib.*` module. Non-executable bench sources
+     outside an explicit proof-probe root are checked too, so an undeclared
+     helper cannot silently import Mathlib.
 
-A narrow exception permits build-only proof-elaboration probes below
-`bench/HexFoo/` when `libraries.yml` declares `HexFoo.mathlib: true`. Such
-files may import Mathlib, but may not import
+A narrow exception permits build-only proof-elaboration probes below explicit
+`proof_probes` paths owned by `mathlib: true` libraries in `libraries.yml`.
+Such files may import Mathlib, but may not import
 LeanBench, register a benchmark, define `main`, time work in-process, or
 serve as a `lean_exe` root.
 
@@ -362,48 +364,116 @@ def _check_manifest_uniqueness(path: Path) -> None:
         )
 
 
-def _mathlib_probe_owners(repo_root: Path) -> set[str]:
-    """Return the manifest-declared owners admitted to the probe carveout."""
+def _mathlib_probe_roots(repo_root: Path) -> tuple[Path, ...]:
+    """Return explicit manifest-owned roots admitted to the probe carveout."""
     manifest = repo_root / "libraries.yml"
     _check_manifest_uniqueness(manifest)
     libraries = load_libraries(manifest)
-    return {name for name, info in libraries.items() if info.mathlib}
+    entries = tuple(
+        (info, repo_root / probe)
+        for info in libraries.values()
+        for probe in info.proof_probes
+    )
+    roots = tuple(root for _, root in entries)
+    physical_bench = (repo_root / "bench").resolve()
+    for owner, root in entries:
+        if root.is_symlink() and not root.exists():
+            raise ValueError(f"broken proof probe root symlink: {root}")
+        if not root.exists():
+            # A manifest entry may reserve a path for a probe delivered by a
+            # later stacked change. Undeclared Mathlib-reaching files are still
+            # caught by the all-bench-source scan.
+            if owner.done_through >= 4:
+                raise ValueError(
+                    f"Phase-4 library {owner.name} has missing proof probe "
+                    f"root: {root}"
+                )
+            continue
+        if not root.is_dir():
+            raise ValueError(f"proof probe root is not a directory: {root}")
+        try:
+            root.resolve().relative_to(physical_bench)
+        except ValueError as exc:
+            raise ValueError(
+                f"proof probe root resolves outside bench/: {root}"
+            ) from exc
+        # Path.rglob deliberately does not descend through directory
+        # symlinks.  Reject every descendant symlink rather than letting a
+        # Lake glob build source that neither the probe scan nor the ordinary
+        # all-bench scan can see.
+        for directory, dirnames, filenames in os.walk(root, followlinks=False):
+            for name in (*dirnames, *filenames):
+                descendant = Path(directory) / name
+                if descendant.is_symlink():
+                    raise ValueError(
+                        f"proof probe root contains symlink: {descendant}"
+                    )
+        if owner.done_through >= 4 and not any(root.rglob("*.lean")):
+            raise ValueError(
+                f"Phase-4 library {owner.name} has empty proof probe root: "
+                f"{root}"
+            )
+    return roots
 
 
 def _is_mathlib_probe_path(path: Path, repo_root: Path,
-                           owners: set[str]) -> bool:
-    """Whether `path` lies below a manifest-declared Mathlib probe owner."""
-    def has_owner(candidate: Path, bench_root: Path) -> bool:
+                           roots: tuple[Path, ...]) -> bool:
+    """Whether `path` lies below an explicit manifest-owned probe root."""
+    def is_below(candidate: Path, root: Path) -> bool:
         try:
-            rel = candidate.relative_to(bench_root)
+            candidate.relative_to(root)
         except ValueError:
             return False
-        return len(rel.parts) >= 2 and rel.parts[0] in owners
+        return True
 
-    # Lexical normalization keeps an owner symlink pointing outward covered;
-    # physical normalization catches a source-root alias pointing inward.
+    # Lexical normalization keeps a configured probe-root symlink pointing
+    # outward covered; physical normalization catches a source-root alias
+    # pointing inward.
     lexical = Path(os.path.abspath(path))
-    lexical_bench = Path(os.path.abspath(repo_root / "bench"))
     physical = path.resolve()
-    physical_bench = (repo_root / "bench").resolve()
-    return has_owner(lexical, lexical_bench) or has_owner(
-        physical, physical_bench
+    return any(
+        is_below(lexical, Path(os.path.abspath(root)))
+        or is_below(physical, root.resolve())
+        for root in roots
     )
 
 
-def _find_mathlib_probe_files(repo_root: Path, owners: set[str]) -> list[Path]:
-    """Find Lean proof probes admitted by the manifest-based carveout."""
+def _find_mathlib_probe_files(repo_root: Path,
+                              roots: tuple[Path, ...]) -> list[Path]:
+    """Find Lean proof probes below explicit manifest-owned roots."""
+    out: set[Path] = set()
+    for root in roots:
+        if root.is_dir():
+            out.update(root.rglob("*.lean"))
+    return sorted(out)
+
+
+def _undeclared_mathlib_bench_failures(
+    repo_root: Path, roots: tuple[Path, ...]
+) -> list[str]:
+    """Reject Mathlib-reaching bench sources outside explicit probe roots."""
     bench_root = repo_root / "bench"
     if not bench_root.is_dir():
         return []
-    out: list[Path] = []
-    for entry in sorted(bench_root.iterdir()):
-        if not entry.is_dir():
+    failures: list[str] = []
+    for source in sorted(bench_root.rglob("*.lean")):
+        if _is_mathlib_probe_path(source, repo_root, roots):
             continue
-        if entry.name not in owners:
-            continue
-        out.extend(sorted(entry.rglob("*.lean")))
-    return out
+        relative = source.relative_to(bench_root)
+        module = ".".join(relative.with_suffix("").parts)
+        target = _ExeTarget(
+            name=f"bench source {relative}", root=module, src_dir=Path("bench")
+        )
+        chain = _walk_for_mathlib(target, repo_root)
+        if chain is not None:
+            chain_str = "\n    → ".join(chain)
+            failures.append(
+                f"  FORBIDDEN: undeclared bench source `{relative}` reaches "
+                f"Mathlib via:\n    {chain_str}\n"
+                f"  Declare an exact proof_probes path owned by a mathlib: "
+                f"true library, or keep the source Mathlib-free."
+            )
+    return failures
 
 
 _PROBE_FORBIDDEN = (
@@ -451,12 +521,62 @@ def _probe_violations(path: Path) -> list[str]:
             if pattern.search(text)]
 
 
+def _probe_closure_violations(
+    probe: Path, repo_root: Path
+) -> list[tuple[Path, str]]:
+    """Return forbidden features in a probe's repository-local closure.
+
+    Mathlib and other Lake packages are leaves for this policy: their source
+    may legitimately define executables or use internal clocks.  Every source
+    resolved below the repository itself (apart from `.lake/packages`) is
+    scanned and traversed, so moving LeanBench registration or timing into a
+    helper does not evade the build-only probe contract.
+    """
+    bench_root = repo_root / "bench"
+    relative = probe.relative_to(bench_root)
+    target = _ExeTarget(
+        name=f"proof probe {relative}",
+        root=".".join(relative.with_suffix("").parts),
+        src_dir=Path("bench"),
+    )
+    repo_abs = Path(os.path.abspath(repo_root))
+    packages_abs = repo_abs / ".lake" / "packages"
+    visited: set[str] = set()
+    frontier = [target.root]
+    failures: list[tuple[Path, str]] = []
+    while frontier:
+        module = frontier.pop(0)
+        if module in visited:
+            continue
+        visited.add(module)
+        path = _resolve_module(module, target, repo_root)
+        if path is None:
+            continue
+        lexical = Path(os.path.abspath(path))
+        try:
+            lexical.relative_to(repo_abs)
+        except ValueError:
+            continue
+        try:
+            lexical.relative_to(packages_abs)
+        except ValueError:
+            pass
+        else:
+            continue
+        for violation in _probe_violations(path):
+            failures.append((path, violation))
+        for imported in _parse_imports(path):
+            if imported not in visited:
+                frontier.append(imported)
+    return failures
+
+
 def _probe_root_path(target: _ExeTarget, repo_root: Path,
-                     owners: set[str]) -> Path | None:
+                     roots: tuple[Path, ...]) -> Path | None:
     """Resolve a module when its source is an admitted Mathlib probe file."""
     candidate = target.root_path(repo_root)
     if candidate.is_file() and _is_mathlib_probe_path(
-        candidate, repo_root, owners
+        candidate, repo_root, roots
     ):
         return candidate
     return None
@@ -501,7 +621,7 @@ def main() -> int:
     try:
         exe_targets = _parse_exe_targets(lakefile)
         _configured_source_roots(repo_root)
-        probe_owners = _mathlib_probe_owners(repo_root)
+        probe_roots = _mathlib_probe_roots(repo_root)
     except (OSError, ValueError, tomllib.TOMLDecodeError) as exc:
         print(f"FATAL: cannot resolve Lake module roots: {exc}", file=sys.stderr)
         return 2
@@ -520,16 +640,17 @@ def main() -> int:
 
     # The build-only proof-probe carveout is intentionally not an executable
     # or a second computational benchmark harness.
-    probe_files = _find_mathlib_probe_files(repo_root, probe_owners)
+    probe_files = _find_mathlib_probe_files(repo_root, probe_roots)
     for probe in probe_files:
-        for violation in _probe_violations(probe):
+        for source, violation in _probe_closure_violations(probe, repo_root):
             failures.append(
-                f"  FORBIDDEN: {probe.relative_to(repo_root)} {violation}.\n"
+                f"  FORBIDDEN: proof probe {probe.relative_to(repo_root)} "
+                f"reaches {source.relative_to(repo_root)}, which {violation}.\n"
                 f"  Mathlib proof probes must be build-only and externally "
                 f"timed; see SPEC/benchmarking.md §Mathlib-free benches."
             )
     for exe, target in sorted(exe_targets.items()):
-        probe = _probe_root_path(target, repo_root, probe_owners)
+        probe = _probe_root_path(target, repo_root, probe_roots)
         if probe is not None:
             failures.append(
                 f"  FORBIDDEN: executable `{exe}` is rooted at Mathlib proof "
@@ -537,6 +658,11 @@ def main() -> int:
                 f"  Proof probes must remain build-only; see "
                 f"SPEC/benchmarking.md §Mathlib-free benches."
             )
+
+    # Files outside an explicit proof-probe root receive no exception merely
+    # because their directory resembles a Mathlib library name. Scan every
+    # bench source, including non-executable helpers, through its import graph.
+    failures.extend(_undeclared_mathlib_bench_failures(repo_root, probe_roots))
 
     # Invariant 2: no bench-exe root reaches `Mathlib.*` via imports.
     for exe, target in sorted(bench_targets.items()):
@@ -558,8 +684,9 @@ def main() -> int:
         print(
             "\nFix: keep executable computational benches Mathlib-free. "
             "A Mathlib proof-elaboration probe may instead be a build-only "
-            "module under bench/<Library>/ when libraries.yml declares that "
-            "owner mathlib: true, with timing performed by an external harness.",
+            "module under an explicit libraries.yml proof_probes path owned by "
+            "a mathlib: true library, with timing performed by an external "
+            "harness.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/ci/test_check_benches_mathlib_free.py
+++ b/scripts/ci/test_check_benches_mathlib_free.py
@@ -29,9 +29,9 @@ class BenchLintTests(unittest.TestCase):
         self.assertEqual(list(targets), ["sample_bench"])
         return targets["sample_bench"]
 
-    def manifest(self, root: Path, entries: str) -> set[str]:
+    def manifest(self, root: Path, entries: str) -> tuple[Path, ...]:
         self.write(root, "libraries.yml", "libraries:\n" + entries)
-        return lint._mathlib_probe_owners(root)
+        return lint._mathlib_probe_roots(root)
 
     def test_src_dir_and_module_import_modifiers_reach_mathlib(self) -> None:
         for import_line in (
@@ -166,36 +166,41 @@ class BenchLintTests(unittest.TestCase):
             path.write_text("module\npublic meta import LeanBench\n")
             self.assertIn("imports LeanBench", lint._probe_violations(path))
 
-    def test_manifest_declares_non_suffix_probe_owner(self) -> None:
+    def test_manifest_declares_explicit_non_suffix_probe_root(self) -> None:
         tmp, root = self.make_repo()
         with tmp:
-            owners = self.manifest(
+            roots = self.manifest(
                 root,
                 "  HexRCF:\n"
                 "    deps: []\n"
                 "    mathlib: true\n"
                 "    done_through: 3\n"
                 "    status: active\n"
+                "    proof_probes: [bench/HexRCF/ProofProbe]\n"
                 "  HexCore:\n"
                 "    deps: []\n"
                 "    mathlib: false\n"
                 "    done_through: 3\n"
                 "    status: active\n",
             )
-            self.assertEqual(owners, {"HexRCF"})
-            self.write(root, "bench/HexRCF/Import.lean", "import LeanBench\n")
+            self.assertEqual(roots, (root / "bench/HexRCF/ProofProbe",))
+            self.write(
+                root, "bench/HexRCF/ProofProbe/Import.lean", "import LeanBench\n"
+            )
             self.write(
                 root,
-                "bench/HexRCF/Register.lean",
+                "bench/HexRCF/ProofProbe/Register.lean",
                 "@[implemented_by ignored] private setup_fixed_benchmark sample := 1\n",
             )
             self.write(
-                root, "bench/HexRCF/Main.lean", "noncomputable def main := pure ()\n"
+                root, "bench/HexRCF/ProofProbe/Main.lean",
+                "noncomputable def main := pure ()\n"
             )
             self.write(
-                root, "bench/HexRCF/Clock.lean", "#check IO.monoNanosNow\n"
+                root, "bench/HexRCF/ProofProbe/Clock.lean",
+                "#check IO.monoNanosNow\n"
             )
-            probes = lint._find_mathlib_probe_files(root, owners)
+            probes = lint._find_mathlib_probe_files(root, roots)
             self.assertEqual(len(probes), 4)
             violations = {
                 violation
@@ -212,10 +217,135 @@ class BenchLintTests(unittest.TestCase):
                 },
             )
 
+    def test_mixed_owner_keeps_compiled_bench_outside_probe_root(self) -> None:
+        tmp, root = self.make_repo()
+        with tmp:
+            roots = self.manifest(
+                root,
+                "  HexRCF:\n"
+                "    deps: []\n"
+                "    mathlib: true\n"
+                "    done_through: 3\n"
+                "    status: active\n"
+                "    proof_probes: [bench/HexRCF/ProofProbe]\n",
+            )
+            target = self.target(
+                root,
+                "lean_exe sample_bench where\n"
+                "  srcDir := \"bench\"\n"
+                "  root := `HexRCF.Bench\n",
+            )
+            self.write(
+                root,
+                "bench/HexRCF/Bench.lean",
+                "import LeanBench\nsetup_fixed_benchmark compiled := 1\n",
+            )
+            self.write(
+                root,
+                "bench/HexRCF/ProofProbe/Tactic.lean",
+                "import Mathlib\n",
+            )
+            self.write(
+                root,
+                "bench/HexRCF/ProofProbeExtra/Hidden.lean",
+                "import Mathlib\n",
+            )
+            self.write(
+                root,
+                "bench/HexRCF/Hidden.lean",
+                "import Project.Helper\n",
+            )
+            self.write(root, "Project/Helper.lean", "import Mathlib\n")
+            self.assertFalse(
+                lint._is_mathlib_probe_path(
+                    root / "bench/HexRCF/Bench.lean", root, roots
+                )
+            )
+            self.assertFalse(
+                lint._is_mathlib_probe_path(
+                    root / "bench/HexRCF/ProofProbeExtra/Hidden.lean",
+                    root,
+                    roots,
+                )
+            )
+            self.assertIsNone(lint._probe_root_path(target, root, roots))
+            self.assertEqual(
+                lint._find_mathlib_probe_files(root, roots),
+                [root / "bench/HexRCF/ProofProbe/Tactic.lean"],
+            )
+            failures = lint._undeclared_mathlib_bench_failures(root, roots)
+            self.assertEqual(len(failures), 2)
+            joined = "\n".join(failures)
+            self.assertIn("HexRCF/Hidden.lean", joined)
+            self.assertIn("Project.Helper", joined)
+            self.assertIn("ProofProbeExtra/Hidden.lean", joined)
+
+    def test_undeclared_suffix_mathlib_source_gets_no_exception(self) -> None:
+        tmp, root = self.make_repo()
+        with tmp:
+            roots = self.manifest(
+                root,
+                "  HexFooMathlib:\n"
+                "    deps: []\n"
+                "    mathlib: true\n"
+                "    done_through: 3\n"
+                "    status: active\n",
+            )
+            self.write(
+                root, "bench/HexFooMathlib/Hidden.lean", "import Mathlib\n"
+            )
+            failures = lint._undeclared_mathlib_bench_failures(root, roots)
+            self.assertEqual(len(failures), 1)
+            self.assertIn("undeclared bench source", failures[0])
+
+    def test_reserved_probe_root_may_not_exist_yet(self) -> None:
+        tmp, root = self.make_repo()
+        with tmp:
+            roots = self.manifest(
+                root,
+                "  HexRCF:\n"
+                "    deps: []\n"
+                "    mathlib: true\n"
+                "    done_through: 3\n"
+                "    status: active\n"
+                "    proof_probes: [bench/HexRCF/ProofProbe]\n",
+            )
+            self.assertEqual(roots, (root / "bench/HexRCF/ProofProbe",))
+            self.assertFalse(roots[0].exists())
+
+    def test_phase4_probe_root_must_exist_and_contain_source(self) -> None:
+        for state, setup, message in (
+            ("missing", lambda _root: None, "missing proof probe root"),
+            (
+                "empty",
+                lambda root: (root / "bench/HexRCF/ProofProbe").mkdir(
+                    parents=True
+                ),
+                "empty proof probe root",
+            ),
+        ):
+            with self.subTest(state=state):
+                tmp, root = self.make_repo()
+                with tmp:
+                    setup(root)
+                    self.write(
+                        root,
+                        "libraries.yml",
+                        "libraries:\n"
+                        "  HexRCF:\n"
+                        "    deps: []\n"
+                        "    mathlib: true\n"
+                        "    done_through: 4\n"
+                        "    status: active\n"
+                        "    proof_probes: [bench/HexRCF/ProofProbe]\n",
+                    )
+                    with self.assertRaisesRegex(ValueError, message):
+                        lint._mathlib_probe_roots(root)
+
     def test_mathlib_false_owner_does_not_gain_probe_exception(self) -> None:
         tmp, root = self.make_repo()
         with tmp:
-            owners = self.manifest(
+            roots = self.manifest(
                 root,
                 "  HexCore:\n"
                 "    deps: []\n"
@@ -225,30 +355,33 @@ class BenchLintTests(unittest.TestCase):
             )
             self.write(root, "bench/HexCore/Probe.lean", "import Mathlib\n")
             probe = root / "bench/HexCore/Probe.lean"
-            self.assertFalse(lint._is_mathlib_probe_path(probe, root, owners))
-            self.assertEqual(lint._find_mathlib_probe_files(root, owners), [])
+            self.assertFalse(lint._is_mathlib_probe_path(probe, root, roots))
+            self.assertEqual(lint._find_mathlib_probe_files(root, roots), [])
 
     def test_manifest_owned_probe_cannot_root_executable(self) -> None:
         tmp, root = self.make_repo()
         with tmp:
-            owners = self.manifest(
+            roots = self.manifest(
                 root,
                 "  HexRCF:\n"
                 "    deps: []\n"
                 "    mathlib: true\n"
                 "    done_through: 3\n"
-                "    status: active\n",
+                "    status: active\n"
+                "    proof_probes: [bench/HexRCF/ProofProbe]\n",
             )
             target = self.target(
                 root,
                 "lean_exe sample_bench where\n"
                 "  srcDir := \"bench\"\n"
-                "  root := `HexRCF.Probe\n",
+                "  root := `HexRCF.ProofProbe.Probe\n",
             )
-            self.write(root, "bench/HexRCF/Probe.lean", "import Mathlib\n")
+            self.write(
+                root, "bench/HexRCF/ProofProbe/Probe.lean", "import Mathlib\n"
+            )
             self.assertEqual(
-                lint._probe_root_path(target, root, owners),
-                root / "bench/HexRCF/Probe.lean",
+                lint._probe_root_path(target, root, roots),
+                root / "bench/HexRCF/ProofProbe/Probe.lean",
             )
 
     def test_malformed_manifest_fails_closed(self) -> None:
@@ -265,7 +398,60 @@ class BenchLintTests(unittest.TestCase):
                 "    status: active\n",
             )
             with self.assertRaises(ValueError):
-                lint._mathlib_probe_owners(root)
+                lint._mathlib_probe_roots(root)
+
+    def test_malformed_probe_schema_fails_closed(self) -> None:
+        cases = (
+            (
+                "    mathlib: false\n"
+                "    done_through: 3\n"
+                "    status: active\n"
+                "    proof_probes: [bench/HexRCF/ProofProbe]\n",
+                "mathlib is false",
+            ),
+            (
+                "    mathlib: true\n"
+                "    done_through: 3\n"
+                "    status: active\n"
+                "    proof_probes: [bench/Other/ProofProbe]\n",
+                "invalid proof probe path",
+            ),
+            (
+                "    mathlib: true\n"
+                "    done_through: 3\n"
+                "    status: active\n"
+                "    proof_probes: [bench/HexRCF/*]\n",
+                "invalid proof probe path",
+            ),
+            (
+                "    mathlib: true\n"
+                "    done_through: 3\n"
+                "    status: active\n"
+                "    proof_probes: [bench/HexRCF/Probe.lean]\n",
+                "invalid proof probe path",
+            ),
+            (
+                "    mathlib: true\n"
+                "    done_through: 3\n"
+                "    status: active\n"
+                "    proof_probe: [bench/HexRCF/ProofProbe]\n",
+                "unknown fields",
+            ),
+            (
+                "    mathlib: true\n"
+                "    done_through: 3\n"
+                "    status: active\n"
+                "    proof_probes: [bench/HexRCF, bench/HexRCF/ProofProbe]\n",
+                "overlapping proof probe paths",
+            ),
+        )
+        for fields, message in cases:
+            with self.subTest(message=message):
+                tmp, root = self.make_repo()
+                with tmp:
+                    entries = "  HexRCF:\n    deps: []\n" + fields
+                    with self.assertRaisesRegex(ValueError, message):
+                        self.manifest(root, entries)
 
     def test_duplicate_manifest_ownership_fails_closed(self) -> None:
         duplicate_library = (
@@ -305,13 +491,14 @@ class BenchLintTests(unittest.TestCase):
     def test_probe_root_path_normalizes_src_dir(self) -> None:
         tmp, root = self.make_repo()
         with tmp:
-            owners = self.manifest(
+            roots = self.manifest(
                 root,
                 "  HexRCF:\n"
                 "    deps: []\n"
                 "    mathlib: true\n"
                 "    done_through: 3\n"
                 "    status: active\n"
+                "    proof_probes: [bench/HexRCF/ProofProbe]\n"
                 "  HexCore:\n"
                 "    deps: []\n"
                 "    mathlib: false\n"
@@ -323,10 +510,12 @@ class BenchLintTests(unittest.TestCase):
                 root,
                 "lean_exe sample_bench where\n"
                 "  srcDir := \"bench/Other/..\"\n"
-                "  root := `HexRCF.Probe\n",
+                "  root := `HexRCF.ProofProbe.Probe\n",
             )
-            self.write(root, "bench/HexRCF/Probe.lean", "import Mathlib\n")
-            self.assertIsNotNone(lint._probe_root_path(target, root, owners))
+            self.write(
+                root, "bench/HexRCF/ProofProbe/Probe.lean", "import Mathlib\n"
+            )
+            self.assertIsNotNone(lint._probe_root_path(target, root, roots))
 
             (root / "bench/HexRCF").mkdir(parents=True, exist_ok=True)
             target = self.target(
@@ -336,48 +525,70 @@ class BenchLintTests(unittest.TestCase):
                 "  root := `HexCore.Probe\n",
             )
             self.write(root, "bench/HexCore/Probe.lean", "import Mathlib\n")
-            self.assertIsNone(lint._probe_root_path(target, root, owners))
+            self.assertIsNone(lint._probe_root_path(target, root, roots))
 
-    def test_probe_root_path_preserves_symlink_owner(self) -> None:
+    def test_probe_root_symlink_outside_bench_is_rejected(self) -> None:
         tmp, root = self.make_repo()
         with tmp:
-            owners = self.manifest(
+            self.write(
                 root,
+                "libraries.yml",
+                "libraries:\n"
                 "  HexRCF:\n"
                 "    deps: []\n"
                 "    mathlib: true\n"
                 "    done_through: 3\n"
-                "    status: active\n",
+                "    status: active\n"
+                "    proof_probes: [bench/HexRCF/ProofProbe]\n",
             )
             self.write(root, "Physical/Probe.lean", "import Mathlib\n")
-            (root / "bench").mkdir()
-            (root / "bench/HexRCF").symlink_to(root / "Physical", target_is_directory=True)
-            target = self.target(
+            (root / "bench/HexRCF").mkdir(parents=True)
+            (root / "bench/HexRCF/ProofProbe").symlink_to(
+                root / "Physical", target_is_directory=True
+            )
+            with self.assertRaisesRegex(ValueError, "resolves outside bench"):
+                lint._mathlib_probe_roots(root)
+
+    def test_nested_probe_symlink_is_rejected(self) -> None:
+        tmp, root = self.make_repo()
+        with tmp:
+            self.write(
                 root,
-                "lean_exe sample_bench where\n"
-                "  srcDir := \"bench\"\n"
-                "  root := `HexRCF.Probe\n",
+                "libraries.yml",
+                "libraries:\n"
+                "  HexRCF:\n"
+                "    deps: []\n"
+                "    mathlib: true\n"
+                "    done_through: 3\n"
+                "    status: active\n"
+                "    proof_probes: [bench/HexRCF/ProofProbe]\n",
             )
-            self.assertEqual(
-                lint._find_mathlib_probe_files(root, owners),
-                [root / "bench/HexRCF/Probe.lean"],
+            self.write(root, "Physical/Evil.lean", "import LeanBench\n")
+            probe_root = root / "bench/HexRCF/ProofProbe"
+            probe_root.mkdir(parents=True)
+            (probe_root / "Escape").symlink_to(
+                root / "Physical", target_is_directory=True
             )
-            self.assertIsNotNone(lint._probe_root_path(target, root, owners))
+            with self.assertRaisesRegex(ValueError, "contains symlink"):
+                lint._mathlib_probe_roots(root)
 
     def test_probe_root_path_follows_alias_into_owner(self) -> None:
         tmp, root = self.make_repo()
         with tmp:
-            owners = self.manifest(
+            roots = self.manifest(
                 root,
                 "  HexRCF:\n"
                 "    deps: []\n"
                 "    mathlib: true\n"
                 "    done_through: 3\n"
-                "    status: active\n",
+                "    status: active\n"
+                "    proof_probes: [bench/HexRCF/ProofProbe]\n",
             )
-            self.write(root, "bench/HexRCF/Probe.lean", "import Mathlib\n")
+            self.write(
+                root, "bench/HexRCF/ProofProbe/Probe.lean", "import Mathlib\n"
+            )
             (root / "Alias").symlink_to(
-                root / "bench/HexRCF", target_is_directory=True
+                root / "bench/HexRCF/ProofProbe", target_is_directory=True
             )
             target = self.target(
                 root,
@@ -385,7 +596,7 @@ class BenchLintTests(unittest.TestCase):
                 "  srcDir := \"Alias\"\n"
                 "  root := `Probe\n",
             )
-            self.assertIsNotNone(lint._probe_root_path(target, root, owners))
+            self.assertIsNotNone(lint._probe_root_path(target, root, roots))
 
     def test_probe_main_and_unqualified_clock_variants_are_forbidden(self) -> None:
         main_variants = (
@@ -409,6 +620,46 @@ class BenchLintTests(unittest.TestCase):
             self.assertIn(
                 "uses an in-process monotonic clock",
                 lint._probe_violations(clock),
+            )
+
+    def test_probe_local_import_closure_is_build_only(self) -> None:
+        tmp, root = self.make_repo()
+        with tmp:
+            roots = self.manifest(
+                root,
+                "  HexRCF:\n"
+                "    deps: []\n"
+                "    mathlib: true\n"
+                "    done_through: 3\n"
+                "    status: active\n"
+                "    proof_probes: [bench/HexRCF/ProofProbe]\n",
+            )
+            self.write(
+                root,
+                "bench/HexRCF/ProofProbe/Tactic.lean",
+                "import Project.Helper\nimport Mathlib\n",
+            )
+            helper = root / "Project/Helper.lean"
+            self.write(
+                root,
+                "Project/Helper.lean",
+                "import LeanBench\n"
+                "setup_fixed_benchmark hidden := 1\n"
+                "def main : IO Unit := IO.monoNanosNow *> pure ()\n",
+            )
+            probes = lint._find_mathlib_probe_files(root, roots)
+            self.assertEqual(
+                probes, [root / "bench/HexRCF/ProofProbe/Tactic.lean"]
+            )
+            violations = lint._probe_closure_violations(probes[0], root)
+            self.assertEqual(
+                violations,
+                [
+                    (helper, "imports LeanBench"),
+                    (helper, "registers a LeanBench benchmark"),
+                    (helper, "defines main"),
+                    (helper, "uses an in-process monotonic clock"),
+                ],
             )
             escaped_clock = root / "EscapedClock.lean"
             escaped_clock.write_text(

--- a/scripts/libgraph.py
+++ b/scripts/libgraph.py
@@ -89,6 +89,15 @@ RELEASE_LIBRARIES = {
 
 VALID_STATUSES = {"active", "planned", "draft"}
 PHASE4_COMPARATOR_CLASSES = {"gating", "informational"}
+LIBRARY_FIELDS = {
+    "deps",
+    "mathlib",
+    "done_through",
+    "status",
+    "proof_probes",
+    "phase4",
+    "external",
+}
 
 
 @dataclass(frozen=True)
@@ -118,6 +127,7 @@ class LibraryInfo:
     mathlib: bool
     done_through: int
     status: str
+    proof_probes: tuple[str, ...] = ()
     phase4: Phase4Info | None = None
     external: str | None = None
 
@@ -152,6 +162,9 @@ def load_libraries(path: Path | None = None) -> "OrderedDict[str, LibraryInfo]":
         nonlocal current_name, current_fields
         if current_name is None:
             return
+        unknown = current_fields.keys() - LIBRARY_FIELDS
+        if unknown:
+            raise ValueError(f"{current_name} has unknown fields: {sorted(unknown)}")
         missing = {"deps", "mathlib", "done_through", "status"} - current_fields.keys()
         if missing:
             raise ValueError(f"{current_name} missing fields: {sorted(missing)}")
@@ -176,6 +189,34 @@ def load_libraries(path: Path | None = None) -> "OrderedDict[str, LibraryInfo]":
                 f"non-active libraries must have done_through == 0 "
                 f"(see PLAN/Conventions.md §'Library status')"
             )
+        proof_probes = current_fields.get("proof_probes", [])
+        if not isinstance(proof_probes, list) or not all(
+            isinstance(probe, str) for probe in proof_probes
+        ):
+            raise ValueError(f"{current_name} has malformed proof_probes")
+        if len(proof_probes) != len(set(proof_probes)):
+            raise ValueError(f"{current_name} has duplicate proof_probes entries")
+        if proof_probes and not mathlib:
+            raise ValueError(
+                f"{current_name} declares proof_probes but mathlib is false"
+            )
+        for probe in proof_probes:
+            parts = Path(probe).parts
+            if (
+                Path(probe).is_absolute()
+                or ".." in parts
+                or "\\" in probe
+                or any(char in probe for char in "*?[]{}")
+                or Path(probe).as_posix() != probe
+                or Path(probe).suffix == ".lean"
+                or len(parts) < 2
+                or parts[0] != "bench"
+                or parts[1] != current_name
+            ):
+                raise ValueError(
+                    f"{current_name} has invalid proof probe path {probe!r}; "
+                    f"expected bench/{current_name} or a subtree below it"
+                )
         phase4 = current_fields.get("phase4")
         if phase4 is not None and not isinstance(phase4, Phase4Info):
             raise ValueError(f"{current_name} has malformed phase4 block")
@@ -188,6 +229,7 @@ def load_libraries(path: Path | None = None) -> "OrderedDict[str, LibraryInfo]":
             mathlib=mathlib,
             done_through=done_through,
             status=status,
+            proof_probes=tuple(proof_probes),
             phase4=phase4,
             external=external,
         )
@@ -234,6 +276,19 @@ def load_libraries(path: Path | None = None) -> "OrderedDict[str, LibraryInfo]":
         for dep in info.deps:
             if dep not in libs:
                 raise ValueError(f"{name} depends on unknown library {dep}")
+
+    probe_paths = [
+        (name, Path(probe))
+        for name, info in libs.items()
+        for probe in info.proof_probes
+    ]
+    for index, (name, probe) in enumerate(probe_paths):
+        for other_name, other in probe_paths[index + 1:]:
+            if probe == other or probe in other.parents or other in probe.parents:
+                raise ValueError(
+                    f"overlapping proof probe paths: {name}:{probe} and "
+                    f"{other_name}:{other}"
+                )
 
     # Invariant: active libraries depend only on active libraries.
     # Non-active libraries may depend on anything (the dep graph is


### PR DESCRIPTION
## Summary

- separate Mathlib-free compiled LeanBench evidence from Mathlib-facing fresh-module proof/tactic evidence
- add explicit manifest-owned proof-probe roots with fail-closed linting and adversarial tests
- specify controlled HexRCF comparator/input families without recording timings or advancing `done_through`

## Validation

- `lake build HexRCF`
- `python3 -m unittest scripts.ci.test_check_benches_mathlib_free` (27 tests)
- `python3 scripts/ci/check_benches_mathlib_free.py`
- DAG, Phase-4, released-manifest, trust-surface, copyright, line-count, conformance-matrix, Python compile, and diff checks
- independent Sol architecture audit: GO

Closes #9008.
Contributes to #8973.

Stacked on #9007; scientific timing remains gated on #8972 and dedicated hardware.