### PR TITLE
docs(rcf): complete reflected API manual

### DIFF
--- a/HexManual/Chapters/HexRCF.lean
+++ b/HexManual/Chapters/HexRCF.lean
@@ -218,18 +218,71 @@ example : ∃ x : ℝ,
 When `rcf` sees `Set.Icc` or `Set.Ioo` directly, its error message includes
 the corresponding rewrite above.
 
+# The reflected and compiled APIs
+%%%
+tag := "hex-rcf-reflected-api"
+%%%
+
+Most users only need the `rcf` tactic. Programs that construct or inspect
+sentences directly use the reflected language below. A comparison applies to
+one integer polynomial, formulas combine comparisons, and a sentence adds the
+single supported quantifier.
+
+{docstring Hex.RCF.Cmp}
+
+{docstring Hex.RCF.Atom}
+
+{docstring Hex.RCF.Formula}
+
+{docstring Hex.RCF.Sentence}
+
+Coefficient arrays use ascending order. This direct construction represents
+`∀ x : ℝ, x² + 1 > 0` and sends it through the same compiled decision
+procedure used by the tactic:
+
+```lean
+open Hex.RCF
+
+private def positiveQuadratic : Sentence :=
+  .forallReal (.atom {
+    p := Hex.DensePoly.ofCoeffs #[1, 0, 1]
+    cmp := .gt
+  })
+
+#guard Hex.RCF.decide positiveQuadratic == some true
+```
+
+For clients that need the evidence as well as the verdict, `build?` returns a
+certificate retained with its replay result:
+
+{docstring Hex.RCF.BuildResult}
+
+```lean
+open Hex.RCF
+
+example (result : BuildResult)
+    (h : build? positiveQuadratic = some result) :
+    result.certificate.replay? positiveQuadratic =
+      some result.verdict :=
+  replay_build h
+```
+
+`none` means certificate construction or replay failed. It is distinct from a
+successful result whose `verdict` is `false`.
+
 # Certificates and the trust boundary
 %%%
 tag := "hex-rcf-trust"
 %%%
 
-The reflected input type records the same four quantifier forms:
+The four certificate shapes correspond to empty bounded domains, constant
+formulas, root-free carriers, and positive-root cell decompositions:
 
-{docstring Hex.RCF.Sentence}
+{docstring Hex.RCF.Certificate}
 
 `HexRCF` is classified as a Mathlib-facing library because its reifier, tactic,
 real semantics, and soundness theorem use Mathlib. There is no separate
-`HexRCFMathlib` bridge library. By contrast, `HexRCF.DecisionCheck` exposes the
+`HexRCFMathlib` library. By contrast, `HexRCF.DecisionCheck` exposes the
 complete compiled search, certificate construction, replay, and
 {name}`Hex.RCF.decide` path, with a mechanically checked Mathlib-free import
 closure. The soundness theorem remains on the Mathlib-facing side of this
@@ -261,11 +314,9 @@ false verdict (`some false`), and a checked true verdict (`some true`).
 `Certificate.check` accepts only the last case. The convenience function
 {name}`Hex.RCF.decide` returns `some true` only after this checker accepts the
 certificate. Advanced clients can use {name}`Hex.RCF.build?` to retain the
-certificate and its diagnostic or proof-producing verdict. A `none` result
-means that compiled construction did not produce a replay-accepted
-certificate; it does not mean that the mathematical sentence is false. A
-successfully checked false sentence instead produces `some false`. Neither
-`check_sound` nor the tactic turns `some false` into a proof of a negation.
+certificate and its diagnostic or proof-producing verdict. A successfully
+checked false sentence produces `some false`. Neither `check_sound` nor the
+tactic turns `some false` into a proof of a negation.
 
 The kernel replays polynomial identities, signs, root counts, endpoint
 comparisons, and Boolean folds on literal data. It does not repeat root

--- a/HexManual/Chapters/HexRCF.lean
+++ b/HexManual/Chapters/HexRCF.lean
@@ -226,7 +226,7 @@ tag := "hex-rcf-reflected-api"
 Most users only need the `rcf` tactic. Programs that construct or inspect
 sentences directly use the reflected language below. A comparison applies to
 one integer polynomial, formulas combine comparisons, and a sentence adds the
-single supported quantifier.
+one quantifier supported by the decision procedure.
 
 {docstring Hex.RCF.Cmp}
 
@@ -235,6 +235,8 @@ single supported quantifier.
 {docstring Hex.RCF.Formula}
 
 {docstring Hex.RCF.Sentence}
+
+{docstring Hex.RCF.Sentence.toProp}
 
 Coefficient arrays use ascending order. This direct construction represents
 `∀ x : ℝ, x² + 1 > 0` and sends it through the same compiled decision
@@ -252,31 +254,51 @@ private def positiveQuadratic : Sentence :=
 #guard Hex.RCF.decide positiveQuadratic == some true
 ```
 
-For clients that need the evidence as well as the verdict, `build?` returns a
-certificate retained with its replay result:
+Bounded sentences use Lean's core `Dyadic` endpoints and the half-open
+interval `(a, b]`. This sentence represents
+`∀ x ∈ Set.Ioc (0 : ℝ) 1, x ≥ 0`:
+
+```lean
+open Hex.RCF
+
+private def nonnegativeOnUnit : Sentence :=
+  .forallIoc (Dyadic.ofInt 0) (Dyadic.ofInt 1)
+    (.atom {
+      p := Hex.DensePoly.ofCoeffs #[0, 1]
+      cmp := .ge
+    })
+
+#guard Hex.RCF.decide nonnegativeOnUnit == some true
+```
+
+For clients that need the evidence as well as the verdict, `build?` returns
+the certificate together with its replay verdict:
+
+{docstring Hex.RCF.build?}
 
 {docstring Hex.RCF.BuildResult}
 
 ```lean
 open Hex.RCF
 
-example (result : BuildResult)
-    (h : build? positiveQuadratic = some result) :
-    result.certificate.replay? positiveQuadratic =
+example (s : Sentence) (result : BuildResult)
+    (h : build? s = some result) :
+    result.certificate.replay? s =
       some result.verdict :=
   replay_build h
 ```
 
-`none` means certificate construction or replay failed. It is distinct from a
-successful result whose `verdict` is `false`.
+`build? s = none` means certificate construction or replay failed. It is
+distinct from a successful result whose `verdict` is `false`.
 
 # Certificates and the trust boundary
 %%%
 tag := "hex-rcf-trust"
 %%%
 
-The four certificate shapes correspond to empty bounded domains, constant
-formulas, root-free carriers, and positive-root cell decompositions:
+The four certificate shapes correspond to empty bounded domains, formulas
+with no nonconstant atom polynomial, root-free carriers, and positive-root
+cell decompositions:
 
 {docstring Hex.RCF.Certificate}
 
@@ -317,6 +339,9 @@ certificate. Advanced clients can use {name}`Hex.RCF.build?` to retain the
 certificate and its diagnostic or proof-producing verdict. A successfully
 checked false sentence produces `some false`. Neither `check_sound` nor the
 tactic turns `some false` into a proof of a negation.
+
+A `none` from {name}`Hex.RCF.decide` means the compiled path did not produce a
+checker-accepted certificate. It does not mean that the sentence is false.
 
 The kernel replays polynomial identities, signs, root counts, endpoint
 comparisons, and Boolean folds on literal data. It does not repeat root

--- a/HexRCF/DecisionCheck.lean
+++ b/HexRCF/DecisionCheck.lean
@@ -136,7 +136,9 @@ private def buildCandidate? (s : Sentence) : Option Certificate :=
 /-- A compiled build result retains the certificate that produced its
 diagnostic or proof-producing verdict. -/
 structure BuildResult where
+  /-- The certificate accepted by three-valued replay. -/
   certificate : Certificate
+  /-- The replay verdict. `false` remains diagnostic only. -/
   verdict : Bool
 
 /-- Assemble a certificate and reject it if replay finds malformed evidence. -/

--- a/HexRCF/Language.lean
+++ b/HexRCF/Language.lean
@@ -21,8 +21,8 @@ Nested quantifiers and additional variables are unrepresentable by
 construction. Rational coefficients are handled by the tactic's reifier,
 which clears denominators before constructing an `Atom`.
 
-Reification transports atom evaluation and dyadic endpoints propositionally,
-through the `aeval` and `Dyadic.toReal` bridge lemmas. Normalisation and
+Reification relates atom evaluation and dyadic endpoints propositionally
+using the `aeval` and `Dyadic.toReal` lemmas. Normalisation and
 denominator clearing are not expected to make the reflected semantics
 definitionally equal to the source goal.
 -/

--- a/HexRCF/Syntax.lean
+++ b/HexRCF/Syntax.lean
@@ -28,11 +28,17 @@ namespace Hex.RCF
 
 /-- The six comparisons supported by reflected polynomial atoms. -/
 inductive Cmp where
+  /-- Strictly less than zero. -/
   | lt
+  /-- Less than or equal to zero. -/
   | le
+  /-- Equal to zero. -/
   | eq
+  /-- Greater than or equal to zero. -/
   | ge
+  /-- Strictly greater than zero. -/
   | gt
+  /-- Not equal to zero. -/
   | ne
   deriving DecidableEq
 

--- a/HexRCF/Syntax.lean
+++ b/HexRCF/Syntax.lean
@@ -28,17 +28,17 @@ namespace Hex.RCF
 
 /-- The six comparisons supported by reflected polynomial atoms. -/
 inductive Cmp where
-  /-- Strictly less than zero. -/
+  /-- The relation `<`. -/
   | lt
-  /-- Less than or equal to zero. -/
+  /-- The relation `≤`. -/
   | le
-  /-- Equal to zero. -/
+  /-- The relation `=`. -/
   | eq
-  /-- Greater than or equal to zero. -/
+  /-- The relation `≥`. -/
   | ge
-  /-- Strictly greater than zero. -/
+  /-- The relation `>`. -/
   | gt
-  /-- Not equal to zero. -/
+  /-- The relation `≠`. -/
   | ne
   deriving DecidableEq
 

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -599,8 +599,8 @@ free to change.
   `HexRCF/CarrierTests.lean`: constant filtering, genuine repeated-factor,
   dropped-root, and other tampered-carrier regressions.
 - `HexRCF/IsolationCheck.lean`: Mathlib-free raw generalized isolation data,
-  checks, and ordering/count consequences; `HexRCF/Isolations.lean`: the
-  bridge to literal isolation and real-root semantics;
+  checks, and ordering/count consequences; `HexRCF/Isolations.lean`: literal
+  isolation and real-root semantics;
   `HexRCF/IsolationsTests.lean`: count, order, completeness, and no-real-root
   regressions.
 - `HexRCF/Certificate.lean`: strict option folds, the four `Certificate`

--- a/progress/20260728T043200Z_rcf-manual-api.md
+++ b/progress/20260728T043200Z_rcf-manual-api.md
@@ -5,14 +5,16 @@
 - Expanded the HexRCF manual from tactic-only use to the reflected-language
   API, embedding the canonical documentation for `Cmp`, `Atom`, `Formula`, and
   `Sentence`.
-- Added a live direct-construction example for a reflected positive quadratic
-  and checked it through `Hex.RCF.decide`.
+- Added live direct-construction examples for an unbounded positive quadratic
+  and a bounded sentence with dyadic endpoints. Both are checked through
+  `Hex.RCF.decide`.
 - Documented `BuildResult`, `Certificate`, `build?`, replay failure, diagnostic
   false verdicts, and the retained-certificate theorem with checked Lean code.
+- Stated explicitly that `decide s = none` carries no claim that `s` is false.
 - Added the constructor and field docstrings required for the new Verso
   documentation blocks.
-- Removed the remaining prohibited use of “bridge” from HexRCF manual and SPEC
-  prose.
+- Removed prohibited terminology from the HexRCF manual, SPEC, and language
+  module prose touched by this milestone.
 - Built the complete `HexManual` target successfully.
 
 ## Current frontier

--- a/progress/20260728T043200Z_rcf-manual-api.md
+++ b/progress/20260728T043200Z_rcf-manual-api.md
@@ -1,0 +1,32 @@
+# HexRCF manual API coverage
+
+## Accomplished
+
+- Expanded the HexRCF manual from tactic-only use to the reflected-language
+  API, embedding the canonical documentation for `Cmp`, `Atom`, `Formula`, and
+  `Sentence`.
+- Added a live direct-construction example for a reflected positive quadratic
+  and checked it through `Hex.RCF.decide`.
+- Documented `BuildResult`, `Certificate`, `build?`, replay failure, diagnostic
+  false verdicts, and the retained-certificate theorem with checked Lean code.
+- Added the constructor and field docstrings required for the new Verso
+  documentation blocks.
+- Removed the remaining prohibited use of “bridge” from HexRCF manual and SPEC
+  prose.
+- Built the complete `HexManual` target successfully.
+
+## Current frontier
+
+- The manual now covers the tactic surface, reflected input construction,
+  compiled decision API, certificate replay, soundness boundary, and dependent
+  libraries with live code and source-derived signatures.
+
+## Next step
+
+- Run the source and conformance checks, publish this as a documentation
+  milestone, and obtain an independent review before merging.
+- Continue the Phase-6 declaration/docstring and dead-code audit separately.
+
+## Blockers
+
+- None for this milestone.


### PR DESCRIPTION
## What changed

- document `Cmp`, `Atom`, `Formula`, and `Sentence` through source-derived Verso blocks
- add a live direct-construction example checked by `Hex.RCF.decide`
- document `BuildResult`, `Certificate`, `build?`, replay failure, and the retained-certificate theorem
- add the constructor and field docstrings required by those manual blocks
- remove prohibited “bridge” terminology from the HexRCF manual and SPEC

## Why

The existing chapter thoroughly documented `by rcf`, but it did not cover the reflected language or the direct compiled/certificate APIs that the SPEC exposes to programmatic clients.

## Validation

- `lake build HexManual`
- `lake build HexRCF HexConformance`
- copyright and file-line-count checks
- `python3 scripts/check_dag.py`
- `python3 scripts/check_phase4.py`
- `git diff --check`
