### PR TITLE
Freeze interval proof payloads transactionally

### DIFF
--- a/HexInterval/Experiment/DyadicRules.lean
+++ b/HexInterval/Experiment/DyadicRules.lean
@@ -210,8 +210,8 @@ a second central recipe tag alongside `PayloadArena.Entry.origin`.
 -/
 
 def factLabel : PayloadId := { index := 0 }
-def instanceLabel : PayloadId := { index := 0 }
-def equalityLabel : PayloadId := { index := 1 }
+def instanceLabel : PayloadId := { index := 1 }
+def equalityLabel : PayloadId := { index := 2 }
 
 def emptyDraft (label : PayloadId) (role : PayloadArena.Role) :
     PayloadArena.Draft :=
@@ -439,6 +439,9 @@ def centeredProposal? (request : RuleRequest Fact)
            payload := equalityLabel }]
       payload := instanceLabel }
 
+/-- Propose the package-owned identity
+`x * (1 - x) = 1/4 - (x - 1/2)^2`. Its instantiation and equality evidence
+use distinct reply-local labels and schema-zero replay formats. -/
 def invokeCenteredInstantiate (request : RuleRequest Fact) : Plan Fact :=
   match centeredBinding? request >>= centeredProposal? request with
   | none => withoutPayloads .inapplicable
@@ -486,7 +489,7 @@ def centeredPackage (config : Config) (real : DomainId) : Package Fact :=
     requiredOperations := centeredRequirements real
     handlers :=
       #[Handler.statelessPlanned centeredForward (invokeCenteredForward config),
-        Handler.stateless centeredSplit invokeCenteredSplit,
+        Handler.statelessDroppingDrafts centeredSplit invokeCenteredSplit,
         Handler.statelessPlanned centeredInstantiate invokeCenteredInstantiate]
     acceptsLimits := fun _ limits =>
       4 ≤ limits.maxObservationValue &&

--- a/HexInterval/Experiment/DyadicRules.lean
+++ b/HexInterval/Experiment/DyadicRules.lean
@@ -201,28 +201,25 @@ structure Config where
   reciprocalBasePrecision : Precision
   maxReciprocalEffort : Nat
 
-/-! ## Stable replay payload keys
+/-! ## Reply-local proof payloads
 
-These identifiers name rule-specific proof recipes; effort is already retained
-in the engine-owned action and therefore is not encoded into a payload number.
+Labels distinguish uses only within one callback reply.  Version-zero recipes
+have empty bodies: after freezing, replay dispatch is determined by the
+engine-owned origin rule, semantic role, and schema.  This deliberately avoids
+a second central recipe tag alongside `PayloadArena.Entry.origin`.
 -/
 
-def onePayload : PayloadId := { index := 1 }
-def negForwardPayload : PayloadId := { index := 10 }
-def negBackwardPayload : PayloadId := { index := 11 }
-def subForwardPayload : PayloadId := { index := 20 }
-def subLeftPayload : PayloadId := { index := 21 }
-def subRightPayload : PayloadId := { index := 22 }
-def mulForwardPayload : PayloadId := { index := 30 }
-def mulLeftPayload : PayloadId := { index := 31 }
-def mulRightPayload : PayloadId := { index := 32 }
-def squareForwardPayload : PayloadId := { index := 40 }
-def reciprocalForwardPayload : PayloadId := { index := 50 }
-def reciprocalBackwardPayload : PayloadId := { index := 60 }
-def centeredForwardPayload : PayloadId := { index := 70 }
-def centeredInstancePayload : PayloadId := { index := 80 }
-/-- Replay obligation: `x * (1 - x) = 1/4 - (x - 1/2)^2`. -/
-def centeredEqualityPayload : PayloadId := { index := 81 }
+def factLabel : PayloadId := { index := 0 }
+def instanceLabel : PayloadId := { index := 0 }
+def equalityLabel : PayloadId := { index := 1 }
+
+def emptyDraft (label : PayloadId) (role : PayloadArena.Role) :
+    PayloadArena.Draft :=
+  { label, role, schema := 0, body := [] }
+
+def withoutPayloads (outcome : Outcome Fact) : Plan Fact :=
+  { outcome, drafts := [] }
+
 def centeredFamilyKey : Nat := 1
 
 def Config.precisionAt (config : Config) (effort : Nat) : Precision :=
@@ -243,13 +240,16 @@ def Config.reciprocalPrecisionsAllowed (config : Config) : Bool :=
 def successCost (arithmeticWork proofNodes : Nat) : CostObservation :=
   { arithmeticWork, estimatedProofNodes := proofNodes }
 
-def outcomeOfResult (target : NodeId) (payload : PayloadId) (work proofNodes : Nat)
-    (suggestions : List Suggestion) : DyadicInterval.Result -> Outcome Fact
+def planOfResult (target : NodeId) (work proofNodes : Nat)
+    (suggestions : List Suggestion) : DyadicInterval.Result -> Plan Fact
   | .ready fact =>
-      .success [{ node := target, fact, payload }]
-        suggestions (successCost work proofNodes)
-  | .inapplicable => .inapplicable
-  | .resourceLimit cost => .resourceLimit (DyadicInterval.workCode cost)
+      { outcome :=
+          .success [{ node := target, fact, payload := factLabel }]
+            suggestions (successCost work proofNodes)
+        drafts := [emptyDraft factLabel .fact] }
+  | .inapplicable => withoutPayloads .inapplicable
+  | .resourceLimit cost =>
+      withoutPayloads (.resourceLimit (DyadicInterval.workCode cost))
 
 def bindResult (result : DyadicInterval.Result)
     (next : Fact -> DyadicInterval.Result) : DyadicInterval.Result :=
@@ -280,101 +280,101 @@ def retrySuggestion (config : Config) (action : Action) : List Suggestion :=
 
 /-! ## Arithmetic callbacks -/
 
-def invokeOneForward (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
+def invokeOneForward (config : Config) (request : RuleRequest Fact) : Plan Fact :=
   match request.inputs, request.writes with
   | [], [target] =>
-      outcomeOfResult target onePayload 1 1 []
+      planOfResult target 1 1 []
         (DyadicInterval.closed config.endpointLimit 1 1)
-  | _, _ => .failed 1
+  | _, _ => withoutPayloads (.failed 1)
 
-def invokeNegForward (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
+def invokeNegForward (config : Config) (request : RuleRequest Fact) : Plan Fact :=
   match request.inputs, request.writes with
   | [input], [target] =>
-      outcomeOfResult target negForwardPayload 1 1 []
+      planOfResult target 1 1 []
         (DyadicInterval.neg config.endpointLimit input.fact)
-  | _, _ => .failed 10
+  | _, _ => withoutPayloads (.failed 10)
 
-def invokeNegBackward (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
+def invokeNegBackward (config : Config) (request : RuleRequest Fact) : Plan Fact :=
   match request.inputs, request.writes with
   | [output], [target] =>
-      outcomeOfResult target negBackwardPayload 1 1 []
+      planOfResult target 1 1 []
         (DyadicInterval.neg config.endpointLimit output.fact)
-  | _, _ => .failed 11
+  | _, _ => withoutPayloads (.failed 11)
 
-def invokeSubForward (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
+def invokeSubForward (config : Config) (request : RuleRequest Fact) : Plan Fact :=
   match request.inputs, request.writes with
   | [left, right], [target] =>
-      outcomeOfResult target subForwardPayload 1 1 []
+      planOfResult target 1 1 []
         (DyadicInterval.sub config.endpointLimit left.fact right.fact)
-  | _, _ => .failed 20
+  | _, _ => withoutPayloads (.failed 20)
 
-def invokeSubLeft (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
+def invokeSubLeft (config : Config) (request : RuleRequest Fact) : Plan Fact :=
   match request.inputs, request.writes with
   | [output, right], [target] =>
-      outcomeOfResult target subLeftPayload 2 2 []
+      planOfResult target 2 2 []
         (addViaSub config.endpointLimit output.fact right.fact)
-  | _, _ => .failed 21
+  | _, _ => withoutPayloads (.failed 21)
 
-def invokeSubRight (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
+def invokeSubRight (config : Config) (request : RuleRequest Fact) : Plan Fact :=
   match request.inputs, request.writes with
   | [left, output], [target] =>
-      outcomeOfResult target subRightPayload 1 1 []
+      planOfResult target 1 1 []
         (DyadicInterval.sub config.endpointLimit left.fact output.fact)
-  | _, _ => .failed 22
+  | _, _ => withoutPayloads (.failed 22)
 
-def invokeMulForward (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
+def invokeMulForward (config : Config) (request : RuleRequest Fact) : Plan Fact :=
   match request.inputs, request.writes with
   | [left, right], [target] =>
-      outcomeOfResult target mulForwardPayload 1 1 []
+      planOfResult target 1 1 []
         (DyadicInterval.mul config.endpointLimit left.fact right.fact)
-  | _, _ => .failed 30
+  | _, _ => withoutPayloads (.failed 30)
 
-def invokeMulLeft (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
+def invokeMulLeft (config : Config) (request : RuleRequest Fact) : Plan Fact :=
   match request.inputs, request.writes with
   | [output, right], [target] =>
       match singleton? right.fact with
-      | none => .inapplicable
+      | none => withoutPayloads .inapplicable
       | some scalar =>
-          outcomeOfResult target mulLeftPayload 1 1 []
+          planOfResult target 1 1 []
             (DyadicInterval.unscaleExact config.endpointLimit scalar output.fact)
-  | _, _ => .failed 31
+  | _, _ => withoutPayloads (.failed 31)
 
-def invokeMulRight (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
+def invokeMulRight (config : Config) (request : RuleRequest Fact) : Plan Fact :=
   match request.inputs, request.writes with
   | [output, left], [target] =>
       match singleton? left.fact with
-      | none => .inapplicable
+      | none => withoutPayloads .inapplicable
       | some scalar =>
-          outcomeOfResult target mulRightPayload 1 1 []
+          planOfResult target 1 1 []
             (DyadicInterval.unscaleExact config.endpointLimit scalar output.fact)
-  | _, _ => .failed 32
+  | _, _ => withoutPayloads (.failed 32)
 
-def invokeSquareForward (config : Config) (request : RuleRequest Fact) : Outcome Fact :=
+def invokeSquareForward (config : Config) (request : RuleRequest Fact) : Plan Fact :=
   match request.inputs, request.writes with
   | [input], [target] =>
-      outcomeOfResult target squareForwardPayload 1 1 []
+      planOfResult target 1 1 []
         (DyadicInterval.square config.endpointLimit input.fact)
-  | _, _ => .failed 40
+  | _, _ => withoutPayloads (.failed 40)
 
 def invokeReciprocalForward (config : Config)
-    (request : RuleRequest Fact) : Outcome Fact :=
+    (request : RuleRequest Fact) : Plan Fact :=
   match request.inputs, request.writes with
   | [input], [target] =>
-      outcomeOfResult target reciprocalForwardPayload 1 1
+      planOfResult target 1 1
         (retrySuggestion config request.action)
         (DyadicInterval.reciprocal config.endpointLimit
           (config.precisionAt request.action.effort) input.fact)
-  | _, _ => .failed 50
+  | _, _ => withoutPayloads (.failed 50)
 
 def invokeReciprocalBackward (config : Config)
-    (request : RuleRequest Fact) : Outcome Fact :=
+    (request : RuleRequest Fact) : Plan Fact :=
   match request.inputs, request.writes with
   | [output], [target] =>
-      outcomeOfResult target reciprocalBackwardPayload 1 1
+      planOfResult target 1 1
         (retrySuggestion config request.action)
         (DyadicInterval.reciprocal config.endpointLimit
           (config.precisionAt request.action.effort) output.fact)
-  | _, _ => .failed 60
+  | _, _ => withoutPayloads (.failed 60)
 
 /-! ## Centered arbitrary function and shape-triggered instantiation -/
 
@@ -391,12 +391,12 @@ def centeredImage (limit : EndpointLimit) (input : Fact) : DyadicInterval.Result
           DyadicInterval.sub limit quarterFact squared
 
 def invokeCenteredForward (config : Config)
-    (request : RuleRequest Fact) : Outcome Fact :=
+    (request : RuleRequest Fact) : Plan Fact :=
   match request.inputs, request.writes with
   | [input], [target] =>
-      outcomeOfResult target centeredForwardPayload 4 4 []
+      planOfResult target 4 4 []
         (centeredImage config.endpointLimit input.fact)
-  | _, _ => .failed 70
+  | _, _ => withoutPayloads (.failed 70)
 
 def invokeCenteredSplit (request : RuleRequest Fact) : Outcome Fact :=
   match request.inputs, request.writes with
@@ -436,16 +436,20 @@ def centeredProposal? (request : RuleRequest Fact)
       equalities :=
         [{ left := .existing binding.anchor
            right := .proposed 0
-           payload := centeredEqualityPayload }]
-      payload := centeredInstancePayload }
+           payload := equalityLabel }]
+      payload := instanceLabel }
 
-def invokeCenteredInstantiate (request : RuleRequest Fact) : Outcome Fact :=
+def invokeCenteredInstantiate (request : RuleRequest Fact) : Plan Fact :=
   match centeredBinding? request >>= centeredProposal? request with
-  | none => .inapplicable
+  | none => withoutPayloads .inapplicable
   | some proposal =>
-      .success [] [.instantiate proposal]
-        { visitedEntries := request.program.operations.size + request.program.nodes.size
-          estimatedProofNodes := 1 }
+      { outcome :=
+          .success [] [.instantiate proposal]
+            { visitedEntries := request.program.operations.size + request.program.nodes.size
+              estimatedProofNodes := 1 }
+        drafts :=
+          [emptyDraft instanceLabel .instance,
+            emptyDraft equalityLabel .equality] }
 
 /-! ## Independently composable function packages -/
 
@@ -454,18 +458,18 @@ def arithmeticPackage (config : Config) (real : DomainId) : Package Fact :=
     cache := ()
     operations := arithmeticOperations real
     handlers :=
-      #[Handler.stateless oneForward (invokeOneForward config),
-        Handler.stateless negForward (invokeNegForward config),
-        Handler.stateless negBackward (invokeNegBackward config),
-        Handler.stateless subForward (invokeSubForward config),
-        Handler.stateless subLeft (invokeSubLeft config),
-        Handler.stateless subRight (invokeSubRight config),
-        Handler.stateless mulForward (invokeMulForward config),
-        Handler.stateless mulLeft (invokeMulLeft config),
-        Handler.stateless mulRight (invokeMulRight config),
-        Handler.stateless squareForward (invokeSquareForward config),
-        Handler.stateless reciprocalForward (invokeReciprocalForward config),
-        Handler.stateless reciprocalBackward (invokeReciprocalBackward config)]
+      #[Handler.statelessPlanned oneForward (invokeOneForward config),
+        Handler.statelessPlanned negForward (invokeNegForward config),
+        Handler.statelessPlanned negBackward (invokeNegBackward config),
+        Handler.statelessPlanned subForward (invokeSubForward config),
+        Handler.statelessPlanned subLeft (invokeSubLeft config),
+        Handler.statelessPlanned subRight (invokeSubRight config),
+        Handler.statelessPlanned mulForward (invokeMulForward config),
+        Handler.statelessPlanned mulLeft (invokeMulLeft config),
+        Handler.statelessPlanned mulRight (invokeMulRight config),
+        Handler.statelessPlanned squareForward (invokeSquareForward config),
+        Handler.statelessPlanned reciprocalForward (invokeReciprocalForward config),
+        Handler.statelessPlanned reciprocalBackward (invokeReciprocalBackward config)]
     acceptsLimits := fun _ limits =>
       config.maxReciprocalEffort ≤ limits.maxEffort &&
         config.reciprocalPrecisionsAllowed &&
@@ -481,9 +485,9 @@ def centeredPackage (config : Config) (real : DomainId) : Package Fact :=
     operations := centeredOperations real
     requiredOperations := centeredRequirements real
     handlers :=
-      #[Handler.stateless centeredForward (invokeCenteredForward config),
+      #[Handler.statelessPlanned centeredForward (invokeCenteredForward config),
         Handler.stateless centeredSplit invokeCenteredSplit,
-        Handler.stateless centeredInstantiate invokeCenteredInstantiate]
+        Handler.statelessPlanned centeredInstantiate invokeCenteredInstantiate]
     acceptsLimits := fun _ limits =>
       4 ≤ limits.maxObservationValue &&
         71 ≤ limits.maxDiagnosticValue &&

--- a/HexInterval/Experiment/PackageRegistry.lean
+++ b/HexInterval/Experiment/PackageRegistry.lean
@@ -25,8 +25,9 @@ operations, registrations, callbacks, routes, or start checks.  Package caches
 are performance state only: for the same request and logical budget, cache
 contents must not change the callback's observable outcome.  Semantic state
 instead needs an explicit versioned dependency and wakeup protocol.  Immutable
-proof-payload drafts travel beside the outcome; `PayloadSession` freezes them
-in a separate per-run arena before their identifiers enter engine provenance.
+proof-payload drafts travel beside the outcome; a session layer must freeze
+them in a separate per-run arena before their identifiers enter engine
+provenance.
 -/
 
 namespace Hex.Interval.Experiment.Propagator
@@ -42,8 +43,8 @@ abbrev Invoke (Fact Cache : Type) :=
   Cache -> RuleRequest Fact -> Plan Fact × Cache
 
 /-- Compatibility shape for a callback that produces no immutable evidence.
-Its positive outcomes are deliberately rejected by the payload session if they
-refer to any payload identifier. -/
+`PayloadArena.freeze` rejects any positive outcome from such a callback if it
+refers to a payload identifier. -/
 abbrev BareInvoke (Fact Cache : Type) :=
   Cache -> RuleRequest Fact -> Outcome Fact × Cache
 
@@ -54,23 +55,25 @@ structure Handler (Fact Cache : Type) where
 
 namespace Handler
 
-/-- Lift a callback with no payload drafts into the planned protocol. -/
-def bare (registration : Registration)
+/-- Lift a callback with no payload drafts into the planned protocol.
+The explicit name prevents proof-producing packages from choosing this
+evidence-discarding compatibility path by accident. -/
+def bareDroppingDrafts (registration : Registration)
     (invoke : BareInvoke Fact Cache) : Handler Fact Cache :=
   { registration
     invoke := fun cache request =>
       let (outcome, cache) := invoke cache request
       ({ outcome, drafts := [] }, cache) }
 
-/-- Lift a cache-independent callback into any package cache. -/
-def readOnly (registration : Registration)
+/-- Lift a cache-independent callback while producing no proof drafts. -/
+def readOnlyDroppingDrafts (registration : Registration)
     (invoke : RuleRequest Fact -> Outcome Fact) : Handler Fact Cache :=
-  bare registration fun cache request => (invoke request, cache)
+  bareDroppingDrafts registration fun cache request => (invoke request, cache)
 
-/-- A cache-independent handler for a package whose cache is `Unit`. -/
-def stateless (registration : Registration)
+/-- A cache-independent handler which produces no proof drafts. -/
+def statelessDroppingDrafts (registration : Registration)
     (invoke : RuleRequest Fact -> Outcome Fact) : Handler Fact Unit :=
-  readOnly registration invoke
+  readOnlyDroppingDrafts registration invoke
 
 /-- A cache-independent callback that returns complete reply-local evidence. -/
 def readOnlyPlanned (registration : Registration)
@@ -329,9 +332,10 @@ def invokePlanned (registry : Registry Fact) (request : RuleRequest Fact) :
                       { registry with
                         packages := registry.packages.set! route.package package })
 
-/-- Compatibility adapter for search experiments that do not yet retain proof
-payloads. Proof-producing runs use `invokePlanned` through `PayloadSession`. -/
-def invoke (registry : Registry Fact) (request : RuleRequest Fact) :
+/-- Explicitly evidence-discarding adapter for search experiments. A
+proof-producing session must use `invokePlanned` and freeze its drafts before
+submission. -/
+def invokeDroppingDrafts (registry : Registry Fact) (request : RuleRequest Fact) :
     Outcome Fact × Registry Fact :=
   let (plan, registry) := registry.invokePlanned request
   (plan.outcome, registry)

--- a/HexInterval/Experiment/PackageRegistry.lean
+++ b/HexInterval/Experiment/PackageRegistry.lean
@@ -6,7 +6,7 @@ Authors: Kim Morrison
 
 module
 
-public import HexInterval.Experiment.Propagator
+public import HexInterval.Experiment.PayloadArena
 
 @[expose] public section
 
@@ -25,14 +25,26 @@ operations, registrations, callbacks, routes, or start checks.  Package caches
 are performance state only: for the same request and logical budget, cache
 contents must not change the callback's observable outcome.  Semantic state
 instead needs an explicit versioned dependency and wakeup protocol.  Immutable
-proof payloads must eventually be frozen in a separate per-run arena before
-their identifiers enter engine provenance.
+proof-payload drafts travel beside the outcome; `PayloadSession` freezes them
+in a separate per-run arena before their identifiers enter engine provenance.
 -/
 
 namespace Hex.Interval.Experiment.Propagator
 
-/-- The callback shape shared by the FIFO and policy-controlled drivers. -/
+/-- One package-produced result before its reply-local proof labels are frozen
+into the run's immutable arena. -/
+structure Plan (Fact : Type) where
+  outcome : Outcome Fact
+  drafts : List PayloadArena.Draft
+
+/-- The callback shape shared by direct and session-owned drivers. -/
 abbrev Invoke (Fact Cache : Type) :=
+  Cache -> RuleRequest Fact -> Plan Fact × Cache
+
+/-- Compatibility shape for a callback that produces no immutable evidence.
+Its positive outcomes are deliberately rejected by the payload session if they
+refer to any payload identifier. -/
+abbrev BareInvoke (Fact Cache : Type) :=
   Cache -> RuleRequest Fact -> Outcome Fact × Cache
 
 /-- One registration and the only callback allowed to interpret its key. -/
@@ -42,16 +54,33 @@ structure Handler (Fact Cache : Type) where
 
 namespace Handler
 
+/-- Lift a callback with no payload drafts into the planned protocol. -/
+def bare (registration : Registration)
+    (invoke : BareInvoke Fact Cache) : Handler Fact Cache :=
+  { registration
+    invoke := fun cache request =>
+      let (outcome, cache) := invoke cache request
+      ({ outcome, drafts := [] }, cache) }
+
 /-- Lift a cache-independent callback into any package cache. -/
 def readOnly (registration : Registration)
     (invoke : RuleRequest Fact -> Outcome Fact) : Handler Fact Cache :=
-  { registration
-    invoke := fun cache request => (invoke request, cache) }
+  bare registration fun cache request => (invoke request, cache)
 
 /-- A cache-independent handler for a package whose cache is `Unit`. -/
 def stateless (registration : Registration)
     (invoke : RuleRequest Fact -> Outcome Fact) : Handler Fact Unit :=
   readOnly registration invoke
+
+/-- A cache-independent callback that returns complete reply-local evidence. -/
+def readOnlyPlanned (registration : Registration)
+    (invoke : RuleRequest Fact -> Plan Fact) : Handler Fact Cache :=
+  { registration, invoke := fun cache request => (invoke request, cache) }
+
+/-- A stateless callback that returns complete reply-local evidence. -/
+def statelessPlanned (registration : Registration)
+    (invoke : RuleRequest Fact -> Plan Fact) : Handler Fact Unit :=
+  readOnlyPlanned registration invoke
 
 end Handler
 
@@ -266,36 +295,46 @@ end Registration
 
 namespace Registry
 
-/-- Route one engine-owned rule identifier to its package callback.  Dispatch
-uses compact validated indices; it never branches on the semantic operation
-or rule key.  Only the selected package cache is replaced. -/
-def invoke (registry : Registry Fact) (request : RuleRequest Fact) :
-    Outcome Fact × Registry Fact :=
+/-- Route one engine-owned rule identifier to its package callback and retain
+its reply-local proof drafts. Dispatch uses compact validated indices; it never
+branches on the semantic operation or rule key. Only the selected package
+cache is replaced. -/
+def invokePlanned (registry : Registry Fact) (request : RuleRequest Fact) :
+    Plan Fact × Registry Fact :=
   match registry.routes[request.action.rule.index]? with
-  | none => (.failed DispatchCode.missingRoute, registry)
+  | none => ({ outcome := .failed DispatchCode.missingRoute, drafts := [] }, registry)
   | some route =>
       match registry.registrations[request.action.rule.index]? with
-      | none => (.failed DispatchCode.missingRegistration, registry)
+      | none =>
+          ({ outcome := .failed DispatchCode.missingRegistration, drafts := [] }, registry)
       | some registration =>
           match registry.packages[route.package]? with
-          | none => (.failed DispatchCode.missingPackage, registry)
+          | none => ({ outcome := .failed DispatchCode.missingPackage, drafts := [] }, registry)
           | some package =>
               match package.handlers[route.handler]? with
-              | none => (.failed DispatchCode.missingHandler, registry)
+              | none =>
+                  ({ outcome := .failed DispatchCode.missingHandler, drafts := [] }, registry)
               | some handler =>
                   if !registration.same handler.registration then
-                    (.failed DispatchCode.registryMismatch, registry)
+                    ({ outcome := .failed DispatchCode.registryMismatch, drafts := [] }, registry)
                   else if !handler.registration.accepts request then
-                    (.failed DispatchCode.requestMismatch, registry)
+                    ({ outcome := .failed DispatchCode.requestMismatch, drafts := [] }, registry)
                   else
-                    let (outcome, cache) := handler.invoke package.cache request
+                    let (plan, cache) := handler.invoke package.cache request
                     let package :=
                       { package with
                         cache := cache
                         invocations := package.invocations + 1 }
-                    (outcome,
+                    (plan,
                       { registry with
                         packages := registry.packages.set! route.package package })
+
+/-- Compatibility adapter for search experiments that do not yet retain proof
+payloads. Proof-producing runs use `invokePlanned` through `PayloadSession`. -/
+def invoke (registry : Registry Fact) (request : RuleRequest Fact) :
+    Outcome Fact × Registry Fact :=
+  let (plan, registry) := registry.invokePlanned request
+  (plan.outcome, registry)
 
 end Registry
 

--- a/HexInterval/Experiment/PackageRegistry.lean
+++ b/HexInterval/Experiment/PackageRegistry.lean
@@ -43,8 +43,10 @@ abbrev Invoke (Fact Cache : Type) :=
   Cache -> RuleRequest Fact -> Plan Fact × Cache
 
 /-- Compatibility shape for a callback that produces no immutable evidence.
-`PayloadArena.freeze` rejects any positive outcome from such a callback if it
-refers to a payload identifier. -/
+Every candidate carries a payload identifier, so a handler lifted through a
+dropping-drafts constructor cannot contribute candidates through a
+proof-producing session: `PayloadArena.freeze` requires a matching draft for
+every payload use, while this callback shape supplies none. -/
 abbrev BareInvoke (Fact Cache : Type) :=
   Cache -> RuleRequest Fact -> Outcome Fact × Cache
 

--- a/HexInterval/Experiment/PayloadArena.lean
+++ b/HexInterval/Experiment/PayloadArena.lean
@@ -1,0 +1,301 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexInterval.Experiment.Propagator
+
+@[expose] public section
+
+/-!
+# Immutable proof-payload arena experiment
+
+A propagator reply uses `PayloadId` values only as reply-local recipe labels.
+Before the reply may enter retained solver state, `freeze` checks a bounded
+list of immutable recipe drafts, appends them to an arena, and relocates every
+payload reference to its fresh arena index.
+
+The arena deliberately stores only replay data and engine-owned provenance.
+It cannot contain a propagator cache, a callback, or any other mutable
+performance state.  Every failure returns the original arena, so callers may
+discard a prospective freeze transaction without rollback.
+-/
+
+namespace Hex.Interval.Experiment.PayloadArena
+
+open Propagator
+
+/-- The semantic consumer of one frozen recipe. -/
+inductive Role where
+  | fact
+  | instance
+  | equality
+  deriving DecidableEq, Repr
+
+/-- One package-produced recipe.  `label` is local to this reply. -/
+structure Draft where
+  label : PayloadId
+  role : Role
+  body : List Nat
+  deriving Repr
+
+/-- One immutable replay entry.  The rule owner is copied from the originating
+action rather than trusted as a second package-supplied identity. -/
+structure Entry where
+  owner : RuleKey
+  origin : Action
+  role : Role
+  body : List Nat
+  deriving Repr
+
+/-- Append-only replay storage.  `bodyCells` is maintained by `freeze`, making
+the aggregate body bound independent of later arena size. -/
+structure Arena where
+  entries : Array Entry
+  bodyCells : Nat
+  deriving Repr
+
+namespace Arena
+
+/-- The initial empty replay arena. -/
+def empty : Arena :=
+  { entries := #[], bodyCells := 0 }
+
+/-- Exact optional lookup of a frozen recipe. -/
+def entry? (arena : Arena) (payload : PayloadId) : Option Entry :=
+  arena.entries[payload.index]?
+
+end Arena
+
+/-- Trusted bounds for the prospective whole arena. -/
+structure Limits where
+  maxEntries : Nat
+  maxBodyCells : Nat
+  maxAtom : Nat
+  maxUses : Nat
+  deriving DecidableEq, Repr
+
+/-- A malformed package recipe set. -/
+inductive Invalid where
+  | duplicateDraft (label : PayloadId)
+  | danglingReference (label : PayloadId)
+  | wrongRole (label : PayloadId) (expected actual : Role)
+  | extraDraft (label : PayloadId)
+  deriving DecidableEq, Repr
+
+/-- A trusted arena limit exhausted before allocation. -/
+inductive Resource where
+  | entries
+  | bodyCells
+  | atom
+  | uses
+  deriving DecidableEq, Repr
+
+/-- Pure result of freezing one outcome.  Failure carries the unchanged arena
+to make the transaction boundary executable and testable. -/
+inductive Result (Fact : Type) where
+  | ready (arena : Arena) (outcome : Outcome Fact)
+  | invalid (error : Invalid) (arena : Arena)
+  | resourceLimit (resource : Resource) (arena : Arena)
+
+structure Use where
+  label : PayloadId
+  role : Role
+
+def equalityUses (equality : ProposedEquality) : List Use :=
+  [{ label := equality.payload, role := .equality }]
+
+def requestUses (request : InstantiationRequest) : List Use :=
+  { label := request.payload, role := .instance } ::
+    request.equalities.flatMap equalityUses
+
+def suggestionUses : Suggestion -> List Use
+  | .retry _ | .split _ => []
+  | .instantiate request => requestUses request
+
+def outcomeUses : Outcome Fact -> List Use
+  | .success candidates suggestions _ =>
+      candidates.map (fun candidate => { label := candidate.payload, role := .fact }) ++
+        suggestions.flatMap suggestionUses
+  | .noChange _ | .inapplicable | .resourceLimit _ | .failed _ => []
+
+/-- Bound payload-bearing output structure before `outcomeUses` allocates its
+flat list. Repeated references are work even when they share one draft. -/
+def consumeCandidates : Nat -> List (Candidate Fact) -> Except Resource Nat
+  | remaining, [] => pure remaining
+  | 0, _ :: _ => throw .uses
+  | remaining + 1, _ :: candidates =>
+      consumeCandidates remaining candidates
+
+def consumeEqualities : Nat -> List ProposedEquality -> Except Resource Nat
+  | remaining, [] => pure remaining
+  | 0, _ :: _ => throw .uses
+  | remaining + 1, _ :: equalities =>
+      consumeEqualities remaining equalities
+
+def consumeSuggestions : Nat -> List Suggestion -> Except Resource Nat
+  | remaining, [] => pure remaining
+  | remaining, .retry _ :: suggestions
+  | remaining, .split _ :: suggestions =>
+      consumeSuggestions remaining suggestions
+  | 0, .instantiate _ :: _ => throw .uses
+  | remaining + 1, .instantiate request :: suggestions => do
+      let remaining ← consumeEqualities remaining request.equalities
+      consumeSuggestions remaining suggestions
+
+def preflightUses (limit : Nat) : Outcome Fact -> Except Resource Unit
+  | .success candidates suggestions _ => do
+      let remaining ← consumeCandidates limit candidates
+      let _ ← consumeSuggestions remaining suggestions
+      pure ()
+  | .noChange _ | .inapplicable | .resourceLimit _ | .failed _ => pure ()
+
+def duplicateDraft? : List Draft -> Option PayloadId
+  | [] => none
+  | draft :: drafts =>
+      if drafts.any (fun other => other.label == draft.label) then some draft.label
+      else duplicateDraft? drafts
+
+def findDraft? (label : PayloadId) (drafts : List Draft) : Option Draft :=
+  drafts.find? fun draft => draft.label == label
+
+def checkUses (drafts : List Draft) : List Use -> Option Invalid
+  | [] => none
+  | use :: uses =>
+      match findDraft? use.label drafts with
+      | none => some (.danglingReference use.label)
+      | some draft =>
+          if draft.role != use.role then
+            some (.wrongRole use.label use.role draft.role)
+          else
+            checkUses drafts uses
+
+def checkCoverage (uses : List Use) : List Draft -> Option Invalid
+  | [] => none
+  | draft :: drafts =>
+      if uses.any (fun use => use.label == draft.label) then checkCoverage uses drafts
+      else some (.extraDraft draft.label)
+
+def validate (uses : List Use) (drafts : List Draft) : Option Invalid :=
+  match duplicateDraft? drafts with
+  | some label => some (.duplicateDraft label)
+  | none =>
+      match checkUses drafts uses with
+      | some error => some error
+      | none => checkCoverage uses drafts
+
+/-- Consume a body-cell budget while checking every encoded recipe atom. -/
+def consumeBody (maxAtom : Nat) : Nat -> List Nat -> Except Resource Nat
+  | remaining, [] => pure remaining
+  | 0, _ :: _ => throw .bodyCells
+  | remaining + 1, atom :: atoms =>
+      if maxAtom < atom then throw .atom
+      else consumeBody maxAtom remaining atoms
+
+def consumeDrafts (maxAtom : Nat) :
+    Nat -> List Draft -> Except Resource Nat
+  | remaining, [] => pure remaining
+  | remaining, draft :: drafts => do
+      let remaining ← consumeBody maxAtom remaining draft.body
+      consumeDrafts maxAtom remaining drafts
+
+/-- Check aggregate entry and cell limits before constructing any new entry. -/
+def preflight (limits : Limits) (arena : Arena) (drafts : List Draft) :
+    Except Resource Nat := do
+  if limits.maxEntries < arena.entries.size then
+    throw .entries
+  let entryRoom := limits.maxEntries - arena.entries.size
+  if !listWithin entryRoom drafts then
+    throw .entries
+  if limits.maxBodyCells < arena.bodyCells then
+    throw .bodyCells
+  let cellRoom := limits.maxBodyCells - arena.bodyCells
+  let remaining ← consumeDrafts limits.maxAtom cellRoom drafts
+  pure (cellRoom - remaining)
+
+structure Relocation where
+  source : PayloadId
+  global : PayloadId
+
+def relocationsFrom : Nat -> List Draft -> List Relocation
+  | _, [] => []
+  | next, draft :: drafts =>
+      { source := draft.label, global := { index := next } } ::
+        relocationsFrom (next + 1) drafts
+
+def relocateId (relocations : List Relocation) (source : PayloadId) :
+    Except Invalid PayloadId :=
+  match relocations.find? (fun relocation => relocation.source == source) with
+  | some relocation => pure relocation.global
+  | none => throw (.danglingReference source)
+
+def relocateCandidate (relocations : List Relocation)
+    (candidate : Candidate Fact) : Except Invalid (Candidate Fact) := do
+  let payload ← relocateId relocations candidate.payload
+  pure { candidate with payload }
+
+def relocateEquality (relocations : List Relocation)
+    (equality : ProposedEquality) : Except Invalid ProposedEquality := do
+  let payload ← relocateId relocations equality.payload
+  pure { equality with payload }
+
+def relocateRequest (relocations : List Relocation)
+    (request : InstantiationRequest) : Except Invalid InstantiationRequest := do
+  let payload ← relocateId relocations request.payload
+  let equalities ← request.equalities.mapM (relocateEquality relocations)
+  pure { request with payload, equalities }
+
+def relocateSuggestion (relocations : List Relocation) :
+    Suggestion -> Except Invalid Suggestion
+  | .retry effort => pure (.retry effort)
+  | .split request => pure (.split request)
+  | .instantiate request => return .instantiate (← relocateRequest relocations request)
+
+def relocateOutcome (relocations : List Relocation) :
+    Outcome Fact -> Except Invalid (Outcome Fact)
+  | .success candidates suggestions cost => do
+      let candidates ← candidates.mapM (relocateCandidate relocations)
+      let suggestions ← suggestions.mapM (relocateSuggestion relocations)
+      pure (.success candidates suggestions cost)
+  | .noChange cost => pure (.noChange cost)
+  | .inapplicable => pure .inapplicable
+  | .resourceLimit budget => pure (.resourceLimit budget)
+  | .failed code => pure (.failed code)
+
+def appendEntries (arena : Arena) (origin : Action)
+    (drafts : List Draft) (addedCells : Nat) : Arena :=
+  { entries := drafts.foldl
+      (fun entries draft => entries.push
+        { owner := origin.key
+          origin
+          role := draft.role
+          body := draft.body })
+      arena.entries
+    bodyCells := arena.bodyCells + addedCells }
+
+/-- Validate and freeze every reply-local payload reference in an outcome.
+
+This function does not mutate the supplied arena.  A caller should retain the
+returned arena only if the surrounding reply transaction also commits. -/
+def freeze (limits : Limits) (arena : Arena) (origin : Action)
+    (outcome : Outcome Fact) (drafts : List Draft) : Result Fact :=
+  match preflightUses limits.maxUses outcome with
+  | .error resource => .resourceLimit resource arena
+  | .ok _ =>
+      let uses := outcomeUses outcome
+      match preflight limits arena drafts with
+      | .error resource => .resourceLimit resource arena
+      | .ok addedCells =>
+          match validate uses drafts with
+          | some error => .invalid error arena
+          | none =>
+              let relocations := relocationsFrom arena.entries.size drafts
+              match relocateOutcome relocations outcome with
+              | .error error => .invalid error arena
+              | .ok outcome =>
+                  .ready (appendEntries arena origin drafts addedCells) outcome
+
+end Hex.Interval.Experiment.PayloadArena

--- a/HexInterval/Experiment/PayloadArena.lean
+++ b/HexInterval/Experiment/PayloadArena.lean
@@ -78,6 +78,13 @@ def entry? (arena : Arena) (payload : PayloadId) (expected : Role) : Option Entr
   let entry ← arena.rawEntry? payload
   if entry.role == expected then some entry else none
 
+/-- Check the cached aggregate used by the body-cell resource bound.  Session
+ownership will eventually make malformed arenas unconstructible; the
+standalone experiment keeps this executable structural check in the meantime. -/
+def wellFormed (arena : Arena) : Bool :=
+  arena.bodyCells ==
+    arena.entries.foldl (fun total entry => total + entry.body.length) 0
+
 end Arena
 
 /-- Trusted bounds for the prospective whole arena. -/
@@ -117,22 +124,60 @@ structure Use where
   label : PayloadId
   role : Role
 
-def equalityUses (equality : ProposedEquality) : List Use :=
-  [{ label := equality.payload, role := .equality }]
+/-- Traverse every payload-bearing position in one candidate.  The explicit
+constructor is intentional: adding another payload field makes this code fail
+to compile instead of silently leaving that field unchecked. -/
+def traverseCandidate [Monad m] (visit : Role -> PayloadId -> m PayloadId)
+    (candidate : Candidate Fact) : m (Candidate Fact) := do
+  let payload ← visit .fact candidate.payload
+  pure { node := candidate.node, fact := candidate.fact, payload }
 
-def requestUses (request : InstantiationRequest) : List Use :=
-  { label := request.payload, role := .instance } ::
-    request.equalities.flatMap equalityUses
+def traverseEquality [Monad m] (visit : Role -> PayloadId -> m PayloadId)
+    (equality : ProposedEquality) : m ProposedEquality := do
+  let payload ← visit .equality equality.payload
+  pure { left := equality.left, right := equality.right, payload }
 
-def suggestionUses : Suggestion -> List Use
-  | .retry _ | .split _ => []
-  | .instantiate request => requestUses request
+def traverseRequest [Monad m] (visit : Role -> PayloadId -> m PayloadId)
+    (request : InstantiationRequest) : m InstantiationRequest := do
+  let payload ← visit .instance request.payload
+  let equalities ← request.equalities.mapM (traverseEquality visit)
+  pure
+    { key := request.key
+      triggers := request.triggers
+      claimedGeneration := request.claimedGeneration
+      nodes := request.nodes
+      equalities
+      payload }
 
-def outcomeUses : Outcome Fact -> List Use
-  | .success candidates suggestions _ =>
-      candidates.map (fun candidate => { label := candidate.payload, role := .fact }) ++
-        suggestions.flatMap suggestionUses
-  | .noChange _ | .inapplicable | .resourceLimit _ | .failed _ => []
+def traverseSuggestion [Monad m] (visit : Role -> PayloadId -> m PayloadId) :
+    Suggestion -> m Suggestion
+  | .retry effort => pure (.retry effort)
+  | .instantiate request => return .instantiate (← traverseRequest visit request)
+  | .split request =>
+      pure (.split
+        { node := request.node, point := request.point, reason := request.reason })
+
+/-- The single structural traversal for collecting and relocating payloads.
+Explicit reconstruction makes additions to existing payload-bearing records a
+compile-time obligation here. -/
+def traverseOutcome [Monad m] (visit : Role -> PayloadId -> m PayloadId) :
+    Outcome Fact -> m (Outcome Fact)
+  | .success candidates suggestions cost => do
+      let candidates ← candidates.mapM (traverseCandidate visit)
+      let suggestions ← suggestions.mapM (traverseSuggestion visit)
+      pure (.success candidates suggestions cost)
+  | .noChange cost => pure (.noChange cost)
+  | .inapplicable => pure .inapplicable
+  | .resourceLimit budget => pure (.resourceLimit budget)
+  | .failed code => pure (.failed code)
+
+def recordUse (role : Role) (label : PayloadId) :
+    StateM (List Use) PayloadId :=
+  fun uses => (label, { label, role } :: uses)
+
+def outcomeUses (outcome : Outcome Fact) : List Use :=
+  let (_, reversed) := traverseOutcome recordUse outcome []
+  reversed.reverse
 
 /-- Bound the complete top-level proposal structure before `outcomeUses`
 allocates its flat payload-use list.  Repeated references are work even when
@@ -224,10 +269,10 @@ def preflight (limits : Limits) (arena : Arena) (drafts : List Draft) :
   if limits.maxEntries < arena.entries.size then
     throw .entries
   let entryRoom := limits.maxEntries - arena.entries.size
-  if !listWithin entryRoom drafts then
-    throw .entries
   if !listWithin limits.maxUses drafts then
     throw .uses
+  if !listWithin entryRoom drafts then
+    throw .entries
   if drafts.any (fun draft => limits.maxSchema < draft.schema) then
     throw .schema
   if limits.maxBodyCells < arena.bodyCells then
@@ -246,38 +291,9 @@ def relocateId (relocations : List Relocation) (source : PayloadId) :
   | some relocation => pure relocation.global
   | none => throw (.danglingReference source)
 
-def relocateCandidate (relocations : List Relocation)
-    (candidate : Candidate Fact) : Except Invalid (Candidate Fact) := do
-  let payload ← relocateId relocations candidate.payload
-  pure { candidate with payload }
-
-def relocateEquality (relocations : List Relocation)
-    (equality : ProposedEquality) : Except Invalid ProposedEquality := do
-  let payload ← relocateId relocations equality.payload
-  pure { equality with payload }
-
-def relocateRequest (relocations : List Relocation)
-    (request : InstantiationRequest) : Except Invalid InstantiationRequest := do
-  let payload ← relocateId relocations request.payload
-  let equalities ← request.equalities.mapM (relocateEquality relocations)
-  pure { request with payload, equalities }
-
-def relocateSuggestion (relocations : List Relocation) :
-    Suggestion -> Except Invalid Suggestion
-  | .retry effort => pure (.retry effort)
-  | .split request => pure (.split request)
-  | .instantiate request => return .instantiate (← relocateRequest relocations request)
-
 def relocateOutcome (relocations : List Relocation) :
-    Outcome Fact -> Except Invalid (Outcome Fact)
-  | .success candidates suggestions cost => do
-      let candidates ← candidates.mapM (relocateCandidate relocations)
-      let suggestions ← suggestions.mapM (relocateSuggestion relocations)
-      pure (.success candidates suggestions cost)
-  | .noChange cost => pure (.noChange cost)
-  | .inapplicable => pure .inapplicable
-  | .resourceLimit budget => pure (.resourceLimit budget)
-  | .failed code => pure (.failed code)
+    Outcome Fact -> Except Invalid (Outcome Fact) :=
+  traverseOutcome fun _ source => relocateId relocations source
 
 /-- Append entries and assign their relocation identifiers in the same
 traversal, so the identifier recorded for a draft is definitionally the index

--- a/HexInterval/Experiment/PayloadArena.lean
+++ b/HexInterval/Experiment/PayloadArena.lean
@@ -144,7 +144,6 @@ def traverseRequest [Monad m] (visit : Role -> PayloadId -> m PayloadId)
   pure
     { key := request.key
       triggers := request.triggers
-      claimedGeneration := request.claimedGeneration
       nodes := request.nodes
       equalities
       payload }

--- a/HexInterval/Experiment/PayloadArena.lean
+++ b/HexInterval/Experiment/PayloadArena.lean
@@ -319,7 +319,9 @@ def freezeDrafts (arena : Arena) (origin : Action)
 /-- Validate and freeze every reply-local payload reference in an outcome.
 
 This function does not mutate the supplied arena.  A caller should retain the
-returned arena only if the surrounding reply transaction also commits. -/
+returned arena only if the surrounding reply transaction also commits.
+Starting from `arena.wellFormed`, every ready result remains well formed; a
+session-owned arena supplies that precondition by construction. -/
 def freeze (limits : Limits) (arena : Arena) (origin : Action)
     (outcome : Outcome Fact) (drafts : List Draft) : Result Fact :=
   match preflightUses limits.maxUses outcome with

--- a/HexInterval/Experiment/PayloadArena.lean
+++ b/HexInterval/Experiment/PayloadArena.lean
@@ -78,9 +78,9 @@ def entry? (arena : Arena) (payload : PayloadId) (expected : Role) : Option Entr
   let entry ← arena.rawEntry? payload
   if entry.role == expected then some entry else none
 
-/-- Check the cached aggregate used by the body-cell resource bound.  Session
-ownership will eventually make malformed arenas unconstructible; the
-standalone experiment keeps this executable structural check in the meantime. -/
+/-- Check the cached aggregate used by the body-cell resource bound.  Callers
+must enforce this condition while the standalone experiment exposes `Arena`; a
+later session abstraction will own the invariant by construction. -/
 def wellFormed (arena : Arena) : Bool :=
   arena.bodyCells ==
     arena.entries.foldl (fun total entry => total + entry.body.length) 0
@@ -320,8 +320,9 @@ def freezeDrafts (arena : Arena) (origin : Action)
 
 This function does not mutate the supplied arena.  A caller should retain the
 returned arena only if the surrounding reply transaction also commits.
-Starting from `arena.wellFormed`, every ready result remains well formed; a
-session-owned arena supplies that precondition by construction. -/
+Starting from `arena.wellFormed`, every ready result remains well formed.
+Callers must supply that precondition until a later session abstraction owns
+the arena by construction. -/
 def freeze (limits : Limits) (arena : Arena) (origin : Action)
     (outcome : Outcome Fact) (drafts : List Draft) : Result Fact :=
   match preflightUses limits.maxUses outcome with

--- a/HexInterval/Experiment/PayloadArena.lean
+++ b/HexInterval/Experiment/PayloadArena.lean
@@ -35,19 +35,21 @@ inductive Role where
   | equality
   deriving DecidableEq, Repr
 
-/-- One package-produced recipe.  `label` is local to this reply. -/
+/-- One package-produced recipe.  `label` is local to this reply, while
+`schema` selects the package-owned decoder for the opaque body. -/
 structure Draft where
   label : PayloadId
   role : Role
+  schema : Nat
   body : List Nat
   deriving Repr
 
-/-- One immutable replay entry.  The rule owner is copied from the originating
-action rather than trusted as a second package-supplied identity. -/
+/-- One immutable replay entry.  Its rule owner is always `origin.key`; it is
+not stored as a second field which could disagree with the action. -/
 structure Entry where
-  owner : RuleKey
   origin : Action
   role : Role
+  schema : Nat
   body : List Nat
   deriving Repr
 
@@ -64,9 +66,17 @@ namespace Arena
 def empty : Arena :=
   { entries := #[], bodyCells := 0 }
 
-/-- Exact optional lookup of a frozen recipe. -/
-def entry? (arena : Arena) (payload : PayloadId) : Option Entry :=
+/-- Exact optional lookup without checking the recipe's semantic role.  Replay
+code should ordinarily use `entry?`; this raw operation is useful to inspect
+malformed untrusted certificates. -/
+def rawEntry? (arena : Arena) (payload : PayloadId) : Option Entry :=
   arena.entries[payload.index]?
+
+/-- Exact optional lookup which rejects a payload used in the wrong semantic
+position. -/
+def entry? (arena : Arena) (payload : PayloadId) (expected : Role) : Option Entry := do
+  let entry ← arena.rawEntry? payload
+  if entry.role == expected then some entry else none
 
 end Arena
 
@@ -75,6 +85,7 @@ structure Limits where
   maxEntries : Nat
   maxBodyCells : Nat
   maxAtom : Nat
+  maxSchema : Nat
   maxUses : Nat
   deriving DecidableEq, Repr
 
@@ -91,6 +102,7 @@ inductive Resource where
   | entries
   | bodyCells
   | atom
+  | schema
   | uses
   deriving DecidableEq, Repr
 
@@ -122,8 +134,9 @@ def outcomeUses : Outcome Fact -> List Use
         suggestions.flatMap suggestionUses
   | .noChange _ | .inapplicable | .resourceLimit _ | .failed _ => []
 
-/-- Bound payload-bearing output structure before `outcomeUses` allocates its
-flat list. Repeated references are work even when they share one draft. -/
+/-- Bound the complete top-level proposal structure before `outcomeUses`
+allocates its flat payload-use list.  Repeated references are work even when
+they share one draft, and suggestions count even when they carry no payload. -/
 def consumeCandidates : Nat -> List (Candidate Fact) -> Except Resource Nat
   | remaining, [] => pure remaining
   | 0, _ :: _ => throw .uses
@@ -138,12 +151,12 @@ def consumeEqualities : Nat -> List ProposedEquality -> Except Resource Nat
 
 def consumeSuggestions : Nat -> List Suggestion -> Except Resource Nat
   | remaining, [] => pure remaining
-  | remaining, .retry _ :: suggestions
-  | remaining, .split _ :: suggestions =>
-      consumeSuggestions remaining suggestions
-  | 0, .instantiate _ :: _ => throw .uses
-  | remaining + 1, .instantiate request :: suggestions => do
-      let remaining ← consumeEqualities remaining request.equalities
+  | 0, _ :: _ => throw .uses
+  | remaining + 1, suggestion :: suggestions => do
+      let remaining ←
+        match suggestion with
+        | .retry _ | .split _ => pure remaining
+        | .instantiate request => consumeEqualities remaining request.equalities
       consumeSuggestions remaining suggestions
 
 def preflightUses (limit : Nat) : Outcome Fact -> Except Resource Unit
@@ -202,7 +215,10 @@ def consumeDrafts (maxAtom : Nat) :
       let remaining ← consumeBody maxAtom remaining draft.body
       consumeDrafts maxAtom remaining drafts
 
-/-- Check aggregate entry and cell limits before constructing any new entry. -/
+/-- Check aggregate entry, draft-work, schema, and cell limits before
+constructing any new entry.  In particular the draft list is bounded by both
+remaining arena room and `maxUses` before the quadratic exact-coverage checks
+run. -/
 def preflight (limits : Limits) (arena : Arena) (drafts : List Draft) :
     Except Resource Nat := do
   if limits.maxEntries < arena.entries.size then
@@ -210,6 +226,10 @@ def preflight (limits : Limits) (arena : Arena) (drafts : List Draft) :
   let entryRoom := limits.maxEntries - arena.entries.size
   if !listWithin entryRoom drafts then
     throw .entries
+  if !listWithin limits.maxUses drafts then
+    throw .uses
+  if drafts.any (fun draft => limits.maxSchema < draft.schema) then
+    throw .schema
   if limits.maxBodyCells < arena.bodyCells then
     throw .bodyCells
   let cellRoom := limits.maxBodyCells - arena.bodyCells
@@ -219,12 +239,6 @@ def preflight (limits : Limits) (arena : Arena) (drafts : List Draft) :
 structure Relocation where
   source : PayloadId
   global : PayloadId
-
-def relocationsFrom : Nat -> List Draft -> List Relocation
-  | _, [] => []
-  | next, draft :: drafts =>
-      { source := draft.label, global := { index := next } } ::
-        relocationsFrom (next + 1) drafts
 
 def relocateId (relocations : List Relocation) (source : PayloadId) :
     Except Invalid PayloadId :=
@@ -265,16 +279,26 @@ def relocateOutcome (relocations : List Relocation) :
   | .resourceLimit budget => pure (.resourceLimit budget)
   | .failed code => pure (.failed code)
 
-def appendEntries (arena : Arena) (origin : Action)
-    (drafts : List Draft) (addedCells : Nat) : Arena :=
-  { entries := drafts.foldl
-      (fun entries draft => entries.push
-        { owner := origin.key
-          origin
+/-- Append entries and assign their relocation identifiers in the same
+traversal, so the identifier recorded for a draft is definitionally the index
+at which that draft's entry is pushed. -/
+def appendDrafts (origin : Action) :
+    Array Entry -> List Draft -> Array Entry × List Relocation
+  | entries, [] => (entries, [])
+  | entries, draft :: drafts =>
+      let global : PayloadId := { index := entries.size }
+      let entry : Entry :=
+        { origin
           role := draft.role
-          body := draft.body })
-      arena.entries
-    bodyCells := arena.bodyCells + addedCells }
+          schema := draft.schema
+          body := draft.body }
+      let (entries, relocations) := appendDrafts origin (entries.push entry) drafts
+      (entries, { source := draft.label, global } :: relocations)
+
+def freezeDrafts (arena : Arena) (origin : Action)
+    (drafts : List Draft) (addedCells : Nat) : Arena × List Relocation :=
+  let (entries, relocations) := appendDrafts origin arena.entries drafts
+  ({ entries, bodyCells := arena.bodyCells + addedCells }, relocations)
 
 /-- Validate and freeze every reply-local payload reference in an outcome.
 
@@ -292,10 +316,11 @@ def freeze (limits : Limits) (arena : Arena) (origin : Action)
           match validate uses drafts with
           | some error => .invalid error arena
           | none =>
-              let relocations := relocationsFrom arena.entries.size drafts
+              let (prospective, relocations) :=
+                freezeDrafts arena origin drafts addedCells
               match relocateOutcome relocations outcome with
               | .error error => .invalid error arena
               | .ok outcome =>
-                  .ready (appendEntries arena origin drafts addedCells) outcome
+                  .ready prospective outcome
 
 end Hex.Interval.Experiment.PayloadArena

--- a/HexInterval/Experiment/PayloadArena.lean
+++ b/HexInterval/Experiment/PayloadArena.lean
@@ -143,7 +143,6 @@ def traverseRequest [Monad m] (visit : Role -> PayloadId -> m PayloadId)
   let equalities ← request.equalities.mapM (traverseEquality visit)
   pure
     { key := request.key
-      triggers := request.triggers
       nodes := request.nodes
       equalities
       payload }

--- a/HexInterval/Experiment/Propagator.lean
+++ b/HexInterval/Experiment/Propagator.lean
@@ -963,6 +963,22 @@ def snapshot (state : Engine Fact) : Snapshot Fact :=
     versions := state.versions
     contradictory := state.contradictory }
 
+/-- Resolve one immutable fact version for replay.  Version zero comes from
+the caller's initial fact array for base nodes and from the domain top for
+search-generated nodes.  Every later version must name an exact history
+event, never the mutable current fact slot. -/
+def factAt? (state : Engine Fact) (seen : SeenVersion) : Option Fact :=
+  if seen.version == 0 then
+    if seen.node.index < state.baseProgram.nodes.size then
+      state.initialFacts[seen.node.index]?
+    else do
+      let node ← state.program.node? seen.node
+      pure (state.factDomain.top node.domain)
+  else
+    (state.history.toList.find? fun event =>
+      event.node == seen.node && event.version == seen.version).map
+        (fun event => event.fact)
+
 /-- Freeze the current bounded expression structure for one registry request. -/
 def programView (state : Engine Fact) : ProgramView :=
   { programVersion := state.programVersion

--- a/HexInterval/Experiment/Propagator.lean
+++ b/HexInterval/Experiment/Propagator.lean
@@ -975,7 +975,7 @@ def factAt? (state : Engine Fact) (seen : SeenVersion) : Option Fact :=
       let node ← state.program.node? seen.node
       pure (state.factDomain.top node.domain)
   else
-    (state.history.toList.find? fun event =>
+    (state.history.find? fun event =>
       event.node == seen.node && event.version == seen.version).map
         (fun event => event.fact)
 

--- a/HexInterval/Experiment/Propagator.lean
+++ b/HexInterval/Experiment/Propagator.lean
@@ -747,10 +747,12 @@ structure Metrics where
   equalityImprovements : Nat := 0
   deriving DecidableEq, Repr
 
-/-- Why one narrowed fact was admitted.  Equality transport is an engine
-operation and therefore does not invent a registry rule or payload. -/
-inductive FactCause where
-  | rule (action : Action) (payload : PayloadId)
+/-- Why one narrowed fact was admitted.  Rule provenance retains the proposed
+fact separately from the narrowed fact installed in the event.  Equality
+transport is an engine operation and therefore does not invent a registry rule
+or payload. -/
+inductive FactCause (Fact : Type) where
+  | rule (action : Action) (proposed : Fact) (payload : PayloadId)
   | transport (equality : EqualityId) (source : SeenVersion)
   deriving Repr
 
@@ -761,7 +763,7 @@ structure FactEvent (Fact : Type) where
   previous : SeenVersion
   fact : Fact
   version : Nat
-  cause : FactCause
+  cause : FactCause Fact
 
 /-- Canonical unordered endpoint pair for one generated equality. -/
 structure EqualityPair where
@@ -822,6 +824,11 @@ structure InstanceEvent where
 structure Engine (Fact : Type) where
   programVersion : Nat
   factDomain : FactDomain Fact
+  /-- Validated caller program before any search-time instantiation. -/
+  baseProgram : Program
+  /-- Caller-supplied version-zero facts. Replay never recovers these from the
+  mutable current fact slots. -/
+  initialFacts : Array Fact
   program : Program
   rules : Array Registration
   applications : Array Application
@@ -921,6 +928,8 @@ def Engine.start (factDomain : FactDomain Fact) (program : Program) (rules : Arr
     | throw .invalidRegistrations
   pure
     { factDomain
+      baseProgram := program
+      initialFacts := facts
       program
       programVersion := 0
       rules
@@ -1378,7 +1387,7 @@ def installImprovement (action : Action) (candidate : Candidate Fact)
             previous
             fact
             version
-            cause := .rule action candidate.payload }
+            cause := .rule action candidate.fact candidate.payload }
         contradictory := state.contradictory || contradiction
         metrics :=
           { state.metrics with

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -828,13 +828,16 @@ structure FactRef where
   node    : NodeId
   version : Nat
 
-inductive FactCause
-  | rule (action : Action) (previous : FactRef) (payload : PayloadId)
-  | transport (equality : EqualityId) (source previous : FactRef)
+inductive FactCause (Fact : Type)
+  | rule      (action : Action) (proposed : Fact) (payload : PayloadId)
+  | transport (equality : EqualityId) (source : FactRef)
 ```
 
-The preceding target fact is required in both cases because the recorded
-result may be the intersection of that fact with a newly justified candidate.
+The surrounding fact event retains the preceding target fact and the installed
+result. A rule cause additionally retains the candidate exactly as proposed:
+the installed result may be the intersection of that candidate with the
+preceding fact, and neither value determines the other in a general partial
+fact domain.
 For transport, replay resolves the source fact, checks equality direction and
 scope, reconstructs the equality proof, transports the exact source fact, and
 then validates its intersection with the preceding target fact.
@@ -1084,19 +1087,33 @@ alternatives to compare once the behavior is established.
    Only companion replay of the retained payload can do that.
 6. In the production replay protocol, every value needed to justify an
    accepted fact is frozen into an immutable per-run payload arena, and the
-   retained `PayloadId` points there rather than into a mutable cache. The
-   current canary has only stable recipe identifiers; it does not yet implement
-   this arena, so it is not evidence that payload freezing is solved.
+   retained `PayloadId` points there rather than into a mutable cache. A
+   separate arena experiment now validates and relocates a complete reply
+   prospectively; it is not yet joined to package invocation and engine
+   admission in one opaque session.
 7. The solver records the snapshot, concrete application, anchor, action kind,
-   effort, input versions, target's preceding fact version, target, and frozen
-   payload in provenance. The preceding target fact is an explicit dependency
-   of intersection even when the rule did not declare that target as an input.
+   effort, input versions, target's preceding fact version, proposed fact,
+   installed fact, and frozen payload in provenance. The preceding target fact
+   is an explicit dependency of intersection even when the rule did not
+   declare that target as an input. The engine also retains the immutable base
+   program and caller-supplied version-zero fact array rather than attempting
+   to recover either from the extended program or narrowed current slots.
 
 Whether freezing is an explicit second request after the solver identifies
 the improving subset, or eager allocation before the `Outcome`, remains an
 experiment. Eager freezing has a simpler protocol but may retain payloads for
 weaker candidates; two-phase freezing adds a failure transition which must
-remain atomic.
+remain atomic. The first executable arena uses an eager but prospective
+transaction: package-local labels in the outcome are matched exactly against
+package-local drafts, checked for duplicate, missing, extra, and wrong-role
+entries, preflighted against whole-arena entry, body-cell, atom, and
+payload-use limits, relocated to fresh global identifiers, and appended to a
+new arena value. Repeated references count as work even when they share one
+draft. Candidate, instantiation, and equality roles are distinct. Failure
+returns the old arena.
+The surrounding session must commit that returned arena only if submission of
+the relocated outcome also succeeds, so this experiment does not prejudge the
+one-phase versus two-phase production choice.
 
 An invalid rule outcome may mislead search, but it cannot produce a theorem.
 The companion reconstructs every retained fact from the rule's soundness
@@ -1124,12 +1141,15 @@ policy learning account for unsuccessful probes. Until measured, a registry
 must label its successful cost model as a versioned declared estimate rather
 than present placeholder weights as exact operation counts.
 
-The current recipe and family identifiers are not yet arena indices with a
-checked cardinality bound. `PayloadId.index`, instantiation family labels,
-equality payloads, and custom split-reason numbers therefore remain an explicit
-representation gap. The production payload arena must bound allocation and
-identifier encoding before any of these values enter retained provenance; the
-presence of small named constants in the canary does not solve that problem.
+The standalone arena experiment gives fact, instantiation, and equality
+`PayloadId`s checked array-index meaning and bounds both entry count and opaque
+recipe-body cells before allocation. Its body is intentionally
+schema-independent `List Nat`: package-owned decoding, schema/version lookup,
+atom encodings, byte limits, and replay are still missing. Instantiation family
+labels and custom split-reason numbers also remain untyped representation
+gaps. The next session experiment must ensure that no unrelocated package-local
+identifier can enter retained provenance and that an arena from one registry
+snapshot cannot be paired with another.
 
 ### Action kinds
 

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -1109,8 +1109,10 @@ slot. For every valid engine state, each event's `previous`, every
 action-input version used by a rule event, and every equality-transport source
 must resolve this way; the event's own identifier resolves to its installed
 fact. The current `(node, versions[node])` lookup likewise agrees with
-`facts[node]`. These properties become checker invariants when engine fields
-are made opaque.
+`facts[node]`. The initial-fact array has exactly the base-program node count,
+and every later program retains the complete base program as an unchanged
+prefix. These properties become checker invariants when engine fields are
+made opaque.
 
 `Engine.factAt?` is an observation over an already-valid engine, not the
 checker for an untrusted trace: it searches the complete retained history.
@@ -1131,6 +1133,11 @@ older edge whose payload remains authoritative. These are permitted arena
 waste, not proof dependencies. They must be measured and bounded; compacting
 only the backwards proof slice, freezing only the improving/admitted subset,
 and accepting this monotone waste are all still viable designs.
+The first protocol also freezes a fresh entry whenever a later reply uses the
+same recipe again: reply-local exact coverage does not yet provide an explicit
+way to cite an older global entry. Interning immutable entries, adding a
+checked global-reference draft, and accepting bounded cross-reply duplication
+are alternatives to measure rather than assumptions of the final format.
 
 The first executable arena uses an eager but prospective transaction:
 package-local labels in the outcome are matched exactly against package-local

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -1015,18 +1015,19 @@ entering the callback, then replaces only the selected package's cache. The
 engine still authenticates the pending serial, application, fact values, and
 versions; direct registry invocation is not an authentication boundary.
 
-The current package type does not yet carry replay schemas. A production
-checked assembly API should return operation metadata, registrations, callback
-routes, configuration validation, and payload-freezing/replay schemas as one
-coherent snapshot. Whether that snapshot retains existential packages,
-compiles one dispatch function, supports hot replacement, or uses another
-lookup structure remains experimental. The present experiment exposes its
-constructors and returns a separable engine/registry pair, so its checked start
-is a conformance canary rather than the final encapsulation boundary. A
-production session should prevent accidentally pairing an engine with an
-unrelated registry; a different callback implementation under the same
-versioned rule schema remains valid only when its retained payloads replay
-under that schema.
+The current package type does not yet carry replay decoders or a schema
+registry. Arena drafts do carry an explicit numeric payload schema, but a
+production checked assembly API should return operation metadata,
+registrations, callback routes, configuration validation, and the
+payload-freezing/replay schema implementations as one coherent snapshot.
+Whether that snapshot retains existential packages, compiles one dispatch
+function, supports hot replacement, or uses another lookup structure remains
+experimental. The present experiment exposes its constructors and returns a
+separable engine/registry pair, so its checked start is a conformance canary
+rather than the final encapsulation boundary. A production session should
+prevent accidentally pairing an engine with an unrelated registry; a
+different callback implementation under the same versioned rule schema
+remains valid only when its retained payloads replay under that schema.
 
 The explicit registration and validation boundary is fixed. Discovery and
 scheduling above it remain empirical: one arm uses an incremental registry
@@ -1099,18 +1100,45 @@ alternatives to compare once the behavior is established.
    program and caller-supplied version-zero fact array rather than attempting
    to recover either from the extended program or narrowed current slots.
 
+The executable `Engine.factAt?` is the replay lookup invariant. Version zero
+of a base-program node resolves from the caller's immutable `initialFacts`;
+version zero of an appended node resolves to `FactDomain.top` at that node's
+domain; every positive version resolves only through the exact `(node,
+version)` event in `history`. It never substitutes the mutable current fact
+slot. For every valid engine state, each event's `previous`, every
+action-input version used by a rule event, and every equality-transport source
+must resolve this way; the event's own identifier resolves to its installed
+fact. The current `(node, versions[node])` lookup likewise agrees with
+`facts[node]`. These properties become checker invariants when engine fields
+are made opaque.
+
 Whether freezing is an explicit second request after the solver identifies
 the improving subset, or eager allocation before the `Outcome`, remains an
 experiment. Eager freezing has a simpler protocol but may retain payloads for
 weaker candidates; two-phase freezing adds a failure transition which must
-remain atomic. The first executable arena uses an eager but prospective
-transaction: package-local labels in the outcome are matched exactly against
-package-local drafts, checked for duplicate, missing, extra, and wrong-role
-entries, preflighted against whole-arena entry, body-cell, atom, and
-payload-use limits, relocated to fresh global identifiers, and appended to a
-new arena value. Repeated references count as work even when they share one
-draft. Candidate, instantiation, and equality roles are distinct. Failure
-returns the old arena.
+remain atomic. In an eager design, a successfully submitted reply can leave
+an unused entry when a candidate does not improve the current intersection,
+when a suggestion is dropped or later dismissed, stale, invalid, or
+structurally duplicate, or when an instantiation's proposed equality reuses an
+older edge whose payload remains authoritative. These are permitted arena
+waste, not proof dependencies. They must be measured and bounded; compacting
+only the backwards proof slice, freezing only the improving/admitted subset,
+and accepting this monotone waste are all still viable designs.
+
+The first executable arena uses an eager but prospective transaction:
+package-local labels in the outcome are matched exactly against package-local
+drafts, checked for duplicate, missing, extra, and wrong-role entries,
+preflighted against whole-arena entry, body-cell, atom, schema, and
+total-proposal limits, relocated to fresh global identifiers, and appended to
+a new arena value. The total-proposal budget charges every candidate, every
+suggestion constructor (including retry and split), and every equality nested
+under an instantiation. Repeated references count as work even when they share
+one draft. Before any quadratic label/coverage scan, the draft list is bounded
+both by the remaining arena-entry capacity and by the same trusted proposal
+limit. Entry construction and identifier assignment are one traversal, so a
+relocated identifier denotes exactly the entry appended for its local draft.
+Candidate, instantiation, and equality roles are distinct, and ordinary replay
+lookup checks the expected role. Failure returns the old arena.
 The surrounding session must commit that returned arena only if submission of
 the relocated outcome also succeeds, so this experiment does not prejudge the
 one-phase versus two-phase production choice.
@@ -1142,14 +1170,17 @@ must label its successful cost model as a versioned declared estimate rather
 than present placeholder weights as exact operation counts.
 
 The standalone arena experiment gives fact, instantiation, and equality
-`PayloadId`s checked array-index meaning and bounds both entry count and opaque
-recipe-body cells before allocation. Its body is intentionally
-schema-independent `List Nat`: package-owned decoding, schema/version lookup,
-atom encodings, byte limits, and replay are still missing. Instantiation family
-labels and custom split-reason numbers also remain untyped representation
-gaps. The next session experiment must ensure that no unrelocated package-local
-identifier can enter retained provenance and that an arena from one registry
-snapshot cannot be paired with another.
+`PayloadId`s checked array-index meaning and bounds entry count, opaque
+recipe-body cells, schemas, atoms, and total proposal work before allocation.
+Each frozen entry stores its originating action, semantic role, numeric
+payload schema, and uninterpreted `List Nat` body. It derives the rule owner
+only from `origin.key`, avoiding two stored identities which could disagree.
+Package-owned decoding and schema lookup, typed atom encodings, byte limits,
+and semantic replay are still missing. Instantiation family labels and custom
+split-reason numbers also remain untyped representation gaps. The next session
+experiment must ensure that no unrelocated package-local identifier can enter
+retained provenance and that an arena from one registry snapshot cannot be
+paired with another.
 
 ### Action kinds
 

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -1011,11 +1011,13 @@ start rather than advertised as compatible.
 
 `Registry.invokePlanned` cross-checks the flattened registration, routed handler
 metadata, and structural projection of an engine-produced request before
-entering the callback, then replaces only the selected package's cache. The
-engine still authenticates the pending serial, application, fact values, and
-versions. The explicitly named `Registry.invokeDroppingDrafts` adapter exists
-only for search experiments; it is not a proof-producing authentication
-boundary.
+entering the callback, then replaces only the selected package's cache. It is
+the proof-producing registry route because it retains the callback's
+reply-local drafts for freezing. Neither it nor
+`Registry.invokeDroppingDrafts` is an authentication boundary: the engine
+still authenticates the pending serial, application, fact values, and
+versions. The explicitly named dropping-drafts adapter exists only for search
+experiments.
 
 The current package type does not yet carry replay decoders or a schema
 registry. Arena drafts do carry an explicit numeric payload schema, but a

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -1009,11 +1009,13 @@ precision ladder against its arithmetic endpoint-height limit; otherwise a
 configuration known in advance to exceed the backend limit is rejected at
 start rather than advertised as compatible.
 
-`Registry.invoke` cross-checks the flattened registration, routed handler
+`Registry.invokePlanned` cross-checks the flattened registration, routed handler
 metadata, and structural projection of an engine-produced request before
 entering the callback, then replaces only the selected package's cache. The
 engine still authenticates the pending serial, application, fact values, and
-versions; direct registry invocation is not an authentication boundary.
+versions. The explicitly named `Registry.invokeDroppingDrafts` adapter exists
+only for search experiments; it is not a proof-producing authentication
+boundary.
 
 The current package type does not yet carry replay decoders or a schema
 registry. Arena drafts do carry an explicit numeric payload schema, but a

--- a/HexInterval/SPEC/hex-interval.md
+++ b/HexInterval/SPEC/hex-interval.md
@@ -1112,6 +1112,13 @@ fact. The current `(node, versions[node])` lookup likewise agrees with
 `facts[node]`. These properties become checker invariants when engine fields
 are made opaque.
 
+`Engine.factAt?` is an observation over an already-valid engine, not the
+checker for an untrusted trace: it searches the complete retained history.
+Certificate replay must instead fold events in chronological order and
+resolve every positive-version dependency only from the already-validated
+prefix. This rejects future references and cyclic provenance even if a forged
+final history contains an entry with the requested `(node, version)`.
+
 Whether freezing is an explicit second request after the solver identifies
 the improving subset, or eager allocation before the `Outcome`, remains an
 experiment. Eager freezing has a simpler protocol but may retain payloads for

--- a/conformance/HexInterval/DyadicRulesConformance.lean
+++ b/conformance/HexInterval/DyadicRulesConformance.lean
@@ -763,7 +763,7 @@ def reciprocalAcrossZeroRequest? : Option (RuleRequest Fact × ConcreteRegistry)
 #guard
   match reciprocalAcrossZeroRequest? with
   | some (request, registry) =>
-      match (registry.invoke request).1 with
+      match (registry.invokeDroppingDrafts request).1 with
       | .inapplicable => true
       | _ => false
   | none => false

--- a/conformance/HexInterval/DyadicRulesConformance.lean
+++ b/conformance/HexInterval/DyadicRulesConformance.lean
@@ -319,6 +319,100 @@ def falseOneRun? : Option (RunResult Fact ConcreteRegistry) := do
 #guard centeredAt half quarter
 #guard centeredAt 1 0
 
+/-! ## Real package payload plans -/
+
+def payloadLimits : PayloadArena.Limits :=
+  { maxEntries := 3
+    maxBodyCells := 0
+    maxAtom := 0
+    maxSchema := 0
+    maxUses := 3 }
+
+def ruleIdFrom? (key : RuleKey) : Nat -> List Registration -> Option RuleId
+  | _, [] => none
+  | index, registration :: registrations =>
+      if registration.key == key then some { index }
+      else ruleIdFrom? key (index + 1) registrations
+
+def ruleId? (registry : ConcreteRegistry) (key : RuleKey) : Option RuleId :=
+  ruleIdFrom? key 0 registry.registrations.toList
+
+def payloadView : ProgramView :=
+  { programVersion := 0
+    operations := centeredProgram.operations
+    nodes := centeredProgram.nodes
+    generations := #[0, 0, 0, 0]
+    depths := #[0, 0, 1, 2] }
+
+def plannedRequest? (registry : ConcreteRegistry) (serial : Nat)
+    (key : RuleKey) (anchor : NodeId) (kind : ActionKind)
+    (writes : List NodeId) : Option (RuleRequest Fact) := do
+  let rule <- ruleId? registry key
+  pure
+    { action :=
+        { serial
+          programVersion := 0
+          application := { index := rule.index }
+          rule
+          key
+          node := anchor
+          kind
+          effort := 0
+          inputs := [] }
+      program := payloadView
+      inputs := []
+      writes }
+
+def sameAction (left right : Action) : Bool :=
+  left.serial == right.serial &&
+    left.programVersion == right.programVersion &&
+    left.application == right.application &&
+    left.rule == right.rule &&
+    left.key == right.key &&
+    left.node == right.node &&
+    left.kind == right.kind &&
+    left.effort == right.effort &&
+    left.inputs == right.inputs
+
+def ownsV0 (arena : PayloadArena.Arena) (payload : PayloadId)
+    (role : PayloadArena.Role) (origin : Action) : Bool :=
+  (arena.entry? payload role).any fun entry =>
+    sameAction entry.origin origin && entry.schema == 0 && entry.body.isEmpty
+
+-- The real nullary fact handler and structural instantiator both use the
+-- planned registry route.  Local label zero is reused across replies, then
+-- relocated to distinct global entries.  Replay needs no central recipe
+-- number: the frozen action key, role, and schema identify each v0 checker.
+#guard
+  match registry? with
+  | none => false
+  | some registry =>
+      match
+          plannedRequest? registry 7 oneForwardKey (node 1) .forward [node 1],
+          plannedRequest? registry 8 centeredInstantiateKey (node 3) .instantiate [] with
+      | some factRequest, some instanceRequest =>
+          let (factPlan, registry) := registry.invokePlanned factRequest
+          match PayloadArena.freeze payloadLimits .empty factRequest.action
+              factPlan.outcome factPlan.drafts with
+          | .ready factArena (.success [candidate] [] _) =>
+              let (instancePlan, _) := registry.invokePlanned instanceRequest
+              match PayloadArena.freeze payloadLimits factArena instanceRequest.action
+                  instancePlan.outcome instancePlan.drafts with
+              | .ready arena (.success [] [.instantiate request] _) =>
+                  match request.equalities with
+                  | [equality] =>
+                      candidate.payload.index == 0 &&
+                        request.payload.index == 1 &&
+                        equality.payload.index == 2 &&
+                        arena.entries.size == 3 && arena.bodyCells == 0 &&
+                        ownsV0 arena candidate.payload .fact factRequest.action &&
+                        ownsV0 arena request.payload .instance instanceRequest.action &&
+                        ownsV0 arena equality.payload .equality instanceRequest.action
+                  | _ => false
+              | _ => false
+          | _ => false
+      | _, _ => false
+
 -- The anchor-local match remains fresh after its own append-only extension.
 -- Selecting it again is a structural duplicate, and the matcher is not
 -- spuriously requeued as a whole-program dependency.

--- a/conformance/HexInterval/DyadicRulesConformance.lean
+++ b/conformance/HexInterval/DyadicRulesConformance.lean
@@ -111,7 +111,7 @@ def scaleStart? : Option (Engine Fact × ConcreteRegistry) :=
 
 def scaleFinal? : Option (RunResult Fact ConcreteRegistry) := do
   let (state, registry) <- scaleStart?
-  pure (drive Propagator.Registry.invoke 32 state registry)
+  pure (drive Propagator.Registry.invokeDroppingDrafts 32 state registry)
 
 #guard scaleProgram.check
 #guard registryChecks scaleProgram
@@ -160,7 +160,7 @@ def cycleStart? : Option (Engine Fact × ConcreteRegistry) :=
 
 def cycleFinal? : Option (RunResult Fact ConcreteRegistry) := do
   let (state, registry) <- cycleStart?
-  pure (drive Propagator.Registry.invoke 48 state registry)
+  pure (drive Propagator.Registry.invokeDroppingDrafts 48 state registry)
 
 #guard cycleProgram.check
 #guard registryChecks cycleProgram
@@ -285,7 +285,7 @@ def centeredAt (input expected : Dyadic) : Bool :=
 
 def centeredInitial? : Option (RunResult Fact ConcreteRegistry) := do
   let (state, registry) <- centeredStart?
-  pure (drive Propagator.Registry.invoke 32 state registry)
+  pure (drive Propagator.Registry.invokeDroppingDrafts 32 state registry)
 
 def centeredAdmitted? : Option (Engine Fact × ConcreteRegistry) := do
   let initial <- centeredInitial?
@@ -299,7 +299,7 @@ def centeredAdmitted? : Option (Engine Fact × ConcreteRegistry) := do
 
 def centeredFinal? : Option (RunResult Fact ConcreteRegistry) := do
   let (state, registry) <- centeredAdmitted?
-  pure (drive Propagator.Registry.invoke 32 state registry)
+  pure (drive Propagator.Registry.invokeDroppingDrafts 32 state registry)
 
 def falseOneRun? : Option (RunResult Fact ConcreteRegistry) := do
   let (state, registry) <-
@@ -311,7 +311,7 @@ def falseOneRun? : Option (RunResult Fact ConcreteRegistry) := do
         limits with
     | .ok state => some state
     | .error _ => none
-  pure (drive Propagator.Registry.invoke 8 state registry)
+  pure (drive Propagator.Registry.invokeDroppingDrafts 8 state registry)
 
 #guard centeredProgram.check
 #guard registryChecks centeredProgram
@@ -623,8 +623,8 @@ def combinedPolicyRun? : Option
       (List ConcreteCommand)) := do
   let (engine, registry) <- combinedStart?
   let state := Propagator.Policy.State.start engine policyLimits
-  pure (Propagator.Policy.Driver.drive concreteController Propagator.Registry.invoke
-    32 state registry concreteCommands)
+  pure (Propagator.Policy.Driver.drive concreteController
+    Propagator.Registry.invokeDroppingDrafts 32 state registry concreteCommands)
 
 def exactConcreteEvents
     (events : Array (Propagator.Policy.Driver.Event Fact)) : Bool :=
@@ -741,7 +741,7 @@ def reciprocalFirstRequest? : Option (RuleRequest Fact × ConcreteRegistry) := d
 #guard
   match reciprocalFirstRequest? with
   | some (request, registry) =>
-      match (registry.invoke request).1 with
+      match (registry.invokeDroppingDrafts request).1 with
       | .success [candidate] [.retry 1] _ =>
           candidate.node == node 1 &&
             candidate.fact.view ==
@@ -793,7 +793,7 @@ def bogusRequest : RuleRequest Fact :=
 #guard
   match registry? with
   | some registry =>
-      match (registry.invoke bogusRequest).1 with
+      match (registry.invokeDroppingDrafts bogusRequest).1 with
       | .failed code => code == DispatchCode.requestMismatch
       | _ => false
   | none => false

--- a/conformance/HexInterval/DyadicRulesConformance.lean
+++ b/conformance/HexInterval/DyadicRulesConformance.lean
@@ -380,9 +380,9 @@ def ownsV0 (arena : PayloadArena.Arena) (payload : PayloadId)
     sameAction entry.origin origin && entry.schema == 0 && entry.body.isEmpty
 
 -- The real nullary fact handler and structural instantiator both use the
--- planned registry route.  Local label zero is reused across replies, then
--- relocated to distinct global entries.  Replay needs no central recipe
--- number: the frozen action key, role, and schema identify each v0 checker.
+-- planned registry route.  Their fact, instantiation, and equality labels are
+-- frozen into distinct global entries.  Replay needs no central recipe number:
+-- the frozen action key, role, and schema identify each v0 checker.
 #guard
   match registry? with
   | none => false

--- a/conformance/HexInterval/PackageRegistryConformance.lean
+++ b/conformance/HexInterval/PackageRegistryConformance.lean
@@ -103,21 +103,21 @@ def sharedPackage : Package Nat :=
     cache := 0
     operations := #[sourceOperation, sharedOperation]
     handlers :=
-      #[{ registration := tickRegistration, invoke := tickInvoke },
-        { registration := observeRegistration, invoke := observeInvoke }] }
+      #[Handler.bare tickRegistration tickInvoke,
+        Handler.bare observeRegistration observeInvoke] }
 
 def thirdPackage : Package Nat :=
   { Cache := List Nat
     cache := []
     operations := #[thirdOperation]
     requiredOperations := #[sourceOperation]
-    handlers := #[{ registration := thirdRegistration, invoke := thirdInvoke }] }
+    handlers := #[Handler.bare thirdRegistration thirdInvoke] }
 
 def limitedPackage : Package Nat :=
   { Cache := Bool
     cache := false
     operations := #[limitedOperation]
-    handlers := #[{ registration := limitedRegistration, invoke := limitedInvoke }]
+    handlers := #[Handler.bare limitedRegistration limitedInvoke]
     acceptsLimits := fun _ limits =>
       8 ≤ limits.maxObservationValue && 1000000 ≤ limits.maxDiagnosticValue }
 

--- a/conformance/HexInterval/PackageRegistryConformance.lean
+++ b/conformance/HexInterval/PackageRegistryConformance.lean
@@ -103,21 +103,21 @@ def sharedPackage : Package Nat :=
     cache := 0
     operations := #[sourceOperation, sharedOperation]
     handlers :=
-      #[Handler.bare tickRegistration tickInvoke,
-        Handler.bare observeRegistration observeInvoke] }
+      #[Handler.bareDroppingDrafts tickRegistration tickInvoke,
+        Handler.bareDroppingDrafts observeRegistration observeInvoke] }
 
 def thirdPackage : Package Nat :=
   { Cache := List Nat
     cache := []
     operations := #[thirdOperation]
     requiredOperations := #[sourceOperation]
-    handlers := #[Handler.bare thirdRegistration thirdInvoke] }
+    handlers := #[Handler.bareDroppingDrafts thirdRegistration thirdInvoke] }
 
 def limitedPackage : Package Nat :=
   { Cache := Bool
     cache := false
     operations := #[limitedOperation]
-    handlers := #[Handler.bare limitedRegistration limitedInvoke]
+    handlers := #[Handler.bareDroppingDrafts limitedRegistration limitedInvoke]
     acceptsLimits := fun _ limits =>
       8 ≤ limits.maxObservationValue && 1000000 ≤ limits.maxDiagnosticValue }
 
@@ -128,18 +128,20 @@ def externalPackage : Package Nat :=
     cache := ()
     requiredOperations := #[externalOperation]
     handlers :=
-      #[Handler.stateless externalRegistration (fun _ => .noChange {})] }
+      #[Handler.statelessDroppingDrafts externalRegistration (fun _ => .noChange {})] }
 
 def duplicateRulePackage : Package Nat :=
   { Cache := Unit
     cache := ()
     requiredOperations := #[sharedOperation]
-    handlers := #[Handler.stateless tickRegistration (fun _ => .inapplicable)] }
+    handlers :=
+      #[Handler.statelessDroppingDrafts tickRegistration (fun _ => .inapplicable)] }
 
 def undeclaredHeadPackage : Package Nat :=
   { Cache := Unit
     cache := ()
-    handlers := #[Handler.stateless tickRegistration (fun _ => .inapplicable)] }
+    handlers :=
+      #[Handler.statelessDroppingDrafts tickRegistration (fun _ => .inapplicable)] }
 
 def duplicateOperationPackage : Package Nat :=
   { Cache := Unit
@@ -288,7 +290,7 @@ def run? : Option (RunResult Nat (Registry Nat)) :=
       else
         match Engine.start factDomain program registry.registrations #[0, 0, 0, 0] limits with
         | .error _ => none
-        | .ok state => some (drive Registry.invoke 12 state registry)
+        | .ok state => some (drive Registry.invokeDroppingDrafts 12 state registry)
 
 /-- Type-level conformance that the policy driver accepts the same
 `Type 1` registry value as its private cache. -/
@@ -296,7 +298,8 @@ def policyDriverTypecheck {PolicyState : Type}
     (controller : Policy.Driver.Controller Nat PolicyState) (fuel : Nat)
     (state : Policy.State Nat) (registry : Registry Nat) (policyState : PolicyState) :
     Policy.Driver.Result Nat (Registry Nat) PolicyState :=
-  Policy.Driver.drive controller Registry.invoke fuel state registry policyState
+  Policy.Driver.drive controller Registry.invokeDroppingDrafts
+    fuel state registry policyState
 
 #guard program.check
 #guard mismatchedProgram.check
@@ -393,10 +396,10 @@ def policyDriverTypecheck {PolicyState : Type}
   match registry? with
   | none => false
   | some registry =>
-      let (first, registry) := registry.invoke tickRequest
-      let (second, registry) := registry.invoke observeRequest
-      let (third, registry) := registry.invoke thirdRequest
-      let (fourth, registry) := registry.invoke thirdRequest
+      let (first, registry) := registry.invokeDroppingDrafts tickRequest
+      let (second, registry) := registry.invokeDroppingDrafts observeRequest
+      let (third, registry) := registry.invokeDroppingDrafts thirdRequest
+      let (fourth, registry) := registry.invokeDroppingDrafts thirdRequest
       match first, second, third, fourth with
       | .noChange _, .success [observed] [] _,
           .success [initialThird] [] _, .success [cachedThird] [] _ =>
@@ -411,10 +414,10 @@ def policyDriverTypecheck {PolicyState : Type}
   match registry? with
   | none => false
   | some registry =>
-      let (wrong, registry) := registry.invoke wrongKeyRequest
-      let (missing, registry) := registry.invoke missingRouteRequest
-      let (tick, registry) := registry.invoke tickRequest
-      let (observed, registry) := registry.invoke observeRequest
+      let (wrong, registry) := registry.invokeDroppingDrafts wrongKeyRequest
+      let (missing, registry) := registry.invokeDroppingDrafts missingRouteRequest
+      let (tick, registry) := registry.invokeDroppingDrafts tickRequest
+      let (observed, registry) := registry.invokeDroppingDrafts observeRequest
       match wrong, missing, tick, observed with
       | .failed wrongCode, .failed missingCode, .noChange _, .success [candidate] [] _ =>
           wrongCode == DispatchCode.requestMismatch &&
@@ -430,7 +433,7 @@ def policyDriverTypecheck {PolicyState : Type}
       let corrupted :=
         { registry with
           routes := registry.routes.set! 0 { package := 1, handler := 0 } }
-      match (corrupted.invoke tickRequest).1 with
+      match (corrupted.invokeDroppingDrafts tickRequest).1 with
       | .failed code => code == DispatchCode.registryMismatch
       | _ => false
 

--- a/conformance/HexInterval/PayloadArenaConformance.lean
+++ b/conformance/HexInterval/PayloadArenaConformance.lean
@@ -100,7 +100,6 @@ def seedPreserved (arena : Arena) : Bool :=
 -- Candidate, instance, and nested equality references are all relocated.
 def mixedRequest : InstantiationRequest :=
   { key := 77
-    triggers := [node 0]
     nodes := []
     equalities :=
       [{ left := .existing (node 0)

--- a/conformance/HexInterval/PayloadArenaConformance.lean
+++ b/conformance/HexInterval/PayloadArenaConformance.lean
@@ -66,6 +66,9 @@ def seedPreserved (arena : Arena) : Bool :=
           entry.schema == 4 && entry.body == [3]
     | none => false
 
+#guard seeded.wellFormed
+#guard !({ seeded with bodyCells := 0 }).wellFormed
+
 -- Identical local labels in separate replies relocate to distinct global IDs.
 #guard
   match freeze generous .empty (action 0) (factOutcome 0) [factDraft 0] with
@@ -73,7 +76,8 @@ def seedPreserved (arena : Arena) : Bool :=
       match freeze generous firstArena (action 1) (factOutcome 0) [factDraft 0] with
       | .ready secondArena (.success [second] [] _) =>
           first.payload.index == 0 && second.payload.index == 1 &&
-            secondArena.entries.size == 2 &&
+            secondArena.entries.size == 2 && secondArena.bodyCells == 2 &&
+            secondArena.wellFormed &&
             (secondArena.entry? second.payload .fact).any fun entry =>
               entry.origin.key == rule && entry.origin.serial == 1 &&
                 entry.schema == 1 && entry.body == [10]
@@ -115,7 +119,7 @@ def mixedRequest : InstantiationRequest :=
       (.success [candidate] [.instantiate request] _) =>
       match request.equalities with
       | [equality] =>
-          arena.entries.size == 3 && arena.bodyCells == 3 &&
+          arena.entries.size == 3 && arena.bodyCells == 3 && arena.wellFormed &&
             candidate.payload.index == 1 && request.payload.index == 2 &&
             equality.payload.index == 0 &&
             (arena.entry? equality.payload .equality).any (fun entry =>
@@ -164,6 +168,18 @@ def mixedRequest : InstantiationRequest :=
   | _ => false
 
 -- Each resource limit is exactly one below the required prospective value.
+#guard
+  match freeze { generous with maxEntries := 0 } seeded (action 0)
+      (.noChange {} : Outcome Nat) [] with
+  | .resourceLimit .entries arena => seedPreserved arena
+  | _ => false
+
+#guard
+  match freeze { generous with maxBodyCells := 0 } seeded (action 0)
+      (.noChange {} : Outcome Nat) [] with
+  | .resourceLimit .bodyCells arena => seedPreserved arena
+  | _ => false
+
 #guard
   match freeze { generous with maxEntries := 1 } seeded (action 0)
       (factOutcome 0) [factDraft 0] with

--- a/conformance/HexInterval/PayloadArenaConformance.lean
+++ b/conformance/HexInterval/PayloadArenaConformance.lean
@@ -101,7 +101,6 @@ def seedPreserved (arena : Arena) : Bool :=
 def mixedRequest : InstantiationRequest :=
   { key := 77
     triggers := [node 0]
-    claimedGeneration := 1
     nodes := []
     equalities :=
       [{ left := .existing (node 0)

--- a/conformance/HexInterval/PayloadArenaConformance.lean
+++ b/conformance/HexInterval/PayloadArenaConformance.lean
@@ -31,24 +31,28 @@ def action (serial : Nat) : Action :=
     inputs := [] }
 
 def generous : PayloadArena.Limits :=
-  { maxEntries := 16, maxBodyCells := 32, maxAtom := 100, maxUses := 16 }
+  { maxEntries := 16
+    maxBodyCells := 32
+    maxAtom := 100
+    maxSchema := 10
+    maxUses := 16 }
 
-def factDraft (label : Nat) (body : List Nat := [10]) : Draft :=
-  { label := payload label, role := .fact, body }
+def factDraft (label : Nat) (body : List Nat := [10]) (schema : Nat := 1) : Draft :=
+  { label := payload label, role := .fact, schema, body }
 
-def instanceDraft (label : Nat) (body : List Nat := [20]) : Draft :=
-  { label := payload label, role := .instance, body }
+def instanceDraft (label : Nat) (body : List Nat := [20]) (schema : Nat := 2) : Draft :=
+  { label := payload label, role := .instance, schema, body }
 
-def equalityDraft (label : Nat) (body : List Nat := [30]) : Draft :=
-  { label := payload label, role := .equality, body }
+def equalityDraft (label : Nat) (body : List Nat := [30]) (schema : Nat := 3) : Draft :=
+  { label := payload label, role := .equality, schema, body }
 
 def factOutcome (label : Nat) : Outcome Nat :=
   .success [{ node := node 0, fact := 7, payload := payload label }] [] {}
 
 def retainedSeed : Entry :=
-  { owner := rule
-    origin := action 9
+  { origin := action 9
     role := .fact
+    schema := 4
     body := [3] }
 
 def seeded : Arena :=
@@ -56,10 +60,10 @@ def seeded : Arena :=
 
 def seedPreserved (arena : Arena) : Bool :=
   arena.entries.size == 1 && arena.bodyCells == 1 &&
-    match arena.entry? (payload 0) with
+    match arena.entry? (payload 0) .fact with
     | some entry =>
-        entry.owner == rule && entry.origin.serial == 9 &&
-          entry.role == .fact && entry.body == [3]
+        entry.origin.key == rule && entry.origin.serial == 9 &&
+          entry.schema == 4 && entry.body == [3]
     | none => false
 
 -- Identical local labels in separate replies relocate to distinct global IDs.
@@ -70,9 +74,9 @@ def seedPreserved (arena : Arena) : Bool :=
       | .ready secondArena (.success [second] [] _) =>
           first.payload.index == 0 && second.payload.index == 1 &&
             secondArena.entries.size == 2 &&
-            (secondArena.entry? second.payload).any fun entry =>
-              entry.owner == rule && entry.origin.serial == 1 &&
-                entry.role == .fact && entry.body == [10]
+            (secondArena.entry? second.payload .fact).any fun entry =>
+              entry.origin.key == rule && entry.origin.serial == 1 &&
+                entry.schema == 1 && entry.body == [10]
       | _ => false
   | _ => false
 
@@ -113,8 +117,23 @@ def mixedRequest : InstantiationRequest :=
       | [equality] =>
           arena.entries.size == 3 && arena.bodyCells == 3 &&
             candidate.payload.index == 1 && request.payload.index == 2 &&
-            equality.payload.index == 0
+            equality.payload.index == 0 &&
+            (arena.entry? equality.payload .equality).any (fun entry =>
+              entry.schema == 3 && entry.body == [30]) &&
+            (arena.entry? candidate.payload .fact).any (fun entry =>
+              entry.schema == 1 && entry.body == [10]) &&
+            (arena.entry? request.payload .instance).any (fun entry =>
+              entry.schema == 2 && entry.body == [20])
       | _ => false
+  | _ => false
+
+-- Role-checked replay lookup cannot reinterpret a well-formed entry.
+#guard
+  match freeze generous .empty (action 0) (factOutcome 0) [factDraft 0] with
+  | .ready arena (.success [candidate] [] _) =>
+      (arena.entry? candidate.payload .fact).isSome &&
+        (arena.entry? candidate.payload .equality).isNone &&
+        (arena.rawEntry? candidate.payload).isSome
   | _ => false
 
 #guard
@@ -164,12 +183,44 @@ def mixedRequest : InstantiationRequest :=
   | _ => false
 
 #guard
+  match freeze { generous with maxSchema := 4 } seeded (action 0)
+      (factOutcome 0) [factDraft 0 [4] 5] with
+  | .resourceLimit .schema arena => seedPreserved arena
+  | _ => false
+
+#guard
   match freeze { generous with maxUses := 1 } seeded (action 0)
       (.success
         [{ node := node 0, fact := 4, payload := payload 0 },
           { node := node 1, fact := 5, payload := payload 0 }]
         [] {})
       [factDraft 0] with
+  | .resourceLimit .uses arena => seedPreserved arena
+  | _ => false
+
+-- Every suggestion constructor consumes the total-proposal budget, including
+-- retry and split suggestions which carry no proof payload.
+#guard
+  match freeze { generous with maxUses := 1 } seeded (action 0)
+      (.success [] [.retry 1, .retry 2] {} : Outcome Nat) [] with
+  | .resourceLimit .uses arena => seedPreserved arena
+  | _ => false
+
+#guard
+  match freeze { generous with maxUses := 1 } seeded (action 0)
+      (.success []
+        [.split { node := node 0, point := 0, reason := .midpoint },
+          .split { node := node 0, point := 1, reason := .midpoint }]
+        {} : Outcome Nat)
+      [] with
+  | .resourceLimit .uses arena => seedPreserved arena
+  | _ => false
+
+-- Drafts are independently bounded by `maxUses` before exact-coverage scans,
+-- even when the arena has ample entry room.
+#guard
+  match freeze { generous with maxUses := 1 } seeded (action 0)
+      (factOutcome 0) [factDraft 0, factDraft 1] with
   | .resourceLimit .uses arena => seedPreserved arena
   | _ => false
 

--- a/conformance/HexInterval/PayloadArenaConformance.lean
+++ b/conformance/HexInterval/PayloadArenaConformance.lean
@@ -1,0 +1,206 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexInterval.Experiment.PayloadArena
+
+/-!
+Focused checks for transactional proof-payload freezing and relocation.
+-/
+
+namespace Hex.Interval.PayloadArenaConformance
+
+open Experiment Propagator PayloadArena
+
+def node (index : Nat) : NodeId := { index }
+def payload (index : Nat) : PayloadId := { index }
+
+def rule : RuleKey := { name := "payload-arena.test" }
+
+def action (serial : Nat) : Action :=
+  { serial
+    programVersion := 3
+    application := { index := 2 }
+    rule := { index := 1 }
+    key := rule
+    node := node 0
+    kind := .forward
+    effort := 0
+    inputs := [] }
+
+def generous : PayloadArena.Limits :=
+  { maxEntries := 16, maxBodyCells := 32, maxAtom := 100, maxUses := 16 }
+
+def factDraft (label : Nat) (body : List Nat := [10]) : Draft :=
+  { label := payload label, role := .fact, body }
+
+def instanceDraft (label : Nat) (body : List Nat := [20]) : Draft :=
+  { label := payload label, role := .instance, body }
+
+def equalityDraft (label : Nat) (body : List Nat := [30]) : Draft :=
+  { label := payload label, role := .equality, body }
+
+def factOutcome (label : Nat) : Outcome Nat :=
+  .success [{ node := node 0, fact := 7, payload := payload label }] [] {}
+
+def retainedSeed : Entry :=
+  { owner := rule
+    origin := action 9
+    role := .fact
+    body := [3] }
+
+def seeded : Arena :=
+  { entries := #[retainedSeed], bodyCells := 1 }
+
+def seedPreserved (arena : Arena) : Bool :=
+  arena.entries.size == 1 && arena.bodyCells == 1 &&
+    match arena.entry? (payload 0) with
+    | some entry =>
+        entry.owner == rule && entry.origin.serial == 9 &&
+          entry.role == .fact && entry.body == [3]
+    | none => false
+
+-- Identical local labels in separate replies relocate to distinct global IDs.
+#guard
+  match freeze generous .empty (action 0) (factOutcome 0) [factDraft 0] with
+  | .ready firstArena (.success [first] [] _) =>
+      match freeze generous firstArena (action 1) (factOutcome 0) [factDraft 0] with
+      | .ready secondArena (.success [second] [] _) =>
+          first.payload.index == 0 && second.payload.index == 1 &&
+            secondArena.entries.size == 2 &&
+            (secondArena.entry? second.payload).any fun entry =>
+              entry.owner == rule && entry.origin.serial == 1 &&
+                entry.role == .fact && entry.body == [10]
+      | _ => false
+  | _ => false
+
+-- Several uses of one local recipe share its single frozen arena entry.
+#guard
+  match freeze generous .empty (action 0)
+      (.success
+        [{ node := node 0, fact := 4, payload := payload 7 },
+          { node := node 1, fact := 5, payload := payload 7 }]
+        [] {})
+      [factDraft 7] with
+  | .ready arena (.success [first, second] [] _) =>
+      arena.entries.size == 1 && first.payload.index == 0 &&
+        second.payload == first.payload
+  | _ => false
+
+-- Candidate, instance, and nested equality references are all relocated.
+def mixedRequest : InstantiationRequest :=
+  { key := 77
+    triggers := [node 0]
+    claimedGeneration := 1
+    nodes := []
+    equalities :=
+      [{ left := .existing (node 0)
+         right := .existing (node 1)
+         payload := payload 9 }]
+    payload := payload 4 }
+
+#guard
+  match freeze generous .empty (action 0)
+      (.success
+        [{ node := node 0, fact := 8, payload := payload 7 }]
+        [.instantiate mixedRequest] {})
+      [equalityDraft 9, factDraft 7, instanceDraft 4] with
+  | .ready arena
+      (.success [candidate] [.instantiate request] _) =>
+      match request.equalities with
+      | [equality] =>
+          arena.entries.size == 3 && arena.bodyCells == 3 &&
+            candidate.payload.index == 1 && request.payload.index == 2 &&
+            equality.payload.index == 0
+      | _ => false
+  | _ => false
+
+#guard
+  match freeze generous seeded (action 0) (factOutcome 2) [] with
+  | .invalid (.danglingReference label) arena =>
+      label.index == 2 && seedPreserved arena
+  | _ => false
+
+#guard
+  match freeze generous seeded (action 0) (factOutcome 0)
+      [equalityDraft 0] with
+  | .invalid (.wrongRole label .fact .equality) arena =>
+      label.index == 0 && seedPreserved arena
+  | _ => false
+
+#guard
+  match freeze generous seeded (action 0) (factOutcome 0)
+      [factDraft 0, factDraft 0 [11]] with
+  | .invalid (.duplicateDraft label) arena =>
+      label.index == 0 && seedPreserved arena
+  | _ => false
+
+#guard
+  match freeze generous seeded (action 0) (factOutcome 0)
+      [factDraft 0, equalityDraft 1] with
+  | .invalid (.extraDraft label) arena =>
+      label.index == 1 && seedPreserved arena
+  | _ => false
+
+-- Each resource limit is exactly one below the required prospective value.
+#guard
+  match freeze { generous with maxEntries := 1 } seeded (action 0)
+      (factOutcome 0) [factDraft 0] with
+  | .resourceLimit .entries arena => seedPreserved arena
+  | _ => false
+
+#guard
+  match freeze { generous with maxBodyCells := 2 } seeded (action 0)
+      (factOutcome 0) [factDraft 0 [4, 5]] with
+  | .resourceLimit .bodyCells arena => seedPreserved arena
+  | _ => false
+
+#guard
+  match freeze { generous with maxAtom := 4 } seeded (action 0)
+      (factOutcome 0) [factDraft 0 [5]] with
+  | .resourceLimit .atom arena => seedPreserved arena
+  | _ => false
+
+#guard
+  match freeze { generous with maxUses := 1 } seeded (action 0)
+      (.success
+        [{ node := node 0, fact := 4, payload := payload 0 },
+          { node := node 1, fact := 5, payload := payload 0 }]
+        [] {})
+      [factDraft 0] with
+  | .resourceLimit .uses arena => seedPreserved arena
+  | _ => false
+
+#guard
+  match freeze { generous with maxUses := 1 } seeded (action 0)
+      (.success [] [.instantiate mixedRequest] {} : Outcome Nat)
+      [instanceDraft 4, equalityDraft 9] with
+  | .resourceLimit .uses arena => seedPreserved arena
+  | _ => false
+
+-- Negative outcomes contain no payload uses and therefore accept no drafts.
+#guard
+  match freeze generous seeded (action 0) (.noChange {} : Outcome Nat) [] with
+  | .ready arena (.noChange _) => seedPreserved arena
+  | _ => false
+
+#guard
+  match freeze generous seeded (action 0) (.resourceLimit 6 : Outcome Nat) [] with
+  | .ready arena (.resourceLimit 6) => seedPreserved arena
+  | _ => false
+
+#guard
+  match freeze generous seeded (action 0) (.inapplicable : Outcome Nat) [factDraft 0] with
+  | .invalid (.extraDraft label) arena =>
+      label.index == 0 && seedPreserved arena
+  | _ => false
+
+#guard
+  match freeze generous seeded (action 0) (.failed 8 : Outcome Nat) [factDraft 0] with
+  | .invalid (.extraDraft label) arena =>
+      label.index == 0 && seedPreserved arena
+  | _ => false
+
+end Hex.Interval.PayloadArenaConformance

--- a/conformance/HexInterval/PropagatorConformance.lean
+++ b/conformance/HexInterval/PropagatorConformance.lean
@@ -857,7 +857,7 @@ def intersectedProposal? : Option (Engine PairRank) := do
       let candidate : Candidate PairRank :=
         { node := node 1, fact := proposed, payload := { index := 149 } }
       match awaiting.submit (request.action.reply (.success [candidate] [] {})) with
-      | .accepted state => some state
+      | .accepted _ state => some state
       | _ => none
   | _ => none
 

--- a/conformance/HexInterval/PropagatorConformance.lean
+++ b/conformance/HexInterval/PropagatorConformance.lean
@@ -386,7 +386,8 @@ def dynamicFinal? : Option (RunResult Rank (List String) × SuggestionId) := do
 #guard
   match dynamicAdmitted? with
   | some (state, _, _) =>
-      state.program.nodes.size == 3 && state.programVersion == 1 &&
+      state.baseProgram.nodes.size == 2 && state.initialFacts.toList == [4, 0] &&
+        state.program.nodes.size == 3 && state.programVersion == 1 &&
         state.generations.toList == [0, 0, 1] && state.applications.size == 3 &&
         state.metrics.admittedInstances == 1 && state.metrics.generatedNodes == 1 &&
         match state.instanceHistory[0]? with
@@ -825,6 +826,25 @@ def pairFinal? (limits : Limits := generous) : Option (RunResult PairRank Nat) :
   let state <- pairAdmitted? limits
   pure (drive pairEqualityInvoke 8 state 1)
 
+/-- Submit a proposal whose intersection differs from both the old fact and
+the proposal, exposing the distinction needed by proof replay. -/
+def intersectedProposal? : Option (Engine PairRank) := do
+  let program : Program :=
+    { operations, nodes := #[sourceNode, unaryNode 0] }
+  let state <- match Engine.start pairDomain program #[copyRule]
+      #[pair 0 0, pair 4 0] generous with
+    | .ok state => some state
+    | .error _ => none
+  match state.poll with
+  | .request request awaiting =>
+      let proposed := pair 0 5
+      let candidate : Candidate PairRank :=
+        { node := node 1, fact := proposed, payload := { index := 149 } }
+      match awaiting.submit (request.action.reply (.success [candidate] [] {})) with
+      | .accepted state => some state
+      | _ => none
+  | _ => none
+
 /-- A second instance adds one node while explicitly reusing the equality
 created by the first instance. -/
 def pairReuseAdmitted? : Option (Engine PairRank) := do
@@ -948,6 +968,25 @@ def pairReuseAdmitted? : Option (Engine PairRank) := do
         | _, _, _ => false
   | none => false
 
+-- Replay retains the callback's proposal, not merely the fact produced by
+-- intersecting that proposal with the previously installed fact.
+#guard
+  match intersectedProposal? with
+  | some state =>
+      state.baseProgram.nodes.size == 2 &&
+        state.initialFacts.toList == [pair 0 0, pair 4 0] &&
+        state.facts.toList == [pair 0 0, pair 4 5] &&
+        match state.history[0]? with
+        | some event =>
+            event.fact == pair 4 5 &&
+              match event.cause with
+              | .rule action proposed payload =>
+                  action.key == copyKey && proposed == pair 0 5 &&
+                    payload == { index := 149 }
+              | _ => false
+        | none => false
+  | none => false
+
 -- Both endpoint updates roll back when their combined history budget is short.
 #guard
   match pairFinal? { generous with maxAcceptedFacts := 1 } with
@@ -1051,7 +1090,7 @@ def alternateEqualityFinal? : Option (RunResult Rank (List String)) := do
         | some transported, some propagated =>
             transported.node == node 2 && propagated.node == node 3 &&
               match transported.cause, propagated.cause with
-              | .transport equality source, .rule action _ =>
+              | .transport equality source, .rule action _ _ =>
                   equality == { index := 0 } && source == { node := node 1, version := 0 } &&
                     action.key == nextCopyKey &&
                       action.inputs == [{ node := node 2, version := 1 }]

--- a/conformance/HexInterval/PropagatorConformance.lean
+++ b/conformance/HexInterval/PropagatorConformance.lean
@@ -395,12 +395,28 @@ def dynamicFinal? : Option (RunResult Rank (List String) × SuggestionId) := do
         | none => false
   | none => false
 
+-- Immutable version lookup uses caller facts for base version zero, domain
+-- top for a generated node's version zero, and exact history thereafter.
+#guard
+  match dynamicAdmitted? with
+  | some (state, _, _) =>
+      state.factAt? { node := node 0, version := 0 } == some 4 &&
+        state.factAt? { node := node 1, version := 0 } == some 0 &&
+        state.factAt? { node := node 1, version := 1 } == some 4 &&
+        state.factAt? { node := node 2, version := 0 } == some 0 &&
+        state.factAt? { node := node 2, version := 1 } == none &&
+        state.factAt? { node := node 3, version := 0 } == none
+  | none => false
+
 #guard
   match dynamicFinal? with
   | some (result, _) =>
       result.stop == .saturated && result.state.facts.toList == [4, 4, 4] &&
         result.state.metrics.requests == 3 && result.state.metrics.improvements == 2 &&
-        result.state.history.size == 2
+        result.state.history.size == 2 &&
+        result.state.factAt? { node := node 2, version := 0 } == some 0 &&
+        result.state.factAt? { node := node 2, version := 1 } == some 4 &&
+        result.state.factAt? { node := node 2, version := 2 } == none
   | none => false
 
 -- Selecting the same structural extension twice allocates nothing.
@@ -959,11 +975,19 @@ def pairReuseAdmitted? : Option (Engine PairRank) := do
             edge.origin.key == pairEqualityKey && edge.origin.node == node 2 &&
               left.node == node 0 && left.previous == { node := node 0, version := 0 } &&
               right.node == node 1 && right.previous == { node := node 1, version := 0 } &&
+              result.state.factAt? left.previous == some (pair 4 0) &&
+              result.state.factAt? right.previous == some (pair 0 5) &&
+              result.state.factAt? { node := left.node, version := left.version } ==
+                some (pair 4 5) &&
+              result.state.factAt? { node := right.node, version := right.version } ==
+                some (pair 4 5) &&
               match left.cause, right.cause with
               | .transport leftEquality leftSource, .transport rightEquality rightSource =>
                   leftEquality == { index := 0 } && rightEquality == { index := 0 } &&
                     leftSource == { node := node 1, version := 0 } &&
-                    rightSource == { node := node 0, version := 0 }
+                    rightSource == { node := node 0, version := 0 } &&
+                    result.state.factAt? leftSource == some (pair 0 5) &&
+                    result.state.factAt? rightSource == some (pair 4 0)
               | _, _ => false
         | _, _, _ => false
   | none => false

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -233,7 +233,8 @@ lean_lib HexIntervalExperiment where
     `HexInterval.Experiment.PolicyDriver,
     `HexInterval.Experiment.PackageRegistry,
     `HexInterval.Experiment.DyadicInterval,
-    `HexInterval.Experiment.DyadicRules]
+    `HexInterval.Experiment.DyadicRules,
+    `HexInterval.Experiment.PayloadArena]
 
 lean_lib HexIntervalMathlibExperiment where
   globs := #[`HexIntervalMathlib.Experiment.Center]
@@ -300,7 +301,7 @@ lean_lib HexRCFProofProbeScientific where
 -- `*_emit_fixtures` exes below, carrying `srcDir := "conformance"`.
 lean_lib HexConformance where
   srcDir := "conformance"
-  globs := #[`HexArith.Conformance, `HexArith.CrossCheck, `HexBerlekamp.Conformance, `HexBerlekampZassenhaus.Conformance, `HexBerlekampZassenhaus.CrossCheck, `HexConway.Conformance, `HexGF2.Conformance, `HexGF2.CrossCheck, `HexGF2.FastCheck, `HexGFq.Conformance, `HexGFq.CrossCheck, `HexGFqField.Conformance, `HexGFqRing.Conformance, `HexGramSchmidt.Conformance, `HexHensel.Conformance, `HexHensel.CrossCheck, `HexInterval.Conformance, `HexInterval.CenterConformance, `HexInterval.ScaleConformance, `HexInterval.PropagatorConformance, `HexInterval.StructureViewConformance, `HexInterval.PolicyConformance, `HexInterval.PolicyFrontierConformance, `HexInterval.PolicyDriverConformance, `HexInterval.PackageRegistryConformance, `HexInterval.DyadicIntervalConformance, `HexInterval.DyadicRulesConformance, `HexLLL.Conformance, `HexMatrix.Conformance, `HexRowReduce.Conformance, `HexDeterminant.Conformance, `HexBareiss.Conformance, `HexModArith.Conformance, `HexModArith.FastCheck, `HexNumberField.Conformance, `HexNumberFieldTower.Conformance, `HexPoly.Conformance, `HexPolyFp.Conformance, `HexPolyZ.Conformance, `HexRCF.Conformance, `HexRealRoots.Conformance, `HexRealRootsMathlib.Conformance, `HexResultant.Conformance, `HexRoots.Conformance].map Glob.one
+  globs := #[`HexArith.Conformance, `HexArith.CrossCheck, `HexBerlekamp.Conformance, `HexBerlekampZassenhaus.Conformance, `HexBerlekampZassenhaus.CrossCheck, `HexConway.Conformance, `HexGF2.Conformance, `HexGF2.CrossCheck, `HexGF2.FastCheck, `HexGFq.Conformance, `HexGFq.CrossCheck, `HexGFqField.Conformance, `HexGFqRing.Conformance, `HexGramSchmidt.Conformance, `HexHensel.Conformance, `HexHensel.CrossCheck, `HexInterval.Conformance, `HexInterval.CenterConformance, `HexInterval.ScaleConformance, `HexInterval.PropagatorConformance, `HexInterval.StructureViewConformance, `HexInterval.PolicyConformance, `HexInterval.PolicyFrontierConformance, `HexInterval.PolicyDriverConformance, `HexInterval.PackageRegistryConformance, `HexInterval.DyadicIntervalConformance, `HexInterval.DyadicRulesConformance, `HexInterval.PayloadArenaConformance, `HexLLL.Conformance, `HexMatrix.Conformance, `HexRowReduce.Conformance, `HexDeterminant.Conformance, `HexBareiss.Conformance, `HexModArith.Conformance, `HexModArith.FastCheck, `HexNumberField.Conformance, `HexNumberFieldTower.Conformance, `HexPoly.Conformance, `HexPolyFp.Conformance, `HexPolyZ.Conformance, `HexRCF.Conformance, `HexRealRoots.Conformance, `HexRealRootsMathlib.Conformance, `HexResultant.Conformance, `HexRoots.Conformance].map Glob.one
 
 -- Public umbrellas intentionally contain only the supported API. Executable
 -- examples and regression tests are compiled through this separate target so

--- a/progress/20260728T051030Z.md
+++ b/progress/20260728T051030Z.md
@@ -1,0 +1,38 @@
+# Immutable interval proof payloads
+
+## Accomplished
+
+- Added a pure, append-only payload arena for arbitrary function packages.
+  Each reply uses local labels; freezing checks exact draft coverage and
+  semantic roles, applies entry, body, atom, and use limits, relocates labels
+  to stable arena indices, and leaves the old arena unchanged on every failure.
+- Preserved the callback's proposed fact separately from the installed
+  intersection in fact provenance.
+- Preserved the caller's base program and version-zero facts across dynamic
+  expression-network growth so replay has immutable source data.
+- Added conformance checks for shared and reply-local labels, mixed fact /
+  instantiation / equality evidence, malformed drafts, one-short resource
+  limits, proposal-versus-intersection provenance, and immutable source state.
+- Updated the SPEC to distinguish this prospective arena transaction from the
+  still-open package/session integration and proof replay.
+- Built the payload arena, propagator conformance, payload conformance, and
+  complete `HexIntervalExperiment` target successfully. Added Lean code
+  contains no `native_decide`, `axiom`, or `sorry`.
+
+## Current frontier
+
+The engine and registry are still separable values. A caller could freeze an
+outcome with one arena and registry, then submit it against another engine.
+The arena also stores schema-independent bodies; no package decoder or
+soundness theorem consumes them yet.
+
+## Next step
+
+Add an opaque per-run session that owns the matching engine, registry, payload
+arena, and limits. Make callback invocation, freezing, relocation, and reply
+submission one atomic transition, then replay one accepted arbitrary-function
+payload through its package-owned checker.
+
+## Blockers
+
+None.

--- a/progress/20260728T052448Z.md
+++ b/progress/20260728T052448Z.md
@@ -1,0 +1,34 @@
+# Payload-arena review hardening
+
+## Accomplished
+
+- Bounded payload drafts by both remaining arena capacity and the trusted
+  proposal budget before exact label-coverage scans.
+- Charged every candidate, suggestion constructor, and nested proposed
+  equality to the arena's proposal budget.
+- Made payload-entry creation and local-to-global identifier assignment one
+  traversal.
+- Removed the duplicate entry owner, added explicit payload schemas, and made
+  ordinary arena lookup enforce the expected fact / instance / equality role.
+- Added immutable historical fact lookup for caller facts, generated top
+  facts, and later accepted history events.
+- Expanded conformance checks for all of these boundaries and documented
+  eager-freeze waste paths and replay invariants in the SPEC.
+- Built the focused arena and propagator conformance targets and the complete
+  `HexIntervalExperiment` target successfully.
+
+## Current frontier
+
+The arena transaction is still intentionally separate from package invocation
+and engine submission. Its numeric schemas and opaque bodies have no
+package-owned decoder or semantic replay theorem yet.
+
+## Next step
+
+Integrate the hardened prospective freeze into the private per-run session,
+then replay one accepted arbitrary-function fact through a package-owned
+schema checker.
+
+## Blockers
+
+None.

--- a/progress/20260728T053730Z.md
+++ b/progress/20260728T053730Z.md
@@ -1,0 +1,25 @@
+# Prefix-safe interval replay
+
+## Accomplished
+
+- Audited the generic payload arena and session as the boundary for arbitrary
+  function propagators rather than extending rational arithmetic.
+- Recorded that the engine's full-history fact lookup is an observation over
+  valid state, not a checker for untrusted certificates.
+- Required certificate replay to resolve every positive-version dependency
+  from the already-validated chronological prefix, rejecting future and cyclic
+  provenance.
+
+## Current frontier
+
+The arena has the immutable information needed for package-owned replay, but a
+generic checker and package schema registry are still being prototyped.
+
+## Next step
+
+Register replay formats with arbitrary function packages and replay one real
+centered-function fact without a central arithmetic recipe switch.
+
+## Blockers
+
+None.

--- a/progress/20260728T053730Z.md
+++ b/progress/20260728T053730Z.md
@@ -9,6 +9,12 @@
 - Required certificate replay to resolve every positive-version dependency
   from the already-validated chronological prefix, rejecting future and cyclic
   provenance.
+- Replaced allocating full-history fact lookup with direct array search.
+- Unified payload collection and relocation behind one exhaustive traversal so
+  a new payload-bearing field becomes a compile-time obligation.
+- Added executable arena aggregate checks and exact conformance for accumulated
+  body cells and already-exhausted limits.
+- Documented bounded cross-reply recipe duplication as an open format choice.
 
 ## Current frontier
 

--- a/progress/20260728T053930Z.md
+++ b/progress/20260728T053930Z.md
@@ -1,0 +1,39 @@
+# Real package payload plans
+
+## Accomplished
+
+- Moved the package registry callback boundary to `Plan`, preserving
+  `Registry.invoke` as the draft-discarding compatibility adapter and exposing
+  `Registry.invokePlanned` for proof-producing sessions.
+- Made every dyadic fact-producing handler return one package-owned, empty-body
+  fact draft at schema zero.
+- Made centered-form instantiation return separate schema-zero instance and
+  equality drafts.
+- Removed rule-specific payload numbers. Frozen replay is now selected by the
+  retained origin rule, semantic role, and schema; payload labels are local
+  relocation names only.
+- Added a focused conformance run which invokes a real fact rule and the real
+  centered instantiator through `Registry.invokePlanned`, freezes both plans,
+  and checks exact origins, roles, schemas, bodies, and relocated identifiers.
+- Kept the existing FIFO and external-policy searches green through the
+  compatibility adapter.
+- Built `HexInterval.Experiment.PackageRegistry`,
+  `HexInterval.Experiment.DyadicRules`,
+  `HexInterval.PackageRegistryConformance`,
+  `HexInterval.DyadicRulesConformance`, and `HexIntervalExperiment`.
+
+## Current frontier
+
+The real packages now produce evidence that `PayloadSession` can freeze.
+Semantic replay still needs package-owned schema-zero checkers for the fact,
+instance, and equality roles.
+
+## Next step
+
+Run the concrete dyadic packages end to end through the private payload
+session, then add package-owned replay checkers without introducing a central
+recipe dispatch.
+
+## Blockers
+
+None.

--- a/progress/20260728T055105Z.md
+++ b/progress/20260728T055105Z.md
@@ -1,0 +1,28 @@
+# Proof-producing package API names
+
+## Accomplished
+
+- Renamed every evidence-discarding handler and registry adapter so the API
+  makes draft loss explicit.
+- Kept planned handlers as the natural path for real fact and instantiation
+  propagators.
+- Made fact, instantiation, and equality labels distinct within any combined
+  reply.
+- Restored the centered identity statement at the package-owned equality
+  schema and clarified the well-formed-arena precondition.
+- Rebuilt the registry, real propagator, payload, conformance, and interval
+  experiment targets.
+
+## Current frontier
+
+Real arbitrary-function handlers now produce immutable drafts, while legacy
+search experiments can discard them only through explicitly named adapters.
+
+## Next step
+
+Bind handler-owned schema validators to the same registry snapshot, then run
+the centered instantiation through the private policy session.
+
+## Blockers
+
+None.

--- a/progress/20260728T060426Z.md
+++ b/progress/20260728T060426Z.md
@@ -1,0 +1,36 @@
+# Arena review follow-up
+
+## Accomplished
+
+- Corrected the dyadic payload conformance comment to match the distinct fact,
+  instantiation, and equality labels exercised by the guard.
+- Restored the SPEC's general statement that neither registry invocation path
+  is an authentication boundary, while identifying `invokePlanned` as the
+  proof-producing path because it retains drafts for freezing.
+- Documented that every candidate carries a payload, so a dropping-drafts
+  handler cannot contribute candidates through a proof-producing session.
+- Clarified that standalone arena callers currently enforce `wellFormed` and a
+  later session abstraction will own that invariant.
+- Verified:
+  - `lake build HexInterval.Experiment.PayloadArena
+    HexInterval.Experiment.PackageRegistry HexInterval.DyadicRulesConformance
+    HexIntervalExperiment`
+  - `lake build HexInterval.PackageRegistryConformance
+    HexInterval.PayloadArenaConformance`
+  - `python3 scripts/release/check_trust_surface.py`
+  - `git diff --check`
+
+## Current frontier
+
+The documentation now matches the existing proof-payload architecture. No
+payload-free candidate constructor was added: the mandatory candidate payload
+and exact draft-coverage check remain the intended evidence boundary.
+
+## Next step
+
+Continue with package-owned schema validators and the later session abstraction
+that owns the arena invariant.
+
+## Blockers
+
+None.

--- a/progress/20260729T052804Z.md
+++ b/progress/20260729T052804Z.md
@@ -1,0 +1,27 @@
+# Payload arena stack refresh
+
+## Accomplished
+
+- Rebased the immutable payload-arena experiments onto the cleaned
+  arbitrary-propagator framework stack.
+- Preserved all current Lake and conformance targets while adding the arena
+  module and its focused checks.
+- Rebuilt the arena, package registry, concrete arbitrary propagators, focused
+  conformance targets, and `HexIntervalExperiment` successfully.
+- Rechecked the conformance target matrix, whitespace, and added Lean lines for
+  banned proof shortcuts.
+
+## Current frontier
+
+The arena and real package draft production are current with the framework.
+The private session and sealed replay-format layers can now be restacked
+without carrying obsolete prerequisite commits.
+
+## Next step
+
+Refresh PR #9035, then rebase the private session and package replay PRs in
+dependency order.
+
+## Blockers
+
+None.

--- a/progress/20260729T061802Z.md
+++ b/progress/20260729T061802Z.md
@@ -1,0 +1,35 @@
+# Payload arena framework restack
+
+## Accomplished
+
+- Restacked the eight payload-arena commits from their old arbitrary-package
+  base onto framework head `79f6ca98`.
+- Preserved transactional payload freezing, bounded traversal, real dyadic
+  package plans, immutable provenance, and the corresponding SPEC material.
+- Resolved the sole content conflict in dyadic-rules conformance while keeping
+  the new anchor-local matcher behavior.
+- Adapted payload traversal to engine-computed instantiation generations,
+  supplied structural depths in the hand-built program view, and routed the
+  inapplicable reciprocal check through the planned registry's outcome-only
+  compatibility projection.
+- Built the interval experiment and focused payload-arena, dyadic-rules,
+  package-registry, propagator, structure-view, policy-frontier, policy, and
+  policy-driver conformance modules.
+- Checked the generated conformance target list, whitespace, the published
+  trust surface, and added Lean lines for banned proof shortcuts.
+
+## Current frontier
+
+The payload arena now sits directly on the current arbitrary-function
+propagator framework. The framework's depth bound, malformed-proposal
+admission, engine-owned generation, and complete policy accounting remain
+authoritative.
+
+## Next step
+
+Restack the private session and sealed package-replay layers on this head, then
+connect package-owned semantic replay to the private policy session.
+
+## Blockers
+
+None.

--- a/progress/20260729T064326Z.md
+++ b/progress/20260729T064326Z.md
@@ -1,0 +1,29 @@
+# Payload arena over recoverable instantiation admission
+
+## Accomplished
+
+- Restacked the payload-arena layer onto arbitrary-propagator head `984c2e77`.
+- Migrated the single explicit payload traversal and its mixed-role fixture
+  after removal of non-authoritative instantiation trigger metadata.
+- Preserved transactional freezing, complete candidate/instance/equality
+  payload relocation, bounded traversal, and the new shared suggestion
+  classification below this layer.
+- Built the experiment and focused payload, dyadic-rule, registry, propagator,
+  structural-view, policy, driver, and frontier conformance graph; the target
+  manifest and diff checks pass.
+
+## Current frontier
+
+The arena is again directly based on the latest arbitrary-function framework.
+Its own behavior is unchanged except that payload traversal no longer copies a
+field the engine and replay no longer use.
+
+## Next step
+
+Publish this restack, then restack the payload-session, package-replay, policy-
+session, and semantic-replay layers after the payload-session review fixes
+land.
+
+## Blockers
+
+None.

--- a/progress/20260729T070759Z.md
+++ b/progress/20260729T070759Z.md
@@ -1,0 +1,25 @@
+# Accomplished
+
+- Restacked payload arena on final arbitrary-propagator head
+  `ebdfb2d3d6889f0c919362b1bd89a0a3500bedf1`.
+- Migrated the branch-local propagator conformance helper to the final
+  `ReplyResult.accepted` shape, which now carries the exact suggestion
+  admission plan alongside the engine.
+- Preserved transactional payload freezing, complete mixed-role relocation,
+  and package-owned program lookup unchanged.
+- Passed the focused 24-target build graph, conformance-target matrix check,
+  diff hygiene, and trust scans.
+
+# Current frontier
+
+Payload arena is green on the final framework with exact capacity/depth
+suggestion-drop provenance.
+
+# Next step
+
+Restack payload sessions and the remaining dependent replay layers on this
+head.
+
+# Blockers
+
+None.


### PR DESCRIPTION
## Purpose

Give arbitrary function packages an immutable, bounded evidence store that is independent of callback caches and suitable for later package-owned proof replay.

## What this establishes

- reply-local payload labels are checked and relocated to stable per-run arena indices;
- fact, instantiation, and equality evidence have distinct checked roles;
- each entry retains the exact originating action and carries a package-defined schema plus opaque bounded body;
- replay identity is the tuple `(origin rule key, role, schema)`, with no central arithmetic recipe switch;
- duplicate, missing, extra, wrong-role, and over-limit drafts fail without changing the arena;
- one exhaustive traversal owns payload collection and relocation, so new payload-bearing fields become compile-time obligations;
- fact history retains the callback proposal separately from the installed intersection;
- version-zero and historical facts have exact immutable lookup semantics, while untrusted replay is required to validate chronological prefixes;
- the real dyadic and centered-function packages now emit planned drafts, including the centered expression/equality instantiation.

The experiment uses prospective eager freezing. Unused and cross-reply duplicate entries are permitted bounded arena waste; selected-only freezing, interning, and checked citation of older entries remain open comparisons.

Package-owned schema validation and semantic replay are deliberately the next stacked layer.

## Verification

- `lake build HexInterval.Experiment.PayloadArena HexInterval.Experiment.PackageRegistry HexInterval.Experiment.DyadicRules HexInterval.PayloadArenaConformance HexInterval.PackageRegistryConformance HexInterval.DyadicRulesConformance HexIntervalExperiment`
- `git diff --check`
- no added `native_decide`, `axiom`, or `sorry`

Stacked on #8984 pending reconstruction of the earlier framework stack.