### PR TITLE
docs(rcf): add tactic manual chapter

### DIFF
--- a/HexManual.lean
+++ b/HexManual.lean
@@ -26,6 +26,7 @@ import HexManual.Chapters.HexGFqField
 import HexManual.Chapters.HexConway
 import HexManual.Chapters.HexGFq
 import HexManual.Chapters.HexRealRoots
+import HexManual.Chapters.HexRCF
 import HexManual.Chapters.FactorTactics
 import HexManual.Chapters.HexRoots
 -- Tutorials (application-first capstone pages, see SPEC/tutorials.md).
@@ -113,7 +114,8 @@ here to keep the reference chapters above focused on the released libraries.
 
 {include 2 HexManual.Chapters.HexRealRoots}
 
+{include 2 HexManual.Chapters.HexRCF}
+
 {include 2 HexManual.Chapters.FactorTactics}
 
 {include 2 HexManual.Chapters.HexRoots}
-

--- a/HexManual/Chapters/HexRCF.lean
+++ b/HexManual/Chapters/HexRCF.lean
@@ -1,0 +1,256 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import VersoManual
+
+import HexRCF
+
+open Verso.Genre Manual
+open Verso.Genre.Manual.InlineLean
+
+set_option pp.rawOnError true
+
+#doc (Manual) "HexRCF: certified univariate real arithmetic" =>
+%%%
+tag := "hex-rcf"
+%%%
+
+# Introduction
+%%%
+tag := "hex-rcf-intro"
+%%%
+
+The `rcf` tactic proves closed propositions about one real variable by exact
+decision. Its input is one universal or existential quantifier over `ℝ`, or
+over a half-open interval `Set.Ioc a b`. The quantifier body may use Boolean
+combinations of comparisons between univariate polynomials with rational
+coefficients.
+
+The computation uses exact integer and rational arithmetic. It isolates the
+real roots that can change an atom's sign, evaluates the formula on the
+resulting cells, and emits a certificate for Lean's kernel to check. No
+floating-point approximation occurs.
+
+Import `HexRCF` and write `rcf` at the goal:
+
+```lean
+example : ∀ x : ℝ, x ^ 2 + 1 > 0 := by
+  rcf
+```
+
+# The four quantifier forms
+%%%
+tag := "hex-rcf-quantifiers"
+%%%
+
+Quantification over the whole real line may be universal or existential. The
+body can combine equalities, inequalities, conjunctions, disjunctions,
+negations, and implications:
+
+```lean
+/-- A universal sentence over the real line. -/
+example : ∀ x : ℝ, x ^ 2 ≤ 1 → x ^ 4 - x ^ 2 ≤ 0 := by
+  rcf
+
+/-- An existential sentence over the real line. -/
+example : ∃ x : ℝ, x ^ 3 - x - 1 = 0 ∧ 1 < x ∧ x < 2 := by
+  rcf
+```
+
+The bounded forms use `Set.Ioc a b`, which denotes `(a, b]`. The lower
+endpoint is excluded and the upper endpoint is included:
+
+```lean
+/-- Universal quantification over `(0, 1]`. -/
+example : ∀ x : ℝ, x ∈ Set.Ioc (0 : ℝ) 1 → x > 0 := by
+  rcf
+
+/-- Existential quantification over `(0, 1]`.
+The upper endpoint is a witness. -/
+example : ∃ x : ℝ, x ∈ Set.Ioc (0 : ℝ) 1 ∧ x = 1 := by
+  rcf
+```
+
+An interval is empty when `a ≥ b`. Universal statements on an empty
+interval are true, while existential statements are false. This example also
+shows that the lower endpoint is not part of a nonempty interval:
+
+```lean
+example : ∀ x : ℝ, x ∈ Set.Ioc (1 : ℝ) 1 → x ^ 2 < 0 := by
+  rcf
+
+example : ∀ x : ℝ, x ∈ Set.Ioc (0 : ℝ) 1 → x ≠ 0 := by
+  rcf
+```
+
+# Polynomial and rational syntax
+%%%
+tag := "hex-rcf-syntax"
+%%%
+
+Polynomial expressions may use numerals, the quantified variable, `+`, `-`,
+`*`, negation, natural powers, and division by rational constants. The tactic
+clears rational denominators before constructing its certificate:
+
+```lean
+example : ∀ x : ℝ, x ^ 2 / 3 + 1 / 5 > 0 := by
+  rcf
+
+example : ∀ x : ℝ,
+    (x < 0 ∨ x ≥ 0) ∧
+      (x ≤ 0 ∨ x > 0) ∧
+      (x = 0 ∨ x ≠ 0) := by
+  rcf
+```
+
+The coefficients may be any exact rationals, but bounded endpoints must be
+dyadic rationals. Thus `1 / 3` is valid as a coefficient and is not valid as
+an endpoint. Integer endpoints, fractions whose reduced denominator is a
+power of two, and their negations are supported.
+
+The proposition must contain exactly one real variable. Nested quantifiers,
+symbolic coefficients, division by an expression containing the variable,
+and non-polynomial functions such as `Real.sin` are outside the supported
+fragment. The tactic reports which of these conditions failed.
+
+# False sentences and fall-through
+%%%
+tag := "hex-rcf-false"
+%%%
+
+The tactic constructs proofs only for true sentences. For a false universal
+sentence it identifies a cell on which the body is false:
+
+```lean
+/-- error: rcf: the universal sentence is false -/
+#guard_msgs (substring := true) in
+example : ∀ x : ℝ, x ^ 2 > 0 := by
+  rcf
+```
+
+For a false existential sentence it reports that all relevant cells were
+checked and that none supplies a witness:
+
+```lean
+/-- error: rcf: the existential sentence is false -/
+#guard_msgs (substring := true) in
+example : ∃ x : ℝ, x ^ 2 + 1 = 0 := by
+  rcf
+```
+
+A false result never becomes a proof term. It is an ordinary tactic failure,
+so tactic combinators can try another method when a goal is not in the
+supported fragment:
+
+```lean
+example : (0 : ℝ) < 1 := by
+  first | rcf | norm_num
+```
+
+# Rewriting other interval conventions
+%%%
+tag := "hex-rcf-interval-rewrites"
+%%%
+
+Only `Set.Ioc` is accepted directly. If a goal uses a closed interval
+`Set.Icc`, separate the lower endpoint from the remaining half-open interval.
+For a predicate `φ` the exact rewrites are:
+
+* `∀ x ∈ Set.Icc a b, φ x` becomes
+  `(a ≤ b → φ a) ∧ ∀ x ∈ Set.Ioc a b, φ x`.
+* `∃ x ∈ Set.Icc a b, φ x` becomes
+  `a ≤ b ∧ (φ a ∨ ∃ x ∈ Set.Ioc a b, φ x)`.
+
+For an open interval `Set.Ioo`, exclude the upper endpoint from `Set.Ioc`:
+
+* `∀ x ∈ Set.Ioo a b, φ x` becomes
+  `∀ x ∈ Set.Ioc a b, x ≠ b → φ x`.
+* `∃ x ∈ Set.Ioo a b, φ x` becomes
+  `∃ x ∈ Set.Ioc a b, φ x ∧ x ≠ b`.
+
+After the endpoint proposition has been handled separately, `rcf` can prove
+the remaining singly quantified part. For example, the open-interval rewrite
+is accepted directly:
+
+```lean
+example : ∀ x : ℝ,
+    x ∈ Set.Ioc (0 : ℝ) 1 → x ≠ 1 → x < 1 := by
+  rcf
+
+example : ∃ x : ℝ,
+    x ∈ Set.Ioc (0 : ℝ) 1 ∧ x = 1 / 2 ∧ x ≠ 1 := by
+  rcf
+```
+
+When `rcf` sees `Set.Icc` or `Set.Ioo` directly, its error message includes
+the corresponding rewrite above.
+
+# Certificates and the trust boundary
+%%%
+tag := "hex-rcf-trust"
+%%%
+
+The reflected input type records the same four quantifier forms:
+
+{docstring Hex.RCF.Sentence}
+
+Certificate construction runs as compiled elaboration code. That search is
+not trusted. The tactic embeds its reflected sentence and a literal
+{name}`Hex.RCF.Certificate`, reduces the public Boolean checker
+{name}`Hex.RCF.Certificate.check`, and applies the soundness theorem
+{name}`Hex.RCF.check_sound`. Lean's kernel also checks the reifier's proof
+that the reflected sentence is equivalent to the source goal.
+
+The public soundness boundary can be used independently of the tactic:
+
+```lean
+open Hex.RCF
+
+example (s : Sentence) (cert : Certificate)
+    (h : Certificate.check s cert = true) : s.toProp :=
+  check_sound s cert h
+
+example (s : Sentence)
+    (h : Hex.RCF.decide s = some true) : s.toProp :=
+  decide_sound s h
+```
+
+`Certificate.replay?` distinguishes malformed evidence (`none`), a checked
+false verdict (`some false`), and a checked true verdict (`some true`).
+`Certificate.check` accepts only the last case. The convenience function
+{name}`Hex.RCF.decide` returns `some true` only after this checker accepts the
+certificate. Advanced clients can use {name}`Hex.RCF.build?` to retain the
+certificate and its diagnostic or proof-producing verdict. A `none` result
+means certificate construction or replay failed. Neither `check_sound` nor
+the tactic turns `some false` into a proof of a negation.
+
+The kernel replays polynomial identities, signs, root counts, endpoint
+comparisons, and Boolean folds on literal data. It does not repeat root
+isolation, polynomial gcd computation, or interval refinement. The emitted
+proof uses ordinary kernel reduction and does not use `native_decide`:
+
+```lean
+theorem rcf_square_nonnegative : ∀ x : ℝ, x ^ 2 ≥ 0 := by
+  rcf
+```
+
+```lean (name := rcfAxioms)
+#print axioms rcf_square_nonnegative
+```
+```leanOutput rcfAxioms
+'rcf_square_nonnegative' depends on axioms: [propext, Classical.choice, Quot.sound]
+```
+
+# Cross-references
+%%%
+tag := "hex-rcf-cross-references"
+%%%
+
+* {ref "hex-poly-z"}[HexPolyZ] provides the dense integer polynomial
+  operations used to normalize atoms and check polynomial identities.
+* {ref "hex-real-roots"}[HexRealRoots] describes the exact Sturm-based root
+  isolation used elsewhere in Hex. `HexRCF` uses related generalized Sturm
+  certificates to partition the real line at every atom root.

--- a/HexManual/Chapters/HexRCF.lean
+++ b/HexManual/Chapters/HexRCF.lean
@@ -13,7 +13,7 @@ open Verso.Genre.Manual.InlineLean
 
 set_option pp.rawOnError true
 
-#doc (Manual) "HexRCF: certified univariate real arithmetic" =>
+#doc (Manual) "HexRCF: a decision procedure for univariate real arithmetic" =>
 %%%
 tag := "hex-rcf"
 %%%
@@ -23,11 +23,11 @@ tag := "hex-rcf"
 tag := "hex-rcf-intro"
 %%%
 
-The `rcf` tactic proves closed propositions about one real variable by exact
-decision. Its input is one universal or existential quantifier over `ℝ`, or
-over a half-open interval `Set.Ioc a b`. The quantifier body may use Boolean
-combinations of comparisons between univariate polynomials with rational
-coefficients.
+The `rcf` tactic proves closed propositions about exactly one quantified real
+variable by exact decision. Its input is one universal or existential
+quantifier over `ℝ`, or over a half-open interval `Set.Ioc a b`, with no other
+free variables. The quantifier body may use Boolean combinations of
+comparisons between univariate polynomials with rational coefficients.
 
 The computation uses exact integer and rational arithmetic. It isolates the
 real roots that can change an atom's sign, evaluates the formula on the
@@ -75,12 +75,16 @@ example : ∃ x : ℝ, x ∈ Set.Ioc (0 : ℝ) 1 ∧ x = 1 := by
 ```
 
 An interval is empty when `a ≥ b`. Universal statements on an empty
-interval are true, while existential statements are false. This example also
-shows that the lower endpoint is not part of a nonempty interval:
+interval are true, while existential statements are false. These examples
+also show that the lower endpoint is not part of a nonempty interval:
 
 ```lean
 example : ∀ x : ℝ, x ∈ Set.Ioc (1 : ℝ) 1 → x ^ 2 < 0 := by
   rcf
+
+example : ¬ ∃ x : ℝ, x ∈ Set.Ioc (1 : ℝ) 1 ∧ x = x := by
+  rintro ⟨x, hx, _⟩
+  exact (not_lt_of_ge hx.2) hx.1
 
 example : ∀ x : ℝ, x ∈ Set.Ioc (0 : ℝ) 1 → x ≠ 0 := by
   rcf
@@ -92,11 +96,13 @@ tag := "hex-rcf-syntax"
 %%%
 
 Polynomial expressions may use numerals, the quantified variable, `+`, `-`,
-`*`, negation, natural powers, and division by rational constants. The tactic
-clears rational denominators before constructing its certificate:
+`*`, negation, natural powers, and division by rational constants. The first
+example exercises all of these arithmetic forms. The tactic clears rational
+denominators before constructing its certificate:
 
 ```lean
-example : ∀ x : ℝ, x ^ 2 / 3 + 1 / 5 > 0 := by
+example : ∀ x : ℝ,
+    -(2 * x - 1) ^ 2 / 3 + 1 / 5 ≤ 1 / 5 := by
   rcf
 
 example : ∀ x : ℝ,
@@ -108,13 +114,14 @@ example : ∀ x : ℝ,
 
 The coefficients may be any exact rationals, but bounded endpoints must be
 dyadic rationals. Thus `1 / 3` is valid as a coefficient and is not valid as
-an endpoint. Integer endpoints, fractions whose reduced denominator is a
-power of two, and their negations are supported.
+an endpoint. An endpoint is supported exactly when its reduced denominator is
+a power of two.
 
-The proposition must contain exactly one real variable. Nested quantifiers,
-symbolic coefficients, division by an expression containing the variable,
-and non-polynomial functions such as `Real.sin` are outside the supported
-fragment. The tactic reports which of these conditions failed.
+The proposition must contain exactly one quantified real variable and no other
+free variables. Nested quantifiers, symbolic coefficients, division by an
+expression containing the variable, and non-polynomial functions such as
+`Real.sin` are outside the supported fragment. The tactic reports which of
+these conditions failed.
 
 # False sentences and fall-through
 %%%
@@ -124,26 +131,33 @@ tag := "hex-rcf-false"
 The tactic constructs proofs only for true sentences. For a false universal
 sentence it identifies a cell on which the body is false:
 
-```lean
-/-- error: rcf: the universal sentence is false -/
-#guard_msgs (substring := true) in
+```lean +error (name := rcfFalseUniversal)
 example : ∀ x : ℝ, x ^ 2 > 0 := by
   rcf
+```
+```leanOutput rcfFalseUniversal
+rcf: the universal sentence is false on the root cell isolated in (-2, 2]
 ```
 
 For a false existential sentence it reports that all relevant cells were
 checked and that none supplies a witness:
 
-```lean
-/-- error: rcf: the existential sentence is false -/
-#guard_msgs (substring := true) in
+```lean +error (name := rcfFalseExistential)
 example : ∃ x : ℝ, x ^ 2 + 1 = 0 := by
   rcf
 ```
+```leanOutput rcfFalseExistential
+rcf: the existential sentence is false; every relevant decomposition
+cell was checked and found false, so there is no witness
+```
 
-A false result never becomes a proof term. It is an ordinary tactic failure,
-so tactic combinators can try another method when a goal is not in the
-supported fragment:
+A supported sentence may be false even though reification and certified
+decision both succeed. Such a checked `false` verdict never becomes a proof
+term: `rcf` reports the relevant false-sentence diagnostic above. An
+out-of-fragment goal is different: reification fails before the decision
+procedure runs. Both are ordinary tactic failures, so tactic combinators may
+fall through to another method. Here the unquantified goal is outside the
+fragment and `norm_num` handles it:
 
 ```lean
 example : (0 : ℝ) < 1 := by
@@ -172,8 +186,24 @@ For an open interval `Set.Ioo`, exclude the upper endpoint from `Set.Ioc`:
   `∃ x ∈ Set.Ioc a b, φ x ∧ x ≠ b`.
 
 After the endpoint proposition has been handled separately, `rcf` can prove
-the remaining singly quantified part. For example, the open-interval rewrite
-is accepted directly:
+the remaining singly quantified part. This worked closed-interval example
+checks the lower endpoint separately and sends the `Set.Ioc` tail to `rcf`:
+
+```lean
+example : ∀ x : ℝ,
+    x ∈ Set.Icc (0 : ℝ) 1 → x ^ 2 ≤ 1 := by
+  have endpoint : (0 : ℝ) ^ 2 ≤ 1 := by norm_num
+  have tail : ∀ x : ℝ,
+      x ∈ Set.Ioc (0 : ℝ) 1 → x ^ 2 ≤ 1 := by
+    rcf
+  intro x hx
+  rcases eq_or_lt_of_le hx.1 with h | h
+  · subst x
+    exact endpoint
+  · exact tail x ⟨h, hx.2⟩
+```
+
+The open-interval rewrite is likewise accepted directly:
 
 ```lean
 example : ∀ x : ℝ,
@@ -196,6 +226,14 @@ tag := "hex-rcf-trust"
 The reflected input type records the same four quantifier forms:
 
 {docstring Hex.RCF.Sentence}
+
+`HexRCF` is classified as a Mathlib-facing library because its reifier, tactic,
+real semantics, and soundness theorem use Mathlib. There is no separate
+`HexRCFMathlib` bridge library. By contrast, `HexRCF.DecisionCheck` exposes the
+complete compiled search, certificate construction, replay, and
+{name}`Hex.RCF.decide` path, with a mechanically checked Mathlib-free import
+closure. The soundness theorem remains on the Mathlib-facing side of this
+boundary.
 
 Certificate construction runs as compiled elaboration code. That search is
 not trusted. The tactic embeds its reflected sentence and a literal
@@ -224,8 +262,10 @@ false verdict (`some false`), and a checked true verdict (`some true`).
 {name}`Hex.RCF.decide` returns `some true` only after this checker accepts the
 certificate. Advanced clients can use {name}`Hex.RCF.build?` to retain the
 certificate and its diagnostic or proof-producing verdict. A `none` result
-means certificate construction or replay failed. Neither `check_sound` nor
-the tactic turns `some false` into a proof of a negation.
+means that compiled construction did not produce a replay-accepted
+certificate; it does not mean that the mathematical sentence is false. A
+successfully checked false sentence instead produces `some false`. Neither
+`check_sound` nor the tactic turns `some false` into a proof of a negation.
 
 The kernel replays polynomial identities, signs, root counts, endpoint
 comparisons, and Boolean folds on literal data. It does not repeat root
@@ -251,6 +291,8 @@ tag := "hex-rcf-cross-references"
 
 * {ref "hex-poly-z"}[HexPolyZ] provides the dense integer polynomial
   operations used to normalize atoms and check polynomial identities.
-* {ref "hex-real-roots"}[HexRealRoots] describes the exact Sturm-based root
-  isolation used elsewhere in Hex. `HexRCF` uses related generalized Sturm
-  certificates to partition the real line at every atom root.
+* {ref "hex-real-roots"}[HexRealRoots] provides the exact real-root isolator
+  used by `HexRCF` during compiled certificate construction. The generalized
+  multiplication-only Sturm certificates in `HexRCF` are kernel-replay
+  evidence for the resulting root-count facts, not a separate compiled
+  isolation algorithm.

--- a/progress/20260728T022727Z_rcf-manual.md
+++ b/progress/20260728T022727Z_rcf-manual.md
@@ -1,0 +1,35 @@
+# HexRCF manual chapter
+
+## Accomplished
+
+- Added the `HexRCF` reference chapter with compiled examples for all four
+  supported quantifier forms, rational coefficients, Boolean combinations,
+  half-open endpoint ownership, and empty bounded domains.
+- Documented false-result diagnostics, tactic fall-through, the exact
+  `Set.Icc` and `Set.Ioo` rewrites, unsupported syntax, and dyadic endpoint
+  requirements.
+- Documented the reflected sentence and certificate APIs, the distinction
+  between malformed, false, and true replay results, and the
+  `Certificate.check` / `check_sound` trust boundary.
+- Added the chapter to the unreleased-library order immediately after
+  `HexRealRoots` and compiled the complete `HexManual` target.
+- Ran the repository copyright, line-count, DAG, release-manifest,
+  trust-surface, Phase-4 registration, conformance-target, style, and diff
+  checks successfully.
+
+## Current frontier
+
+- The manual milestone is implementation-complete and ready for a stacked
+  draft PR on the HexRCF proof-probe branch.
+
+## Next step
+
+- Publish the draft, obtain and address an independent Claude review, and
+  restack it as its parent PRs merge.
+- Continue the remaining HexRCF SPEC completion audit after the manual review.
+
+## Blockers
+
+- None for the manual milestone.
+- Final Phase-4 evidence remains dependent on clean-host scientific runs and
+  the HexRealRootsMathlib Phase-4 dependency.

--- a/progress/20260728T030042Z_rcf-manual-review.md
+++ b/progress/20260728T030042Z_rcf-manual-review.md
@@ -1,0 +1,33 @@
+# HexRCF manual review follow-up
+
+## Accomplished
+
+- Addressed the independent review of draft PR #9020 and rebuilt the complete
+  manual successfully.
+- Replaced internal `#guard_msgs` presentation with named Verso examples that
+  render the exact false-universal and false-existential diagnostics for the
+  reader, using the current warning-free `+error` flag syntax.
+- Distinguished a supported false verdict from an out-of-fragment reification
+  failure and clarified the `build?` `none` / checked `some false` cases.
+- Corrected the HexRealRoots relationship: compiled construction uses the
+  HexRealRoots isolator, while HexRCF's generalized multiplication-only Sturm
+  certificates are kernel-replay evidence for the resulting root counts.
+- Tightened the quantified-variable, dyadic-endpoint, Mathlib-boundary, and
+  arithmetic-syntax descriptions, and added worked empty-existential and
+  closed-interval rewrite examples.
+
+## Current frontier
+
+- The source-level review findings are addressed locally on the manual branch.
+- `lake build HexManual` and `git diff --check` pass; only pre-existing
+  dependency warnings remain.
+
+## Next step
+
+- Commit and push the review follow-up to PR #9020, let CI rerun, and advance
+  the milestone once the refreshed check is green.
+- Rebase the stacked FLINT comparator branch onto this corrected manual head.
+
+## Blockers
+
+- None for the manual milestone.


### PR DESCRIPTION
## Summary

- add a compiled `HexRCF` manual chapter covering all four supported quantifier forms, rational coefficients, Boolean syntax, and exact `(a, b]` endpoint behavior
- document false-result diagnostics, unsupported syntax, and the exact `Set.Icc` / `Set.Ioo` rewrites
- explain the reflected API and the `Certificate.check` / `check_sound` trust boundary, including the generated theorem axiom cone
- include the chapter immediately after `HexRealRoots` in the unreleased manual section

## Validation

- `lake build HexManual`
- copyright and file-line-count checks
- DAG, release-manifest, trust-surface, Phase-4 registration, and conformance-target checks
- manual writing-style scan and `git diff --check`

## Dependency

This draft is based on `issue-9017-rcf-proof-probes` (PR #9018). Its content is one manual commit beyond that parent.

Closes #9019.