### PR TITLE
RCF: finish Phase 6 documentation and API audit

### DIFF
--- a/HexManual/Chapters/HexRCF.lean
+++ b/HexManual/Chapters/HexRCF.lean
@@ -147,7 +147,7 @@ example : ∃ x : ℝ, x ^ 2 + 1 = 0 := by
   rcf
 ```
 ```leanOutput rcfFalseExistential
-rcf: the existential sentence is false; every relevant decomposition
+rcf: the existential sentence is false. Every relevant decomposition
 cell was checked and found false, so there is no witness
 ```
 

--- a/HexRCF/Builder.lean
+++ b/HexRCF/Builder.lean
@@ -102,7 +102,7 @@ relating the executable rational gcd to its primitive integer representative. -/
 private def commonDen3 (left right : DensePoly Rat) (unit : Rat) : Nat :=
   Nat.lcm (Nat.lcm (ratCommonDen left) (ratCommonDen right)) unit.den
 
-/-- Constants need no replay; nonconstant common-root polynomials do. -/
+/-- Constants need no replay. Nonconstant common-root polynomials do. -/
 private def buildGcdReplay? (gcd : ZPoly) : Option (Option SturmReplay) :=
   if gcd.size = 1 then some none
   else (buildSturmReplay? gcd).map some

--- a/HexRCF/CarrierCheck.lean
+++ b/HexRCF/CarrierCheck.lean
@@ -24,12 +24,6 @@ checker. Real-polynomial consequences live in `HexRCF.Carrier`.
 
 namespace Hex.RCF
 
-/-- Check that every polynomial in a literal list has positive degree. -/
-@[expose]
-def checkPosDegrees : List ZPoly → Bool
-  | [] => true
-  | p :: ps => decide (0 < p.degree?.getD 0) && checkPosDegrees ps
-
 /-- Multiplication-checkable witnesses that a polynomial is a square-free
 carrier for the atom product of a sentence. -/
 structure CarrierCert where
@@ -55,7 +49,7 @@ def check (s : Sentence) (cert : CarrierCert) : Bool :=
   let q := s.product
   -- `Sentence.polys` filters by this predicate. Retaining the explicit walk
   -- states the certificate condition at the point where it is checked.
-  checkPosDegrees s.polys &&
+  s.polys.all (fun p => decide (0 < p.degree?.getD 0)) &&
   decide (0 < q.degree?.getD 0) &&
   !cert.repeated.isZero &&
   decide (cert.factorScale ≠ 0) &&
@@ -80,26 +74,15 @@ def Valid (s : Sentence) (cert : CarrierCert) : Prop :=
     cert.repeated * cert.derivPart ∧
   cert.replay.check cert.carrier = true
 
-/-- A successful positive-degree walk proves its proposition-level form. -/
-theorem checkPosDegrees_sound {ps : List ZPoly} (h : checkPosDegrees ps = true) :
-    ∀ p ∈ ps, 0 < p.degree?.getD 0 := by
-  induction ps with
-  | nil => simp
-  | cons p ps ih =>
-      simp only [checkPosDegrees, Bool.and_eq_true, decide_eq_true_eq] at h
-      intro q hq
-      simp only [List.mem_cons] at hq
-      rcases hq with rfl | hq
-      · exact h.1
-      · exact ih h.2 q hq
-
 /-- Soundness of the executable carrier checker. -/
 theorem check_sound {s : Sentence} {cert : CarrierCert}
     (h : cert.check s = true) : cert.Valid s := by
   simp only [check, Bool.and_eq_true, decide_eq_true_eq] at h
   obtain ⟨⟨⟨⟨⟨⟨⟨hdegrees, hqdeg⟩, hr0⟩, hk0⟩, hd0⟩, hfactor⟩,
     hderiv⟩, hreplay⟩ := h
-  refine ⟨checkPosDegrees_sound hdegrees, hqdeg, ?_, hk0, hd0, ?_, ?_, hreplay⟩
+  have hdegrees' : ∀ p ∈ s.polys, 0 < p.degree?.getD 0 := by
+    simpa only [List.all_eq_true, decide_eq_true_eq] using hdegrees
+  refine ⟨hdegrees', hqdeg, ?_, hk0, hd0, ?_, ?_, hreplay⟩
   · simp only [Bool.not_eq_true'] at hr0
     have hr := (DensePoly.isZero_eq_false_iff cert.repeated).mp hr0
     intro hzero

--- a/HexRCF/CarrierCheck.lean
+++ b/HexRCF/CarrierCheck.lean
@@ -47,8 +47,8 @@ sentence and is never supplied by the certificate. -/
 @[expose]
 def check (s : Sentence) (cert : CarrierCert) : Bool :=
   let q := s.product
-  -- `Sentence.polys` filters by this predicate. Retaining the explicit walk
-  -- states the certificate condition at the point where it is checked.
+  -- `Sentence.polys` filters by this predicate. Retaining this redundant
+  -- re-check states the certificate condition where it is checked.
   s.polys.all (fun p => decide (0 < p.degree?.getD 0)) &&
   decide (0 < q.degree?.getD 0) &&
   !cert.repeated.isZero &&

--- a/HexRCF/CarrierCheck.lean
+++ b/HexRCF/CarrierCheck.lean
@@ -53,8 +53,8 @@ sentence and is never supplied by the certificate. -/
 @[expose]
 def check (s : Sentence) (cert : CarrierCert) : Bool :=
   let q := s.product
-  -- `Sentence.polys` filters by this predicate; retaining the explicit walk
-  -- makes the certificate contract visible at its trust boundary.
+  -- `Sentence.polys` filters by this predicate. Retaining the explicit walk
+  -- states the certificate condition at the point where it is checked.
   checkPosDegrees s.polys &&
   decide (0 < q.degree?.getD 0) &&
   !cert.repeated.isZero &&

--- a/HexRCF/Cells.lean
+++ b/HexRCF/Cells.lean
@@ -45,6 +45,7 @@ noncomputable def rootAt {f : ZPoly} {replay : SturmReplay}
     (hcert : cert.check replay = true) (i : Fin cert.intervals.size) : ℝ :=
   Classical.choose (exists_unique_root_of_check hreplay hcert i)
 
+/-- The chosen point is a root of the polynomial in the specified interval. -/
 theorem rootAt_spec {f : ZPoly} {replay : SturmReplay}
     (cert : IsolationCert) (hreplay : replay.check f = true)
     (hcert : cert.check replay = true) (i : Fin cert.intervals.size) :
@@ -52,6 +53,7 @@ theorem rootAt_spec {f : ZPoly} {replay : SturmReplay}
       Literal.InInterval cert.intervals[i] (cert.rootAt hreplay hcert i) :=
   (Classical.choose_spec (exists_unique_root_of_check hreplay hcert i)).1
 
+/-- Every root in the specified interval equals the chosen root. -/
 theorem rootAt_unique {f : ZPoly} {replay : SturmReplay}
     (cert : IsolationCert) (hreplay : replay.check f = true)
     (hcert : cert.check replay = true) (i : Fin cert.intervals.size)
@@ -236,6 +238,7 @@ theorem exists_mem {f : ZPoly} {cert : IsolationCert}
     refine ⟨.open (Fin.last cert.intervals.size), ?_⟩
     simpa [Sem, hzero, last] using hlast
 
+/-- A point in an open cell lies below the root at the cell's upper boundary. -/
 private theorem open_lt_upper {f : ZPoly} {cert : IsolationCert}
     (M : RootModel f cert) (cut : Fin (cert.intervals.size + 1)) (x : ℝ)
     (hcut : cut.val < cert.intervals.size) (hx : Sem M (.open cut) x) :
@@ -247,6 +250,7 @@ private theorem open_lt_upper {f : ZPoly} {cert : IsolationCert}
     simp [Sem, hzero, hleft, hright] at hx
     exact hx.2
 
+/-- A point in an open cell lies above the root at the cell's lower boundary. -/
 private theorem lower_lt_open {f : ZPoly} {cert : IsolationCert}
     (M : RootModel f cert) (cut : Fin (cert.intervals.size + 1)) (x : ℝ)
     (hcut : 0 < cut.val) (hx : Sem M (.open cut) x) :
@@ -516,16 +520,19 @@ end IocCmps
 
 namespace Cell
 
+/-- A valid root comparison equals `gt` exactly when the endpoint is below the root. -/
 private theorem eq_gt_iff {cmp : Separation.RootCmp} {root endpoint : ℝ}
     (h : cmp.Holds root endpoint) :
     (cmp == .gt) = true ↔ endpoint < root := by
   cases cmp <;> simp [Separation.RootCmp.Holds] at h ⊢ <;> linarith
 
+/-- A valid root comparison differs from `gt` exactly when the root is at most the endpoint. -/
 private theorem ne_gt_iff {cmp : Separation.RootCmp} {root endpoint : ℝ}
     (h : cmp.Holds root endpoint) :
     (cmp != .gt) = true ↔ root ≤ endpoint := by
   cases cmp <;> simp [Separation.RootCmp.Holds] at h ⊢ <;> linarith
 
+/-- A valid root comparison equals `lt` exactly when the root is below the endpoint. -/
 private theorem eq_lt_iff {cmp : Separation.RootCmp} {root endpoint : ℝ}
     (h : cmp.Holds root endpoint) :
     (cmp == .lt) = true ↔ root < endpoint := by

--- a/HexRCF/Cells.lean
+++ b/HexRCF/Cells.lean
@@ -43,7 +43,7 @@ namespace IsolationCert
 noncomputable def rootAt {f : ZPoly} {replay : SturmReplay}
     (cert : IsolationCert) (hreplay : replay.check f = true)
     (hcert : cert.check replay = true) (i : Fin cert.intervals.size) : ℝ :=
-  Classical.choose (exists_unique_root_of_check hreplay hcert i)
+  Classical.choose (existsUnique_root hreplay hcert i)
 
 /-- The chosen point is a root of the polynomial in the specified interval. -/
 theorem rootAt_spec {f : ZPoly} {replay : SturmReplay}
@@ -51,7 +51,7 @@ theorem rootAt_spec {f : ZPoly} {replay : SturmReplay}
     (hcert : cert.check replay = true) (i : Fin cert.intervals.size) :
     (toPolyℝ f).IsRoot (cert.rootAt hreplay hcert i) ∧
       Literal.InInterval cert.intervals[i] (cert.rootAt hreplay hcert i) :=
-  (Classical.choose_spec (exists_unique_root_of_check hreplay hcert i)).1
+  (Classical.choose_spec (existsUnique_root hreplay hcert i)).1
 
 /-- Every root in the specified interval equals the chosen root. -/
 theorem rootAt_unique {f : ZPoly} {replay : SturmReplay}
@@ -60,7 +60,7 @@ theorem rootAt_unique {f : ZPoly} {replay : SturmReplay}
     {x : ℝ} (hx : (toPolyℝ f).IsRoot x)
     (hmem : Literal.InInterval cert.intervals[i] x) :
     x = cert.rootAt hreplay hcert i :=
-  (Classical.choose_spec (exists_unique_root_of_check hreplay hcert i)).2 x
+  (Classical.choose_spec (existsUnique_root hreplay hcert i)).2 x
     ⟨hx, hmem⟩
 
 /-- Package all semantic consequences of an accepted strict isolation array. -/
@@ -454,7 +454,7 @@ theorem root_mem_leftSpan {carrier : ZPoly} {cert : IsolationCert}
     exact ⟨M.strictMono (Fin.mk_lt_mk.mpr (by omega)), le_rfl⟩
 
 /-- A carrier root in the left span of root `i` is root `i` itself. -/
-theorem root_eq_of_mem_leftSpan
+theorem root_unique_leftSpan
     {carrier : ZPoly} {cert : IsolationCert}
     (M : RootModel carrier cert) (i : Fin cert.intervals.size) {x : ℝ}
     (hxroot : (toPolyℝ carrier).IsRoot x) (hx : x ∈ M.leftSpan i) :

--- a/HexRCF/CellsCheck.lean
+++ b/HexRCF/CellsCheck.lean
@@ -90,18 +90,6 @@ def openPoint (cert : IsolationCert) :
         ((cert.intervals[cut.val - 1]'(by omega)).upper +
           (cert.intervals[cut.val]'(by omega)).lower) >>> (1 : Int)
 
-/-- Open cells carry exact dyadic samples. Root cells are represented by their
-certified isolation instead. -/
-@[expose]
-def sample? (cert : IsolationCert) : Cell cert.intervals.size → Option Dyadic
-  | .open cut => some (cert.openPoint cut)
-  | .root _ => none
-
-/-- Sampling an open cell returns its exact dyadic sample point. -/
-@[simp] theorem sample?_open (cert : IsolationCert)
-    (cut : Fin (cert.intervals.size + 1)) :
-    cert.sample? (.open cut) = some (cert.openPoint cut) := rfl
-
 end IsolationCert
 
 /-- Claimed carrier-root comparisons against the lower and upper endpoints of

--- a/HexRCF/CellsCheck.lean
+++ b/HexRCF/CellsCheck.lean
@@ -52,6 +52,7 @@ def all (n : Nat) : Array (Cell n) :=
       [Cell.open i.castSucc, Cell.root i]) ++
     [Cell.open (Fin.last n)]).toArray
 
+/-- The enumeration for `n` roots contains `2 * n + 1` cells. -/
 @[simp] theorem size_all (n : Nat) : (all n).size = 2 * n + 1 := by
   simp [all, List.map_const']
   omega
@@ -89,13 +90,14 @@ def openPoint (cert : IsolationCert) :
         ((cert.intervals[cut.val - 1]'(by omega)).upper +
           (cert.intervals[cut.val]'(by omega)).lower) >>> (1 : Int)
 
-/-- Open cells carry exact dyadic samples; root cells are represented by their
+/-- Open cells carry exact dyadic samples. Root cells are represented by their
 certified isolation instead. -/
 @[expose]
 def sample? (cert : IsolationCert) : Cell cert.intervals.size → Option Dyadic
   | .open cut => some (cert.openPoint cut)
   | .root _ => none
 
+/-- Sampling an open cell returns its exact dyadic sample point. -/
 @[simp] theorem sample?_open (cert : IsolationCert)
     (cut : Fin (cert.intervals.size + 1)) :
     cert.sample? (.open cut) = some (cert.openPoint cut) := rfl
@@ -114,7 +116,7 @@ structure IocCmps (n : Nat) where
 namespace IocCmps
 
 /-- Recompute every claimed endpoint comparison. This validates comparison
-data only; the bounded-domain layer separately checks `a < b`. -/
+data only. The bounded-domain layer separately checks `a < b`. -/
 @[expose]
 def check (f : ZPoly) (replay : SturmReplay) (cert : IsolationCert)
     (a b : Dyadic) (cmps : IocCmps cert.intervals.size) : Bool :=
@@ -129,8 +131,8 @@ end IocCmps
 namespace Cell
 
 /-- Executable bounded-domain relevance test for a cell. The surrounding
-certificate first checks `a < b`; this core assumes that nonempty-domain
-hypothesis. -/
+certificate first checks `a < b`. This definition assumes that the domain is
+nonempty. -/
 @[expose]
 def meetsIoc (cmps : IocCmps n) : Cell n → Bool
   | .root i => cmps.lower[i] == .gt && cmps.upper[i] != .gt

--- a/HexRCF/CellsTests.lean
+++ b/HexRCF/CellsTests.lean
@@ -53,7 +53,6 @@ and right of both roots. -/
 example : strict.openPoint ⟨0, by decide⟩ = Dyadic.ofInt (-3) := by decide
 example : strict.openPoint ⟨1, by decide⟩ = 0 := by decide
 example : strict.openPoint ⟨2, by decide⟩ = Dyadic.ofInt 3 := by decide
-example : strict.sample? (Cell.root ⟨0, by decide⟩) = none := by decide
 
 /-- The proof-facing sample and partition APIs consume the same checked data. -/
 example : Cell.Sem (strict.rootModel (f := quad) (replay := replay)
@@ -135,7 +134,6 @@ private def emptyVec : Vector Separation.RootCmp 0 := ⟨#[], rfl⟩
 private def noRootCmps : IocCmps 0 := ⟨emptyVec, emptyVec⟩
 
 example : noRoots.openPoint ⟨0, by decide⟩ = 0 := by decide
-example : noRoots.sample? (Cell.open ⟨0, by decide⟩) = some 0 := by decide
 example : Cell.meetsIoc noRootCmps (Cell.open ⟨0, by decide⟩) = true := by decide
 example : IocCmps.check posQuad posReplay noRoots 0 (Dyadic.ofInt 1)
     noRootCmps = true := by decide

--- a/HexRCF/Certificate.lean
+++ b/HexRCF/Certificate.lean
@@ -67,15 +67,24 @@ end OptionFold
 
 /-- Carrier and isolation data for a carrier with no real roots. -/
 structure DecompCert where
+  /-- Certificate data for the proposed square-free carrier. -/
   carrier : CarrierCert
+  /-- Proposed carrier isolation data. The root-free replay branch requires
+  this array to contain no intervals. -/
   isolations : IsolationCert
 
 /-- Full positive-root decomposition data. Endpoint comparisons are present
 exactly for bounded sentences. -/
 structure CellsCert where
+  /-- Certificate data for the proposed square-free carrier. -/
   carrier : CarrierCert
+  /-- Proposed carrier isolation data. Cell replay requires at least one
+  interval. -/
   isolations : IsolationCert
+  /-- Common-root data used to compute atom signs on every cell. -/
   signs : SignMatrixCert
+  /-- Endpoint comparisons for bounded sentences, or `none` for sentences over
+  the whole real line. -/
   iocCmps : Option (IocCmps isolations.intervals.size)
 
 /-- The four disjoint replay branches. -/
@@ -96,7 +105,7 @@ def Sentence.evalOpen? (s : Sentence) (isolations : IsolationCert)
   s.formula.evalSigns fun p => openCellSign? p isolations cut
 
 /-- Replay the carrier-free constant branch. Nonempty bounded domains are
-checked here; empty domains belong to `Certificate.emptyIoc`. -/
+checked here. Empty domains belong to `Certificate.emptyIoc`. -/
 @[expose]
 def Sentence.replayConstants? (s : Sentence) : Option Bool :=
   if s.polys.isEmpty then
@@ -120,7 +129,7 @@ def Sentence.replayNoRoots? (s : Sentence) (data : DecompCert) : Option Bool :=
   else none
 
 /-- Replay a checked positive-root decomposition. Real sentences forbid
-endpoint data; bounded sentences require and verify it. -/
+endpoint data. Bounded sentences require and verify it. -/
 @[expose]
 def Sentence.replayCells? (s : Sentence) (data : CellsCert) : Option Bool :=
   if data.carrier.check s &&

--- a/HexRCF/CommonRoot.lean
+++ b/HexRCF/CommonRoot.lean
@@ -125,7 +125,7 @@ theorem count_eq_one_iff {carrier : ZPoly} {carrierReplay : SturmReplay}
       (Polynomial.mem_roots'.mp hrootMem.1).2
     have hboth := (common.isRoot_iff hcommon y).mp hgRoot
     have hrootEq : y = root :=
-      (IsolationCert.exists_unique_root_of_check hcarrier hcert i).unique
+      (IsolationCert.existsUnique_root hcarrier hcert i).unique
         ⟨hboth.2, hrootMem.2⟩ ⟨hroot, hmem⟩
     simpa only [hrootEq] using hboth.1
   · intro hatomRoot

--- a/HexRCF/CommonRootCheck.lean
+++ b/HexRCF/CommonRootCheck.lean
@@ -124,7 +124,7 @@ theorem replay_of_check {atom carrier : ZPoly} {cert : CommonRootCert}
   exact hvalid.2
 
 /-- Decide whether the cached common-root polynomial has a root in an
-interval. The constant branch is root-free; the nonconstant branch reads its
+interval. The constant branch is root-free. The nonconstant branch reads its
 shared generalized Sturm replay. -/
 @[expose]
 def hasRoot (cert : CommonRootCert) (I : DyadicInterval) : Bool :=

--- a/HexRCF/Decision.lean
+++ b/HexRCF/Decision.lean
@@ -23,7 +23,7 @@ namespace Hex.RCF
 
 /-- Every true compiled verdict proves the reflected sentence. -/
 theorem decide_sound (s : Sentence) (h : decide s = some true) : s.toProp := by
-  obtain ⟨cert, hcert⟩ := decide_eq_some_true_imp_exists_cert h
+  obtain ⟨cert, hcert⟩ := exists_cert_of_decide h
   exact check_sound s cert hcert
 
 end Hex.RCF

--- a/HexRCF/DecisionCheck.lean
+++ b/HexRCF/DecisionCheck.lean
@@ -50,7 +50,7 @@ theorem check_buildIsolations {carrier : CarrierCert}
   · simp at h
   · dsimp only at h
     split at h
-    · exact Separation.check_of_separate_eq_some h
+    · exact Separation.check_separate h
     · simp at h
 
 /-- Classify every isolated carrier root against one exact endpoint. -/
@@ -170,7 +170,7 @@ def decide (s : Sentence) : Option Bool :=
       else some false
 
 /-- A true compiled verdict exposes a certificate accepted by the checker. -/
-theorem decide_eq_some_true_imp_exists_cert {s : Sentence}
+theorem exists_cert_of_decide {s : Sentence}
     (h : decide s = some true) :
     ∃ cert, Certificate.check s cert = true := by
   unfold decide at h

--- a/HexRCF/DecisionCheck.lean
+++ b/HexRCF/DecisionCheck.lean
@@ -159,7 +159,7 @@ theorem replay_build {s : Sentence} {result : BuildResult}
   · cases Option.some.inj h
     exact hreplay
 
-/-- Compiled convenience decision. False is diagnostic; true is returned only
+/-- Compiled convenience decision. False is diagnostic. True is returned only
 after the kernel-facing Boolean checker accepts the retained certificate. -/
 def decide (s : Sentence) : Option Bool :=
   match build? s with

--- a/HexRCF/DecisionCheck.lean
+++ b/HexRCF/DecisionCheck.lean
@@ -54,7 +54,7 @@ theorem check_buildIsolations {carrier : CarrierCert}
     · simp at h
 
 /-- Classify every isolated carrier root against one exact endpoint. -/
-def buildRootCmps? (carrier : CarrierCert) (isolations : IsolationCert)
+private def buildRootCmps? (carrier : CarrierCert) (isolations : IsolationCert)
     (endpoint : Dyadic) :
     Option (Vector Separation.RootCmp isolations.intervals.size) :=
   Vector.ofFnM fun i =>

--- a/HexRCF/DecisionTests.lean
+++ b/HexRCF/DecisionTests.lean
@@ -175,7 +175,7 @@ example {s : Sentence} {result : BuildResult} (h : build? s = some result) :
 
 example {s : Sentence} (h : Hex.RCF.decide s = some true) :
     ∃ cert : Certificate, cert.check s = true :=
-  decide_eq_some_true_imp_exists_cert h
+  exists_cert_of_decide h
 
 example {s : Sentence} (h : Hex.RCF.decide s = some true) : s.toProp :=
   decide_sound s h

--- a/HexRCF/IsolationCheck.lean
+++ b/HexRCF/IsolationCheck.lean
@@ -38,7 +38,7 @@ def checkCounts (replay : SturmReplay) (cert : IsolationCert) : Bool :=
     else false
 
 /-- Check the emitted order in linear time using only adjacent pairs. This is
-intentionally non-strict for half-open isolations; strict gaps are checked by
+intentionally non-strict for half-open isolations. Strict gaps are checked by
 the later cell-separation certificate. -/
 @[expose]
 def checkOrder (cert : IsolationCert) : Bool :=
@@ -75,7 +75,7 @@ theorem adjacent_of_check {cert : IsolationCert} (h : cert.checkOrder = true)
   simp only [hi, dif_pos] at hstep
   exact of_decide_eq_true hstep
 
-/-- `Dyadic` version of `le_of_lt`, derived from the core total order API. -/
+/-- Derive non-strict dyadic order from strict dyadic order. -/
 private theorem dyadic_le_of_lt {a b : Dyadic} (h : a < b) : a ≤ b := by
   rcases Dyadic.le_total a b with hle | hle
   · exact hle

--- a/HexRCF/Isolations.lean
+++ b/HexRCF/Isolations.lean
@@ -45,11 +45,13 @@ def toLiteral (replay : SturmReplay) (cert : IsolationCert)
   complete := by
     simpa using complete_of_check h
 
+/-- Converting an isolation certificate preserves the number of intervals. -/
 @[simp] theorem size_toLiteral (replay : SturmReplay) (cert : IsolationCert)
     (h : cert.check replay = true) :
     (cert.toLiteral replay h).isolations.size = cert.intervals.size := by
   simp [toLiteral]
 
+/-- The interval at each index is unchanged by conversion to literal isolations. -/
 theorem interval_toLiteral (replay : SturmReplay) (cert : IsolationCert)
     (h : cert.check replay = true)
     (i : Nat) (hi : i < (cert.toLiteral replay h).isolations.size) :

--- a/HexRCF/Isolations.lean
+++ b/HexRCF/Isolations.lean
@@ -17,7 +17,7 @@ public section
 
 The Mathlib-free certificate and checker live in `HexRCF.IsolationCheck`.
 Soundness packages accepted raw intervals into `LiteralIsolations` and applies
-the generic semantic isolation theorem; it never identifies the replay with
+the generic semantic isolation theorem. It never identifies the replay with
 the executable pseudo-remainder chain.
 -/
 

--- a/HexRCF/Isolations.lean
+++ b/HexRCF/Isolations.lean
@@ -60,7 +60,7 @@ theorem interval_toLiteral (replay : SturmReplay) (cert : IsolationCert)
   simp [toLiteral]
 
 /-- Every accepted interval contains exactly one real root of the replay head. -/
-theorem exists_unique_root_of_check {f : ZPoly} {replay : SturmReplay}
+theorem existsUnique_root {f : ZPoly} {replay : SturmReplay}
     {cert : IsolationCert} (hreplay : replay.check f = true)
     (hcert : cert.check replay = true) (i : Fin cert.intervals.size) :
     ∃! r : ℝ, (toPolyℝ f).IsRoot r ∧

--- a/HexRCF/IsolationsTests.lean
+++ b/HexRCF/IsolationsTests.lean
@@ -63,7 +63,7 @@ example : empty.check replay = false := by decide
 
 example : ∃! r : ℝ, (HexRealRootsMathlib.toPolyℝ quad).IsRoot r ∧
     HexRealRootsMathlib.Literal.InInterval (valid.intervals[0]'(by decide)) r :=
-  IsolationCert.exists_unique_root_of_check
+  IsolationCert.existsUnique_root
     (f := quad) (replay := replay) (cert := valid) (by decide) (by decide)
       ⟨0, by decide⟩
 

--- a/HexRCF/LintTests.lean
+++ b/HexRCF/LintTests.lean
@@ -5,7 +5,10 @@ Authors: Kim Morrison
 -/
 
 import HexRCF
-import Mathlib.Tactic.Linter
+import Batteries.Tactic.Lint
+import Mathlib.Tactic.Linter.Lint
+import Mathlib.Tactic.Linter.Style
+import Mathlib.Tactic.Linter.TacticDocumentation
 
 /-!
 # Public RCF lint regression
@@ -15,4 +18,4 @@ docstring metadata is not available to the linter through module imports, which
 would make every imported declaration appear undocumented.
 -/
 
-#lint in HexRCF
+#lint- in HexRCF

--- a/HexRCF/LintTests.lean
+++ b/HexRCF/LintTests.lean
@@ -1,0 +1,18 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexRCF
+import Mathlib.Tactic.Linter
+
+/-!
+# Public RCF lint regression
+
+This file intentionally uses legacy file syntax rather than `module`. Imported
+docstring metadata is not available to the linter through module imports, which
+would make every imported declaration appear undocumented.
+-/
+
+#lint in HexRCF

--- a/HexRCF/Reify.lean
+++ b/HexRCF/Reify.lean
@@ -162,15 +162,15 @@ private meta partial def parsePoly (x : Expr) (fuel : Nat)
       return powRatPoly (← parsePoly x fuel base) n
   | (``HDiv.hDiv, #[_, _, _, _, numerator, denominator]) =>
       if denominator.containsFVar x.fvarId! then
-        throwError "rcf: division by an expression containing the variable is not polynomial; \
-          clear denominators by hand"
+        throwError "rcf: division by an expression containing the variable is not polynomial. \
+          Clear denominators by hand"
       let q ← scalarRat denominator
       if q = 0 then throwError "rcf: division by zero in a polynomial coefficient"
       return DensePoly.scale q⁻¹ (← parsePoly x fuel numerator)
   | (``Inv.inv, #[_, _, value]) =>
       if value.containsFVar x.fvarId! then
-        throwError "rcf: inversion of an expression containing the variable is not polynomial; \
-          clear denominators by hand"
+        throwError "rcf: inversion of an expression containing the variable is not polynomial. \
+          Clear denominators by hand"
       return DensePoly.C (← scalarRat input)
   | _ =>
       let (fn, _) := input.getAppFnArgs
@@ -479,23 +479,23 @@ private meta def rejectInterval (kind : Name) (universal : Bool) :
     MetaM SentenceResult := do
   if kind == ``Set.Icc then
     if universal then
-      throwError "rcf: Set.Icc quantifiers are unsupported; rewrite
+      throwError "rcf: Set.Icc quantifiers are unsupported. Rewrite
   ∀ x ∈ Set.Icc a b, φ x
 as
   (a ≤ b → φ a) ∧ ∀ x ∈ Set.Ioc a b, φ x"
     else
-      throwError "rcf: Set.Icc quantifiers are unsupported; rewrite
+      throwError "rcf: Set.Icc quantifiers are unsupported. Rewrite
   ∃ x ∈ Set.Icc a b, φ x
 as
   a ≤ b ∧ (φ a ∨ ∃ x ∈ Set.Ioc a b, φ x)"
   else if kind == ``Set.Ioo then
     if universal then
-      throwError "rcf: Set.Ioo quantifiers are unsupported; rewrite
+      throwError "rcf: Set.Ioo quantifiers are unsupported. Rewrite
   ∀ x ∈ Set.Ioo a b, φ x
 as
   ∀ x ∈ Set.Ioc a b, x ≠ b → φ x"
     else
-      throwError "rcf: Set.Ioo quantifiers are unsupported; rewrite
+      throwError "rcf: Set.Ioo quantifiers are unsupported. Rewrite
   ∃ x ∈ Set.Ioo a b, φ x
 as
   ∃ x ∈ Set.Ioc a b, φ x ∧ x ≠ b"
@@ -507,7 +507,7 @@ denominator instead of approximating it. -/
 private meta def ratDyadic (q : Rat) : MetaM Dyadic := do
   let shift := q.den.log2
   unless q.den = 2 ^ shift do
-    throwError "rcf: bounded endpoints must be dyadic rationals; got {q}"
+    throwError "rcf: bounded endpoints must be dyadic rationals. Got {q}"
   return Dyadic.ofInt q.num >>> (Int.ofNat shift)
 
 /-- Certify that a literal dyadic denotes the source rational real endpoint. -/

--- a/HexRCF/Reify.lean
+++ b/HexRCF/Reify.lean
@@ -8,12 +8,12 @@ module
 
 public import HexRCF.Soundness
 public import HexRealRootsMathlib.IsolateRoots
-public import Mathlib.Tactic.NormNum
-public import Mathlib.Tactic.Ring
-public meta import HexRCF.DecisionCheck
+public meta import HexRCF.Syntax
+public meta import Mathlib.Tactic.NormNum
+public meta import Mathlib.Tactic.Ring
 public meta import Mathlib.Lean.Elab.Tactic.Meta
 public meta import Qq
-public import Lean
+public meta import Lean
 
 public section
 set_option backward.proofsInPublic true

--- a/HexRCF/Reify.lean
+++ b/HexRCF/Reify.lean
@@ -101,7 +101,7 @@ end Sentence
 /-- Close evaluation identities for literal `ZPoly` coefficients and accepted
 ring syntax. The parser remains untrusted: unsupported or misparsed syntax
 merely makes this proof fail during elaboration. -/
-macro "rcf_ring" : tactic =>
+macro (name := rcfRing) "rcf_ring" : tactic =>
   `(tactic|
     (simp only [HexRealRootsMathlib.aeval_toPolynomial_ofCoeffs] <;>
      simp [Hex.DensePoly.coeff_ofCoeffs, Finset.sum_range_succ,
@@ -115,8 +115,8 @@ namespace Reify
 
 open Lean Meta Qq
 
-/-- Runtime and literal forms of a reflected formula, plus its checked bridge
-to the source proposition at the current bound variable. -/
+/-- Runtime and literal forms of a reflected formula, together with its checked
+equivalence to the source proposition at the current bound variable. -/
 private meta structure FormulaResult where
   formula : Formula
   expr : Expr
@@ -362,7 +362,7 @@ meta def certificateExpr : Certificate → MetaM Expr
             cmps]
       mkAppM ``Certificate.cells #[cells]
 
-/-- Discharge one proposed polynomial evaluation bridge with the kernel ring
+/-- Discharge one proposed polynomial evaluation identity with the kernel ring
 normalizer. -/
 private meta def proveRing (type : Expr) : MetaM Expr := do
   let goal ← mkFreshExprMVar type
@@ -400,7 +400,7 @@ private meta def reifyAtom (x source : Expr) (cmp : Cmp)
     #[polynomialE, cmpExpr cmp, x, lhs, rhs, mkNatLit scale, positive, heval]
   unless ← isDefEq (← inferType proof)
       (← mkAppM ``Iff #[← mkAppM ``Formula.toProp #[formulaE, x], source]) do
-    throwError "rcf: internal comparison bridge mismatch"
+    throwError "rcf: internal comparison equivalence mismatch"
   return { formula := .atom atom, expr := formulaE, proof := proof }
 
 /-- Reify a Boolean formula under one real bound variable. -/
@@ -451,11 +451,14 @@ private meta partial def reifyFormula (x source : Expr) : MetaM FormulaResult :=
           return { formula := formula, expr := expr, proof := proof }
       | _ => throwError "rcf: unsupported proposition in the quantifier body{indentExpr source}"
 
-/-- Runtime and literal forms of a reflected sentence, plus its checked bridge
-to the source goal. -/
+/-- Runtime and literal forms of a reflected sentence, together with its
+checked equivalence to the source goal. -/
 meta structure SentenceResult where
+  /-- The reflected sentence used by compiled certificate construction. -/
   sentence : Sentence
+  /-- The literal expression representing `sentence` in the generated proof. -/
   expr : Expr
+  /-- A proof that `sentence` is equivalent to the source goal. -/
   proof : Expr
 
 /-- Recognize membership in a standard two-ended interval without unfolding it
@@ -522,13 +525,13 @@ private meta def proveEndpoint (dyadicExpr source : Expr) : MetaM Expr := do
     throwError "rcf: failed to certify a dyadic endpoint{indentExpr source}"
   instantiateMVars goal
 
-/-- Check the final sentence bridge before returning it to the tactic. -/
+/-- Check the final sentence equivalence before returning it to the tactic. -/
 private meta def finishSentence (source : Expr) (sentence : Sentence)
     (expr proof : Expr) : MetaM SentenceResult := do
   let reflected ← mkAppM ``Sentence.toProp #[expr]
   let expected ← mkAppM ``Iff #[reflected, source]
   unless ← isDefEq (← inferType proof) expected do
-    throwError "rcf: internal quantified-sentence bridge mismatch"
+    throwError "rcf: internal quantified-sentence equivalence mismatch"
   return { sentence, expr, proof }
 
 /-- Reify a universal sentence, preferring the exact `Set.Ioc` shape before
@@ -552,19 +555,19 @@ private meta def reifyForall (source domain body : Expr) : MetaM SentenceResult 
           let expr ← mkAppM ``Sentence.forallIoc #[aExpr, bExpr, formula.expr]
           let ha ← proveEndpoint aExpr aSource
           let hb ← proveEndpoint bExpr bSource
-          let bridge ← mkLambdaFVars #[x] formula.proof
+          let formulaProof ← mkLambdaFVars #[x] formula.proof
           let predicate ← mkLambdaFVars #[x] consequent
           let proof := mkAppN (mkConst ``Sentence.forallIoc_iff)
             #[aExpr, bExpr, aSource, bSource, formula.expr, predicate,
-              ha, hb, bridge]
+              ha, hb, formulaProof]
           return ← finishSentence source sentence expr proof
     let formula ← reifyFormula x instantiated
     let sentence := Sentence.forallReal formula.formula
     let expr ← mkAppM ``Sentence.forallReal #[formula.expr]
-    let bridge ← mkLambdaFVars #[x] formula.proof
+    let formulaProof ← mkLambdaFVars #[x] formula.proof
     let predicate ← mkLambdaFVars #[x] instantiated
     let proof := mkAppN (mkConst ``Sentence.forallReal_iff)
-      #[formula.expr, predicate, bridge]
+      #[formula.expr, predicate, formulaProof]
     finishSentence source sentence expr proof
 
 /-- Reify an existential sentence, recognizing an `Ioc` membership conjunct
@@ -592,19 +595,19 @@ private meta def reifyExists (source domain predicate : Expr) : MetaM SentenceRe
         let expr ← mkAppM ``Sentence.existsIoc #[aExpr, bExpr, formula.expr]
         let ha ← proveEndpoint aExpr aSource
         let hb ← proveEndpoint bExpr bSource
-        let bridge ← mkLambdaFVars #[x] formula.proof
+        let formulaProof ← mkLambdaFVars #[x] formula.proof
         let predicate ← mkLambdaFVars #[x] consequent
         let proof := mkAppN (mkConst ``Sentence.existsIoc_iff)
           #[aExpr, bExpr, aSource, bSource, formula.expr, predicate,
-            ha, hb, bridge]
+            ha, hb, formulaProof]
         return ← finishSentence source sentence expr proof
     let formula ← reifyFormula x instantiated
     let sentence := Sentence.existsReal formula.formula
     let expr ← mkAppM ``Sentence.existsReal #[formula.expr]
-    let bridge ← mkLambdaFVars #[x] formula.proof
+    let formulaProof ← mkLambdaFVars #[x] formula.proof
     let predicateExpr ← mkLambdaFVars #[x] instantiated
     let proof := mkAppN (mkConst ``Sentence.existsReal_iff)
-      #[formula.expr, predicateExpr, bridge]
+      #[formula.expr, predicateExpr, formulaProof]
     finishSentence source sentence expr proof
 
 /-- Reify one supported, singly quantified real sentence. -/

--- a/HexRCF/ReifyTests.lean
+++ b/HexRCF/ReifyTests.lean
@@ -102,7 +102,7 @@ example : ∀ x : ℝ, x ^ 2 > 0 := by
   rcf
 
 /--
-error: rcf: the existential sentence is false; every relevant decomposition
+error: rcf: the existential sentence is false. Every relevant decomposition
 cell was checked and found false, so there is no witness
 -/
 #guard_msgs in
@@ -110,7 +110,7 @@ example : ∃ x : ℝ, x ^ 2 + 1 = 0 := by
   rcf
 
 /--
-error: rcf: the existential sentence is false; every relevant decomposition
+error: rcf: the existential sentence is false. Every relevant decomposition
 cell was checked and found false, so there is no witness
 -/
 #guard_msgs in
@@ -118,7 +118,7 @@ example : ∃ x : ℝ, x ∈ Set.Ioc (1 : ℝ) 1 ∧ x = x := by
   rcf
 
 /--
-error: rcf: the existential sentence is false; every relevant decomposition
+error: rcf: the existential sentence is false. Every relevant decomposition
 cell was checked and found false, so there is no witness
 -/
 #guard_msgs in
@@ -160,13 +160,13 @@ example : ∀ x : ℝ, ∀ _y : ℝ, x = x := by
 example : ∀ x : ℝ, Real.sin x = 0 := by
   rcf
 
-/-- error: rcf: division by an expression containing the variable is not polynomial; clear denominators by hand -/
+/-- error: rcf: division by an expression containing the variable is not polynomial. Clear denominators by hand -/
 #guard_msgs in
 example : ∀ x : ℝ, x + 1 / x ≥ 2 := by
   rcf
 
 /--
-error: rcf: Set.Icc quantifiers are unsupported; rewrite
+error: rcf: Set.Icc quantifiers are unsupported. Rewrite
   ∀ x ∈ Set.Icc a b, φ x
 as
   (a ≤ b → φ a) ∧ ∀ x ∈ Set.Ioc a b, φ x
@@ -176,7 +176,7 @@ example : ∀ x : ℝ, x ∈ Set.Icc (0 : ℝ) 1 → x ≤ 1 := by
   rcf
 
 /--
-error: rcf: Set.Icc quantifiers are unsupported; rewrite
+error: rcf: Set.Icc quantifiers are unsupported. Rewrite
   ∃ x ∈ Set.Icc a b, φ x
 as
   a ≤ b ∧ (φ a ∨ ∃ x ∈ Set.Ioc a b, φ x)
@@ -186,7 +186,7 @@ example : ∃ x : ℝ, x ∈ Set.Icc (0 : ℝ) 1 ∧ x = x := by
   rcf
 
 /--
-error: rcf: Set.Ioo quantifiers are unsupported; rewrite
+error: rcf: Set.Ioo quantifiers are unsupported. Rewrite
   ∀ x ∈ Set.Ioo a b, φ x
 as
   ∀ x ∈ Set.Ioc a b, x ≠ b → φ x
@@ -196,7 +196,7 @@ example : ∀ x : ℝ, x ∈ Set.Ioo (0 : ℝ) 1 → x ≤ 1 := by
   rcf
 
 /--
-error: rcf: Set.Ioo quantifiers are unsupported; rewrite
+error: rcf: Set.Ioo quantifiers are unsupported. Rewrite
   ∃ x ∈ Set.Ioo a b, φ x
 as
   ∃ x ∈ Set.Ioc a b, φ x ∧ x ≠ b
@@ -205,7 +205,7 @@ as
 example : ∃ x : ℝ, x ∈ Set.Ioo (0 : ℝ) 1 ∧ x = x := by
   rcf
 
-/-- error: rcf: bounded endpoints must be dyadic rationals; got 1/3 -/
+/-- error: rcf: bounded endpoints must be dyadic rationals. Got 1/3 -/
 #guard_msgs in
 example : ∀ x : ℝ, x ∈ Set.Ioc ((1 : ℝ) / 3) 1 → x ≤ 1 := by
   rcf

--- a/HexRCF/Separation.lean
+++ b/HexRCF/Separation.lean
@@ -62,7 +62,7 @@ theorem classify_sound {f : ZPoly} {replay : SturmReplay}
       cmp.Holds root (Dyadic.toReal endpoint) := by
   classical
   obtain ⟨root, hroot, huniq⟩ :=
-    IsolationCert.exists_unique_root_of_check hreplay hcert i
+    IsolationCert.existsUnique_root hreplay hcert i
   have hP : toPolyℝ f ≠ 0 := by
     intro hzero
     exact SturmReplay.head_ne_zero hreplay (toPolyℝ_eq_zero_iff.mp hzero)

--- a/HexRCF/SeparationCheck.lean
+++ b/HexRCF/SeparationCheck.lean
@@ -204,7 +204,7 @@ def separate? (p : ZPoly) (replay : SturmReplay)
       if out.checkStrict replay then some out else none
 
 /-- The public builder never returns an unchecked strict isolation array. -/
-theorem check_of_separate_eq_some {p : ZPoly} {replay : SturmReplay}
+theorem check_separate {p : ZPoly} {replay : SturmReplay}
     {input output : IsolationCert} (h : separate? p replay input = some output) :
     output.checkStrict replay = true := by
   unfold separate? at h

--- a/HexRCF/SeparationCheck.lean
+++ b/HexRCF/SeparationCheck.lean
@@ -63,7 +63,7 @@ theorem gap_of_check {cert : IsolationCert} (h : cert.checkGaps = true)
   simp only [hi, dif_pos] at hstep
   exact of_decide_eq_true hstep
 
-/-- Transitivity for the core dyadic strict order. -/
+/-- Transitivity of strict order on dyadic numbers. -/
 private theorem dlt_trans {a b c : Dyadic} (hab : a < b) (hbc : b < c) : a < c := by
   rw [← Dyadic.toRat_lt_toRat_iff] at hab hbc ⊢
   exact Std.lt_trans hab hbc
@@ -114,8 +114,8 @@ def classify? (f : ZPoly) (replay : SturmReplay)
   if hleft : endpoint ≤ I.lower then some .gt
   else if _hright : I.upper < endpoint then some .lt
   else
-    -- Core's names are the converses of the usual Mathlib convention:
-    -- `Dyadic.not_lt` turns `¬e ≤ l` into `l < e`.
+    -- `Dyadic.not_lt` uses the converse naming convention from Mathlib and
+    -- turns `¬e ≤ l` into `l < e`.
     let initial := DyadicInterval.mk I.lower endpoint (Dyadic.not_lt.mp hleft)
     if replay.count initial = 0 then some .gt
     else if replay.count initial = 1 then
@@ -192,7 +192,7 @@ def separateList? (p : ZPoly) (replay : SturmReplay) :
   | first :: rest => separateFrom? p replay first rest
 
 /-- Run untrusted strict separation and retain only checker-approved output.
-The caller pairs `p` with a replay checked against it; a mismatch can only
+The caller pairs `p` with a replay checked against it. A mismatch can only
 choose inadequate fuel and make this builder return `none`, because the output
 checker reads counts solely from `replay`. -/
 def separate? (p : ZPoly) (replay : SturmReplay)

--- a/HexRCF/SignMatrix.lean
+++ b/HexRCF/SignMatrix.lean
@@ -50,9 +50,13 @@ theorem ofInt_spec (value : Int) :
 
 end Sign
 
+end Hex.RCF
+
+namespace Polynomial
+
 /-- The sign of a continuous polynomial evaluation is constant on a
 preconnected set containing no root of the polynomial. -/
-theorem Polynomial.sign_eq_of_noRoot {p : Polynomial ℝ} {s : Set ℝ}
+theorem sign_eq_of_noRoot {p : Polynomial ℝ} {s : Set ℝ}
     (hs : IsPreconnected s) (hnz : ∀ z ∈ s, ¬p.IsRoot z)
     {x y : ℝ} (hx : x ∈ s) (hy : y ∈ s) :
     SignType.sign (p.eval x) = SignType.sign (p.eval y) := by
@@ -63,6 +67,12 @@ theorem Polynomial.sign_eq_of_noRoot {p : Polynomial ℝ} {s : Set ℝ}
     exact continuousAt_sign_of_ne_zero (fun hzero => hnz z hz hzero)
   exact (hs.image _ hcont).subsingleton
     (Set.mem_image_of_mem _ hx) (Set.mem_image_of_mem _ hy)
+
+end Polynomial
+
+namespace Hex.RCF
+
+open HexRealRootsMathlib Polynomial
 
 /-- Exact dyadic Horner evaluation computes the sign of the corresponding
 real-polynomial evaluation. -/

--- a/HexRCF/SignMatrix.lean
+++ b/HexRCF/SignMatrix.lean
@@ -52,7 +52,7 @@ end Sign
 
 /-- The sign of a continuous polynomial evaluation is constant on a
 preconnected set containing no root of the polynomial. -/
-theorem sign_eval_eq_of_noRoot {p : Polynomial ℝ} {s : Set ℝ}
+theorem Polynomial.sign_eq_of_noRoot {p : Polynomial ℝ} {s : Set ℝ}
     (hs : IsPreconnected s) (hnz : ∀ z ∈ s, ¬p.IsRoot z)
     {x y : ℝ} (hx : x ∈ s) (hy : y ∈ s) :
     SignType.sign (p.eval x) = SignType.sign (p.eval y) := by
@@ -74,7 +74,7 @@ theorem evalSign_spec (p : ZPoly) (x : Dyadic) :
 
 /-- A polynomial whose executable degree is not positive is constant after
 casting, including the zero polynomial. -/
-theorem eval_eq_eval_zero_of_degree_nonpos (p : ZPoly)
+theorem eval_eq_at_zero (p : ZPoly)
     (hdegree : ¬0 < p.degree?.getD 0) (x : ℝ) :
     (toPolyℝ p).eval x = (toPolyℝ p).eval 0 := by
   have hnat : (toPolyℝ p).natDegree = 0 := by
@@ -95,7 +95,7 @@ theorem sign_eval_eq_open {carrier : ZPoly} {replay : SturmReplay}
       (Dyadic.toReal (isolations.openPoint cut))) =
       SignType.sign ((toPolyℝ atom).eval x) := by
   let model := isolations.rootModel hreplay hstrict
-  apply sign_eval_eq_of_noRoot (Cell.isPreconnected_open model cut)
+  apply Polynomial.sign_eq_of_noRoot (Cell.isPreconnected_open model cut)
   · intro z hz hatom
     exact Cell.open_not_root model hz (hroot z hatom)
   · exact Cell.openPoint_mem isolations hreplay hstrict cut
@@ -143,11 +143,11 @@ theorem sign_eval_eq_leftRoot {carrier atom : ZPoly} {cert : IsolationCert}
     {sample : ℝ} (hsample : Cell.Sem model (.open i.castSucc) sample) :
     SignType.sign ((toPolyℝ atom).eval sample) =
       SignType.sign ((toPolyℝ atom).eval (model.root i)) := by
-  apply sign_eval_eq_of_noRoot (model.isPreconnected_leftSpan i) _
+  apply Polynomial.sign_eq_of_noRoot (model.isPreconnected_leftSpan i) _
       (model.leftOpen_mem_leftSpan i hsample) (model.root_mem_leftSpan i)
   intro z hz hzroot
   exact hnonzero (by
-    rw [← model.root_eq_of_mem_leftSpan i (hroot z hzroot) hz]
+    rw [← model.root_unique_leftSpan i (hroot z hzroot) hz]
     exact hzroot)
 
 /-- Exact left-open sample sign at a carrier root where the atom does not
@@ -200,7 +200,7 @@ theorem evalSign_commonLeft
   exact evalSign_leftRoot hreplay hstrict hroot i hnonzero
 
 /-- Exact evaluation cannot report zero at a certified nonroot. -/
-theorem evalSign_ne_zero_of_not_root (p : ZPoly) (x : Dyadic)
+theorem evalSign_ne_zero (p : ZPoly) (x : Dyadic)
     (hroot : ¬(toPolyℝ p).IsRoot (Dyadic.toReal x)) :
     evalSign p x ≠ .zero := by
   intro hzero
@@ -243,12 +243,12 @@ theorem openCellSign_spec {sentence : Sentence} {carrier : CarrierCert}
       intro hpRoot
       exact Cell.open_not_root model hsample (hroot _ hpRoot)
     have hnonzero : evalSign p (isolations.openPoint cut) ≠ .zero :=
-      evalSign_ne_zero_of_not_root p _ hnotroot
+      evalSign_ne_zero p _ hnotroot
     refine ⟨evalSign p (isolations.openPoint cut), ?_, ?_⟩
     · simp [openCellSign?, hdegree, openSign?_eq_some hnonzero]
     · exact evalSign_open_of_atom hcarrier hstrict hpmem cut hx
   · refine ⟨evalSign p 0, by simp [openCellSign?, hdegree], ?_⟩
-    rw [eval_eq_eval_zero_of_degree_nonpos p hdegree x]
+    rw [eval_eq_at_zero p hdegree x]
     simpa using evalSign_spec p 0
 
 namespace SignMatrixCert
@@ -330,7 +330,7 @@ theorem signWith?_spec {sentence : Sentence} {carrier : CarrierCert}
             intro hpRoot
             exact Cell.open_not_root model hsample (hroot _ hpRoot)
           have hnonzero : evalSign p (isolations.openPoint i.castSucc) ≠ .zero :=
-            evalSign_ne_zero_of_not_root p _ hnotroot
+            evalSign_ne_zero p _ hnotroot
           refine ⟨evalSign p (isolations.openPoint i.castSucc), ?_, ?_⟩
           · simp only [signWith?, if_pos hdegree]
             rw [hfind']
@@ -347,12 +347,12 @@ theorem signWith?_spec {sentence : Sentence} {carrier : CarrierCert}
     | «open» cut =>
         refine ⟨evalSign p 0, by simp [signWith?, openCellSign?, hdegree], ?_⟩
         intro x _hx
-        rw [eval_eq_eval_zero_of_degree_nonpos p hdegree x]
+        rw [eval_eq_at_zero p hdegree x]
         simpa using evalSign_spec p 0
     | root i =>
         refine ⟨evalSign p 0, by simp [signWith?, hdegree], ?_⟩
         intro x _hx
-        rw [eval_eq_eval_zero_of_degree_nonpos p hdegree x]
+        rw [eval_eq_at_zero p hdegree x]
         simpa using evalSign_spec p 0
 
 /-- Public atom-sign lookup is total and exact under the combined checker. -/
@@ -501,7 +501,7 @@ theorem evalConstants_eq_true_iff {formula : Formula}
   apply evalSigns_eq_true_iff
   intro p hp
   refine ⟨Hex.RCF.evalSign p 0, rfl, ?_⟩
-  rw [eval_eq_eval_zero_of_degree_nonpos p (hconstant p hp) x]
+  rw [eval_eq_at_zero p (hconstant p hp) x]
   simpa using Hex.RCF.evalSign_spec p 0
 
 end Formula

--- a/HexRCF/SignMatrix.lean
+++ b/HexRCF/SignMatrix.lean
@@ -413,7 +413,7 @@ theorem evalSign_iff {cmp : Cmp} {sign : Sign} {value : ℝ}
 
 end Cmp
 
-/-- Bridge the reflected atom semantics to real-cast polynomial evaluation. -/
+/-- Relate the reflected atom semantics to real-cast polynomial evaluation. -/
 theorem Atom.toProp_iff_eval (a : Atom) (x : ℝ) :
     a.toProp x ↔ a.cmp.toProp ((toPolyℝ a.p).eval x) 0 := by
   unfold Atom.toProp

--- a/HexRCF/SignMatrixCheck.lean
+++ b/HexRCF/SignMatrixCheck.lean
@@ -27,8 +27,11 @@ namespace Hex.RCF
 
 /-- The three possible signs stored by an RCF sign matrix. -/
 inductive Sign where
+  /-- A negative value. -/
   | neg
+  /-- A zero value. -/
   | zero
+  /-- A positive value. -/
   | pos
   deriving DecidableEq, Repr
 
@@ -60,6 +63,7 @@ def containsPoly (p : ZPoly) : List ZPoly → Bool
   | [] => false
   | q :: qs => DensePoly.beqCoeffs p q || containsPoly p qs
 
+/-- Coefficient-based polynomial membership agrees with list membership. -/
 theorem containsPoly_iff {p : ZPoly} {ps : List ZPoly} :
     containsPoly p ps = true ↔ p ∈ ps := by
   induction ps with
@@ -87,6 +91,8 @@ coefficient equality. -/
 @[expose]
 def dedupPolys (ps : List ZPoly) : List ZPoly := dedupPolysAux [] ps
 
+/-- A polynomial survives duplicate removal exactly when it occurs in the
+input and has not already occurred in `seen`. -/
 theorem mem_dedupPolysAux {p : ZPoly} {seen ps : List ZPoly} :
     p ∈ dedupPolysAux seen ps ↔ p ∈ ps ∧ p ∉ seen := by
   classical
@@ -110,10 +116,12 @@ theorem mem_dedupPolysAux {p : ZPoly} {seen ps : List ZPoly} :
           simp [hqmem]
         · simp [hpq]
 
+/-- Duplicate removal preserves polynomial membership. -/
 theorem mem_dedupPolys {p : ZPoly} {ps : List ZPoly} :
     p ∈ dedupPolys ps ↔ p ∈ ps := by
   simp [dedupPolys, mem_dedupPolysAux]
 
+/-- Duplicate removal with an initial seen list produces no duplicate entries. -/
 theorem dedupPolysAux_nodup (seen ps : List ZPoly) :
     (dedupPolysAux seen ps).Nodup := by
   induction ps generalizing seen with
@@ -125,6 +133,7 @@ theorem dedupPolysAux_nodup (seen ps : List ZPoly) :
       · apply List.nodup_cons.mpr
         exact ⟨by simp [mem_dedupPolysAux], ih (p :: seen)⟩
 
+/-- Duplicate removal produces no duplicate entries. -/
 theorem dedupPolys_nodup (ps : List ZPoly) : (dedupPolys ps).Nodup :=
   dedupPolysAux_nodup [] ps
 
@@ -174,6 +183,8 @@ theorem findCommon?_of_check {carrier p : ZPoly} {ps : List ZPoly}
 /-- Common-root data carried by the sign-matrix layer. No signs or formula
 truth values are trusted fields: both are recomputed exactly. -/
 structure SignMatrixCert where
+  /-- Proposed common-root certificates. The checker aligns them with the
+  distinct nonconstant atom polynomials in their recomputed order. -/
   commonRoots : List CommonRootCert
 
 /-- Exact sign on an open cell, rejecting zero for a nonconstant atom of a
@@ -195,6 +206,7 @@ def rootSign? (p : ZPoly) (common : CommonRootCert)
   | true => some .zero
   | false => openSign? p isolations i.castSucc
 
+/-- A nonzero open-cell evaluation is returned unchanged by `openSign?`. -/
 theorem openSign?_eq_some {p : ZPoly} {isolations : IsolationCert}
     {cut : Fin (isolations.intervals.size + 1)}
     (hnonzero : evalSign p (isolations.openPoint cut) ≠ .zero) :
@@ -213,7 +225,9 @@ def openCellSign? (p : ZPoly) (isolations : IsolationCert)
 
 /-- One cached sign associated with its literal polynomial. -/
 structure SignEntry where
+  /-- The polynomial whose sign is cached. -/
   poly : ZPoly
+  /-- The cached sign of the polynomial. -/
   sign : Sign
 
 /-- Coefficient-equality lookup in a cached sign row. -/

--- a/HexRCF/Soundness.lean
+++ b/HexRCF/Soundness.lean
@@ -19,6 +19,7 @@ open HexRealRootsMathlib
 
 namespace OptionFold
 
+/-- A strict universal fold returns `none` exactly when an input evaluates to `none`. -/
 theorem all_eq_none_iff {f : α → Option Bool} {xs : List α} :
     all f xs = none ↔ ∃ x ∈ xs, f x = none := by
   induction xs with
@@ -42,6 +43,7 @@ theorem all_eq_none_iff {f : α → Option Bool} {xs : List α} :
         · have htail := ih.mpr ⟨y, hy, hfy⟩
           cases hx : f x <;> simp [all, hx, htail]
 
+/-- A strict existential fold returns `none` exactly when an input evaluates to `none`. -/
 theorem any_eq_none_iff {f : α → Option Bool} {xs : List α} :
     any f xs = none ↔ ∃ x ∈ xs, f x = none := by
   induction xs with
@@ -65,6 +67,7 @@ theorem any_eq_none_iff {f : α → Option Bool} {xs : List α} :
         · have htail := ih.mpr ⟨y, hy, hfy⟩
           cases hx : f x <;> simp [any, hx, htail]
 
+/-- A total strict universal fold is true exactly when every input is true. -/
 theorem all_spec {f : α → Option Bool} {xs : List α}
     (htotal : ∀ x ∈ xs, ∃ value, f x = some value) :
     ∃ value, all f xs = some value ∧
@@ -79,6 +82,7 @@ theorem all_spec {f : α → Option Bool} {xs : List α}
       refine ⟨head && tail, by simp [all, hhead, htail], ?_⟩
       cases head <;> cases tail <;> simp_all
 
+/-- A total strict existential fold is true exactly when some input is true. -/
 theorem any_spec {f : α → Option Bool} {xs : List α}
     (htotal : ∀ x ∈ xs, ∃ value, f x = some value) :
     ∃ value, any f xs = some value ∧
@@ -93,14 +97,17 @@ theorem any_spec {f : α → Option Bool} {xs : List α}
       refine ⟨head || tail, by simp [any, hhead, htail], ?_⟩
       cases head <;> cases tail <;> simp_all
 
+/-- A strict universal array fold returns `none` exactly when an entry evaluates to `none`. -/
 theorem allArray_none {xs : Array α} {f : α → Option Bool} :
     allArray xs f = none ↔ ∃ x ∈ xs, f x = none := by
   simpa [allArray] using all_eq_none_iff (xs := xs.toList) (f := f)
 
+/-- A strict existential array fold returns `none` exactly when an entry evaluates to `none`. -/
 theorem anyArray_none {xs : Array α} {f : α → Option Bool} :
     anyArray xs f = none ↔ ∃ x ∈ xs, f x = none := by
   simpa [anyArray] using any_eq_none_iff (xs := xs.toList) (f := f)
 
+/-- A filtered universal array fold returns `none` exactly at a relevant undefined entry. -/
 theorem allWhereArray_none {xs : Array α}
     {relevant : α → Bool} {f : α → Option Bool} :
     allWhereArray xs relevant f = none ↔
@@ -109,6 +116,7 @@ theorem allWhereArray_none {xs : Array α}
   simp only [List.mem_filter]
   aesop
 
+/-- A filtered existential array fold returns `none` exactly at a relevant undefined entry. -/
 theorem anyWhereArray_none {xs : Array α}
     {relevant : α → Bool} {f : α → Option Bool} :
     anyWhereArray xs relevant f = none ↔
@@ -117,6 +125,7 @@ theorem anyWhereArray_none {xs : Array α}
   simp only [List.mem_filter]
   aesop
 
+/-- A total strict universal array fold is true exactly when every entry is true. -/
 theorem allArray_spec {xs : Array α} {f : α → Option Bool}
     (htotal : ∀ x ∈ xs, ∃ value, f x = some value) :
     ∃ value, allArray xs f = some value ∧
@@ -126,6 +135,7 @@ theorem allArray_spec {xs : Array α} {f : α → Option Bool}
       intro x hx
       exact htotal x (by simpa using hx))
 
+/-- A total strict existential array fold is true exactly when some entry is true. -/
 theorem anyArray_spec {xs : Array α} {f : α → Option Bool}
     (htotal : ∀ x ∈ xs, ∃ value, f x = some value) :
     ∃ value, anyArray xs f = some value ∧
@@ -135,6 +145,7 @@ theorem anyArray_spec {xs : Array α} {f : α → Option Bool}
       intro x hx
       exact htotal x (by simpa using hx))
 
+/-- A total filtered universal fold is true exactly when every relevant entry is true. -/
 theorem allWhereArray_spec {xs : Array α} {relevant : α → Bool}
     {f : α → Option Bool}
     (htotal : ∀ x ∈ xs, relevant x = true → ∃ value, f x = some value) :
@@ -151,6 +162,7 @@ theorem allWhereArray_spec {xs : Array α} {relevant : α → Bool}
   simp only [List.mem_filter]
   aesop
 
+/-- A total filtered existential fold is true exactly when some relevant entry is true. -/
 theorem anyWhereArray_spec {xs : Array α} {relevant : α → Bool}
     {f : α → Option Bool}
     (htotal : ∀ x ∈ xs, relevant x = true → ∃ value, f x = some value) :
@@ -173,6 +185,9 @@ namespace CellFold
 
 open OptionFold
 
+/--
+Universal folding over all cells is equivalent to universal quantification over the real line.
+-/
 theorem forall_spec {carrier : ZPoly} {cert : IsolationCert}
     (M : RootModel carrier cert) (eval : Cell cert.intervals.size → Option Bool)
     (P : ℝ → Prop)
@@ -203,6 +218,9 @@ theorem forall_spec {carrier : ZPoly} {cert : IsolationCert}
     have hvtrue : v = true := (hsound x hx).mpr (hP x)
     simpa [hvtrue] using hev
 
+/--
+Existential folding over all cells is equivalent to existential quantification over the real line.
+-/
 theorem exists_spec {carrier : ZPoly} {cert : IsolationCert}
     (M : RootModel carrier cert) (eval : Cell cert.intervals.size → Option Bool)
     (P : ℝ → Prop)
@@ -233,6 +251,9 @@ theorem exists_spec {carrier : ZPoly} {cert : IsolationCert}
     have hvtrue : v = true := (hsound x hcx).mpr hPx
     simpa [hvtrue] using hev
 
+/--
+Universal folding over relevant cells is equivalent to quantification over the specified domain.
+-/
 theorem forallWhere_spec {carrier : ZPoly} {cert : IsolationCert}
     (M : RootModel carrier cert) (eval : Cell cert.intervals.size → Option Bool)
     (relevant : Cell cert.intervals.size → Bool) (D P : ℝ → Prop)
@@ -267,6 +288,9 @@ theorem forallWhere_spec {carrier : ZPoly} {cert : IsolationCert}
     have hvtrue : v = true := (hsound x hcx).mpr (hP x hDx)
     simpa [hvtrue] using hev
 
+/--
+Existential folding over relevant cells is equivalent to quantification over the specified domain.
+-/
 theorem existsWhere_spec {carrier : ZPoly} {cert : IsolationCert}
     (M : RootModel carrier cert) (eval : Cell cert.intervals.size → Option Bool)
     (relevant : Cell cert.intervals.size → Bool) (D P : ℝ → Prop)
@@ -300,6 +324,7 @@ theorem existsWhere_spec {carrier : ZPoly} {cert : IsolationCert}
     have hvtrue : v = true := (hsound x hcx).mpr hPx
     simpa [hvtrue] using hev
 
+/-- Universal folding over cells that meet `(a, b]` computes the bounded universal proposition. -/
 theorem forallIoc_spec {carrier : ZPoly} {replay : SturmReplay}
     (hreplay : replay.check carrier = true) {cert : IsolationCert}
     (hstrict : cert.checkStrict replay = true)
@@ -318,6 +343,9 @@ theorem forallIoc_spec {carrier : ZPoly} {replay : SturmReplay}
     (fun x => x ∈ Set.Ioc (Dyadic.toReal a) (Dyadic.toReal b)) P hcell
   exact fun c => Cell.meetsIocOn_iff_of_check cmps a b hreplay hstrict hcmps c
 
+/--
+Existential folding over cells that meet `(a, b]` computes the bounded existential proposition.
+-/
 theorem existsIoc_spec {carrier : ZPoly} {replay : SturmReplay}
     (hreplay : replay.check carrier = true) {cert : IsolationCert}
     (hstrict : cert.checkStrict replay = true)
@@ -338,6 +366,7 @@ theorem existsIoc_spec {carrier : ZPoly} {replay : SturmReplay}
 
 end CellFold
 
+/-- An accepted certificate has three-valued replay result `some true`. -/
 theorem Certificate.replay_true {s : Sentence}
     {cert : Certificate} (h : cert.check s = true) :
     cert.replay? s = some true := by

--- a/HexRCF/SturmBuilder.lean
+++ b/HexRCF/SturmBuilder.lean
@@ -119,7 +119,7 @@ def buildSturmReplay? (f : ZPoly) : Option SturmReplay :=
 
 /-- Every certificate returned by the builder has passed the kernel-facing
 Boolean checker. -/
-theorem check_of_build_eq_some {f : ZPoly} {replay : SturmReplay}
+theorem check_buildSturmReplay {f : ZPoly} {replay : SturmReplay}
     (h : buildSturmReplay? f = some replay) : replay.check f = true := by
   unfold buildSturmReplay? at h
   split at h

--- a/HexRCF/SturmBuilder.lean
+++ b/HexRCF/SturmBuilder.lean
@@ -69,7 +69,7 @@ private def buildSpem (dividend divisor : ZPoly) : Option SpemWitness :=
     remainder := dividend }
 
 /-- Extend a replay until its current entry is a nonzero constant. A zero
-remainder before that point detects a nonsquarefree input; fuel exhaustion is
+remainder before that point detects a nonsquarefree input. Fuel exhaustion is
 rejected directly. -/
 private def buildReplayAux (derivScale : Int) :
     Nat → ZPoly → ZPoly → Array ZPoly → Array SturmStep → Option SturmReplay

--- a/HexRCF/Tactic.lean
+++ b/HexRCF/Tactic.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexRCF.Reify
+public meta import HexRCF.DecisionCheck
 
 public section
 

--- a/HexRCF/Tactic.lean
+++ b/HexRCF/Tactic.lean
@@ -54,7 +54,7 @@ private meta def falseMessage (sentence : Sentence)
     (certificate : Certificate) : MessageData :=
   match sentence with
   | .existsReal _ | .existsIoc _ _ _ =>
-      "rcf: the existential sentence is false; every relevant decomposition\n\
+      "rcf: the existential sentence is false. Every relevant decomposition\n\
         cell was checked and found false, so there is no witness"
   | .forallReal _ | .forallIoc _ _ _ =>
       match certificate with

--- a/HexRCF/Tactic.lean
+++ b/HexRCF/Tactic.lean
@@ -96,6 +96,7 @@ private meta def proveRCFGoal (target : Expr) : MetaM Expr := do
 building and replaying a literal certificate. -/
 syntax (name := rcfTac) "rcf" : tactic
 
+/-- Elaborate `rcf` by constructing and replaying a checked certificate. -/
 @[tactic rcfTac] meta def evalRCFTac : Tactic := fun stx => do
   match stx with
   | `(tactic| rcf) =>

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -648,6 +648,9 @@ free to change.
 - `HexRCF/Reify.lean`: `Qq`/`MetaM` reification, normalisation,
   fall-through messages; `HexRCF/ReifyTests.lean`: checked tactic examples,
   false-sentence diagnostics, and out-of-fragment rejection tests.
+- `HexRCF/LintTests.lean`: the standard Mathlib linter suite over the public
+  `HexRCF` namespace. It intentionally uses legacy file syntax so imported
+  docstring metadata is available to the linter.
 - `HexRCF/Tactic.lean`: the `rcf` front end.
 - `conformance/HexRCF/{Conformance,EmitFixtures}.lean`: conformance
   in the shared sub-project.

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -648,9 +648,13 @@ free to change.
 - `HexRCF/Reify.lean`: `Qq`/`MetaM` reification, normalisation,
   fall-through messages; `HexRCF/ReifyTests.lean`: checked tactic examples,
   false-sentence diagnostics, and out-of-fragment rejection tests.
-- `HexRCF/LintTests.lean`: the standard Mathlib linter suite over the public
-  `HexRCF` namespace. It intentionally uses legacy file syntax so imported
-  docstring metadata is available to the linter.
+- `HexRCF/LintTests.lean`: Batteries' default environment linters, applied to
+  declarations whose defining module is under the `HexRCF` module prefix. This
+  enforces definition, structure, field, and tactic documentation plus the
+  default naming/style checks. Theorem docstrings remain a review convention:
+  `docBlameThm` is not default-enabled and also flags generated constructor-index
+  theorems. The file intentionally uses legacy syntax so imported docstring
+  metadata is available to the linters.
 - `HexRCF/Tactic.lean`: the `rcf` front end.
 - `conformance/HexRCF/{Conformance,EmitFixtures}.lean`: conformance
   in the shared sub-project.

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -257,7 +257,7 @@ proved equivalences.
    For root-cell transfer, `RootModel.leftSpan` is the interval from the open
    cell immediately left of root `i` through that root. Its preconnectedness,
    open-sample and root membership lemmas, together with
-   `RootModel.root_eq_of_mem_leftSpan`, show that the only carrier root in the
+   `RootModel.root_unique_leftSpan`, show that the only carrier root in the
    span is root `i` itself.
 
 7. **Prepare common-root packages.** Do the expensive work once per
@@ -519,7 +519,7 @@ cannot pass a fixture expecting either verdict. The required one-way
 connections are
 
 ```lean
-theorem decide_eq_some_true_imp_exists_cert :
+theorem exists_cert_of_decide :
     decide s = some true → ∃ cert, Certificate.check s cert = true
 
 theorem decide_sound (s : Sentence) :

--- a/conformance/HexRCF/Conformance.lean
+++ b/conformance/HexRCF/Conformance.lean
@@ -179,12 +179,12 @@ example : ∀ a x : ℝ, a * x ^ 2 + 1 > 0 := by rcf
 #guard_msgs in
 example : ∀ x : ℝ, Real.sin x = 0 := by rcf
 
-/-- error: rcf: division by an expression containing the variable is not polynomial; clear denominators by hand -/
+/-- error: rcf: division by an expression containing the variable is not polynomial. Clear denominators by hand -/
 #guard_msgs in
 example : ∀ x : ℝ, x + 1 / x ≥ 2 := by rcf
 
 /--
-error: rcf: Set.Icc quantifiers are unsupported; rewrite
+error: rcf: Set.Icc quantifiers are unsupported. Rewrite
   ∀ x ∈ Set.Icc a b, φ x
 as
   (a ≤ b → φ a) ∧ ∀ x ∈ Set.Ioc a b, φ x
@@ -197,7 +197,7 @@ example : ∀ x : ℝ, x ∈ Set.Icc (0 : ℝ) 1 → x ≤ 1 := by rcf
 example : ∀ x : ℝ, x ^ 2 > 0 := by rcf
 
 /--
-error: rcf: the existential sentence is false; every relevant decomposition
+error: rcf: the existential sentence is false. Every relevant decomposition
 cell was checked and found false, so there is no witness
 -/
 #guard_msgs in

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -296,7 +296,8 @@ lean_lib HexRCFTests where
     `HexRCF.BuilderTests,
     `HexRCF.CertificateTests,
     `HexRCF.DecisionTests,
-    `HexRCF.ReifyTests]
+    `HexRCF.ReifyTests,
+    `HexRCF.LintTests]
 
 -- Canonical end-to-end examples are release artifacts rather than public API.
 -- Keep their target separate for the same reason as the regression tests.

--- a/progress/20260728T044510Z_rcf-phase6-docstrings.md
+++ b/progress/20260728T044510Z_rcf-phase6-docstrings.md
@@ -55,12 +55,17 @@
   and the strict module-mode tactic/replay axiom guards.
 - Repository DAG, release-manifest, trust-surface, Phase 4, copyright, and diff
   checks pass.
+- PR #9036 has passed independent review with no blockers, and every actionable
+  documentation, import, namespace, and public-surface finding is addressed.
+  Auto-merge is enabled pending CI.
 
 ## Next step
 
-- Publish the Phase 6 quality milestone, obtain an independent Claude Opus
-  review, address any actionable findings, and merge after CI.
+- Confirm PR #9036 merges green, then audit the merged main tree. Complete the
+  external Phase 4 evidence only after its dependency and dedicated-host gates
+  are available.
 
 ## Blockers
 
-- None for this milestone.
+- None for PR #9036. Phase 4 remains dependency-gated by HexRealRootsMathlib
+  issue #8972 and requires scientific evidence from the named quiescent host.

--- a/progress/20260728T044510Z_rcf-phase6-docstrings.md
+++ b/progress/20260728T044510Z_rcf-phase6-docstrings.md
@@ -4,7 +4,7 @@
 
 - Ran the Mathlib linter with legacy import semantics, which retain imported
   documentation metadata under Lean's module system. The final audit reports
-  zero errors across 391 HexRCF declarations and 14 linters.
+  zero errors across 391 HexRCF declarations and the default 14 linters.
 - Added documentation for every genuinely undocumented public structure field
   and tactic implementation reported by the linter.
 - Added documentation for 31 public theorems that another module could
@@ -39,6 +39,9 @@
   public `rcf_ring` macro, so retained it.
 - Added `HexRCF.LintTests` to the existing default regression target, making
   the zero-error public namespace lint a permanent build invariant.
+- Made every linter import explicit so an umbrella import-graph change cannot
+  silently shrink the enforced set. The non-default theorem-doc linter was
+  separately audited; only three generated constructor-index theorems fail it.
 - Verified that every private HexRCF declaration has at least one textual use,
   then built all changed modules and the complete `HexRCF` target.
 
@@ -47,8 +50,9 @@
 - The documentation, linter, API, dead-declaration, and import-boundary audits
   are complete on `rcf-phase6-docstrings`, rebased over merged PRs #9032 and
   #9033.
-- `lake build HexRCF HexRCFTests HexConformance HexManual` succeeds with 9,526
-  jobs, including the permanent zero-error lint regression.
+- `lake build HexRCF HexRCFTests HexConformance HexManual HexRCFProofProbe`
+  succeeds with 9,538 jobs, including the permanent zero-error lint regression
+  and the strict module-mode tactic/replay axiom guards.
 - Repository DAG, release-manifest, trust-surface, Phase 4, copyright, and diff
   checks pass.
 

--- a/progress/20260728T044510Z_rcf-phase6-docstrings.md
+++ b/progress/20260728T044510Z_rcf-phase6-docstrings.md
@@ -1,0 +1,37 @@
+# HexRCF Phase 6 documentation audit
+
+## Accomplished
+
+- Ran the Mathlib linter with legacy import semantics, which retain imported
+  documentation metadata under Lean's module system. The final audit reports
+  zero errors across 396 HexRCF declarations and 14 linters.
+- Added documentation for every genuinely undocumented public structure field
+  and tactic implementation reported by the linter.
+- Added documentation for 31 public theorems that another module could
+  reasonably import, plus the non-obvious private open-cell boundary lemmas.
+- Named the internal `rcf_ring` macro declaration `rcfRing` so its generated
+  declaration follows Lean naming conventions without changing tactic syntax.
+- Removed prohibited terminology and semicolon run-ons from the HexRCF source
+  prose touched by this audit.
+- Verified that every private HexRCF declaration has at least one textual use,
+  then built all changed modules and the complete `HexRCF` target.
+
+## Current frontier
+
+- The documentation and linter corrections are complete on the stacked
+  `rcf-phase6-docstrings` branch.
+- The branch still needs the public/test separation milestone from PR #9032
+  before its lint audit can become a permanent non-public test module.
+- Public characterising lemmas with no current in-repository caller remain
+  under API and dead-declaration review. They are not being removed solely
+  because a textual search found no caller.
+
+## Next step
+
+- Rebase onto main after PRs #9032 and #9033 merge.
+- Add the permanent lint module to `HexRCFTests`, finish the API and
+  dead-declaration review, and publish the Phase 6 quality milestone.
+
+## Blockers
+
+- None. The two preceding milestone PRs are already queued to merge after CI.

--- a/progress/20260728T044510Z_rcf-phase6-docstrings.md
+++ b/progress/20260728T044510Z_rcf-phase6-docstrings.md
@@ -13,6 +13,9 @@
   declaration follows Lean naming conventions without changing tactic syntax.
 - Removed prohibited terminology and semicolon run-ons from the HexRCF source
   prose touched by this audit.
+- Rephrased tactic diagnostics as separate sentences and updated their exact
+  regression, conformance, and manual outputs without changing refusal or
+  false-verdict behavior.
 - Verified that every private HexRCF declaration has at least one textual use,
   then built all changed modules and the complete `HexRCF` target.
 

--- a/progress/20260728T044510Z_rcf-phase6-docstrings.md
+++ b/progress/20260728T044510Z_rcf-phase6-docstrings.md
@@ -16,6 +16,23 @@
 - Rephrased tactic diagnostics as separate sentences and updated their exact
   regression, conformance, and manual outputs without changing refusal or
   false-verdict behavior.
+- Shortened the public builder-characterisation names to
+  `check_buildSturmReplay`, `Separation.check_separate`, and
+  `exists_cert_of_decide`.
+- Removed the unused `IsolationCert.sample?` wrapper and its theorem. The
+  implemented pipeline and SPEC use `IsolationCert.openPoint` directly.
+- Replaced the checker-local positive-degree recursion with `List.all`. Kept
+  endpoint-vector, duplicate-removal, and separation helpers public because
+  exposed definitions depend on them or the SPEC and tests exercise them.
+- Shortened five overqualified semantic theorem names, including
+  `IsolationCert.existsUnique_root`, `RootModel.root_unique_leftSpan`, and
+  `Polynomial.sign_eq_of_noRoot`.
+- Moved the decision-builder meta import from `Reify` to its actual consumer,
+  `Tactic`, and made tactic-only Mathlib and Lean imports meta-only. Added the
+  direct Syntax meta dependency required to compile reifier constructors.
+- Confirmed by downstream tactic tests that the direct public
+  `HexRealRootsMathlib.IsolateRoots` import is required for expansion of the
+  public `rcf_ring` macro, so retained it.
 - Verified that every private HexRCF declaration has at least one textual use,
   then built all changed modules and the complete `HexRCF` target.
 

--- a/progress/20260728T044510Z_rcf-phase6-docstrings.md
+++ b/progress/20260728T044510Z_rcf-phase6-docstrings.md
@@ -4,7 +4,7 @@
 
 - Ran the Mathlib linter with legacy import semantics, which retain imported
   documentation metadata under Lean's module system. The final audit reports
-  zero errors across 392 HexRCF declarations and 14 linters.
+  zero errors across 391 HexRCF declarations and 14 linters.
 - Added documentation for every genuinely undocumented public structure field
   and tactic implementation reported by the linter.
 - Added documentation for 31 public theorems that another module could
@@ -21,9 +21,10 @@
   `exists_cert_of_decide`.
 - Removed the unused `IsolationCert.sample?` wrapper and its theorem. The
   implemented pipeline and SPEC use `IsolationCert.openPoint` directly.
-- Replaced the checker-local positive-degree recursion with `List.all`. Kept
-  endpoint-vector, duplicate-removal, and separation helpers public because
-  exposed definitions depend on them or the SPEC and tests exercise them.
+- Replaced the checker-local positive-degree recursion with `List.all` and made
+  the endpoint-vector builder private. Kept duplicate-removal and separation
+  helpers public because exposed definitions depend on them or the SPEC and
+  tests exercise them.
 - Shortened five overqualified semantic theorem names, including
   `IsolationCert.existsUnique_root`, `RootModel.root_unique_leftSpan`, and
   `Polynomial.sign_eq_of_noRoot`.

--- a/progress/20260728T044510Z_rcf-phase6-docstrings.md
+++ b/progress/20260728T044510Z_rcf-phase6-docstrings.md
@@ -28,6 +28,9 @@
 - Shortened five overqualified semantic theorem names, including
   `IsolationCert.existsUnique_root`, `RootModel.root_unique_leftSpan`, and
   `Polynomial.sign_eq_of_noRoot`.
+- Verified with a downstream import probe that the generic sign-constancy
+  theorem is in the root `Polynomial` namespace rather than an RCF-local
+  namespace with the same suffix.
 - Moved the decision-builder meta import from `Reify` to its actual consumer,
   `Tactic`, and made tactic-only Mathlib and Lean imports meta-only. Added the
   direct Syntax meta dependency required to compile reifier constructors.

--- a/progress/20260728T044510Z_rcf-phase6-docstrings.md
+++ b/progress/20260728T044510Z_rcf-phase6-docstrings.md
@@ -4,7 +4,7 @@
 
 - Ran the Mathlib linter with legacy import semantics, which retain imported
   documentation metadata under Lean's module system. The final audit reports
-  zero errors across 396 HexRCF declarations and 14 linters.
+  zero errors across 392 HexRCF declarations and 14 linters.
 - Added documentation for every genuinely undocumented public structure field
   and tactic implementation reported by the linter.
 - Added documentation for 31 public theorems that another module could
@@ -33,25 +33,26 @@
 - Confirmed by downstream tactic tests that the direct public
   `HexRealRootsMathlib.IsolateRoots` import is required for expansion of the
   public `rcf_ring` macro, so retained it.
+- Added `HexRCF.LintTests` to the existing default regression target, making
+  the zero-error public namespace lint a permanent build invariant.
 - Verified that every private HexRCF declaration has at least one textual use,
   then built all changed modules and the complete `HexRCF` target.
 
 ## Current frontier
 
-- The documentation and linter corrections are complete on the stacked
-  `rcf-phase6-docstrings` branch.
-- The branch still needs the public/test separation milestone from PR #9032
-  before its lint audit can become a permanent non-public test module.
-- Public characterising lemmas with no current in-repository caller remain
-  under API and dead-declaration review. They are not being removed solely
-  because a textual search found no caller.
+- The documentation, linter, API, dead-declaration, and import-boundary audits
+  are complete on `rcf-phase6-docstrings`, rebased over merged PRs #9032 and
+  #9033.
+- `lake build HexRCF HexRCFTests HexConformance HexManual` succeeds with 9,526
+  jobs, including the permanent zero-error lint regression.
+- Repository DAG, release-manifest, trust-surface, Phase 4, copyright, and diff
+  checks pass.
 
 ## Next step
 
-- Rebase onto main after PRs #9032 and #9033 merge.
-- Add the permanent lint module to `HexRCFTests`, finish the API and
-  dead-declaration review, and publish the Phase 6 quality milestone.
+- Publish the Phase 6 quality milestone, obtain an independent Claude Opus
+  review, address any actionable findings, and merge after CI.
 
 ## Blockers
 
-- None. The two preceding milestone PRs are already queued to merge after CI.
+- None for this milestone.


### PR DESCRIPTION
## Summary

- document the complete public HexRCF namespace and improve tactic diagnostics
- remove the unused isolation sample wrapper and shorten overqualified public theorem names
- tighten the reifier/tactic meta import boundary
- keep regression modules outside the public umbrella and enforce the default linter suite through HexRCFTests
- update the HexRCF SPEC and session progress record

## Validation

- lake build HexRCF HexRCFTests HexConformance HexManual HexRCFProofProbe
- 391 HexRCF declarations, default 14 linters, zero errors
- proof-probe tactic and replay guards use only propext, Classical.choice, and Quot.sound
- copyright, file-line-count, DAG, release-manifest, trust-surface, Phase 4, and diff checks

## Review

Fresh Claude Opus verdict: GO, no blockers. Review record and resolved findings: https://github.com/kim-em/hex-dev/pull/9036#issuecomment-5100342150