### PR TITLE
docs(factor): clarify tactics and factorization API

### DIFF
--- a/HexBerlekamp/FactorPolyElab.lean
+++ b/HexBerlekamp/FactorPolyElab.lean
@@ -211,52 +211,53 @@ syntax (name := factorPolyTerm) "factor_poly" term:max : term
         Term.ensureHasType expectedType? e
     | _ => Elab.throwUnsupportedSyntax
 
-/-- Destructure an emitted `Factored.mk` application into `scalar`/`factors`
-`let` bindings plus `factors_mul`/`factors_irred` hypotheses (the FpPoly
-shape carries the modulus and instance; providers may emit other
-`*.Factored.mk` shapes with the same final four fields, e.g.
-`Hex.ZPoly.Factored.mk`). Unrecognized shapes land as a single `factored`
-hypothesis. Shared by the `factor_poly` and `factor_poly!` tactic forms. -/
+/-- Introduce the four fields of a recognized factorization result as
+`scalar`/`factors` `let` bindings plus `factors_mul`/`factors_irred`
+hypotheses. Inspecting the result type rather than the emitted constructor
+lets provider assemblers return opaque `Hex.FactoredPoly` terms while exposing
+the same tactic interface as the executable `FpPoly` and `ZPoly` providers.
+Unrecognized provider result types land as a single `factored` hypothesis.
+Shared by the `factor_poly` and `factor_poly!` tactic forms. -/
 meta def introFactored (e : Expr) : Tactic.TacticM Unit := do
-  let args := e.getAppArgs
-  let fields? :
-      Option (Name × Expr × Expr × Expr × Expr × Expr × Expr) :=
-    if e.getAppFn.isConstOf ``Hex.FpPoly.Factored.mk && args.size == 7 then
-      some (``Hex.FpPoly.Irreducible,
-        Hex.CertReify.zmodType args[0]! args[1]!,
-        Hex.CertReify.fpPolyType args[0]! args[1]!,
-        args[3]!, args[4]!, args[5]!, args[6]!)
-    else if e.getAppFn.isConstOf `Hex.ZPoly.Factored.mk &&
-        args.size == 5 then
-      some (`Hex.ZPoly.Irreducible, mkConst ``Int, mkConst `Hex.ZPoly,
-        args[1]!, args[2]!, args[3]!, args[4]!)
+  let ty ← whnf (← inferType e)
+  let args := ty.getAppArgs
+  let shape? : Option (Name × Name × Name × Name) :=
+    if ty.getAppFn.isConstOf ``Hex.FpPoly.Factored && args.size == 3 then
+      some (``Hex.FpPoly.Factored.scalar, ``Hex.FpPoly.Factored.factors,
+        ``Hex.FpPoly.Factored.factors_mul, ``Hex.FpPoly.Factored.factors_irred)
+    else if ty.getAppFn.isConstOf `Hex.ZPoly.Factored && args.size == 1 then
+      some (`Hex.ZPoly.Factored.scalar, `Hex.ZPoly.Factored.factors,
+        `Hex.ZPoly.Factored.factors_mul, `Hex.ZPoly.Factored.factors_irred)
+    else if ty.getAppFn.isConstOf `Hex.FactoredPoly && args.size == 3 then
+      some (`Hex.FactoredPoly.scalar, `Hex.FactoredPoly.factors,
+        `Hex.FactoredPoly.factors_mul, `Hex.FactoredPoly.factors_irred)
     else
       none
-  let some (predName, scalarTy, polyTy, scalarE, factorsE, hmulE, hirredE) :=
-      fields? |
+  let some (scalarName, factorsName, mulName, irredName) := shape? |
     -- Unrecognized provider result: fall back to a plain `have`.
     Tactic.liftMetaTactic fun g => do
-      let ty ← inferType e
       let (_, g) ← (← g.assert `factored ty e).intro1P
       return [g]
-  let fE := args[if args.size == 7 then 2 else 0]!
+  let scalarE ← mkAppM scalarName #[e]
+  let factorsE ← mkAppM factorsName #[e]
+  let hmulE ← mkAppM mulName #[e]
+  let hirredE ← mkAppM irredName #[e]
+  let scalarTy ← inferType scalarE
+  let factorsTy ← inferType factorsE
   Tactic.liftMetaTactic fun g => do
-    let listTy := mkApp (mkConst ``List [Level.zero]) polyTy
     let (fvS, g) ← (← g.define `scalar scalarTy scalarE).intro1P
-    let (fvF, g) ← (← g.define `factors listTy factorsE).intro1P
+    let (fvF, g) ← (← g.define `factors factorsTy factorsE).intro1P
     g.withContext do
       let sE := mkFVar fvS
       let fsE := mkFVar fvF
-      let lhs ← mkAppM ``HMul.hMul
-        #[← mkAppM ``Hex.DensePoly.C #[sE], ← mkAppM ``List.prod #[fsE]]
-      let hmulTy ← mkAppM ``Eq #[lhs, fE]
+      let replaceFields (x : Expr) : Option Expr :=
+        if x == scalarE then some sE
+        else if x == factorsE then some fsE
+        else none
+      let hmulTy := (← inferType hmulE).replace replaceFields
       let (_, g) ← (← g.assert `factors_mul hmulTy hmulE).intro1P
       g.withContext do
-        let hirredTy ←
-          withLocalDeclD `q polyTy fun q => do
-            let mem ← mkAppM ``Membership.mem #[fsE, q]
-            let irred ← mkAppM predName #[q]
-            mkForallFVars #[q] (← mkArrow mem irred)
+        let hirredTy := (← inferType hirredE).replace replaceFields
         let (_, g) ← (← g.assert `factors_irred hirredTy hirredE).intro1P
         return [g]
 

--- a/HexBerlekamp/RabinSoundness/RabinShape.lean
+++ b/HexBerlekamp/RabinSoundness/RabinShape.lean
@@ -447,7 +447,7 @@ private theorem eq_of_dvd_of_size_eq_of_monic
   rw [show (DensePoly.C (1 : ZMod64 p) : FpPoly p) = 1 from rfl, FpPoly.mul_one]
 
 /-- The variable prime-field product identity: the canonical product over field
-constants equals `xPowSubX 1`. This is the headline deliverable for #4085. -/
+constants equals `xPowSubX 1`. -/
 theorem primeFieldProduct_X_eq_xPowSubX :
     (ZMod64.values p).foldl
       (fun acc c => acc * (FpPoly.X - FpPoly.C c)) 1 =

--- a/HexBerlekampMathlib/FactorPolyTests.lean
+++ b/HexBerlekampMathlib/FactorPolyTests.lean
@@ -33,10 +33,13 @@ example : True := by
     factor_poly ((X + 1) * (X + 1) * (X ^ 2 + 2) * 3 : Polynomial (ZMod 5))
   trivial
 
--- Tactic form: providers emitting `FactoredPoly.ofFp` land as a single
--- `factored` hypothesis.
+-- Tactic form: Mathlib providers expose the same four local names as the
+-- executable providers.
 example : True := by
   factor_poly ((X + 1) * (X + 1) * (X ^ 2 + 2) * 3 : Polynomial (ZMod 5))
+  have : factors.length = 3 := rfl
+  have := factors_mul
+  have := factors_irred
   exact True.intro
 
 -- Negation and subtraction arms; `Polynomial.C` coefficients.

--- a/HexBerlekampZassenhaus/FactorEntryPoints.lean
+++ b/HexBerlekampZassenhaus/FactorEntryPoints.lean
@@ -1478,17 +1478,17 @@ def factorTraced (f : ZPoly) : Factorization × FactorTrace :=
       | none => (factorTrial f, { trace with tier := "trial" })  -- totality backstop
 
 /--
-The public factorisation (SPEC *Hybrid dispatch*). There is no up-front tier
-selection: the classical tier runs first under a level-aware subset budget and
-its answer is accepted only when the packed product reconstructs `f`; on decline
-(budget exhaustion or no admissible prime) the CLD lattice tier runs at the
-lattice precision cap under the same self-certifying acceptance check; and any
-residual falls through to the `factorTrial` totality backstop, which is
-`choosePrimeData?`-independent and so makes `factorize` unconditionally correct
-on every `ZPoly`. Total.
+The public total factorisation of a {name}`Hex.ZPoly`.
 
-Lives in the `ZPoly` namespace so the public surface is dot-notation on a
-polynomial: `f.factorize`.
+{name}`Hex.factorClassical` first tries a bounded subset search. If it declines,
+{name}`Hex.factorLattice` tries CLD lattice recombination. An answer from either
+optional tier is accepted only when {name}`Hex.Factorization.product`
+reconstructs `f`. If both tiers decline, {name}`Hex.factorTrial` supplies the
+total backstop. The trial tier does not depend on {name}`Hex.choosePrimeData?`,
+so this function still returns a factorisation when prime selection fails.
+
+This definition lives in the {name}`Hex.ZPoly` namespace, so it can be called
+with dot notation as `f.factorize`.
 -/
 @[expose]
 def ZPoly.factorize (f : ZPoly) : Factorization :=
@@ -1553,7 +1553,7 @@ of `factorFactors`-consuming structural lemmas.
 Each non-backstop tier (`factorClassicalFactorsWithBound` / lattice) is accepted
 only when its `factorizationOfFactors`-packed answer reconstructs `f` (the
 self-certifying guard mirrored here), and every fallback is the proven
-`factorTrial` backstop's raw array. The headline contract
+`factorTrial` backstop's raw array. The identity
 `ZPoly.factorize f = factorizationOfFactors f (factorFactors f)` is
 `factorize_eq_factorizationOfFactors`. -/
 def factorFactors (f : ZPoly) : Array ZPoly :=
@@ -1571,8 +1571,8 @@ def factorFactors (f : ZPoly) : Array ZPoly :=
 /-- The cost-based hybrid factorisation is the `factorizationOfFactors`-packed
 form of its raw factor array `factorFactors`. Every tier (classical /
 lattice / trial) assembles via `factorizationOfFactors f`, so this bridge lets
-the structural `factorizationOfFactors_entry_*` lemmas re-point every
-`factorize`-level entry contract onto the hybrid. -/
+the structural `factorizationOfFactors_entry_*` lemmas apply to every entry
+of the hybrid result. -/
 theorem factorize_eq_factorizationOfFactors (f : ZPoly) :
     ZPoly.factorize f = factorizationOfFactors f (factorFactors f) := by
   have htrial : factorTrial f =
@@ -1719,7 +1719,7 @@ private theorem content_ne_zero_of_zpoly_ne_zero (f : ZPoly) (hf : f ≠ 0) :
   rw [hzero] at hreconstruct
   exact hreconstruct.symm
 
-private theorem signedContentScalarContract_eq_zero_iff (f : ZPoly) :
+private theorem signedContentScalar_eq_zero_iff (f : ZPoly) :
     (if f = 0 then
         0
       else if DensePoly.leadingCoeff f < 0 then
@@ -1774,7 +1774,7 @@ theorem factorizationOfFactors_scalar_eq_zero_iff
     (f : ZPoly) (rawFactors : Array ZPoly) :
     (factorizationOfFactors f rawFactors).scalar = 0 ↔ f = 0 := by
   rw [factorizationOfFactors_scalar]
-  exact signedContentScalarContract_eq_zero_iff f
+  exact signedContentScalar_eq_zero_iff f
 
 /-- Scalar contract for the default public factorization entry point. -/
 theorem factorize_scalar (f : ZPoly) :

--- a/HexBerlekampZassenhaus/FactorProvider.lean
+++ b/HexBerlekampZassenhaus/FactorProvider.lean
@@ -189,8 +189,8 @@ meta def balancedDecline (tactic : String) (q : Hex.ZPoly) : MetaM MessageData :
       bridge's multi-prime degree-obstruction certificates may certify it \
       — import HexBerlekampZassenhausMathlib."
 
-/-- The opaque-input contract check: the user's term must be definitionally
-transparent down to its evaluated literal. -/
+/-- Checks that the user's term is definitionally transparent down to its
+evaluated literal. -/
 meta def checkTransparent (tactic : String) (f : Hex.ZPoly) (fE : Expr) :
     MetaM Expr := do
   let fLit ← Hex.CertReify.reifyZPoly f

--- a/HexBerlekampZassenhaus/ProductProofs.lean
+++ b/HexBerlekampZassenhaus/ProductProofs.lean
@@ -346,12 +346,12 @@ theorem factorTrialWithBound_product (f : ZPoly) (B : Nat) :
           exact factorTrialWithBound_product_of_trial_branch
             f B hf hdeg hquad
 
-/-- Product contract for the public trial-division slow-path entry point. -/
+/-- The public trial-division entry point reconstructs its input. -/
 theorem factorTrial_product (f : ZPoly) :
     Factorization.product (factorTrial f) = f := by
   exact factorTrialWithBound_product f (ZPoly.defaultFactorCoeffBound f)
 
-/-- Product contract for the public total factorization entry point. Holds
+/-- The public total factorization reconstructs its input. This holds
 unconditionally: each non-backstop tier's result is accepted only when it
 reconstructs `f` (the self-certifying guard in `factorTraced`), and every
 fallback is the proven `factorTrial` backstop. -/

--- a/HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md
+++ b/HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md
@@ -636,14 +636,14 @@ B8. **Verification certifies `L' = W` (BHKS Lemma 3.4) — the load-bearing obli
     *Sketch:* The classes refine (or equal) the irreducible-factor partition because every class union must be an integer-factor support (else its product wouldn't lift to a true integer divisor). Pathway: import `Polynomial.UniqueFactorizationMonoid` over `Int` from Mathlib for uniqueness-of-factorisation; use `Polynomial.Gauss` infrastructure for content/primitivity; the verified divisibility witnesses + uniqueness give the irreducibility conclusion. This is the theorem that *justifies the algorithm's stopping criterion*; B7 alone is too weak. **Read BHKS Lemma 3.4 in §3 before attempting.**
 
 B9. **Conditional correctness of `factorLattice`.** `factorLattice f = some gs ⟹ gs is the irreducible factorisation of f` (up to associates and ordering).
-    *Sketch:* the tier has two `some` exits. Recombination exit: `some gs` is returned only when (i) every candidate verified via exact division and (ii) `∏ gs = f`; by B8, (i) + (ii) together imply `L' = W` and `gs = irreducible factors of f`. Certificate exit: at cap precision the single all-ones equivalence class certifies the core irreducible (the forward count bound B6-side plus the class partition give exactly one factor), so `some #[core]` is correct. This is the tier's headline theorem; the proof is one application of B8 per exit.
+    *Sketch:* the tier has two `some` exits. Recombination exit: `some gs` is returned only when (i) every candidate verified via exact division and (ii) `∏ gs = f`; by B8, (i) + (ii) together imply `L' = W` and `gs = irreducible factors of f`. Certificate exit: at cap precision the single all-ones equivalence class certifies the core irreducible (the forward count bound B6-side plus the class partition give exactly one factor), so `some #[core]` is correct. This is the tier's correctness theorem; the proof is one application of B8 per exit.
 
 ### Group C — combined `factorize` correctness (drives the public API)
 
 C1. **`factorize` unconditional correctness.** `factorize f = irreducibleFactorisationOf f`.
-    *Sketch:* `factorize` dispatches classical-first: try `factorClassical` at the default Mignotte bound; on its decline try `factorLattice` at the lattice precision cap; otherwise the `factorTrial` backstop. Case analysis on the three branches, using each tier's correctness from *Recombination tiers* above — a product-checked `some` from `factorClassical` (Group A) or `factorLattice` (Group B) is the irreducible factorisation, and the `factorTrial` branch is unconditionally the irreducible factorisation (Group A, via A4/A5). Each tier is entered at its own precision, so no single bound drives the whole combinator. This is the headline correctness theorem, assembled over the hybrid's three branches.
+    *Sketch:* `factorize` dispatches classical-first: try `factorClassical` at the default Mignotte bound; on its decline try `factorLattice` at the lattice precision cap; otherwise the `factorTrial` backstop. Case analysis on the three branches, using each tier's correctness from *Recombination tiers* above — a product-checked `some` from `factorClassical` (Group A) or `factorLattice` (Group B) is the irreducible factorisation, and the `factorTrial` branch is unconditionally the irreducible factorisation (Group A, via A4/A5). Each tier is entered at its own precision, so no single bound drives the whole combinator. This is the combined correctness theorem for the three branches.
 
-C2. **Public-API contracts** (`checkIrreducibleCert_sound`, `Hex.ZPoly.isIrreducible_iff`, and the `Decidable (Hex.ZPoly.Irreducible f)` instance it backs) follow from C1. Like C1 itself, these are bridge-side and are stated in `hex-berlekamp-zassenhaus-mathlib` (the Mathlib-free library provides only the `Irreducible` class and the `isIrreducible` checker — see the §`Mathlib-free Hex.ZPoly.Irreducible class`). Product preservation needs no separate bound-aware contract: it is clause 1 of the headline theorem, and the dispatch's acceptance guard makes it self-certifying per tier.
+C2. **Public-API consequences** (`checkIrreducibleCert_sound`, `Hex.ZPoly.isIrreducible_iff`, and the `Decidable (Hex.ZPoly.Irreducible f)` instance it backs) follow from C1. Like C1 itself, these are bridge-side and are stated in `hex-berlekamp-zassenhaus-mathlib` (the Mathlib-free library provides only the `Irreducible` class and the `isIrreducible` checker — see the §`Mathlib-free Hex.ZPoly.Irreducible class`). Product preservation needs no separate bound-aware theorem: it is clause 1 of C1, and the dispatch's acceptance guard makes it self-certifying per tier.
 
 ### Group D — leaf performance theorem (BHKS Theorem 5.2; not on the correctness critical path)
 
@@ -688,32 +688,32 @@ D2. **Tight characterisation of trial-backstop inputs.** Statement shape:
 
     **Executable precondition.** D2 is about the `none` case only: `choosePrimeData? f = none` must mean *no* element of `HotPathCandidates` is suitable, so the `none` path MUST test every one of the 95 primes in `[3, 500]` before concluding `none`. First-suitable selection short-circuits on *success* (returning at the first suitable prime, which is correct and required for performance), but it must **not** short-circuit the `none` conclusion: a curated subset that skips primes, or an input-dependent fuel cap on the `none`-case walk, is a SPEC violation that would weaken D2.
 
-## Headline correctness theorem
+## Normalized factorization theorem
 
 `HexBerlekampZassenhausMathlib` must carry, and the `done_through ≥ 4` bump is blocked on, an end-to-end theorem with the following **semantic shape**:
 
 > For every nonzero `f : Hex.ZPoly`, the public-API output `φ := Hex.factorize f : Hex.Factorization` satisfies all five clauses:
 >
 > 1. **Product preservation.** `Hex.Factorization.product φ = f`.
-> 2. **Primitive irreducibility.** Every `entry ∈ φ.factors` is primitive and `Polynomial.Irreducible (HexPolyZMathlib.toPolynomial entry.1)` holds in the Mathlib sense.
+> 2. **Normalized primitive irreducibility.** Every `entry ∈ φ.factors` is primitive, has positive leading coefficient, and `Polynomial.Irreducible (HexPolyZMathlib.toPolynomial entry.1)` holds in the Mathlib sense.
 > 3. **Positive multiplicities.** Every `entry ∈ φ.factors` has `entry.2 > 0`.
 > 4. **No factor associates.** For any two distinct positions in `φ.factors`, the underlying polynomials are not associates of each other.
 > 5. **Scalar carries sign and content.** `φ.scalar` equals the signed integer content of `f` (sign × content per `ZPoly.content` and `ZPoly.leadingCoeff` conventions).
 
-The final Lean name (e.g. `factor_correct`, `factor_irreducible_factorisation`) may differ from this prose, and intermediate predicates such as `IsIrreducibleFactorization` may abbreviate the conjunction, but the five-clause shape is binding.
+The theorem is `HexBerlekampZassenhausMathlib.factorize_normalized`. Intermediate predicates such as `IsIrreducibleFactorization` may abbreviate the conjunction, but the five-clause shape is binding.
 
-This is the post-condition of the public API and the contract the combinator advertises in its docstring. **The headline theorem is the critical-path artefact for `done_through ≥ 4`.** Intermediate lemmas are admissible when they are either
+This is the post-condition of the public API. **This theorem is required for `done_through ≥ 4`.** Intermediate lemmas are admissible when they are either
 
-- (a) load-bearing for some proof of the headline theorem, or
+- (a) needed to prove the normalized factorization theorem, or
 - (b) independently justified as public API, executable checker, or regression guard with stated rationale.
 
 Lemmas that satisfy neither are dead weight and should be removed or refactored until they earn their place.
 
-A bridge file that proves an arbitrary collection of intermediate lemmas but does not prove the headline correctness theorem is incomplete by SPEC: the orchestrator must not bump `done_through` to 4 in that state. The local realisation of this clause for the open BZ architectural directive is rewritten in the dispatched rollback issue.
+A bridge file that proves an arbitrary collection of intermediate lemmas but does not prove the normalized factorization theorem is incomplete by SPEC: the orchestrator must not bump `done_through` to 4 in that state. The local realisation of this clause for the open BZ architectural directive is rewritten in the dispatched rollback issue.
 
-### Invariant contracts and dispatch soundness
+### Factorization invariants and dispatch soundness
 
-Beyond the five-clause headline, the cost-based dispatch adds contracts
+Beyond the five clauses above, the cost-based dispatch adds properties
 that the implementation must satisfy and that **conformance checks from
 the start, even though the formal proofs land last** (freezing the
 proof-shaped surface early so the migration does not discover, late,

--- a/HexBerlekampZassenhausMathlib/FactorPolyTests.lean
+++ b/HexBerlekampZassenhausMathlib/FactorPolyTests.lean
@@ -316,10 +316,13 @@ example : True := by
     factor_poly (X ^ 2 - 2 : Polynomial ℤ)
   trivial
 
--- Tactic form (providers emitting `FactoredPoly.ofZ` land as a single
--- `factored` hypothesis).
+-- Tactic form: Mathlib providers expose the same four local names as the
+-- executable providers.
 example : True := by
   factor_poly (X ^ 2 - 2 : Polynomial ℤ)
+  have : factors.length = 1 := rfl
+  have := factors_mul
+  have := factors_irred
   exact True.intro
 
 /-! ### The decline→multi-prime handover on `Hex.ZPoly`

--- a/HexBerlekampZassenhausMathlib/FactorSoundness.lean
+++ b/HexBerlekampZassenhausMathlib/FactorSoundness.lean
@@ -63,154 +63,22 @@ theorem factorize_entries_leadingCoeff_pos (f : Hex.ZPoly) :
   exact Hex.factorize_entry_leadingCoeff_pos f entry (Array.mem_toList_iff.mpr hentry)
 
 /--
-Bundled public contract currently available for the default executable
-factorization surface.
+The normalized irreducible factorization produced for a nonzero polynomial.
 
-This packages the clauses that are already exposed by the Mathlib-free and
-Mathlib bridge layers: product preservation, Mathlib irreducibility of each
-recorded polynomial factor, positive multiplicities, syntactic absence of
-duplicate polynomial keys, and the signed-content scalar convention. Stronger
-siblings below add primitivity, positive leading coefficients, and
-non-association without making this smaller bundle harder to reuse.
+The product reconstructs the input. Every recorded factor is primitive, has
+positive leading coefficient, and is irreducible after transport to
+`Polynomial ℤ`; multiplicities are positive; distinct entries are not
+associates; and the scalar is the signed content of the input.
+
+The hypothesis `f ≠ 0` is necessary because the factorization of zero is
+degenerate: its scalar and product are zero, while zero is not primitive.
 -/
-theorem factorize_headline_contract_core (f : Hex.ZPoly) :
-    Hex.Factorization.product (Hex.ZPoly.factorize f) = f ∧
-      (∀ entry ∈ (Hex.ZPoly.factorize f).factors,
-        Irreducible (HexPolyZMathlib.toPolynomial entry.1)) ∧
-      (∀ entry ∈ (Hex.ZPoly.factorize f).factors, 0 < entry.2) ∧
-      List.Pairwise (fun a b : Hex.ZPoly × Nat => a.1 ≠ b.1)
-        (Hex.ZPoly.factorize f).factors.toList ∧
-      (Hex.ZPoly.factorize f).scalar =
-        if f = 0 then
-          0
-        else if Hex.DensePoly.leadingCoeff f < 0 then
-          -Hex.ZPoly.content f
-        else
-          Hex.ZPoly.content f := by
-  refine ⟨factorize_product f, ?_, ?_, Hex.factorize_pairwise_first f, Hex.factorize_scalar f⟩
-  · intro entry hentry
-    exact factorize_polynomialIrreducible_of_nonUnit f entry hentry
-  · intro entry hentry
-    exact Hex.factorize_entry_multiplicity_pos f entry (Array.mem_toList_iff.mpr hentry)
-
-/--
-Positive-leading-coefficient sibling of `factorize_headline_contract_core`.
-
-This keeps the existing default public factorization clauses and additionally
-packages the canonical positive-leading convention for every recorded
-polynomial factor.
--/
-theorem factorize_headline_contract_core_with_posLeading (f : Hex.ZPoly) :
-    Hex.Factorization.product (Hex.ZPoly.factorize f) = f ∧
-      (∀ entry ∈ (Hex.ZPoly.factorize f).factors,
-        Irreducible (HexPolyZMathlib.toPolynomial entry.1)) ∧
-      (∀ entry ∈ (Hex.ZPoly.factorize f).factors,
-        0 < Hex.DensePoly.leadingCoeff entry.1) ∧
-      (∀ entry ∈ (Hex.ZPoly.factorize f).factors, 0 < entry.2) ∧
-      List.Pairwise (fun a b : Hex.ZPoly × Nat => a.1 ≠ b.1)
-        (Hex.ZPoly.factorize f).factors.toList ∧
-      (Hex.ZPoly.factorize f).scalar =
-        if f = 0 then
-          0
-        else if Hex.DensePoly.leadingCoeff f < 0 then
-          -Hex.ZPoly.content f
-        else
-          Hex.ZPoly.content f := by
-  rcases factorize_headline_contract_core f with
-    ⟨hproduct, hirreducible, hmultiplicity, hpairwise, hscalar⟩
-  exact
-    ⟨hproduct, hirreducible, factorize_entries_leadingCoeff_pos f, hmultiplicity,
-      hpairwise, hscalar⟩
-
-/--
-Primitive-strengthened sibling of `factorize_headline_contract_core`.
-
-This is the same default public factorization contract, but packages the
-headline primitive-irreducibility clause as a single per-entry conjunction under
-the raw-branch primitive hypothesis supplied by the executable layer.
--/
-theorem factorize_headline_contract_core_with_primitive
-    (f : Hex.ZPoly) (hf : f ≠ 0) :
+theorem factorize_normalized (f : Hex.ZPoly) (hf : f ≠ 0) :
     Hex.Factorization.product (Hex.ZPoly.factorize f) = f ∧
       (∀ entry ∈ (Hex.ZPoly.factorize f).factors,
         Hex.ZPoly.Primitive entry.1 ∧
-          Irreducible (HexPolyZMathlib.toPolynomial entry.1)) ∧
-      (∀ entry ∈ (Hex.ZPoly.factorize f).factors, 0 < entry.2) ∧
-      List.Pairwise (fun a b : Hex.ZPoly × Nat => a.1 ≠ b.1)
-        (Hex.ZPoly.factorize f).factors.toList ∧
-      (Hex.ZPoly.factorize f).scalar =
-        if f = 0 then
-          0
-        else if Hex.DensePoly.leadingCoeff f < 0 then
-          -Hex.ZPoly.content f
-        else
-          Hex.ZPoly.content f := by
-  refine ⟨factorize_product f, ?_, ?_, Hex.factorize_pairwise_first f, Hex.factorize_scalar f⟩
-  · intro entry hentry
-    exact
-      ⟨factorize_entries_primitive_of_chosen_raw_primitive f hf entry hentry,
-        factorize_polynomialIrreducible_of_nonUnit f entry hentry⟩
-  · intro entry hentry
-    exact Hex.factorize_entry_multiplicity_pos f entry (Array.mem_toList_iff.mpr hentry)
-
-/--
-Closed primitive-strengthened headline for the default executable factorization
-of a nonzero input.
-
-This is the same bundle as `factorize_headline_contract_core_with_primitive` but
-with the raw-source primitivity hypothesis `h_raw` discharged internally via
-`Hex.factor_chosen_raw_primitive_of_ne_zero`, so callers no longer supply it:
-product preservation, primitive plus Mathlib irreducibility per recorded factor,
-positive multiplicities, the syntactic distinct-key clause, and the
-signed-content scalar convention.
-
-The `f ≠ 0` side condition is essential rather than incidental. For `f = 0` the
-square-free core is `0` (content `0`, hence not primitive), so the raw-source
-primitivity statement quantified over the dispatch is literally false; the
-factorization of `0` is itself degenerate (`scalar = 0`, product `0`).
--/
-theorem factorize_headline_primitive (f : Hex.ZPoly) (hf : f ≠ 0) :
-    Hex.Factorization.product (Hex.ZPoly.factorize f) = f ∧
-      (∀ entry ∈ (Hex.ZPoly.factorize f).factors,
-        Hex.ZPoly.Primitive entry.1 ∧
-          Irreducible (HexPolyZMathlib.toPolynomial entry.1)) ∧
-      (∀ entry ∈ (Hex.ZPoly.factorize f).factors, 0 < entry.2) ∧
-      List.Pairwise (fun a b : Hex.ZPoly × Nat => a.1 ≠ b.1)
-        (Hex.ZPoly.factorize f).factors.toList ∧
-      (Hex.ZPoly.factorize f).scalar =
-        if f = 0 then
-          0
-        else if Hex.DensePoly.leadingCoeff f < 0 then
-          -Hex.ZPoly.content f
-        else
-          Hex.ZPoly.content f :=
-  factorize_headline_contract_core_with_primitive f hf
-
-/--
-The HO-1 headline contract for the default executable factorization of a nonzero
-input.
-
-This is the strengthened public surface required by directive #2564: it is the
-same bundle as `factorize_headline_primitive` but replaces the syntactic
-distinct-key clause `a.1 ≠ b.1` with genuine pairwise non-association after
-transport to `Polynomial ℤ`. The clauses are product preservation, primitive
-plus Mathlib irreducibility per recorded factor, positive multiplicities,
-pairwise non-association of the recorded polynomial factors, and the
-signed-content scalar convention.
-
-Non-association is the headline strengthening: distinct `ZPoly` keys could in
-principle be associated in `Polynomial ℤ` (differ by a unit); this rules that
-out, so the recorded factors are genuinely distinct irreducibles up to
-association. The clause is discharged via `factorize_entries_not_associated` with
-the raw-source primitivity hypothesis supplied internally by
-`Hex.factor_chosen_raw_primitive_of_ne_zero`, which is why `f ≠ 0` is required
-(see `factorize_headline_primitive` for why the `f = 0` case is degenerate).
--/
-theorem factorize_headline (f : Hex.ZPoly) (hf : f ≠ 0) :
-    Hex.Factorization.product (Hex.ZPoly.factorize f) = f ∧
-      (∀ entry ∈ (Hex.ZPoly.factorize f).factors,
-        Hex.ZPoly.Primitive entry.1 ∧
-          Irreducible (HexPolyZMathlib.toPolynomial entry.1)) ∧
+          Irreducible (HexPolyZMathlib.toPolynomial entry.1) ∧
+          0 < Hex.DensePoly.leadingCoeff entry.1) ∧
       (∀ entry ∈ (Hex.ZPoly.factorize f).factors, 0 < entry.2) ∧
       List.Pairwise
         (fun a b : Hex.ZPoly × Nat =>
@@ -224,12 +92,16 @@ theorem factorize_headline (f : Hex.ZPoly) (hf : f ≠ 0) :
           -Hex.ZPoly.content f
         else
           Hex.ZPoly.content f := by
-  rcases factorize_headline_primitive f hf with
-    ⟨hproduct, hentries, hmultiplicity, _, hscalar⟩
-  exact
-    ⟨hproduct, hentries, hmultiplicity,
-      factorize_entries_not_associated f hf,
-      hscalar⟩
+  refine
+    ⟨factorize_product f, ?_, ?_, factorize_entries_not_associated f hf,
+      Hex.factorize_scalar f⟩
+  · intro entry hentry
+    exact
+      ⟨factorize_entries_primitive_of_chosen_raw_primitive f hf entry hentry,
+        factorize_polynomialIrreducible_of_nonUnit f entry hentry,
+        factorize_entries_leadingCoeff_pos f entry hentry⟩
+  · intro entry hentry
+    exact Hex.factorize_entry_multiplicity_pos f entry (Array.mem_toList_iff.mpr hentry)
 
 /--
 The sign-normalization side condition for the default executable factorization:

--- a/HexBerlekampZassenhausMathlib/README.md
+++ b/HexBerlekampZassenhausMathlib/README.md
@@ -29,22 +29,20 @@ import HexBerlekampZassenhausMathlib
 # Functionality
 
 For nonzero `f : Hex.ZPoly`,
-`HexBerlekampZassenhausMathlib.factorize_headline f hf` packages the
-release-facing result:
+`HexBerlekampZassenhausMathlib.factorize_normalized f hf` states:
 
 - the factorization product is exactly `f`;
 - its scalar is the signed content prescribed by the normalization convention;
 - every entry has positive multiplicity;
-- every entry is primitive and irreducible; and
+- every entry is primitive and irreducible, with positive leading
+  coefficient; and
 - distinct entries are not associates.
 
-The sibling theorem
-`HexBerlekampZassenhausMathlib.factorize_headline_contract_core_with_posLeading`
-adds the positive-leading convention. Lower-level theorems such as
+Lower-level theorems such as
 `HexBerlekampZassenhausMathlib.factorize_product`,
 `HexBerlekampZassenhausMathlib.factorize_irreducible_of_nonUnit`, and
 `HexBerlekampZassenhausMathlib.factorize_unique` are available when a client
-wants only one part of the contract.
+wants only one of these conclusions.
 
 # Tactics for `Polynomial ℤ`
 
@@ -74,7 +72,7 @@ The computational package is Mathlib-free. This bridge owns all statements in
 terms of Mathlib's `Polynomial`, unique factorization, Gauss's lemma, and
 correspondence with modular/Hensel data. Keeping that boundary explicit lets
 runtime-only users avoid the Mathlib dependency while proof clients get the
-full semantic contract.
+full mathematical specification.
 
 See the [SPEC](SPEC/hex-berlekamp-zassenhaus-mathlib.md) and the Hex manual's
 factor-tactics chapter for theorem maps, certificate coverage, examples, and

--- a/HexBerlekampZassenhausMathlib/SPEC/hex-berlekamp-zassenhaus-mathlib.md
+++ b/HexBerlekampZassenhausMathlib/SPEC/hex-berlekamp-zassenhaus-mathlib.md
@@ -6,10 +6,10 @@ with the Mignotte bound from hex-poly-z-mathlib, giving unconditional
 results. All statements use the `Factorization` record from
 `hex-berlekamp-zassenhaus.md`'s output-convention section.
 
-The headline theorems below hold over the **cost-based hybrid `factorize`**
+The factorization theorems below hold over the **cost-based hybrid `factorize`**
 (the `factorClassical` / `factorLattice` / `factorTrial` tiers). By the
-tier-result-equivalence and dispatch-soundness contracts (main spec
-§*Invariant contracts and dispatch soundness*), `factorize`'s output is
+tier-result-equivalence and dispatch-soundness properties (main spec
+§*Factorization invariants and dispatch soundness*), `factorize`'s output is
 independent of which tier the dispatcher selects, so these theorems
 reduce to the per-tier correctness — Group A for the classical tier,
 Group B for the lattice tier, Group C for the combinator. Per the

--- a/HexManual/Chapters/FactorTactics.lean
+++ b/HexManual/Chapters/FactorTactics.lean
@@ -281,7 +281,8 @@ a suitable modular prime and therefore provides a slower but unconditional
 last resort. These complementary costs explain the three tiers:
 
 * {name}`Hex.factorClassical` runs subset recombination under a fixed search
-  budget and returns `none` if that budget is exhausted.
+  budget and returns `none` if that budget is exhausted or no admissible prime
+  is found.
 * {name}`Hex.factorLattice` runs van Hoeij recombination and returns `none` if
   the available prime or precision does not produce a verified answer.
 * {name}`Hex.factorTrial` performs the direct exact search.
@@ -291,11 +292,36 @@ last resort. These complementary costs explain the three tiers:
 * {name}`Hex.factorTraced` returns the same result together with a
   {name}`Hex.FactorTrace` recording which route was taken.
 
-The product check and the final direct search make
-{name}`Hex.ZPoly.factorize` unconditionally correct. A stronger, separate
-theorem would show that the lattice method cannot decline when a suitable
-prime and sufficient precision are available; that completeness theorem has
-not yet been proved.
+For each optional tier there are two separate proof questions: whether a
+successful answer is correct, and whether the tier is guaranteed to return an
+answer. These should not be conflated.
+
+On the first question, the Mathlib bridge already proves that every factor
+which would be recorded from a successful default-bound classical run is
+irreducible; the corresponding result holds for a successful lattice run at
+the public precision cap. These are
+{name}`HexBerlekampZassenhausMathlib.factorClassicalFactorsWithBound_factor_irreducible`
+and
+{name}`HexBerlekampZassenhausMathlib.factorLatticeFactorsWithBound_factor_irreducible`.
+The library does not yet expose the complementary packed-product implications
+`factorClassical f = some φ → φ.product = f` and
+`factorLattice f = some φ → φ.product = f`. Consequently, the reconstruction
+check in {name}`Hex.factorTraced` is not yet redundant: an optional answer is
+accepted only if its product is `f`; otherwise the proved
+{name}`Hex.factorTrial_product` backstop supplies the result. This case split
+is what the current {name}`Hex.factorize_product` theorem uses.
+
+On the second question, classical recombination is deliberately allowed to
+decline when its resource budget is exhausted. The stronger theorem intended
+for the lattice tier says that it cannot decline once the monic-core prime
+selector has succeeded and the public precision cap is used. That conditional
+completeness theorem has not yet been proved. It would not say that
+{name}`Hex.factorLattice` succeeds on every input: the fixed admissible-prime
+search can itself fail. A further selector theorem will give checkable
+sufficient conditions for prime selection and, together with lattice
+completeness and the two packed-product implications, show that the hybrid
+never reaches trial division on those inputs. The trial tier remains the
+unconditional backstop for arbitrary inputs.
 
 Other formal precedents are the Isabelle/HOL developments
 [Polynomial Factorization](https://www.isa-afp.org/entries/Polynomial_Factorization.html),

--- a/HexManual/Chapters/FactorTactics.lean
+++ b/HexManual/Chapters/FactorTactics.lean
@@ -256,6 +256,26 @@ coefficient vectors. LLL reduction then isolates the short indicator vectors
 that can describe integer factors. Building and reducing the lattice costs
 more for small examples, but avoids the exponential dependence on `r`.
 
+This use of LLL should not be confused with the older *LLL factorization
+algorithm*. The
+[1982 Lenstra–Lenstra–Lovász paper](https://eudml.org/doc/182903) uses lattice
+reduction to recover an integer factor itself from sufficiently accurate
+modular information. Its historical significance is that it gave the first
+polynomial-time algorithm for factoring univariate polynomials over `ℚ`.
+That algorithm was not competitive with Berlekamp–Zassenhaus in practice: its
+lattices had large dimensions and coefficients. Van Hoeij retains the
+practical modular factorization and Hensel-lifting pipeline, and gives lattice
+reduction the narrower job of determining which lifted factors belong
+together.
+
+The Isabelle/HOL development
+[LLL Factorization](https://www.isa-afp.org/entries/LLL_Factorization.html)
+formalizes the 1982 algorithm for square-free integer polynomials, including
+its polynomial complexity. Hex does not implement that factorization
+algorithm. {name}`Hex.lll` provides the lattice-basis reduction used by the
+van Hoeij recombination tier, but factor recovery follows van Hoeij's CLD
+method rather than the older LLL factorizer.
+
 There is also a direct search for exact divisors over `ℤ`. It does not require
 a suitable modular prime and therefore provides a slower but unconditional
 last resort. These complementary costs explain the three tiers:
@@ -277,12 +297,11 @@ theorem would show that the lattice method cannot decline when a suitable
 prime and sufficient precision are available; that completeness theorem has
 not yet been proved.
 
-The closest formal precedents are the Isabelle/HOL developments
+Other formal precedents are the Isabelle/HOL developments
 [Polynomial Factorization](https://www.isa-afp.org/entries/Polynomial_Factorization.html),
 [The Factorization Algorithm of Berlekamp and Zassenhaus](https://www.isa-afp.org/entries/Berlekamp_Zassenhaus.html),
-and [LLL Factorization](https://www.isa-afp.org/entries/LLL_Factorization.html).
-They verify, respectively, the surrounding polynomial algorithms, classical
-Berlekamp–Zassenhaus recombination, and the older LLL factorization algorithm.
+which verify the surrounding polynomial algorithms and classical
+Berlekamp–Zassenhaus recombination.
 The accompanying
 [Isabelle LLL paper](https://doi.org/10.1007/s10817-020-09552-1) identifies a
 verified van Hoeij algorithm as future work. We have not found a later

--- a/HexManual/Chapters/FactorTactics.lean
+++ b/HexManual/Chapters/FactorTactics.lean
@@ -24,23 +24,21 @@ tag := "factor-tactics"
 tag := "factor-tactics-intro"
 %%%
 
-`factor_poly` and `irreducibility` factor a concrete polynomial, or
-prove one irreducible, in a single call. The factorization runs as
-compiled, untrusted search while the file elaborates; the emitted proof
-term carries only certificate checks the kernel replays on literal
-data. One call site, no visible certificates, no `native_decide`, and
-no axioms beyond the standard three.
+The `factor_poly` and `irreducibility` tactics can be used to factorize a
+specific polynomial, or prove that it is irreducible.
 
-The tactics accept four input types, enabled by imports. The drivers
-live in `HexBerlekamp` and handle {name}`Hex.FpPoly` (dense
-polynomials over a prime field) natively. Importing
-`HexBerlekampZassenhaus` adds {name}`Hex.ZPoly` (dense integer
-polynomials); the correspondence libraries `HexBerlekampMathlib` and
-`HexBerlekampZassenhausMathlib` add `Polynomial (ZMod q)` and
-`Polynomial ℤ`. Each library registers its arm as a provider probed by
-name at elaboration time, so the drivers need no imports in that
-direction; with everything imported the tactics simply accept all four
-types.
+The tactics accept four input types, and become increasingly capable
+as further libraries are imported.
+
+Once `HexBerlekampZassenhausMathlib` is imported, the tactics
+handle `Polynomial ℤ`, `Polynomial (ZMod q)`,
+{name}`Hex.ZPoly` (dense integer polynomials),
+and {name}`Hex.FpPoly` (dense polynomials over a prime field).
+
+If you don't need all these capabilities (or want to avoid the extra dependencies),
+`import HexBerlekampMathlib` suffices for `Polynomial (ZMod q)` and {name}`Hex.FpPoly`,
+`import HexBerlekampZassenhaus` suffices for {name}`Hex.ZPoly`,
+and `import HexBerlekamp` suffices for {name}`Hex.FpPoly` alone.
 
 # Proving irreducibility
 %%%
@@ -58,8 +56,7 @@ example : Irreducible (X ^ 2 - 2 : Polynomial ℤ) := by
   irreducibility
 ```
 
-The same name is a term elaborator, so the proof can be a definition's
-entire body:
+`irreducibility` can also be used as a term elaborator:
 
 ```lean
 open Polynomial
@@ -67,6 +64,21 @@ open Polynomial
 theorem sqrt2_irred :
     Irreducible (X ^ 2 - 2 : Polynomial ℤ) :=
   irreducibility (X ^ 2 - 2 : Polynomial ℤ)
+```
+
+When the current goal is something else, `irreducibility f` adds the
+corresponding theorem as `this`; the form `irreducibility h : f` gives it an
+explicit name:
+
+```lean
+open Polynomial
+
+example :
+    Irreducible (X ^ 2 - 2 : Polynomial ℤ) ∧
+      Irreducible (X ^ 2 + X + 1 : Polynomial ℤ) := by
+  irreducibility (X ^ 2 - 2 : Polynomial ℤ)
+  irreducibility h : (X ^ 2 + X + 1 : Polynomial ℤ)
+  exact ⟨this, h⟩
 ```
 
 Behind the call, the input expression is parsed to an executable
@@ -114,20 +126,53 @@ example : ∀ q ∈ facSplit.factors, Irreducible q :=
   facSplit.factors_irred
 ```
 
+`factor_poly` can also be invoked as a tactic. It introduces `scalar` and
+`factors` as transparent `let` bindings, followed by the reconstruction
+hypothesis `factors_mul` and the irreducibility hypothesis `factors_irred`:
+
+```lean
+open Polynomial
+
+example :
+    ∃ (scalar : ℤ) (factors : List (Polynomial ℤ)),
+      Polynomial.C scalar * factors.prod =
+          ((X ^ 2 - 1) * (X + 2) : Polynomial ℤ) ∧
+        ∀ q ∈ factors, Irreducible q := by
+  factor_poly ((X ^ 2 - 1) * (X + 2) : Polynomial ℤ)
+  exact ⟨scalar, factors, factors_mul, factors_irred⟩
+```
+
+If you need to name these fields, it is best to use the term elaborator with `obtain`, e.g., as:
+
+```lean
+open Polynomial
+
+example :
+    ∃ (content : ℤ) (factors : List (Polynomial ℤ)),
+      Polynomial.C content * factors.prod =
+          ((X ^ 2 - 1) * (X + 2) : Polynomial ℤ) ∧
+        ∀ q ∈ factors, Irreducible q := by
+  obtain ⟨content, factors, hproduct, hirreducible⟩ :=
+    factor_poly ((X ^ 2 - 1) * (X + 2) : Polynomial ℤ)
+  exact ⟨content, factors, hproduct, hirreducible⟩
+```
+
 # The executable types
 %%%
 tag := "factor-tactics-executable"
 %%%
 
 The Mathlib-facing forms above are transports of the same machinery
-working on the executable types, which are user surfaces in their
-own right. Over a prime field the input is a {name}`Hex.FpPoly`
+working on the executable types. Over a prime field the input is a {name}`Hex.FpPoly`
 (see the {ref "hex-poly-fp"}[HexPolyFp chapter]) and the result is an
 {name}`Hex.FpPoly.Factored`:
 
 {docstring Hex.FpPoly.Factored}
 
-The example below factors `3 · (x+1)² · (x²+2)` over `F₅`: non-monic
+The literal `#p[a₀, a₁, ...]` lists polynomial coefficients in ascending
+degree order.
+
+The example below factors `3 * (x+1)² * (x²+2)` over `F₅`: non-monic
 and non-square-free, so the scalar, multiplicity, and normalization
 conventions are all visible. The factors come back monic, in
 nondecreasing degree order, repeated to multiplicity, with the leading
@@ -138,22 +183,17 @@ open Hex
 
 instance : ZMod64.Bounds 5 := ⟨by decide, by decide⟩
 
-def z (n : Nat) : ZMod64 5 := ZMod64.ofNat 5 n
-
 /-- `3 · (x+1)² · (x²+2)` over `F₅`: non-monic and
 non-square-free. -/
 def testF : FpPoly 5 :=
-  DensePoly.C (z 3) *
-    (FpPoly.ofCoeffs #[z 1, z 1] *
-     FpPoly.ofCoeffs #[z 1, z 1] *
-     FpPoly.ofCoeffs #[z 2, z 0, z 1])
+  .C 3 * #p[1, 1] * #p[1, 1] * #p[2, 0, 1]
 
 noncomputable def facF := factor_poly testF
 
 example : facF.factors.length = 3 := rfl
-example : facF.scalar = z 3 := rfl
+example : facF.scalar = 3 := rfl
 
-def irrF : FpPoly 5 := FpPoly.ofCoeffs #[z 2, z 0, z 1]
+def irrF : FpPoly 5 := #p[2, 0, 1]
 
 theorem irrF_irred : FpPoly.Irreducible irrF :=
   irreducibility irrF
@@ -169,7 +209,7 @@ primitive positive-leading-coefficient factors:
 ```lean
 open Hex
 
-def quadZ : ZPoly := DensePoly.ofCoeffs #[1, 0, 1]
+def quadZ : ZPoly := #p[1, 0, 1]
 
 theorem quadZ_irred : ZPoly.Irreducible quadZ :=
   irreducibility quadZ
@@ -194,42 +234,81 @@ The tactic result is proof-oriented. Runtime clients instead use the total
 
 {docstring Hex.ZPoly.factorize}
 
-The factorizer normalizes content, sign, powers of `X`, and repeated factors;
-factors the square-free core modulo a small admissible prime; Hensel-lifts the
-modular factors; and recombines them. Small modular factor counts use
-size-ordered classical recombination. When its subset budget is exhausted, the
-van Hoeij CLD lattice tier is tried. Exact integer trial division is the total
-backstop when neither modular tier answers.
+After removing content and repeated factors, modular factorization replaces a
+problem over `ℤ` by one over a small finite field. For a suitable prime `p`,
+factor the square-free polynomial modulo `p`, then use Hensel lifting to obtain
+factors modulo a sufficiently large power `pᵃ`. Each irreducible integer
+factor is represented by a product of some of these lifted modular factors.
+The remaining problem—deciding which modular factors belong together—is
+called *recombination*.
 
-This separation is part of the public contract:
+No single recombination method is best at every size. Classical Zassenhaus
+recombination tries subsets of the lifted factors, reconstructs the
+corresponding integer polynomial, and tests it by exact division. This has low
+overhead when the number `r` of modular factors is small, but its worst-case
+search is exponential in `r`.
 
-* {name}`Hex.factorClassical` and {name}`Hex.factorLattice` are
-  `Option`-valued diagnostic entry points. `factorLattice` never silently runs
-  the exponential trial backstop.
-* {name}`Hex.factorTrial` is the explicit exact backstop.
-* {name}`Hex.factorTraced` returns the production result with a
-  {name}`Hex.FactorTrace`, making the chosen tier and decline status visible to
-  conformance and performance tests.
-* {name}`Hex.ZPoly.factorize` is the ordinary total API. Its soundness does not
-  depend on a polynomial-time claim: the unconditional guarantee is exact
-  factorization, while no-fallback lattice success is a separate conditional
-  theorem programme with explicit prime and precision hypotheses.
+[Van Hoeij's method](https://doi.org/10.1006/jnth.2001.2763) replaces that
+subset search by a lattice problem. For a lifted factor `g`, its combined
+logarithmic derivative is `Φ(g) = f · g′ / g` modulo `pᵃ`. The identity
+`Φ(gh) = Φ(g) + Φ(h)` turns products of modular factors into sums of
+coefficient vectors. LLL reduction then isolates the short indicator vectors
+that can describe integer factors. Building and reducing the lattice costs
+more for small examples, but avoids the exponential dependence on `r`.
+
+There is also a direct search for exact divisors over `ℤ`. It does not require
+a suitable modular prime and therefore provides a slower but unconditional
+last resort. These complementary costs explain the three tiers:
+
+* {name}`Hex.factorClassical` runs subset recombination under a fixed search
+  budget and returns `none` if that budget is exhausted.
+* {name}`Hex.factorLattice` runs van Hoeij recombination and returns `none` if
+  the available prime or precision does not produce a verified answer.
+* {name}`Hex.factorTrial` performs the direct exact search.
+* {name}`Hex.ZPoly.factorize` tries the two optional methods in that order,
+  accepts an answer only after its product reconstructs the input, and uses
+  the direct search if both decline.
+* {name}`Hex.factorTraced` returns the same result together with a
+  {name}`Hex.FactorTrace` recording which route was taken.
+
+The product check and the final direct search make
+{name}`Hex.ZPoly.factorize` unconditionally correct. A stronger, separate
+theorem would show that the lattice method cannot decline when a suitable
+prime and sufficient precision are available; that completeness theorem has
+not yet been proved.
+
+The closest formal precedents are the Isabelle/HOL developments
+[Polynomial Factorization](https://www.isa-afp.org/entries/Polynomial_Factorization.html),
+[The Factorization Algorithm of Berlekamp and Zassenhaus](https://www.isa-afp.org/entries/Berlekamp_Zassenhaus.html),
+and [LLL Factorization](https://www.isa-afp.org/entries/LLL_Factorization.html).
+They verify, respectively, the surrounding polynomial algorithms, classical
+Berlekamp–Zassenhaus recombination, and the older LLL factorization algorithm.
+The accompanying
+[Isabelle LLL paper](https://doi.org/10.1007/s10817-020-09552-1) identifies a
+verified van Hoeij algorithm as future work. We have not found a later
+formalization in the current AFP or published prover literature, so, to the
+best of our knowledge, Hex is the first implementation of van Hoeij's CLD
+method inside an interactive theorem prover. This is a cautious claim about
+the implementation, not a claim that the outstanding completeness theorem
+above has already been proved.
 
 For proof clients,
-{name}`HexBerlekampZassenhausMathlib.factorize_headline` bundles
-reconstruction, primitive irreducible factors, positive multiplicities,
-pairwise non-association, and the normalized signed scalar for every nonzero
-input. The sibling
-{name}`HexBerlekampZassenhausMathlib.factorize_headline_contract_core_with_posLeading`
-records the positive-leading convention.
+{name}`HexBerlekampZassenhausMathlib.factorize_normalized` gives the full
+mathematical description of the output on a nonzero input. It proves that the
+recorded product reconstructs the input; each factor is primitive,
+irreducible, and has positive leading coefficient; every multiplicity is
+positive; distinct factors are not associates; and the scalar is the signed
+content of the input.
 
 Finally, `Polynomial (ZMod q)` inputs reuse the prime-field pipeline
 through the parser-with-proof of `HexBerlekampMathlib`, producing the
 same {name}`Hex.FactoredPoly` shape as the integer case. The modulus
-must be a literal prime with `q ≤ 2²⁶`: the emitted term kernel-replays
-a trial-division primality check costing roughly `q` steps, so larger
-moduli are declined even inside the `ZMod64` bound, and the per-factor
-`(degree + 1) · q` replay budget of the
+must be a literal prime with `q ≤ 2²⁶`. The current primality checker tests
+every candidate divisor in `[2, q)`, so checking the emitted proof takes
+`Θ(q)` remainder tests. This is a limitation of the present checker, not of
+trial division in general: a conventional implementation stops at `√q`.
+The linear replay explains why larger moduli are declined even inside the
+`ZMod64` bound. The per-factor `(degree + 1) · q` replay budget of the
 {ref "factor-tactics-coverage"}[coverage section] applies as well:
 
 ```lean
@@ -244,45 +323,6 @@ noncomputable def facP :=
     ((X + 1) ^ 2 * (X ^ 2 + 2) * 3 : Polynomial (ZMod 5))
 
 example : facP.factors.length = 3 := rfl
-```
-
-# Tactic forms
-%%%
-tag := "factor-tactics-tactic-forms"
-%%%
-
-Both names are also tactics. For the executable types,
-`factor_poly f` introduces `scalar` and `factors` as transparent `let`
-bindings plus the two hypotheses `factors_mul` and `factors_irred`;
-because the `let`s are transparent, facts about them are available by
-`rfl`:
-
-```lean
-open Hex
-
-example : True := by
-  factor_poly testF
-  have : factors.length = 3 := rfl
-  exact True.intro
-```
-
-(For the `Polynomial` input types the tactic form instead lands the
-whole structure as a single `factored` hypothesis.)
-
-The `irreducibility` tactic has three forms: bare, closing an
-`Irreducible` goal as in the {ref "factor-tactics-irreducibility"}[lead
-example]; `irreducibility f`, adding the fact as an anonymous
-hypothesis; and `irreducibility h : f`, naming it:
-
-```lean
-open Hex Polynomial
-
-example : FpPoly.Irreducible irrF := by irreducibility
-
-example : True := by
-  irreducibility (X ^ 2 - 2 : Polynomial ℤ)
-  irreducibility h : (X ^ 2 + X + 1 : Polynomial ℤ)
-  exact True.intro
 ```
 
 # What the proofs cost, and what to trust
@@ -306,8 +346,8 @@ The factorizer itself never runs in the kernel, except in the opt-in
 
 Kernel time therefore scales with the certificate replays, not with
 the search: it does not matter how many candidate recombinations the
-elaboration-time factorizer explored. And because everything is an
-ordinary proof term, the axiom cone stays clean:
+elaboration-time factorizer explored. The generated proof adds no
+project-specific axioms:
 
 ```lean (name := axiomsCheck)
 #print axioms sqrt2_irred
@@ -375,7 +415,7 @@ shift search finds exactly that certificate:
 ```lean
 open Hex Polynomial
 
-def x4p1 : ZPoly := DensePoly.ofCoeffs #[1, 0, 0, 0, 1]
+def x4p1 : ZPoly := #p[1, 0, 0, 0, 1]
 
 theorem x4p1_irred : ZPoly.Irreducible x4p1 :=
   irreducibility x4p1
@@ -400,7 +440,7 @@ open Hex Polynomial
 multi-prime degree obstruction, since no single-prime or
 Eisenstein witness exists. -/
 def quarticA4 : ZPoly :=
-  DensePoly.ofCoeffs #[12, 8, 0, 0, 1]
+  #p[12, 8, 0, 0, 1]
 
 theorem quarticA4_irred : ZPoly.Irreducible quarticA4 :=
   irreducibility quarticA4
@@ -441,7 +481,7 @@ quartic:
 open Hex Polynomial
 
 def swinDyer : ZPoly :=
-  DensePoly.ofCoeffs #[1, 0, -10, 0, 1]
+  #p[1, 0, -10, 0, 1]
 
 theorem swinDyer_irred : ZPoly.Irreducible swinDyer := by
   irreducibility!

--- a/HexPoly/Dense.lean
+++ b/HexPoly/Dense.lean
@@ -250,6 +250,14 @@ def ofCoeffs (coeffs : Array R) : DensePoly R :=
       unfold trimTrailingZeros DensePolyNormalized
       simpa using trimTrailingZerosList_normalized (R := R) coeffs.toList }
 
+/-- `#p[a₀, a₁, ...]` constructs a dense polynomial whose coefficient of
+`xⁱ` is `aᵢ`. Trailing zero coefficients are removed by `ofCoeffs`. -/
+syntax (name := densePolyLiteral) "#p[" term,* "]" : term
+
+macro_rules
+  | `(#p[$coeffs,*]) =>
+      `(Hex.DensePoly.ofCoeffs #[$coeffs,*])
+
 /-- The zero polynomial. -/
 @[expose]
 def zero : DensePoly R :=

--- a/HexPoly/SPEC/hex-poly.md
+++ b/HexPoly/SPEC/hex-poly.md
@@ -12,6 +12,11 @@ structure DensePoly (R : Type*) [Zero R] [DecidableEq R] where
 The normalization invariant (no trailing zeros) ensures structural equality
 = semantic equality. Every operation maintains this invariant.
 
+The polynomial literal `#p[a₀, a₁, ...]` abbreviates
+`DensePoly.ofCoeffs #[a₀, a₁, ...]`. Coefficients are listed in ascending
+degree order, and the expected polynomial type determines the coefficient
+type. As with `ofCoeffs`, trailing zero coefficients are removed.
+
 - Index = degree, `coeffs[i]` is coefficient of `x^i`
 - Normalization invariant: no trailing zeros
 - Structural equality = semantic equality

--- a/HexPolyFp/Compose.lean
+++ b/HexPolyFp/Compose.lean
@@ -18,7 +18,7 @@ Non-modular composition laws for `DensePoly` over `FpPoly p`.
 These narrowly scoped homomorphism-style laws are exactly what is needed
 to substitute an arbitrary witness polynomial `w` into the prime-field
 product identity `(∏_{c ∈ F_p} (X - C c)) = linearPow X p - X` proved in
-`HexBerlekamp.RabinSoundness`. The headline result here is
+`HexBerlekamp.RabinSoundness`. The main identity here is
 
 ```
 compose ((values p).foldl (fun acc c => acc * (X - C c)) 1) w =
@@ -514,7 +514,7 @@ theorem compose_sub_X [ZMod64.PrimeModulus p] (a w : FpPoly p) :
     DensePoly.compose (a - FpPoly.X) w = DensePoly.compose a w - w := by
   rw [compose_sub, compose_X]
 
-/-- The headline `linearPow X k - X` substitution: substituting `w`
+/-- The `linearPow X k - X` substitution: substituting `w`
 for `X` in `linearPow X k - X` yields `linearPow w k - w`. -/
 theorem compose_linearPow_X_sub_X
     [ZMod64.PrimeModulus p] (w : FpPoly p) (k : Nat) :

--- a/HexPolyZ/Mignotte.lean
+++ b/HexPolyZ/Mignotte.lean
@@ -251,7 +251,7 @@ private theorem sqrtStep_gap_halves
 /-- While the iterate has not yet undershot, `fuel` Newton steps shrink the gap
 by a factor `2 ^ fuel`: `2 ^ fuel * sqrtGap n (sqrtAux n fuel x) ≤ sqrtGap n x`.
 This geometric gap contraction drives phase-one convergence. -/
-private theorem sqrtAux_gap_contract_of_not_done
+private theorem sqrtAux_gap_le_of_not_done
     (n fuel x : Nat) (hx : 0 < x)
     (hnot_sq :
       ¬ (sqrtAux n fuel x) * (sqrtAux n fuel x) ≤ n) :
@@ -306,9 +306,9 @@ private theorem sqrtAux_phase_one_sq_le
   by_cases hsq :
       (sqrtAux n (n.log2 + 1) n) * (sqrtAux n (n.log2 + 1) n) ≤ n
   · exact hsq
-  · have hcontract :
+  · have hgap_le :
         2 ^ (n.log2 + 1) * sqrtGap n (sqrtAux n (n.log2 + 1) n) ≤ sqrtGap n n :=
-      sqrtAux_gap_contract_of_not_done n (n.log2 + 1) n hn hsq
+      sqrtAux_gap_le_of_not_done n (n.log2 + 1) n hn hsq
     have hgap_pos :
         0 < sqrtGap n (sqrtAux n (n.log2 + 1) n) := by
       have hpos : 0 < sqrtAux n (n.log2 + 1) n := by
@@ -323,7 +323,7 @@ private theorem sqrtAux_phase_one_sq_le
         2 ^ (n.log2 + 1) ≤
             2 ^ (n.log2 + 1) * sqrtGap n (sqrtAux n (n.log2 + 1) n) := by
               exact Nat.le_mul_of_pos_right _ hgap_pos
-        _ ≤ sqrtGap n n := hcontract
+        _ ≤ sqrtGap n n := hgap_le
     have hgap_lt : sqrtGap n n < 2 ^ (n.log2 + 1) := by
       unfold sqrtGap
       have hdiv : n / n = 1 := Nat.div_self hn

--- a/SPEC/writing-style.md
+++ b/SPEC/writing-style.md
@@ -109,6 +109,30 @@ If the fact matters, put it in its own note.
   `mul_identity`, not `identity_mulVec` (which is the left unit on
   vectors).
 
+## Make Lean names navigable in rendered prose
+
+Docstrings are part of the reference manual when a chapter includes them with
+Verso's `{docstring}` command. When prose in a docstring or manual chapter names
+a Lean declaration, use the Verso name role:
+
+```text
+{name}`Hex.ZPoly.factorize`
+```
+
+Use a fully qualified name whenever that makes the target unambiguous. The
+rendered name must link to the declaration and provide its hover information.
+
+Plain code spans remain appropriate for local variables, expressions, syntax,
+shell commands, filenames, and terms that do not denote a linkable Lean
+declaration. Do not leave a declaration name in a plain code span merely
+because the prose was first written outside the manual. Build the relevant
+`HexManual` module so unresolved name roles fail during elaboration, and inspect
+the rendered documentation when changing how docstrings are presented.
+
+Public docstrings describe the API in ordinary language. Do not refer to issue
+numbers, planning labels, SPEC section nicknames, or other internal project
+shorthand in place of explaining the behavior.
+
 ## Manual examples that cross into Mathlib
 
 A recipe that shows how to prove a *Mathlib* fact by running the

--- a/progress/20260728T025520Z_factor-tactics-docs.md
+++ b/progress/20260728T025520Z_factor-tactics-docs.md
@@ -1,0 +1,40 @@
+# Factor tactics and documentation cleanup
+
+## Accomplished
+
+- Documented `factor_poly` as both a term elaborator and a tactic, with a
+  `Polynomial ℤ` tactic example.
+- Made the executable and Mathlib tactic providers introduce the same
+  `scalar`, `factors`, `factors_mul`, and `factors_irred` locals, and added
+  regression coverage for both Mathlib coefficient domains.
+- Removed the unnecessary manual `z` helper; the existing `ZMod64` `OfNat`
+  instance now supplies the example's literals directly.
+- Rewrote the `ZPoly.factorize` docstring in ordinary API language with Verso
+  name roles, and added the rendered-name requirement to
+  `SPEC/writing-style.md`.
+- Replaced the polynomial-factorization `factorize_headline*` theorem family
+  with `factorize_normalized`, including the positive-leading conclusion, and
+  updated its README, SPEC, and manual references.
+- Removed nearby `headline`, `contract`, issue-number, and `axiom cone` wording
+  from polynomial-factorization declarations and documentation.
+- Opened #9022 for the repository-wide docstring audit and #9023 for the
+  repository-wide declaration-name audit.
+- Confirmed that unconditional factorization correctness is proved through
+  the trial backstop, while lattice success without fallback remains tracked
+  by #8369 and #8370.
+- Ran the factor tactic tests, focused factorization/manual builds, the full
+  `lake build`, and `git diff --check` successfully.
+
+## Current frontier
+
+The requested local factor-tactics, factorization naming, and documentation
+changes are complete and build successfully.
+
+## Next step
+
+Carry out the full-library audits in #9022 and #9023; pursue #8369 and #8370
+for the separate conditional lattice-completeness theorem programme.
+
+## Blockers
+
+None.

--- a/progress/20260728T034953Z_factor-tactics-obtain-example.md
+++ b/progress/20260728T034953Z_factor-tactics-obtain-example.md
@@ -1,0 +1,22 @@
+# Named factorization fields example
+
+## Accomplished
+
+- Added a compiling `obtain` example after the manual sentence explaining how
+  to give custom names to the fields returned by the `factor_poly` term
+  elaborator.
+- Wrapped the example to satisfy Verso's narrow-screen code-width check.
+- Built `HexManual.Chapters.FactorTactics` and ran `git diff --check`
+  successfully.
+
+## Current frontier
+
+The requested example is complete and verified.
+
+## Next step
+
+None for this change.
+
+## Blockers
+
+None.

--- a/progress/20260728T040624Z_factor-tactics-review.md
+++ b/progress/20260728T040624Z_factor-tactics-review.md
@@ -17,6 +17,10 @@
   Hoeij recombination, recorded its polynomial-time significance and Isabelle
   formalization, and made explicit that Hex uses LLL reduction but does not
   implement the older factorizer.
+- Separated optional-tier partial correctness from non-decline in the manual,
+  documenting the proved irreducibility results, the still-guarded product
+  obligations, and the good-prime hypothesis of the planned lattice-totality
+  theorem.
 - Opened follow-up issues #9022, #9023, #9029, and #9030 for the library-wide
   documentation, naming, primality-check, and manual-notation reviews.
 - Verified the complete repository with `lake build` (9502 jobs).

--- a/progress/20260728T040624Z_factor-tactics-review.md
+++ b/progress/20260728T040624Z_factor-tactics-review.md
@@ -1,0 +1,33 @@
+# Factor tactics and factorization manual review
+
+## Accomplished
+
+- Expanded the Factor Tactics chapter with tactic-form examples, mathematical
+  motivation for the integer-factorization tiers, Isabelle/HOL references,
+  and a cautious account of the van Hoeij implementation's formal status.
+- Simplified the normalized-factorization API names and aligned the executable
+  and Mathlib tactic forms around the same generated bindings.
+- Added `OfNat` support for `ZMod64` and the `#p[...]` dense-polynomial literal,
+  then used the resulting notation where it improves the chapter examples.
+- Replaced internal/specification jargon in public documentation, added Verso
+  name-link requirements to the writing specification, and clarified that the
+  current primality replay is linear only because it scans all divisors below
+  the modulus.
+- Opened follow-up issues #9022, #9023, #9029, and #9030 for the library-wide
+  documentation, naming, primality-check, and manual-notation reviews.
+- Verified the complete repository with `lake build` (9502 jobs).
+
+## Current frontier
+
+The requested implementation and documentation changes are complete and the
+full build is green. They are being published together from
+`agent/factor-tactics-manual`.
+
+## Next step
+
+Merge the review PR, then execute the four focused follow-up issues while the
+manual review continues.
+
+## Blockers
+
+None.

--- a/progress/20260728T040624Z_factor-tactics-review.md
+++ b/progress/20260728T040624Z_factor-tactics-review.md
@@ -13,6 +13,10 @@
   name-link requirements to the writing specification, and clarified that the
   current primality replay is linear only because it scans all divisors below
   the modulus.
+- Distinguished the 1982 LLL polynomial-factorization algorithm from van
+  Hoeij recombination, recorded its polynomial-time significance and Isabelle
+  formalization, and made explicit that Hex uses LLL reduction but does not
+  implement the older factorizer.
 - Opened follow-up issues #9022, #9023, #9029, and #9030 for the library-wide
   documentation, naming, primality-check, and manual-notation reviews.
 - Verified the complete repository with `lake build` (9502 jobs).


### PR DESCRIPTION
## Summary

- align executable and Mathlib `factor_poly` tactic forms around named scalar/factor bindings and reconstruction/irreducibility hypotheses
- replace software-oriented factorization theorem names with mathematical names and tighten public factorization docstrings/spec language
- add `OfNat` support for `ZMod64` and the `#p[...]` dense-polynomial literal, then simplify Factor Tactics examples
- rewrite the runtime-factorization section around the mathematics of classical and van Hoeij recombination, with Isabelle/HOL references and a precise statement of the remaining lattice-completeness gap
- document Verso name-link expectations and clarify the current linear primality replay as an implementation limitation

## Why

The existing chapter mixed implementation dispatch jargon with the mathematical story, repeated tactic material, and exposed awkward API names and verbose constructors. The revised API and manual make the theorem statements, generated tactic context, polynomial examples, and trust/performance boundaries legible to proof clients.

Follow-up work is tracked in #9022, #9023, #9029, and #9030.

## Validation

- `lake build HexManual.Chapters.FactorTactics`
- `lake build` after rebasing onto current `origin/main` (9509 jobs)
- `git diff --check`