### PR TITLE
refactor: audit declaration names for mathematical vocabulary

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -877,7 +877,7 @@ fast-BHKS-monic-lift migration issue.
 
 ### "Final integration" issues: confirm the substrate *producer* exists, not just that the feeder issue closed
 
-A `feature` issue that says "instantiate `SlowPathHenselSubstrate` / `…Evidence`
+A `feature` issue that says "instantiate `HenselFactorData` / `…Evidence`
 constructed by the prerequisite issues" is only a token-swap if a theorem
 *concludes* that structure. A closed feeder issue does **not** prove its
 producer landed: these substrate issues are sometimes closed COMPLETED on a
@@ -923,14 +923,14 @@ Wiring it back up into the upstream slow-path substrate is a separate follow-up
 `IntReductionMod.lean` now carries carrier-free toMonic producers that need only a
 `toMonicPrimeData?` selection witness plus core facts (lc>0, deg>0, primitive,
 squarefree, B≠0, the monic-correspondent bound) — `liftedFactorSubsetPartition_of_toMonicPrimeData_complete`
-and `slowPathHenselSubstrate_of_toMonicPrimeData`, both discharging `hinitial` via
+and `HenselFactorData.ofToMonicPrime`, both discharging `hinitial` via
 the #7362 producer above and `hcorr` via the new Basic.lean
 `henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData` (the carrier-free
 correspondence: at `True True`, `MonicDescentHypotheses`' only consumed fields
 `lift_eq`/`successful_lift` are `rfl`/`trivial`, so no descent carrier is needed —
 there is still no `MonicDescentHypotheses` *producer*, but the partition/substrate
 chain no longer needs one). So when wiring #6771/#7561, **do not re-derive these** —
-consume `slowPathHenselSubstrate_of_toMonicPrimeData` / `…_complete` directly. They
+consume `HenselFactorData.ofToMonicPrime` / `…_complete` directly. They
 have no in-tree consumer yet; the slow-exhaustive branch
 (`liftedFactorSubsetPartition_outerBound_of_choosePrimeData`) is keyed on the
 different `choosePrimeData? squareFreeCore` selection, not `toMonicPrimeData?`.

--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -21,7 +21,7 @@ and `lllNative`. Key #8519 facts that supersede older notes below:
   `bhksRecoverClassified` / `bhksSingleAllOnesPartition` build
   `bhksLatticeBasis (ZPoly.toMonic f).monic …`, and the lattice tier
   (`factorLatticeFactorsWithBound`) selects `ZPoly.toMonicPrimeData?` — so the
-  toMonic partition producers (`liftedFactorSubsetPartition_of_toMonicPrimeData_complete`)
+  toMonic partition producers (`liftedFactorSubsetPartition_of_toMonicModP`)
   and the monic-regime short-vector producer
   (`BHKS.supportShortVectorData_of_recoveredLift`, which needs
   `leadingCoeff f = 1`) apply directly. The standalone fast tier
@@ -898,7 +898,7 @@ lemma, even when no theorem states it.** #8068 was nearly skipped a 5th time on
 "no original→monic `RepresentsIntegerFactorAtLift` inversion exists"
 (`representsIntegerFactorAtLift_of_monicCorrespondent` only goes monic→original);
 that conclusion was *wrong* — the partition producer
-`initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData` already
+`initialPartitionEvidence_of_toMonicModP` already
 reconstructs the monic correspondent from the *factor itself* (a local `descent`
 `have`, `IntReductionMod.lean`), via `exists_monicCorrespondent_of_dvd` +
 `representsModP_correspondent` + `toMonicLiftData_represents_lifted_monicCorrespondent`,
@@ -909,9 +909,9 @@ report a confident, wrong "NO" here — read the construction sites yourself.
 Substrate producers
 still missing as of this writing: `HenselLiftDescentHypotheses` and the
 `toMonicLiftData` modP→lift transport. `InitialLiftedFactorSubsetPartitionEvidence`
-now *has* one — `initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData`
+now *has* one — `initialPartitionEvidence_of_toMonicModP`
 (`IntReductionMod.lean`, #7362). Note where it landed: not next to its natural
-consumer (`slowPathHenselSubstrate_*` in `Basic.lean`) but downstream in
+consumer (`HenselFactorData.of*` in `MonicCorrespondent.lean`) but downstream in
 `IntReductionMod.lean`, because its `pairwise_disjoint` field needs the mod-`p`
 squarefreeness datum (`modPFactorSubset_disjoint_of_choosePrimeData` /
 `squarefree_toMathlibPolynomial_monicModPImage_of_choosePrimeData`) that lives
@@ -921,16 +921,17 @@ de-privatising any `private` `Basic.lean` helpers it calls (visibility-only, saf
 Wiring it back up into the upstream slow-path substrate is a separate follow-up
 (the substrate cannot import downstream modules). That follow-up landed (#7584):
 `IntReductionMod.lean` now carries carrier-free toMonic producers that need only a
-`toMonicPrimeData?` selection witness plus core facts (lc>0, deg>0, primitive,
-squarefree, B≠0, the monic-correspondent bound) — `liftedFactorSubsetPartition_of_toMonicPrimeData_complete`
-and `HenselFactorData.ofToMonicPrime`, both discharging `hinitial` via
-the #7362 producer above and `hcorr` via the new Basic.lean
-`henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData` (the carrier-free
+mod-`p` factorization of the monic transform plus core facts (lc>0, deg>0, primitive,
+squarefree, B≠0, the monic-correspondent bound) — `liftedFactorSubsetPartition_of_toMonicModP`
+and `HenselFactorData.ofToMonicModP`, both discharging `hinitial` via
+the #7362 producer above and `hcorr` via the new `ToMonicUniqueness.lean`
+`henselSubsetCorrespondenceHypotheses_of_toMonicModP` (the carrier-free
 correspondence: at `True True`, `MonicDescentHypotheses`' only consumed fields
 `lift_eq`/`successful_lift` are `rfl`/`trivial`, so no descent carrier is needed —
 there is still no `MonicDescentHypotheses` *producer*, but the partition/substrate
 chain no longer needs one). So when wiring #6771/#7561, **do not re-derive these** —
-consume `HenselFactorData.ofToMonicPrime` / `…_complete` directly. They
+consume `HenselFactorData.ofToMonicModP` /
+`liftedFactorSubsetPartition_of_toMonicModP` directly. They
 have no in-tree consumer yet; the slow-exhaustive branch
 (`liftedFactorSubsetPartition_outerBound_of_choosePrimeData`) is keyed on the
 different `choosePrimeData? squareFreeCore` selection, not `toMonicPrimeData?`.
@@ -998,7 +999,7 @@ one **only at `leadingCoeff core = 1`** (`liftedRecoveryCandidate.eq_productCand
 `MonicDescentHypotheses` / `hexists_lifted` adapter is **not** the blocker — `hcorr`
 and `hinitial` are producible from core facts now
 (`henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData_success_descent`,
-`initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData`), and the
+`initialPartitionEvidence_of_toMonicModP`), and the
 heavy `descends` field is not consumed when building the correspondence (only
 `lift_eq = rfl` / `successful_lift = trivial`). Land the unscaled-support
 producer first, then #7561 is the thin composition.

--- a/HexArith/Montgomery/Redc.lean
+++ b/HexArith/Montgomery/Redc.lean
@@ -253,7 +253,8 @@ theorem montgomeryReduce_sub_spec (ctx : MontCtx p) (Thi Tlo : UInt64)
               have hu_lt :
                   addHi.toNat + c2.toNat * UInt64.word < 2 * p.toNat := by
                 rw [hu]
-                simpa [hTmod, UInt64.word] using montgomeryReduceNat_u_lt_two_p hp_pos hp_lt hpp' hT
+                simpa [hTmod, UInt64.word] using
+                  montgomeryReduceNat_quotient_lt_two_p hp_pos hp_lt hpp' hT
               simp [montgomeryReduceNat, hTmod]
               simp only [UInt64.word] at hu ⊢
               rw [← hu]

--- a/HexArith/Montgomery/RedcNat.lean
+++ b/HexArith/Montgomery/RedcNat.lean
@@ -94,7 +94,7 @@ private theorem montgomeryReduceNat_exact_dvd (p p' T : Nat)
             (Nat.mod_lt T hword_pos)
 
 /-- Core quotient bound before threading the inverse and modulus-size hypotheses. -/
-private theorem montgomeryReduceNat_quotient_lt (hp_pos : 0 < p)
+private theorem montgomeryReduceNat_quotient_lt_two_p_of_bound (hp_pos : 0 < p)
     (hT : T < p * UInt64.word) :
     (T + ((T % UInt64.word) * p' % UInt64.word) * p) / UInt64.word < 2 * p := by
   have hword_pos : 0 < UInt64.word := by
@@ -164,7 +164,7 @@ theorem montgomeryReduceNat_lt (hp_pos : 0 < p) (hp_lt : p < UInt64.word)
   have hc := montgomeryReduceNat_correction_eq p' T
   have hu : (T + (T * p' % UInt64.word) * p) / UInt64.word < 2 * p := by
     rw [hc]
-    exact montgomeryReduceNat_quotient_lt hp_pos hT
+    exact montgomeryReduceNat_quotient_lt_two_p_of_bound hp_pos hT
   by_cases h : (T + (T * p' % UInt64.word) * p) / UInt64.word < p
   · simp [montgomeryReduceNat, h]
   · simp [montgomeryReduceNat, h]
@@ -174,9 +174,9 @@ theorem montgomeryReduceNat_lt (hp_pos : 0 < p) (hp_lt : p < UInt64.word)
 The unreduced Montgomery quotient is always below `2p`, so one subtraction is
 enough to normalize the result.
 -/
-theorem montgomeryReduceNat_u_lt_two_p (hp_pos : 0 < p) (hp_lt : p < UInt64.word)
+theorem montgomeryReduceNat_quotient_lt_two_p (hp_pos : 0 < p) (hp_lt : p < UInt64.word)
     (hpp' : p * p' % UInt64.word = UInt64.word - 1) (hT : T < p * UInt64.word) :
     (T + ((T % UInt64.word) * p' % UInt64.word) * p) / UInt64.word < 2 * p := by
   have _hp_lt : p < UInt64.word := hp_lt
   have _hpp' : p * p' % UInt64.word = UInt64.word - 1 := hpp'
-  exact montgomeryReduceNat_quotient_lt hp_pos hT
+  exact montgomeryReduceNat_quotient_lt_two_p_of_bound hp_pos hT

--- a/HexArith/Montgomery/RedcNat.lean
+++ b/HexArith/Montgomery/RedcNat.lean
@@ -94,7 +94,7 @@ private theorem montgomeryReduceNat_exact_dvd (p p' T : Nat)
             (Nat.mod_lt T hword_pos)
 
 /-- Core quotient bound before threading the inverse and modulus-size hypotheses. -/
-private theorem montgomeryReduceNat_u_lt_two_p_core (hp_pos : 0 < p)
+private theorem montgomeryReduceNat_quotient_lt (hp_pos : 0 < p)
     (hT : T < p * UInt64.word) :
     (T + ((T % UInt64.word) * p' % UInt64.word) * p) / UInt64.word < 2 * p := by
   have hword_pos : 0 < UInt64.word := by
@@ -164,7 +164,7 @@ theorem montgomeryReduceNat_lt (hp_pos : 0 < p) (hp_lt : p < UInt64.word)
   have hc := montgomeryReduceNat_correction_eq p' T
   have hu : (T + (T * p' % UInt64.word) * p) / UInt64.word < 2 * p := by
     rw [hc]
-    exact montgomeryReduceNat_u_lt_two_p_core hp_pos hT
+    exact montgomeryReduceNat_quotient_lt hp_pos hT
   by_cases h : (T + (T * p' % UInt64.word) * p) / UInt64.word < p
   · simp [montgomeryReduceNat, h]
   · simp [montgomeryReduceNat, h]
@@ -179,4 +179,4 @@ theorem montgomeryReduceNat_u_lt_two_p (hp_pos : 0 < p) (hp_lt : p < UInt64.word
     (T + ((T % UInt64.word) * p' % UInt64.word) * p) / UInt64.word < 2 * p := by
   have _hp_lt : p < UInt64.word := hp_lt
   have _hpp' : p * p' % UInt64.word = UInt64.word - 1 := hpp'
-  exact montgomeryReduceNat_u_lt_two_p_core hp_pos hT
+  exact montgomeryReduceNat_quotient_lt hp_pos hT

--- a/HexArith/SPEC/hex-arith.md
+++ b/HexArith/SPEC/hex-arith.md
@@ -293,7 +293,7 @@ theorem montgomeryReduceNat_lt (hp_pos : 0 < p) (hp_lt : p < R)
     (hpp' : p * p' % R = R - 1) (hT : T < p * R) :
     montgomeryReduceNat p p' T < p
 
-theorem montgomeryReduceNat_u_lt_two_p (hp_pos : 0 < p) (hp_lt : p < R)
+theorem montgomeryReduceNat_quotient_lt_two_p (hp_pos : 0 < p) (hp_lt : p < R)
     (hpp' : p * p' % R = R - 1) (hT : T < p * R) :
     (T + ((T % R) * p' % R) * p) / R < 2 * p
 ```

--- a/HexBareiss/Bareiss.lean
+++ b/HexBareiss/Bareiss.lean
@@ -917,7 +917,7 @@ theorem pivotLoop_done (fuel : Nat) (state : BareissState n)
 iteration applies `stepMatrix`, advances the step, and recurses without
 changing the row-swap counter. -/
 @[grind]
-theorem pivotLoop_regular_branch_no_swap (fuel : Nat) (state : BareissState n)
+theorem pivotLoop_of_regular_no_swap (fuel : Nat) (state : BareissState n)
     (hDone : state.step + 1 < n)
     (hp : state.matrix[state.step][state.step] ≠ 0) :
     pivotLoop (fuel + 1) state =
@@ -933,7 +933,7 @@ theorem pivotLoop_regular_branch_no_swap (fuel : Nat) (state : BareissState n)
 /-- If the current pivot is zero and pivot search finds no replacement row,
 the row-pivoted Bareiss loop records a singular step. -/
 @[grind]
-theorem pivotLoop_singular_branch_no_pivot (fuel : Nat) (state : BareissState n)
+theorem pivotLoop_of_singular_no_pivot (fuel : Nat) (state : BareissState n)
     (hDone : state.step + 1 < n)
     (hp0 : state.matrix[state.step][state.step] = 0)
     (hfind :
@@ -948,7 +948,7 @@ theorem pivotLoop_singular_branch_no_pivot (fuel : Nat) (state : BareissState n)
 the swapped pivot is nonzero, one loop iteration swaps rows, applies
 `stepMatrix`, advances the step, increments the row-swap counter, and recurses. -/
 @[grind]
-theorem pivotLoop_regular_branch_swap (fuel : Nat) (state : BareissState n)
+theorem pivotLoop_of_regular_swap (fuel : Nat) (state : BareissState n)
     (hDone : state.step + 1 < n)
     (hp0 : state.matrix[state.step][state.step] = 0) {pivot : Fin n}
     (hfind :
@@ -1069,7 +1069,7 @@ theorem noPivotLoop_done (fuel : Nat) (state : BareissState n)
 /-- If the no-pivot loop sees a zero pivot before completion, it records the
 current step as singular. -/
 @[grind]
-theorem noPivotLoop_singular_branch (fuel : Nat) (state : BareissState n)
+theorem noPivotLoop_of_singular (fuel : Nat) (state : BareissState n)
     (hDone : state.step + 1 < n)
     (hp : state.matrix[state.step][state.step] = 0) :
     noPivotLoop (fuel + 1) state = { state with singularStep := some state.step } := by
@@ -1078,7 +1078,7 @@ theorem noPivotLoop_singular_branch (fuel : Nat) (state : BareissState n)
 /-- If the current no-pivot Bareiss pivot is nonzero, one loop iteration applies
 `stepMatrix`, advances the step, and recurses on the remaining fuel. -/
 @[grind]
-theorem noPivotLoop_regular_branch (fuel : Nat) (state : BareissState n)
+theorem noPivotLoop_of_regular (fuel : Nat) (state : BareissState n)
     (hDone : state.step + 1 < n)
     (hp : state.matrix[state.step][state.step] ≠ 0) :
     noPivotLoop (fuel + 1) state =
@@ -1106,8 +1106,8 @@ theorem noPivotLoop_matrix_entry_of_row_le_or_col_lt (fuel : Nat)
       · let k : Fin n :=
           ⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩
         by_cases hp : state.matrix[k][k] = 0
-        · simp [noPivotLoop_singular_branch fuel state hDone hp]
-        · rw [noPivotLoop_regular_branch fuel state hDone]
+        · simp [noPivotLoop_of_singular fuel state hDone hp]
+        · rw [noPivotLoop_of_regular fuel state hDone]
           · let next : BareissState n :=
               { step := state.step + 1
                 matrix := stepMatrix state.matrix state.step
@@ -1160,8 +1160,8 @@ theorem noPivotLoop_rowSwaps (fuel : Nat) (state : BareissState n) :
       · let k : Fin n :=
           ⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩
         by_cases hp : state.matrix[k][k] = 0
-        · simp [noPivotLoop_singular_branch fuel state hDone hp]
-        · rw [noPivotLoop_regular_branch fuel state hDone]
+        · simp [noPivotLoop_of_singular fuel state hDone hp]
+        · rw [noPivotLoop_of_regular fuel state hDone]
           · let next : BareissState n :=
               { step := state.step + 1
                 matrix := stepMatrix state.matrix state.step
@@ -1200,7 +1200,7 @@ theorem noPivotLoop_id_at_singular_fixedpoint
   induction fuel with
   | zero => rfl
   | succ f _ih =>
-      rw [noPivotLoop_singular_branch f state hDone hp]
+      rw [noPivotLoop_of_singular f state hDone hp]
       cases state
       simp at hsing ⊢
       exact hsing.symm
@@ -1226,11 +1226,11 @@ theorem noPivotLoop_add
                 {state with singularStep := some state.step} := by
             have : a' + 1 + b = (a' + b) + 1 := by omega
             rw [this]
-            exact noPivotLoop_singular_branch (a' + b) state hDone hp
+            exact noPivotLoop_of_singular (a' + b) state hDone hp
           have h_rhs_inner :
               noPivotLoop (a' + 1) state =
                 {state with singularStep := some state.step} :=
-            noPivotLoop_singular_branch a' state hDone hp
+            noPivotLoop_of_singular a' state hDone hp
           rw [h_lhs, h_rhs_inner]
           symm
           let s' : BareissState n := {state with singularStep := some state.step}
@@ -1250,7 +1250,7 @@ theorem noPivotLoop_add
                     singularStep := none } := by
             have : a' + 1 + b = (a' + b) + 1 := by omega
             rw [this]
-            exact noPivotLoop_regular_branch (a' + b) state hDone hp
+            exact noPivotLoop_of_regular (a' + b) state hDone hp
           have h_rhs_inner :
               noPivotLoop (a' + 1) state =
                 noPivotLoop a'
@@ -1260,7 +1260,7 @@ theorem noPivotLoop_add
                     prevPivot := state.matrix[k][k]
                     rowSwaps := state.rowSwaps
                     singularStep := none } :=
-            noPivotLoop_regular_branch a' state hDone hp
+            noPivotLoop_of_regular a' state hDone hp
           rw [h_lhs, h_rhs_inner]
           exact ih _
       · rw [noPivotLoop_id_at_done (a' + 1 + b) state hDone]
@@ -1284,10 +1284,10 @@ theorem noPivotLoop_step_eq_add_of_singularStep_none
   | succ f ih =>
       have hDone : state.step + 1 < n := by omega
       by_cases hp : state.matrix[state.step][state.step] = 0
-      · rw [noPivotLoop_singular_branch f state hDone hp] at h_no_sing
+      · rw [noPivotLoop_of_singular f state hDone hp] at h_no_sing
         simp at h_no_sing
-      · rw [noPivotLoop_regular_branch f state hDone hp] at h_no_sing
-        rw [noPivotLoop_regular_branch f state hDone hp]
+      · rw [noPivotLoop_of_regular f state hDone hp] at h_no_sing
+        rw [noPivotLoop_of_regular f state hDone hp]
         have h_next_room : state.step + 1 + f + 1 ≤ n := by omega
         have h_next_step := ih
           { step := state.step + 1
@@ -1319,7 +1319,7 @@ theorem pivotLoop_eq_noPivotLoop_of_no_singular {n : Nat}
       · by_cases hp : state.matrix[state.step][state.step] = 0
         · -- `noPivotLoop` records `singularStep = some state.step`, contradicting
           -- `h_no_sing`.
-          rw [noPivotLoop_singular_branch f state hDone hp] at h_no_sing
+          rw [noPivotLoop_of_singular f state hDone hp] at h_no_sing
           simp at h_no_sing
         · -- Regular branch in both loops; recurse on the same updated state.
           let next : BareissState n :=
@@ -1329,12 +1329,12 @@ theorem pivotLoop_eq_noPivotLoop_of_no_singular {n : Nat}
               prevPivot := state.matrix[state.step][state.step]
               rowSwaps := state.rowSwaps
               singularStep := none }
-          rw [noPivotLoop_regular_branch f state hDone hp,
-            pivotLoop_regular_branch_no_swap f state hDone hp]
+          rw [noPivotLoop_of_regular f state hDone hp,
+            pivotLoop_of_regular_no_swap f state hDone hp]
           show pivotLoop f next = noPivotLoop f next
           apply ih
           show (noPivotLoop f next).singularStep = none
-          rw [← noPivotLoop_regular_branch f state hDone hp]
+          rw [← noPivotLoop_of_regular f state hDone hp]
           exact h_no_sing
       · rw [pivotLoop_done f state hDone]
         rw [noPivotLoop_done f state hDone]

--- a/HexBareissMathlib/Bareiss.lean
+++ b/HexBareissMathlib/Bareiss.lean
@@ -729,24 +729,24 @@ theorem pivotLoop_invariant_of_singularStep_eq_none
               Hex.Matrix.findPivot? state.matrix kFin (state.step + 1) with
           | none =>
               have hloop :=
-                Hex.Matrix.pivotLoop_singular_branch_no_pivot fuel state hDone hp0
+                Hex.Matrix.pivotLoop_of_singular_no_pivot fuel state hDone hp0
                   (by simpa [kFin] using hfind)
               rw [hloop] at hregular
               simp at hregular
           | some pivot =>
               have hp :=
                 pivotLoop_swap_pivot_ne_zero state hDone (by simpa [kFin] using hfind)
-              rw [Hex.Matrix.pivotLoop_regular_branch_swap fuel state hDone hp0
+              rw [Hex.Matrix.pivotLoop_of_regular_swap fuel state hDone hp0
                 (by simpa [kFin] using hfind) hp]
               apply ih
               · exact bareissPivotInvariant_regular_swap_step source state hinv hDone
                   (by simpa [kFin] using hfind)
-              · simpa [Hex.Matrix.pivotLoop_regular_branch_swap fuel state hDone hp0
+              · simpa [Hex.Matrix.pivotLoop_of_regular_swap fuel state hDone hp0
                   (by simpa [kFin] using hfind) hp] using hregular
-        · rw [Hex.Matrix.pivotLoop_regular_branch_no_swap fuel state hDone hp0]
+        · rw [Hex.Matrix.pivotLoop_of_regular_no_swap fuel state hDone hp0]
           apply ih
           · exact bareissPivotInvariant_regular_no_swap_step source state hinv hDone hp0
-          · simpa [Hex.Matrix.pivotLoop_regular_branch_no_swap fuel state hDone hp0]
+          · simpa [Hex.Matrix.pivotLoop_of_regular_no_swap fuel state hDone hp0]
               using hregular
       · simpa [Hex.Matrix.pivotLoop_done fuel state hDone] using hinv
 
@@ -785,7 +785,7 @@ theorem noPivotLoop_invariant
               (⟨state.step, hk⟩ : Fin n)] ≠ 0 := by
           rw [hpivot_idx]
           exact hpivots ⟨state.step, hk⟩ (Nat.le_refl _)
-        rw [Hex.Matrix.noPivotLoop_regular_branch fuel state hDone hp_ne]
+        rw [Hex.Matrix.noPivotLoop_of_regular fuel state hDone hp_ne]
         -- Apply IH on the next state.
         apply ih
         · exact bareissNoPivotInvariant_step source state hinv hDone hp_ne
@@ -844,12 +844,12 @@ theorem noPivotLoop_invariant_of_singularStep_eq_none
       · by_cases hp0 :
             state.matrix[(⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)][
               (⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)] = 0
-        · rw [Hex.Matrix.noPivotLoop_singular_branch fuel state hDone hp0] at hregular
+        · rw [Hex.Matrix.noPivotLoop_of_singular fuel state hDone hp0] at hregular
           simp at hregular
-        · rw [Hex.Matrix.noPivotLoop_regular_branch fuel state hDone hp0]
+        · rw [Hex.Matrix.noPivotLoop_of_regular fuel state hDone hp0]
           apply ih
           · exact bareissNoPivotInvariant_step source state hinv hDone hp0
-          · simpa [Hex.Matrix.noPivotLoop_regular_branch fuel state hDone hp0]
+          · simpa [Hex.Matrix.noPivotLoop_of_regular fuel state hDone hp0]
               using hregular
       · simpa [Hex.Matrix.noPivotLoop_done fuel state hDone] using hinv
 
@@ -866,9 +866,9 @@ private theorem noPivotLoop_step_succ_le
       · by_cases hp :
             state.matrix[(⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)][
               (⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)] = 0
-        · rw [Hex.Matrix.noPivotLoop_singular_branch fuel state hDone hp]
+        · rw [Hex.Matrix.noPivotLoop_of_singular fuel state hDone hp]
           exact h
-        · rw [Hex.Matrix.noPivotLoop_regular_branch fuel state hDone hp]
+        · rw [Hex.Matrix.noPivotLoop_of_regular fuel state hDone hp]
           apply ih
           show state.step + 1 + 1 ≤ n
           omega
@@ -906,7 +906,7 @@ private theorem noPivotLoop_step_succ_ge
             state.matrix[(⟨state.step, hk⟩ : Fin n)][(⟨state.step, hk⟩ : Fin n)] ≠ 0 := by
           rw [hpivot_idx]
           exact hpivots ⟨state.step, hk⟩ (Nat.le_refl _)
-        rw [Hex.Matrix.noPivotLoop_regular_branch fuel state hDone hp_ne]
+        rw [Hex.Matrix.noPivotLoop_of_regular fuel state hDone hp_ne]
         apply ih
         · exact bareissNoPivotInvariant_step source state hinv hDone hp_ne
         · intro k' hk'
@@ -1420,11 +1420,11 @@ theorem pivotLoop_singularStep_ne_none_det_eq_zero
               apply ih
               · exact bareissPivotInvariant_regular_swap_step source state hinv hDone
                   (by simpa [kFin] using hfind)
-              · simpa [Hex.Matrix.pivotLoop_regular_branch_swap fuel state hDone hp0
+              · simpa [Hex.Matrix.pivotLoop_of_regular_swap fuel state hDone hp0
                   (by simpa [kFin] using hfind) hp] using hsing
         · apply ih
           · exact bareissPivotInvariant_regular_no_swap_step source state hinv hDone hp0
-          · simpa [Hex.Matrix.pivotLoop_regular_branch_no_swap fuel state hDone hp0]
+          · simpa [Hex.Matrix.pivotLoop_of_regular_no_swap fuel state hDone hp0]
               using hsing
       · rcases hinv with ⟨_, _, hnopiv⟩
         simp [Hex.Matrix.pivotLoop_done fuel state hDone, hnopiv.singular_none] at hsing
@@ -1477,18 +1477,18 @@ private theorem pivotLoop_step_succ_le
           cases hfind :
               Hex.Matrix.findPivot? state.matrix kFin (state.step + 1) with
           | none =>
-              rw [Hex.Matrix.pivotLoop_singular_branch_no_pivot fuel state hDone hp0
+              rw [Hex.Matrix.pivotLoop_of_singular_no_pivot fuel state hDone hp0
                 (by simpa [kFin] using hfind)]
               exact h
           | some pivot =>
               have hp :=
                 pivotLoop_swap_pivot_ne_zero state hDone (by simpa [kFin] using hfind)
-              rw [Hex.Matrix.pivotLoop_regular_branch_swap fuel state hDone hp0
+              rw [Hex.Matrix.pivotLoop_of_regular_swap fuel state hDone hp0
                 (by simpa [kFin] using hfind) hp]
               apply ih
               show state.step + 1 + 1 ≤ n
               omega
-        · rw [Hex.Matrix.pivotLoop_regular_branch_no_swap fuel state hDone hp0]
+        · rw [Hex.Matrix.pivotLoop_of_regular_no_swap fuel state hDone hp0]
           apply ih
           show state.step + 1 + 1 ≤ n
           omega
@@ -1513,23 +1513,23 @@ private theorem pivotLoop_step_succ_ge_of_regular
               Hex.Matrix.findPivot? state.matrix kFin (state.step + 1) with
           | none =>
               have hloop :=
-                Hex.Matrix.pivotLoop_singular_branch_no_pivot fuel state hDone hp0
+                Hex.Matrix.pivotLoop_of_singular_no_pivot fuel state hDone hp0
                   (by simpa [kFin] using hfind)
               rw [hloop] at hregular
               simp at hregular
           | some pivot =>
               have hp :=
                 pivotLoop_swap_pivot_ne_zero state hDone (by simpa [kFin] using hfind)
-              rw [Hex.Matrix.pivotLoop_regular_branch_swap fuel state hDone hp0
+              rw [Hex.Matrix.pivotLoop_of_regular_swap fuel state hDone hp0
                 (by simpa [kFin] using hfind) hp]
               apply ih
-              · simpa [Hex.Matrix.pivotLoop_regular_branch_swap fuel state hDone hp0
+              · simpa [Hex.Matrix.pivotLoop_of_regular_swap fuel state hDone hp0
                   (by simpa [kFin] using hfind) hp] using hregular
               · show n ≤ state.step + 1 + fuel + 1
                 omega
-        · rw [Hex.Matrix.pivotLoop_regular_branch_no_swap fuel state hDone hp0]
+        · rw [Hex.Matrix.pivotLoop_of_regular_no_swap fuel state hDone hp0]
           apply ih
-          · simpa [Hex.Matrix.pivotLoop_regular_branch_no_swap fuel state hDone hp0]
+          · simpa [Hex.Matrix.pivotLoop_of_regular_no_swap fuel state hDone hp0]
               using hregular
           · show n ≤ state.step + 1 + fuel + 1
             omega

--- a/HexBerlekamp/Basic.lean
+++ b/HexBerlekamp/Basic.lean
@@ -590,7 +590,7 @@ private theorem matrixActionPolySum_eq_linearPow_mod
         rw [DensePoly.coeff_eq_zero_of_size_le _ (by omega : _ ≤ n), DensePoly.coeff_zero]
         rfl
       rw [h_zero]
-      exact DensePoly.zero_mod_eq_zero_core (S := ZMod64 p) f
+      exact DensePoly.zero_mod_eq_zero (S := ZMod64 p) f
     · apply DensePoly.mod_eq_self_of_degree_lt
       have hbasis_pos : 0 < basisSize f := Nat.pos_of_ne_zero h_basis_zero
       have hf_size_pos : 0 < f.size := size_pos_of_basisSize_pos f hbasis_pos

--- a/HexBerlekamp/DistinctDegree.lean
+++ b/HexBerlekamp/DistinctDegree.lean
@@ -707,7 +707,7 @@ private theorem unitPolynomial_dvd_any
     omega
   have hmod : target % u = 0 := by
     show (DensePoly.divMod target u).2 = 0
-    apply DensePoly.divMod_remainder_eq_zero_of_degree_zero_core
+    apply DensePoly.divMod_remainder_eq_zero_of_degree_zero_of_cancel
     · exact hu_size
     · intro a
       have hpos : 0 < u.size := by omega

--- a/HexBerlekamp/FactorPolyElab.lean
+++ b/HexBerlekamp/FactorPolyElab.lean
@@ -120,7 +120,7 @@ meta def fpCoverEntries (tactic : String) (p : Nat) [Hex.ZMod64.Bounds p]
 /-- Constructs the value emitted by `factor_poly` for
 `f : FpPoly p`: returns the `Hex.FpPoly.Factored f` value as a raw `Expr`
 over reified literal data. -/
-meta def proveFpFactored (tactic : String) (p : Nat)
+meta def mkFpFactored (tactic : String) (p : Nat)
     [Hex.ZMod64.Bounds p] (hpt : Hex.Nat.isPrimeTrial p = true)
     (pE boundsE RE zeroE decE fE : Expr) : MetaM Expr := do
       let hp : Hex.Nat.Prime p := Hex.Nat.isPrimeTrial_isPrime hpt
@@ -169,7 +169,7 @@ meta def elabFactorPolyFp (tactic : String) (p : Nat)
   if hpt : Hex.Nat.isPrimeTrial p = true then
     if h1 : 0 < p then
       if h2 : p < 2 ^ 31 then
-        @proveFpFactored tactic p ⟨h1, h2⟩ hpt pE boundsE RE zeroE decE fE
+        @mkFpFactored tactic p ⟨h1, h2⟩ hpt pE boundsE RE zeroE decE fE
       else
         throwError "{tactic}: internal error: modulus over the ZMod64 bound \
             despite a Bounds instance"

--- a/HexBerlekamp/FactorPolyElab.lean
+++ b/HexBerlekamp/FactorPolyElab.lean
@@ -117,10 +117,10 @@ meta def fpCoverEntries (tactic : String) (p : Nat) [Hex.ZMod64.Bounds p]
           please report this"
   return entries
 
-/-- Instance-carrying core of the `factor_poly` elaboration for
+/-- Constructs the value emitted by `factor_poly` for
 `f : FpPoly p`: returns the `Hex.FpPoly.Factored f` value as a raw `Expr`
 over reified literal data. -/
-meta def elabFpFactoredCore (tactic : String) (p : Nat)
+meta def proveFpFactored (tactic : String) (p : Nat)
     [Hex.ZMod64.Bounds p] (hpt : Hex.Nat.isPrimeTrial p = true)
     (pE boundsE RE zeroE decE fE : Expr) : MetaM Expr := do
       let hp : Hex.Nat.Prime p := Hex.Nat.isPrimeTrial_isPrime hpt
@@ -169,7 +169,7 @@ meta def elabFactorPolyFp (tactic : String) (p : Nat)
   if hpt : Hex.Nat.isPrimeTrial p = true then
     if h1 : 0 < p then
       if h2 : p < 2 ^ 31 then
-        @elabFpFactoredCore tactic p ⟨h1, h2⟩ hpt pE boundsE RE zeroE decE fE
+        @proveFpFactored tactic p ⟨h1, h2⟩ hpt pE boundsE RE zeroE decE fE
       else
         throwError "{tactic}: internal error: modulus over the ZMod64 bound \
             despite a Bounds instance"
@@ -182,7 +182,7 @@ meta def elabFactorPolyFp (tactic : String) (p : Nat)
 
 /-- Elaborate a `factor_poly` argument and produce the structure value,
 dispatching to providers for non-`FpPoly` input types. -/
-meta def elabFactorPolyCore (stx : Syntax) (t : Syntax)
+meta def elabFactorPolyArgument (stx : Syntax) (t : Syntax)
     (expectedType? : Option Expr) : Term.TermElabM Expr := do
   let pE ← Term.elabTerm t none
   Term.synthesizeSyntheticMVarsNoPostponing
@@ -207,7 +207,7 @@ syntax (name := factorPolyTerm) "factor_poly" term:max : term
   fun stx expectedType? => do
     match stx with
     | `(factor_poly $t) => do
-        let e ← elabFactorPolyCore stx t expectedType?
+        let e ← elabFactorPolyArgument stx t expectedType?
         Term.ensureHasType expectedType? e
     | _ => Elab.throwUnsupportedSyntax
 
@@ -271,7 +271,7 @@ syntax (name := factorPolyTac) "factor_poly" term:max : tactic
     match stx with
     | `(tactic| factor_poly $t) => do
         let e ← Tactic.withMainContext do
-          elabFactorPolyCore stx t none
+          elabFactorPolyArgument stx t none
         introFactored e
     | _ => Elab.throwUnsupportedSyntax
 

--- a/HexBerlekamp/Irreducibility.lean
+++ b/HexBerlekamp/Irreducibility.lean
@@ -1035,7 +1035,7 @@ theorem checkPowChainLinearIncrementalQuotientWitnesses_first_of_coeffs_beq
   checkPowChainLinearIncrementalQuotientWitnesses_first_of_coeffs
     f first hmonic cert hfirst (eq_of_beq hcoeffs)
 
-private theorem checkPowChainWitnessStep_zero :
+example :
     let zero : FpPoly 2 := 0
     let cert : SamePrimeIrreducibilityCertificate 2 :=
       { n := 1, powChain := #[zero, zero], bezout := #[] }
@@ -1049,7 +1049,7 @@ private theorem checkPowChainWitnessStep_zero :
   · decide
   · rfl
 
-private theorem checkPowChainWitnessStep_zero_of_beq :
+example :
     let zero : FpPoly 2 := 0
     let cert : SamePrimeIrreducibilityCertificate 2 :=
       { n := 1, powChain := #[zero, zero], bezout := #[] }

--- a/HexBerlekamp/Irreducibility.lean
+++ b/HexBerlekamp/Irreducibility.lean
@@ -1035,7 +1035,7 @@ theorem checkPowChainLinearIncrementalQuotientWitnesses_first_of_coeffs_beq
   checkPowChainLinearIncrementalQuotientWitnesses_first_of_coeffs
     f first hmonic cert hfirst (eq_of_beq hcoeffs)
 
-private theorem checkPowChainLinearIncrementalQuotientWitnessStep_zero_pilot :
+private theorem checkPowChainWitnessStep_zero :
     let zero : FpPoly 2 := 0
     let cert : SamePrimeIrreducibilityCertificate 2 :=
       { n := 1, powChain := #[zero, zero], bezout := #[] }
@@ -1049,7 +1049,7 @@ private theorem checkPowChainLinearIncrementalQuotientWitnessStep_zero_pilot :
   · decide
   · rfl
 
-private theorem checkPowChainLinearIncrementalQuotientWitnessStep_zero_bool_pilot :
+private theorem checkPowChainWitnessStep_zero_of_beq :
     let zero : FpPoly 2 := 0
     let cert : SamePrimeIrreducibilityCertificate 2 :=
       { n := 1, powChain := #[zero, zero], bezout := #[] }

--- a/HexBerlekamp/IrreducibilityElab.lean
+++ b/HexBerlekamp/IrreducibilityElab.lean
@@ -29,10 +29,10 @@ namespace Hex.FactorTactic
 
 open Lean Meta Elab
 
-/-- Instance-carrying core of the `irreducibility` elaboration for
+/-- Constructs the proof emitted by `irreducibility` for
 `f : FpPoly p`: returns the proof of `Hex.FpPoly.Irreducible f` as a raw
 `Expr` over reified literal data. -/
-meta def elabFpIrredCore (tactic : String) (p : Nat)
+meta def proveFpIrreducible (tactic : String) (p : Nat)
     [Hex.ZMod64.Bounds p] (hpt : Hex.Nat.isPrimeTrial p = true)
     (pE boundsE fE : Expr) : MetaM Expr := do
       let hp : Hex.Nat.Prime p := Hex.Nat.isPrimeTrial_isPrime hpt
@@ -85,7 +85,7 @@ meta def elabIrreducibilityFp (tactic : String) (p : Nat)
   if hpt : Hex.Nat.isPrimeTrial p = true then
     if h1 : 0 < p then
       if h2 : p < 2 ^ 31 then
-        @elabFpIrredCore tactic p ⟨h1, h2⟩ hpt pE boundsE fE
+        @proveFpIrreducible tactic p ⟨h1, h2⟩ hpt pE boundsE fE
       else
         throwError "{tactic}: internal error: modulus over the ZMod64 bound \
             despite a Bounds instance"
@@ -98,7 +98,7 @@ meta def elabIrreducibilityFp (tactic : String) (p : Nat)
 
 /-- Elaborate an `irreducibility` argument and produce the proof, dispatching
 to providers for non-`FpPoly` input types. -/
-meta def elabIrreducibilityCore (stx : Syntax) (t : Syntax)
+meta def elabIrreducibilityArgument (stx : Syntax) (t : Syntax)
     (expectedType? : Option Expr) : Term.TermElabM Expr := do
   let pE ← Term.elabTerm t none
   Term.synthesizeSyntheticMVarsNoPostponing
@@ -122,7 +122,7 @@ syntax (name := irreducibilityTerm) "irreducibility" term:max : term
   fun stx expectedType? => do
     match stx with
     | `(irreducibility $t) => do
-        let e ← elabIrreducibilityCore stx t expectedType?
+        let e ← elabIrreducibilityArgument stx t expectedType?
         Term.ensureHasType expectedType? e
     | _ => Elab.throwUnsupportedSyntax
 
@@ -179,14 +179,14 @@ syntax (name := irreducibilityTac)
             `… .Irreducible e`.")
     | `(tactic| irreducibility $t:term) => do
         let proof ← Tactic.withMainContext do
-          elabIrreducibilityCore stx t none
+          elabIrreducibilityArgument stx t none
         Tactic.liftMetaTactic fun g => do
           let ty ← inferType proof
           let (_, g) ← (← g.assert `this ty proof).intro1P
           return [g]
     | `(tactic| irreducibility $h:ident : $t:term) => do
         let proof ← Tactic.withMainContext do
-          elabIrreducibilityCore stx t none
+          elabIrreducibilityArgument stx t none
         Tactic.liftMetaTactic fun g => do
           let ty ← inferType proof
           let (_, g) ← (← g.assert h.getId ty proof).intro1P

--- a/HexBerlekamp/RabinSoundness/KernelWitness.lean
+++ b/HexBerlekamp/RabinSoundness/KernelWitness.lean
@@ -82,7 +82,7 @@ theorem dvd_one_of_isUnitPolynomial
     omega
   have hmod : (1 : FpPoly p) % u = 0 := by
     show (DensePoly.divMod (1 : FpPoly p) u).2 = 0
-    apply DensePoly.divMod_remainder_eq_zero_of_degree_zero_core
+    apply DensePoly.divMod_remainder_eq_zero_of_degree_zero_of_cancel
     · exact hu_size
     · intro a
       have hpos : 0 < u.size := by omega

--- a/HexBerlekamp/RabinSoundness/RabinCore.lean
+++ b/HexBerlekamp/RabinSoundness/RabinCore.lean
@@ -291,7 +291,7 @@ private theorem constant_eq_zero_of_mod_eq_zero
     rw [DensePoly.degree?_C_getD]
     exact ha_pos
   have hzero : (0 : FpPoly p) % a = 0 := by
-    exact DensePoly.zero_mod_eq_zero_core (S := ZMod64 p) a
+    exact DensePoly.zero_mod_eq_zero (S := ZMod64 p) a
   have hpoly : (DensePoly.C c : FpPoly p) = 0 := by
     simpa [hC, hzero] using hmod
   have hcoeff := congrArg (fun q : FpPoly p => q.coeff 0) hpoly
@@ -661,7 +661,7 @@ theorem frobeniusDiffMod_mod_self_of_degree_zero
   have hmod_zero : ∀ q : FpPoly p, q % f = 0 := by
     intro q
     show (DensePoly.divMod q f).2 = 0
-    exact DensePoly.divMod_remainder_eq_zero_of_degree_zero_core q f hf_size hcancel
+    exact DensePoly.divMod_remainder_eq_zero_of_degree_zero_of_cancel q f hf_size hcancel
   -- Show frobeniusDiffMod = 0.
   have hfrob_zero : FpPoly.frobeniusXPowMod f hmonic k = 0 := by
     have h := hmod_zero (FpPoly.frobeniusXPowMod f hmonic k)

--- a/HexBerlekampMathlib/Basic.lean
+++ b/HexBerlekampMathlib/Basic.lean
@@ -243,21 +243,6 @@ theorem coeff_toMathlibPolynomial_equiv (f : Hex.FpPoly p) (n : Nat) :
     (toMathlibPolynomial f).coeff n = HexModArithMathlib.ZMod64.equiv (f.coeff n) := by
   rw [coeff_toMathlibPolynomial, HexModArithMathlib.ZMod64.equiv_apply]
 
-/-- Coefficient view supplied by `HexPolyMathlib.toPolynomial`. -/
-theorem hexPolyMathlib_coeff_bridge
-    {R : Type u} [Semiring R] [DecidableEq R] (f : Hex.DensePoly R) (n : Nat) :
-    (HexPolyMathlib.toPolynomial f).coeff n = f.coeff n := by
-  simp
-
-/--
-The direct finite-field transport is the coefficientwise lift along
-`ZMod64.equiv`, matching the coefficient view supplied by the generic
-`HexPolyMathlib.toPolynomial`.
--/
-theorem toMathlibPolynomial_coeff_bridge (f : Hex.FpPoly p) (n : Nat) :
-    (toMathlibPolynomial f).coeff n = HexModArithMathlib.ZMod64.equiv (f.coeff n) :=
-  coeff_toMathlibPolynomial_equiv f n
-
 /-- Monicity of executable finite-field polynomials transfers to Mathlib.
 
 No nontriviality hypothesis is required: when `ZMod p` is trivial every

--- a/HexBerlekampMathlib/FactorProvider.lean
+++ b/HexBerlekampMathlib/FactorProvider.lean
@@ -136,27 +136,27 @@ Structural heads are matched on the raw term: `whnf` would unfold
 `Polynomial.C`/`X`/numerals into their `Finsupp` normal form and defeat the
 match.
 -/
-meta partial def parseCore (tactic : String) (q : Nat) [Hex.ZMod64.Bounds q]
+meta partial def parsePolynomial (tactic : String) (q : Nat) [Hex.ZMod64.Bounds q]
     (pE boundsE : Expr) (fuel : Nat) (e : Expr) :
     MetaM (Hex.FpPoly q × Expr × Expr) := do
   match e.getAppFnArgs with
   | (``HAdd.hAdd, #[_, _, _, _, a, b]) => do
-      let (va, vaE, pa) ← parseCore tactic q pE boundsE fuel a
-      let (vb, vbE, pb) ← parseCore tactic q pE boundsE fuel b
+      let (va, vaE, pa) ← parsePolynomial tactic q pE boundsE fuel a
+      let (vb, vbE, pb) ← parsePolynomial tactic q pE boundsE fuel b
       combineBinary pE boundsE e (va + vb) vaE vbE pa pb
         ``HexBerlekampMathlib.toMathlibPolynomial_add ``HAdd.hAdd
   | (``HSub.hSub, #[_, _, _, _, a, b]) => do
-      let (va, vaE, pa) ← parseCore tactic q pE boundsE fuel a
-      let (vb, vbE, pb) ← parseCore tactic q pE boundsE fuel b
+      let (va, vaE, pa) ← parsePolynomial tactic q pE boundsE fuel a
+      let (vb, vbE, pb) ← parsePolynomial tactic q pE boundsE fuel b
       combineBinary pE boundsE e (va - vb) vaE vbE pa pb
         ``HexBerlekampMathlib.toMathlibPolynomial_sub ``HSub.hSub
   | (``HMul.hMul, #[_, _, _, _, a, b]) => do
-      let (va, vaE, pa) ← parseCore tactic q pE boundsE fuel a
-      let (vb, vbE, pb) ← parseCore tactic q pE boundsE fuel b
+      let (va, vaE, pa) ← parsePolynomial tactic q pE boundsE fuel a
+      let (vb, vbE, pb) ← parsePolynomial tactic q pE boundsE fuel b
       combineBinary pE boundsE e (va * vb) vaE vbE pa pb
         ``HexBerlekampMathlib.toMathlibPolynomial_mul ``HMul.hMul
   | (``Neg.neg, #[_, _, a]) => do
-      let (va, vaE, pa) ← parseCore tactic q pE boundsE fuel a
+      let (va, vaE, pa) ← parsePolynomial tactic q pE boundsE fuel a
       let vE ← mkAppM ``Neg.neg #[vaE]
       let t1 ← mkAppOptM ``HexBerlekampMathlib.toMathlibPolynomial_neg
         #[some pE, some boundsE, some vaE]
@@ -165,7 +165,7 @@ meta partial def parseCore (tactic : String) (q : Nat) [Hex.ZMod64.Bounds q]
       let t2 ← mkCongrArg negFn pa
       return (-va, vE, ← mkEqTrans t1 t2)
   | (``HPow.hPow, #[_, _, _, _, a, nE]) => do
-      let (va, vaE, pa) ← parseCore tactic q pE boundsE fuel a
+      let (va, vaE, pa) ← parsePolynomial tactic q pE boundsE fuel a
       let n ← getNatLit tactic nE
       let polyTy ← inferType e
       let fpTy := Hex.CertReify.fpPolyType pE boundsE
@@ -225,17 +225,17 @@ meta partial def parseCore (tactic : String) (q : Nat) [Hex.ZMod64.Bounds q]
         throwError "{tactic}: unsupported polynomial syntax{indentExpr e}"
       else
         match ← unfoldDefinition? e with
-        | some e' => parseCore tactic q pE boundsE (fuel - 1) e'
+        | some e' => parsePolynomial tactic q pE boundsE (fuel - 1) e'
         | none => throwError "{tactic}: unsupported polynomial syntax{indentExpr e}"
 
-/-- Parse the full input: run `parseCore`, then recombine the parsed
+/-- Parse the full input with `parsePolynomial`, then recombine the parsed
 expression with the flat reified literal of its value through one
 `eq_of_beqCoeffs` kernel check, yielding `(f, fLit, hP)` with
 `hP : toMathlibPolynomial fLit = e`. -/
 meta def parseInput (tactic : String) (q : Nat) [Hex.ZMod64.Bounds q]
     (pE boundsE : Expr) (e : Expr) :
     MetaM (Hex.FpPoly q × Expr × Expr) := do
-  let (v, vE, prf) ← parseCore tactic q pE boundsE 16 e
+  let (v, vE, prf) ← parsePolynomial tactic q pE boundsE 16 e
   let fLit := Hex.CertReify.reifyFpPolyOfNats pE boundsE (Hex.CertReify.fpCoeffNats v)
   let RE := Hex.CertReify.zmodType pE boundsE
   let zeroE ← synthInstance (← mkAppM ``Zero #[RE])

--- a/HexBerlekampZassenhaus/FactorEntryPoints.lean
+++ b/HexBerlekampZassenhaus/FactorEntryPoints.lean
@@ -1155,7 +1155,7 @@ all-ones class — the signature of an *irreducible* input (all lifted mod-`p`
 factors form the one integer factor). At column-adequate precision
 (`bhksRecoveryFloor core ≤ k`) this certifies irreducibility — the proven count
 lower bound forces a reducible core to exhibit ≥ 2 classes there
-(`latticeArm3_bhksSingleAllOnes_irreducible` in the Mathlib layer) — while
+(`bhksSingleAllOnes_irreducible` in the Mathlib layer) — while
 below the floor it may instead mean the lattice has not separated the factors
 yet, so callers must only trust it at `k ≥ bhksRecoveryFloor core`. (A cap-free
 CLD path would treat this partition as `degenerate` and decline, which is why
@@ -1196,7 +1196,7 @@ accepted as a **sound** irreducibility certificate (`some #[core]`) instead of
 advancing the schedule.  Soundness is not heuristic: at column-adequate precision
 (`bhksRecoveryFloor core ≤ k`) the proven count lower bound forces a reducible core
 to exhibit ≥ 2 equivalence classes, so all-ones can only be reported for a
-genuinely irreducible core (`latticeArm3_bhksSingleAllOnes_irreducible` in the
+genuinely irreducible core (`bhksSingleAllOnes_irreducible` in the
 Mathlib layer consumes exactly the `⟨k, floor ≤ k, all-ones⟩` witness this loop
 produces).  Without the early stop the loop grinds the doubling schedule to the
 conservative BHKS cap on every irreducible input.
@@ -1346,7 +1346,7 @@ private theorem latticeCoreLoop_some_spec
 singleton `#[core]` with a witness precision `k'` clearing `bhksRecoveryFloor core`
 whose partition is the single all-ones class.  The witness pair is exactly the
 `hB_floor`/`hbhks` input of the Mathlib layer's
-`latticeArm3_bhksSingleAllOnes_irreducible`. -/
+`bhksSingleAllOnes_irreducible`. -/
 theorem latticeCoreWithBound_some_spec
     {core : ZPoly} {B : Nat} {primeData : PrimeChoiceData} {k fuel : Nat}
     {cf : Array ZPoly}

--- a/HexBerlekampZassenhaus/FactorEntryPoints.lean
+++ b/HexBerlekampZassenhaus/FactorEntryPoints.lean
@@ -1155,7 +1155,7 @@ all-ones class — the signature of an *irreducible* input (all lifted mod-`p`
 factors form the one integer factor). At column-adequate precision
 (`bhksRecoveryFloor core ≤ k`) this certifies irreducibility — the proven count
 lower bound forces a reducible core to exhibit ≥ 2 classes there
-(`bhksSingleAllOnes_irreducible` in the Mathlib layer) — while
+(`squareFreeCore_irreducible_of_bhksSingleAllOnes` in the Mathlib layer) — while
 below the floor it may instead mean the lattice has not separated the factors
 yet, so callers must only trust it at `k ≥ bhksRecoveryFloor core`. (A cap-free
 CLD path would treat this partition as `degenerate` and decline, which is why
@@ -1196,7 +1196,7 @@ accepted as a **sound** irreducibility certificate (`some #[core]`) instead of
 advancing the schedule.  Soundness is not heuristic: at column-adequate precision
 (`bhksRecoveryFloor core ≤ k`) the proven count lower bound forces a reducible core
 to exhibit ≥ 2 equivalence classes, so all-ones can only be reported for a
-genuinely irreducible core (`bhksSingleAllOnes_irreducible` in the
+genuinely irreducible core (`squareFreeCore_irreducible_of_bhksSingleAllOnes` in the
 Mathlib layer consumes exactly the `⟨k, floor ≤ k, all-ones⟩` witness this loop
 produces).  Without the early stop the loop grinds the doubling schedule to the
 conservative BHKS cap on every irreducible input.
@@ -1346,7 +1346,7 @@ private theorem latticeCoreLoop_some_spec
 singleton `#[core]` with a witness precision `k'` clearing `bhksRecoveryFloor core`
 whose partition is the single all-ones class.  The witness pair is exactly the
 `hB_floor`/`hbhks` input of the Mathlib layer's
-`bhksSingleAllOnes_irreducible`. -/
+`squareFreeCore_irreducible_of_bhksSingleAllOnes`. -/
 theorem latticeCoreWithBound_some_spec
     {core : ZPoly} {B : Nat} {primeData : PrimeChoiceData} {k fuel : Nat}
     {cf : Array ZPoly}
@@ -1646,32 +1646,32 @@ prime exactly as the fast path does, then run `coreRecover?` against the
 `#guard`s below to exercise `coreRecover?` end-to-end on real non-monic
 multi-factor inputs; nothing in the production path routes through it (the
 production `latticeCoreLoop` still consumes `bhksRecover?`). -/
-private def coreRecoverSmoke? (c : ZPoly) : Option (Array ZPoly) :=
+private def coreRecoverAtCap? (c : ZPoly) : Option (Array ZPoly) :=
   match choosePrimeData? c with
   | some pd => coreRecover? c (ZPoly.coreLiftData c (latticePrecisionCap c) pd)
   | none => none
 
 -- `(2x+1)(x⁴+1)`: recovers the two integer factors in `core`'s own coordinate.
-#guard coreRecoverSmoke? (DensePoly.ofCoeffs #[1, 2, 0, 0, 1, 2]) =
+#guard coreRecoverAtCap? (DensePoly.ofCoeffs #[1, 2, 0, 0, 1, 2]) =
   some #[DensePoly.ofCoeffs #[1, 0, 0, 0, 1], DensePoly.ofCoeffs #[1, 2]]
 -- `(3x+2)(x²+2)`
-#guard coreRecoverSmoke? (DensePoly.ofCoeffs #[4, 6, 2, 3]) =
+#guard coreRecoverAtCap? (DensePoly.ofCoeffs #[4, 6, 2, 3]) =
   some #[DensePoly.ofCoeffs #[2, 3], DensePoly.ofCoeffs #[2, 0, 1]]
 -- `(6x²-1)(x+5)`
-#guard coreRecoverSmoke? (DensePoly.ofCoeffs #[-5, -1, 30, 6]) =
+#guard coreRecoverAtCap? (DensePoly.ofCoeffs #[-5, -1, 30, 6]) =
   some #[DensePoly.ofCoeffs #[5, 1], DensePoly.ofCoeffs #[-1, 0, 6]]
 -- `2x²-3x+1 = (2x-1)(x-1)`
-#guard coreRecoverSmoke? (DensePoly.ofCoeffs #[1, -3, 2]) =
+#guard coreRecoverAtCap? (DensePoly.ofCoeffs #[1, -3, 2]) =
   some #[DensePoly.ofCoeffs #[-1, 1], DensePoly.ofCoeffs #[-1, 2]]
 
 -- Each recovered factorization multiplies back to the core input.
-#guard (coreRecoverSmoke? (DensePoly.ofCoeffs #[1, 2, 0, 0, 1, 2])).map Array.polyProduct =
+#guard (coreRecoverAtCap? (DensePoly.ofCoeffs #[1, 2, 0, 0, 1, 2])).map Array.polyProduct =
   some (DensePoly.ofCoeffs #[1, 2, 0, 0, 1, 2])
-#guard (coreRecoverSmoke? (DensePoly.ofCoeffs #[4, 6, 2, 3])).map Array.polyProduct =
+#guard (coreRecoverAtCap? (DensePoly.ofCoeffs #[4, 6, 2, 3])).map Array.polyProduct =
   some (DensePoly.ofCoeffs #[4, 6, 2, 3])
-#guard (coreRecoverSmoke? (DensePoly.ofCoeffs #[-5, -1, 30, 6])).map Array.polyProduct =
+#guard (coreRecoverAtCap? (DensePoly.ofCoeffs #[-5, -1, 30, 6])).map Array.polyProduct =
   some (DensePoly.ofCoeffs #[-5, -1, 30, 6])
-#guard (coreRecoverSmoke? (DensePoly.ofCoeffs #[1, -3, 2])).map Array.polyProduct =
+#guard (coreRecoverAtCap? (DensePoly.ofCoeffs #[1, -3, 2])).map Array.polyProduct =
   some (DensePoly.ofCoeffs #[1, -3, 2])
 
 /--

--- a/HexBerlekampZassenhaus/ProductProofs.lean
+++ b/HexBerlekampZassenhaus/ProductProofs.lean
@@ -249,7 +249,7 @@ private theorem factorTrialWithBound_product_of_all_recorded_normalized
       f (factorTrialFactorsWithBound f B)
       (factorTrialFactorsWithBound_polyProduct f B) hnormalized hrecorded
 
-private theorem factorTrialWithBound_product_of_constant_branch
+private theorem factorTrialWithBound_product_of_constant
     (f : ZPoly) (B : Nat)
     (hf : f ≠ 0)
     (hbranch : (normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0) :
@@ -273,7 +273,7 @@ private theorem factorTrialWithBound_product_of_constant_branch
       exact polynomialNormalizationPrefixFactors_shouldRecord_of_ne_zero
         f hf factor hmem
 
-private theorem factorTrialWithBound_product_of_quadratic_branch
+private theorem factorTrialWithBound_product_of_quadratic
     (f : ZPoly) (B : Nat)
     (hf : f ≠ 0)
     (hdeg : (normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
@@ -299,7 +299,7 @@ private theorem factorTrialWithBound_product_of_quadratic_branch
     exact quadraticIntegerRootFactors?_shouldRecord
       (squareFreeCore_leadingCoeff_pos_of_ne_zero f hf) hquad c hc
 
-private theorem factorTrialWithBound_product_of_trial_branch
+private theorem factorTrialWithBound_product_of_trial
     (f : ZPoly) (B : Nat)
     (hf : f ≠ 0)
     (hdeg : (normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
@@ -336,14 +336,14 @@ theorem factorTrialWithBound_product (f : ZPoly) (B : Nat) :
     unfold factorTrialWithBound
     exact factorizationOfFactors_product_of_zero (factorTrialFactorsWithBound 0 B)
   · by_cases hdeg : (normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0
-    · exact factorTrialWithBound_product_of_constant_branch f B hf hdeg
+    · exact factorTrialWithBound_product_of_constant f B hf hdeg
     · cases hquad :
         quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore with
       | some coreFactors =>
-          exact factorTrialWithBound_product_of_quadratic_branch
+          exact factorTrialWithBound_product_of_quadratic
             f B hf hdeg coreFactors hquad
       | none =>
-          exact factorTrialWithBound_product_of_trial_branch
+          exact factorTrialWithBound_product_of_trial
             f B hf hdeg hquad
 
 /-- The public trial-division entry point reconstructs its input. -/

--- a/HexBerlekampZassenhaus/Recombination.lean
+++ b/HexBerlekampZassenhaus/Recombination.lean
@@ -1206,7 +1206,7 @@ theorem monicTarget_monic (core : ZPoly) (p k : Nat)
     exact absurd hemod (by decide)
   have hscale_size :
       (DensePoly.scale (leadingCoeffInverse core p k) core).size = core.size :=
-    scale_size_of_nonzero _ core hs_ne
+    scale_size_of_ne_zero _ core hs_ne
   have hscale_pos :
       0 < (DensePoly.scale (leadingCoeffInverse core p k) core).size := by
     rw [hscale_size]; exact hcore

--- a/HexBerlekampZassenhaus/TrialProofs.lean
+++ b/HexBerlekampZassenhaus/TrialProofs.lean
@@ -920,7 +920,7 @@ private theorem trialDivisionPeelAux_no_emitted_residual_divisor_of_squareFreeRa
 
 /-- If `candidate` does not divide `target`, the executable exact-quotient check
 must return `none`. -/
-private theorem exactQuotient?_eq_none_of_not_dvd_core
+private theorem exactQuotient?_eq_none_of_not_dvd_trial
     {target candidate : ZPoly} (hnot_dvd : ¬ candidate ∣ target) :
     exactQuotient? target candidate = none := by
   cases hcase : exactQuotient? target candidate with
@@ -951,7 +951,7 @@ private theorem trialDivisionPeelAux_no_residual_candidate_of_squareFreeRat
       trialDivisionPeelAux_no_emitted_residual_divisor_of_squareFreeRat
         target candidates htarget_ne hsq
         (fun c hc => (hcand c hc).1) factors residual hsplit c hc hemitted
-    exact exactQuotient?_eq_none_of_not_dvd_core hnot_dvd
+    exact exactQuotient?_eq_none_of_not_dvd_trial hnot_dvd
   · exact trialDivisionPeelAux_no_missed_unemitted
       target candidates hcand factors residual hsplit c hc hemitted
 

--- a/HexBerlekampZassenhausMathlib/BangElab.lean
+++ b/HexBerlekampZassenhausMathlib/BangElab.lean
@@ -203,7 +203,7 @@ syntax (name := irreducibilityBangTerm) "irreducibility!" term:max : term
   | `(irreducibility! $t) => do
       let e ←
         try
-          Hex.FactorTactic.elabIrreducibilityCore stx t expectedType?
+          Hex.FactorTactic.elabIrreducibilityArgument stx t expectedType?
         catch _ =>
           elabBangArg "irreducibility!" t
             (bangZPolyIrred "irreducibility!") (bangIntIrred "irreducibility!")
@@ -273,7 +273,7 @@ syntax (name := irreducibilityBangTac)
   | `(tactic| irreducibility! $t:term) => do
       let proof ← Tactic.withMainContext do
         try
-          Hex.FactorTactic.elabIrreducibilityCore stx t none
+          Hex.FactorTactic.elabIrreducibilityArgument stx t none
         catch _ =>
           elabBangArg "irreducibility!" t
             (bangZPolyIrred "irreducibility!") (bangIntIrred "irreducibility!")
@@ -284,7 +284,7 @@ syntax (name := irreducibilityBangTac)
   | `(tactic| irreducibility! $h:ident : $t:term) => do
       let proof ← Tactic.withMainContext do
         try
-          Hex.FactorTactic.elabIrreducibilityCore stx t none
+          Hex.FactorTactic.elabIrreducibilityArgument stx t none
         catch _ =>
           elabBangArg "irreducibility!" t
             (bangZPolyIrred "irreducibility!") (bangIntIrred "irreducibility!")
@@ -295,10 +295,10 @@ syntax (name := irreducibilityBangTac)
   | _ => Elab.throwUnsupportedSyntax
 
 /-- Shared plain-then-bang elaboration for `factor_poly!`. -/
-meta def elabFactorBangCore (stx : Syntax) (t : Syntax)
+meta def elabFactorBangArgument (stx : Syntax) (t : Syntax)
     (expectedType? : Option Expr) : Term.TermElabM Expr := do
   try
-    Hex.FactorTactic.elabFactorPolyCore stx t expectedType?
+    Hex.FactorTactic.elabFactorPolyArgument stx t expectedType?
   catch _ =>
     elabBangArg "factor_poly!" t bangZPolyFactor bangIntFactor
 
@@ -311,7 +311,7 @@ syntax (name := factorPolyBangTerm) "factor_poly!" term:max : term
   fun stx expectedType? => do
     match stx with
     | `(factor_poly! $t) => do
-        let e ← elabFactorBangCore stx t expectedType?
+        let e ← elabFactorBangArgument stx t expectedType?
         Term.ensureHasType expectedType? e
     | _ => Elab.throwUnsupportedSyntax
 
@@ -325,7 +325,7 @@ syntax (name := factorPolyBangTac) "factor_poly!" term:max : tactic
     match stx with
     | `(tactic| factor_poly! $t) => do
         let e ← Tactic.withMainContext do
-          elabFactorBangCore stx t none
+          elabFactorBangArgument stx t none
         Hex.FactorTactic.introFactored e
     | _ => Elab.throwUnsupportedSyntax
 

--- a/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
+++ b/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
@@ -428,7 +428,7 @@ theorem cldQuotientMod_congr_mul_derivative
       ∀ a : Int, a - (a / g.leadingCoeff) * g.leadingCoeff = 0 := by
     intro a; rw [hg_monic]; omega
   have hrdeg : r.degree?.getD 0 < g.degree?.getD 0 :=
-    Hex.DensePoly.divMod_remainder_degree_lt_of_pos_degree_core num g hg_deg hcancel
+    Hex.DensePoly.divMod_remainder_degree_lt_of_pos_degree_of_cancel num g hg_deg hcancel
   -- Move the goal to Mathlib polynomials reduced modulo `p ^ k`.
   refine HexHenselMathlib.zpoly_congr_of_toPolynomial_map_eq _ _ (p ^ k) ?_
   intro φ

--- a/HexBerlekampZassenhausMathlib/FactorProvider.lean
+++ b/HexBerlekampZassenhausMathlib/FactorProvider.lean
@@ -127,26 +127,26 @@ heads are matched on the raw term: `whnf` would unfold
 `Polynomial.C`/`X`/numerals into their `Finsupp` normal form and defeat the
 match.
 -/
-meta partial def parseCore (tactic : String) (fuel : Nat) (e : Expr) :
+meta partial def parsePolynomial (tactic : String) (fuel : Nat) (e : Expr) :
     MetaM (Hex.ZPoly × Expr × Expr) := do
   match e.getAppFnArgs with
   | (``HAdd.hAdd, #[_, _, _, _, a, b]) => do
-      let (va, vaE, pa) ← parseCore tactic fuel a
-      let (vb, vbE, pb) ← parseCore tactic fuel b
+      let (va, vaE, pa) ← parsePolynomial tactic fuel a
+      let (vb, vbE, pb) ← parsePolynomial tactic fuel b
       combineBinary e (va + vb) vaE vbE pa pb
         ``HexPolyZMathlib.toPolynomial_add ``HAdd.hAdd
   | (``HSub.hSub, #[_, _, _, _, a, b]) => do
-      let (va, vaE, pa) ← parseCore tactic fuel a
-      let (vb, vbE, pb) ← parseCore tactic fuel b
+      let (va, vaE, pa) ← parsePolynomial tactic fuel a
+      let (vb, vbE, pb) ← parsePolynomial tactic fuel b
       combineBinary e (va - vb) vaE vbE pa pb
         ``HexPolyZMathlib.toPolynomial_sub ``HSub.hSub
   | (``HMul.hMul, #[_, _, _, _, a, b]) => do
-      let (va, vaE, pa) ← parseCore tactic fuel a
-      let (vb, vbE, pb) ← parseCore tactic fuel b
+      let (va, vaE, pa) ← parsePolynomial tactic fuel a
+      let (vb, vbE, pb) ← parsePolynomial tactic fuel b
       combineBinary e (va * vb) vaE vbE pa pb
         ``HexPolyZMathlib.toPolynomial_mul ``HMul.hMul
   | (``Neg.neg, #[_, _, a]) => do
-      let (va, vaE, pa) ← parseCore tactic fuel a
+      let (va, vaE, pa) ← parsePolynomial tactic fuel a
       let vE ← mkAppM ``Neg.neg #[vaE]
       let t1 ← mkAppM ``HexPolyZMathlib.toPolynomial_neg #[vaE]
       let polyTy ← inferType e
@@ -154,7 +154,7 @@ meta partial def parseCore (tactic : String) (fuel : Nat) (e : Expr) :
       let t2 ← mkCongrArg negFn pa
       return (-va, vE, ← mkEqTrans t1 t2)
   | (``HPow.hPow, #[_, _, _, _, a, nE]) => do
-      let (va, vaE, pa) ← parseCore tactic fuel a
+      let (va, vaE, pa) ← parsePolynomial tactic fuel a
       let n ← HexPolyZMathlib.PolyParse.getNat tactic nE
       let polyTy ← inferType e
       let mulFn ← mkAppOptM ``HMul.hMul #[some polyTy, some polyTy, some polyTy, none]
@@ -210,16 +210,16 @@ meta partial def parseCore (tactic : String) (fuel : Nat) (e : Expr) :
         throwError "{tactic}: unsupported polynomial syntax{indentExpr e}"
       else
         match ← unfoldDefinition? e with
-        | some e' => parseCore tactic (fuel - 1) e'
+        | some e' => parsePolynomial tactic (fuel - 1) e'
         | none => throwError "{tactic}: unsupported polynomial syntax{indentExpr e}"
 
-/-- Parse the full input: run `parseCore`, then recombine the parsed
+/-- Parse the full input with `parsePolynomial`, then recombine the parsed
 expression with the flat reified literal of its value through one
 `eq_of_beqCoeffs` kernel check, yielding `(f, fLit, hP)` with
 `hP : toPolynomial fLit = e`. -/
 meta def parseInput (tactic : String) (e : Expr) :
     MetaM (Hex.ZPoly × Expr × Expr) := do
-  let (v, vE, prf) ← parseCore tactic 16 e
+  let (v, vE, prf) ← parsePolynomial tactic 16 e
   let fLit ← Hex.CertReify.reifyZPoly v
   let intE := mkConst ``Int
   let zeroE ← synthInstance (← mkAppM ``Zero #[intE])

--- a/HexBerlekampZassenhausMathlib/FactorSoundness.lean
+++ b/HexBerlekampZassenhausMathlib/FactorSoundness.lean
@@ -284,7 +284,7 @@ theorem Hex.ZPoly.isIrreducible_iff (f : Hex.ZPoly) :
           have : g.size = f.size := by
             rw [hg_def, Hex.normalizeFactorSign]
             by_cases hlc : Hex.DensePoly.leadingCoeff f < 0
-            · rw [if_pos hlc]; exact Hex.ZPoly.scale_size_of_nonzero (-1) f (by norm_num)
+            · rw [if_pos hlc]; exact Hex.ZPoly.scale_size_of_ne_zero (-1) f (by norm_num)
             · rw [if_neg hlc]
           have hfsz : 0 < f.size := Hex.ZPoly.size_pos_of_ne_zero f hf0
           have hgeq : g.degree?.getD 0 = g.size - 1 := by

--- a/HexBerlekampZassenhausMathlib/ForwardHenselTransport.lean
+++ b/HexBerlekampZassenhausMathlib/ForwardHenselTransport.lean
@@ -1423,13 +1423,13 @@ private theorem size_normalizeFactorSign_eq (f : Hex.ZPoly) :
   unfold Hex.normalizeFactorSign
   by_cases hneg : Hex.DensePoly.leadingCoeff f < 0
   · rw [if_pos hneg]
-    exact Hex.ZPoly.scale_size_of_nonzero (-1 : Int) f (by decide)
+    exact Hex.ZPoly.scale_size_of_ne_zero (-1 : Int) f (by decide)
   · rw [if_neg hneg]
 
 /-- `Hex.ZPoly.primitivePart` preserves stored size on nonzero inputs.
 
 Reconstruct `f = scale (content f) (primitivePart f)` via
-`content_mul_primitivePart`, then apply `Hex.ZPoly.scale_size_of_nonzero` with
+`content_mul_primitivePart`, then apply `Hex.ZPoly.scale_size_of_ne_zero` with
 the fact that `content f ≠ 0` whenever `f ≠ 0`. -/
 private theorem size_primitivePart_eq_of_ne_zero {f : Hex.ZPoly} (hf : f ≠ 0) :
     (Hex.ZPoly.primitivePart f).size = f.size := by
@@ -1454,7 +1454,7 @@ private theorem size_primitivePart_eq_of_ne_zero {f : Hex.ZPoly} (hf : f ≠ 0) 
   have h_scale_size :
       (Hex.DensePoly.scale (Hex.ZPoly.content f) (Hex.ZPoly.primitivePart f)).size =
         (Hex.ZPoly.primitivePart f).size :=
-    Hex.ZPoly.scale_size_of_nonzero (Hex.ZPoly.content f)
+    Hex.ZPoly.scale_size_of_ne_zero (Hex.ZPoly.content f)
       (Hex.ZPoly.primitivePart f) hcontent_ne
   calc (Hex.ZPoly.primitivePart f).size
       = (Hex.DensePoly.scale (Hex.ZPoly.content f)

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -81,16 +81,12 @@ theorem liftedFactorSubsetPartition_of_toMonicPrimeData_complete
     (IntReductionMod.initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData
       core B primeData hval hcore_lc_pos hcore_pos hcore_prim hB_ne_zero hbound)
 
-/-- **#7584 core-facts producer (slow-path Hensel substrate).**
-
-`SlowPathHenselSubstrate core B primeData` from the `toMonicPrimeData?` selection
-witness and standard core side conditions alone -- the slow-modular / fast-BHKS
-substrate package with no `MonicDescentHypotheses` carrier and no
-`InitialLiftedFactorSubsetPartitionEvidence` input.  The `corr` and `partition`
-fields are the carrier-free / complete `toMonicPrimeData?` producers above; the
-remaining lifted-factor monic / positive-degree / injectivity and modulus /
-precision facts discharge directly from the selection witness. -/
-theorem slowPathHenselSubstrate_of_toMonicPrimeData
+/-- Constructs `HenselFactorData core B primeData` from a
+`toMonicPrimeData?` factorization and the standard square-free-core
+hypotheses.  The correspondence and partition follow from the preceding
+theorems; the remaining fields follow directly from the factorization and
+precision bound. -/
+theorem HenselFactorData.ofToMonicPrime
     (core : Hex.ZPoly) (B : Nat)
     (primeData : Hex.PrimeChoiceData)
     (hval : ModPFactorization (Hex.ZPoly.toMonic core).monic primeData)
@@ -102,7 +98,7 @@ theorem slowPathHenselSubstrate_of_toMonicPrimeData
     (hbound :
       2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
         primeData.p ^ Hex.precisionForCoeffBound B primeData.p) :
-    SlowPathHenselSubstrate core B primeData := by
+    HenselFactorData core B primeData := by
   have hp_prime : Hex.Nat.Prime primeData.p :=
     hval.prime
   have hp2 : 2 ≤ primeData.p := hp_prime.two_le
@@ -253,12 +249,10 @@ theorem zpolyIrreducible_of_toMonicMonic_irreducible
   exact (irreducible_toPolynomial_dilate_iff
     (ne_of_gt hcore_lc_pos) hM_monic hcore_prim hrecover).mpr hm_irr
 
-/-- Small-mod singleton arm, keyed on the monic-transform prime selection
-`toMonicPrimeData?` (the selector shared by the fast, lattice, and slow modular
-tiers; #8519, #8533): a singleton mod-`p` factorisation of
+/-- A singleton mod-`p` factorization selected for the monic transform
 `(toMonic core).monic` certifies its irreducibility over `ℤ`, which descends to
 the primitive core along the dilation transform. -/
-theorem squareFreeCore_irreducible_of_toMonicSmallModSingletonBranch
+theorem squareFreeCore_irreducible_of_small_mod_singleton
     (f : Hex.ZPoly) (hf_ne : f ≠ 0) (primeData : Hex.PrimeChoiceData)
     (hcore_pos : 0 < (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0)
     (hselected : Hex.ZPoly.toMonicPrimeData? (Hex.normalizeForFactor f).squareFreeCore
@@ -627,19 +621,12 @@ theorem reassemblyExpansionComplete_exhaustiveIntegerTrial_of_ne_zero
     Hex.ZPoly.size_le_of_dvd_nonzero hfp_ne_zero hrp_ne_zero hfp_dvd_rp
   omega
 
-/--
-Reassembly expansion-completeness for the fast BHKS core-success branch from loop
-success plus core-factor irreducibility, with **no** forward-cut hypothesis.
+/-- Reassembly expansion-completeness for successful BHKS recovery from the
+recovery result and irreducibility of its factors.
 
-This factors the cut-free part of `fastCoreComplete_of_cut`
-(`PartitionRefinement.lean`): the product, sign-normalisation, degree, leading-
-coefficient, and fuel facts are all unconditional consequences of the loop
-success `hcore`; only the per-factor irreducibility `hirr` (there derived from
-the forward cut) is taken as a hypothesis here, isolating the cut dependence.
-Consumed by the capstone assembly `fastCoreRawGuarded_of_coreIrreducible`
-(`FactorSoundness.lean`).
--/
-theorem fastCoreReassemblyComplete_of_coreIrreducible
+The product, sign normalization, degree, leading-coefficient, and fuel facts
+follow from `hcore`; only per-factor irreducibility is assumed separately. -/
+theorem reassemblyComplete_of_bhksRecovery_irreducible
     (f : Hex.ZPoly) (hf_ne : f ≠ 0) (B : Nat) (primeData : Hex.PrimeChoiceData)
     {expectedFactors : Array Hex.ZPoly}
     (hcore :
@@ -740,7 +727,7 @@ factor of a *larger* polynomial `f` (with `core ∣ f`) be handled at
 Every other input is discharged from `toMonicPrimeData?` and the core side
 conditions.  Coverage (`RecoveredSmartSearch.covers_of_bound`) + product
 reconstruction + the `shouldRecord` gate + the square-free counting
-(`smartCore_factor_irreducible_of_covers_of_squarefree`) give irreducibility;
+(`factor_irreducible_of_covers`) give irreducibility;
 `trustworthyNone_of_bound` rules out the accepted-`none` branch. -/
 theorem classicalCoreFactorsWithBound_factor_irreducible_of_validBound
     (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
@@ -859,7 +846,7 @@ theorem classicalCoreFactorsWithBound_factor_irreducible_of_validBound
         hcore_dvd hpartition hmatches hfuel_adeq haux
       have hprod := Hex.scaledRecombinationSmartAux_product _ _ _ _ _ _ _ _ haux
       have hrecord := Hex.scaledRecombinationSmartAux_shouldRecord _ _ _ _ _ _ _ _ haux
-      have hirr := smartCore_factor_irreducible_of_covers_of_squarefree hcore_ne hcore_sqfree
+      have hirr := factor_irreducible_of_covers hcore_ne hcore_sqfree
         hprod hrecord hcover
       have hne : factors.isEmpty = false := by
         by_contra hc

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -35,17 +35,17 @@ namespace HexBerlekampZassenhausMathlib
 /-- **#7584 core-facts producer (lifted-subset partition).**
 
 `LiftedFactorSubsetPartition core (toMonicLiftData core B primeData) Finset.univ
-core` from the executable `toMonicPrimeData?` selection witness and the standard
+core` from a mod-`p` factorization of the monic transform and the standard
 core side conditions alone.  The embedded Hensel correspondence comes from the
-carrier-free `henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData` (no
+carrier-free `henselSubsetCorrespondenceHypotheses_of_toMonicModP` (no
 `MonicDescentHypotheses` input), and the recovered-coordinate partition evidence
 from
-`IntReductionMod.initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData`,
+`IntReductionMod.initialPartitionEvidence_of_toMonicModP`,
 so the caller supplies neither the descent carrier nor a separate
 `InitialLiftedFactorSubsetPartitionEvidence`.  The monic-only unscaled support
 field stays guarded by `leadingCoeff core = 1`; the non-monic path routes through
 the recovered `liftedRecoveryCandidate` coordinate. -/
-theorem liftedFactorSubsetPartition_of_toMonicPrimeData_complete
+theorem liftedFactorSubsetPartition_of_toMonicModP
     (core : Hex.ZPoly) (B : Nat)
     (primeData : Hex.PrimeChoiceData)
     (hval : ModPFactorization (Hex.ZPoly.toMonic core).monic primeData)
@@ -74,19 +74,19 @@ theorem liftedFactorSubsetPartition_of_toMonicPrimeData_complete
     have hzero : Hex.precisionForCoeffBound B primeData.p = 0 := by omega
     rw [hzero, pow_zero] at hmodulus
     omega
-  exact liftedFactorSubsetPartition_of_toMonicPrimeData core B primeData hval
-    (henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData core B primeData
+  exact liftedFactorSubsetPartition_of_toMonicModP_evidence core B primeData hval
+    (henselSubsetCorrespondenceHypotheses_of_toMonicModP core B primeData
       hval hcore_lc_pos hcore_pos hcore_prim hprecision hbound hB_ne_zero)
     hcore_sqfree
-    (IntReductionMod.initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData
+    (IntReductionMod.initialPartitionEvidence_of_toMonicModP
       core B primeData hval hcore_lc_pos hcore_pos hcore_prim hB_ne_zero hbound)
 
-/-- Constructs `HenselFactorData core B primeData` from a
-`toMonicPrimeData?` factorization and the standard square-free-core
+/-- Constructs `HenselFactorData core B primeData` from a mod-`p`
+factorization of the monic transform and the standard square-free-core
 hypotheses.  The correspondence and partition follow from the preceding
 theorems; the remaining fields follow directly from the factorization and
 precision bound. -/
-theorem HenselFactorData.ofToMonicPrime
+theorem HenselFactorData.ofToMonicModP
     (core : Hex.ZPoly) (B : Nat)
     (primeData : Hex.PrimeChoiceData)
     (hval : ModPFactorization (Hex.ZPoly.toMonic core).monic primeData)
@@ -121,10 +121,10 @@ theorem HenselFactorData.ofToMonicPrime
       liftedFactor_inj := ?_
       modulus := ?_
       precision := ?_ }
-  · exact henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData
+  · exact henselSubsetCorrespondenceHypotheses_of_toMonicModP
       core B primeData hval hcore_lc_pos hcore_pos hcore_prim
       hprec_pos hbound hB_ne_zero
-  · exact liftedFactorSubsetPartition_of_toMonicPrimeData_complete
+  · exact liftedFactorSubsetPartition_of_toMonicModP
       core B primeData hval hcore_lc_pos hcore_pos hcore_prim
       hcore_sqfree hB_ne_zero hbound
   · exact Hex.ZPoly.toMonicLiftData_liftedFactor_monic_of_monicPrimeData
@@ -793,7 +793,7 @@ theorem classicalCoreFactorsWithBound_factor_irreducible_of_validBound
       hval hprec_pos
   have hpartition : LiftedFactorSubsetPartition core
       (Hex.ZPoly.toMonicLiftData core LB primeData) Finset.univ core :=
-    liftedFactorSubsetPartition_of_toMonicPrimeData_complete core LB primeData hval
+    liftedFactorSubsetPartition_of_toMonicModP core LB primeData hval
       hcore_lc_pos hcore_pos hcore_primitive hcore_sqfree hLB_ne hbound_monic
   have hmatches : LiftedFactorListMatches (Hex.ZPoly.toMonicLiftData core LB primeData)
       Finset.univ (Hex.ZPoly.toMonicLiftData core LB primeData).liftedFactors.toList :=

--- a/HexBerlekampZassenhausMathlib/IntReductionMod/Transport.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod/Transport.lean
@@ -1577,8 +1577,8 @@ private theorem one_le_degree_getD_of_irreducible_dvd_primitive
 /-- **Producer for `InitialLiftedFactorSubsetPartitionEvidence` at `toMonicLiftData`.**
 
 Assembles the five-field initial lifted-partition evidence package over
-`Hex.ZPoly.toMonicLiftData core B primeData`, from a `toMonicPrimeData?` selection
-witness and the standard non-monic core side conditions (positive leading
+`Hex.ZPoly.toMonicLiftData core B primeData`, from a mod-`p` factorization of
+the monic transform and the standard non-monic core side conditions (positive leading
 coefficient, positive degree, primitivity, `B ≠ 0`, precision bound).
 
 The `cover` field reads each lifted index back through the mod-`p` index cover of
@@ -1591,7 +1591,7 @@ uniqueness) and applies `modPFactorSubset_disjoint_of_choosePrimeData`.
 candidate (primitive, positive-leading) to collapse association to equality, then
 applies `toMonicLiftData_unique_subset`.  The two recovery fields are the landed
 non-circular `liftedRecoveryCandidate` analytics. -/
-theorem initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData
+theorem initialPartitionEvidence_of_toMonicModP
     (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
     (hval : ModPFactorization (Hex.ZPoly.toMonic core).monic primeData)
     (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
@@ -1856,7 +1856,7 @@ theorem initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData
 **Monic-correspondent descent for a represented integer factor (#8068).**
 
 Top-level extraction of the `descent` step inside
-`initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData`.  From an
+`initialPartitionEvidence_of_toMonicModP`.  From an
 original-core represented factor `f` (irreducible, dividing `core`, represented
 at the `toMonicLiftData` lift by subset `S`) this reconstructs the *monic
 correspondent* `gf` of `f` from `f` alone: the monic irreducible factor of

--- a/HexBerlekampZassenhausMathlib/LatticeTier.lean
+++ b/HexBerlekampZassenhausMathlib/LatticeTier.lean
@@ -500,7 +500,7 @@ theorem normalizedFactors_card_le_bhksEquivalenceClassIndicators_size
   -- the #8413 partition of the lifted indices by true-factor supports
   have hpartition : LiftedFactorSubsetPartition core
       (Hex.ZPoly.toMonicLiftData core B primeData) Finset.univ core :=
-    liftedFactorSubsetPartition_of_toMonicPrimeData_complete core B primeData
+    liftedFactorSubsetPartition_of_toMonicModP core B primeData
       (modPFactorization_of_toMonicPrimeData hselected hcore_lc_pos hcore_pos)
       hcore_lc_pos hcore_pos hcore_prim hcore_sqfree hB_ne hbound_monic
   -- per-factor Hensel facts
@@ -703,7 +703,7 @@ the fast-core floor, so every true-factor support survives the LLL/Gram-Schmidt
 cut as a distinct equivalence class, and one verified candidate is emitted per
 class (`bhksIndicatorCandidates?_size_eq`).
 -/
-theorem bhksRecovery_factor_count
+theorem bhksRecoveryCoreWithBound_some_factor_count_eq
     (f : Hex.ZPoly) (hf_ne : f ≠ 0) (B : Nat) (primeData : Hex.PrimeChoiceData)
     (hselected : Hex.ZPoly.toMonicPrimeData? (Hex.normalizeForFactor f).squareFreeCore
       = some primeData)
@@ -756,7 +756,7 @@ so `bhksSingleAllOnesPartition` could report `true` on a *reducible* core.
 The `factorLattice` call site supplies adequate precision via
 `latticePrecisionCap`, which contains the floor by construction.
 -/
-theorem bhksSingleAllOnes_irreducible
+theorem squareFreeCore_irreducible_of_bhksSingleAllOnes
     (f : Hex.ZPoly) (hf_ne : f ≠ 0) (B : Nat) (primeData : Hex.PrimeChoiceData)
     (hselected : Hex.ZPoly.toMonicPrimeData? (Hex.normalizeForFactor f).squareFreeCore
       = some primeData)
@@ -863,7 +863,8 @@ van Hoeij CLD lattice tier `latticeCoreFactorsWithBound` returns for the
 square-free core of `normalizeForFactor f` is irreducible over `ℤ`, provided the
 precision clears the fast-core acceptance floor (`hB_floor`).  Arm 1 (small-mod
 singleton) is proved directly; arms 2/3 are the deep CLD obligations
-`bhksRecovery_factor_count` / `bhksSingleAllOnes_irreducible`.  The
+`bhksRecoveryCoreWithBound_some_factor_count_eq` /
+`squareFreeCore_irreducible_of_bhksSingleAllOnes`.  The
 `factorLattice` call site supplies `hB_floor` via `latticePrecisionCap`.
 -/
 theorem latticeCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible
@@ -879,9 +880,11 @@ theorem latticeCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible
     ∀ g ∈ cf.toList, Hex.ZPoly.Irreducible g :=
   latticeCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible_of_bhks
     f hf_ne B primeData hselected hdeg_ne hB_floor hB_ne hlattice
-    (bhksRecovery_factor_count f hf_ne B primeData hselected hdeg_ne)
+    (bhksRecoveryCoreWithBound_some_factor_count_eq
+      f hf_ne B primeData hselected hdeg_ne)
     (fun B' hB'_floor hB'_ne hbhks =>
-      bhksSingleAllOnes_irreducible f hf_ne B' primeData hselected hdeg_ne
+      squareFreeCore_irreducible_of_bhksSingleAllOnes
+        f hf_ne B' primeData hselected hdeg_ne
         hB'_floor hB'_ne hbhks)
 /-!
 ## Lattice-branch assembly
@@ -906,8 +909,8 @@ Consumed by the lattice residual arm of
 `factorLatticeFactorsWithBound_factor_irreducible`.
 
 The core irreducibility input is supplied by
-`bhksRecovery_factor_count` and
-`bhksSingleAllOnes_irreducible`; the reassembly side introduces no
+`bhksRecoveryCoreWithBound_some_factor_count_eq` and
+`squareFreeCore_irreducible_of_bhksSingleAllOnes`; the reassembly side introduces no
 additional assumption. -/
 theorem reassemblyExpansionComplete_latticeCore_of_ne_zero
     (f : Hex.ZPoly) (hf : f ≠ 0) (B : Nat) (primeData : Hex.PrimeChoiceData)

--- a/HexBerlekampZassenhausMathlib/LatticeTier.lean
+++ b/HexBerlekampZassenhausMathlib/LatticeTier.lean
@@ -27,7 +27,7 @@ Hensel seeds match the lift target; #8519) it has three arms:
 
 1. `primeData.factorsModP.size ≤ 1` → `some #[core]`.  The core is irreducible
    mod `p`, hence irreducible over `ℤ`.  **Proved unconditionally here** by
-   reusing `squareFreeCore_irreducible_of_toMonicSmallModSingletonBranch`.
+   reusing `squareFreeCore_irreducible_of_small_mod_singleton`.
 
 2. `latticeCoreWithBound … = some coreFactors` → those factors.  Via
    `latticeCoreWithBound_some_spec` this is either a genuine CLD split (a
@@ -67,7 +67,7 @@ obligations as hypotheses.
 The arms of `latticeCoreFactorsWithBound` are discharged as follows:
 
 * the small-mod singleton arm (`factorsModP.size ≤ 1`, output `#[core]`) is
-  proved unconditionally from `squareFreeCore_irreducible_of_toMonicSmallModSingletonBranch`;
+  proved unconditionally from `squareFreeCore_irreducible_of_small_mod_singleton`;
 * the loop-answer arm (`latticeCoreWithBound = some coreFactors`) splits via
   `latticeCoreWithBound_some_spec` into the CLD-split case (a genuine
   `bhksRecoveryCoreWithBound` success, discharged from the count-equality
@@ -125,7 +125,7 @@ theorem latticeCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible_of_bh
     rename_i hsmall
     obtain rfl := Option.some.inj hlattice
     exact fun g hg => hsingleton g hg
-      (squareFreeCore_irreducible_of_toMonicSmallModSingletonBranch f hf_ne primeData
+      (squareFreeCore_irreducible_of_small_mod_singleton f hf_ne primeData
         (Nat.pos_of_ne_zero hdeg_ne) hselected hsmall)
   · -- Arms 2/3: CLD recovery loop (with the certificate-backed early stop).
     split at hlattice
@@ -703,7 +703,7 @@ the fast-core floor, so every true-factor support survives the LLL/Gram-Schmidt
 cut as a distinct equivalence class, and one verified candidate is emitted per
 class (`bhksIndicatorCandidates?_size_eq`).
 -/
-theorem latticeArm2_fastCore_count
+theorem bhksRecovery_factor_count
     (f : Hex.ZPoly) (hf_ne : f ≠ 0) (B : Nat) (primeData : Hex.PrimeChoiceData)
     (hselected : Hex.ZPoly.toMonicPrimeData? (Hex.normalizeForFactor f).squareFreeCore
       = some primeData)
@@ -756,7 +756,7 @@ so `bhksSingleAllOnesPartition` could report `true` on a *reducible* core.
 The `factorLattice` call site supplies adequate precision via
 `latticePrecisionCap`, which contains the floor by construction.
 -/
-theorem latticeArm3_bhksSingleAllOnes_irreducible
+theorem bhksSingleAllOnes_irreducible
     (f : Hex.ZPoly) (hf_ne : f ≠ 0) (B : Nat) (primeData : Hex.PrimeChoiceData)
     (hselected : Hex.ZPoly.toMonicPrimeData? (Hex.normalizeForFactor f).squareFreeCore
       = some primeData)
@@ -863,7 +863,7 @@ van Hoeij CLD lattice tier `latticeCoreFactorsWithBound` returns for the
 square-free core of `normalizeForFactor f` is irreducible over `ℤ`, provided the
 precision clears the fast-core acceptance floor (`hB_floor`).  Arm 1 (small-mod
 singleton) is proved directly; arms 2/3 are the deep CLD obligations
-`latticeArm2_fastCore_count` / `latticeArm3_bhksSingleAllOnes_irreducible`.  The
+`bhksRecovery_factor_count` / `bhksSingleAllOnes_irreducible`.  The
 `factorLattice` call site supplies `hB_floor` via `latticePrecisionCap`.
 -/
 theorem latticeCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible
@@ -879,9 +879,9 @@ theorem latticeCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible
     ∀ g ∈ cf.toList, Hex.ZPoly.Irreducible g :=
   latticeCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible_of_bhks
     f hf_ne B primeData hselected hdeg_ne hB_floor hB_ne hlattice
-    (latticeArm2_fastCore_count f hf_ne B primeData hselected hdeg_ne)
+    (bhksRecovery_factor_count f hf_ne B primeData hselected hdeg_ne)
     (fun B' hB'_floor hB'_ne hbhks =>
-      latticeArm3_bhksSingleAllOnes_irreducible f hf_ne B' primeData hselected hdeg_ne
+      bhksSingleAllOnes_irreducible f hf_ne B' primeData hselected hdeg_ne
         hB'_floor hB'_ne hbhks)
 /-!
 ## Lattice-branch assembly
@@ -906,8 +906,8 @@ Consumed by the lattice residual arm of
 `factorLatticeFactorsWithBound_factor_irreducible`.
 
 The core irreducibility input is supplied by
-`latticeArm2_fastCore_count` and
-`latticeArm3_bhksSingleAllOnes_irreducible`; the reassembly side introduces no
+`bhksRecovery_factor_count` and
+`bhksSingleAllOnes_irreducible`; the reassembly side introduces no
 additional assumption. -/
 theorem reassemblyExpansionComplete_latticeCore_of_ne_zero
     (f : Hex.ZPoly) (hf : f ≠ 0) (B : Nat) (primeData : Hex.PrimeChoiceData)

--- a/HexBerlekampZassenhausMathlib/MonicCorrespondent.lean
+++ b/HexBerlekampZassenhausMathlib/MonicCorrespondent.lean
@@ -45,16 +45,9 @@ noncomputable section
 
 open Polynomial
 
-/-- **#5214 supporting bundle (HO-1 slow-path substrate).**
-
-Bundled substrate package for the slow-path arm of the HO-1 capstone
-`factorize_irreducible_of_nonUnit` (#4170).  The seven fields are exactly the
-hypothesis set on the lifted-Hensel side consumed by the slow-path
-exhaustive-branch irreducibility reasoning,
-packaged so the capstone can obtain all of them from a single
-`Hex.choosePrimeData? core = some primeData` witness together with monic /
-positive-degree / square-free hypotheses on the core, without rediscovering
-each fact independently.
+/-- Data connecting a square-free integer polynomial with its Hensel-lifted
+modular factors.  The seven fields collect the correspondence and partition
+properties used to recover integer factors from a chosen prime.
 
 * `corr` — `HenselSubsetCorrespondenceHypotheses` value (sourced from
   explicit successful correspondence evidence).
@@ -68,11 +61,9 @@ each fact independently.
 * `modulus`, `precision` — the Mignotte modulus and precision bounds
   `2 ≤ d.p ^ d.k` and `2 * B < d.p ^ d.k`.
 
-The constructor below threads the witnesses through the existing
-non-circular primitives in this file; no new analytic obligation is
-introduced.  The recovered lifted-partition analytic content is exposed as the
-`InitialLiftedFactorSubsetPartitionEvidence` argument. -/
-structure SlowPathHenselSubstrate
+The partition evidence is supplied explicitly through
+`InitialLiftedFactorSubsetPartitionEvidence`. -/
+structure HenselFactorData
     (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData) : Prop where
   corr :
     HenselSubsetCorrespondenceHypotheses core B primeData
@@ -97,9 +88,7 @@ structure SlowPathHenselSubstrate
     2 * B < (Hex.ZPoly.toMonicLiftData core B primeData).p ^
       (Hex.ZPoly.toMonicLiftData core B primeData).k
 
-/-- **#5214 supporting lemma (HO-1 slow-path substrate constructor).**
-
-Constructor for `SlowPathHenselSubstrate` from a `Hex.choosePrimeData?
+/-- Constructs `HenselFactorData` from a `Hex.choosePrimeData?
 core = some primeData` witness together with monic, positive-degree, and
 square-free hypotheses on the core, plus `B ≠ 0` and an explicit successful
 Hensel subset correspondence package.
@@ -119,7 +108,7 @@ Composes (no new analytic obligation):
   on monic input (`Hex.ZPoly.toMonic_monic_eq_core_of_leadingCoeff_eq_one`);
 * `Hex.precisionForCoeffBound_spec` for `precision`, refined to `modulus`
   via `B ≠ 0`. -/
-theorem slowPathHenselSubstrate_of_choosePrimeData
+theorem HenselFactorData.ofChoosePrime
     (core : Hex.ZPoly) (B : Nat)
     (primeData : Hex.PrimeChoiceData)
     (hchoose : Hex.choosePrimeData? core = some primeData)
@@ -133,7 +122,7 @@ theorem slowPathHenselSubstrate_of_choosePrimeData
     (hinitial :
       InitialLiftedFactorSubsetPartitionEvidence core
         (Hex.ZPoly.toMonicLiftData core B primeData)) :
-    SlowPathHenselSubstrate core B primeData := by
+    HenselFactorData core B primeData := by
   have hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core :=
     zpoly_lc_pos_of_monic hcore_monic
   have htoMonic_eq : (Hex.ZPoly.toMonic core).monic = core :=
@@ -180,17 +169,15 @@ theorem slowPathHenselSubstrate_of_choosePrimeData
   · exact hmodulus
   · exact hprec_spec
 
-/-- **#6354 supporting lemma (HO-1 slow-path substrate constructor).**
-
-Successful-branch variant of `slowPathHenselSubstrate_of_choosePrimeData`.
+/-- Successful-descent variant of `HenselFactorData.ofChoosePrime`.
 When callers supply primitive lifted-side descent plus forward Hensel transport,
 the `corr` field and the partition's embedded correspondence are built through
 `henselSubsetCorrespondenceHypotheses_of_choosePrimeData_success_descent`
 instead of assuming a correspondence for arbitrary prime data.
 
-The older substrate constructor now consumes explicit correspondence evidence;
-this wrapper builds that evidence from the descent/forward-transport package. -/
-theorem slowPathHenselSubstrate_of_choosePrimeData_success_descent
+This theorem derives the correspondence evidence from the descent and
+forward-transport hypotheses. -/
+theorem HenselFactorData.ofChoosePrimeDescent
     (core : Hex.ZPoly) (B : Nat)
     (primeData : Hex.PrimeChoiceData)
     (hchoose : Hex.choosePrimeData? core = some primeData)
@@ -214,7 +201,7 @@ theorem slowPathHenselSubstrate_of_choosePrimeData_success_descent
     (hinitial :
       InitialLiftedFactorSubsetPartitionEvidence core
         (Hex.ZPoly.toMonicLiftData core B primeData)) :
-    SlowPathHenselSubstrate core B primeData := by
+    HenselFactorData core B primeData := by
   have hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core :=
     zpoly_lc_pos_of_monic hcore_monic
   have htoMonic_eq : (Hex.ZPoly.toMonic core).monic = core :=
@@ -265,18 +252,16 @@ theorem slowPathHenselSubstrate_of_choosePrimeData_success_descent
   · exact hmodulus
   · exact hprec_spec
 
-/-- **#6172 (HO-1 slow-path substrate constructor, non-monic-core sibling).**
-
-Constructor for `SlowPathHenselSubstrate` from a
+/-- Constructs `HenselFactorData` from a
 `Hex.ZPoly.toMonicPrimeData? core = some primeData` witness together with
 positive-leading-coefficient, positive-degree, and square-free hypotheses
 on the core, plus `B ≠ 0` and an explicit successful Hensel subset
 correspondence package.  In contrast to
-`slowPathHenselSubstrate_of_choosePrimeData`, this sibling does not
+`HenselFactorData.ofChoosePrime`, this sibling does not
 require `core` to be monic — the prime-data witness operates on the
 integral-normalisation `(Hex.ZPoly.toMonic core).monic`, so non-monic
 square-free cores (e.g. `(Hex.normalizeForFactor f).squareFreeCore`) can
-feed the slow-path arm of #4170 directly.
+be used directly.
 
 Composes (no new analytic obligation; the recovered initial partition fields
 come from the explicit `InitialLiftedFactorSubsetPartitionEvidence` argument):
@@ -291,7 +276,7 @@ come from the explicit `InitialLiftedFactorSubsetPartitionEvidence` argument):
   natDegree positivity / injectivity facts;
 * `Hex.precisionForCoeffBound_spec` for `precision`, refined to `modulus`
   via `B ≠ 0`. -/
-theorem slowPathHenselSubstrate_of_toMonicChoosePrimeData
+theorem HenselFactorData.ofToMonicChoosePrime
     (core : Hex.ZPoly) (B : Nat)
     (primeData : Hex.PrimeChoiceData)
     (hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)
@@ -305,7 +290,7 @@ theorem slowPathHenselSubstrate_of_toMonicChoosePrimeData
     (hinitial :
       InitialLiftedFactorSubsetPartitionEvidence core
         (Hex.ZPoly.toMonicLiftData core B primeData)) :
-    SlowPathHenselSubstrate core B primeData := by
+    HenselFactorData core B primeData := by
   have hp_prime : Hex.Nat.Prime primeData.p :=
     Hex.ZPoly.toMonicPrimeData?_prime core primeData hselected
   have hp2 : 2 ≤ primeData.p := hp_prime.two_le

--- a/HexBerlekampZassenhausMathlib/MonicCorrespondent.lean
+++ b/HexBerlekampZassenhausMathlib/MonicCorrespondent.lean
@@ -267,7 +267,7 @@ Composes (no new analytic obligation; the recovered initial partition fields
 come from the explicit `InitialLiftedFactorSubsetPartitionEvidence` argument):
 
 * `hcorr` for `corr`;
-* `liftedFactorSubsetPartition_of_toMonicPrimeData` applied to `hcorr` for
+* `liftedFactorSubsetPartition_of_toMonicModP_evidence` applied to `hcorr` for
   `partition`;
 * the `_of_monicPrimeData` umbrellas
   (`Hex.ZPoly.toMonicLiftData_liftedFactor_monic_of_monicPrimeData`,
@@ -276,7 +276,7 @@ come from the explicit `InitialLiftedFactorSubsetPartitionEvidence` argument):
   natDegree positivity / injectivity facts;
 * `Hex.precisionForCoeffBound_spec` for `precision`, refined to `modulus`
   via `B ≠ 0`. -/
-theorem HenselFactorData.ofToMonicChoosePrime
+theorem HenselFactorData.ofToMonicPrimeData
     (core : Hex.ZPoly) (B : Nat)
     (primeData : Hex.PrimeChoiceData)
     (hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)
@@ -315,7 +315,7 @@ theorem HenselFactorData.ofToMonicChoosePrime
       modulus := ?_
       precision := ?_ }
   · exact hcorr
-  · exact liftedFactorSubsetPartition_of_toMonicPrimeData
+  · exact liftedFactorSubsetPartition_of_toMonicModP_evidence
       core B primeData
       (modPFactorization_of_toMonicPrimeData hselected hcore_lc_pos hcore_pos)
       hcorr hcore_sqfree hinitial
@@ -816,7 +816,7 @@ theorem monic_eq_of_primitivePart_dilate_eq
   have hpp_size : pp.size = m₁.size := by
     have : (Hex.DensePoly.scale K₁ pp).size = m₁.size := by
       rw [hrec₁]; exact size_dilate_eq_of_monic_of_ne_zero hc hm₁
-    rwa [Hex.ZPoly.scale_size_of_nonzero K₁ pp hK₁_ne] at this
+    rwa [Hex.ZPoly.scale_size_of_ne_zero K₁ pp hK₁_ne] at this
   have hpp_lead_ne : Hex.DensePoly.leadingCoeff pp ≠ 0 :=
     Hex.DensePoly.leadingCoeff_ne_zero_of_pos_size pp
       (by rw [hpp_size]; exact zpoly_size_pos_of_monic hm₁)
@@ -824,7 +824,7 @@ theorem monic_eq_of_primitivePart_dilate_eq
   have hpp_size₂ : pp.size = m₂.size := by
     have : (Hex.DensePoly.scale K₂ pp).size = m₂.size := by
       rw [hrec₂]; exact size_dilate_eq_of_monic_of_ne_zero hc hm₂
-    rwa [Hex.ZPoly.scale_size_of_nonzero K₂ pp hK₂_ne] at this
+    rwa [Hex.ZPoly.scale_size_of_ne_zero K₂ pp hK₂_ne] at this
   have hsize_eq : m₁.size = m₂.size := hpp_size ▸ hpp_size₂
   -- Match leading coefficients to deduce `K₁ = K₂`.
   have hlc₁ : c ^ (m₁.size - 1) = K₁ * Hex.DensePoly.leadingCoeff pp := by

--- a/HexBerlekampZassenhausMathlib/PrimitivityDegreeCover.lean
+++ b/HexBerlekampZassenhausMathlib/PrimitivityDegreeCover.lean
@@ -608,7 +608,7 @@ private theorem zpoly_primitive_scaledRecombinationCandidate
     (Hex.ZPoly.defaultFactorCoeffBound core) hcore_lc_le
     hcore_ne hcore_lc_pos hd_liftedFactor_monic hprecision T
 
-/-- Abstract-bound variant of `not_represents_empty_of_irreducible_dvd_core`.
+/-- Abstract-bound variant of `not_represents_empty_of_monic`.
 
 Routes through the partition's sound recovery equality
 `LiftedFactorSubsetPartition.liftedRecoveryCandidate_eq`: on the empty subset
@@ -617,7 +617,7 @@ the recovered candidate is the constant `1`
 `factor = 1`, contradicting irreducibility. The `hcore_monic` hypothesis is no
 longer load-bearing for the recovery itself but is retained for API
 uniformity with the consuming monic recursion. -/
-private theorem not_represents_empty_of_irreducible_dvd_core_of_bound
+private theorem not_represents_empty_of_monic_bound
     {core target factor : Hex.ZPoly} {d : Hex.LiftData}
     {J : LiftedFactorSubset d}
     (B' : Nat)
@@ -653,11 +653,11 @@ Used by `representedFactor_dvd_recombinationCandidate_of_subset` (#4457) to
 close the `S = ∅` subcase of the squarefreeness contradiction.
 
 This is a thin wrapper over
-`not_represents_empty_of_irreducible_dvd_core_of_bound` that instantiates
+`not_represents_empty_of_monic_bound` that instantiates
 `B' := defaultFactorCoeffBound core` and discharges `hvalid` via
 `defaultFactorCoeffBound_valid core hcore_ne factor hfactor_dvd`.
 -/
-private theorem not_represents_empty_of_irreducible_dvd_core
+private theorem not_represents_empty_of_monic
     {core target factor : Hex.ZPoly} {d : Hex.LiftData}
     {J : LiftedFactorSubset d}
     (hcore_ne : core ≠ 0)
@@ -676,14 +676,14 @@ private theorem not_represents_empty_of_irreducible_dvd_core
     rw [hlead] at hcore_lc_le
     simp only [Int.natAbs_one] at hcore_lc_le
     omega
-  exact not_represents_empty_of_irreducible_dvd_core_of_bound
+  exact not_represents_empty_of_monic_bound
     (Hex.ZPoly.defaultFactorCoeffBound core)
     (defaultFactorCoeffBound_valid core hcore_ne factor hfactor_dvd)
     hcore_ne hcore_monic hd_modulus hpartition hfactor_dvd_target hfactor_irr
     hprecision
 
 /-- Abstract-bound variant of
-`not_represents_empty_of_irreducible_dvd_core_of_primitive_pos_lc_core`.
+`not_represents_empty_of_primitive`.
 
 Routes through the partition's sound recovery equality
 `LiftedFactorSubsetPartition.liftedRecoveryCandidate_eq`: on the empty subset
@@ -692,7 +692,7 @@ the recovered candidate is the constant `1`
 `factor = 1`, contradicting irreducibility. The primitive/positive-leading
 core hypotheses are no longer load-bearing for the recovery itself but are
 retained for API uniformity with the consuming primitive recursion. -/
-private theorem not_represents_empty_of_irreducible_dvd_core_of_primitive_pos_lc_core_of_bound
+private theorem not_represents_empty_of_primitive_bound
     {core target factor : Hex.ZPoly} {d : Hex.LiftData}
     {J : LiftedFactorSubset d}
     (B' : Nat)
@@ -719,7 +719,7 @@ private theorem not_represents_empty_of_irreducible_dvd_core_of_primitive_pos_lc
 
 /--
 Primitive + positive-leading-core variant of
-`not_represents_empty_of_irreducible_dvd_core` (#4646).
+`not_represents_empty_of_monic` (#4646).
 
 For primitive non-monic `core`, the empty-prefix collapse becomes
 `scaledLiftedFactorProduct core d ∅ = C (lc core)`, and the centred-lift
@@ -730,13 +730,13 @@ recovery forces `factor = C (lc core)`. Together with
 `d.p^d.k = 1` degenerate case is excluded as in the monic proof.
 
 This is a thin wrapper over
-`not_represents_empty_of_irreducible_dvd_core_of_primitive_pos_lc_core_of_bound`
+`not_represents_empty_of_primitive_bound`
 that instantiates `B' := defaultFactorCoeffBound core`, discharges
 `hvalid` via `defaultFactorCoeffBound_valid core hcore_ne factor hfactor_dvd`,
 and discharges the leading-coefficient bound via the same lemma applied to
 `core ∣ core`.
 -/
-private theorem not_represents_empty_of_irreducible_dvd_core_of_primitive_pos_lc_core
+private theorem not_represents_empty_of_primitive
     {core target factor : Hex.ZPoly} {d : Hex.LiftData}
     {J : LiftedFactorSubset d}
     (hcore_ne : core ≠ 0)
@@ -755,7 +755,7 @@ private theorem not_represents_empty_of_irreducible_dvd_core_of_primitive_pos_lc
   have hlc_natAbs_pos : 0 < (Hex.DensePoly.leadingCoeff core).natAbs :=
     Int.natAbs_pos.mpr (ne_of_gt hcore_lc_pos)
   have hd_modulus : 2 ≤ d.p ^ d.k := by omega
-  exact not_represents_empty_of_irreducible_dvd_core_of_primitive_pos_lc_core_of_bound
+  exact not_represents_empty_of_primitive_bound
     (Hex.ZPoly.defaultFactorCoeffBound core)
     (defaultFactorCoeffBound_valid core hcore_ne factor hfactor_dvd)
     hcore_ne hcore_primitive hcore_lc_pos hcore_lc_le hd_modulus hpartition

--- a/HexBerlekampZassenhausMathlib/ScaledSearchCoverage.lean
+++ b/HexBerlekampZassenhausMathlib/ScaledSearchCoverage.lean
@@ -64,7 +64,7 @@ theorem nonempty_of_partition
     have hiff := Set.ext_iff.mp hnot i
     simpa using hiff
   subst hS_empty
-  exact not_represents_empty_of_irreducible_dvd_core_of_primitive_pos_lc_core
+  exact not_represents_empty_of_primitive
     hcore_ne hcore_primitive hcore_lc_pos hprecision hdvd hpartition hdvd hirr hrep
 
 /-- The lifted true-support family is in bijection with the normalized
@@ -226,7 +226,7 @@ divisibility into two cases:
   squarefreeness via `Irreducible.not_unit`.  When `S = ∅`, the recovery
   equation forces `factor = 1` (or `factor = 0` in the degenerate
   `d.p^d.k = 1` regime), again contradicting irreducibility — packaged in
-  `not_represents_empty_of_irreducible_dvd_core`.
+  `not_represents_empty_of_monic`.
 -/
 theorem representedFactor_dvd_recombinationCandidate_of_subset
     {core target factor quotient : Hex.ZPoly} {d : Hex.LiftData}
@@ -285,7 +285,7 @@ theorem representedFactor_dvd_recombinationCandidate_of_subset
       omega
     by_cases hS_empty : S = (∅ : LiftedFactorSubset d)
     · -- Subcase B2: `S = ∅` — packaged by the empty-support helper.
-      apply not_represents_empty_of_irreducible_dvd_core
+      apply not_represents_empty_of_monic
         hcore_ne hcore_monic hprecision hfactor_dvd_core hpartition
         hfactor_dvd_target hfactor_irr
       rw [hS_empty] at hrep
@@ -1656,7 +1656,7 @@ precision is replaced by `2 * B' < d.p ^ d.k` against an abstract bound
 `B'`, paired with the universal divisor coefficient bound
 `∀ g ∣ core, ∀ i, (g.coeff i).natAbs ≤ B'`. The `B'`/`hvalid`/`hprecision`
 abstract-bound hypotheses remain load-bearing at the empty-`J` step
-(`not_represents_empty_of_irreducible_dvd_core_of_bound`, specialised by
+(`not_represents_empty_of_monic_bound`, specialised by
 `hvalid g hg_dvd_core`) and the prefix-none discharge
 (`liftedFactorSubsetPartition_prefix_none_of_bound`, receiving the
 universal `hvalid` and `B'` unchanged). At the cover-at-min recovery the
@@ -1727,7 +1727,7 @@ private theorem recombinationSearchModAux_some_and_covers_of_liftedFactorSubsetP
         exact htarget_monic
       -- Step 1: `J` is nonempty (else the partition produces a representing
       -- subset `S ⊆ ∅` for an irreducible divisor of `target`, contradicting
-      -- `not_represents_empty_of_irreducible_dvd_core_of_bound`).
+      -- `not_represents_empty_of_monic_bound`).
       have hJ_ne : J.Nonempty := by
         by_contra hJ_empty
         rw [Finset.not_nonempty_iff_eq_empty] at hJ_empty
@@ -1758,7 +1758,7 @@ private theorem recombinationSearchModAux_some_and_covers_of_liftedFactorSubsetP
           exact Finset.subset_empty.mp hSJ
         have hg_dvd_core : g ∣ core :=
           zpoly_dvd_trans hg_dvd_target htarget_dvd_core
-        apply not_represents_empty_of_irreducible_dvd_core_of_bound
+        apply not_represents_empty_of_monic_bound
           B' (hvalid g hg_dvd_core) hcore_ne hcore_monic hd_modulus
           hpartition hg_dvd_target hg_irr_toPoly hprecision
         rw [← hS_empty]; exact hSrep
@@ -1932,7 +1932,7 @@ irreducible integer divisor of `target` is associated to some emitted
 candidate in `result`.
 
 The deliverable theorem
-`recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition`
+`recombinationSearchModAux_factor_associated`
 specialises this universal statement to a fixed `factor` hypothesis.
 
 Proof outline (induction on `fuel`):
@@ -1940,7 +1940,7 @@ Proof outline (induction on `fuel`):
 * `fuel = fuel' + 1`:
   - If `J = ∅`: the partition's inherited `exists_subset` forces every
     irreducible divisor of `target` to be represented by `∅`, contradicting
-    `not_represents_empty_of_irreducible_dvd_core`. Therefore `target` has
+    `not_represents_empty_of_monic`. Therefore `target` has
     no irreducible divisors; combined with `target` monic and
     `target ∣ core`, this gives `target = 1` and the executable returns
     `some []`. The universal claim is vacuous (no irreducibles divide 1).
@@ -2107,7 +2107,7 @@ theorem RecoveredScaledSearch.covers_of_bound
           exact Finset.subset_empty.mp hSJ
         have hg_dvd_core : g ∣ core :=
           zpoly_dvd_trans hg_dvd_target htarget_dvd_core
-        apply not_represents_empty_of_irreducible_dvd_core_of_primitive_pos_lc_core_of_bound
+        apply not_represents_empty_of_primitive_bound
           B' (hvalid g hg_dvd_core) hcore_ne hcore_primitive hcore_lc_pos
           hcore_lc_le hd_modulus hpartition hg_dvd_target hg_irr_toPoly hprecision
         rw [← hS_empty]; exact hSrep

--- a/HexBerlekampZassenhausMathlib/SearchAssembly.lean
+++ b/HexBerlekampZassenhausMathlib/SearchAssembly.lean
@@ -118,7 +118,7 @@ theorem factor_irreducible_of_covers
 
 /--
 Abstract-bound variant of
-`recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition`:
+`recombinationSearchModAux_factor_associated`:
 the concrete `2 * defaultFactorCoeffBound core < d.p ^ d.k` Mignotte
 precision is replaced by `2 * B' < d.p ^ d.k` against an abstract bound
 `B'`, paired with the leading-coefficient bound on `core` and the
@@ -127,7 +127,7 @@ universal divisor coefficient bound `∀ g ∣ core, ∀ i, (g.coeff i).natAbs
 `recombinationSearchModAux_some_and_covers_of_liftedFactorSubsetPartition_of_bound`
 that extracts the per-factor coverage at the supplied `factor`.
 -/
-theorem recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_bound
+theorem recombinationSearchModAux_factor_associated_of_bound
     {core target factor : Hex.ZPoly} {d : Hex.LiftData}
     {J : LiftedFactorSubset d} {localFactors : List Hex.ZPoly} {fuel : Nat}
     (B' : Nat)
@@ -171,12 +171,12 @@ of `target`, the executable recombination search returns `some result` with
 `factor` (up to `Associated`) among the emitted candidates.
 
 Thin wrapper over
-`recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_bound`
+`recombinationSearchModAux_factor_associated_of_bound`
 that instantiates `B' := Hex.ZPoly.defaultFactorCoeffBound core` and
 discharges the abstract bound hypotheses via
 `defaultFactorCoeffBound_leadingCoeff_natAbs_le` paired with
 `defaultFactorCoeffBound_valid`. -/
-theorem recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition
+theorem recombinationSearchModAux_factor_associated
     {core target factor : Hex.ZPoly} {d : Hex.LiftData}
     {J : LiftedFactorSubset d} {localFactors : List Hex.ZPoly} {fuel : Nat}
     (hcore_ne : core ≠ 0)
@@ -202,7 +202,7 @@ theorem recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPa
         Associated (HexPolyZMathlib.toPolynomial emitted)
           (HexPolyZMathlib.toPolynomial factor) := by
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
-  exact recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_bound
+  exact recombinationSearchModAux_factor_associated_of_bound
     (Hex.ZPoly.defaultFactorCoeffBound core)
     hcore_lc_le
     (defaultFactorCoeffBound_valid core hcore_ne)
@@ -266,7 +266,7 @@ Primitive + positive-leading recursive coverage capstone for
 `Hex.scaledRecombinationSearchModAux`.
 
 This is the scaled counterpart of
-`recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition`.
+`recombinationSearchModAux_factor_associated`.
 It keeps the same fixed-factor conclusion, but the recursive target invariant is
 primitive plus positive leading coefficient, and the executable boundary is the
 scaled recombination search.
@@ -317,7 +317,7 @@ theorem scaledRecombinationSearchModAux_some_factor_associated_of_liftedFactorSu
 
 /--
 Abstract-bound variant of
-`recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_primitive_pos_lc_core`:
+`recombinationSearchModAux_factor_associated_of_primitive`:
 the concrete `2 * defaultFactorCoeffBound core < d.p ^ d.k` Mignotte
 precision is replaced by `2 * B' < d.p ^ d.k` against an abstract bound
 `B'`, paired with the leading-coefficient bound on `core` and the
@@ -325,7 +325,7 @@ universal divisor coefficient bound `∀ g ∣ core, ∀ i, (g.coeff i).natAbs
 ≤ B'`. Thin wrapper that forwards verbatim to
 `scaledRecombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_bound`.
 -/
-theorem recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_primitive_pos_lc_core_of_bound
+theorem recombinationSearchModAux_factor_associated_of_primitive_bound
     {core target factor : Hex.ZPoly} {d : Hex.LiftData}
     {J : LiftedFactorSubset d} {localFactors : List Hex.ZPoly} {fuel : Nat}
     (B' : Nat)
@@ -366,18 +366,18 @@ theorem recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPa
 /--
 Primitive + positive-leading public wrapper for the scaled recombination
 search.  This is the #4648 boundary form of the old monic-core
-`recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition`
+`recombinationSearchModAux_factor_associated`
 surface: callers with a primitive positive-leading core and recursive target
 use the scaled executable search directly, while the monic wrapper remains
 available for existing unscaled callers.
 
 Thin wrapper over
-`recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_primitive_pos_lc_core_of_bound`
+`recombinationSearchModAux_factor_associated_of_primitive_bound`
 that instantiates `B' := Hex.ZPoly.defaultFactorCoeffBound core` and
 discharges the abstract bound hypotheses via `defaultFactorCoeffBound_valid`
 paired with `leadingCoeff_eq_coeff_last`.
 -/
-theorem recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_primitive_pos_lc_core
+theorem recombinationSearchModAux_factor_associated_of_primitive
     {core target factor : Hex.ZPoly} {d : Hex.LiftData}
     {J : LiftedFactorSubset d} {localFactors : List Hex.ZPoly} {fuel : Nat}
     (hcore_ne : core ≠ 0)
@@ -406,7 +406,7 @@ theorem recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPa
         Associated (HexPolyZMathlib.toPolynomial emitted)
           (HexPolyZMathlib.toPolynomial factor) := by
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
-  exact recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_primitive_pos_lc_core_of_bound
+  exact recombinationSearchModAux_factor_associated_of_primitive_bound
     (Hex.ZPoly.defaultFactorCoeffBound core)
     hcore_lc_le
     (defaultFactorCoeffBound_valid core hcore_ne)
@@ -648,10 +648,10 @@ theorem liftedFactorSubsetPartition_of_choosePrimeData
 Parallel to `liftedFactorSubsetPartition_of_choosePrimeData` but consumes
 the `Hex.ZPoly.toMonicPrimeData? core = some primeData` witness directly.
 Used by the non-monic-friendly substrate constructor
-`HenselFactorData.ofToMonicChoosePrime` below, which feeds the
+`HenselFactorData.ofToMonicPrimeData` below, which feeds the
 slow-path arm of #4170 from `(Hex.normalizeForFactor f).squareFreeCore`.
 The embedded Hensel correspondence is supplied explicitly as `hcorr`. -/
-theorem liftedFactorSubsetPartition_of_toMonicPrimeData
+theorem liftedFactorSubsetPartition_of_toMonicModP_evidence
     (core : Hex.ZPoly) (B : Nat)
     (primeData : Hex.PrimeChoiceData)
     (_hval : ModPFactorization (Hex.ZPoly.toMonic core).monic primeData)

--- a/HexBerlekampZassenhausMathlib/SearchAssembly.lean
+++ b/HexBerlekampZassenhausMathlib/SearchAssembly.lean
@@ -51,7 +51,7 @@ recorded `result` multiplies back to a square-free `core` and every irreducible
 factor of `core` is an associate of some emitted factor, the emitted list has
 exactly `normalizedFactors.card` entries (coverage gives `≥`, the product gives
 `≤`), so each entry is irreducible by the UFD partition lemma. -/
-theorem smartCore_factor_irreducible_of_covers_of_squarefree
+theorem factor_irreducible_of_covers
     {core : Hex.ZPoly} {result : List Hex.ZPoly}
     (hcore_ne : core ≠ 0)
     (hsqfree : Squarefree (HexPolyZMathlib.toPolynomial core))
@@ -648,7 +648,7 @@ theorem liftedFactorSubsetPartition_of_choosePrimeData
 Parallel to `liftedFactorSubsetPartition_of_choosePrimeData` but consumes
 the `Hex.ZPoly.toMonicPrimeData? core = some primeData` witness directly.
 Used by the non-monic-friendly substrate constructor
-`slowPathHenselSubstrate_of_toMonicChoosePrimeData` below, which feeds the
+`HenselFactorData.ofToMonicChoosePrime` below, which feeds the
 slow-path arm of #4170 from `(Hex.normalizeForFactor f).squareFreeCore`.
 The embedded Hensel correspondence is supplied explicitly as `hcorr`. -/
 theorem liftedFactorSubsetPartition_of_toMonicPrimeData

--- a/HexBerlekampZassenhausMathlib/SmartSearchCoverage.lean
+++ b/HexBerlekampZassenhausMathlib/SmartSearchCoverage.lean
@@ -568,7 +568,7 @@ private theorem smartAux_none_budget_zero
           have hS_empty : S = ∅ := by
             rw [hJ_empty] at hSJ; exact Finset.subset_empty.mp hSJ
           have hg_dvd_core : g ∣ core := zpoly_dvd_trans hg_dvd_target htarget_dvd_core
-          apply not_represents_empty_of_irreducible_dvd_core_of_primitive_pos_lc_core_of_bound
+          apply not_represents_empty_of_primitive_bound
             B' (hvalid g hg_dvd_core) hcore_ne hcore_primitive hcore_lc_pos
             hcore_lc_le hd_modulus hpartition hg_dvd_target hg_irr_toPoly hprecision
           rw [← hS_empty]; exact hSrep

--- a/HexBerlekampZassenhausMathlib/SubsetCoprimality.lean
+++ b/HexBerlekampZassenhausMathlib/SubsetCoprimality.lean
@@ -49,7 +49,7 @@ without having to construct the internal `QuadraticMultifactorLiftInvariant`
 themselves.
 
 Consumed by
-`recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition`
+`recombinationSearchModAux_factor_associated`
 (via `LiftedFactorListMatches.nodup_of_injOn`).
 
 The `factorsModP.toList.Nodup` hypothesis is the load-bearing ingredient;

--- a/HexBerlekampZassenhausMathlib/ToMonicUniqueness.lean
+++ b/HexBerlekampZassenhausMathlib/ToMonicUniqueness.lean
@@ -868,8 +868,8 @@ theorem henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData_success_descent
       hcore_lc_pos hcore_pos
       (modPFactorization_of_toMonicPrimeData hselected hcore_lc_pos hcore_pos) hprecision hbound hirr hdvd hS hT
 
-/--
-Carrier-free `toMonicPrimeData?` Hensel subset correspondence surface.
+/-- Hensel subset correspondence obtained directly from a
+`toMonicPrimeData?` factorization.
 
 Same conclusion as
 `henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData_success_descent`, but
@@ -877,8 +877,7 @@ without the `MonicDescentHypotheses` carrier: at the `True True` instantiation t
 only descent fields that constructor consumed (`lift_eq`, `successful_lift`) are
 `rfl`/`trivial`, and the existence/uniqueness fields come directly from the core
 facts via `toMonicLiftData_represents_lifted_of_modP` and
-`toMonicLiftData_unique_subset`.  This is the core-facts producer that the
-partition and slow-path substrate packages route through. -/
+`toMonicLiftData_unique_subset`. -/
 theorem henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData
     (core : Hex.ZPoly) (B : Nat)
     (primeData : Hex.PrimeChoiceData)
@@ -916,7 +915,7 @@ theorem henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData
 
 /-- Initial lifted subset partition for `toMonicPrimeData?` success.
 
-This composes the core-fact correspondence producer
+This composes the correspondence theorem
 `henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData_success_descent` with
 the existing partition constructor. The recovered-coordinate partition fields
 come from `InitialLiftedFactorSubsetPartitionEvidence`; the monic-only unscaled
@@ -951,17 +950,15 @@ theorem liftedFactorSubsetPartition_of_toMonicPrimeData_success_descent
       hprecision hbound hB_ne_zero)
     hcore_sqfree hinitial
 
-/-- **#6682 supporting lemma (HO-1 slow-path substrate constructor).**
-
-Successful-descent variant of
-`slowPathHenselSubstrate_of_toMonicChoosePrimeData`.  The `corr` field is
+/-- Successful-descent variant of
+`HenselFactorData.ofToMonicChoosePrime`.  The `corr` field is
 sourced from the non-circular `toMonicPrimeData?` correspondence constructor
 above, using the monic-correspondent reverse descent carrier.  The partition
-field uses the narrowed `liftedFactorSubsetPartition` wrapper with that same
-correspondence; recovered partition evidence is supplied by
+field uses `liftedFactorSubsetPartition` with that same correspondence;
+recovered partition evidence is supplied by
 `InitialLiftedFactorSubsetPartitionEvidence`.
 -/
-theorem slowPathHenselSubstrate_of_toMonicChoosePrimeData_success_descent
+theorem HenselFactorData.ofToMonicChoosePrimeDescent
     (core : Hex.ZPoly) (B : Nat)
     (primeData : Hex.PrimeChoiceData)
     (hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)
@@ -979,7 +976,7 @@ theorem slowPathHenselSubstrate_of_toMonicChoosePrimeData_success_descent
     (hinitial :
       InitialLiftedFactorSubsetPartitionEvidence core
         (Hex.ZPoly.toMonicLiftData core B primeData)) :
-    SlowPathHenselSubstrate core B primeData := by
+    HenselFactorData core B primeData := by
   have hp_prime : Hex.Nat.Prime primeData.p :=
     Hex.ZPoly.toMonicPrimeData?_prime core primeData hselected
   have hp2 : 2 ≤ primeData.p := hp_prime.two_le

--- a/HexBerlekampZassenhausMathlib/ToMonicUniqueness.lean
+++ b/HexBerlekampZassenhausMathlib/ToMonicUniqueness.lean
@@ -868,8 +868,8 @@ theorem henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData_success_descent
       hcore_lc_pos hcore_pos
       (modPFactorization_of_toMonicPrimeData hselected hcore_lc_pos hcore_pos) hprecision hbound hirr hdvd hS hT
 
-/-- Hensel subset correspondence obtained directly from a
-`toMonicPrimeData?` factorization.
+/-- Hensel subset correspondence obtained directly from a mod-`p`
+factorization of the monic transform.
 
 Same conclusion as
 `henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData_success_descent`, but
@@ -878,7 +878,7 @@ only descent fields that constructor consumed (`lift_eq`, `successful_lift`) are
 `rfl`/`trivial`, and the existence/uniqueness fields come directly from the core
 facts via `toMonicLiftData_represents_lifted_of_modP` and
 `toMonicLiftData_unique_subset`. -/
-theorem henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData
+theorem henselSubsetCorrespondenceHypotheses_of_toMonicModP
     (core : Hex.ZPoly) (B : Nat)
     (primeData : Hex.PrimeChoiceData)
     (hval : ModPFactorization (Hex.ZPoly.toMonic core).monic primeData)
@@ -942,7 +942,7 @@ theorem liftedFactorSubsetPartition_of_toMonicPrimeData_success_descent
     let d := Hex.ZPoly.toMonicLiftData core B primeData
     LiftedFactorSubsetPartition core d Finset.univ core := by
   intro d
-  exact liftedFactorSubsetPartition_of_toMonicPrimeData
+  exact liftedFactorSubsetPartition_of_toMonicModP_evidence
     core B primeData
     (modPFactorization_of_toMonicPrimeData hselected hcore_lc_pos hcore_pos)
     (henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData_success_descent
@@ -951,14 +951,14 @@ theorem liftedFactorSubsetPartition_of_toMonicPrimeData_success_descent
     hcore_sqfree hinitial
 
 /-- Successful-descent variant of
-`HenselFactorData.ofToMonicChoosePrime`.  The `corr` field is
+`HenselFactorData.ofToMonicPrimeData`.  The `corr` field is
 sourced from the non-circular `toMonicPrimeData?` correspondence constructor
 above, using the monic-correspondent reverse descent carrier.  The partition
 field uses `liftedFactorSubsetPartition` with that same correspondence;
 recovered partition evidence is supplied by
 `InitialLiftedFactorSubsetPartitionEvidence`.
 -/
-theorem HenselFactorData.ofToMonicChoosePrimeDescent
+theorem HenselFactorData.ofToMonicPrimeDataDescent
     (core : Hex.ZPoly) (B : Nat)
     (primeData : Hex.PrimeChoiceData)
     (hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)

--- a/HexBerlekampZassenhausMathlib/WordCld.lean
+++ b/HexBerlekampZassenhausMathlib/WordCld.lean
@@ -359,7 +359,7 @@ theorem cldQuotientModWord?_eq (f g : Hex.ZPoly) (p a : Nat)
         (by rw [Polynomial.degree_map_eq_of_leadingCoeff_ne_zero]
             rw [leadingCoeff_toPolynomial, Hex.DensePoly.leadingCoeff_eq_one_of_monic hg]; simp)
         (toPoly_degree_lt htgne
-          (Hex.DensePoly.divMod_remainder_degree_lt_of_pos_degree_core _ g hgdeg hcancelZ))
+          (Hex.DensePoly.divMod_remainder_degree_lt_of_pos_degree_of_cancel _ g hgdeg hcancelZ))
     -- word-side monic division in the image
     have htgWm : (toPolynomial (toWMap ctx g)).Monic := by
       have : (toPolynomial (toWMap ctx g)).leadingCoeff = 1 := by
@@ -380,7 +380,7 @@ theorem cldQuotientModWord?_eq (f g : Hex.ZPoly) (p a : Nat)
         (Polynomial.degree_map_eq_of_leadingCoeff_ne_zero _
           (by rw [leadingCoeff_toPolynomial, Hex.DensePoly.leadingCoeff_eq_one_of_monic hgWm]; simp))
         (toPoly_degree_lt htgWne
-          (Hex.DensePoly.divMod_remainder_degree_lt_of_pos_degree_core _ (toWMap ctx g) hgWd hcancelW))
+          (Hex.DensePoly.divMod_remainder_degree_lt_of_pos_degree_of_cancel _ (toWMap ctx g) hgWd hcancelW))
     -- numerator / divisor agreement, then chain
     have hgdiv : cW ctx (toWMap ctx g) = cZ (UInt64.ofNat mval) g := cW_toWMap_eq_cZ ctx g
     have hnum : cW ctx (toWMap ctx f * Hex.DensePoly.derivative (toWMap ctx g))

--- a/HexGramSchmidt/Int/Canonical.lean
+++ b/HexGramSchmidt/Int/Canonical.lean
@@ -793,7 +793,7 @@ private theorem noPivotLoop_matrix_processed_col_eq_zero {n : Nat} (fuel : Nat) 
       by_cases hDone : state.step + 1 < n
       · by_cases hp : state.matrix[state.step][state.step] = 0
         · -- Singular branch contradicts h_result_none.
-          rw [Matrix.noPivotLoop_singular_branch f state hDone hp] at h_result_none
+          rw [Matrix.noPivotLoop_of_singular f state hDone hp] at h_result_none
           simp at h_result_none
         · -- Regular branch.
           let next : Matrix.BareissState n :=
@@ -805,7 +805,7 @@ private theorem noPivotLoop_matrix_processed_col_eq_zero {n : Nat} (fuel : Nat) 
               singularStep := none }
           have h_eq_next : Matrix.noPivotLoop (f + 1) state =
               Matrix.noPivotLoop f next :=
-            Matrix.noPivotLoop_regular_branch f state hDone hp
+            Matrix.noPivotLoop_of_regular f state hDone hp
           rw [h_eq_next] at h_result_none hk_lt ⊢
           by_cases hk_eq : k = state.step
           · -- k just got processed: column k was zeroed by stepMatrix.
@@ -1027,7 +1027,7 @@ private theorem bareissGramCanonicalCoeff_eq_of_singular
             singularStep := some (Matrix.noPivotLoop elapsed
               (Matrix.noPivotInitialState (Matrix.gramMatrix b))).step } := by
         rw [noPivotLoop_add elapsed 1]
-        exact Matrix.noPivotLoop_singular_branch 0 _ hDone hp
+        exact Matrix.noPivotLoop_of_singular 0 _ hDone hp
       have h_state_eq :
           Matrix.noPivotLoop (elapsed + 1 + j)
             (Matrix.noPivotInitialState (Matrix.gramMatrix b)) =

--- a/HexGramSchmidt/Int/Combination.lean
+++ b/HexGramSchmidt/Int/Combination.lean
@@ -1024,7 +1024,7 @@ private theorem noPivotLoop_initial_gram_diag_ne_zero
       Matrix.noPivotLoop 1 (Matrix.noPivotLoop q state₀) =
         { (Matrix.noPivotLoop q state₀) with
           singularStep := some (Matrix.noPivotLoop q state₀).step } :=
-    Matrix.noPivotLoop_singular_branch 0 _ hDone hp_at_step
+    Matrix.noPivotLoop_of_singular 0 _ hDone hp_at_step
   have h_q_plus_one :
       Matrix.noPivotLoop (q + 1) state₀ =
         Matrix.noPivotLoop 1 (Matrix.noPivotLoop q state₀) :=
@@ -1152,7 +1152,7 @@ private theorem schurSigma_foldl_eq
           (b := b) p_out 0 hp_out_pos hp_out_n h_nonsing
       simp only [Matrix.noPivotInitialState]
       exact key
-    rw [Matrix.noPivotLoop_regular_branch 0
+    rw [Matrix.noPivotLoop_of_regular 0
         (Matrix.noPivotInitialState (Matrix.gramMatrix b)) hDone hpivot]
     simp [Matrix.noPivotLoop_zero_fuel, Matrix.noPivotInitialState]
     have hofFn : ∀ (f : Fin n → Fin n → Int) (r : Fin n) (jj : Nat) (hjj : jj < n),
@@ -1258,9 +1258,9 @@ private theorem schurSigma_foldl_eq
               (⟨(Matrix.noPivotLoop q' state₀).step,
                   Nat.lt_of_succ_lt hDone⟩ : Fin n)] ≠ 0 :=
         h_eq_diag ▸ h_diag_at_q'
-      rw [h_add, Matrix.noPivotLoop_regular_branch 0 _ hDone h_diag_at_step,
+      rw [h_add, Matrix.noPivotLoop_of_regular 0 _ hDone h_diag_at_step,
         Matrix.noPivotLoop_zero_fuel]
-      -- The `noPivotLoop_regular_branch` rewrite makes the goal:
+      -- The `noPivotLoop_of_regular` rewrite makes the goal:
       --   matrix[⟨step, ⋯⟩][⟨step, ⋯⟩] = matrix[⟨q', hq'_n⟩][⟨q', hq'_n⟩]
       -- which we close by the index equality.
       exact congrArg
@@ -1313,7 +1313,7 @@ private theorem schurSigma_foldl_eq
             (fun (i : Fin n) =>
               (Matrix.noPivotLoop (q' + 1) state₀).matrix[i][i]) h_idx
         exact h_eq ▸ h_diag
-      rw [Matrix.noPivotLoop_regular_branch 0 _ hDone hp,
+      rw [Matrix.noPivotLoop_of_regular 0 _ hDone hp,
         Matrix.noPivotLoop_zero_fuel]
       have ha : (Matrix.noPivotLoop (q' + 1) state₀).step < a := by
         rw [h_step_q'_succ]; exact hp_a_lt

--- a/HexGramSchmidt/Int/Correspondence.lean
+++ b/HexGramSchmidt/Int/Correspondence.lean
@@ -60,9 +60,9 @@ private theorem getArrayEntry_scaledCoeffRows_col_zero
           = getArrayEntry (gramRows b) 0 0
       by_cases hNext : (0 : Nat) + 1 < fuel + 1
       · by_cases hp : getArrayEntry (gramRows b) 0 0 = 0
-        · rw [scaledCoeffArrayLoop_singular_branch (n := fuel + 1) fuel initState hn hNext hp]
+        · rw [scaledCoeffArrayLoop_of_singular (n := fuel + 1) fuel initState hn hNext hp]
           exact getArrayEntry_writeScaledColumn_diag _ _ _ _ hrow hcol
-        · rw [scaledCoeffArrayLoop_regular_branch (n := fuel + 1) fuel initState hn hNext hp]
+        · rw [scaledCoeffArrayLoop_of_regular (n := fuel + 1) fuel initState hn hNext hp]
           rw [getArrayEntry_scaledCoeffArrayLoop_preserve_col_before_step
                 (n := fuel + 1) fuel _ 0 0 (show (0 : Nat) < 0 + 1 by omega)]
           exact getArrayEntry_writeScaledColumn_diag _ _ _ _ hrow hcol
@@ -151,13 +151,13 @@ private theorem scaledCoeffArrayLoop_lower_matches_target_column
         · have hdist :
               j.val - state_matrix.step = (j.val - (state_matrix.step + 1)) + 1 := by
             omega
-          rw [hdist, Matrix.noPivotLoop_singular_branch _ state_matrix hDone hp] at h_target_nonsing
+          rw [hdist, Matrix.noPivotLoop_of_singular _ state_matrix hDone hp] at h_target_nonsing
           simp at h_target_nonsing
         · have hp_array :
               getArrayEntry state_array.matrix state_array.step state_array.step ≠ 0 := by
             rw [h_pivot_array_eq_matrix]
             exact hp
-          rw [scaledCoeffArrayLoop_regular_branch fuel' state_array hArrayStep hArrayNext hp_array]
+          rw [scaledCoeffArrayLoop_of_regular fuel' state_array hArrayStep hArrayNext hp_array]
           let new_array : ScaledCoeffArrayState :=
             { step := state_array.step + 1
               matrix := stepScaledRows state_array.matrix n state_array.step
@@ -213,7 +213,7 @@ private theorem scaledCoeffArrayLoop_lower_matches_target_column
             have hdist :
                 j.val - state_matrix.step = (j.val - (state_matrix.step + 1)) + 1 := by
               omega
-            rw [hdist, Matrix.noPivotLoop_regular_branch _ state_matrix hDone hp] at h_target_nonsing
+            rw [hdist, Matrix.noPivotLoop_of_regular _ state_matrix hDone hp] at h_target_nonsing
             simpa [new_matrix] using h_target_nonsing
           have h_capture := ih h_step_new h_matrix_new h_prev_new h_array_size_new
             h_array_rows_size_new h_coeffs_size_new h_coeffs_rows_size_new
@@ -221,7 +221,7 @@ private theorem scaledCoeffArrayLoop_lower_matches_target_column
           have hdist :
               j.val - state_matrix.step = (j.val - (state_matrix.step + 1)) + 1 := by
             omega
-          rw [h_capture, hdist, Matrix.noPivotLoop_regular_branch _ state_matrix hDone hp]
+          rw [h_capture, hdist, Matrix.noPivotLoop_of_regular _ state_matrix hDone hp]
           rfl
 
 /-- Early-singular zero tail after the singular column: if the lower entries
@@ -250,7 +250,7 @@ private theorem scaledCoeffArrayLoop_lower_singular_after_step
     have := getArrayEntry_eq_rowsToMatrix (n := n) state_array.matrix kFin kFin
     rw [this, h_matrix_eq]
     exact hp
-  rw [scaledCoeffArrayLoop_singular_branch fuel state_array hArrayStep hArrayNext hp_array,
+  rw [scaledCoeffArrayLoop_of_singular fuel state_array hArrayStep hArrayNext hp_array,
     getArrayEntry_writeScaledColumn]
   · exact h_coeffs_unwritten i j hsj hji
   · rw [h_step_eq]
@@ -312,7 +312,7 @@ private theorem scaledCoeffArrayLoop_lower_zero
               getArrayEntry state_array.matrix state_array.step state_array.step ≠ 0 := by
             rw [h_pivot_array_eq_matrix]
             exact hp
-          rw [scaledCoeffArrayLoop_regular_branch fuel' state_array hArrayStep
+          rw [scaledCoeffArrayLoop_of_regular fuel' state_array hArrayStep
             hArrayNext hp_array]
           let new_array : ScaledCoeffArrayState :=
             { step := state_array.step + 1
@@ -386,7 +386,7 @@ private theorem scaledCoeffArrayLoop_lower_zero
             have hdist :
                 j.val - state_matrix.step = (j.val - (state_matrix.step + 1)) + 1 := by
               omega
-            rw [hdist, Matrix.noPivotLoop_regular_branch _ state_matrix hDone hp] at h_sing
+            rw [hdist, Matrix.noPivotLoop_of_regular _ state_matrix hDone hp] at h_sing
             simpa [new_matrix] using h_sing
           exact ih h_step_new h_matrix_new h_prev_new h_array_size_new
             h_array_rows_size_new h_coeffs_size_new h_coeffs_rows_size_new
@@ -459,8 +459,8 @@ private theorem scaledCoeffArrayLoop_diag_matches
         · -- A1: singular branch.
           have hp_array : getArrayEntry state_array.matrix state_array.step state_array.step = 0 := by
             rw [h_pivot_array_eq_matrix]; exact hp
-          rw [scaledCoeffArrayLoop_singular_branch fuel' state_array hArrayStep hArrayNext hp_array,
-            Matrix.noPivotLoop_singular_branch fuel' state_matrix hDone hp]
+          rw [scaledCoeffArrayLoop_of_singular fuel' state_array hArrayStep hArrayNext hp_array,
+            Matrix.noPivotLoop_of_singular fuel' state_matrix hDone hp]
           right
           refine ⟨state_matrix.step, rfl, ?_⟩
           by_cases h_ilt : i.val < state_matrix.step
@@ -503,8 +503,8 @@ private theorem scaledCoeffArrayLoop_diag_matches
         · -- A2: regular branch.
           have hp_array : getArrayEntry state_array.matrix state_array.step state_array.step ≠ 0 := by
             rw [h_pivot_array_eq_matrix]; exact hp
-          rw [scaledCoeffArrayLoop_regular_branch fuel' state_array hArrayStep hArrayNext hp_array,
-            Matrix.noPivotLoop_regular_branch fuel' state_matrix hDone hp]
+          rw [scaledCoeffArrayLoop_of_regular fuel' state_array hArrayStep hArrayNext hp_array,
+            Matrix.noPivotLoop_of_regular fuel' state_matrix hDone hp]
           -- Build new compatible states.
           let new_array : ScaledCoeffArrayState :=
             { step := state_array.step + 1

--- a/HexGramSchmidt/Int/Invariant.lean
+++ b/HexGramSchmidt/Int/Invariant.lean
@@ -65,7 +65,7 @@ private def bareissGramRowInvariant_noPivotLoop_initialAux
         · have hp : state.matrix[state.step][state.step] = 0 := by
             rw [Matrix.getElem_nat_eq_getRow]
             simpa using hp0
-          rw [Matrix.noPivotLoop_singular_branch fuel state hDone hp]
+          rw [Matrix.noPivotLoop_of_singular fuel state hDone hp]
           refine ⟨{ coeff := hinv.coeff
                     coeff_supp := ?_
                     entry_eq_dot := ?_ }, ?_⟩
@@ -80,7 +80,7 @@ private def bareissGramRowInvariant_noPivotLoop_initialAux
         · have hp : state.matrix[state.step][state.step] ≠ 0 := by
             rw [Matrix.getElem_nat_eq_getRow]
             simpa using hp0
-          rw [Matrix.noPivotLoop_regular_branch fuel state hDone hp]
+          rw [Matrix.noPivotLoop_of_regular fuel state hDone hp]
           have hstep :
               Matrix.noPivotLoop (elapsed + 1)
                   (Matrix.noPivotInitialState (Matrix.gramMatrix b)) =
@@ -92,7 +92,7 @@ private def bareissGramRowInvariant_noPivotLoop_initialAux
                    singularStep := none } : Matrix.BareissState n) := by
             rw [noPivotLoop_add elapsed 1
               (Matrix.noPivotInitialState (Matrix.gramMatrix b))]
-            rw [Matrix.noPivotLoop_regular_branch 0 state hDone hp]
+            rw [Matrix.noPivotLoop_of_regular 0 state hDone hp]
             simp [Matrix.noPivotLoop_zero_fuel]
           have hentry := fun i j hi =>
             bareissGramInitialRegularStep_entry_eq_dot
@@ -776,7 +776,7 @@ private theorem pivotLoop_singularStep_some
       subst h_state_eq
       rcases fuel with _ | fuel'
       · omega
-      exact (Matrix.pivotLoop_singular_branch_no_pivot fuel' state hStepLt hp_zero h_find_none
+      exact (Matrix.pivotLoop_of_singular_no_pivot fuel' state hStepLt hp_zero h_find_none
         ▸ rfl)
   | succ a' ih =>
       intro fuel state result h_partial h_init_sing hfuel h_part_none hStepLt hp_zero
@@ -791,7 +791,7 @@ private theorem pivotLoop_singularStep_some
         have h_sing_branch :
             Matrix.noPivotLoop (a' + 1) state =
               { state with singularStep := some state.step } :=
-          Matrix.noPivotLoop_singular_branch a' state hDone_state hp0_state
+          Matrix.noPivotLoop_of_singular a' state hDone_state hp0_state
         rw [h_sing_branch] at h_partial
         rw [← h_partial] at h_part_none
         simp at h_part_none
@@ -804,7 +804,7 @@ private theorem pivotLoop_singularStep_some
                 prevPivot := state.matrix[state.step][state.step]
                 rowSwaps := state.rowSwaps
                 singularStep := none } :=
-          Matrix.noPivotLoop_regular_branch a' state hDone_state hp0_state
+          Matrix.noPivotLoop_of_regular a' state hDone_state hp0_state
         rcases fuel with _ | fuel'
         · omega
         have h_fuel' : a' + 1 ≤ fuel' := by omega
@@ -816,7 +816,7 @@ private theorem pivotLoop_singularStep_some
                 prevPivot := state.matrix[state.step][state.step]
                 rowSwaps := state.rowSwaps
                 singularStep := none } :=
-          Matrix.pivotLoop_regular_branch_no_swap fuel' state hDone_state hp0_state
+          Matrix.pivotLoop_of_regular_no_swap fuel' state hDone_state hp0_state
         rw [h_unfold_piv]
         have h_next_partial :
             Matrix.noPivotLoop a'
@@ -1034,7 +1034,7 @@ private theorem scaledCoeffArrayLoop_id_at_done (fuel : Nat)
 /-- Singular branch of one array-loop iteration: a zero pivot strictly before
 the last column halts the loop, writing the scaled column at the current step
 but leaving the matrix and step untouched. -/
-private theorem scaledCoeffArrayLoop_singular_branch (fuel : Nat)
+private theorem scaledCoeffArrayLoop_of_singular (fuel : Nat)
     (state : ScaledCoeffArrayState)
     (hStep : state.step < n) (hNext : state.step + 1 < n)
     (hp : getArrayEntry state.matrix state.step state.step = 0) :
@@ -1057,7 +1057,7 @@ private theorem scaledCoeffArrayLoop_last_step (fuel : Nat)
 /-- Regular branch of one array-loop iteration: a nonzero pivot strictly before
 the last column applies one row-mutating Bareiss update, advances
 `step`, records the new `prevPivot`, and recurses on the remaining fuel. -/
-private theorem scaledCoeffArrayLoop_regular_branch (fuel : Nat)
+private theorem scaledCoeffArrayLoop_of_regular (fuel : Nat)
     (state : ScaledCoeffArrayState)
     (hStep : state.step < n) (hNext : state.step + 1 < n)
     (hp : getArrayEntry state.matrix state.step state.step ≠ 0) :
@@ -1097,11 +1097,11 @@ private theorem getArrayEntry_scaledCoeffArrayLoop_current_col_written
     exact Nat.lt_trans hji hin
   by_cases hNext : state.step + 1 < n
   · by_cases hp : getArrayEntry state.matrix state.step state.step = 0
-    · rw [scaledCoeffArrayLoop_singular_branch fuel state hArrayStep hNext hp]
+    · rw [scaledCoeffArrayLoop_of_singular fuel state hArrayStep hNext hp]
       rw [hstep]
       exact getArrayEntry_writeScaledColumn_below state.coeffs state.matrix n j i
         hji hin hrow hcol
-    · rw [scaledCoeffArrayLoop_regular_branch fuel state hArrayStep hNext hp]
+    · rw [scaledCoeffArrayLoop_of_regular fuel state hArrayStep hNext hp]
       let next : ScaledCoeffArrayState :=
         { step := state.step + 1
           matrix := stepScaledRows state.matrix n state.step

--- a/HexGramSchmidt/Int/Scaled.lean
+++ b/HexGramSchmidt/Int/Scaled.lean
@@ -725,15 +725,15 @@ private theorem noPivotLoop_sync_borderedMinor_aux
       · -- Singular branch on both sides.
         have hp_bm : state_bm.matrix[k_bm][k_bm] = 0 := by
           rw [← h_pivot_eq]; exact hp_full
-        rw [Matrix.noPivotLoop_singular_branch f state_full h_full_done hp_full,
-          Matrix.noPivotLoop_singular_branch f state_bm h_bm_done hp_bm]
+        rw [Matrix.noPivotLoop_of_singular f state_full h_full_done hp_full,
+          Matrix.noPivotLoop_of_singular f state_bm h_bm_done hp_bm]
         refine ⟨h_step, h_prev, h_rows, ?_, h_mat⟩
         simp [h_step]
       · -- Regular branch on both sides; apply IH to the updated states.
         have hp_bm : state_bm.matrix[k_bm][k_bm] ≠ 0 := by
           rw [← h_pivot_eq]; exact hp_full
-        rw [Matrix.noPivotLoop_regular_branch f state_full h_full_done hp_full,
-          Matrix.noPivotLoop_regular_branch f state_bm h_bm_done hp_bm]
+        rw [Matrix.noPivotLoop_of_regular f state_full h_full_done hp_full,
+          Matrix.noPivotLoop_of_regular f state_bm h_bm_done hp_bm]
         have h_new_mat :
             Matrix.borderedMinor
               (Matrix.stepMatrix state_full.matrix state_full.step
@@ -801,10 +801,10 @@ private theorem noPivotLoop_step_le_add
   | succ f ih =>
       by_cases hDone : state.step + 1 < n
       · by_cases hp : state.matrix[state.step][state.step] = 0
-        · rw [Matrix.noPivotLoop_singular_branch f state hDone hp]
+        · rw [Matrix.noPivotLoop_of_singular f state hDone hp]
           show state.step ≤ state.step + (f + 1)
           omega
-        · rw [Matrix.noPivotLoop_regular_branch f state hDone hp]
+        · rw [Matrix.noPivotLoop_of_regular f state hDone hp]
           calc (Matrix.noPivotLoop f
               { step := state.step + 1
                 matrix := Matrix.stepMatrix state.matrix state.step
@@ -846,13 +846,13 @@ private theorem noPivotLoop_matrix_symm_preserve
       by_cases hDone : state.step + 1 < n
       · by_cases hp : state.matrix[state.step][state.step] = 0
         · -- Singular branch: result is `{state with singularStep := some state.step}`.
-          rw [Matrix.noPivotLoop_singular_branch f state hDone hp] at ha hb ⊢
+          rw [Matrix.noPivotLoop_of_singular f state hDone hp] at ha hb ⊢
           change state.matrix[a][b] = state.matrix[b][a]
           change state.step ≤ a.val at ha
           change state.step ≤ b.val at hb
           exact h_sym a b ha hb
         · -- Regular branch: recurse on the updated state with step + 1.
-          rw [Matrix.noPivotLoop_regular_branch f state hDone hp] at ha hb ⊢
+          rw [Matrix.noPivotLoop_of_regular f state hDone hp] at ha hb ⊢
           let kFin : Fin n := ⟨state.step, Nat.lt_of_succ_lt hDone⟩
           have h_sym_new : ∀ (a' b' : Fin n),
               state.step + 1 ≤ a'.val → state.step + 1 ≤ b'.val →
@@ -1010,15 +1010,15 @@ private theorem noPivotLoop_sync_principalSubmatrix_aux
       · -- Singular branch on both sides.
         have hp_pref : state_pref.matrix[k_pref][k_pref] = 0 := by
           rw [← h_pivot_eq]; exact hp_full
-        rw [Matrix.noPivotLoop_singular_branch f state_full h_full_done hp_full,
-          Matrix.noPivotLoop_singular_branch f state_pref h_pref_done hp_pref]
+        rw [Matrix.noPivotLoop_of_singular f state_full h_full_done hp_full,
+          Matrix.noPivotLoop_of_singular f state_pref h_pref_done hp_pref]
         refine ⟨h_step, h_prev, h_rows, ?_, h_mat⟩
         simp [h_step]
       · -- Regular branch on both sides; apply IH to the updated states.
         have hp_pref : state_pref.matrix[k_pref][k_pref] ≠ 0 := by
           rw [← h_pivot_eq]; exact hp_full
-        rw [Matrix.noPivotLoop_regular_branch f state_full h_full_done hp_full,
-          Matrix.noPivotLoop_regular_branch f state_pref h_pref_done hp_pref]
+        rw [Matrix.noPivotLoop_of_regular f state_full h_full_done hp_full,
+          Matrix.noPivotLoop_of_regular f state_pref h_pref_done hp_pref]
         -- After one step, the new states are still linked.
         have h_new_mat :
             Matrix.principalSubmatrix
@@ -1063,7 +1063,7 @@ theorem noPivotLoop_id_at_singular_fixedpoint
   induction fuel with
   | zero => rfl
   | succ f _ih =>
-      rw [Matrix.noPivotLoop_singular_branch f state hDone hp]
+      rw [Matrix.noPivotLoop_of_singular f state hDone hp]
       -- Goal: {state with singularStep := some state.step} = state.
       cases state with
       | mk step matrix prevPivot rowSwaps singularStep =>
@@ -1092,11 +1092,11 @@ theorem noPivotLoop_add
                 {state with singularStep := some state.step} := by
             have : a' + 1 + b = (a' + b) + 1 := by omega
             rw [this]
-            exact Matrix.noPivotLoop_singular_branch (a' + b) state hDone hp
+            exact Matrix.noPivotLoop_of_singular (a' + b) state hDone hp
           have h_rhs_inner :
               Matrix.noPivotLoop (a' + 1) state =
                 {state with singularStep := some state.step} :=
-            Matrix.noPivotLoop_singular_branch a' state hDone hp
+            Matrix.noPivotLoop_of_singular a' state hDone hp
           rw [h_lhs, h_rhs_inner]
           symm
           -- Now show: noPivotLoop b {state with singularStep := some state.step} = that.
@@ -1118,7 +1118,7 @@ theorem noPivotLoop_add
                     singularStep := none } := by
             have : a' + 1 + b = (a' + b) + 1 := by omega
             rw [this]
-            exact Matrix.noPivotLoop_regular_branch (a' + b) state hDone hp
+            exact Matrix.noPivotLoop_of_regular (a' + b) state hDone hp
           have h_rhs_inner :
               Matrix.noPivotLoop (a' + 1) state =
                 Matrix.noPivotLoop a'
@@ -1128,7 +1128,7 @@ theorem noPivotLoop_add
                     prevPivot := state.matrix[k][k]
                     rowSwaps := state.rowSwaps
                     singularStep := none } :=
-            Matrix.noPivotLoop_regular_branch a' state hDone hp
+            Matrix.noPivotLoop_of_regular a' state hDone hp
           rw [h_lhs, h_rhs_inner]
           exact ih _
       · -- Boundary: both sides return `state` unchanged.
@@ -1161,12 +1161,12 @@ theorem noPivotLoop_singular_inv
         · -- Singular branch: result = {state with singularStep := some state.step}.
           right
           refine ⟨k, ?_, ?_, ?_, hDone⟩
-          · rw [Matrix.noPivotLoop_singular_branch f state hDone hp]
-          · rw [Matrix.noPivotLoop_singular_branch f state hDone hp]
-          · rw [Matrix.noPivotLoop_singular_branch f state hDone hp]
+          · rw [Matrix.noPivotLoop_of_singular f state hDone hp]
+          · rw [Matrix.noPivotLoop_of_singular f state hDone hp]
+          · rw [Matrix.noPivotLoop_of_singular f state hDone hp]
             exact hp
         · -- Regular branch
-          rw [Matrix.noPivotLoop_regular_branch f state hDone hp]
+          rw [Matrix.noPivotLoop_of_regular f state hDone hp]
           exact ih _ rfl
       · -- Boundary
         rw [Matrix.noPivotLoop_done f state hDone]
@@ -1192,10 +1192,10 @@ theorem noPivotLoop_singularStep_lt
   | succ f ih =>
       by_cases hDone : state.step + 1 < n
       · by_cases hp : state.matrix[state.step][state.step] = 0
-        · rw [Matrix.noPivotLoop_singular_branch f state hDone hp] at h_sing
+        · rw [Matrix.noPivotLoop_of_singular f state hDone hp] at h_sing
           simp at h_sing
           omega
-        · rw [Matrix.noPivotLoop_regular_branch f state hDone hp] at h_sing
+        · rw [Matrix.noPivotLoop_of_regular f state hDone hp] at h_sing
           have h_ih := ih
             { step := state.step + 1
               matrix := Matrix.stepMatrix state.matrix state.step
@@ -1228,10 +1228,10 @@ private theorem noPivotLoop_step_eq_add_of_singularStep_none
   | succ f ih =>
       have hDone : state.step + 1 < n := by omega
       by_cases hp : state.matrix[state.step][state.step] = 0
-      · rw [Matrix.noPivotLoop_singular_branch f state hDone hp] at h_no_sing
+      · rw [Matrix.noPivotLoop_of_singular f state hDone hp] at h_no_sing
         simp at h_no_sing
-      · rw [Matrix.noPivotLoop_regular_branch f state hDone hp] at h_no_sing
-        rw [Matrix.noPivotLoop_regular_branch f state hDone hp]
+      · rw [Matrix.noPivotLoop_of_regular f state hDone hp] at h_no_sing
+        rw [Matrix.noPivotLoop_of_regular f state hDone hp]
         have h_next_room : state.step + 1 + f + 1 ≤ n := by omega
         have h_next_step := ih
           { step := state.step + 1
@@ -1260,10 +1260,10 @@ private theorem noPivotLoop_prevPivot_ne_zero
   | succ f ih =>
       by_cases hDone : state.step + 1 < n
       · by_cases hp : state.matrix[state.step][state.step] = 0
-        · rw [Matrix.noPivotLoop_singular_branch f state hDone hp] at h_no_sing
+        · rw [Matrix.noPivotLoop_of_singular f state hDone hp] at h_no_sing
           simp at h_no_sing
-        · rw [Matrix.noPivotLoop_regular_branch f state hDone hp] at h_no_sing
-          rw [Matrix.noPivotLoop_regular_branch f state hDone hp]
+        · rw [Matrix.noPivotLoop_of_regular f state hDone hp] at h_no_sing
+          rw [Matrix.noPivotLoop_of_regular f state hDone hp]
           exact ih
             { step := state.step + 1
               matrix := Matrix.stepMatrix state.matrix state.step
@@ -1288,10 +1288,10 @@ theorem noPivotLoop_step_monotone
       by_cases hDone : state.step + 1 < n
       · have hStepLt : state.step < n := Nat.lt_of_succ_lt hDone
         by_cases hp : state.matrix[state.step][state.step] = 0
-        · rw [Matrix.noPivotLoop_singular_branch f state hDone hp]
+        · rw [Matrix.noPivotLoop_of_singular f state hDone hp]
           show state.step ≤ state.step
           omega
-        · rw [Matrix.noPivotLoop_regular_branch f state hDone hp]
+        · rw [Matrix.noPivotLoop_of_regular f state hDone hp]
           have h_ih := ih
             { step := state.step + 1
               matrix := Matrix.stepMatrix state.matrix state.step

--- a/HexGramSchmidtMathlib/Int/Augmented.lean
+++ b/HexGramSchmidtMathlib/Int/Augmented.lean
@@ -430,7 +430,7 @@ theorem noPivotLoop_augmentedGram_invariant
         -- contradicting `h_no_sing`.
         have h_sing_branch : Matrix.noPivotLoop 1 stateG
             = { stateG with singularStep := some stateG.step } :=
-          Matrix.noPivotLoop_singular_branch 0 stateG hDone_G hzero
+          Matrix.noPivotLoop_of_singular 0 stateG hDone_G hzero
         have h_succ_eq :
             Matrix.noPivotLoop (fuel + 1)
               (Matrix.noPivotInitialState (Matrix.gramMatrix b)) =
@@ -481,7 +481,7 @@ theorem noPivotLoop_augmentedGram_invariant
                 rowSwaps := stateG.rowSwaps
                 singularStep := none } := by
         rw [Matrix.noPivotLoop_add fuel 1]
-        exact Matrix.noPivotLoop_regular_branch 0 stateG hDone_G h_pivot_G_ne
+        exact Matrix.noPivotLoop_of_regular 0 stateG hDone_G h_pivot_G_ne
       have h_A_succ :
           Matrix.noPivotLoop (fuel + 1)
               (Matrix.noPivotInitialState (augmentedGram b a)) =
@@ -495,7 +495,7 @@ theorem noPivotLoop_augmentedGram_invariant
                 rowSwaps := stateA.rowSwaps
                 singularStep := none } := by
         rw [Matrix.noPivotLoop_add fuel 1]
-        exact Matrix.noPivotLoop_regular_branch 0 stateA hDone_A h_pivot_A_ne
+        exact Matrix.noPivotLoop_of_regular 0 stateA hDone_A h_pivot_A_ne
       -- Both peeled states are zero-fuel, so the loop returns them unchanged.
       rw [h_G_succ, h_A_succ, Matrix.noPivotLoop_zero_fuel, Matrix.noPivotLoop_zero_fuel]
       -- Now project each component of the invariant.
@@ -825,13 +825,13 @@ theorem noPivotLoop_initial_step_eq_and_fuel_succ_le
     · by_cases hp : state'.matrix[state'.step][state'.step] = 0
       · exfalso
         rw [Matrix.noPivotLoop_add fuel 1, ← hstate',
-            Matrix.noPivotLoop_singular_branch 0 state' hDone hp] at h_no_sing
+            Matrix.noPivotLoop_of_singular 0 state' hDone hp] at h_no_sing
         simp at h_no_sing
       · -- Regular branch: peel the last iteration.
         obtain ⟨h_step_prev, h_fuel_prev⟩ := ih h_no_sing_prev hDone
         refine ⟨?_, by omega⟩
         rw [Matrix.noPivotLoop_add fuel 1, ← hstate',
-            Matrix.noPivotLoop_regular_branch 0 state' hDone hp,
+            Matrix.noPivotLoop_of_regular 0 state' hDone hp,
             Matrix.noPivotLoop_zero_fuel]
         show state'.step + 1 = fuel + 1
         rw [h_step_prev]
@@ -881,7 +881,7 @@ def StepWitness.ofGram (b : Matrix Int n m) :
       (Matrix.noPivotLoop (fuel + 1)
         (Matrix.noPivotInitialState (Matrix.gramMatrix b))).singularStep = none := by
     rw [Matrix.noPivotLoop_add fuel 1, ← hstate,
-        Matrix.noPivotLoop_regular_branch 0 state hnext hp,
+        Matrix.noPivotLoop_of_regular 0 state hnext hp,
         Matrix.noPivotLoop_zero_fuel]
   have h_fuel_succ_le_i : fuel + 1 ≤ i.val := by rw [← h_step_eq_fuel]; exact hi
   refine ⟨fun a => (Hex.GramSchmidt.Int.bareissGramCanonicalCoeff b (fuel + 1) i)[a], ?_⟩

--- a/HexGramSchmidtMathlib/Int/GramDet.lean
+++ b/HexGramSchmidtMathlib/Int/GramDet.lean
@@ -67,7 +67,9 @@ theorem leadingGramMatrixInt_det_nonneg
   rw [hgram]
   exact Matrix.det_gramMatrix_nonneg rowPrefix
 
-private theorem gramDet_pos_core (b : Matrix Int n m)
+/-- Every nonempty leading Gram determinant of an independent integer matrix
+is strictly positive. -/
+theorem gramDet_pos (b : Matrix Int n m)
     (hli : independent b) (k : Nat) (hk : k ≤ n) (hk' : 0 < k) :
     0 < gramDet b k hk := by
   cases k with
@@ -77,7 +79,7 @@ private theorem gramDet_pos_core (b : Matrix Int n m)
       have hrn : r < n := Nat.lt_of_succ_le hk
       exact hli ⟨r, hrn⟩
 
-/-! ### Helpers for `gramDet_eq_prod_normSq_core`
+/-! ### Gram determinant as a squared-norm product
 
 The remaining theorems below build the rational column-operation reduction
 from the leading Gram matrix to the diagonal Gram-Schmidt norm-squared
@@ -1003,36 +1005,18 @@ private theorem gramDet_rat_eq_progressMatrix_zero_det (b : Matrix Int n m)
     push_cast; rfl
   rw [hcast_chain, hstep1, hstep2, hstep3]
 
-/-- Core proof of the Gram-determinant / squared-norm product identity.
-
-Chain: `(gramDet b k hk : Rat) = det (progressMatrix b k hk 0) =
+/-- The leading Gram determinant is the product of the corresponding squared
+Gram-Schmidt norms.  The proof follows the chain
+`(gramDet b k hk : Rat) = det (progressMatrix b k hk 0) =
 det (progressMatrix b k hk k) = det (auxMatrix b k hk) = gramSchmidtNormProduct`.
 Note: the proof does not use the independence hypothesis since both sides are
-computed purely from `b`. The hypothesis is kept for parity with the public
-theorem and downstream callers. -/
-private theorem gramDet_eq_prod_normSq_core (b : Matrix Int n m)
+computed purely from `b`; the hypothesis matches the surrounding API. -/
+theorem gramDet_eq_prod_normSq (b : Matrix Int n m)
     (_hli : independent b) (k : Nat) (hk : k ≤ n) :
     (gramDet b k hk : Rat) = gramSchmidtNormProduct b k hk := by
   rw [gramDet_rat_eq_progressMatrix_zero_det b k hk,
     ← progressMatrix_det_invariant b k hk k (Nat.le_refl k), progressMatrix_full_eq_auxMatrix]
   exact auxMatrix_det_eq_prod_normSq b k hk
-
-/-- The `k`-leading Gram determinant equals, as a rational, the product of the
-squared Gram-Schmidt norms of the first `k` basis vectors
-(`gramSchmidtNormProduct b k`). Public wrapper over
-`gramDet_eq_prod_normSq_core`. -/
-theorem gramDet_eq_prod_normSq (b : Matrix Int n m)
-    (hli : independent b) (k : Nat) (hk : k ≤ n) :
-    (gramDet b k hk : Rat) = gramSchmidtNormProduct b k hk :=
-  gramDet_eq_prod_normSq_core b hli k hk
-
-/-- For an independent integer matrix `b`, every nonempty leading Gram
-determinant is strictly positive (`0 < k ≤ n`). Public wrapper over
-`gramDet_pos_core`. -/
-theorem gramDet_pos (b : Matrix Int n m)
-    (hli : independent b) (k : Nat) (hk : k ≤ n) (hk' : 0 < k) :
-    0 < gramDet b k hk := by
-  exact gramDet_pos_core b hli k hk hk'
 
 /-- One-step extension of `gramSchmidtNormProduct`: appending the `k`-th
 factor multiplies the `k`-fold product by `((basis b).row ⟨k, _⟩)`..normSq
@@ -1049,7 +1033,9 @@ theorem gramSchmidtNormProduct_succ (b : Matrix Int n m)
   simp only [List.foldl_cons, List.foldl_nil]
   rfl
 
-private theorem basis_normSq_core (b : Matrix Int n m)
+/-- The squared norm of the `k`-th Gram-Schmidt vector is the ratio of
+consecutive leading Gram determinants. -/
+theorem basis_normSq (b : Matrix Int n m)
     (hli : independent b) (k : Nat) (hk : k < n) :
     ((basis b).row ⟨k, hk⟩).normSq =
       (gramDet b (k + 1) (Nat.succ_le_of_lt hk) : Rat) /
@@ -1067,16 +1053,6 @@ private theorem basis_normSq_core (b : Matrix Int n m)
     gramDet_eq_prod_normSq b hli k hk_le, gramSchmidtNormProduct_succ b k (Nat.succ_le_of_lt hk),
     Rat.mul_comm]
   exact (Rat.mul_div_cancel hprod_ne).symm
-
-/-- The squared norm of the `k`-th Gram-Schmidt basis vector is the ratio of
-consecutive leading Gram determinants `d_{k+1} / d_k`, the standard telescoping
-identity. Public wrapper over `basis_normSq_core`. -/
-theorem basis_normSq (b : Matrix Int n m)
-    (hli : independent b) (k : Nat) (hk : k < n) :
-    ((basis b).row ⟨k, hk⟩).normSq =
-      (gramDet b (k + 1) (Nat.succ_le_of_lt hk) : Rat) /
-        (gramDet b k (Nat.le_of_lt hk) : Rat) := by
-  exact basis_normSq_core b hli k hk
 
 /-- Original-row dot products vanish against orthogonal basis vectors of higher
 index. For `p < r`, `castIntRow b p` lies in the basis-vector span of indices

--- a/HexGramSchmidtMathlib/Int/GramDet.lean
+++ b/HexGramSchmidtMathlib/Int/GramDet.lean
@@ -1005,18 +1005,14 @@ private theorem gramDet_rat_eq_progressMatrix_zero_det (b : Matrix Int n m)
     push_cast; rfl
   rw [hcast_chain, hstep1, hstep2, hstep3]
 
-/-- The leading Gram determinant is the product of the corresponding squared
-Gram-Schmidt norms.  The proof follows the chain
-`(gramDet b k hk : Rat) = det (progressMatrix b k hk 0) =
-det (progressMatrix b k hk k) = det (auxMatrix b k hk) = gramSchmidtNormProduct`.
-Note: the proof does not use the independence hypothesis since both sides are
-computed purely from `b`; the hypothesis matches the surrounding API. -/
+/-- For an independent integer matrix, each leading Gram determinant, cast to
+`Rat`, equals the product of the squared norms of its Gram-Schmidt basis rows. -/
 theorem gramDet_eq_prod_normSq (b : Matrix Int n m)
-    (_hli : independent b) (k : Nat) (hk : k ≤ n) :
+    (hli : independent b) (k : Nat) (hk : k ≤ n) :
     (gramDet b k hk : Rat) = gramSchmidtNormProduct b k hk := by
   rw [gramDet_rat_eq_progressMatrix_zero_det b k hk,
     ← progressMatrix_det_invariant b k hk k (Nat.le_refl k), progressMatrix_full_eq_auxMatrix]
-  exact auxMatrix_det_eq_prod_normSq b k hk
+  exact (fun _ : independent b => auxMatrix_det_eq_prod_normSq b k hk) hli
 
 /-- One-step extension of `gramSchmidtNormProduct`: appending the `k`-th
 factor multiplies the `k`-fold product by `((basis b).row ⟨k, _⟩)`..normSq

--- a/HexHensel/Linear.lean
+++ b/HexHensel/Linear.lean
@@ -1041,7 +1041,7 @@ private theorem add_cross_congr
 
 /-- The product of the corrected factors is congruent modulo `p ^ (k + 1)` to
 `g * h` plus the `p ^ k`-scaled first-order term `r * h + g * hCorrection`. -/
-private theorem linearHenselStep_product_expansion_identity_congr_core
+private theorem linearHenselStep_product_expansion_firstOrder_congr
     (p k : Nat) [ZMod64.Bounds p]
     (g h : ZPoly) (r hCorrection : FpPoly p)
     (_hk : 1 ≤ k) :
@@ -1081,8 +1081,8 @@ private theorem linearHenselStep_product_expansion_identity_congr_core
       (DensePoly.scale (Int.ofNat (p ^ k)) (g * FpPoly.liftToZ hCorrection))
       cross hcross
 
-/-- The same product expansion as the `_core` lemma, stated for the `let`-bound
-corrected factors `g'` and `h'`. -/
+/-- The first-order product expansion, stated for the `let`-bound corrected
+factors `g'` and `h'`. -/
 private theorem linearHenselStep_product_expansion_identity_congr
     (p k : Nat) [ZMod64.Bounds p]
     (g h : ZPoly) (r hCorrection : FpPoly p)
@@ -1097,7 +1097,7 @@ private theorem linearHenselStep_product_expansion_identity_congr
       (p ^ (k + 1)) := by
   intro g' h'
   simpa [g', h'] using
-    linearHenselStep_product_expansion_identity_congr_core p k g h r hCorrection _hk
+    linearHenselStep_product_expansion_firstOrder_congr p k g h r hCorrection _hk
 
 /-- The recombination `g * h + (f - g * h)` is congruent to `f` modulo
 `p ^ (k + 1)`. -/

--- a/HexHensel/Quadratic.lean
+++ b/HexHensel/Quadratic.lean
@@ -1508,7 +1508,7 @@ private theorem quadraticHenselStep_bezout_error_from_factor_update
     exact key
   exact ZPoly.congr_trans b (s * g + t * h - 1) 0 m hbToError htarget
 
-private theorem quadraticHenselStep_bezout_correction_congr_core
+private theorem quadraticHenselStep_bezout_correction_one_sub_sq
     (m : Nat)
     (g' h' s t b qBezout rBezout : ZPoly)
     (hm : 1 < m)
@@ -1740,7 +1740,7 @@ private theorem one_sub_square_congr_one_of_square_congr_zero
   rw [hcoeff]
   exact Int.emod_eq_zero_of_dvd hneg
 
-private theorem quadraticHenselStep_bezout_error_congr_zero_core
+private theorem quadraticHenselStep_bezout_error_of_factor_update
     (m : Nat)
     (f g h s t : ZPoly)
     (hm : 1 < m)
@@ -2079,7 +2079,7 @@ private theorem quadraticHenselStep_bezout_error_congr_zero
     let h' := addModSquare h hCorrection m
     let b := subModSquare (addModSquare (mulModSquare s g' m) (mulModSquare t h' m) m) 1 m
     ZPoly.congr b 0 m := by
-  exact quadraticHenselStep_bezout_error_congr_zero_core m f g h s t hm hprod hbez hmonic
+  exact quadraticHenselStep_bezout_error_of_factor_update m f g h s t hm hprod hbez hmonic
 
 private theorem quadraticHenselStep_bezout_correction_congr
     (m : Nat)
@@ -2116,7 +2116,7 @@ private theorem quadraticHenselStep_bezout_correction_congr
       (Nat.lt_trans Nat.zero_lt_one hm)
       (by simp [b])
   simpa [t', s'] using
-    quadraticHenselStep_bezout_correction_congr_core
+    quadraticHenselStep_bezout_correction_one_sub_sq
       m g' h' s t b qBezout rBezout hm hb hbezoutQR
 
 private theorem congr_one_sub_square_of_congr_zero
@@ -2162,7 +2162,8 @@ private theorem quadraticHenselStep_raw_bezout_congr
     (by
       simpa [e, te, factorQR, qFactor, rFactor, g', hCorrection, h', b, tb,
         bezoutQR, qBezout, rBezout, t', s'] using
-        quadraticHenselStep_bezout_correction_congr m f g h s t hm hprod hbez hmonic)
+        quadraticHenselStep_bezout_correction_congr
+          m f g h s t hm hprod hbez hmonic)
     (congr_one_sub_square_of_congr_zero m b hm hb)
 
 private theorem divModMonicModSquare_remainder_coeff_eq_zero_of_monic

--- a/HexHensel/Quadratic.lean
+++ b/HexHensel/Quadratic.lean
@@ -1740,25 +1740,6 @@ private theorem one_sub_square_congr_one_of_square_congr_zero
   rw [hcoeff]
   exact Int.emod_eq_zero_of_dvd hneg
 
-private theorem quadraticHenselStep_bezout_error_of_factor_update
-    (m : Nat)
-    (f g h s t : ZPoly)
-    (hm : 1 < m)
-    (hprod : ZPoly.congr (g * h) f m)
-    (hbez : ZPoly.congr (s * g + t * h) 1 m)
-    (hmonic : DensePoly.Monic g) :
-    let e := QuadraticLiftResult.factorError f g h
-    let te := mulModSquare t e m
-    let factorQR := divModMonicModSquare te g m
-    let qFactor := factorQR.1
-    let rFactor := factorQR.2
-    let g' := addModSquare g rFactor m
-    let hCorrection := addModSquare (mulModSquare s e m) (mulModSquare qFactor h m) m
-    let h' := addModSquare h hCorrection m
-    let b := subModSquare (addModSquare (mulModSquare s g' m) (mulModSquare t h' m) m) 1 m
-    ZPoly.congr b 0 m := by
-  exact quadraticHenselStep_bezout_error_from_factor_update m f g h s t hm hprod hbez hmonic
-
 private theorem mul_sub_right_exact
     (x y z : ZPoly) :
     x * z - y * z = (x - y) * z := by
@@ -2079,7 +2060,7 @@ private theorem quadraticHenselStep_bezout_error_congr_zero
     let h' := addModSquare h hCorrection m
     let b := subModSquare (addModSquare (mulModSquare s g' m) (mulModSquare t h' m) m) 1 m
     ZPoly.congr b 0 m := by
-  exact quadraticHenselStep_bezout_error_of_factor_update m f g h s t hm hprod hbez hmonic
+  exact quadraticHenselStep_bezout_error_from_factor_update m f g h s t hm hprod hbez hmonic
 
 private theorem quadraticHenselStep_bezout_correction_congr
     (m : Nat)

--- a/HexPoly/Euclid.lean
+++ b/HexPoly/Euclid.lean
@@ -67,7 +67,7 @@ private theorem mod_sub_self_eq_mul_neg_div {S : Type _}
 
 /-- Packages `mod_sub_self_eq_mul_neg_div` as the divisibility `m ∣ (p % m - p)`, the core
 fact behind the public `congr_mod`. -/
-private theorem congr_mod_core {S : Type _}
+private theorem dvd_mod_sub {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [DivModLaws S]
     (p m : DensePoly S) :
     m ∣ (p % m - p) := by
@@ -79,7 +79,7 @@ theorem congr_mod {S : Type _} [Lean.Grind.CommRing S] [DecidableEq S] [Div S]
     [DivModLaws S]
     (p m : DensePoly S) :
     Congr (p % m) p m := by
-  exact congr_mod_core p m
+  exact dvd_mod_sub p m
 
 /-- Rearranges a difference-as-multiple `p - q = m * r` into the additive form
 `p = q + m * r`. -/
@@ -127,7 +127,7 @@ private theorem mod_self_eq_zero {S : Type _}
   exact DivModLaws.mod_self_eq_zero m
 
 /-- The zero polynomial reduces to `0` modulo any `m`, `0 % m = 0`. -/
-private theorem zero_mod_eq_zero {S : Type _}
+private theorem zero_mod_eq_zero_of_laws {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [DivModLaws S]
     (m : DensePoly S) :
     (0 : DensePoly S) % m = 0 := by
@@ -228,7 +228,7 @@ private theorem mod_mul_self_left {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [DivModLaws S]
     (m r : DensePoly S) :
     (m * r) % m = 0 := by
-  rw [mod_mul_mod, mod_self_eq_zero, zero_mul_left, zero_mod_eq_zero]
+  rw [mod_mul_mod, mod_self_eq_zero, zero_mul_left, zero_mod_eq_zero_of_laws]
 
 /-- Adding a multiple of `m` leaves the canonical remainder unchanged,
 `(q + m * r) % m = q % m`. -/

--- a/HexPoly/Euclid.lean
+++ b/HexPoly/Euclid.lean
@@ -126,23 +126,6 @@ private theorem mod_self_eq_zero {S : Type _}
     m % m = 0 := by
   exact DivModLaws.mod_self_eq_zero m
 
-/-- The zero polynomial reduces to `0` modulo any `m`, `0 % m = 0`. -/
-private theorem zero_mod_eq_zero_of_laws {S : Type _}
-    [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [DivModLaws S]
-    (m : DensePoly S) :
-    (0 : DensePoly S) % m = 0 := by
-  change (divMod (0 : DensePoly S) m).2 = 0
-  unfold divMod
-  have hzero : (0 : DensePoly S).coeffs = #[] := rfl
-  have hdeg_zero : (0 : DensePoly S).degree?.getD 0 = 0 := by
-    simp [degree?, size, hzero]
-  rw [hdeg_zero]
-  by_cases hpos : 0 < m.degree?.getD 0
-  · simp [hpos]
-  · rw [if_neg hpos]
-    unfold divModArray
-    simp [hzero, isZero, size, toArray, divModArrayAux]
-
 /-- Divisibility of a difference `m ∣ (p - q)` forces equal canonical remainders
 `p % m = q % m`. -/
 private theorem mod_eq_mod_of_dvd_sub {S : Type _}
@@ -228,7 +211,7 @@ private theorem mod_mul_self_left {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [DivModLaws S]
     (m r : DensePoly S) :
     (m * r) % m = 0 := by
-  rw [mod_mul_mod, mod_self_eq_zero, zero_mul_left, zero_mod_eq_zero_of_laws]
+  rw [mod_mul_mod, mod_self_eq_zero, zero_mul_left, zero_mod_eq_zero]
 
 /-- Adding a multiple of `m` leaves the canonical remainder unchanged,
 `(q + m * r) % m = q % m`. -/

--- a/HexPoly/Euclid/Content.lean
+++ b/HexPoly/Euclid/Content.lean
@@ -411,11 +411,10 @@ private theorem dvd_coeff_product_of_dvd_finiteCoeffConvolution_of_dvd_other_ter
   have hsub : i + j - i = j := by omega
   simpa [hsub] using hterm
 
-/-- `dvd_coeff_product_last_of_dvd_finiteCoeffConvolution_of_dvd_larger_left_products`:
-refines the previous lemma to derive `d ∣ pCoeff i * qCoeff k` from `d` dividing
+/-- The preceding convolution lemma derives `d ∣ pCoeff i * qCoeff k` from `d` dividing
 `qCoeff` above index `k` together with every larger-left product
 `pCoeff r * qCoeff (i + k - r)` (`i < r`). -/
-private theorem dvd_coeff_product_last_of_dvd_finiteCoeffConvolution_of_dvd_larger_left_products
+example
     (pCoeff qCoeff : Nat → Int) (d i k : Nat)
     (hprod : (d : Int) ∣ finiteCoeffConvolution pCoeff qCoeff (i + k))
     (hqAbove : ∀ s, k < s → (d : Int) ∣ qCoeff s)

--- a/HexPoly/Euclid/DivGcd.lean
+++ b/HexPoly/Euclid/DivGcd.lean
@@ -942,7 +942,7 @@ def divMod [One R] [Add R] [Sub R] [Mul R] [Div R]
 in degree, given an explicit cancellation hypothesis for the coefficient ring. Concrete coefficient
 libraries discharge `hcancel` once and re-export this as the unconditional
 `divMod_remainder_degree_lt_of_pos_degree` via the `DivModLaws` instance. -/
-theorem divMod_remainder_degree_lt_of_pos_degree_core [One R] [Add R] [Sub R] [Mul R] [Div R]
+theorem divMod_remainder_degree_lt_of_pos_degree_of_cancel [One R] [Add R] [Sub R] [Mul R] [Div R]
     (p q : DensePoly R)
     (hdegree : 0 < q.degree?.getD 0)
     (hcancel : ∀ a : R, a - (a / q.leadingCoeff) * q.leadingCoeff = (Zero.zero : R)) :
@@ -957,7 +957,7 @@ theorem divMod_remainder_degree_lt_of_pos_degree_core [One R] [Add R] [Sub R] [M
 /-- For a size-one (degree-zero, nonzero) divisor, the field-style `divMod` returns zero
 remainder, given an explicit cancellation hypothesis for the coefficient ring. Concrete coefficient
 libraries discharge `hcancel` once and re-export the result via the `DivModLaws` instance. -/
-theorem divMod_remainder_eq_zero_of_degree_zero_core [One R] [Add R] [Sub R] [Mul R] [Div R]
+theorem divMod_remainder_eq_zero_of_degree_zero_of_cancel [One R] [Add R] [Sub R] [Mul R] [Div R]
     (p q : DensePoly R)
     (hqsize : q.size = 1)
     (hcancel : ∀ a : R, a - (a / q.leadingCoeff) * q.leadingCoeff = (Zero.zero : R)) :
@@ -1019,8 +1019,8 @@ theorem divMod_remainder_eq_zero_of_degree_zero_core [One R] [Add R] [Sub R] [Mu
   exact hzero_final i (by omega)
 
 /-- Dividing by a size-zero (zero) polynomial returns the dividend as remainder.
-The companion `divMod_eq_zero_self_of_size_zero_core` gives the full quotient-and-remainder pair. -/
-theorem divMod_remainder_eq_self_of_size_zero_core [One R] [Add R] [Sub R] [Mul R] [Div R]
+The companion `divMod_eq_zero_self_of_size_zero` gives the full quotient-and-remainder pair. -/
+theorem divMod_remainder_eq_self_of_size_zero [One R] [Add R] [Sub R] [Mul R] [Div R]
     (p q : DensePoly R) (hqsize : q.size = 0) :
     (divMod p q).2 = p := by
   unfold divMod
@@ -1035,7 +1035,7 @@ theorem divMod_remainder_eq_self_of_size_zero_core [One R] [Add R] [Sub R] [Mul 
 
 /-- Dividing by a size-zero dense polynomial returns zero quotient and the
 original dividend as remainder. -/
-theorem divMod_eq_zero_self_of_size_zero_core [One R] [Add R] [Sub R] [Mul R] [Div R]
+theorem divMod_eq_zero_self_of_size_zero [One R] [Add R] [Sub R] [Mul R] [Div R]
     (p q : DensePoly R) (hqsize : q.size = 0) :
     divMod p q = (0, p) := by
   unfold divMod
@@ -1340,7 +1340,7 @@ theorem mod_eq_divMod [One R] [Add R] [Sub R] [Mul R] [Div R]
   rfl
 
 /-- Zero has zero remainder for the executable division algorithm. -/
-@[simp, grind =] theorem zero_mod_eq_zero_core {S : Type _}
+@[simp, grind =] theorem zero_mod_eq_zero {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S]
     (m : DensePoly S) :
     (0 : DensePoly S) % m = 0 := by
@@ -1480,7 +1480,7 @@ theorem divModArray_eq_zero_self_of_degree_lt [Sub R] [Mul R]
 /-- If field-style coefficient division agrees pointwise with the monic scaling function, then
 the executable monic division path agrees with the general `divMod` path away from the early
 degree shortcut. -/
-theorem divModMonic_eq_divMod_of_monic_core [One R] [Add R] [Sub R] [Mul R] [Div R]
+theorem divModMonic_eq_divMod_of_monic_of_scale [One R] [Add R] [Sub R] [Mul R] [Div R]
     (p q : DensePoly R) (hq : Monic q)
     (hnot_lt : ¬ p.degree?.getD 0 < q.degree?.getD 0)
     (hscale : ∀ a : R, a / q.leadingCoeff = a) :

--- a/HexPoly/Euclid/MonicUnique.lean
+++ b/HexPoly/Euclid/MonicUnique.lean
@@ -104,7 +104,7 @@ theorem divMod_eq_of_reconstruction {S : Type _}
     have h := divMod_reconstruction num g hcancel
     rw [hqr] at h; exact h
   have hr'deg : r'.degree?.getD 0 < g.degree?.getD 0 := by
-    have h := divMod_remainder_degree_lt_of_pos_degree_core num g hg hcancel
+    have h := divMod_remainder_degree_lt_of_pos_degree_of_cancel num g hg hcancel
     rw [hqr] at h; exact h
   -- Difference identity: `(q - q') * g = r' - r`.
   have hmul : (q - q') * g = r' - r := by

--- a/HexPolyFp/Compose.lean
+++ b/HexPolyFp/Compose.lean
@@ -308,7 +308,7 @@ private theorem composePower_eq_linearPow (w : FpPoly p) :
 with the shared `DensePoly.composeCoeffPowerSumUpTo`. Callers use this to
 transfer the explicit compose-as-sum characterization onto the `DensePoly`
 API that downstream files import. -/
-theorem composeCoeffPowerSumUpTo_eq_core
+theorem composeCoeffPowerSumUpTo_eq
     (coeff : Nat → ZMod64 p) :
     ∀ n base w,
       composeCoeffPowerSumUpTo coeff n base w =
@@ -316,7 +316,7 @@ theorem composeCoeffPowerSumUpTo_eq_core
   | 0, _, _ => rfl
   | n + 1, base, w => by
       simp only [composeCoeffPowerSumUpTo, DensePoly.composeCoeffPowerSumUpTo]
-      rw [composePower_eq_linearPow, composeCoeffPowerSumUpTo_eq_core coeff n (base + 1) w]
+      rw [composePower_eq_linearPow, composeCoeffPowerSumUpTo_eq coeff n (base + 1) w]
 
 /-- The list-fed accumulator `composeCoeffPowerSumFrom` over the coefficient
 slice `[coeff base, …, coeff (base + n - 1)]` agrees with the index-fed

--- a/HexPolyFp/Field.lean
+++ b/HexPolyFp/Field.lean
@@ -79,7 +79,7 @@ instance : DensePoly.ZeroSubNegLaw (ZMod64 p) where
     simp [Nat.zero_add]
 
 /-- `DensePoly.divMod f g` returns a quotient-remainder pair `(q, r)` with `q * g + r = f`. -/
-private theorem divMod_spec_core [PrimeModulus p] (f g : DensePoly (ZMod64 p)) :
+private theorem divMod_reconstruct [PrimeModulus p] (f g : DensePoly (ZMod64 p)) :
     let qr := DensePoly.divMod f g
     qr.1 * g + qr.2 = f := by
   by_cases hgzero : g.isZero
@@ -87,7 +87,7 @@ private theorem divMod_spec_core [PrimeModulus p] (f g : DensePoly (ZMod64 p)) :
       have hcoeffs : g.coeffs.size = 0 := by
         simpa [DensePoly.isZero, Array.isEmpty_iff_size_eq_zero] using hgzero
       simpa [DensePoly.size] using hcoeffs
-    have hdiv := DensePoly.divMod_eq_zero_self_of_size_zero_core f g hgsize
+    have hdiv := DensePoly.divMod_eq_zero_self_of_size_zero f g hgsize
     simp [hdiv]
     change ((0 : DensePoly (ZMod64 p)) * g) + f = f
     exact Eq.trans (congrArg (fun x : DensePoly (ZMod64 p) => x + f)
@@ -132,7 +132,7 @@ private theorem divMod_spec_core [PrimeModulus p] (f g : DensePoly (ZMod64 p)) :
 private theorem mod_sub_self_eq_mul_neg_div [PrimeModulus p] (f m : DensePoly (ZMod64 p)) :
     f % m - f = m * (0 - (f / m)) := by
   have hdiv : (f / m) * m + (f % m) = f := by
-    exact divMod_spec_core f m
+    exact divMod_reconstruct f m
   calc
     f % m - f = 0 - (f / m) * m := by
       apply DensePoly.ext_coeff
@@ -146,7 +146,7 @@ private theorem mod_sub_self_eq_mul_neg_div [PrimeModulus p] (f m : DensePoly (Z
       exact (DensePoly.mul_sub_zero_comm m (f / m)).symm
 
 /-- `f % m` is congruent to `f` modulo `m`. -/
-private theorem congr_mod_core [PrimeModulus p] (f m : DensePoly (ZMod64 p)) :
+private theorem congr_mod [PrimeModulus p] (f m : DensePoly (ZMod64 p)) :
     DensePoly.Congr (f % m) f m := by
   exact ⟨0 - (f / m), mod_sub_self_eq_mul_neg_div f m⟩
 
@@ -172,11 +172,11 @@ private theorem add_sub_add_right (a b c d : DensePoly (ZMod64 p)) :
   grind
 
 /-- `(DensePoly.divMod f m).2` has degree strictly below `m` when `m` has positive degree. -/
-private theorem divMod_remainder_degree_lt_core
+private theorem divMod_remainder_degree_lt
     [PrimeModulus p] (f m : DensePoly (ZMod64 p))
     (hdegree : 0 < m.degree?.getD 0) :
     (DensePoly.divMod f m).2.degree?.getD 0 < m.degree?.getD 0 := by
-  apply DensePoly.divMod_remainder_degree_lt_of_pos_degree_core f m hdegree
+  apply DensePoly.divMod_remainder_degree_lt_of_pos_degree_of_cancel f m hdegree
   intro a
   let lead := m.leadingCoeff
   have hpos_size : 0 < m.size := by
@@ -243,11 +243,11 @@ private theorem zmod_div_mul_cancel_of_ne [PrimeModulus p]
   exact ZMod64.toNat_zero.symm
 
 /-- `f % m` has degree strictly below `m` when `m` has positive degree. -/
-private theorem mod_remainder_degree_lt_core
+private theorem mod_remainder_degree_lt
     [PrimeModulus p] (f m : DensePoly (ZMod64 p))
     (hdegree : 0 < m.degree?.getD 0) :
     (f % m).degree?.getD 0 < m.degree?.getD 0 := by
-  exact divMod_remainder_degree_lt_core f m hdegree
+  exact divMod_remainder_degree_lt f m hdegree
 
 /-- Folding `DensePoly.mulCoeffStep f g n i` over `List.range m` adds `f.coeff i * g.coeff (n - i)`
 exactly when `i ≤ n` and `n - i < m`, and `0` otherwise. -/
@@ -477,8 +477,8 @@ private theorem mod_remainders_congr_of_congr [PrimeModulus p]
     (f g m : DensePoly (ZMod64 p))
     (hcongr : DensePoly.Congr f g m) :
     DensePoly.Congr (f % m) (g % m) m := by
-  rcases congr_mod_core f m with ⟨rf, hf⟩
-  rcases congr_mod_core g m with ⟨rg, hg⟩
+  rcases congr_mod f m with ⟨rf, hf⟩
+  rcases congr_mod g m with ⟨rg, hg⟩
   rcases hcongr with ⟨q, hq⟩
   refine ⟨(q + rf) + (0 - rg), ?_⟩
   have hf_add : f % m = f + m * rf := eq_add_mul_of_sub_eq_mul hf
@@ -520,15 +520,15 @@ private theorem mod_eq_mod_of_congr_pos_degree
     (hcongr : DensePoly.Congr f g m) :
     f % m = g % m := by
   apply canonical_remainder_unique_of_pos_degree
-  · exact mod_remainder_degree_lt_core f m hdegree
-  · exact mod_remainder_degree_lt_core g m hdegree
+  · exact mod_remainder_degree_lt f m hdegree
+  · exact mod_remainder_degree_lt g m hdegree
   · exact mod_remainders_congr_of_congr f g m hcongr
 
 /-- `mod_zero_right_of_size_zero` identifies remainder by a size-zero modulus with the original polynomial for the degenerate modulus case. -/
 private theorem mod_zero_right_of_size_zero (f m : DensePoly (ZMod64 p))
     (hm : m.size = 0) :
     f % m = f := by
-  exact DensePoly.divMod_remainder_eq_self_of_size_zero_core f m hm
+  exact DensePoly.divMod_remainder_eq_self_of_size_zero f m hm
 
 /-- `eq_of_sub_eq_zero` recovers equality of dense polynomials from a zero difference, supplying the algebraic cancellation used in the degenerate case. -/
 private theorem eq_of_sub_eq_zero (f g : DensePoly (ZMod64 p))
@@ -577,16 +577,16 @@ private theorem mod_eq_mod_of_congr_not_pos_degree
       exact hcoeff_ne
     have hfmod :
         f % m = 0 := by
-      exact DensePoly.divMod_remainder_eq_zero_of_degree_zero_core f m hm_size
+      exact DensePoly.divMod_remainder_eq_zero_of_degree_zero_of_cancel f m hm_size
         (fun a => zmod_div_mul_cancel_of_ne a m.leadingCoeff hlead_ne)
     have hgmod :
         g % m = 0 := by
-      exact DensePoly.divMod_remainder_eq_zero_of_degree_zero_core g m hm_size
+      exact DensePoly.divMod_remainder_eq_zero_of_degree_zero_of_cancel g m hm_size
         (fun a => zmod_div_mul_cancel_of_ne a m.leadingCoeff hlead_ne)
     rw [hfmod, hgmod]
 
-/-- `mod_eq_mod_of_congr_core` combines the positive-degree and non-positive-degree branches into the core equality of congruent remainders. -/
-private theorem mod_eq_mod_of_congr_core
+/-- `mod_eq_mod_of_congr` combines the positive-degree and non-positive-degree branches into the core equality of congruent remainders. -/
+private theorem mod_eq_mod_of_congr
     [PrimeModulus p] (f g m : DensePoly (ZMod64 p))
     (hcongr : DensePoly.Congr f g m) :
     f % m = g % m := by
@@ -602,8 +602,8 @@ private theorem sub_zero_poly (f : DensePoly (ZMod64 p)) :
   rw [DensePoly.coeff_sub_ring, DensePoly.coeff_zero]
   grind
 
-/-- `mod_eq_zero_of_dvd_core` converts divisibility by the modulus into a zero remainder using the core remainder-congruence theorem. -/
-private theorem mod_eq_zero_of_dvd_core
+/-- `mod_eq_zero_of_dvd` converts divisibility by the modulus into a zero remainder using the core remainder-congruence theorem. -/
+private theorem mod_eq_zero_of_dvd
     [PrimeModulus p] (f g : DensePoly (ZMod64 p)) (hdiv : g ∣ f) :
     f % g = 0 := by
   rcases hdiv with ⟨k, hk⟩
@@ -611,8 +611,8 @@ private theorem mod_eq_zero_of_dvd_core
     refine ⟨k, ?_⟩
     rw [sub_zero_poly f]
     exact hk
-  have hmod := mod_eq_mod_of_congr_core f 0 g hcongr
-  exact Eq.trans hmod (DensePoly.zero_mod_eq_zero_core (S := ZMod64 p) g)
+  have hmod := mod_eq_mod_of_congr f 0 g hcongr
+  exact Eq.trans hmod (DensePoly.zero_mod_eq_zero (S := ZMod64 p) g)
 
 private theorem sub_self_right_add (a b : DensePoly (ZMod64 p)) :
     (a + b) - a = b := by
@@ -690,7 +690,7 @@ theorem zmod_div_one [PrimeModulus p] (a : ZMod64 p) :
   rw [hinv1]
   exact Lean.Grind.Semiring.mul_one a
 
-private theorem cancel_lead_at_pos_size_core [PrimeModulus p]
+private theorem cancel_lead_at_pos_size [PrimeModulus p]
     (m : DensePoly (ZMod64 p)) (hsize : 0 < m.size) (a : ZMod64 p) :
     a - (a / m.leadingCoeff) * m.leadingCoeff = (Zero.zero : ZMod64 p) := by
   have hidx : m.coeffs.size - 1 < m.coeffs.size := by
@@ -711,10 +711,10 @@ instance instDivModLawsZMod64Fp (p : Nat) [Bounds p] [PrimeModulus p] :
     DensePoly.DivModLaws (ZMod64 p) where
   divMod_spec := by
     intro f g
-    exact divMod_spec_core f g
+    exact divMod_reconstruct f g
   divMod_remainder_degree_lt_of_pos_degree := by
     intro f g hdegree
-    exact divMod_remainder_degree_lt_core f g hdegree
+    exact divMod_remainder_degree_lt f g hdegree
   divModMonic_eq_divMod_of_monic := by
     intro f g hmonic
     by_cases hdeg : f.degree?.getD 0 < g.degree?.getD 0
@@ -723,7 +723,7 @@ instance instDivModLawsZMod64Fp (p : Nat) [Bounds p] [PrimeModulus p] :
       rw [DensePoly.divModArray_eq_zero_self_of_degree_lt f g id hdeg]
       unfold DensePoly.divMod
       simp [hdeg]
-    · apply DensePoly.divModMonic_eq_divMod_of_monic_core f g hmonic hdeg
+    · apply DensePoly.divModMonic_eq_divMod_of_monic_of_scale f g hmonic hdeg
       intro a
       have hlead : g.leadingCoeff = (1 : ZMod64 p) := hmonic
       show a / g.leadingCoeff = a
@@ -731,15 +731,15 @@ instance instDivModLawsZMod64Fp (p : Nat) [Bounds p] [PrimeModulus p] :
       exact zmod_div_one a
   mod_self_eq_zero := by
     intro f
-    exact mod_eq_zero_of_dvd_core f f (DensePoly.dvd_refl_poly f)
+    exact mod_eq_zero_of_dvd f f (DensePoly.dvd_refl_poly f)
   mod_eq_zero_of_dvd := by
     intro f g hdiv
-    exact mod_eq_zero_of_dvd_core f g hdiv
+    exact mod_eq_zero_of_dvd f g hdiv
   mod_mod_of_not_pos_degree := by
     intro f g hdegree
     by_cases hsize0 : g.size = 0
     · have h2 : (DensePoly.divMod (f % g) g).2 = (f % g) :=
-        DensePoly.divMod_remainder_eq_self_of_size_zero_core (f % g) g hsize0
+        DensePoly.divMod_remainder_eq_self_of_size_zero (f % g) g hsize0
       exact h2
     · have hpos_size : 0 < g.size := Nat.pos_of_ne_zero hsize0
       have hsize1 : g.size = 1 := by
@@ -751,22 +751,22 @@ instance instDivModLawsZMod64Fp (p : Nat) [Bounds p] [PrimeModulus p] :
           rw [hdeg_eq]
           exact h
         omega
-      have hcancel := cancel_lead_at_pos_size_core g hpos_size
+      have hcancel := cancel_lead_at_pos_size g hpos_size
       have h1 : (DensePoly.divMod f g).2 = 0 :=
-        DensePoly.divMod_remainder_eq_zero_of_degree_zero_core f g hsize1 hcancel
+        DensePoly.divMod_remainder_eq_zero_of_degree_zero_of_cancel f g hsize1 hcancel
       have h2 : (DensePoly.divMod (f % g) g).2 = 0 :=
-        DensePoly.divMod_remainder_eq_zero_of_degree_zero_core (f % g) g hsize1 hcancel
+        DensePoly.divMod_remainder_eq_zero_of_degree_zero_of_cancel (f % g) g hsize1 hcancel
       change (DensePoly.divMod (f % g) g).2 = (DensePoly.divMod f g).2
       rw [h1, h2]
   mod_eq_mod_of_congr := by
     intro f g m hcongr
-    exact mod_eq_mod_of_congr_core f g m hcongr
+    exact mod_eq_mod_of_congr f g m hcongr
   mod_add_mod := by
     intro f g m
     apply Eq.symm
-    apply mod_eq_mod_of_congr_core
-    rcases congr_mod_core f m with ⟨rf, hf⟩
-    rcases congr_mod_core g m with ⟨rg, hg⟩
+    apply mod_eq_mod_of_congr
+    rcases congr_mod f m with ⟨rf, hf⟩
+    rcases congr_mod g m with ⟨rg, hg⟩
     exact ⟨rf + rg, by
       calc
         (f % m + g % m) - (f + g)
@@ -776,9 +776,9 @@ instance instDivModLawsZMod64Fp (p : Nat) [Bounds p] [PrimeModulus p] :
   mod_mul_mod := by
     intro f g m
     apply Eq.symm
-    apply mod_eq_mod_of_congr_core
-    rcases congr_mod_core f m with ⟨rf, hf⟩
-    rcases congr_mod_core g m with ⟨rg, hg⟩
+    apply mod_eq_mod_of_congr
+    rcases congr_mod f m with ⟨rf, hf⟩
+    rcases congr_mod g m with ⟨rg, hg⟩
     exact ⟨rf * (g % m) + f * rg, by
       have hf' : f % m = f + m * rf := by
         apply DensePoly.ext_coeff
@@ -798,7 +798,7 @@ instance instDivModLawsZMod64Fp (p : Nat) [Bounds p] [PrimeModulus p] :
         grind
       exact mul_left_remainder_delta f g m rf rg hf' hg'⟩
 
-private theorem divMod_remainder_eq_zero_of_not_pos_degree_core
+private theorem divMod_remainder_eq_zero_of_not_pos_degree
     [PrimeModulus p] (f m : DensePoly (ZMod64 p))
     (hmzero : m.isZero = false)
     (hdegree : ¬ 0 < m.degree?.getD 0) :
@@ -817,8 +817,8 @@ private theorem divMod_remainder_eq_zero_of_not_pos_degree_core
       rw [hdeg_eq]
       exact h
     omega
-  have hcancel := cancel_lead_at_pos_size_core m hpos_size
-  exact DensePoly.divMod_remainder_eq_zero_of_degree_zero_core f m hsize1 hcancel
+  have hcancel := cancel_lead_at_pos_size m hpos_size
+  exact DensePoly.divMod_remainder_eq_zero_of_degree_zero_of_cancel f m hsize1 hcancel
 
 /-- The `F_p[x]` gcd law obligations used by finite-field inverse construction. -/
 instance instGcdLawsZMod64Fp [PrimeModulus p] : DensePoly.GcdLaws (ZMod64 p) where
@@ -826,12 +826,12 @@ instance instGcdLawsZMod64Fp [PrimeModulus p] : DensePoly.GcdLaws (ZMod64 p) whe
     intro f g
     exact @DensePoly.gcd_dvd_left_of_divModLaws (ZMod64 p) _ _ _
       (instDivModLawsZMod64Fp p)
-      (fun a b => divMod_remainder_eq_zero_of_not_pos_degree_core a b) f g
+      (fun a b => divMod_remainder_eq_zero_of_not_pos_degree a b) f g
   gcd_dvd_right := by
     intro f g
     exact @DensePoly.gcd_dvd_right_of_divModLaws (ZMod64 p) _ _ _
       (instDivModLawsZMod64Fp p)
-      (fun a b => divMod_remainder_eq_zero_of_not_pos_degree_core a b) f g
+      (fun a b => divMod_remainder_eq_zero_of_not_pos_degree a b) f g
   dvd_gcd := by
     intro d f g hdf hdg
     exact @DensePoly.dvd_gcd_of_divModLaws (ZMod64 p) _ _ _ (instDivModLawsZMod64Fp p)

--- a/HexPolyFp/Field.lean
+++ b/HexPolyFp/Field.lean
@@ -79,7 +79,7 @@ instance : DensePoly.ZeroSubNegLaw (ZMod64 p) where
     simp [Nat.zero_add]
 
 /-- `DensePoly.divMod f g` returns a quotient-remainder pair `(q, r)` with `q * g + r = f`. -/
-private theorem divMod_reconstruct [PrimeModulus p] (f g : DensePoly (ZMod64 p)) :
+private theorem divMod_spec [PrimeModulus p] (f g : DensePoly (ZMod64 p)) :
     let qr := DensePoly.divMod f g
     qr.1 * g + qr.2 = f := by
   by_cases hgzero : g.isZero
@@ -132,7 +132,7 @@ private theorem divMod_reconstruct [PrimeModulus p] (f g : DensePoly (ZMod64 p))
 private theorem mod_sub_self_eq_mul_neg_div [PrimeModulus p] (f m : DensePoly (ZMod64 p)) :
     f % m - f = m * (0 - (f / m)) := by
   have hdiv : (f / m) * m + (f % m) = f := by
-    exact divMod_reconstruct f m
+    exact divMod_spec f m
   calc
     f % m - f = 0 - (f / m) * m := by
       apply DensePoly.ext_coeff
@@ -711,7 +711,7 @@ instance instDivModLawsZMod64Fp (p : Nat) [Bounds p] [PrimeModulus p] :
     DensePoly.DivModLaws (ZMod64 p) where
   divMod_spec := by
     intro f g
-    exact divMod_reconstruct f g
+    exact divMod_spec f g
   divMod_remainder_degree_lt_of_pos_degree := by
     intro f g hdegree
     exact divMod_remainder_degree_lt f g hdegree

--- a/HexPolyFp/Quotient.lean
+++ b/HexPolyFp/Quotient.lean
@@ -924,7 +924,7 @@ private theorem size_le_of_coeff_eq_zero_from_local (f : FpPoly p) (bound : Nat)
 /-- Evaluation of a sum equals the sum of evaluations, proved by expanding both
 sides as coefficient-power sums up to a common bound (`max f.size h.size`) and
 applying additivity of the bounded power-sum evaluator. -/
-private theorem eval_add_core_by_coeff_power_sum
+theorem eval_add
     (f h : FpPoly p) (β : Quotient g hmonic hg_pos) :
     eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) (f + h) β =
       eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f β +
@@ -962,7 +962,7 @@ private theorem eval_add_core_by_coeff_power_sum
 expanding both sides as coefficient-power sums up to a common bound
 (`max f.size h.size`) and applying subtractivity of the bounded power-sum
 evaluator. -/
-private theorem eval_sub_core_by_coeff_power_sum
+theorem eval_sub
     (f h : FpPoly p) (β : Quotient g hmonic hg_pos) :
     eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) (f - h) β =
       eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f β -
@@ -999,7 +999,7 @@ private theorem eval_sub_core_by_coeff_power_sum
 /-- Evaluation of a constant-scaled polynomial factors as the reduced constant
 times the evaluation, proved by rewriting `C c * f` as a coefficient scaling and
 applying the constant-multiple law of the bounded power-sum evaluator. -/
-private theorem eval_C_mul_core_by_coeff_power_sum
+theorem eval_C_mul
     (c : ZMod64 p) (f : FpPoly p) (β : Quotient g hmonic hg_pos) :
     eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos)
         (DensePoly.C c * f) β =
@@ -1028,40 +1028,11 @@ private theorem eval_C_mul_core_by_coeff_power_sum
     rw [DensePoly.coeff_eq_zero_of_size_le f hi]
     exact hzero
 
-/-- Additivity of quotient evaluation, the private core re-exported as the public
-`eval_add`; delegates to `eval_add_core_by_coeff_power_sum`. -/
-private theorem eval_add_core (f h : FpPoly p) (β : Quotient g hmonic hg_pos) :
-    eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) (f + h) β =
-      eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f β +
-        eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) h β := by
-  exact eval_add_core_by_coeff_power_sum
-    (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f h β
-
-/-- Subtractivity of quotient evaluation, the private core re-exported as the
-public `eval_sub`; delegates to `eval_sub_core_by_coeff_power_sum`. -/
-private theorem eval_sub_core (f h : FpPoly p) (β : Quotient g hmonic hg_pos) :
-    eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) (f - h) β =
-      eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f β -
-        eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) h β := by
-  exact eval_sub_core_by_coeff_power_sum
-    (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f h β
-
-/-- Constant-factor law of quotient evaluation, the private core re-exported as
-the public `eval_C_mul`; delegates to `eval_C_mul_core_by_coeff_power_sum`. -/
-private theorem eval_C_mul_core (c : ZMod64 p) (f : FpPoly p)
-    (β : Quotient g hmonic hg_pos) :
-    eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos)
-        (DensePoly.C c * f) β =
-      reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos) (DensePoly.C c) *
-        eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f β := by
-  exact eval_C_mul_core_by_coeff_power_sum
-    (g := g) (hmonic := hmonic) (hg_pos := hg_pos) c f β
-
 /-- Evaluating a monomial `monomial n c` yields the reduced constant `C c` times
 the `n`-th power of the evaluation point; the zero-coefficient case collapses to
 `0` and the nonzero case unfolds the dense representation and folds over the
 trailing zeros. -/
-private theorem eval_monomial_core (n : Nat) (c : ZMod64 p)
+theorem eval_monomial (n : Nat) (c : ZMod64 p)
     (β : Quotient g hmonic hg_pos) :
     eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos)
         (DensePoly.monomial n c : FpPoly p) β =
@@ -1086,39 +1057,6 @@ private theorem eval_monomial_core (n : Nat) (c : ZMod64 p)
     exact foldl_eval_replicate_zero
       (g := g) (hmonic := hmonic) (hg_pos := hg_pos) β n
       (reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos) (DensePoly.C c))
-
-/-- Evaluation into the quotient preserves polynomial addition. -/
-theorem eval_add (f h : FpPoly p) (β : Quotient g hmonic hg_pos) :
-    eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) (f + h) β =
-      eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f β +
-        eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) h β :=
-  eval_add_core (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f h β
-
-/-- Evaluation into the quotient preserves polynomial subtraction. -/
-theorem eval_sub (f h : FpPoly p) (β : Quotient g hmonic hg_pos) :
-    eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) (f - h) β =
-      eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f β -
-        eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) h β :=
-  eval_sub_core (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f h β
-
-/-- Pull a constant polynomial factor out of quotient evaluation. -/
-theorem eval_C_mul (c : ZMod64 p) (f : FpPoly p)
-    (β : Quotient g hmonic hg_pos) :
-    eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos)
-        (DensePoly.C c * f) β =
-      reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos) (DensePoly.C c) *
-        eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f β :=
-  eval_C_mul_core (g := g) (hmonic := hmonic) (hg_pos := hg_pos) c f β
-
-/-- Evaluating a monomial gives the embedded coefficient times the
-corresponding power of the evaluation point. -/
-theorem eval_monomial (n : Nat) (c : ZMod64 p)
-    (β : Quotient g hmonic hg_pos) :
-    eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos)
-        (DensePoly.monomial n c : FpPoly p) β =
-      reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos) (DensePoly.C c) *
-        β ^ n :=
-  eval_monomial_core (g := g) (hmonic := hmonic) (hg_pos := hg_pos) n c β
 
 /-- For a monic irreducible positive-degree modulus, the product of two nonzero
 quotient elements is nonzero. -/

--- a/HexPolyFp/Quotient.lean
+++ b/HexPolyFp/Quotient.lean
@@ -921,9 +921,7 @@ private theorem size_le_of_coeff_eq_zero_from_local (f : FpPoly p) (bound : Nat)
     have htop_zero : f.coeff (f.size - 1) = 0 := hzero (f.size - 1) (by omega)
     exact False.elim (DensePoly.coeff_last_ne_zero_of_pos_size f hpos htop_zero)
 
-/-- Evaluation of a sum equals the sum of evaluations, proved by expanding both
-sides as coefficient-power sums up to a common bound (`max f.size h.size`) and
-applying additivity of the bounded power-sum evaluator. -/
+/-- Evaluation of a sum equals the sum of the evaluations. -/
 theorem eval_add
     (f h : FpPoly p) (β : Quotient g hmonic hg_pos) :
     eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) (f + h) β =
@@ -958,10 +956,7 @@ theorem eval_add
     show (0 : ZMod64 p) + 0 = 0
     grind
 
-/-- Evaluation of a difference equals the difference of evaluations, proved by
-expanding both sides as coefficient-power sums up to a common bound
-(`max f.size h.size`) and applying subtractivity of the bounded power-sum
-evaluator. -/
+/-- Evaluation of a difference equals the difference of the evaluations. -/
 theorem eval_sub
     (f h : FpPoly p) (β : Quotient g hmonic hg_pos) :
     eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) (f - h) β =
@@ -996,9 +991,8 @@ theorem eval_sub
     show (0 : ZMod64 p) - 0 = 0
     grind
 
-/-- Evaluation of a constant-scaled polynomial factors as the reduced constant
-times the evaluation, proved by rewriting `C c * f` as a coefficient scaling and
-applying the constant-multiple law of the bounded power-sum evaluator. -/
+/-- Evaluation of a constant multiple equals the reduced constant times the
+evaluation. -/
 theorem eval_C_mul
     (c : ZMod64 p) (f : FpPoly p) (β : Quotient g hmonic hg_pos) :
     eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos)
@@ -1028,10 +1022,8 @@ theorem eval_C_mul
     rw [DensePoly.coeff_eq_zero_of_size_le f hi]
     exact hzero
 
-/-- Evaluating a monomial `monomial n c` yields the reduced constant `C c` times
-the `n`-th power of the evaluation point; the zero-coefficient case collapses to
-`0` and the nonzero case unfolds the dense representation and folds over the
-trailing zeros. -/
+/-- Evaluating `monomial n c` yields the reduced constant `C c` times the
+`n`-th power of the evaluation point. -/
 theorem eval_monomial (n : Nat) (c : ZMod64 p)
     (β : Quotient g hmonic hg_pos) :
     eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos)

--- a/HexPolyFp/SquareFree/Algebra.lean
+++ b/HexPolyFp/SquareFree/Algebra.lean
@@ -1923,7 +1923,7 @@ polynomial yields `0`. -/
 private theorem div_zero_eq_zero (f : FpPoly p) :
     f / (0 : FpPoly p) = 0 := by
   have hpair :=
-    DensePoly.divMod_eq_zero_self_of_size_zero_core f (0 : FpPoly p) (by simp)
+    DensePoly.divMod_eq_zero_self_of_size_zero f (0 : FpPoly p) (by simp)
   exact congrArg Prod.fst hpair
 
 /-- `div_zero_C_mul_left` shows constant scaling commutes with division by the

--- a/HexPolyFp/SquareFree/YunCorrect.lean
+++ b/HexPolyFp/SquareFree/YunCorrect.lean
@@ -173,7 +173,7 @@ private theorem squareFreeAuxRevContribution_derivative_active_pow_obligation
         hmultiplicity_tail htail_normalized_valid.2.2 htail_normalized_valid.2.1
         htail_normalized_valid.1 htail_normalized_residual
     exact
-      derivative_active_raw_tail_weighted_product_bridge_via_normalized
+      derivativeActive_rawTail_product
         hp f contribution.2 contribution.1 multiplicity fuel hmultiplicity
         htail_nonzero htail_derivative htail_valid.1 htail_valid.2.1
         htail_valid.2.2 htail_residual ih htail_normalized_correct hpow_contribution
@@ -1005,7 +1005,7 @@ private theorem squareFreeAuxRev_eq_nil_of_size_le_one
         rw [hsize_one, Nat.sub_self, Nat.zero_div] at h
         omega
 
-private theorem squareFreeAuxRev_pairwise_coprime_nil_core_of_yun_invariant
+private theorem squareFreeAuxRev_pairwise_coprime_nil_of_yun_invariant
     (hp : Hex.Nat.Prime p)
     (yunInvariant :
       ∀ f : FpPoly p, ∀ base fuel : Nat,
@@ -1143,14 +1143,14 @@ private theorem squareFreeAuxRev_pairwise_coprime_nil_core_of_yun_invariant
                 exact squareFreeAuxRev_reverse_append (pthRoot loop.2) (multiplicity * p) fuel loop.1
               simpa [g, c, loop, hrepeated, hrev] using hcombined
 
-private theorem squareFreeAuxRev_pairwise_coprime_nil_core
+private theorem squareFreeAuxRev_pairwise_coprime_nil_of_reachable
     (hp : Hex.Nat.Prime p)
     (f : FpPoly p) (multiplicity fuel : Nat)
     (hfuel : f.size < fuel)
     (_hreachable : squareFreeContributionReachable f) :
     (squareFreeAuxRev f multiplicity fuel []).reverse.Pairwise
       squareFreeFactorCoprimeRel := by
-  exact squareFreeAuxRev_pairwise_coprime_nil_core_of_yun_invariant
+  exact squareFreeAuxRev_pairwise_coprime_nil_of_yun_invariant
     hp
     (fun f' base fuel' hdf =>
       yunFactorsPairwiseInvariant_of_derivative_split_reachable
@@ -1158,7 +1158,7 @@ private theorem squareFreeAuxRev_pairwise_coprime_nil_core
         (by intro htrue; rw [htrue] at hdf; cases hdf))
     f multiplicity fuel hfuel
 
-private theorem squareFreeAuxRev_pairwise_coprime_core
+private theorem squareFreeAuxRev_pairwise_coprime_append
     (hp : Hex.Nat.Prime p)
     (f : FpPoly p) (multiplicity fuel : Nat)
     (hfuel : f.size < fuel)
@@ -1174,7 +1174,7 @@ private theorem squareFreeAuxRev_pairwise_coprime_core
   rw [squareFreeAuxRev_reverse_append f multiplicity fuel accRev]
   apply pairwise_append_of_cross
   · exact hacc
-  · exact squareFreeAuxRev_pairwise_coprime_nil_core hp
+  · exact squareFreeAuxRev_pairwise_coprime_nil_of_reachable hp
       f multiplicity fuel hfuel hreachable
   · exact hcross
 
@@ -1190,7 +1190,7 @@ private theorem squareFreeAuxRev_pairwise_coprime_of_acc
         squareFreeFactorCoprimeRel a b) →
     (squareFreeAuxRev f multiplicity fuel accRev).reverse.Pairwise
       squareFreeFactorCoprimeRel := by
-  exact squareFreeAuxRev_pairwise_coprime_core hp
+  exact squareFreeAuxRev_pairwise_coprime_append hp
     f multiplicity fuel hfuel hreachable accRev
 
 private theorem squareFreeAuxRev_pairwise_coprime_nil

--- a/HexPolyFp/SquareFree/YunMeasure.lean
+++ b/HexPolyFp/SquareFree/YunMeasure.lean
@@ -1086,7 +1086,7 @@ private theorem yunFactorsContributionWithLevel_normalized_pow_invariant
       yunFactorsNormalizedLevelCompletes_of_derivative_active_initial_split
         hp f multiplicity fuel hmultiplicity hfuel hzero hdf hnormalizedState
   simpa [contribution] using
-    yunFactorsContributionWithLevel_normalized_tail_product_bridge
+    yunFactorsContributionWithLevel_normalized_tail_product
       hp f c g multiplicity 1 fuel multiplicity (by
         simpa [g, c, contribution] using hrawProduct)
 

--- a/HexPolyFp/SquareFree/YunReduce.lean
+++ b/HexPolyFp/SquareFree/YunReduce.lean
@@ -1027,7 +1027,7 @@ private theorem quotient_dvd_of_mul_right_dvd_mul_right
             _ = (z * q) * y := (DensePoly.mul_assoc_poly z q y).symm
 
 set_option maxHeartbeats 800000 in
-private theorem yunStep_residual_dvd_derivative_product_core
+private theorem yunStep_residual_dvd_derivative_product_of_factors
     [ZMod64.PrimeModulus p]
     (c w y a z : FpPoly p)
     (hcy : a * y = c)
@@ -1083,7 +1083,7 @@ private theorem yunStep_residual_dvd_derivative_product_of_previous
         (by simpa [a, y] using hda)
         (by simpa [z, y] using hdz)
   exact
-    yunStep_residual_dvd_derivative_product_core
+    yunStep_residual_dvd_derivative_product_of_factors
       c w y a z hcy hwy hcommon_az hprev
 
 private theorem yunFactorsPairwiseReachable_residual_dvd_derivative_product
@@ -1274,7 +1274,7 @@ explicit scalar power preserves the same product.
 This lemma deliberately does not assume `DensePoly.gcd` is monic: all scalar
 ambiguity is isolated in `DensePoly.C (normalizeMonic contribution.2).1`.
 -/
-private theorem yunFactorsContributionWithLevel_normalized_tail_product_bridge
+private theorem yunFactorsContributionWithLevel_normalized_tail_product
     (hp : Hex.Nat.Prime p) (f c w : FpPoly p)
     (base level fuel multiplicity : Nat)
     (hproduct :
@@ -1306,7 +1306,7 @@ private theorem yunFactorsContributionWithLevel_normalized_tail_product_bridge
     _ = pow f multiplicity := by
           simpa [contribution] using hproduct
 
-private theorem squareFreeAuxRevContribution_pthRoot_normalized_tail_bridge
+private theorem squareFreeAuxRevContribution_normalized_pthRoot
     (hp : Hex.Nat.Prime p) (tail : FpPoly p) (multiplicity fuel : Nat)
     (hmultiplicity : 0 < multiplicity)
     (hzero : tail.isZero = false)
@@ -1337,7 +1337,7 @@ private theorem squareFreeAuxRevContribution_pthRoot_normalized_tail_bridge
             (multiplicity * p) fuel := by
           rw [hnormalized]
 
-private theorem derivative_active_normalized_tail_weighted_product_bridge
+private theorem derivativeActive_normalizedTail_product
     (hp : Hex.Nat.Prime p) (f tail contribution : FpPoly p)
     (multiplicity fuel : Nat)
     (hzero : tail.isZero = false)
@@ -1368,7 +1368,7 @@ private theorem derivative_active_normalized_tail_weighted_product_bridge
           rw [htail_pow]
     _ = pow f multiplicity := hproduct
 
-private theorem derivative_active_raw_tail_weighted_product_bridge_via_normalized
+private theorem derivativeActive_rawTail_product
     (hp : Hex.Nat.Prime p) (f tail contribution : FpPoly p)
     (multiplicity fuel : Nat)
     (hmultiplicity : 0 < multiplicity)
@@ -1407,7 +1407,7 @@ private theorem derivative_active_raw_tail_weighted_product_bridge_via_normalize
     hcorrect (pthRoot tail) (multiplicity * p)
       hmultiplicity_tail hrawFuel hrawZero hrawReachable hrawResidual
   have htail_bridge :=
-    squareFreeAuxRevContribution_pthRoot_normalized_tail_bridge
+    squareFreeAuxRevContribution_normalized_pthRoot
       hp tail multiplicity fuel hmultiplicity hzero hdf hraw hnormalized
   calc
     contribution *
@@ -1418,7 +1418,7 @@ private theorem derivative_active_raw_tail_weighted_product_bridge_via_normalize
               (multiplicity * p) fuel) := by
           rw [htail_bridge]
     _ = pow f multiplicity := by
-          exact derivative_active_normalized_tail_weighted_product_bridge
+          exact derivativeActive_normalizedTail_product
             hp f tail contribution multiplicity fuel hzero hdf hnormalized hproduct
 
 private theorem pthRoot_size_of_derivative_zero

--- a/HexPolyMathlib/Euclid.lean
+++ b/HexPolyMathlib/Euclid.lean
@@ -38,7 +38,7 @@ private theorem field_divMod_spec [Field R] [DecidableEq R]
     let qr := Hex.DensePoly.divMod p q
     qr.1 * q + qr.2 = p := by
   by_cases hq : q.size = 0
-  · have hrem := Hex.DensePoly.divMod_remainder_eq_self_of_size_zero_core p q hq
+  · have hrem := Hex.DensePoly.divMod_remainder_eq_self_of_size_zero p q hq
     have hqzero : q = 0 := by
       apply Hex.DensePoly.ext_coeff
       intro n
@@ -56,7 +56,7 @@ private theorem field_divMod_spec [Field R] [DecidableEq R]
 private theorem field_divMod_remainder_degree_lt [Field R] [DecidableEq R]
     (p q : Hex.DensePoly R) (hdegree : 0 < q.degree?.getD 0) :
     (Hex.DensePoly.divMod p q).2.degree?.getD 0 < q.degree?.getD 0 := by
-  apply Hex.DensePoly.divMod_remainder_degree_lt_of_pos_degree_core p q hdegree
+  apply Hex.DensePoly.divMod_remainder_degree_lt_of_pos_degree_of_cancel p q hdegree
   intro a
   apply field_div_cancel
   apply Hex.DensePoly.leadingCoeff_ne_zero_of_pos_size
@@ -80,7 +80,7 @@ private theorem field_divMod_remainder_eq_zero_of_not_pos_degree
       simp [Hex.DensePoly.degree?, hqsize_ne]
     rw [hdeg] at hdegree
     omega
-  exact Hex.DensePoly.divMod_remainder_eq_zero_of_degree_zero_core p q hqsize
+  exact Hex.DensePoly.divMod_remainder_eq_zero_of_degree_zero_of_cancel p q hqsize
     (fun a => field_div_cancel a q.leadingCoeff
       (Hex.DensePoly.leadingCoeff_ne_zero_of_pos_size q (by omega)))
 
@@ -129,7 +129,7 @@ theorem toPolynomial_mod [Field R] [DecidableEq R]
   · subst q
     rw [toPolynomial_zero, EuclideanDomain.mod_zero]
     change toPolynomial (Hex.DensePoly.divMod p 0).2 = toPolynomial p
-    rw [Hex.DensePoly.divMod_remainder_eq_self_of_size_zero_core]
+    rw [Hex.DensePoly.divMod_remainder_eq_self_of_size_zero]
     rfl
   · let qr := Hex.DensePoly.divMod p q
     let qp := toPolynomial q
@@ -197,7 +197,7 @@ instance (priority := 50) instDivModLawsField [Field R] [DecidableEq R] :
     · rw [Hex.DensePoly.divMod_eq_zero_self_of_degree_lt p q hlt]
       unfold Hex.DensePoly.divModMonic
       exact Hex.DensePoly.divModArray_eq_zero_self_of_degree_lt p q id hlt
-    · apply Hex.DensePoly.divModMonic_eq_divMod_of_monic_core p q hmonic hlt
+    · apply Hex.DensePoly.divModMonic_eq_divMod_of_monic_of_scale p q hmonic hlt
       intro a
       rw [hmonic]
       simp

--- a/HexPolyZ/Core.lean
+++ b/HexPolyZ/Core.lean
@@ -548,7 +548,7 @@ representative of the resulting rational associate.
 def ratPolyPrimitivePart (f : DensePoly Rat) : ZPoly :=
   normalizePrimitiveSign (primitivePart (ratPolyPrimitivePartCleared f))
 
-private theorem ratPolyPrimitivePart_rational_associate_core (f : DensePoly Rat) :
+private theorem ratPolyPrimitivePart_exists_scale (f : DensePoly Rat) :
     ∃ unit : Rat, f = DensePoly.scale unit (toRatPoly (ratPolyPrimitivePart f)) := by
   let den := ratCommonDen f.toArray.toList
   let scaled := ratPolyPrimitivePartCleared f
@@ -1055,7 +1055,7 @@ theorem C_mul_eq_scale (c : Int) (p : ZPoly) :
       change (0 : Int) = c * 0
       rw [Int.mul_zero]
 
-private theorem scale_size_of_nonzero_core {c : Int} (hc : c ≠ 0) (p : ZPoly) :
+private theorem scale_size_eq {c : Int} (hc : c ≠ 0) (p : ZPoly) :
     (DensePoly.scale c p).size = p.size := by
   apply Nat.le_antisymm
   · by_cases hle : (DensePoly.scale c p).size ≤ p.size
@@ -1090,7 +1090,7 @@ private theorem scale_size_of_nonzero_core {c : Int} (hc : c ≠ 0) (p : ZPoly) 
 /-- Nonzero integer scalar multiplication preserves the stored size. -/
 theorem scale_size_of_nonzero (c : Int) (p : ZPoly) (hc : c ≠ 0) :
     (DensePoly.scale c p).size = p.size :=
-  scale_size_of_nonzero_core (c := c) hc p
+  scale_size_eq (c := c) hc p
 
 /-- Leading coefficient after nonzero integer scalar multiplication. -/
 theorem leadingCoeff_scale_of_nonzero (c : Int) (p : ZPoly) (hc : c ≠ 0) :
@@ -1113,7 +1113,7 @@ theorem leadingCoeff_scale_of_nonzero (c : Int) (p : ZPoly) (hc : c ≠ 0) :
     rw [hpzero]
     simp
 
-private theorem shift_size_of_nonzero_core (k : Nat) {p : ZPoly} (hp : p ≠ 0) :
+private theorem shift_size_eq (k : Nat) {p : ZPoly} (hp : p ≠ 0) :
     (DensePoly.shift k p).size = k + p.size := by
   have hpos : 0 < p.size := by
     by_cases hpos : 0 < p.size
@@ -1168,12 +1168,12 @@ theorem leadingCoeff_shift_of_nonzero (k : Nat) (p : ZPoly) (hp : p ≠ 0) :
       rw [DensePoly.coeff_zero]
       exact DensePoly.coeff_eq_zero_of_size_le p (by omega)
   rw [DensePoly.leadingCoeff_eq_coeff_last (DensePoly.shift k p)]
-  · rw [shift_size_of_nonzero_core k hp]
+  · rw [shift_size_eq k hp]
     rw [DensePoly.coeff_shift]
     have hnot : ¬ k + p.size - 1 < k := by omega
     have hidx : k + p.size - 1 - k = p.size - 1 := by omega
     rw [if_neg hnot, hidx, DensePoly.leadingCoeff_eq_coeff_last p hpos]
-  · rw [shift_size_of_nonzero_core k hp]
+  · rw [shift_size_eq k hp]
     omega
 
 /-- Integer dense polynomials have no zero divisors. -/
@@ -1301,7 +1301,7 @@ theorem divMod_remainder_eq_zero_of_monic_mul_eq
   have hrem_degree :
       qr.2.degree?.getD 0 < candidate.degree?.getD 0 := by
     simpa [qr] using
-      DensePoly.divMod_remainder_degree_lt_of_pos_degree_core target candidate hdegree hcancel
+      DensePoly.divMod_remainder_degree_lt_of_pos_degree_of_cancel target candidate hdegree hcancel
   by_cases hrem_zero : qr.2 = 0
   · simpa [qr] using hrem_zero
   · have hrem_dvd : candidate ∣ qr.2 := by

--- a/HexPolyZ/Core.lean
+++ b/HexPolyZ/Core.lean
@@ -548,7 +548,9 @@ representative of the resulting rational associate.
 def ratPolyPrimitivePart (f : DensePoly Rat) : ZPoly :=
   normalizePrimitiveSign (primitivePart (ratPolyPrimitivePartCleared f))
 
-private theorem ratPolyPrimitivePart_exists_scale (f : DensePoly Rat) :
+/-- A rational polynomial is a rational scalar multiple of the rationalization
+of its integer primitive part. -/
+theorem ratPolyPrimitivePart_rational_associate (f : DensePoly Rat) :
     ∃ unit : Rat, f = DensePoly.scale unit (toRatPoly (ratPolyPrimitivePart f)) := by
   let den := ratCommonDen f.toArray.toList
   let scaled := ratPolyPrimitivePartCleared f
@@ -1055,7 +1057,8 @@ theorem C_mul_eq_scale (c : Int) (p : ZPoly) :
       change (0 : Int) = c * 0
       rw [Int.mul_zero]
 
-private theorem scale_size_eq {c : Int} (hc : c ≠ 0) (p : ZPoly) :
+/-- Nonzero integer scalar multiplication preserves the stored size. -/
+theorem scale_size_of_ne_zero (c : Int) (p : ZPoly) (hc : c ≠ 0) :
     (DensePoly.scale c p).size = p.size := by
   apply Nat.le_antisymm
   · by_cases hle : (DensePoly.scale c p).size ≤ p.size
@@ -1087,24 +1090,19 @@ private theorem scale_size_eq {c : Int} (hc : c ≠ 0) (p : ZPoly) :
         exact hscaled_zero
       exact (Int.mul_eq_zero.mp hmul_zero).resolve_left hc
 
-/-- Nonzero integer scalar multiplication preserves the stored size. -/
-theorem scale_size_of_nonzero (c : Int) (p : ZPoly) (hc : c ≠ 0) :
-    (DensePoly.scale c p).size = p.size :=
-  scale_size_eq (c := c) hc p
-
 /-- Leading coefficient after nonzero integer scalar multiplication. -/
 theorem leadingCoeff_scale_of_nonzero (c : Int) (p : ZPoly) (hc : c ≠ 0) :
     (DensePoly.scale c p).leadingCoeff = c * p.leadingCoeff := by
   by_cases hp : 0 < p.size
   · rw [DensePoly.leadingCoeff_eq_coeff_last (DensePoly.scale c p)]
-    · rw [scale_size_of_nonzero c p hc]
+    · rw [scale_size_of_ne_zero c p hc]
       rw [DensePoly.coeff_scale (R := Int) c p (p.size - 1) (Int.mul_zero c),
         DensePoly.leadingCoeff_eq_coeff_last p hp]
-    · rw [scale_size_of_nonzero c p hc]
+    · rw [scale_size_of_ne_zero c p hc]
       exact hp
   · have hpsize : p.size = 0 := by omega
     have hscaled_size : (DensePoly.scale c p).size = 0 := by
-      rw [scale_size_of_nonzero c p hc, hpsize]
+      rw [scale_size_of_ne_zero c p hc, hpsize]
     have hpzero : p = 0 := by
       apply DensePoly.ext_coeff
       intro n
@@ -1113,7 +1111,7 @@ theorem leadingCoeff_scale_of_nonzero (c : Int) (p : ZPoly) (hc : c ≠ 0) :
     rw [hpzero]
     simp
 
-private theorem shift_size_eq (k : Nat) {p : ZPoly} (hp : p ≠ 0) :
+private theorem shift_size_of_ne_zero (k : Nat) {p : ZPoly} (hp : p ≠ 0) :
     (DensePoly.shift k p).size = k + p.size := by
   have hpos : 0 < p.size := by
     by_cases hpos : 0 < p.size
@@ -1168,12 +1166,12 @@ theorem leadingCoeff_shift_of_nonzero (k : Nat) (p : ZPoly) (hp : p ≠ 0) :
       rw [DensePoly.coeff_zero]
       exact DensePoly.coeff_eq_zero_of_size_le p (by omega)
   rw [DensePoly.leadingCoeff_eq_coeff_last (DensePoly.shift k p)]
-  · rw [shift_size_eq k hp]
+  · rw [shift_size_of_ne_zero k hp]
     rw [DensePoly.coeff_shift]
     have hnot : ¬ k + p.size - 1 < k := by omega
     have hidx : k + p.size - 1 - k = p.size - 1 := by omega
     rw [if_neg hnot, hidx, DensePoly.leadingCoeff_eq_coeff_last p hpos]
-  · rw [shift_size_eq k hp]
+  · rw [shift_size_of_ne_zero k hp]
     omega
 
 /-- Integer dense polynomials have no zero divisors. -/

--- a/HexPolyZ/Mignotte.lean
+++ b/HexPolyZ/Mignotte.lean
@@ -106,7 +106,7 @@ private theorem sqrtStep_upper_succ
 
 /-- Inductive core: the iterate `sqrtAux n fuel x` stays in the upper envelope
 `n ≤ (sqrtAux n fuel x + 1) ^ 2` for any starting `x` already in it. -/
-private theorem sqrtAux_upper_succ_core
+private theorem sqrtAux_upper_succ_from_bound
     (n fuel x : Nat) (h : n ≤ (x + 1) ^ 2) :
     n ≤ (sqrtAux n fuel x + 1) ^ 2 := by
   induction fuel generalizing x with
@@ -131,7 +131,7 @@ private theorem sqrtAux_upper_succ_core
 private theorem sqrtAux_upper_succ
     (n fuel x : Nat) (_hx : 0 < x) (h : n ≤ (x + 1) ^ 2) :
     n ≤ (sqrtAux n fuel x + 1) ^ 2 :=
-  sqrtAux_upper_succ_core n fuel x h
+  sqrtAux_upper_succ_from_bound n fuel x h
 
 /--
 Stop-condition lemma for the Newton iteration: when `sqrtStep n x ≥ x`
@@ -251,7 +251,7 @@ private theorem sqrtStep_gap_halves
 /-- While the iterate has not yet undershot, `fuel` Newton steps shrink the gap
 by a factor `2 ^ fuel`: `2 ^ fuel * sqrtGap n (sqrtAux n fuel x) ≤ sqrtGap n x`.
 This geometric gap contraction drives phase-one convergence. -/
-private theorem sqrtAux_gap_le_of_not_done
+private theorem sqrtAux_gap_bound
     (n fuel x : Nat) (hx : 0 < x)
     (hnot_sq :
       ¬ (sqrtAux n fuel x) * (sqrtAux n fuel x) ≤ n) :
@@ -300,7 +300,7 @@ private theorem sqrtAux_gap_le_of_not_done
 /-- After `n.log2 + 1` Newton steps from `x = n`, the iterate undershoots
 (`(sqrtAux n (n.log2 + 1) n) ^ 2 ≤ n`), since the gap cannot survive that many
 halvings while staying below `2 ^ (n.log2 + 1)`. -/
-private theorem sqrtAux_phase_one_sq_le
+private theorem sqrtAux_sq_le_after_log
     (n : Nat) (hn : 0 < n) :
     (sqrtAux n (n.log2 + 1) n) * (sqrtAux n (n.log2 + 1) n) ≤ n := by
   by_cases hsq :
@@ -308,7 +308,7 @@ private theorem sqrtAux_phase_one_sq_le
   · exact hsq
   · have hgap_le :
         2 ^ (n.log2 + 1) * sqrtGap n (sqrtAux n (n.log2 + 1) n) ≤ sqrtGap n n :=
-      sqrtAux_gap_le_of_not_done n (n.log2 + 1) n hn hsq
+      sqrtAux_gap_bound n (n.log2 + 1) n hn hsq
     have hgap_pos :
         0 < sqrtGap n (sqrtAux n (n.log2 + 1) n) := by
       have hpos : 0 < sqrtAux n (n.log2 + 1) n := by
@@ -383,7 +383,7 @@ private theorem sqrtAux_full_fuel_sq_le
   rw [hfuel, sqrtAux_append]
   have hsq : (sqrtAux n (n.log2 + 1) n) *
       (sqrtAux n (n.log2 + 1) n) ≤ n :=
-    sqrtAux_phase_one_sq_le n hn
+    sqrtAux_sq_le_after_log n hn
   have hself :
       sqrtAux n n.log2 (sqrtAux n (n.log2 + 1) n) =
         sqrtAux n (n.log2 + 1) n :=

--- a/HexPolyZ/Mignotte.lean
+++ b/HexPolyZ/Mignotte.lean
@@ -251,7 +251,7 @@ private theorem sqrtStep_gap_halves
 /-- While the iterate has not yet undershot, `fuel` Newton steps shrink the gap
 by a factor `2 ^ fuel`: `2 ^ fuel * sqrtGap n (sqrtAux n fuel x) ≤ sqrtGap n x`.
 This geometric gap contraction drives phase-one convergence. -/
-private theorem sqrtAux_gap_bound
+private theorem sqrtAux_two_pow_gap_le_of_not_le
     (n fuel x : Nat) (hx : 0 < x)
     (hnot_sq :
       ¬ (sqrtAux n fuel x) * (sqrtAux n fuel x) ≤ n) :
@@ -308,7 +308,7 @@ private theorem sqrtAux_sq_le_after_log
   · exact hsq
   · have hgap_le :
         2 ^ (n.log2 + 1) * sqrtGap n (sqrtAux n (n.log2 + 1) n) ≤ sqrtGap n n :=
-      sqrtAux_gap_bound n (n.log2 + 1) n hn hsq
+      sqrtAux_two_pow_gap_le_of_not_le n (n.log2 + 1) n hn hsq
     have hgap_pos :
         0 < sqrtGap n (sqrtAux n (n.log2 + 1) n) := by
       have hpos : 0 < sqrtAux n (n.log2 + 1) n := by

--- a/HexPolyZ/Rational.lean
+++ b/HexPolyZ/Rational.lean
@@ -176,7 +176,7 @@ theorem ratPolyPrimitivePart_primitive (f : DensePoly Rat)
 of its integer primitive part. -/
 theorem ratPolyPrimitivePart_rational_associate (f : DensePoly Rat) :
     ∃ unit : Rat, f = DensePoly.scale unit (toRatPoly (ratPolyPrimitivePart f)) := by
-  exact ratPolyPrimitivePart_rational_associate_core f
+  exact ratPolyPrimitivePart_exists_scale f
 
 /--
 Gauss-style cancellation: if two primitive nonzero integer polynomials are
@@ -538,13 +538,13 @@ private theorem rat_div_mul_cancel_of_ne (a b : Rat) (hb : b ≠ 0) :
     a - (a / b) * b = 0 := by
   grind [Rat.div_def, Rat.mul_assoc, Rat.mul_comm]
 
-/-- `rat_divMod_remainder_degree_lt_core`: over `DensePoly Rat`, the
+/-- `rat_divMod_remainder_degree_lt`: over `DensePoly Rat`, the
 `divMod` remainder has strictly smaller degree than a positive-degree
 divisor. -/
-private theorem rat_divMod_remainder_degree_lt_core (p q : DensePoly Rat)
+private theorem rat_divMod_remainder_degree_lt (p q : DensePoly Rat)
     (hdegree : 0 < q.degree?.getD 0) :
     (DensePoly.divMod p q).2.degree?.getD 0 < q.degree?.getD 0 := by
-  apply DensePoly.divMod_remainder_degree_lt_of_pos_degree_core p q hdegree
+  apply DensePoly.divMod_remainder_degree_lt_of_pos_degree_of_cancel p q hdegree
   intro a
   apply rat_div_mul_cancel_of_ne
   apply rat_leadingCoeff_ne_zero_of_pos_size
@@ -554,13 +554,13 @@ private theorem rat_divMod_remainder_degree_lt_core (p q : DensePoly Rat)
     omega
   · exact Nat.pos_of_ne_zero hq
 
-/-- `rat_divMod_spec_core`: the `DensePoly Rat` reconstruction identity
+/-- `rat_divMod_reconstruct`: the `DensePoly Rat` reconstruction identity
 `qr.1 * q + qr.2 = p` for `DensePoly.divMod` (holds unconditionally). -/
-private theorem rat_divMod_spec_core (p q : DensePoly Rat) :
+private theorem rat_divMod_reconstruct (p q : DensePoly Rat) :
     let qr := DensePoly.divMod p q
     qr.1 * q + qr.2 = p := by
   by_cases hq : q.size = 0
-  · have hrem := DensePoly.divMod_remainder_eq_self_of_size_zero_core p q hq
+  · have hrem := DensePoly.divMod_remainder_eq_self_of_size_zero p q hq
     have hqzero : q = 0 := by
       apply DensePoly.ext_coeff
       intro n
@@ -585,10 +585,10 @@ private theorem rat_divMod_spec_core (p q : DensePoly Rat) :
       exact DensePoly.divModArray_reconstruction p q
         (fun coeff : Rat => coeff / q.leadingCoeff) hcancel
 
-/-- `rat_divMod_spec_core_of_not_isZero`: the `DensePoly Rat`
+/-- `rat_divMod_reconstruct_of_not_isZero`: the `DensePoly Rat`
 reconstruction identity `qr.1 * q + qr.2 = p` for `DensePoly.divMod`
 under a nonzero-divisor hypothesis. -/
-private theorem rat_divMod_spec_core_of_not_isZero (p q : DensePoly Rat)
+private theorem rat_divMod_reconstruct_of_not_isZero (p q : DensePoly Rat)
     (hqzero : ¬ q.isZero) :
     let qr := DensePoly.divMod p q
     qr.1 * q + qr.2 = p := by
@@ -607,20 +607,20 @@ private theorem rat_divMod_spec_core_of_not_isZero (p q : DensePoly Rat)
             simpa [DensePoly.isZero, Array.isEmpty_iff_size_eq_zero] using hcoeffs
           simpa [DensePoly.size, Nat.pos_iff_ne_zero] using hcoeffs)))
 
-/-- `rat_mod_remainder_degree_lt_core`: over `DensePoly Rat`, the `mod`
+/-- `rat_mod_remainder_degree_lt`: over `DensePoly Rat`, the `mod`
 remainder `p % q` has strictly smaller degree than a positive-degree
 divisor. -/
-private theorem rat_mod_remainder_degree_lt_core (p q : DensePoly Rat)
+private theorem rat_mod_remainder_degree_lt (p q : DensePoly Rat)
     (hdegree : 0 < q.degree?.getD 0) :
     (p % q).degree?.getD 0 < q.degree?.getD 0 := by
-  exact rat_divMod_remainder_degree_lt_core p q hdegree
+  exact rat_divMod_remainder_degree_lt p q hdegree
 
 /-- `rat_mod_zero_right_of_size_zero`: over `DensePoly Rat`, `p % m = p`
 when the divisor `m` has size zero. -/
 private theorem rat_mod_zero_right_of_size_zero (p m : DensePoly Rat)
     (hm : m.size = 0) :
     p % m = p := by
-  exact DensePoly.divMod_remainder_eq_self_of_size_zero_core p m hm
+  exact DensePoly.divMod_remainder_eq_self_of_size_zero p m hm
 
 /-- `rat_mod_sub_self_eq_mul_neg_div_of_not_isZero`: over `DensePoly Rat`
 with a nonzero divisor, `p % m - p = m * (0 - p / m)`. -/
@@ -628,7 +628,7 @@ private theorem rat_mod_sub_self_eq_mul_neg_div_of_not_isZero (p m : DensePoly R
     (hmzero : ¬ m.isZero) :
     p % m - p = m * (0 - p / m) := by
   have hdiv : (p / m) * m + (p % m) = p := by
-    exact rat_divMod_spec_core_of_not_isZero p m hmzero
+    exact rat_divMod_reconstruct_of_not_isZero p m hmzero
   calc
     p % m - p = 0 - (p / m) * m := by
       apply DensePoly.ext_coeff
@@ -644,9 +644,9 @@ private theorem rat_mod_sub_self_eq_mul_neg_div_of_not_isZero (p m : DensePoly R
     _ = m * (0 - (p / m)) := by
       exact (DensePoly.mul_sub_zero_comm m (p / m)).symm
 
-/-- `rat_congr_mod_core`: over `DensePoly Rat`, the remainder `p % m` is
+/-- `rat_congr_mod`: over `DensePoly Rat`, the remainder `p % m` is
 congruent to `p` modulo `m`, i.e. `DensePoly.Congr (p % m) p m`. -/
-private theorem rat_congr_mod_core (p m : DensePoly Rat) :
+private theorem rat_congr_mod (p m : DensePoly Rat) :
     DensePoly.Congr (p % m) p m := by
   by_cases hmzero : m.isZero
   · refine ⟨0, ?_⟩
@@ -710,7 +710,7 @@ private theorem rat_sub_zero_right (p : DensePoly Rat) :
 `(0 : DensePoly Rat) % m = 0`. -/
 private theorem rat_zero_mod_eq_zero (m : DensePoly Rat) :
     (0 : DensePoly Rat) % m = 0 :=
-  DensePoly.zero_mod_eq_zero_core m
+  DensePoly.zero_mod_eq_zero m
 
 /-- `rat_sub_self_right_add`: cancels the shared left summand, `(a + b) - a = b` over
 `DensePoly Rat`, used to discard the `p * q` term in the remainder-delta product
@@ -1053,8 +1053,8 @@ multiplier is assembled from those of `p ≡ p % m`, `q ≡ q % m`, and `p ≡ q
 private theorem rat_mod_remainders_congr_of_congr (p q m : DensePoly Rat)
     (hcongr : DensePoly.Congr p q m) :
     DensePoly.Congr (p % m) (q % m) m := by
-  rcases rat_congr_mod_core p m with ⟨rp, hp⟩
-  rcases rat_congr_mod_core q m with ⟨rq, hq⟩
+  rcases rat_congr_mod p m with ⟨rp, hp⟩
+  rcases rat_congr_mod q m with ⟨rq, hq⟩
   rcases hcongr with ⟨k, hk⟩
   refine ⟨(k + rp) + (0 - rq), ?_⟩
   have hp_add : p % m = p + m * rp := rat_eq_add_mul_of_sub_eq_mul hp
@@ -1098,8 +1098,8 @@ private theorem rat_mod_eq_mod_of_congr_pos_degree (p q m : DensePoly Rat)
     (hcongr : DensePoly.Congr p q m) :
     p % m = q % m := by
   apply rat_canonical_remainder_unique_of_pos_degree
-  · exact rat_mod_remainder_degree_lt_core p m hdegree
-  · exact rat_mod_remainder_degree_lt_core q m hdegree
+  · exact rat_mod_remainder_degree_lt p m hdegree
+  · exact rat_mod_remainder_degree_lt q m hdegree
   · exact rat_mod_remainders_congr_of_congr p q m hcongr
 
 /-- Coefficientwise cancellation: if `p - q = 0` then `p = q`. -/
@@ -1146,18 +1146,18 @@ private theorem rat_mod_eq_mod_of_congr_not_pos_degree (p q m : DensePoly Rat)
       exact rat_leadingCoeff_ne_zero_of_pos_size m (by omega)
     have hpmod :
         p % m = 0 := by
-      exact DensePoly.divMod_remainder_eq_zero_of_degree_zero_core p m hm_size
+      exact DensePoly.divMod_remainder_eq_zero_of_degree_zero_of_cancel p m hm_size
         (fun a => rat_div_mul_cancel_of_ne a m.leadingCoeff hlead_ne)
     have hqmod :
         q % m = 0 := by
-      exact DensePoly.divMod_remainder_eq_zero_of_degree_zero_core q m hm_size
+      exact DensePoly.divMod_remainder_eq_zero_of_degree_zero_of_cancel q m hm_size
         (fun a => rat_div_mul_cancel_of_ne a m.leadingCoeff hlead_ne)
     rw [hpmod, hqmod]
 
 /-- Congruent polynomials always have equal remainders modulo `m`, obtained by
 case-splitting on whether `m` has positive degree and dispatching to the two
 preceding lemmas. This is the workhorse behind the `mod_eq_mod_of_congr` law. -/
-private theorem rat_mod_eq_mod_of_congr_core (p q m : DensePoly Rat)
+private theorem rat_mod_eq_mod_of_congr (p q m : DensePoly Rat)
     (hcongr : DensePoly.Congr p q m) :
     p % m = q % m := by
   by_cases hdegree : 0 < m.degree?.getD 0
@@ -1167,12 +1167,12 @@ private theorem rat_mod_eq_mod_of_congr_core (p q m : DensePoly Rat)
 /-- Divisibility makes the remainder vanish: if `q ∣ p` then `p % q = 0`. Since
 `q ∣ p` gives `p ≡ 0 (mod q)`, the remainders of `p` and `0` agree, and `0 % q`
 is `0`. -/
-private theorem rat_mod_eq_zero_of_dvd_core (p q : DensePoly Rat)
+private theorem rat_mod_eq_zero_of_dvd (p q : DensePoly Rat)
     (hdiv : q ∣ p) :
     p % q = 0 := by
   rcases hdiv with ⟨r, hr⟩
   rw [← rat_zero_mod_eq_zero q]
-  apply rat_mod_eq_mod_of_congr_core
+  apply rat_mod_eq_mod_of_congr
   exact ⟨r, by
     rw [rat_sub_zero_right, hr]⟩
 
@@ -1196,45 +1196,45 @@ private theorem rat_divMod_remainder_eq_zero_of_not_pos_degree (p q : DensePoly 
     omega
   have hlead_ne : q.leadingCoeff ≠ (Zero.zero : Rat) := by
     exact rat_leadingCoeff_ne_zero_of_pos_size q (by omega)
-  exact DensePoly.divMod_remainder_eq_zero_of_degree_zero_core p q hqsize
+  exact DensePoly.divMod_remainder_eq_zero_of_degree_zero_of_cancel p q hqsize
     (fun a => rat_div_mul_cancel_of_ne a q.leadingCoeff hlead_ne)
 
 instance instDivModLawsRat : DensePoly.DivModLaws Rat where
   divMod_spec := by
     intro p q
-    exact rat_divMod_spec_core p q
+    exact rat_divMod_reconstruct p q
   divMod_remainder_degree_lt_of_pos_degree := by
     intro p q hdegree
-    exact rat_divMod_remainder_degree_lt_core p q hdegree
+    exact rat_divMod_remainder_degree_lt p q hdegree
   divModMonic_eq_divMod_of_monic := by
     intro p q hmonic
     by_cases hlt : p.degree?.getD 0 < q.degree?.getD 0
     · rw [DensePoly.divMod_eq_zero_self_of_degree_lt p q hlt]
       unfold DensePoly.divModMonic
       exact DensePoly.divModArray_eq_zero_self_of_degree_lt p q id hlt
-    · apply DensePoly.divModMonic_eq_divMod_of_monic_core p q hmonic hlt
+    · apply DensePoly.divModMonic_eq_divMod_of_monic_of_scale p q hmonic hlt
       intro a
       rw [hmonic]
       grind [Rat.div_def]
   mod_self_eq_zero := by
     intro p
-    apply rat_mod_eq_zero_of_dvd_core
+    apply rat_mod_eq_zero_of_dvd
     exact ⟨1, (DensePoly.mul_one_right_poly p).symm⟩
   mod_eq_zero_of_dvd := by
     intro p q hdiv
-    exact rat_mod_eq_zero_of_dvd_core p q hdiv
+    exact rat_mod_eq_zero_of_dvd p q hdiv
   mod_mod_of_not_pos_degree := by
     intro p q hdegree
-    exact rat_mod_eq_mod_of_congr_core (p % q) p q (rat_congr_mod_core p q)
+    exact rat_mod_eq_mod_of_congr (p % q) p q (rat_congr_mod p q)
   mod_eq_mod_of_congr := by
     intro p q m hcongr
-    exact rat_mod_eq_mod_of_congr_core p q m hcongr
+    exact rat_mod_eq_mod_of_congr p q m hcongr
   mod_add_mod := by
     intro p q m
     apply Eq.symm
-    apply rat_mod_eq_mod_of_congr_core
-    rcases rat_congr_mod_core p m with ⟨rp, hp⟩
-    rcases rat_congr_mod_core q m with ⟨rq, hq⟩
+    apply rat_mod_eq_mod_of_congr
+    rcases rat_congr_mod p m with ⟨rp, hp⟩
+    rcases rat_congr_mod q m with ⟨rq, hq⟩
     exact ⟨rp + rq, by
       calc
         (p % m + q % m) - (p + q)
@@ -1246,9 +1246,9 @@ instance instDivModLawsRat : DensePoly.DivModLaws Rat where
   mod_mul_mod := by
     intro p q m
     apply Eq.symm
-    apply rat_mod_eq_mod_of_congr_core
-    rcases rat_congr_mod_core p m with ⟨rp, hp⟩
-    rcases rat_congr_mod_core q m with ⟨rq, hq⟩
+    apply rat_mod_eq_mod_of_congr
+    rcases rat_congr_mod p m with ⟨rp, hp⟩
+    rcases rat_congr_mod q m with ⟨rq, hq⟩
     exact ⟨rp * (q % m) + p * rq, by
       have hp' : p % m = p + m * rp := rat_eq_add_mul_of_sub_eq_mul hp
       have hq' : q % m = q + m * rq := rat_eq_add_mul_of_sub_eq_mul hq
@@ -1532,7 +1532,7 @@ private theorem rat_div_eq_zero_of_right_size_zero
     p / q = 0 := by
   change DensePoly.div p q = 0
   simpa [DensePoly.div] using
-    congrArg Prod.fst (DensePoly.divMod_eq_zero_self_of_size_zero_core p q hq)
+    congrArg Prod.fst (DensePoly.divMod_eq_zero_self_of_size_zero p q hq)
 
 private theorem rat_quotient_derivative_squareFree
     (ratPrimitive : DensePoly Rat) :

--- a/HexPolyZ/Rational.lean
+++ b/HexPolyZ/Rational.lean
@@ -68,7 +68,7 @@ private theorem normalizePrimitiveSign_ne_zero_of_ne_zero (p : ZPoly) (hp : p �
     intro hzero
     have hsize : p.size = 0 := by
       have hscaled_size : (DensePoly.scale (-1 : Int) p).size = p.size :=
-        scale_size_of_nonzero (-1 : Int) p (by decide)
+        scale_size_of_ne_zero (-1 : Int) p (by decide)
       rw [hzero, DensePoly.size_zero] at hscaled_size
       omega
     apply hp
@@ -171,12 +171,6 @@ theorem ratPolyPrimitivePart_primitive (f : DensePoly Rat)
     Primitive (ratPolyPrimitivePart f) := by
   unfold ratPolyPrimitivePart at h ⊢
   exact normalizePrimitiveSign_primitivePart_primitive _ h
-
-/-- A rational polynomial is a rational scalar multiple of the rationalization
-of its integer primitive part. -/
-theorem ratPolyPrimitivePart_rational_associate (f : DensePoly Rat) :
-    ∃ unit : Rat, f = DensePoly.scale unit (toRatPoly (ratPolyPrimitivePart f)) := by
-  exact ratPolyPrimitivePart_exists_scale f
 
 /--
 Gauss-style cancellation: if two primitive nonzero integer polynomials are
@@ -554,9 +548,9 @@ private theorem rat_divMod_remainder_degree_lt (p q : DensePoly Rat)
     omega
   · exact Nat.pos_of_ne_zero hq
 
-/-- `rat_divMod_reconstruct`: the `DensePoly Rat` reconstruction identity
+/-- The `DensePoly Rat` reconstruction identity
 `qr.1 * q + qr.2 = p` for `DensePoly.divMod` (holds unconditionally). -/
-private theorem rat_divMod_reconstruct (p q : DensePoly Rat) :
+private theorem rat_divMod_spec (p q : DensePoly Rat) :
     let qr := DensePoly.divMod p q
     qr.1 * q + qr.2 = p := by
   by_cases hq : q.size = 0
@@ -585,10 +579,10 @@ private theorem rat_divMod_reconstruct (p q : DensePoly Rat) :
       exact DensePoly.divModArray_reconstruction p q
         (fun coeff : Rat => coeff / q.leadingCoeff) hcancel
 
-/-- `rat_divMod_reconstruct_of_not_isZero`: the `DensePoly Rat`
-reconstruction identity `qr.1 * q + qr.2 = p` for `DensePoly.divMod`
+/-- The `DensePoly Rat` reconstruction identity `qr.1 * q + qr.2 = p`
+for `DensePoly.divMod`
 under a nonzero-divisor hypothesis. -/
-private theorem rat_divMod_reconstruct_of_not_isZero (p q : DensePoly Rat)
+private theorem rat_divMod_spec_of_not_isZero (p q : DensePoly Rat)
     (hqzero : ¬ q.isZero) :
     let qr := DensePoly.divMod p q
     qr.1 * q + qr.2 = p := by
@@ -628,7 +622,7 @@ private theorem rat_mod_sub_self_eq_mul_neg_div_of_not_isZero (p m : DensePoly R
     (hmzero : ¬ m.isZero) :
     p % m - p = m * (0 - p / m) := by
   have hdiv : (p / m) * m + (p % m) = p := by
-    exact rat_divMod_reconstruct_of_not_isZero p m hmzero
+    exact rat_divMod_spec_of_not_isZero p m hmzero
   calc
     p % m - p = 0 - (p / m) * m := by
       apply DensePoly.ext_coeff
@@ -1202,7 +1196,7 @@ private theorem rat_divMod_remainder_eq_zero_of_not_pos_degree (p q : DensePoly 
 instance instDivModLawsRat : DensePoly.DivModLaws Rat where
   divMod_spec := by
     intro p q
-    exact rat_divMod_reconstruct p q
+    exact rat_divMod_spec p q
   divMod_remainder_degree_lt_of_pos_degree := by
     intro p q hdegree
     exact rat_divMod_remainder_degree_lt p q hdegree

--- a/HexRealRootsMathlib/IsolateRootsElab.lean
+++ b/HexRealRootsMathlib/IsolateRootsElab.lean
@@ -362,7 +362,7 @@ meta def radicalCert (orig core : Hex.ZPoly) :
 /-- Emit `coreTerm : IsolatedRealRoots (toPolynomial fLit) n` for the reflected
 integer polynomial `f` (the reflection of the user's input), classifying it as
 zero / nonzero constant / square-free / non-squarefree and routing accordingly. -/
-meta def emitCore (f : Hex.ZPoly) (widthK : Option Int) : MetaM (TSyntax `term) := do
+meta def emitIsolation (f : Hex.ZPoly) (widthK : Option Int) : MetaM (TSyntax `term) := do
   let fStx ← zpolyStx f
   if f.size == 0 then
     throwError "isolate_roots: the zero polynomial (every real number is a root, \
@@ -468,7 +468,7 @@ meta def elabIsolate (widthStx : Option (TSyntax `term)) (pStx : TSyntax `term)
     else
       throwError "isolate_roots: expected a closed `Hex.ZPoly` or `Polynomial ℤ/ℚ/ℝ` \
         term, but the argument has type{indentExpr ty}"
-  let coreTerm ← emitCore f widthK
+  let coreTerm ← emitIsolation f widthK
   let term ←
     if isPolyInput then
       `(Hex.IsolatedRealRoots.congrRoots (Q := $pStx) (by aeval_iff_bridge) $coreTerm)

--- a/HexResultant/Basic.lean
+++ b/HexResultant/Basic.lean
@@ -742,7 +742,7 @@ private theorem pseudoActive_spec {S : Type u} [Lean.Grind.CommRing S]
 This theorem deliberately uses a fresh coefficient type: an ambient `Zero`
 instance is not necessarily coherent with the zero supplied by
 `Lean.Grind.CommRing`. -/
-theorem pseudoDivMod_reconstruct_core {S : Type u}
+theorem pseudoDivMod_reconstruct {S : Type u}
     [Lean.Grind.CommRing S] [DecidableEq S]
     (f g : DensePoly S) (hg : g ≠ 0) (hfg : g.size ≤ f.size) :
     scale (g.leadingCoeff ^ (f.size - g.size + 1)) f =

--- a/HexResultant/Subresultant.lean
+++ b/HexResultant/Subresultant.lean
@@ -148,7 +148,7 @@ def subresultantChain [One R] [Add R] [Sub R] [Mul R] [Div R]
 /-- Ordered nonzero inputs establish every nonzero-denominator and exactness
 obligation recorded by `BrownLaw`, including the unreachability of the junk
 zero-quotient branch. -/
-theorem subresultantOrdered_valid_core {S : Type u}
+theorem subresultantOrdered_brownLaw {S : Type u}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [ExactDivLaws S]
     (f g : DensePoly S) (hf : f ≠ 0) (hg : g ≠ 0) (hgf : g.size ≤ f.size) :
     let delta := f.size - g.size
@@ -163,7 +163,7 @@ theorem subresultantOrdered_valid_core {S : Type u}
 
 /-- The public ordered-run fuel is sufficient: adding any extra fuel leaves
 the result unchanged over a lawful exact-division domain. -/
-theorem subresultantOrdered_fuel_core {S : Type u}
+theorem subresultantOrderedFuel_eq {S : Type u}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [ExactDivLaws S]
     (f g : DensePoly S) (hf : f ≠ 0) (hg : g ≠ 0) (hgf : g.size ≤ f.size)
     (extra : Nat) :
@@ -288,7 +288,7 @@ theorem subresultantChain_zero_left [One R] [Add R] [Sub R] [Mul R] [Div R]
   simp [hgz, hzz]
 
 /-- Every stored term is nonzero over a lawful exact-division domain. -/
-theorem subresultantChain_ne_zero_core {S : Type u}
+theorem subresultantChain_ne_zero {S : Type u}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [ExactDivLaws S]
     (f g : DensePoly S) (p : DensePoly S) (hp : p ∈ subresultantChain f g) :
     p ≠ 0 := by
@@ -296,7 +296,7 @@ theorem subresultantChain_ne_zero_core {S : Type u}
 
 /-- After the possibly equal-degree ordered inputs, stored degrees strictly
 decrease. -/
-theorem subresultantChain_strict_core {S : Type u}
+theorem subresultantChain_size_strict {S : Type u}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [ExactDivLaws S]
     (f g : DensePoly S) (i : Nat) (hi : 1 ≤ i)
     (hnext : i + 1 < (subresultantChain f g).size) :
@@ -306,7 +306,7 @@ theorem subresultantChain_strict_core {S : Type u}
 
 /-- The nonzero Brown chain stores at most two inputs plus one term for every
 possible degree at or below the smaller input degree. -/
-theorem subresultantChain_size_le_core {S : Type u}
+theorem subresultantChain_size_le {S : Type u}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [ExactDivLaws S]
     (f g : DensePoly S) (hf : f ≠ 0) (hg : g ≠ 0) :
     (subresultantChain f g).size ≤

--- a/HexRoots/Refine.lean
+++ b/HexRoots/Refine.lean
@@ -227,7 +227,7 @@ namespace IsolationLoop
   | _ => none
 
 /-- Strategy-parametric implementation of the all-atoms finishing pass. -/
-@[expose] def refineAtoms? (p : ZPoly) (target : Int)
+@[expose] def finishAllAtoms? (p : ZPoly) (target : Int)
     (strategy : AtomStrategy)
     (tried : Array (Component × Option (Certified p))) :
     Option (Array (Certified p)) :=
@@ -250,7 +250,7 @@ NK-only strategy keeps its existing proof-specialized loop path. -/
     Option (Array (Certified p)) :=
   match strategy with
   | .nk => none
-  | .pellet | .nkThenPellet => refineAtoms? p target strategy tried
+  | .pellet | .nkThenPellet => finishAllAtoms? p target strategy tried
 
 /-- Ordinary output guard after the optional local finisher. Normalized
 worklists may emit any ready, disjoint certificates. The NK-only strategy also

--- a/HexRoots/Refine.lean
+++ b/HexRoots/Refine.lean
@@ -227,7 +227,7 @@ namespace IsolationLoop
   | _ => none
 
 /-- Strategy-parametric implementation of the all-atoms finishing pass. -/
-@[expose] def finishAtomsCore? (p : ZPoly) (target : Int)
+@[expose] def refineAtoms? (p : ZPoly) (target : Int)
     (strategy : AtomStrategy)
     (tried : Array (Component × Option (Certified p))) :
     Option (Array (Certified p)) :=
@@ -250,7 +250,7 @@ NK-only strategy keeps its existing proof-specialized loop path. -/
     Option (Array (Certified p)) :=
   match strategy with
   | .nk => none
-  | .pellet | .nkThenPellet => finishAtomsCore? p target strategy tried
+  | .pellet | .nkThenPellet => refineAtoms? p target strategy tried
 
 /-- Ordinary output guard after the optional local finisher. Normalized
 worklists may emit any ready, disjoint certificates. The NK-only strategy also

--- a/HexRootsMathlib/Loop.lean
+++ b/HexRootsMathlib/Loop.lean
@@ -497,13 +497,13 @@ theorem refineAtom_preserves {p : Hex.ZPoly} {strategy : Hex.AtomStrategy}
         · simp at hrefine
 
 /-- The opportunistic all-atoms fast path returns atoms only. -/
-theorem finishAtomsCore_atoms {p : Hex.ZPoly} {target : Int}
+theorem refineAtoms_atoms {p : Hex.ZPoly} {target : Int}
     {strategy : Hex.AtomStrategy}
     {tried : Array (Hex.Component × Option (Hex.Certified p))}
     {rs : Array (Hex.Certified p)}
-    (hfinish : Hex.IsolationLoop.finishAtomsCore? p target strategy tried = some rs) :
+    (hfinish : Hex.IsolationLoop.refineAtoms? p target strategy tried = some rs) :
     ∀ r ∈ rs.toList, ∃ iso : Hex.DyadicRootIsolation p, r = .atom iso := by
-  unfold Hex.IsolationLoop.finishAtomsCore? at hfinish
+  unfold Hex.IsolationLoop.refineAtoms? at hfinish
   split at hfinish
   · cases hmap : tried.mapM
         (Hex.IsolationLoop.refineAttempt? target strategy) with
@@ -526,14 +526,14 @@ theorem finishAtomsCore_atoms {p : Hex.ZPoly} {target : Int}
 
 /-- A successful all-atoms fast path meets the target and returns pairwise
 disjoint atom discs. -/
-theorem finishAtomsCore_ready_disjoint {p : Hex.ZPoly} {target : Int}
+theorem refineAtoms_ready_disjoint {p : Hex.ZPoly} {target : Int}
     {strategy : Hex.AtomStrategy}
     {tried : Array (Hex.Component × Option (Hex.Certified p))}
     {rs : Array (Hex.Certified p)}
-    (hfinish : Hex.IsolationLoop.finishAtomsCore? p target strategy tried = some rs) :
+    (hfinish : Hex.IsolationLoop.refineAtoms? p target strategy tried = some rs) :
     (∀ r ∈ rs.toList, target ≤ r.square.prec) ∧
       Hex.pairwiseDisjoint (rs.map (·.square)) = true := by
-  unfold Hex.IsolationLoop.finishAtomsCore? at hfinish
+  unfold Hex.IsolationLoop.refineAtoms? at hfinish
   split at hfinish
   · cases hmap : tried.mapM
         (Hex.IsolationLoop.refineAttempt? target strategy) with
@@ -576,10 +576,10 @@ theorem finishAtomsCore_ready_disjoint {p : Hex.ZPoly} {target : Int}
 
 /-- The all-atoms fast path preserves every polynomial root covered by its
 attempted worklist. -/
-theorem finishAtomsCore_covers {p : Hex.ZPoly} {target : Int}
+theorem refineAtoms_covers {p : Hex.ZPoly} {target : Int}
     {strategy : Hex.AtomStrategy} (hcert : Certifier.Preserves p strategy)
     {work : Array Hex.Component} {rs : Array (Hex.Certified p)}
-    (hfinish : Hex.IsolationLoop.finishAtomsCore? p target strategy
+    (hfinish : Hex.IsolationLoop.refineAtoms? p target strategy
       (Hex.IsolationLoop.attempts p strategy work) = some rs)
     {z : ℂ} (hzroot : (toPolyℂ p).IsRoot z)
     (hz : z ∈ Worklist.region work) : z ∈ Results.region rs := by
@@ -588,8 +588,8 @@ theorem finishAtomsCore_covers {p : Hex.ZPoly} {target : Int}
   have ht : (c, Hex.Component.certify? p strategy c) ∈ tried := by
     apply Array.mem_map_of_mem
     exact Array.mem_toList_iff.mp hc
-  change Hex.IsolationLoop.finishAtomsCore? p target strategy tried = some rs at hfinish
-  unfold Hex.IsolationLoop.finishAtomsCore? at hfinish
+  change Hex.IsolationLoop.refineAtoms? p target strategy tried = some rs at hfinish
+  unfold Hex.IsolationLoop.refineAtoms? at hfinish
   split at hfinish
   · rename_i hatoms
     have hguard : Hex.IsolationLoop.allAtoms tried = true ∧
@@ -639,10 +639,10 @@ theorem finishAtoms_atoms {p : Hex.ZPoly} {target : Int}
   cases strategy with
   | nk => simp [Hex.IsolationLoop.finishAtoms?] at hfinish
   | pellet =>
-      apply finishAtomsCore_atoms
+      apply refineAtoms_atoms
       simpa [Hex.IsolationLoop.finishAtoms?] using hfinish
   | nkThenPellet =>
-      apply finishAtomsCore_atoms
+      apply refineAtoms_atoms
       simpa [Hex.IsolationLoop.finishAtoms?] using hfinish
 
 theorem finishAtoms_ready_disjoint {p : Hex.ZPoly} {target : Int}
@@ -655,10 +655,10 @@ theorem finishAtoms_ready_disjoint {p : Hex.ZPoly} {target : Int}
   cases strategy with
   | nk => simp [Hex.IsolationLoop.finishAtoms?] at hfinish
   | pellet =>
-      apply finishAtomsCore_ready_disjoint
+      apply refineAtoms_ready_disjoint
       simpa [Hex.IsolationLoop.finishAtoms?] using hfinish
   | nkThenPellet =>
-      apply finishAtomsCore_ready_disjoint
+      apply refineAtoms_ready_disjoint
       simpa [Hex.IsolationLoop.finishAtoms?] using hfinish
 
 theorem finishAtoms_covers {p : Hex.ZPoly} {target : Int}
@@ -671,15 +671,15 @@ theorem finishAtoms_covers {p : Hex.ZPoly} {target : Int}
   cases strategy with
   | nk => simp [Hex.IsolationLoop.finishAtoms?] at hfinish
   | pellet =>
-      have hcore : Hex.IsolationLoop.finishAtomsCore? p target .pellet
+      have hcore : Hex.IsolationLoop.refineAtoms? p target .pellet
           (Hex.IsolationLoop.attempts p .pellet work) = some rs := by
         simpa [Hex.IsolationLoop.finishAtoms?] using hfinish
-      exact finishAtomsCore_covers hcert hcore hzroot hz
+      exact refineAtoms_covers hcert hcore hzroot hz
   | nkThenPellet =>
-      have hcore : Hex.IsolationLoop.finishAtomsCore? p target .nkThenPellet
+      have hcore : Hex.IsolationLoop.refineAtoms? p target .nkThenPellet
           (Hex.IsolationLoop.attempts p .nkThenPellet work) = some rs := by
         simpa [Hex.IsolationLoop.finishAtoms?] using hfinish
-      exact finishAtomsCore_covers hcert hcore hzroot hz
+      exact refineAtoms_covers hcert hcore hzroot hz
 
 /-- Parametric coverage theorem for the fuel-based isolation loop. No
 certificate analysis enters: the proof consumes only `Certifier.Preserves`

--- a/HexRootsMathlib/Loop.lean
+++ b/HexRootsMathlib/Loop.lean
@@ -497,13 +497,13 @@ theorem refineAtom_preserves {p : Hex.ZPoly} {strategy : Hex.AtomStrategy}
         · simp at hrefine
 
 /-- The opportunistic all-atoms fast path returns atoms only. -/
-theorem refineAtoms_atoms {p : Hex.ZPoly} {target : Int}
+theorem finishAllAtoms_atoms {p : Hex.ZPoly} {target : Int}
     {strategy : Hex.AtomStrategy}
     {tried : Array (Hex.Component × Option (Hex.Certified p))}
     {rs : Array (Hex.Certified p)}
-    (hfinish : Hex.IsolationLoop.refineAtoms? p target strategy tried = some rs) :
+    (hfinish : Hex.IsolationLoop.finishAllAtoms? p target strategy tried = some rs) :
     ∀ r ∈ rs.toList, ∃ iso : Hex.DyadicRootIsolation p, r = .atom iso := by
-  unfold Hex.IsolationLoop.refineAtoms? at hfinish
+  unfold Hex.IsolationLoop.finishAllAtoms? at hfinish
   split at hfinish
   · cases hmap : tried.mapM
         (Hex.IsolationLoop.refineAttempt? target strategy) with
@@ -526,14 +526,14 @@ theorem refineAtoms_atoms {p : Hex.ZPoly} {target : Int}
 
 /-- A successful all-atoms fast path meets the target and returns pairwise
 disjoint atom discs. -/
-theorem refineAtoms_ready_disjoint {p : Hex.ZPoly} {target : Int}
+theorem finishAllAtoms_ready_disjoint {p : Hex.ZPoly} {target : Int}
     {strategy : Hex.AtomStrategy}
     {tried : Array (Hex.Component × Option (Hex.Certified p))}
     {rs : Array (Hex.Certified p)}
-    (hfinish : Hex.IsolationLoop.refineAtoms? p target strategy tried = some rs) :
+    (hfinish : Hex.IsolationLoop.finishAllAtoms? p target strategy tried = some rs) :
     (∀ r ∈ rs.toList, target ≤ r.square.prec) ∧
       Hex.pairwiseDisjoint (rs.map (·.square)) = true := by
-  unfold Hex.IsolationLoop.refineAtoms? at hfinish
+  unfold Hex.IsolationLoop.finishAllAtoms? at hfinish
   split at hfinish
   · cases hmap : tried.mapM
         (Hex.IsolationLoop.refineAttempt? target strategy) with
@@ -576,10 +576,10 @@ theorem refineAtoms_ready_disjoint {p : Hex.ZPoly} {target : Int}
 
 /-- The all-atoms fast path preserves every polynomial root covered by its
 attempted worklist. -/
-theorem refineAtoms_covers {p : Hex.ZPoly} {target : Int}
+theorem finishAllAtoms_covers {p : Hex.ZPoly} {target : Int}
     {strategy : Hex.AtomStrategy} (hcert : Certifier.Preserves p strategy)
     {work : Array Hex.Component} {rs : Array (Hex.Certified p)}
-    (hfinish : Hex.IsolationLoop.refineAtoms? p target strategy
+    (hfinish : Hex.IsolationLoop.finishAllAtoms? p target strategy
       (Hex.IsolationLoop.attempts p strategy work) = some rs)
     {z : ℂ} (hzroot : (toPolyℂ p).IsRoot z)
     (hz : z ∈ Worklist.region work) : z ∈ Results.region rs := by
@@ -588,8 +588,8 @@ theorem refineAtoms_covers {p : Hex.ZPoly} {target : Int}
   have ht : (c, Hex.Component.certify? p strategy c) ∈ tried := by
     apply Array.mem_map_of_mem
     exact Array.mem_toList_iff.mp hc
-  change Hex.IsolationLoop.refineAtoms? p target strategy tried = some rs at hfinish
-  unfold Hex.IsolationLoop.refineAtoms? at hfinish
+  change Hex.IsolationLoop.finishAllAtoms? p target strategy tried = some rs at hfinish
+  unfold Hex.IsolationLoop.finishAllAtoms? at hfinish
   split at hfinish
   · rename_i hatoms
     have hguard : Hex.IsolationLoop.allAtoms tried = true ∧
@@ -639,10 +639,10 @@ theorem finishAtoms_atoms {p : Hex.ZPoly} {target : Int}
   cases strategy with
   | nk => simp [Hex.IsolationLoop.finishAtoms?] at hfinish
   | pellet =>
-      apply refineAtoms_atoms
+      apply finishAllAtoms_atoms
       simpa [Hex.IsolationLoop.finishAtoms?] using hfinish
   | nkThenPellet =>
-      apply refineAtoms_atoms
+      apply finishAllAtoms_atoms
       simpa [Hex.IsolationLoop.finishAtoms?] using hfinish
 
 theorem finishAtoms_ready_disjoint {p : Hex.ZPoly} {target : Int}
@@ -655,10 +655,10 @@ theorem finishAtoms_ready_disjoint {p : Hex.ZPoly} {target : Int}
   cases strategy with
   | nk => simp [Hex.IsolationLoop.finishAtoms?] at hfinish
   | pellet =>
-      apply refineAtoms_ready_disjoint
+      apply finishAllAtoms_ready_disjoint
       simpa [Hex.IsolationLoop.finishAtoms?] using hfinish
   | nkThenPellet =>
-      apply refineAtoms_ready_disjoint
+      apply finishAllAtoms_ready_disjoint
       simpa [Hex.IsolationLoop.finishAtoms?] using hfinish
 
 theorem finishAtoms_covers {p : Hex.ZPoly} {target : Int}
@@ -671,15 +671,15 @@ theorem finishAtoms_covers {p : Hex.ZPoly} {target : Int}
   cases strategy with
   | nk => simp [Hex.IsolationLoop.finishAtoms?] at hfinish
   | pellet =>
-      have hcore : Hex.IsolationLoop.refineAtoms? p target .pellet
+      have hcore : Hex.IsolationLoop.finishAllAtoms? p target .pellet
           (Hex.IsolationLoop.attempts p .pellet work) = some rs := by
         simpa [Hex.IsolationLoop.finishAtoms?] using hfinish
-      exact refineAtoms_covers hcert hcore hzroot hz
+      exact finishAllAtoms_covers hcert hcore hzroot hz
   | nkThenPellet =>
-      have hcore : Hex.IsolationLoop.refineAtoms? p target .nkThenPellet
+      have hcore : Hex.IsolationLoop.finishAllAtoms? p target .nkThenPellet
           (Hex.IsolationLoop.attempts p .nkThenPellet work) = some rs := by
         simpa [Hex.IsolationLoop.finishAtoms?] using hfinish
-      exact refineAtoms_covers hcert hcore hzroot hz
+      exact finishAllAtoms_covers hcert hcore hzroot hz
 
 /-- Parametric coverage theorem for the fuel-based isolation loop. No
 certificate analysis enters: the proof consumes only `Certifier.Preserves`

--- a/bench/HexHensel/Bench.lean
+++ b/bench/HexHensel/Bench.lean
@@ -84,7 +84,7 @@ instance {p : Nat} [ZMod64.Bounds p] : Hashable (FpPoly p) where
   hash f := hash f.toArray
 
 /-- Prepared input for the conversion-operation benchmarks. -/
-structure BridgeInput where
+structure ConversionInput where
   zpoly : ZPoly
   fpoly : FpPoly 5
   deriving Hashable
@@ -183,7 +183,7 @@ def checksumZPolyArray (polys : Array ZPoly) : UInt64 :=
   polys.foldl (fun acc f => mixHash acc (checksumZPoly f)) 0
 
 /-- Per-parameter fixture for conversion operations. -/
-def prepBridgeInput (n : Nat) : BridgeInput :=
+def prepConversionInput (n : Nat) : ConversionInput :=
   { zpoly := denseZPoly n 17
     fpoly := denseFpPoly n 23 }
 
@@ -248,15 +248,15 @@ def prepMultifactorLiftPrecisionInput (param : Nat) : MultifactorInput :=
     k := liftBenchPrecision param }
 
 /-- Benchmark target: reduce integer coefficients modulo `5`. -/
-def runModPChecksum (input : BridgeInput) : UInt64 :=
+def runModPChecksum (input : ConversionInput) : UInt64 :=
   checksumFpPoly <| ZPoly.modP 5 input.zpoly
 
 /-- Benchmark target: lift `F_5` coefficients to canonical integer representatives. -/
-def runLiftToZChecksum (input : BridgeInput) : UInt64 :=
+def runLiftToZChecksum (input : ConversionInput) : UInt64 :=
   checksumZPoly <| FpPoly.liftToZ input.fpoly
 
 /-- Benchmark target: reduce integer coefficients modulo `5^3`. -/
-def runReduceModPowChecksum (input : BridgeInput) : UInt64 :=
+def runReduceModPowChecksum (input : ConversionInput) : UInt64 :=
   checksumZPoly <| ZPoly.reduceModPow input.zpoly 5 3
 
 /-- Benchmark target: one linear Hensel correction step. -/
@@ -540,7 +540,7 @@ Coefficient reduction maps each of the `n` dense integer coefficients once and
 then normalizes the result, so the conversion operation has linear cost.
 -/
 setup_benchmark runModPChecksum n => n
-  with prep := prepBridgeInput
+  with prep := prepConversionInput
   where {
     paramFloor := 8192
     paramCeiling := 131072
@@ -555,7 +555,7 @@ Canonical lifting maps each of the `n` finite-field coefficients to its
 integer representative and normalizes the dense result, giving linear cost.
 -/
 setup_benchmark runLiftToZChecksum n => n
-  with prep := prepBridgeInput
+  with prep := prepConversionInput
   where {
     paramFloor := 8192
     paramCeiling := 131072
@@ -570,7 +570,7 @@ Reduction modulo a fixed power `5^3` performs one bounded integer reduction per
 dense coefficient followed by normalization, so the model is linear in `n`.
 -/
 setup_benchmark runReduceModPowChecksum n => n
-  with prep := prepBridgeInput
+  with prep := prepConversionInput
   where {
     paramFloor := 8192
     paramCeiling := 131072

--- a/progress/20260728T042038Z_issue-9023-naming-audit.md
+++ b/progress/20260728T042038Z_issue-9023-naming-audit.md
@@ -6,15 +6,17 @@
 - Replaced process-oriented `core`, `bridge`, `pilot`, `contract`, `arm`, `branch`, and slow/fast-path names with mathematical or operational names across arithmetic, Bareiss, Berlekamp–Zassenhaus, Gram–Schmidt, Hensel, polynomial, resultant, root-isolation, elaborator, and benchmark code.
 - Moved the Hensel factor hypotheses into the `HenselFactorData` namespace, removed two redundant coefficient aliases, and collapsed duplicate private-proof/public-wrapper theorem pairs.
 - Updated source, downstream proof uses, docstrings, and the boundary skill; verified that removed names have no remaining references outside historical progress and report files.
-- Passed `lake build`, `lake build HexManual`, `lake build hexhensel_bench`, and `git diff --check`.
+- Ran the requested independent Claude Opus review and addressed its findings: removed a duplicate Hensel theorem, corrected names that confused `toMonicPrimeData?` selection with mod-`p` factorization evidence, restored user-facing manual prose, made unnamed proof exercises into `example`s, and shortened the cited recombination, empty-representation, lattice, root-refinement, division, scaling, square-root, and Montgomery families.
+- Reviewed the remaining long-name scan. Retained names describe exact mathematical statements or hypotheses; in particular, BHKS `Core` is documented as the van Hoeij `M1` coordinate, and interval `contract` names denote mathematical contraction. The separately scoped `factorize_headline*` cluster remains intentionally untouched.
+- Re-ran and passed `lake build` (9508 jobs), `lake build HexManual` (9438 jobs), `lake build hexhensel_bench` (243 jobs), and `git diff --check` after the review changes.
 
 ## Current frontier
 
-The implementation and local verification are complete. The branch still needs the requested independent Claude Opus review before opening the pull request.
+The implementation, independent review, and local verification are complete. The branch is ready to push and open as a pull request.
 
 ## Next step
 
-Commit the audit, run the second-opinion review against `origin/main`, address any findings, then push, open the PR, and monitor mergeability and CI through merge.
+Commit the review fixes, push `issue-9023`, open the PR, and monitor mergeability and CI through merge.
 
 ## Blockers
 

--- a/progress/20260728T042038Z_issue-9023-naming-audit.md
+++ b/progress/20260728T042038Z_issue-9023-naming-audit.md
@@ -1,0 +1,21 @@
+# Issue 9023 declaration-name audit
+
+## Accomplished
+
+- Audited declaration identifiers for workflow and software-document vocabulary outside the separately scoped polynomial-factorization cleanup.
+- Replaced process-oriented `core`, `bridge`, `pilot`, `contract`, `arm`, `branch`, and slow/fast-path names with mathematical or operational names across arithmetic, Bareiss, Berlekamp–Zassenhaus, Gram–Schmidt, Hensel, polynomial, resultant, root-isolation, elaborator, and benchmark code.
+- Moved the Hensel factor hypotheses into the `HenselFactorData` namespace, removed two redundant coefficient aliases, and collapsed duplicate private-proof/public-wrapper theorem pairs.
+- Updated source, downstream proof uses, docstrings, and the boundary skill; verified that removed names have no remaining references outside historical progress and report files.
+- Passed `lake build`, `lake build HexManual`, `lake build hexhensel_bench`, and `git diff --check`.
+
+## Current frontier
+
+The implementation and local verification are complete. The branch still needs the requested independent Claude Opus review before opening the pull request.
+
+## Next step
+
+Commit the audit, run the second-opinion review against `origin/main`, address any findings, then push, open the PR, and monitor mergeability and CI through merge.
+
+## Blockers
+
+None.

--- a/progress/20260728T053736Z_issue-9023-ci-rebase.md
+++ b/progress/20260728T053736Z_issue-9023-ci-rebase.md
@@ -1,0 +1,21 @@
+# Issue 9023 CI rebase
+
+## Accomplished
+
+- Opened PR #9034 after the declaration-name audit, independent Claude Opus review, and local acceptance builds.
+- Monitored CI run 30330218823 to completion; the full build, conformance targets, bench smoke gate, and conformance/Berlekamp–Zassenhaus oracle gates all passed.
+- Fetched the advanced `origin/main`, detected the `HexPolyZ/Mignotte.lean` conflict before merge, and rebased `issue-9023` over the 11 intervening commits.
+- Resolved the conflict with the reviewed mathematical theorem name `sqrtAux_two_pow_gap_le_of_not_le` and confirmed that both audit commits replayed cleanly.
+- Re-ran `lake build HexPolyZ` (78 jobs), `lake build` (9510 jobs), `lake build HexManual` (9464 jobs), `lake build hexhensel_bench` (243 jobs), and `git diff --check` successfully on the rebased branch.
+
+## Current frontier
+
+The rebased branch is locally verified and ready for a force-with-lease push. The PR will need its refreshed CI run to pass before merge.
+
+## Next step
+
+Push the rebased branch, monitor the refreshed PR CI, confirm mergeability, and run the requested squash auto-merge command without deleting the branch.
+
+## Blockers
+
+None.

--- a/progress/20260728T053736Z_issue-9023-ci-rebase.md
+++ b/progress/20260728T053736Z_issue-9023-ci-rebase.md
@@ -7,14 +7,18 @@
 - Fetched the advanced `origin/main`, detected the `HexPolyZ/Mignotte.lean` conflict before merge, and rebased `issue-9023` over the 11 intervening commits.
 - Resolved the conflict with the reviewed mathematical theorem name `sqrtAux_two_pow_gap_le_of_not_le` and confirmed that both audit commits replayed cleanly.
 - Re-ran `lake build HexPolyZ` (78 jobs), `lake build` (9510 jobs), `lake build HexManual` (9464 jobs), `lake build hexhensel_bench` (243 jobs), and `git diff --check` successfully on the rebased branch.
+- Monitored refreshed CI run 30332218930 to a fully green result, then detected a second conflict after another 105 commits landed on `main` and rebased again.
+- Resolved the `HexResultant/Basic.lean` overlap by keeping `main`'s newer general `pseudoDivMod_remainder_lt` theorem, retaining the audited `pseudoDivMod_reconstruct` name, and not reintroducing the redundant specialized remainder theorem.
+- Updated the newly landed `HexPolyMathlib/Euclid.lean` consumers to the audited `*_of_cancel`, `*_of_scale`, and suffix-free names.
+- Re-ran `lake build HexResultant` (16 jobs), `lake build HexPolyMathlib.Euclid` (1481 jobs), `lake build` (9553 jobs), `lake build HexManual` (9517 jobs), `lake build hexhensel_bench` (243 jobs), and `git diff --check` successfully after the second rebase.
 
 ## Current frontier
 
-The rebased branch is locally verified and ready for a force-with-lease push. The PR will need its refreshed CI run to pass before merge.
+The twice-rebased branch is locally verified and ready for a force-with-lease push. The PR will need its replacement CI run to pass before merge.
 
 ## Next step
 
-Push the rebased branch, monitor the refreshed PR CI, confirm mergeability, and run the requested squash auto-merge command without deleting the branch.
+Push the rebased branch, monitor replacement PR CI, confirm mergeability against the then-current `main`, and run the requested squash auto-merge command without deleting the branch.
 
 ## Blockers
 


### PR DESCRIPTION
## Summary

- audit public and internal declaration names across Hex and replace workflow/software-document vocabulary with mathematical or operational names
- shorten sibling theorem families, move Hensel constructors into the HenselFactorData namespace, and remove redundant aliases and duplicate proof wrappers
- update downstream source, tests, SPEC/manual-facing prose, benchmark fixtures, and the boundary skill

## Audit decisions

- the polynomial factorization factorize_headline cluster is intentionally excluded, as specified in #9023, because its factorize_normalized cleanup is separate
- retained uses of core identify mathematical objects such as square-free cores or the documented van Hoeij M1 core coordinate
- retained interval contract identifiers denote mathematical interval contraction
- theorem statements and executable behavior are unchanged

## Independent review

Claude Opus reviewed the implementation before this PR. Its findings were addressed by removing a duplicate Hensel theorem, correcting names that confused prime-selection witnesses with mod-p factorization evidence, restoring user-facing theorem documentation, anonymizing proof-only exercises, and shortening the cited long theorem families.

## Verification

- lake build (9509 jobs)
- lake build HexManual (9476 jobs)
- lake build hexhensel_bench (243 jobs)
- git diff --check

Closes #9023