### PR TITLE
bench(rcf): add python-flint decision comparator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
           python3 -m unittest scripts/ci/test_check_benches_mathlib_free.py
           python3 -m unittest scripts/bench/test_fresh_module_sweep.py
           python3 -m unittest scripts/bench/test_hexrcf_proof_sweep.py
+          python3 -m unittest scripts/oracle/test_rcf_flint_bench.py
           python3 scripts/ci/check_benches_mathlib_free.py
       - name: Verify conformance matrix invariant
         run: python3 scripts/conformance_targets.py --check

--- a/Hex/BenchOracle/Flint.lean
+++ b/Hex/BenchOracle/Flint.lean
@@ -30,11 +30,10 @@ This module owns:
   process is not reaped while the bench process holds a reference).
 * `flintDriverRef` — module-level `IO.Ref` caching the running
   driver across calls inside one fixed-benchmark child process.
-* `runRequest`, `runOp` — high-level helpers that build a JSON
-  request, send it through the driver, parse the reply, and surface
-  driver-side errors as `IO.userError`. On stream errors the cached
-  child is dropped, a fresh driver is spawned, and the request is
-  retried once.
+* `sendRequestLine`, `sendRequest`, `runLine`, `runOp` — helpers for
+  precompressed or structured JSON requests. They parse replies and surface
+  driver-side errors as `IO.userError`. On stream errors the cached child is
+  dropped, a fresh driver is spawned, and the request is retried once.
 
 ## Per-library wiring
 
@@ -133,13 +132,12 @@ def resolveDriver : IO PersistentComparator := do
   flintDriverRef.set (some ch)
   return ch
 
-/-- Send a single JSON request line and return the parsed JSON
+/-- Send one already-compressed JSON request line and return the parsed JSON
 reply. On any `IO` error from the stream (driver crash, pipe close)
 the cached child handle is dropped, a fresh driver is spawned, and
 the request is retried once. Persistent failure surfaces as an
 `IO.userError` from the retry path. -/
-def sendRequest (request : Json) : IO Json := do
-  let line := request.compress
+def sendRequestLine (line : String) : IO Json := do
   let reply ←
     try
       (← resolveDriver).requestLine line
@@ -151,17 +149,13 @@ def sendRequest (request : Json) : IO Json := do
   | .error err =>
     throw <| IO.userError s!"flint_bench_driver reply not valid JSON: {err}; reply: {reply}"
 
-/-- Build the request JSON object from `family`, `op`, and a list of
-extra fields, send it through the driver, and return the unwrapped
-`result` field on success. Raises `IO.userError` on a driver-side
-error frame (`{"ok": false, "error": ...}`) or on a reply that does
-not match either the success or failure shape. -/
-def runOp (family : String) (op : String) (fields : Array (String × Json))
-    : IO Json := do
-  let mut obj : Array (String × Json) := #[("family", Json.str family), ("op", Json.str op)]
-  for kv in fields do
-    obj := obj.push kv
-  let reply ← sendRequest (Json.mkObj obj.toList)
+/-- Compress and send one structured JSON request. Consumers whose timing
+contract excludes Lean-side request serialization can precompress once and
+call `sendRequestLine` or `runLine` instead. -/
+def sendRequest (request : Json) : IO Json :=
+  sendRequestLine request.compress
+
+private def resultOf (family op : String) (reply : Json) : IO Json := do
   match reply.getObjValAs? Bool "ok" with
   | Except.ok true =>
     match reply.getObjVal? "result" with
@@ -175,6 +169,23 @@ def runOp (family : String) (op : String) (fields : Array (String × Json))
   | Except.error msg =>
     throw (IO.userError
       s!"flint_bench_driver: reply missing/non-bool 'ok' field: {msg}; reply: {reply.compress}")
+
+/-- Send an already-compressed request and unwrap its successful `result`.
+`family` and `op` provide error context and must match the fields in `line`. -/
+def runLine (family op line : String) : IO Json := do
+  resultOf family op (← sendRequestLine line)
+
+/-- Build the request JSON object from `family`, `op`, and a list of
+extra fields, send it through the driver, and return the unwrapped
+`result` field on success. Raises `IO.userError` on a driver-side
+error frame (`{"ok": false, "error": ...}`) or on a reply that does
+not match either the success or failure shape. -/
+def runOp (family : String) (op : String) (fields : Array (String × Json))
+    : IO Json := do
+  let mut obj : Array (String × Json) := #[("family", Json.str family), ("op", Json.str op)]
+  for kv in fields do
+    obj := obj.push kv
+  runLine family op (Json.mkObj obj.toList).compress
 
 /-- Helper: encode an `Int` list (e.g. polynomial coefficient list,
 ascending degree) as a JSON array suitable for a `runOp` field. -/

--- a/Hex/BenchOracle/Flint.lean
+++ b/Hex/BenchOracle/Flint.lean
@@ -16,8 +16,11 @@ This module is the Lean-side companion to
 §"Process call", FLINT comparators with non-negligible per-call
 overhead are wired as a persistent subprocess: the driver loops on
 stdin (one JSON request per line, see the driver's docstring for the
-framing protocol), and the bench harness reuses one driver process
-across every measured call inside a single
+framing protocol). LeanBench starts a fresh child for every outer
+fixed-benchmark warmup or repeat. Inside that child, a
+`warmupFirstIter` call starts one driver before timing and the
+auto-tuned inner-repeat batch reuses it. The process is therefore
+persistent within a child batch, not across the whole
 `lake exe hexfoo_bench run` invocation.
 
 This module owns:
@@ -26,7 +29,7 @@ This module owns:
   `IO.Process.Child` plus its persistent stdin handle (so the
   process is not reaped while the bench process holds a reference).
 * `flintDriverRef` — module-level `IO.Ref` caching the running
-  driver across calls inside one bench process.
+  driver across calls inside one fixed-benchmark child process.
 * `runRequest`, `runOp` — high-level helpers that build a JSON
   request, send it through the driver, parse the reply, and surface
   driver-side errors as `IO.userError`. On stream errors the cached
@@ -36,7 +39,7 @@ This module owns:
 ## Per-library wiring
 
 Each consuming library (HexPoly, HexPolyZ, HexHensel, HexMatrix,
-HexBerlekamp, HexGFqRing) calls `Hex.BenchOracle.Flint.runOp` from
+HexBerlekamp, HexGFqRing, HexRCF) calls `Hex.BenchOracle.Flint.runOp` from
 its `Bench.lean` and parses the returned `Json` per its family's
 result schema. Example (sketch — actual wiring lands in the
 per-library HOs, HO-21..HO-26)::

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -755,14 +755,17 @@ version-1 fixture encoding. The persistent-driver request and response are
   -> {"ok":true,"result":<bool>}
 ```
 
-Both sides return `Bool`, pin `Hashable.hash true`, use five repeats and a
-0.2-second minimum total, and differ only in the FLINT registration's
+Both sides return `Bool` and share one config that pins `Hashable.hash true`,
+uses five repeats and a 0.2-second minimum total, and enables
 `warmupFirstIter`. LeanBench starts one fresh child per outer warmup or repeat.
-That discarded first call starts one `python3` process in the child, and the
-timed auto-tuned inner-repeat batch reuses its streams; no driver process is
-shared between outer children. Routine `hexrcf_bench verify` performs one
-semantic call through every fixed registration. Scientific runs and ratio
-reporting require `python3` with `python-flint` and remain on the scheduled
+The discarded first call warms the Lean decision path on both sides; for FLINT
+it also starts one `python3` process in the child. The timed auto-tuned
+inner-repeat batch reuses that process's streams, and no driver is shared
+between outer children. The complete FLINT request line, including the exact
+version-1 sentence encoding, is precomputed; pipe transport and Python JSON
+decoding remain measured comparator overhead. Routine `hexrcf_bench verify`
+performs one semantic call through every fixed registration. Scientific runs
+and ratio reporting require `python3` with `python-flint` on the named release
 benchmark host.
 
 This comparison covers carrier degree and real-root count only. It does not

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -743,13 +743,36 @@ structural sentence and certificate hashes, so a successful build forces the
 compiled result instead of merely invoking the builder and discarding its
 output.
 
-python-flint is an **informational** comparator for the compiled decision
-verdict on committed shared sentence families. It is not proof-producing, and
-no comparable proof-producing univariate RCF tactic is currently named; the
-tactic/elaboration track is therefore
-`no-comparable-surface-in-named-comparator` rather than assigned a fake ratio.
-The Phase-3 `local` emitter exercises related compiled workloads but is neither
-an elaboration benchmark nor Phase-4 asymptotic evidence.
+python-flint is an **informational**, scheduled-only comparator for the
+compiled carrier-degree decision family. The paired fixed registrations are
+`runLeanDecision{16,20,24,28,32}` and
+`runFlintDecision{16,20,24,28,32}`. At each rung both sides consume the same
+precomputed `Sentence`; the FLINT side also consumes its precomputed exact
+version-1 fixture encoding. The persistent-driver request and response are
+
+```text
+{"family":"rcf","op":"decide","sentence":<v1 sentence>}
+  -> {"ok":true,"result":<bool>}
+```
+
+Both sides return `Bool`, pin `Hashable.hash true`, use five repeats and a
+0.2-second minimum total, and differ only in the FLINT registration's
+`warmupFirstIter`. LeanBench starts one fresh child per outer warmup or repeat.
+That discarded first call starts one `python3` process in the child, and the
+timed auto-tuned inner-repeat batch reuses its streams; no driver process is
+shared between outer children. Routine `hexrcf_bench verify` performs one
+semantic call through every fixed registration. Scientific runs and ratio
+reporting require `python3` with `python-flint` and remain on the scheduled
+benchmark host.
+
+This comparison covers carrier degree and real-root count only. It does not
+measure atom multiplicity, common-root preparation, separation, certificate
+replay, reification, literal elaboration, or end-to-end tactic cost.
+python-flint is not proof-producing, and no comparable proof-producing
+univariate RCF tactic is currently named; the tactic/elaboration track is
+therefore `no-comparable-surface-in-named-comparator` rather than assigned a
+fake ratio. The Phase-3 `local` emitter exercises related compiled workloads
+but is neither an elaboration benchmark nor Phase-4 asymptotic evidence.
 
 This contract and the pure-module extraction do not advance the phase marker.
 `HexRCF.done_through` remains `3` until every dependency, including

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -382,11 +382,14 @@ Two integration patterns:
   - **Persistent-subprocess is the preferred shape when overhead is
     non-negligible.** Wrap the comparator in a driver that loops on
     stdin (one problem per request, length- or delimiter-framed)
-    and emits answers on stdout. The bench harness spawns the
-    driver once per `lake exe hexfoo_bench run` invocation and
-    reuses the file descriptors across calls, amortising one process
-    startup across all comparator calls in that registration.
-    Document the protocol in the bench module docstring.
+    and emits answers on stdout. For a fixed benchmark, the harness
+    spawns one Lean child per outer warmup or repeat. Configure
+    `warmupFirstIter` so that each child starts its driver before the
+    timed region, then reuses the file descriptors across the
+    auto-tuned inner-repeat batch. This amortises one driver startup
+    across the measured calls in that child; driver state is not
+    shared across outer repeats. Document the protocol and lifetime
+    in the bench module docstring.
   - **Per-call process spawn is acceptable only as a last resort.**
     FFI is preferred when feasible; persistent-subprocess is the
     fallback when FFI isn't viable. Per-call process spawn (the

--- a/bench/HexRCF/Bench.lean
+++ b/bench/HexRCF/Bench.lean
@@ -26,13 +26,14 @@ version-1 JSON encoding through the shared persistent driver protocol:
   -> {"ok":true,"result":<bool>}
 ```
 
-Every outer fixed-benchmark warmup or repeat runs in a fresh Lean child. The
-FLINT registration uses `warmupFirstIter`, so that child starts one Python
-process before timing and reuses it for its auto-tuned inner-repeat batch.
-Scientific execution and ratio reporting are scheduled-only and require
-`python3` with `python-flint`; routine `verify` still exercises one semantic
-smoke call for every fixed registration. This comparator is not
-proof-producing and supplies no tactic/elaboration or kernel-replay ratio.
+Every outer fixed-benchmark warmup or repeat runs in a fresh Lean child. Both
+paired registrations use `warmupFirstIter`, giving a steady-state comparison;
+on the FLINT side that call also starts one Python process before timing. The
+child then reuses it for its auto-tuned inner-repeat batch. Scheduled-only
+release execution and ratio reporting require `python3` with `python-flint`;
+routine `verify` still exercises one semantic smoke call for every fixed
+registration. This comparator is not proof-producing and supplies no
+tactic/elaboration or kernel-replay ratio.
 -/
 
 namespace Hex.RCFBench
@@ -125,25 +126,72 @@ private def sentenceJson : Sentence → Lean.Json
       ("bounds", boundsJson lower upper),
       ("formula", formulaJson formula)]
 
+private def jsonMatches (actual : Lean.Json) (expected : String) : Bool :=
+  match Lean.Json.parse expected with
+  | .ok value => actual == value
+  | .error _ => false
+
+private def wireX : ZPoly := DensePoly.ofCoeffs #[(0 : Int), 1]
+private def wireAtom (cmp : Cmp) : Formula := .atom ⟨wireX, cmp⟩
+
+/- These guards cover the complete version-1 wire vocabulary, including
+constructors not used by the five current comparator inputs. Schema drift is
+therefore a build failure rather than a scheduled-host surprise. -/
+#guard jsonMatches (cmpJson .lt) "\"lt\""
+#guard jsonMatches (cmpJson .le) "\"le\""
+#guard jsonMatches (cmpJson .eq) "\"eq\""
+#guard jsonMatches (cmpJson .ge) "\"ge\""
+#guard jsonMatches (cmpJson .gt) "\"gt\""
+#guard jsonMatches (cmpJson .ne) "\"ne\""
+#guard jsonMatches (formulaJson (wireAtom .lt))
+  "{\"tag\":\"atom\",\"coeffs\":[0,1],\"cmp\":\"lt\"}"
+#guard jsonMatches (formulaJson .tt) "{\"tag\":\"tt\"}"
+#guard jsonMatches (formulaJson .ff) "{\"tag\":\"ff\"}"
+#guard jsonMatches (formulaJson (.not .tt))
+  "{\"tag\":\"not\",\"arg\":{\"tag\":\"tt\"}}"
+#guard jsonMatches (formulaJson (.and .tt .ff))
+  "{\"tag\":\"and\",\"left\":{\"tag\":\"tt\"},\"right\":{\"tag\":\"ff\"}}"
+#guard jsonMatches (formulaJson (.or .tt .ff))
+  "{\"tag\":\"or\",\"left\":{\"tag\":\"tt\"},\"right\":{\"tag\":\"ff\"}}"
+#guard jsonMatches (formulaJson (.imp .tt .ff))
+  "{\"tag\":\"imp\",\"left\":{\"tag\":\"tt\"},\"right\":{\"tag\":\"ff\"}}"
+#guard jsonMatches (dyadicJson 0) "[0,0]"
+#guard jsonMatches (dyadicJson ((Dyadic.ofInt (-1)) >>> (1 : Int))) "[-1,1]"
+#guard jsonMatches (sentenceJson (.forallReal .tt))
+  "{\"quantifier\":\"forall_real\",\"bounds\":null,\"formula\":{\"tag\":\"tt\"}}"
+#guard jsonMatches (sentenceJson (.existsReal .ff))
+  "{\"quantifier\":\"exists_real\",\"bounds\":null,\"formula\":{\"tag\":\"ff\"}}"
+#guard jsonMatches (sentenceJson (.forallIoc 0 1 .tt))
+  "{\"quantifier\":\"forall_ioc\",\"bounds\":{\"lower\":[0,0],\"upper\":[1,0]},\"formula\":{\"tag\":\"tt\"}}"
+#guard jsonMatches
+  (sentenceJson (.existsIoc ((Dyadic.ofInt (-1)) >>> (1 : Int)) 0 .ff))
+  "{\"quantifier\":\"exists_ioc\",\"bounds\":{\"lower\":[-1,1],\"upper\":[0,0]},\"formula\":{\"tag\":\"ff\"}}"
+
 private structure DecisionInput where
+  degree : Nat
   sentence : Sentence
-  json : Lean.Json
+  request : String
 
 private def prepDecisionInput (n : Nat) : DecisionInput :=
   let sentence := prepDecisionCarrierDegree n
-  { sentence, json := sentenceJson sentence }
+  let request := Lean.Json.mkObj [
+    ("family", .str "rcf"),
+    ("op", .str "decide"),
+    ("sentence", sentenceJson sentence)]
+  { degree := n, sentence, request := request.compress }
 
-/-- The five Sentence/JSON pairs are allocated once at module initialization.
-The timed wrappers perform only the same indexed reference read before entering
-their respective decision engines. -/
+/-- The five Sentence/request-line pairs are allocated once at module
+initialization. Both timed wrappers read the same degree-keyed record. The
+FLINT timing includes pipe transport and Python JSON decoding, but not Lean
+request construction or serialization. -/
 private initialize decisionInputs : IO.Ref (Array DecisionInput) ←
   IO.mkRef <| #[16, 20, 24, 28, 32].map prepDecisionInput
 
-private def decisionInput (index : Nat) : IO DecisionInput := do
+private def decisionInput (degree : Nat) : IO DecisionInput := do
   let inputs ← decisionInputs.get
-  match inputs[index]? with
+  match inputs.find? fun input => input.degree == degree with
   | some input => return input
-  | none => throw <| IO.userError s!"HexRCF decision comparator: missing input {index}"
+  | none => throw <| IO.userError s!"HexRCF decision comparator: missing degree {degree}"
 
 private def runLeanDecision (input : DecisionInput) : IO Bool :=
   match runDecisionCarrierDegree input.sentence with
@@ -151,29 +199,28 @@ private def runLeanDecision (input : DecisionInput) : IO Bool :=
   | none => throw <| IO.userError "HexRCF decision comparator: Lean builder failed"
 
 private def runFlintDecision (input : DecisionInput) : IO Bool := do
-  let result ← Hex.BenchOracle.Flint.runOp "rcf" "decide"
-    #[("sentence", input.json)]
+  let result ← Hex.BenchOracle.Flint.runLine "rcf" "decide" input.request
   match result.getBool? with
   | Except.ok value => return value
   | Except.error message =>
       throw <| IO.userError s!"HexRCF decision comparator: FLINT result was not Boolean: {message}"
 
-private def runLeanDecisionAt (index : Nat) : Unit → IO Bool := fun _ => do
-  runLeanDecision (← decisionInput index)
+private def runLeanDecisionAt (degree : Nat) : Unit → IO Bool := fun _ => do
+  runLeanDecision (← decisionInput degree)
 
-private def runFlintDecisionAt (index : Nat) : Unit → IO Bool := fun _ => do
-  runFlintDecision (← decisionInput index)
+private def runFlintDecisionAt (degree : Nat) : Unit → IO Bool := fun _ => do
+  runFlintDecision (← decisionInput degree)
 
-def runLeanDecision16 : Unit → IO Bool := runLeanDecisionAt 0
-def runFlintDecision16 : Unit → IO Bool := runFlintDecisionAt 0
-def runLeanDecision20 : Unit → IO Bool := runLeanDecisionAt 1
-def runFlintDecision20 : Unit → IO Bool := runFlintDecisionAt 1
-def runLeanDecision24 : Unit → IO Bool := runLeanDecisionAt 2
-def runFlintDecision24 : Unit → IO Bool := runFlintDecisionAt 2
-def runLeanDecision28 : Unit → IO Bool := runLeanDecisionAt 3
-def runFlintDecision28 : Unit → IO Bool := runFlintDecisionAt 3
-def runLeanDecision32 : Unit → IO Bool := runLeanDecisionAt 4
-def runFlintDecision32 : Unit → IO Bool := runFlintDecisionAt 4
+def runLeanDecision16 : Unit → IO Bool := runLeanDecisionAt 16
+def runFlintDecision16 : Unit → IO Bool := runFlintDecisionAt 16
+def runLeanDecision20 : Unit → IO Bool := runLeanDecisionAt 20
+def runFlintDecision20 : Unit → IO Bool := runFlintDecisionAt 20
+def runLeanDecision24 : Unit → IO Bool := runLeanDecisionAt 24
+def runFlintDecision24 : Unit → IO Bool := runFlintDecisionAt 24
+def runLeanDecision28 : Unit → IO Bool := runLeanDecisionAt 28
+def runFlintDecision28 : Unit → IO Bool := runFlintDecisionAt 28
+def runLeanDecision32 : Unit → IO Bool := runLeanDecisionAt 32
+def runFlintDecision32 : Unit → IO Bool := runFlintDecisionAt 32
 
 def prepDedupRepeated (n : Nat) : List ZPoly :=
   List.replicate (positiveParam n) x
@@ -322,32 +369,30 @@ setup_benchmark runDecisionCarrierDegree n => n ^ 4
     signalFloorMultiplier := 1.0
   }
 
-/-- Matching steady-state timing floor for the in-process Lean decisions. -/
-def leanDecisionConfig : LeanBench.FixedBenchmarkConfig :=
-  { repeats := 5
-    maxSecondsPerCall := 8.0
-    minTotalSeconds := 0.2
-    expectedHash := some (Hashable.hash true) }
-
-/-- The same shape for FLINT, with its persistent driver started before the
-timed auto-tuner batch in each outer child. -/
-def flintDecisionConfig : LeanBench.FixedBenchmarkConfig :=
+/-- Shared steady-state timing shape. The discarded first call warms the Lean
+decision path on both sides and starts the persistent driver on the FLINT side. -/
+def decisionConfig : LeanBench.FixedBenchmarkConfig :=
   { repeats := 5
     maxSecondsPerCall := 8.0
     minTotalSeconds := 0.2
     warmupFirstIter := true
     expectedHash := some (Hashable.hash true) }
 
-setup_fixed_benchmark runLeanDecision16 where leanDecisionConfig
-setup_fixed_benchmark runFlintDecision16 where flintDecisionConfig
-setup_fixed_benchmark runLeanDecision20 where leanDecisionConfig
-setup_fixed_benchmark runFlintDecision20 where flintDecisionConfig
-setup_fixed_benchmark runLeanDecision24 where leanDecisionConfig
-setup_fixed_benchmark runFlintDecision24 where flintDecisionConfig
-setup_fixed_benchmark runLeanDecision28 where leanDecisionConfig
-setup_fixed_benchmark runFlintDecision28 where flintDecisionConfig
-setup_fixed_benchmark runLeanDecision32 where leanDecisionConfig
-setup_fixed_benchmark runFlintDecision32 where flintDecisionConfig
+#guard decisionConfig.repeats == 5
+#guard decisionConfig.minTotalSeconds == 0.2
+#guard decisionConfig.warmupFirstIter
+#guard decisionConfig.expectedHash == some (Hashable.hash true)
+
+setup_fixed_benchmark runLeanDecision16 where decisionConfig
+setup_fixed_benchmark runFlintDecision16 where decisionConfig
+setup_fixed_benchmark runLeanDecision20 where decisionConfig
+setup_fixed_benchmark runFlintDecision20 where decisionConfig
+setup_fixed_benchmark runLeanDecision24 where decisionConfig
+setup_fixed_benchmark runFlintDecision24 where decisionConfig
+setup_fixed_benchmark runLeanDecision28 where decisionConfig
+setup_fixed_benchmark runFlintDecision28 where decisionConfig
+setup_fixed_benchmark runLeanDecision32 where decisionConfig
+setup_fixed_benchmark runFlintDecision32 where decisionConfig
 
 /-
 After the first occurrence the seen prefix has size one, so each of the `u`

--- a/bench/HexRCF/Bench.lean
+++ b/bench/HexRCF/Bench.lean
@@ -5,6 +5,7 @@ Authors: Kim Morrison
 -/
 
 import HexRCF.BenchHash
+import Hex.BenchOracle.Flint
 import LeanBench
 
 /-!
@@ -14,6 +15,24 @@ certificate-replay pipeline.
 All fixture construction is hoisted through `with prep := ...`. In particular,
 the replay targets time only `Certificate.replay?` on already accepted `.cells`
 certificates; they never rebuild witnesses in the timed region.
+
+The informational python-flint comparator covers only the compiled
+carrier-degree decision family at `n = 16, 20, 24, 28, 32`. Both sides consume
+the same precomputed reflected sentence; FLINT receives its precomputed
+version-1 JSON encoding through the shared persistent driver protocol:
+
+```text
+{"family":"rcf","op":"decide","sentence":<v1 sentence>}
+  -> {"ok":true,"result":<bool>}
+```
+
+Every outer fixed-benchmark warmup or repeat runs in a fresh Lean child. The
+FLINT registration uses `warmupFirstIter`, so that child starts one Python
+process before timing and reuses it for its auto-tuned inner-repeat batch.
+Scientific execution and ratio reporting are scheduled-only and require
+`python3` with `python-flint`; routine `verify` still exercises one semantic
+smoke call for every fixed registration. This comparator is not
+proof-producing and supplies no tactic/elaboration or kernel-replay ratio.
 -/
 
 namespace Hex.RCFBench
@@ -46,6 +65,115 @@ def prepDecisionCarrierDegree (n : Nat) : Sentence :=
 
 def runDecisionCarrierDegree (sentence : Sentence) : Option Bool :=
   Hex.RCF.decide sentence
+
+/-! ## Informational python-flint decision comparator -/
+
+private def cmpJson : Cmp → Lean.Json
+  | .lt => .str "lt"
+  | .le => .str "le"
+  | .eq => .str "eq"
+  | .ge => .str "ge"
+  | .gt => .str "gt"
+  | .ne => .str "ne"
+
+private def formulaJson : Formula → Lean.Json
+  | .atom atom => .mkObj [
+      ("tag", .str "atom"),
+      ("coeffs", Hex.BenchOracle.Flint.intsToJson atom.p.toArray.toList),
+      ("cmp", cmpJson atom.cmp)]
+  | .tt => .mkObj [("tag", .str "tt")]
+  | .ff => .mkObj [("tag", .str "ff")]
+  | .not formula => .mkObj [
+      ("tag", .str "not"),
+      ("arg", formulaJson formula)]
+  | .and left right => .mkObj [
+      ("tag", .str "and"),
+      ("left", formulaJson left),
+      ("right", formulaJson right)]
+  | .or left right => .mkObj [
+      ("tag", .str "or"),
+      ("left", formulaJson left),
+      ("right", formulaJson right)]
+  | .imp left right => .mkObj [
+      ("tag", .str "imp"),
+      ("left", formulaJson left),
+      ("right", formulaJson right)]
+
+private def dyadicJson : Dyadic → Lean.Json
+  | .zero => Hex.BenchOracle.Flint.intsToJson [0, 0]
+  | .ofOdd numerator exponent _ =>
+      Hex.BenchOracle.Flint.intsToJson [numerator, exponent]
+
+private def boundsJson (lower upper : Dyadic) : Lean.Json :=
+  .mkObj [("lower", dyadicJson lower), ("upper", dyadicJson upper)]
+
+private def sentenceJson : Sentence → Lean.Json
+  | .forallReal formula => .mkObj [
+      ("quantifier", .str "forall_real"),
+      ("bounds", .null),
+      ("formula", formulaJson formula)]
+  | .existsReal formula => .mkObj [
+      ("quantifier", .str "exists_real"),
+      ("bounds", .null),
+      ("formula", formulaJson formula)]
+  | .forallIoc lower upper formula => .mkObj [
+      ("quantifier", .str "forall_ioc"),
+      ("bounds", boundsJson lower upper),
+      ("formula", formulaJson formula)]
+  | .existsIoc lower upper formula => .mkObj [
+      ("quantifier", .str "exists_ioc"),
+      ("bounds", boundsJson lower upper),
+      ("formula", formulaJson formula)]
+
+private structure DecisionInput where
+  sentence : Sentence
+  json : Lean.Json
+
+private def prepDecisionInput (n : Nat) : DecisionInput :=
+  let sentence := prepDecisionCarrierDegree n
+  { sentence, json := sentenceJson sentence }
+
+/-- The five Sentence/JSON pairs are allocated once at module initialization.
+The timed wrappers perform only the same indexed reference read before entering
+their respective decision engines. -/
+private initialize decisionInputs : IO.Ref (Array DecisionInput) ←
+  IO.mkRef <| #[16, 20, 24, 28, 32].map prepDecisionInput
+
+private def decisionInput (index : Nat) : IO DecisionInput := do
+  let inputs ← decisionInputs.get
+  match inputs[index]? with
+  | some input => return input
+  | none => throw <| IO.userError s!"HexRCF decision comparator: missing input {index}"
+
+private def runLeanDecision (input : DecisionInput) : IO Bool :=
+  match runDecisionCarrierDegree input.sentence with
+  | some value => return value
+  | none => throw <| IO.userError "HexRCF decision comparator: Lean builder failed"
+
+private def runFlintDecision (input : DecisionInput) : IO Bool := do
+  let result ← Hex.BenchOracle.Flint.runOp "rcf" "decide"
+    #[("sentence", input.json)]
+  match result.getBool? with
+  | Except.ok value => return value
+  | Except.error message =>
+      throw <| IO.userError s!"HexRCF decision comparator: FLINT result was not Boolean: {message}"
+
+private def runLeanDecisionAt (index : Nat) : Unit → IO Bool := fun _ => do
+  runLeanDecision (← decisionInput index)
+
+private def runFlintDecisionAt (index : Nat) : Unit → IO Bool := fun _ => do
+  runFlintDecision (← decisionInput index)
+
+def runLeanDecision16 : Unit → IO Bool := runLeanDecisionAt 0
+def runFlintDecision16 : Unit → IO Bool := runFlintDecisionAt 0
+def runLeanDecision20 : Unit → IO Bool := runLeanDecisionAt 1
+def runFlintDecision20 : Unit → IO Bool := runFlintDecisionAt 1
+def runLeanDecision24 : Unit → IO Bool := runLeanDecisionAt 2
+def runFlintDecision24 : Unit → IO Bool := runFlintDecisionAt 2
+def runLeanDecision28 : Unit → IO Bool := runLeanDecisionAt 3
+def runFlintDecision28 : Unit → IO Bool := runFlintDecisionAt 3
+def runLeanDecision32 : Unit → IO Bool := runLeanDecisionAt 4
+def runFlintDecision32 : Unit → IO Bool := runFlintDecisionAt 4
 
 def prepDedupRepeated (n : Nat) : List ZPoly :=
   List.replicate (positiveParam n) x
@@ -193,6 +321,33 @@ setup_benchmark runDecisionCarrierDegree n => n ^ 4
     targetInnerNanos := 100000000
     signalFloorMultiplier := 1.0
   }
+
+/-- Matching steady-state timing floor for the in-process Lean decisions. -/
+def leanDecisionConfig : LeanBench.FixedBenchmarkConfig :=
+  { repeats := 5
+    maxSecondsPerCall := 8.0
+    minTotalSeconds := 0.2
+    expectedHash := some (Hashable.hash true) }
+
+/-- The same shape for FLINT, with its persistent driver started before the
+timed auto-tuner batch in each outer child. -/
+def flintDecisionConfig : LeanBench.FixedBenchmarkConfig :=
+  { repeats := 5
+    maxSecondsPerCall := 8.0
+    minTotalSeconds := 0.2
+    warmupFirstIter := true
+    expectedHash := some (Hashable.hash true) }
+
+setup_fixed_benchmark runLeanDecision16 where leanDecisionConfig
+setup_fixed_benchmark runFlintDecision16 where flintDecisionConfig
+setup_fixed_benchmark runLeanDecision20 where leanDecisionConfig
+setup_fixed_benchmark runFlintDecision20 where flintDecisionConfig
+setup_fixed_benchmark runLeanDecision24 where leanDecisionConfig
+setup_fixed_benchmark runFlintDecision24 where flintDecisionConfig
+setup_fixed_benchmark runLeanDecision28 where leanDecisionConfig
+setup_fixed_benchmark runFlintDecision28 where flintDecisionConfig
+setup_fixed_benchmark runLeanDecision32 where leanDecisionConfig
+setup_fixed_benchmark runFlintDecision32 where flintDecisionConfig
 
 /-
 After the first occurrence the seen prefix has size one, so each of the `u`

--- a/libraries.yml
+++ b/libraries.yml
@@ -549,7 +549,7 @@ libraries:
       comparators:
         - tool: "python-flint univariate RCF verdict oracle"
           class: informational
-          rationale: "python-flint supplies an independent exact/ball-arithmetic verdict on the committed shared sentence families, but it does not emit a proof term or exercise Lean certificate replay. Ratios orient the Mathlib-free compiled DecisionCheck track and are scheduled-only; they do not gate the proof-producing tactic surface. No comparable proof-producing univariate RCF tactic is named, so the tactic track is declared no-comparable-surface-in-named-comparator in the HexRCF SPEC."
+          rationale: "python-flint supplies an independent exact/ball-arithmetic verdict on the carrier-degree family at n = 16, 20, 24, 28, 32, but it does not emit a proof term or exercise Lean certificate replay. Ratios orient the Mathlib-free compiled DecisionCheck track and are scheduled-only; they do not gate the proof-producing tactic surface. No comparable proof-producing univariate RCF tactic is named, so the tactic track is declared no-comparable-surface-in-named-comparator in the HexRCF SPEC."
       input_families:
         - name: carrier-degree-roots
           description: One-atom square-free families varying carrier degree and real-root count while holding atom multiplicity, coefficient-height regime, and Boolean shape fixed.

--- a/progress/20260728T025118Z_rcf-flint-comparator.md
+++ b/progress/20260728T025118Z_rcf-flint-comparator.md
@@ -1,0 +1,41 @@
+# HexRCF python-flint decision comparator
+
+## Accomplished
+
+- Exposed the conformance oracle's independent sentence decider and reused it
+  from the shared persistent python-flint benchmark driver without duplicating
+  the root or cell algorithm.
+- Added the `rcf/decide` request protocol and focused Python tests covering the
+  public decision entry point, shared dispatch, malformed requests, and
+  continued service after an error frame.
+- Added an exact Mathlib-free encoder for the version-1 reflected sentence
+  schema and precomputed the five shared Sentence/JSON inputs at carrier
+  degrees 16, 20, 24, 28, and 32 outside every timed body.
+- Registered paired fixed Lean and FLINT Boolean decisions at all five rungs,
+  with matching five-repeat and 0.2-second steady-state floors, a pinned true
+  hash, and per-child FLINT warmup.
+- Corrected the persistent-driver lifetime documentation: LeanBench creates a
+  fresh child for each outer fixed warmup or repeat, while the Python process
+  is warmed and reused across the auto-tuned inner batch inside that child.
+- Built `hexrcf_bench`, exercised all twenty registrations through `verify`
+  with python-flint 0.9.0, passed the 360-second smoke budget in 12 seconds
+  including incremental build, and rechecked all thirty conformance sentences.
+
+## Current frontier
+
+- Directive #9021 is implementation-complete locally and is undergoing a
+  read-only preflight before commit and draft PR publication.
+- The comparator is structural wiring only. No scheduled scientific timing,
+  performance report, or release artifact has been produced.
+
+## Next step
+
+- Address any preflight findings, rerun the repository checks from the committed
+  state, publish the draft PR, and obtain the requested fresh Claude review.
+- Rebase the milestone as the HexRCF stack advances.
+
+## Blockers
+
+- None for registration or routine CI verification.
+- Informational ratios still require the named scheduled benchmark host and a
+  release-quality run; that work is intentionally outside this directive.

--- a/progress/20260728T025118Z_rcf-flint-comparator.md
+++ b/progress/20260728T025118Z_rcf-flint-comparator.md
@@ -9,11 +9,12 @@
   public decision entry point, shared dispatch, malformed requests, and
   continued service after an error frame.
 - Added an exact Mathlib-free encoder for the version-1 reflected sentence
-  schema and precomputed the five shared Sentence/JSON inputs at carrier
-  degrees 16, 20, 24, 28, and 32 outside every timed body.
+  schema, pinned its complete vocabulary with build guards, and precomputed
+  the five shared Sentence/request-line inputs at carrier degrees 16, 20, 24,
+  28, and 32 outside every timed body.
 - Registered paired fixed Lean and FLINT Boolean decisions at all five rungs,
-  with matching five-repeat and 0.2-second steady-state floors, a pinned true
-  hash, and per-child FLINT warmup.
+  with one shared five-repeat and 0.2-second steady-state config, a pinned true
+  hash, and matched per-child warmups.
 - Corrected the persistent-driver lifetime documentation: LeanBench creates a
   fresh child for each outer fixed warmup or repeat, while the Python process
   is warmed and reused across the auto-tuned inner batch inside that child.

--- a/progress/20260728T031236Z_rcf-flint-review.md
+++ b/progress/20260728T031236Z_rcf-flint-review.md
@@ -1,0 +1,30 @@
+# HexRCF FLINT comparator review
+
+## Accomplished
+
+- Addressed the independent review's measurement findings by using one shared
+  warmed fixed-benchmark config for both engines and by precomputing the full
+  FLINT request line outside the timed body.
+- Added build guards for every constructor in the version-1 sentence wire
+  schema, made the input lookup degree-keyed, and isolated an unavailable RCF
+  oracle from the driver's other comparator families.
+- Rebuilt `hexrcf_bench`, rechecked all thirty oracle sentences, passed the
+  focused Python tests, and verified all twenty benchmark registrations with
+  python-flint 0.9.0.
+
+## Current frontier
+
+- The comparator implementation and review fixes are complete locally.
+- No scientific timing or ratio claim has been made from this development
+  machine.
+
+## Next step
+
+- Run the repository structural checks from the committed state, update draft
+  PR #9024, and let CI validate the corrected stack.
+- Carry the reviewed comparator into the release-evidence milestone.
+
+## Blockers
+
+- None for the comparator implementation.
+- Release-quality timings still require the named benchmark host.

--- a/scripts/oracle/flint_bench_driver.py
+++ b/scripts/oracle/flint_bench_driver.py
@@ -8,12 +8,13 @@ is JSON encode/decode and the FLINT operation itself.
 
 Per `SPEC/benchmarking.md` (post-#3657) §"External comparators"
 §"Process call": this driver is the persistent-subprocess shape
-required when per-call overhead is non-negligible. The bench harness
-spawns the driver once per `lake exe hexfoo_bench run` invocation,
-holds its stdin / stdout handles in an `IO.Ref` (see
-`Hex/BenchOracle/Flint.lean`), and reuses the file descriptors
-across every measured call in that bench process. One process
-startup is amortised across all comparator calls in the run.
+required when per-call overhead is non-negligible. A fixed benchmark
+starts a fresh Lean child for each outer warmup or repeat. Within one
+child, `warmupFirstIter` starts this driver before timing, stores its
+stdin / stdout handles in an `IO.Ref` (see
+`Hex/BenchOracle/Flint.lean`), and the auto-tuned inner-repeat batch
+reuses those handles. Thus one driver startup is amortised across the
+measured calls in that child; it is not shared across outer repeats.
 
 ## Framing
 
@@ -141,6 +142,15 @@ schema is the textbook Newton-style quadratic lift. HO-24 owns
 the Hensel-family wiring on the Lean side and may extend the
 operation set here as its bench targets require.
 
+### `rcf` (univariate real-closed-field sentences)
+
+Request field: ``sentence``, a version-1 HexRCF sentence object using the
+same schema as ``scripts/oracle/rcf_flint.py``.
+
+* ``decide`` — returns the Boolean verdict produced by the shared independent
+  python-flint RCF engine. The benchmark driver imports that engine rather
+  than duplicating its carrier, root certification, or cell evaluation.
+
 ## Per-call overhead
 
 The driver imports ``flint`` once at startup; per-call cost in the
@@ -164,11 +174,17 @@ from __future__ import annotations
 import json
 import sys
 import traceback
+from pathlib import Path
 from typing import Any, Callable
 
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.oracle.rcf_flint import decide_sentence
+
 # Import flint at startup so the first request does not pay the
-# `import flint` cost. The CI workflow installs python-flint at the
-# top of `conformance.yml`; if it is unavailable the driver still
+# `import flint` cost. The CI workflow installs python-flint in its
+# shared dependency step; if it is unavailable the driver still
 # starts but every request that needs flint will reply with an
 # error frame.
 try:
@@ -578,6 +594,23 @@ _NMOD_POLY_HENSEL_OPS: dict[str, Callable[[dict[str, Any]], Any]] = {
 
 
 # ---------------------------------------------------------------------
+# `rcf` (univariate real-closed-field sentences)
+# ---------------------------------------------------------------------
+
+
+def _rcf_decide(req: dict[str, Any]) -> bool:
+    sentence = req.get("sentence")
+    if not isinstance(sentence, dict):
+        raise ValueError("rcf/decide request missing object 'sentence' field")
+    return decide_sentence(sentence)
+
+
+_RCF_OPS: dict[str, Callable[[dict[str, Any]], Any]] = {
+    "decide": _rcf_decide,
+}
+
+
+# ---------------------------------------------------------------------
 # Dispatch
 # ---------------------------------------------------------------------
 
@@ -588,6 +621,7 @@ _FAMILIES: dict[str, dict[str, Callable[[dict[str, Any]], Any]]] = {
     "fmpz_mat": _FMPZ_MAT_OPS,
     "fq_default": _FQ_DEFAULT_OPS,
     "nmod_poly_hensel": _NMOD_POLY_HENSEL_OPS,
+    "rcf": _RCF_OPS,
 }
 
 
@@ -641,6 +675,7 @@ def _serve(stdin, stdout) -> None:
 #       '{"family":"fmpz_poly","op":"mul","a":[1,2,3],"b":[4,5]}' \\
 #       '{"family":"nmod_poly","op":"is_irreducible","p":7,"a":[1,1,1]}' \\
 #       '{"family":"fmpz_mat","op":"det","rows":[[1,2],[3,4]]}' \\
+#       '{"family":"rcf","op":"decide","sentence":{"quantifier":"exists_real","bounds":null,"formula":{"tag":"tt"}}}' \\
 #       | python3 scripts/oracle/flint_bench_driver.py
 #
 # Expected replies (one per request, in order)::
@@ -648,6 +683,7 @@ def _serve(stdin, stdout) -> None:
 #   {"ok":true,"result":[4,13,22,15]}
 #   {"ok":true,"result":true}
 #   {"ok":true,"result":-2}
+#   {"ok":true,"result":true}
 #
 # Malformed requests are echoed back as `{"ok":false,"error":"..."}`
 # and never terminate the driver.

--- a/scripts/oracle/flint_bench_driver.py
+++ b/scripts/oracle/flint_bench_driver.py
@@ -180,7 +180,13 @@ from typing import Any, Callable
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.oracle.rcf_flint import decide_sentence
+try:
+    from scripts.oracle.rcf_flint import decide_sentence
+
+    _rcf_import_error: str | None = None
+except Exception as exc:  # pragma: no cover - defensive isolation
+    decide_sentence = None  # type: ignore[assignment]
+    _rcf_import_error = f"HexRCF oracle unavailable: {exc!r}"
 
 # Import flint at startup so the first request does not pay the
 # `import flint` cost. The CI workflow installs python-flint in its
@@ -599,6 +605,8 @@ _NMOD_POLY_HENSEL_OPS: dict[str, Callable[[dict[str, Any]], Any]] = {
 
 
 def _rcf_decide(req: dict[str, Any]) -> bool:
+    if decide_sentence is None:
+        raise RuntimeError(_rcf_import_error or "HexRCF oracle unavailable")
     sentence = req.get("sentence")
     if not isinstance(sentence, dict):
         raise ValueError("rcf/decide request missing object 'sentence' field")

--- a/scripts/oracle/rcf_flint.py
+++ b/scripts/oracle/rcf_flint.py
@@ -294,7 +294,13 @@ def _bounded_values(
     return relevant
 
 
-def _decide(sentence: dict[str, Any]) -> bool:
+def decide_sentence(sentence: dict[str, Any]) -> bool:
+    """Decide one version-1 RCF sentence with the independent FLINT engine.
+
+    This is the shared algorithmic entry point for both JSONL conformance and
+    the persistent benchmark driver. Keeping the two callers here prevents
+    the timing comparator from drifting onto a second implementation.
+    """
     formula = sentence["formula"]
     bounds = sentence["bounds"]
     quantifier = sentence["quantifier"]
@@ -371,7 +377,7 @@ def check(
             lean_value = emitted[0]["value"]
             if type(lean_value) is not bool:
                 raise OracleMismatch(f"decide result must be bool, got {lean_value!r}")
-            oracle_value = _decide(record["sentence"])
+            oracle_value = decide_sentence(record["sentence"])
             if lean_value != oracle_value:
                 raise OracleMismatch(
                     f"Lean verdict {lean_value!r} != python-flint verdict {oracle_value!r}"

--- a/scripts/oracle/test_rcf_flint_bench.py
+++ b/scripts/oracle/test_rcf_flint_bench.py
@@ -91,9 +91,6 @@ class RcfFlintBenchTests(unittest.TestCase):
             for engine in ("Lean", "Flint")
         ]
         self.assertCountEqual(names, expected)
-        self.assertIn("minTotalSeconds := 0.2", source)
-        self.assertIn("warmupFirstIter := true", source)
-        self.assertGreaterEqual(source.count("expectedHash := some (Hashable.hash true)"), 2)
 
 
 if __name__ == "__main__":

--- a/scripts/oracle/test_rcf_flint_bench.py
+++ b/scripts/oracle/test_rcf_flint_bench.py
@@ -1,0 +1,100 @@
+"""Focused tests for the shared HexRCF python-flint bench protocol."""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from scripts.oracle import flint_bench_driver as driver
+from scripts.oracle import rcf_flint
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+class RcfFlintBenchTests(unittest.TestCase):
+    def test_public_decider_handles_constant_sentence(self) -> None:
+        sentence = {
+            "quantifier": "exists_real",
+            "bounds": None,
+            "formula": {"tag": "tt"},
+        }
+        with (
+            mock.patch.object(rcf_flint, "_carrier_factors", return_value=[]),
+            mock.patch.object(rcf_flint, "_certified_roots", return_value=[]),
+        ):
+            self.assertTrue(rcf_flint.decide_sentence(sentence))
+
+    def test_driver_delegates_to_shared_decider(self) -> None:
+        sentence = {
+            "quantifier": "forall_real",
+            "bounds": None,
+            "formula": {"tag": "ff"},
+        }
+        with (
+            mock.patch.object(driver, "_require_flint"),
+            mock.patch.object(driver, "decide_sentence", return_value=False) as decide,
+        ):
+            self.assertFalse(
+                driver._dispatch(
+                    {"family": "rcf", "op": "decide", "sentence": sentence}
+                )
+            )
+        decide.assert_called_once_with(sentence)
+
+    def test_driver_requires_sentence_object(self) -> None:
+        with mock.patch.object(driver, "_require_flint"):
+            with self.assertRaisesRegex(ValueError, "missing object 'sentence'"):
+                driver._dispatch(
+                    {"family": "rcf", "op": "decide", "sentence": "not-an-object"}
+                )
+
+    def test_protocol_reports_error_and_continues(self) -> None:
+        sentence = {
+            "quantifier": "exists_real",
+            "bounds": None,
+            "formula": {"tag": "tt"},
+        }
+        requests = [
+            {"family": "rcf", "op": "decide", "sentence": sentence},
+            {"family": "rcf", "op": "decide"},
+            {"family": "rcf", "op": "decide", "sentence": sentence},
+        ]
+        stdin = io.StringIO("".join(json.dumps(req) + "\n" for req in requests))
+        stdout = io.StringIO()
+        with (
+            mock.patch.object(driver, "_require_flint"),
+            mock.patch.object(driver, "decide_sentence", return_value=True),
+        ):
+            driver._serve(stdin, stdout)
+        replies = [json.loads(line) for line in stdout.getvalue().splitlines()]
+        self.assertEqual(replies[0], {"ok": True, "result": True})
+        self.assertFalse(replies[1]["ok"])
+        self.assertIn("missing object 'sentence'", replies[1]["error"])
+        self.assertEqual(replies[2], {"ok": True, "result": True})
+
+    def test_exact_five_paired_registrations(self) -> None:
+        source = (REPO_ROOT / "bench" / "HexRCF" / "Bench.lean").read_text(
+            encoding="utf-8"
+        )
+        names = re.findall(
+            r"^setup_fixed_benchmark (run(?:Lean|Flint)Decision\d+) where",
+            source,
+            re.MULTILINE,
+        )
+        expected = [
+            f"run{engine}Decision{degree}"
+            for degree in (16, 20, 24, 28, 32)
+            for engine in ("Lean", "Flint")
+        ]
+        self.assertCountEqual(names, expected)
+        self.assertIn("minTotalSeconds := 0.2", source)
+        self.assertIn("warmupFirstIter := true", source)
+        self.assertGreaterEqual(source.count("expectedHash := some (Hashable.hash true)"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #9021. Contributes to #8973.

This wires the scheduled-only informational python-flint comparator for the compiled carrier-degree decision family at n = 16, 20, 24, 28, and 32.

Highlights:

- shares the independent RCF decision algorithm with the existing conformance oracle
- adds the persistent rcf/decide JSON protocol
- precomputes the same reflected Sentence and exact v1 JSON input for both sides
- registers five paired fixed Lean and FLINT Boolean targets with matching steady-state floors and pinned true hashes
- corrects the documented process lifetime to one warmed driver per Lean child inner batch
- extends the existing single CI job with focused protocol and registration tests

Validation:

- lake build hexrcf_bench
- all 20 benchmark registrations pass verify with python-flint 0.9.0
- all 30 committed RCF oracle fixtures pass
- 52 focused bench, harness, and oracle tests pass
- Mathlib-free bench lint, Phase 4 checks, DAG, release/trust checks, conformance matrix, copyright, line-count, and diff checks pass

No timing artifact, performance report, done_through update, proof-surface ratio, new workflow, job, or matrix is included.