### PR TITLE
bench(rcf): calibrate Phase-4 evidence collection

### DIFF
--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -689,14 +689,20 @@ distinct sign entries, and formula occurrences). The fixed
 quadratic/degree-10/degree-50 cases below do not participate in those
 complexity verdicts.
 
-The tactic track uses matched fresh-module variants for each fixed case:
+The tactic track begins with one same-module `Baseline − Baseline` null control,
+then uses matched fresh-module variants for each fixed case:
 `Baseline` (identical imports), `Reify` (reify-only checksum), `Input`
 (reflected sentence literal), `Search` (the same input plus a meta checksum of
 compiled certificate construction, emitting no proof), `Literal` (input plus
 the pre-generated certificate), `Replay` (literal plus its kernel-checked
 theorem), and `Tactic` (the source goal closed by `rcf`). An external runner
-rotates fresh builds and reports raw paired deltas for reification, search,
-literal elaboration, replay, and the full tactic. `Search − Input` is
+rotates fresh builds and reports the null calibration followed by raw paired
+deltas for reification, search, literal elaboration, replay, and the full
+tactic. The null's five signed deltas, range, and median describe fresh-build
+noise only: they are reported before the substantive pairs and are never
+subtracted, promoted to a significance test, or used to alter the fixed tactic
+budgets. A substantive delta inside the observed null spread is noise-sized or
+unresolved. `Search − Input` is
 phase-attribution evidence only; the matching LeanBench target supplies the
 scientific asymptotic verdict, and the report neither substitutes nor adds the
 two. The headline report records source hashes, commit/toolchain/host/load
@@ -713,7 +719,9 @@ independently rebuildable. All measured modules import the same generated
 support module and no measured module imports another measured module.
 
 There is one shared `Baseline` and six measured modules under each of
-`Quadratic/`, `Degree10/`, and `Degree50/`. The five report pairs are exactly:
+`Quadratic/`, `Degree10/`, and `Degree50/`. The report contains sixteen pairs:
+the `Baseline − Baseline` null control first, then these five pairs for each of
+the three cases:
 
 | Report component | Reference | Candidate |
 | --- | --- | --- |

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -754,7 +754,10 @@ output.
 python-flint is an **informational**, scheduled-only comparator for the
 compiled carrier-degree decision family. The paired fixed registrations are
 `runLeanDecision{16,20,24,28,32}` and
-`runFlintDecision{16,20,24,28,32}`. At each rung both sides consume the same
+`runFlintDecision{16,20,24,28,32}`. The additional fixed registration
+`runFlintDecisionOverhead` sends the atom-free sentence `∀ x, True` through the
+same warmed `rcf/decide` path and supplies a conservative steady-state
+per-call floor. At each substantive rung both sides consume the same
 precomputed `Sentence`; the FLINT side also consumes its precomputed exact
 version-1 fixture encoding. The persistent-driver request and response are
 
@@ -771,10 +774,15 @@ it also starts one `python3` process in the child. The timed auto-tuned
 inner-repeat batch reuses that process's streams, and no driver is shared
 between outer children. The complete FLINT request line, including the exact
 version-1 sentence encoding, is precomputed; pipe transport and Python JSON
-decoding remain measured comparator overhead. Routine `hexrcf_bench verify`
-performs one semantic call through every fixed registration. Scientific runs
-and ratio reporting require `python3` with `python-flint` on the named release
-benchmark host.
+decoding remain measured comparator overhead. The floor includes the complete
+request/reply path and minimal formula evaluation, but excludes process startup
+and understates the parsing cost of the longer degree-rung requests. The
+headline report retains raw times and ratios at every rung, then subtracts the
+floor median from the FLINT median only when positive to produce the adjusted
+ratio; a floor-dominated rung is identified rather than assigned a negative
+adjusted time. Routine `hexrcf_bench verify` performs one semantic call through
+every fixed registration. Scientific runs and ratio reporting require
+`python3` with `python-flint` on the named release benchmark host.
 
 This comparison covers carrier degree and real-root count only. It does not
 measure atom multiplicity, common-root preparation, separation, certificate

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -689,20 +689,23 @@ distinct sign entries, and formula occurrences). The fixed
 quadratic/degree-10/degree-50 cases below do not participate in those
 complexity verdicts.
 
-The tactic track begins with one same-module `Baseline − Baseline` null control,
-then uses matched fresh-module variants for each fixed case:
+The tactic track begins with same-module `Baseline − Baseline` and
+`Degree50.Tactic − Degree50.Tactic` null controls, then uses matched
+fresh-module variants for each fixed case:
 `Baseline` (identical imports), `Reify` (reify-only checksum), `Input`
 (reflected sentence literal), `Search` (the same input plus a meta checksum of
 compiled certificate construction, emitting no proof), `Literal` (input plus
 the pre-generated certificate), `Replay` (literal plus its kernel-checked
 theorem), and `Tactic` (the source goal closed by `rcf`). An external runner
-rotates fresh builds and reports the null calibration followed by raw paired
+rotates fresh builds and reports both null calibrations followed by raw paired
 deltas for reification, search, literal elaboration, replay, and the full
-tactic. The null's five signed deltas, range, and median describe fresh-build
-noise only: they are reported before the substantive pairs and are never
-subtracted, promoted to a significance test, or used to alter the fixed tactic
-budgets. A substantive delta inside the observed null spread is noise-sized or
-unresolved. `Search − Input` is
+tactic. Six rounds balance which role builds first. Each null's signed deltas,
+absolute and relative ranges, and median describe fresh-build noise only: they
+are reported before the substantive pairs in artifact `config.order` and are
+never subtracted, promoted to a significance test, or used to alter the fixed
+tactic budgets. A substantive delta is noise-sized only against a null with a
+comparable total build magnitude, or when its relative spread agrees with both
+controls; otherwise the sweep leaves it unresolved. `Search − Input` is
 phase-attribution evidence only; the matching LeanBench target supplies the
 scientific asymptotic verdict, and the report neither substitutes nor adds the
 two. The headline report records source hashes, commit/toolchain/host/load
@@ -719,9 +722,9 @@ independently rebuildable. All measured modules import the same generated
 support module and no measured module imports another measured module.
 
 There is one shared `Baseline` and six measured modules under each of
-`Quadratic/`, `Degree10/`, and `Degree50/`. The report contains sixteen pairs:
-the `Baseline − Baseline` null control first, then these five pairs for each of
-the three cases:
+`Quadratic/`, `Degree10/`, and `Degree50/`. The report contains seventeen
+pairs: the baseline and degree-50-tactic null controls first, then these five
+pairs for each of the three cases:
 
 | Report component | Reference | Candidate |
 | --- | --- | --- |
@@ -742,7 +745,7 @@ build-only Lake libraries; there is no proof-probe executable or in-process
 clock. The complete external sweep is:
 
 ```bash
-python3 scripts/bench/hexrcf_proof_sweep.py --samples 5
+python3 scripts/bench/hexrcf_proof_sweep.py --samples 6
 ```
 
 Only `Replay` and `Tactic` print an axiom report, fixed to
@@ -768,7 +771,9 @@ version-1 fixture encoding. The persistent-driver request and response are
 
 Both sides return `Bool` and share one config that pins `Hashable.hash true`,
 uses five repeats and a 0.2-second minimum total, and enables
-`warmupFirstIter`. LeanBench starts one fresh child per outer warmup or repeat.
+`warmupFirstIter`. `runFlintDecisionOverhead` shares it except for eleven outer
+repeats, which stabilize the floor median without changing the timed inner
+batch. LeanBench starts one fresh child per outer warmup or repeat.
 The discarded first call warms the Lean decision path on both sides; for FLINT
 it also starts one `python3` process in the child. The timed auto-tuned
 inner-repeat batch reuses that process's streams, and no driver is shared
@@ -778,11 +783,13 @@ decoding remain measured comparator overhead. The floor includes the complete
 request/reply path and minimal formula evaluation, but excludes process startup
 and understates the parsing cost of the longer degree-rung requests. The
 headline report retains raw times and ratios at every rung, then subtracts the
-floor median from the FLINT median only when positive to produce the adjusted
-ratio; a floor-dominated rung is identified rather than assigned a negative
-adjusted time. Routine `hexrcf_bench verify` performs one semantic call through
-every fixed registration. Scientific runs and ratio reporting require
-`python3` with `python-flint` on the named release benchmark host.
+floor median from the FLINT median only on rungs where the floor is at most 50%
+of the FLINT median. A rung above that threshold is floor-dominated, ineligible,
+and reported raw-only. On an eligible rung where the floor exceeds 5%, both raw
+and adjusted ratios are mandatory; below 5%, the raw ratio suffices. Routine
+`hexrcf_bench verify` performs one semantic call through every fixed
+registration. Scientific runs and ratio reporting require `python3` with
+`python-flint` on the named release benchmark host.
 
 This comparison covers carrier degree and real-root count only. It does not
 measure atom multiplicity, common-root preparation, separation, certificate

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -287,6 +287,16 @@ in-process clock, or contain a timing loop. A probe also cannot root any
 - refuse a release-quality verdict on a dirty tree, a busy shared host, a
   timed-out build, or a provenance mismatch.
 
+A proof-track sweep may precede its substantive pairs with a marked
+same-module null control: the exact same committed module is independently
+rebuilt in the reference and candidate roles under the ordinary alternating
+orientation. Its raw signed deltas describe fresh-build noise under that run's
+host conditions. The report records their range and median before interpreting
+the proof deltas, but does not subtract the null median, widen a budget by the
+null range, assign significance, or use the control as scientific evidence.
+With the small preregistered sample counts used here, a substantive delta
+inside the observed null spread is described only as noise-sized or unresolved.
+
 Phase attribution uses matched module variants, not clocks embedded in the
 probe. A tactic library may use a baseline; a reify-only module; an input module
 containing the reflected sentence literal; a search module that runs compiled
@@ -849,7 +859,8 @@ The report contains five subsections:
    "inconclusive", with the verdict text). Each fixed registration's
    median per-call time and observed-hash agreement. Proof-track entries report
    all raw rotated fresh-build samples and paired deltas, never a complexity
-   verdict.
+   verdict. When the sweep has a null control, its raw deltas, range, and median
+   precede the substantive proof deltas and remain descriptive only.
 3. **Comparator ratios.** Each comparator named in the per-library
    SPEC ([§Comparator naming](#comparator-naming)) — `gating` and
    `informational` alike — with measured ratios across the full

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -287,15 +287,19 @@ in-process clock, or contain a timing loop. A probe also cannot root any
 - refuse a release-quality verdict on a dirty tree, a busy shared host, a
   timed-out build, or a provenance mismatch.
 
-A proof-track sweep may precede its substantive pairs with a marked
-same-module null control: the exact same committed module is independently
-rebuilt in the reference and candidate roles under the ordinary alternating
-orientation. Its raw signed deltas describe fresh-build noise under that run's
-host conditions. The report records their range and median before interpreting
-the proof deltas, but does not subtract the null median, widen a budget by the
-null range, assign significance, or use the control as scientific evidence.
-With the small preregistered sample counts used here, a substantive delta
-inside the observed null spread is described only as noise-sized or unresolved.
+A proof-track sweep may precede its substantive pairs with one or more marked
+same-module null controls at representative build magnitudes. Each control uses
+the exact same module and axiom policy in both roles, independently rebuilds it
+under the ordinary alternating orientation, and requires an even preregistered
+sample count so each role is built first equally often. Its raw signed deltas
+describe fresh-build noise under that run's host conditions. The report follows
+the manifest's `config.order`, records each control's absolute and relative
+range and median before interpreting a magnitude-comparable proof delta, but
+does not subtract a null median, widen a budget by a null range, assign
+significance, or use a control as scientific evidence. With the small
+preregistered sample counts used here, a substantive delta inside a comparable
+null spread is described only as noise-sized or unresolved; a cheap control
+does not resolve noise for a much more expensive build.
 
 Phase attribution uses matched module variants, not clocks embedded in the
 probe. A tactic library may use a baseline; a reify-only module; an input module
@@ -859,8 +863,9 @@ The report contains five subsections:
    "inconclusive", with the verdict text). Each fixed registration's
    median per-call time and observed-hash agreement. Proof-track entries report
    all raw rotated fresh-build samples and paired deltas, never a complexity
-   verdict. When the sweep has a null control, its raw deltas, range, and median
-   precede the substantive proof deltas and remain descriptive only.
+   verdict. When the sweep has null controls, their raw deltas, absolute and
+   relative ranges, and medians precede the substantive proof deltas in
+   `config.order` and remain descriptive only.
 3. **Comparator ratios.** Each comparator named in the per-library
    SPEC ([§Comparator naming](#comparator-naming)) — `gating` and
    `informational` alike — with measured ratios across the full

--- a/bench/HexRCF/Bench.lean
+++ b/bench/HexRCF/Bench.lean
@@ -185,23 +185,20 @@ private structure DecisionInput where
   sentence : Sentence
   request : String
 
-private def prepDecisionInput (n : Nat) : DecisionInput :=
-  let sentence := prepDecisionCarrierDegree n
+private def prepDecisionInput (n : Nat) (sentence : Sentence) : DecisionInput :=
   let request := decisionRequest sentence
   { degree := n, sentence, request := request.compress }
 
-/-- The five Sentence/request-line pairs are allocated once at module
-initialization. Both timed wrappers read the same degree-keyed record. The
-FLINT timing includes pipe transport and Python JSON decoding, but not Lean
-request construction or serialization. -/
-private initialize decisionInputs : IO.Ref (Array DecisionInput) ←
-  IO.mkRef <| #[16, 20, 24, 28, 32].map prepDecisionInput
+private def prepDecisionCarrierInput (n : Nat) : DecisionInput :=
+  prepDecisionInput n (prepDecisionCarrierDegree n)
 
-/-- The protocol-floor request is compressed once at module initialization, so
-its timed body measures only the same persistent-driver path as the substantive
-FLINT rungs. -/
-private initialize decisionOverheadRequest : IO.Ref String ←
-  IO.mkRef (decisionRequest (.forallReal .tt)).compress
+/-- The five substantive Sentence/request-line pairs and the key-zero protocol
+floor are allocated once at module initialization. Every timed wrapper reads
+the same degree-keyed array. The FLINT timing includes pipe transport and
+Python JSON decoding, but not Lean request construction or serialization. -/
+private initialize decisionInputs : IO.Ref (Array DecisionInput) ←
+  IO.mkRef <| #[prepDecisionInput 0 (.forallReal .tt)] ++
+    #[16, 20, 24, 28, 32].map prepDecisionCarrierInput
 
 private def decisionInput (degree : Nat) : IO DecisionInput := do
   let inputs ← decisionInputs.get
@@ -235,7 +232,7 @@ floor. The request still runs the public `rcf/decide` path, but has no atom or
 root work. Reports retain the raw FLINT medians and subtract this floor only
 when the difference is positive. -/
 def runFlintDecisionOverhead : Unit → IO Bool := fun _ => do
-  runFlintRequest (← decisionOverheadRequest.get)
+  runFlintDecision (← decisionInput 0)
 
 def runLeanDecision16 : Unit → IO Bool := runLeanDecisionAt 16
 def runFlintDecision16 : Unit → IO Bool := runFlintDecisionAt 16

--- a/bench/HexRCF/Bench.lean
+++ b/bench/HexRCF/Bench.lean
@@ -19,7 +19,10 @@ certificates; they never rebuild witnesses in the timed region.
 The informational python-flint comparator covers only the compiled
 carrier-degree decision family at `n = 16, 20, 24, 28, 32`. Both sides consume
 the same precomputed reflected sentence; FLINT receives its precomputed
-version-1 JSON encoding through the shared persistent driver protocol:
+version-1 JSON encoding through the shared persistent driver protocol. A
+separate `runFlintDecisionOverhead` registration sends `∀ x, True` through the
+same path to measure the steady-state protocol floor used by the eventual
+raw/overhead-adjusted ratio report:
 
 ```text
 {"family":"rcf","op":"decide","sentence":<v1 sentence>}
@@ -126,6 +129,12 @@ private def sentenceJson : Sentence → Lean.Json
       ("bounds", boundsJson lower upper),
       ("formula", formulaJson formula)]
 
+private def decisionRequest (sentence : Sentence) : Lean.Json :=
+  .mkObj [
+    ("family", .str "rcf"),
+    ("op", .str "decide"),
+    ("sentence", sentenceJson sentence)]
+
 private def jsonMatches (actual : Lean.Json) (expected : String) : Bool :=
   match Lean.Json.parse expected with
   | .ok value => actual == value
@@ -159,6 +168,10 @@ therefore a build failure rather than a scheduled-host surprise. -/
 #guard jsonMatches (dyadicJson ((Dyadic.ofInt (-1)) >>> (1 : Int))) "[-1,1]"
 #guard jsonMatches (sentenceJson (.forallReal .tt))
   "{\"quantifier\":\"forall_real\",\"bounds\":null,\"formula\":{\"tag\":\"tt\"}}"
+#guard jsonMatches (decisionRequest (.forallReal .tt))
+  "{\"family\":\"rcf\",\"op\":\"decide\",\"sentence\":{\"quantifier\":\"forall_real\",\"bounds\":null,\"formula\":{\"tag\":\"tt\"}}}"
+#guard (decisionRequest (.forallReal .tt)).compress ==
+  "{\"family\":\"rcf\",\"op\":\"decide\",\"sentence\":{\"bounds\":null,\"formula\":{\"tag\":\"tt\"},\"quantifier\":\"forall_real\"}}"
 #guard jsonMatches (sentenceJson (.existsReal .ff))
   "{\"quantifier\":\"exists_real\",\"bounds\":null,\"formula\":{\"tag\":\"ff\"}}"
 #guard jsonMatches (sentenceJson (.forallIoc 0 1 .tt))
@@ -174,10 +187,7 @@ private structure DecisionInput where
 
 private def prepDecisionInput (n : Nat) : DecisionInput :=
   let sentence := prepDecisionCarrierDegree n
-  let request := Lean.Json.mkObj [
-    ("family", .str "rcf"),
-    ("op", .str "decide"),
-    ("sentence", sentenceJson sentence)]
+  let request := decisionRequest sentence
   { degree := n, sentence, request := request.compress }
 
 /-- The five Sentence/request-line pairs are allocated once at module
@@ -186,6 +196,12 @@ FLINT timing includes pipe transport and Python JSON decoding, but not Lean
 request construction or serialization. -/
 private initialize decisionInputs : IO.Ref (Array DecisionInput) ←
   IO.mkRef <| #[16, 20, 24, 28, 32].map prepDecisionInput
+
+/-- The protocol-floor request is compressed once at module initialization, so
+its timed body measures only the same persistent-driver path as the substantive
+FLINT rungs. -/
+private initialize decisionOverheadRequest : IO.Ref String ←
+  IO.mkRef (decisionRequest (.forallReal .tt)).compress
 
 private def decisionInput (degree : Nat) : IO DecisionInput := do
   let inputs ← decisionInputs.get
@@ -198,18 +214,28 @@ private def runLeanDecision (input : DecisionInput) : IO Bool :=
   | some value => return value
   | none => throw <| IO.userError "HexRCF decision comparator: Lean builder failed"
 
-private def runFlintDecision (input : DecisionInput) : IO Bool := do
-  let result ← Hex.BenchOracle.Flint.runLine "rcf" "decide" input.request
+private def runFlintRequest (request : String) : IO Bool := do
+  let result ← Hex.BenchOracle.Flint.runLine "rcf" "decide" request
   match result.getBool? with
   | Except.ok value => return value
   | Except.error message =>
       throw <| IO.userError s!"HexRCF decision comparator: FLINT result was not Boolean: {message}"
+
+private def runFlintDecision (input : DecisionInput) : IO Bool :=
+  runFlintRequest input.request
 
 private def runLeanDecisionAt (degree : Nat) : Unit → IO Bool := fun _ => do
   runLeanDecision (← decisionInput degree)
 
 private def runFlintDecisionAt (degree : Nat) : Unit → IO Bool := fun _ => do
   runFlintDecision (← decisionInput degree)
+
+/-- Minimal valid RCF decision request for the steady-state JSON/pipe/dispatch
+floor. The request still runs the public `rcf/decide` path, but has no atom or
+root work. Reports retain the raw FLINT medians and subtract this floor only
+when the difference is positive. -/
+def runFlintDecisionOverhead : Unit → IO Bool := fun _ => do
+  runFlintRequest (← decisionOverheadRequest.get)
 
 def runLeanDecision16 : Unit → IO Bool := runLeanDecisionAt 16
 def runFlintDecision16 : Unit → IO Bool := runFlintDecisionAt 16
@@ -383,6 +409,17 @@ def decisionConfig : LeanBench.FixedBenchmarkConfig :=
 #guard decisionConfig.warmupFirstIter
 #guard decisionConfig.expectedHash == some (Hashable.hash true)
 
+/-- The protocol floor uses more outer children than a substantive rung so the
+release report gets a stable median without changing the timed inner batch. -/
+def decisionOverheadConfig : LeanBench.FixedBenchmarkConfig :=
+  { decisionConfig with repeats := 11 }
+
+#guard decisionOverheadConfig.repeats == 11
+#guard decisionOverheadConfig.minTotalSeconds == 0.2
+#guard decisionOverheadConfig.warmupFirstIter
+#guard decisionOverheadConfig.expectedHash == some (Hashable.hash true)
+
+setup_fixed_benchmark runFlintDecisionOverhead where decisionOverheadConfig
 setup_fixed_benchmark runLeanDecision16 where decisionConfig
 setup_fixed_benchmark runFlintDecision16 where decisionConfig
 setup_fixed_benchmark runLeanDecision20 where decisionConfig

--- a/progress/20260728T031929Z_rcf-null-control.md
+++ b/progress/20260728T031929Z_rcf-null-control.md
@@ -14,8 +14,8 @@
 
 ## Current frontier
 
-- The null-control infrastructure is implementation-complete and independently
-  audited with no blocker or medium finding.
+- The null-control infrastructure is implemented with focused validation,
+  orientation, sign, schema, and manifest tests.
 - No timing samples or release claims have been produced on this development
   machine.
 

--- a/progress/20260728T031929Z_rcf-null-control.md
+++ b/progress/20260728T031929Z_rcf-null-control.md
@@ -1,0 +1,31 @@
+# HexRCF fresh-build null control
+
+## Accomplished
+
+- Added a marked same-module null-control mode to the reusable fresh-module
+  sweep, with validation that ordinary pairs are distinct and null pairs are
+  exact module identities.
+- Put a `Baseline − Baseline` calibration first in the HexRCF manifest while
+  leaving the fifteen substantive attribution pairs unchanged.
+- Added focused validation, orientation, sign, schema, and manifest tests and
+  documented the control as descriptive noise context only.
+- Passed the 29 focused tests, Python compilation, the full HexRCF proof-probe
+  build, and all repository structural and Mathlib-boundary checks.
+
+## Current frontier
+
+- The null-control infrastructure is implementation-complete and independently
+  audited with no blocker or medium finding.
+- No timing samples or release claims have been produced on this development
+  machine.
+
+## Next step
+
+- Publish the draft evidence PR on top of the reviewed comparator milestone.
+- Once the named benchmark host and HexRealRootsMathlib Phase-4 prerequisite
+  are available, run the preregistered scientific suite and write the report.
+
+## Blockers
+
+- Final `HexRCF.done_through: 4` remains gated on HexRealRootsMathlib Phase 4.
+- Release-quality measurements require a clean, quiescent named benchmark host.

--- a/progress/20260728T033453Z_rcf-flint-floor.md
+++ b/progress/20260728T033453Z_rcf-flint-floor.md
@@ -1,0 +1,33 @@
+# HexRCF FLINT steady-state floor
+
+## Accomplished
+
+- Added `runFlintDecisionOverhead`, an atom-free `∀ x, True` request through
+  the exact warmed `rcf/decide` path used by the five python-flint rungs.
+- Precompressed and guarded the complete request line, shared reply decoding
+  with the substantive rungs, and configured eleven outer repeats for a stable
+  floor median.
+- Documented the conservative adjustment contract: retain every raw ratio,
+  subtract the floor only when positive, and mark floor-dominated rungs instead
+  of manufacturing adjusted values.
+- Built the bench, passed the focused tests and thirty-sentence oracle check,
+  and verified all twenty-one registrations with python-flint 0.9.0.
+
+## Current frontier
+
+- The comparator now contains all wiring needed to collect raw and
+  overhead-adjusted ratios on the named release host.
+- The local diagnostic proof sweep exercised the null and all fifteen
+  substantive pairs end to end, but was explicitly non-release-quality.
+
+## Next step
+
+- Run repository checks from the committed state, update draft PR #9027, and
+  obtain an independent Claude review of the artifact milestone.
+- Land the remaining parent stack while its CI completes.
+
+## Blockers
+
+- Release-quality ratios, complexity verdicts, profiles, and proof samples
+  require the clean named benchmark host.
+- The final phase marker remains gated on HexRealRootsMathlib Phase 4 (#8972).

--- a/progress/20260728T034819Z_rcf-balanced-nulls.md
+++ b/progress/20260728T034819Z_rcf-balanced-nulls.md
@@ -1,0 +1,35 @@
+# HexRCF balanced null calibration
+
+## Accomplished
+
+- Replaced the odd five-round proof sweep with an enforced six-round contract,
+  balancing reference-first and candidate-first builds for every null control.
+- Added a second exact same-module null at the degree-50 tactic magnitude so
+  the cheap baseline spread is not misused as a noise bound for expensive
+  builds.
+- Tightened reusable validation to require identical null axiom policies and
+  added exact sample-count, parity, metadata-spoofing, magnitude, and manifest
+  tests.
+- Defined mechanical comparator-floor thresholds: above 50% is raw-only and
+  ineligible; above 5% within the eligible range requires both raw and adjusted
+  ratios.
+- Routed the floor through the same degree-keyed input lookup as the five FLINT
+  rungs, rebuilt the bench, and verified all twenty-one registrations.
+
+## Current frontier
+
+- The preregistered artifact shape now has two null controls followed by
+  fifteen substantive pairs, with six balanced rounds fixed in code.
+- No release-quality samples have been collected under the revised manifest.
+
+## Next step
+
+- Run the full repository checks from the committed state, update draft PR
+  #9027, and restack it onto the corrected comparator parent.
+- Collect the two null distributions and scientific evidence only on the clean
+  named benchmark host.
+
+## Blockers
+
+- Dedicated-host execution is external to this development worktree.
+- HexRCF Phase 4 remains dependency-gated on #8972.

--- a/scripts/bench/fresh_module_sweep.py
+++ b/scripts/bench/fresh_module_sweep.py
@@ -75,6 +75,7 @@ class SweepSpec:
     output_stem: str
     src_dir: Path = Path("bench")
     extra_sources: tuple[Path, ...] = ()
+    required_samples: int | None = None
 
 
 def parse_args(
@@ -316,13 +317,16 @@ def validate_spec(spec: SweepSpec) -> None:
         raise RuntimeError("fresh-module sweep pair names must be unique")
     measured = probe_modules(spec)
     for pair in spec.pairs:
-        identical = pair.reference.module == pair.candidate.module
+        identical = pair.reference == pair.candidate
         if pair.null_control and not identical:
             raise RuntimeError(
-                f"{pair.name}: null control modules must be identical"
+                f"{pair.name}: null control modules and axiom policies "
+                "must be identical"
             )
-        if not pair.null_control and identical:
+        if not pair.null_control and pair.reference.module == pair.candidate.module:
             raise RuntimeError(f"{pair.name}: reference and candidate are identical")
+    if spec.required_samples is not None and spec.required_samples < 1:
+        raise RuntimeError("fresh-module sweep required_samples must be positive")
     target = _ExeTarget(spec.probe_target, "", spec.src_dir)
     package_root = ROOT / ".lake" / "packages"
     for root_module in measured:
@@ -617,6 +621,16 @@ def run_cli(
 ) -> int:
     validate_spec(spec)
     args = parse_args(spec.description, argv)
+    if spec.required_samples is not None and args.samples != spec.required_samples:
+        raise RuntimeError(
+            f"this sweep requires --samples {spec.required_samples}, "
+            f"got {args.samples}"
+        )
+    if any(pair.null_control for pair in spec.pairs) and args.samples % 2 != 0:
+        raise RuntimeError(
+            "null-control sweeps require an even --samples so pair "
+            "orientation is balanced"
+        )
     warm_imports(spec, args.warm_timeout)
     env = environment()
     validity_exceptions: list[str] = []

--- a/scripts/bench/fresh_module_sweep.py
+++ b/scripts/bench/fresh_module_sweep.py
@@ -60,6 +60,7 @@ class ProbePair:
     reference: ProbeModule
     candidate: ProbeModule
     metadata: dict[str, object]
+    null_control: bool = False
 
 
 @dataclass(frozen=True)
@@ -315,7 +316,12 @@ def validate_spec(spec: SweepSpec) -> None:
         raise RuntimeError("fresh-module sweep pair names must be unique")
     measured = probe_modules(spec)
     for pair in spec.pairs:
-        if pair.reference.module == pair.candidate.module:
+        identical = pair.reference.module == pair.candidate.module
+        if pair.null_control and not identical:
+            raise RuntimeError(
+                f"{pair.name}: null control modules must be identical"
+            )
+        if not pair.null_control and identical:
             raise RuntimeError(f"{pair.name}: reference and candidate are identical")
     target = _ExeTarget(spec.probe_target, "", spec.src_dir)
     package_root = ROOT / ".lake" / "packages"
@@ -560,6 +566,7 @@ def summarize(
         deltas = [int(sample["signed_wall_delta_nanos"]) for sample in samples]
         result: dict[str, object] = {
             **pair.metadata,
+            "null_control": pair.null_control,
             "reference": {
                 "module": pair.reference.module,
                 "expected_axioms": pair.reference.expected_axioms,

--- a/scripts/bench/hexrcf_proof_sweep.py
+++ b/scripts/bench/hexrcf_proof_sweep.py
@@ -72,6 +72,18 @@ SPEC = SweepSpec(
             {
                 "component": "fresh-build-noise",
                 "interpretation": "calibration-only",
+                "magnitude": "baseline",
+            },
+            null_control=True,
+        ),
+        ProbePair(
+            "degree50-tactic-null",
+            ProbeModule("HexRCF.ProofProbe.Degree50.Tactic", ALLOWED_AXIOMS),
+            ProbeModule("HexRCF.ProofProbe.Degree50.Tactic", ALLOWED_AXIOMS),
+            {
+                "component": "fresh-build-noise",
+                "interpretation": "calibration-only",
+                "magnitude": "degree50-tactic",
             },
             null_control=True,
         ),
@@ -89,6 +101,7 @@ SPEC = SweepSpec(
         Path("SPEC/benchmarking.md"),
         Path("SPEC/Libraries/hex-rcf.md"),
     ),
+    required_samples=6,
 )
 
 

--- a/scripts/bench/hexrcf_proof_sweep.py
+++ b/scripts/bench/hexrcf_proof_sweep.py
@@ -65,12 +65,22 @@ def case_pairs(case: str, module_case: str, budget_ms: int) -> tuple[ProbePair, 
 SPEC = SweepSpec(
     description=__doc__ or "HexRCF fresh-module proof probes",
     pairs=(
+        ProbePair(
+            "fresh-build-null",
+            BASELINE,
+            BASELINE,
+            {
+                "component": "fresh-build-noise",
+                "interpretation": "calibration-only",
+            },
+            null_control=True,
+        ),
         *case_pairs("quadratic", "Quadratic", 100),
         *case_pairs("degree10", "Degree10", 1_000),
         *case_pairs("degree50", "Degree50", 30_000),
     ),
     probe_target="HexRCFProofProbe",
-    schema="hexrcf-proof-probes-v1",
+    schema="hexrcf-proof-probes-v2",
     measurement="paired-fresh-module-olean-wall-v1",
     output_stem="hexrcf-proof-probes",
     extra_sources=(

--- a/scripts/bench/test_fresh_module_sweep.py
+++ b/scripts/bench/test_fresh_module_sweep.py
@@ -247,6 +247,12 @@ class PairingTests(unittest.TestCase):
             sweep.ordered_modules(pair, 1),
             [("candidate", module), ("reference", module)],
         )
+        first_roles = [
+            sweep.ordered_modules(pair, round_index)[0][0]
+            for round_index in range(6)
+        ]
+        self.assertEqual(first_roles.count("reference"), 3)
+        self.assertEqual(first_roles.count("candidate"), 3)
 
     def test_null_summary_preserves_candidate_minus_reference_sign(self) -> None:
         module = sweep.ProbeModule("Probe.Baseline")
@@ -283,6 +289,30 @@ class PairingTests(unittest.TestCase):
         self.assertTrue(summary["null_control"])
         self.assertEqual(summary["signed_wall_delta_nanos"], [-20])
         self.assertEqual(summary["median_signed_wall_delta_nanos"], -20)
+
+    def test_summary_metadata_cannot_spoof_null_control(self) -> None:
+        module = sweep.ProbeModule("Probe.Baseline")
+        pair = sweep.ProbePair(
+            "null", module, module, {"null_control": False}, null_control=True
+        )
+        spec = sweep.SweepSpec(
+            description="null",
+            pairs=(pair,),
+            probe_target="Probe",
+            schema="test",
+            measurement="test",
+            output_stem="test",
+        )
+        rows = {
+            pair.name: [{
+                "reference": {"wall_nanos": 1, "peak_rss_kb": None},
+                "candidate": {"wall_nanos": 1, "peak_rss_kb": None},
+                "signed_wall_delta_nanos": 0,
+            }]
+        }
+        with mock.patch.object(sweep, "artifact_sizes", return_value={}):
+            summary = sweep.summarize(spec, rows)[pair.name]
+        self.assertTrue(summary["null_control"])
 
 
 class HarnessValidationTests(unittest.TestCase):
@@ -378,6 +408,25 @@ class HarnessValidationTests(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "must be identical"):
             sweep.validate_spec(spec)
 
+    def test_null_control_requires_identical_axiom_policies(self) -> None:
+        pair = sweep.ProbePair(
+            "null",
+            sweep.ProbeModule("Probe.Same"),
+            sweep.ProbeModule("Probe.Same", EXPECTED_AXIOMS),
+            {},
+            null_control=True,
+        )
+        spec = sweep.SweepSpec(
+            description="invalid null policy",
+            pairs=(pair,),
+            probe_target="Probe",
+            schema="test",
+            measurement="test",
+            output_stem="test",
+        )
+        with self.assertRaisesRegex(RuntimeError, "axiom policies"):
+            sweep.validate_spec(spec)
+
     def test_same_module_null_control_is_valid(self) -> None:
         module = sweep.ProbeModule("Probe.Same")
         pair = sweep.ProbePair("null", module, module, {}, null_control=True)
@@ -394,6 +443,35 @@ class HarnessValidationTests(unittest.TestCase):
                 mock.patch.object(Path, "is_file", return_value=True), \
                 mock.patch.object(sweep, "_parse_imports", return_value=[]):
             sweep.validate_spec(spec)
+
+    def test_required_sample_count_is_enforced_before_warmup(self) -> None:
+        spec = sweep.SweepSpec(
+            description="required samples",
+            pairs=(PAIR,),
+            probe_target="Probe",
+            schema="test",
+            measurement="test",
+            output_stem="test",
+            required_samples=6,
+        )
+        with mock.patch.object(sweep, "validate_spec"):
+            with self.assertRaisesRegex(RuntimeError, "requires --samples 6"):
+                sweep.run_cli(spec, CALLER, ["--samples", "4"])
+
+    def test_null_control_requires_even_sample_count(self) -> None:
+        module = sweep.ProbeModule("Probe.Same")
+        pair = sweep.ProbePair("null", module, module, {}, null_control=True)
+        spec = sweep.SweepSpec(
+            description="balanced null",
+            pairs=(pair,),
+            probe_target="Probe",
+            schema="test",
+            measurement="test",
+            output_stem="test",
+        )
+        with mock.patch.object(sweep, "validate_spec"):
+            with self.assertRaisesRegex(RuntimeError, "even --samples"):
+                sweep.run_cli(spec, CALLER, ["--samples", "5"])
 
     def test_transitive_measured_module_import_fails_closed(self) -> None:
         pair = sweep.ProbePair(

--- a/scripts/bench/test_fresh_module_sweep.py
+++ b/scripts/bench/test_fresh_module_sweep.py
@@ -202,6 +202,7 @@ class PairingTests(unittest.TestCase):
         self.assertEqual(
             summary[PAIR.name]["signed_wall_delta_nanos"], [25]
         )
+        self.assertFalse(summary[PAIR.name]["null_control"])
 
     def test_axiom_policy_is_per_module(self) -> None:
         sample = {
@@ -232,6 +233,56 @@ class PairingTests(unittest.TestCase):
             [role for role, _module in sweep.ordered_modules(PAIR, 1)],
             ["candidate", "reference"],
         )
+
+    def test_null_pair_orientation_alternates_with_one_module(self) -> None:
+        module = sweep.ProbeModule("Probe.Baseline")
+        pair = sweep.ProbePair(
+            "null", module, module, {}, null_control=True
+        )
+        self.assertEqual(
+            sweep.ordered_modules(pair, 0),
+            [("reference", module), ("candidate", module)],
+        )
+        self.assertEqual(
+            sweep.ordered_modules(pair, 1),
+            [("candidate", module), ("reference", module)],
+        )
+
+    def test_null_summary_preserves_candidate_minus_reference_sign(self) -> None:
+        module = sweep.ProbeModule("Probe.Baseline")
+        pair = sweep.ProbePair(
+            "null", module, module, {}, null_control=True
+        )
+        spec = sweep.SweepSpec(
+            description="null",
+            pairs=(pair,),
+            probe_target="Probe",
+            schema="test",
+            measurement="test",
+            output_stem="test",
+        )
+        rows = {
+            pair.name: [{
+                "round": 1,
+                "build_order": ["candidate", "reference"],
+                "reference": {
+                    "wall_nanos": 120,
+                    "peak_rss_kb": None,
+                    "axioms": None,
+                },
+                "candidate": {
+                    "wall_nanos": 100,
+                    "peak_rss_kb": None,
+                    "axioms": None,
+                },
+                "signed_wall_delta_nanos": -20,
+            }]
+        }
+        with mock.patch.object(sweep, "artifact_sizes", return_value={}):
+            summary = sweep.summarize(spec, rows)[pair.name]
+        self.assertTrue(summary["null_control"])
+        self.assertEqual(summary["signed_wall_delta_nanos"], [-20])
+        self.assertEqual(summary["median_signed_wall_delta_nanos"], -20)
 
 
 class HarnessValidationTests(unittest.TestCase):
@@ -293,6 +344,55 @@ class HarnessValidationTests(unittest.TestCase):
             output_stem="test",
         )
         with self.assertRaisesRegex(RuntimeError, "must be unique"):
+            sweep.validate_spec(spec)
+
+    def test_ordinary_identical_pair_fails_closed(self) -> None:
+        module = sweep.ProbeModule("Probe.Same")
+        spec = sweep.SweepSpec(
+            description="ordinary identical",
+            pairs=(sweep.ProbePair("same", module, module, {}),),
+            probe_target="Probe",
+            schema="test",
+            measurement="test",
+            output_stem="test",
+        )
+        with self.assertRaisesRegex(RuntimeError, "are identical"):
+            sweep.validate_spec(spec)
+
+    def test_null_control_requires_identical_modules(self) -> None:
+        pair = sweep.ProbePair(
+            "null",
+            sweep.ProbeModule("Probe.Reference"),
+            sweep.ProbeModule("Probe.Candidate"),
+            {},
+            null_control=True,
+        )
+        spec = sweep.SweepSpec(
+            description="invalid null",
+            pairs=(pair,),
+            probe_target="Probe",
+            schema="test",
+            measurement="test",
+            output_stem="test",
+        )
+        with self.assertRaisesRegex(RuntimeError, "must be identical"):
+            sweep.validate_spec(spec)
+
+    def test_same_module_null_control_is_valid(self) -> None:
+        module = sweep.ProbeModule("Probe.Same")
+        pair = sweep.ProbePair("null", module, module, {}, null_control=True)
+        spec = sweep.SweepSpec(
+            description="valid null",
+            pairs=(pair,),
+            probe_target="Probe",
+            schema="test",
+            measurement="test",
+            output_stem="test",
+        )
+        source = Path("/unused/Probe/Same.lean")
+        with mock.patch.object(sweep, "probe_source", return_value=source), \
+                mock.patch.object(Path, "is_file", return_value=True), \
+                mock.patch.object(sweep, "_parse_imports", return_value=[]):
             sweep.validate_spec(spec)
 
     def test_transitive_measured_module_import_fails_closed(self) -> None:

--- a/scripts/bench/test_hexrcf_proof_sweep.py
+++ b/scripts/bench/test_hexrcf_proof_sweep.py
@@ -11,15 +11,31 @@ from scripts.bench import hexrcf_proof_sweep as rcf
 
 class ManifestTests(unittest.TestCase):
     def test_five_pairs_per_fixed_case(self) -> None:
-        self.assertEqual(len(rcf.SPEC.pairs), 15)
+        self.assertEqual(len(rcf.SPEC.pairs), 16)
         self.assertEqual(
             [pair.name for pair in rcf.SPEC.pairs],
-            [
+            ["fresh-build-null", *[
                 f"{case}-{component}"
                 for case in ("quadratic", "degree10", "degree50")
                 for component in ("reify", "search", "literal", "replay", "tactic")
-            ],
+            ]],
         )
+
+    def test_null_control_is_first_and_uses_exact_module_identity(self) -> None:
+        null = rcf.SPEC.pairs[0]
+        self.assertTrue(null.null_control)
+        self.assertIs(null.reference, rcf.BASELINE)
+        self.assertIs(null.candidate, rcf.BASELINE)
+        self.assertEqual(null.metadata["interpretation"], "calibration-only")
+
+    def test_substantive_pairs_remain_five_per_case(self) -> None:
+        substantive = [pair for pair in rcf.SPEC.pairs if not pair.null_control]
+        self.assertEqual(len(substantive), 15)
+        for case in ("quadratic", "degree10", "degree50"):
+            self.assertEqual(
+                len([pair for pair in substantive if pair.name.startswith(case)]),
+                5,
+            )
 
     def test_only_replay_and_tactic_report_axioms(self) -> None:
         for pair in rcf.SPEC.pairs:

--- a/scripts/bench/test_hexrcf_proof_sweep.py
+++ b/scripts/bench/test_hexrcf_proof_sweep.py
@@ -10,23 +10,30 @@ from scripts.bench import hexrcf_proof_sweep as rcf
 
 
 class ManifestTests(unittest.TestCase):
-    def test_five_pairs_per_fixed_case(self) -> None:
-        self.assertEqual(len(rcf.SPEC.pairs), 16)
+    def test_manifest_is_two_nulls_plus_five_pairs_per_case(self) -> None:
+        self.assertEqual(len(rcf.SPEC.pairs), 17)
         self.assertEqual(
             [pair.name for pair in rcf.SPEC.pairs],
-            ["fresh-build-null", *[
+            ["fresh-build-null", "degree50-tactic-null", *[
                 f"{case}-{component}"
                 for case in ("quadratic", "degree10", "degree50")
                 for component in ("reify", "search", "literal", "replay", "tactic")
             ]],
         )
 
-    def test_null_control_is_first_and_uses_exact_module_identity(self) -> None:
-        null = rcf.SPEC.pairs[0]
-        self.assertTrue(null.null_control)
-        self.assertIs(null.reference, rcf.BASELINE)
-        self.assertIs(null.candidate, rcf.BASELINE)
-        self.assertEqual(null.metadata["interpretation"], "calibration-only")
+    def test_null_controls_are_first_and_use_exact_module_identity(self) -> None:
+        baseline, expensive = rcf.SPEC.pairs[:2]
+        self.assertTrue(baseline.null_control)
+        self.assertIs(baseline.reference, rcf.BASELINE)
+        self.assertIs(baseline.candidate, rcf.BASELINE)
+        self.assertEqual(baseline.metadata["interpretation"], "calibration-only")
+        self.assertTrue(expensive.null_control)
+        self.assertEqual(expensive.reference, expensive.candidate)
+        self.assertEqual(expensive.reference.expected_axioms, rcf.ALLOWED_AXIOMS)
+        self.assertEqual(expensive.metadata["magnitude"], "degree50-tactic")
+
+    def test_sample_count_is_preregistered_and_balanced(self) -> None:
+        self.assertEqual(rcf.SPEC.required_samples, 6)
 
     def test_substantive_pairs_remain_five_per_case(self) -> None:
         substantive = [pair for pair in rcf.SPEC.pairs if not pair.null_control]
@@ -39,6 +46,9 @@ class ManifestTests(unittest.TestCase):
 
     def test_only_replay_and_tactic_report_axioms(self) -> None:
         for pair in rcf.SPEC.pairs:
+            if pair.null_control:
+                self.assertEqual(pair.reference, pair.candidate, pair.name)
+                continue
             self.assertIsNone(pair.reference.expected_axioms, pair.name)
             expected = (
                 rcf.ALLOWED_AXIOMS

--- a/scripts/oracle/test_rcf_flint_bench.py
+++ b/scripts/oracle/test_rcf_flint_bench.py
@@ -18,15 +18,23 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 class RcfFlintBenchTests(unittest.TestCase):
     def test_public_decider_handles_constant_sentence(self) -> None:
         sentence = {
-            "quantifier": "exists_real",
+            "quantifier": "forall_real",
             "bounds": None,
             "formula": {"tag": "tt"},
         }
         with (
-            mock.patch.object(rcf_flint, "_carrier_factors", return_value=[]),
-            mock.patch.object(rcf_flint, "_certified_roots", return_value=[]),
+            mock.patch.object(
+                rcf_flint,
+                "_carrier_factors",
+                return_value=[],
+            ) as carrier,
+            mock.patch.object(
+                rcf_flint, "_certified_roots", return_value=[]
+            ) as roots,
         ):
             self.assertTrue(rcf_flint.decide_sentence(sentence))
+        carrier.assert_called_once_with(sentence["formula"])
+        roots.assert_called_once_with([], ())
 
     def test_driver_delegates_to_shared_decider(self) -> None:
         sentence = {
@@ -91,6 +99,13 @@ class RcfFlintBenchTests(unittest.TestCase):
             for engine in ("Lean", "Flint")
         ]
         self.assertCountEqual(names, expected)
+        self.assertEqual(
+            source.count(
+                "setup_fixed_benchmark runFlintDecisionOverhead where "
+                "decisionOverheadConfig"
+            ),
+            1,
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/oracle/test_rcf_flint_bench.py
+++ b/scripts/oracle/test_rcf_flint_bench.py
@@ -84,28 +84,21 @@ class RcfFlintBenchTests(unittest.TestCase):
         self.assertIn("missing object 'sentence'", replies[1]["error"])
         self.assertEqual(replies[2], {"ok": True, "result": True})
 
-    def test_exact_five_paired_registrations(self) -> None:
+    def test_exact_fixed_registration_mapping(self) -> None:
         source = (REPO_ROOT / "bench" / "HexRCF" / "Bench.lean").read_text(
             encoding="utf-8"
         )
-        names = re.findall(
-            r"^setup_fixed_benchmark (run(?:Lean|Flint)Decision\d+) where",
-            source,
-            re.MULTILINE,
+        registrations = re.findall(
+            r"^setup_fixed_benchmark (\w+) where (\w+)$", source, re.MULTILINE
         )
-        expected = [
-            f"run{engine}Decision{degree}"
+        expected = {
+            (f"run{engine}Decision{degree}", "decisionConfig")
             for degree in (16, 20, 24, 28, 32)
             for engine in ("Lean", "Flint")
-        ]
-        self.assertCountEqual(names, expected)
-        self.assertEqual(
-            source.count(
-                "setup_fixed_benchmark runFlintDecisionOverhead where "
-                "decisionOverheadConfig"
-            ),
-            1,
-        )
+        }
+        expected.add(("runFlintDecisionOverhead", "decisionOverheadConfig"))
+        self.assertEqual(set(registrations), expected)
+        self.assertEqual(len(registrations), len(expected))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add exact same-module null controls at baseline and degree-50-tactic build magnitudes before the fifteen HexRCF proof-attribution pairs
- enforce six rounds so reference-first and candidate-first orientation is balanced, and pin that preregistered sample count in code
- preserve raw candidate-minus-reference deltas and mark both controls explicitly in the v2 artifact schema
- add `runFlintDecisionOverhead`, an eleven-repeat atom-free request through the exact warmed and degree-keyed `rcf/decide` path
- define mechanical ratio handling: floor above 50% is raw-only/ineligible; floor above 5% inside the eligible range requires raw and adjusted ratios
- add focused harness, manifest, schema, and overhead tests

## Validation

- 34 fresh-module/manifest tests and 5 focused FLINT comparator tests
- `lake build HexRCFProofProbe`
- `lake build hexrcf_bench`
- all 21 benchmark registrations through `verify` with python-flint 0.9.0
- all 30 RCF oracle sentences
- copyright, line-count, DAG, release-manifest, trust-surface, Phase-4, and Mathlib-free bench checks
- independent Sol preflights on the null and floor design
- independent Claude review findings addressed: balanced rounds, magnitude-matched second null, enforced sample count, numeric floor threshold, exact registration mapping, and full null identity
- CI green on the final head

## Scientific follow-up

This PR intentionally contains no release timing artifact, report, or phase-marker change. The completed six-round local diagnostic was rejected by its own provenance checks because the host was dirty and busy. Issue #9025 remains open for the clean named-host runs, artifact interpretation, report, profiles, and the dependency-gated HexRCF Phase-4 marker.

Contributes to #9025.