### PR TITLE
docs: use type-directed notation in manual examples

### DIFF
--- a/HexManual/Chapters/HexGFqField.lean
+++ b/HexManual/Chapters/HexGFqField.lean
@@ -181,12 +181,17 @@ private def cert :
     Berlekamp.IrreducibilityCertificate where
   p := 5
   n := 4
-  powChain :=
-    #[#p[0, 1], #p[0, 3], #p[0, 4], #p[0, 2],
-      #p[0, 1]]
-  bezout :=
-    #[{ left := #p[3]
-        right := #p[0, 0, 0, 4] }]
+  powChain := #[
+    #p[0, 1],
+    #p[0, 3],
+    #p[0, 4],
+    #p[0, 2],
+    #p[0, 1]
+  ]
+  bezout := #[
+    { left := #p[3]
+      right := #p[0, 0, 0, 4] }
+  ]
 
 set_option maxRecDepth 131072 in
 set_option maxHeartbeats 8000000 in

--- a/HexManual/Chapters/HexGFqField.lean
+++ b/HexManual/Chapters/HexGFqField.lean
@@ -142,13 +142,6 @@ namespace HexGFqFieldChapterExample
 private instance : ZMod64.Bounds 5 :=
   ⟨by decide, by decide⟩
 
-private theorem one_ne_zero_five :
-    (1 : ZMod64 5) ≠ 0 := by
-  intro h
-  have hm :=
-    (ZMod64.natCast_eq_natCast_iff (p := 5) 1 0).mp h
-  simp at hm
-
 private theorem prime_five : Hex.Nat.Prime 5 := by
   constructor
   · decide
@@ -170,16 +163,8 @@ private theorem prime_five : Hex.Nat.Prime 5 := by
 private instance : ZMod64.PrimeModulus 5 :=
   ZMod64.primeModulusOfPrime prime_five
 
-private def polyFive (coeffs : Array Nat) : FpPoly 5 :=
-  FpPoly.ofCoeffs
-    (coeffs.map (fun n => ZMod64.ofNat 5 n))
-
 /-- Monic degree-4 modulus x⁴ + 2 over F₅. -/
-private def modulus : FpPoly 5 :=
-  { coeffs := #[(2 : ZMod64 5), 0, 0, 0, 1]
-    normalized := by
-      right
-      decide }
+private def modulus : FpPoly 5 := #p[2, 0, 0, 0, 1]
 
 private theorem modulus_pos_degree :
     0 < FpPoly.degree modulus := by decide
@@ -197,12 +182,11 @@ private def cert :
   p := 5
   n := 4
   powChain :=
-    #[polyFive #[0, 1], polyFive #[0, 3],
-      polyFive #[0, 4], polyFive #[0, 2],
-      polyFive #[0, 1]]
+    #[#p[0, 1], #p[0, 3], #p[0, 4], #p[0, 2],
+      #p[0, 1]]
   bezout :=
-    #[{ left := polyFive #[3]
-        right := polyFive #[0, 0, 0, 4] }]
+    #[{ left := #p[3]
+        right := #p[0, 0, 0, 4] }]
 
 set_option maxRecDepth 131072 in
 set_option maxHeartbeats 8000000 in
@@ -215,7 +199,7 @@ private theorem cert_check :
     Berlekamp.checkRabinBezoutWitnesses,
     Berlekamp.checkRabinBezoutWitness,
     Berlekamp.certifiedFrobeniusDiffMod,
-    maxProperDiv_4, modulus, polyFive]
+    maxProperDiv_4, modulus]
   constructor
   · constructor
     · constructor
@@ -241,16 +225,16 @@ private abbrev F :=
   FiniteField modulus modulus_pos_degree
     prime_five modulus_irreducible
 
-private def ff (coeffs : Array Nat) : F :=
+private def ff (f : FpPoly 5) : F :=
   ofPoly modulus modulus_pos_degree
-    prime_five modulus_irreducible (polyFive coeffs)
+    prime_five modulus_irreducible f
 
 private def reprNats (x : F) : List Nat :=
   (repr x).toArray.toList.map ZMod64.toNat
 
-private def a : F := ff #[2, 3]
-private def b : F := ff #[4, 1, 0, 1]
-private def x : F := ff #[0, 1]
+private def a : F := ff #p[2, 3]
+private def b : F := ff #p[4, 1, 0, 1]
+private def x : F := ff #p[0, 1]
 
 -- (2 + 3x) + (4 + x + x³) ≡ 1 + 4x + x³
 #guard reprNats (a + b) = [1, 4, 0, 1]

--- a/HexManual/Chapters/HexGFqRing.lean
+++ b/HexManual/Chapters/HexGFqRing.lean
@@ -143,28 +143,15 @@ private theorem prime_five : Hex.Nat.Prime 5 := by
 
 private instance : ZMod64.PrimeModulus 5 := ⟨prime_five⟩
 
-private theorem one_ne_zero_five : (1 : ZMod64 5) ≠ 0 := by
-  intro h
-  have :=
-    (ZMod64.natCast_eq_natCast_iff (p := 5) 1 0).mp h
-  simp at this
-
 /-- Monic degree-4 polynomial x⁴ + 2 over F₅. -/
-private def modulus : FpPoly 5 :=
-  { coeffs := #[(2 : ZMod64 5), 0, 0, 0, 1]
-    normalized := by
-      right
-      show some (1 : ZMod64 5) ≠ some 0
-      exact fun h => one_ne_zero_five (Option.some.inj h) }
+private def modulus : FpPoly 5 := #p[2, 0, 0, 0, 1]
 
 private theorem modulus_pos_degree :
     0 < FpPoly.degree modulus := by decide
 
-private def q (coeffs : Array Nat) :
+private def q (f : FpPoly 5) :
     PolyQuotient modulus modulus_pos_degree :=
-  ofPoly modulus modulus_pos_degree
-    (FpPoly.ofCoeffs
-      (coeffs.map (fun n => ZMod64.ofNat 5 n)))
+  ofPoly modulus modulus_pos_degree f
 
 private def reprNats
     (x : PolyQuotient modulus modulus_pos_degree) :
@@ -172,11 +159,11 @@ private def reprNats
   (repr x).toArray.toList.map ZMod64.toNat
 
 private def a : PolyQuotient modulus modulus_pos_degree :=
-  q #[2, 3]
+  q #p[2, 3]
 private def b : PolyQuotient modulus modulus_pos_degree :=
-  q #[4, 1, 0, 1]
+  q #p[4, 1, 0, 1]
 private def x : PolyQuotient modulus modulus_pos_degree :=
-  q #[0, 1]
+  q #p[0, 1]
 
 -- (2 + 3x) + (4 + x + x³) ≡ 1 + 4x + x³ (mod 5)
 #guard reprNats (a + b) = [1, 4, 0, 1]

--- a/HexManual/Chapters/HexHensel.lean
+++ b/HexManual/Chapters/HexHensel.lean
@@ -79,7 +79,7 @@ open Hex Hex.DensePoly Hex.QuadraticLiftResult
 
 namespace HexHenselChapterReduce
 
-private def f : ZPoly := ofCoeffs #[100, -3, 50]
+private def f : ZPoly := #p[100, -3, 50]
 
 -- 100 ≡ 2, -3 ≡ 46, 50 ≡ 1  (mod 7² = 49)
 private def a : ZPoly := ZPoly.reduceModPow f 7 2

--- a/HexManual/Chapters/HexModArith.lean
+++ b/HexManual/Chapters/HexModArith.lean
@@ -217,11 +217,11 @@ def b : ZMod64 7 := ofNat 7 5
 
 -- Barrett context for the small prime 7.
 def bar : Hex.BarrettCtx 7 :=
-  .ofModulus (p := 7) (by decide) (by decide)
+  Hex.BarrettCtx.ofModulus (p := 7) (by decide) (by decide)
 
 -- Montgomery context (7 is odd).
 def mon : Hex.MontCtx 7 :=
-  .ofOddModulus (by decide) (by decide)
+  Hex.MontCtx.ofOddModulus (by decide) (by decide)
 
 -- Barrett multiplication matches the ordinary product.
 #guard (bar.mulMod a b).toNat = (a * b).toNat

--- a/HexManual/Chapters/HexModArith.lean
+++ b/HexManual/Chapters/HexModArith.lean
@@ -217,11 +217,11 @@ def b : ZMod64 7 := ofNat 7 5
 
 -- Barrett context for the small prime 7.
 def bar : Hex.BarrettCtx 7 :=
-  Hex.BarrettCtx.ofModulus (p := 7) (by decide) (by decide)
+  .ofModulus (p := 7) (by decide) (by decide)
 
 -- Montgomery context (7 is odd).
 def mon : Hex.MontCtx 7 :=
-  Hex.MontCtx.ofOddModulus (by decide) (by decide)
+  .ofOddModulus (by decide) (by decide)
 
 -- Barrett multiplication matches the ordinary product.
 #guard (bar.mulMod a b).toNat = (a * b).toNat

--- a/HexManual/Chapters/HexPoly.lean
+++ b/HexManual/Chapters/HexPoly.lean
@@ -76,6 +76,11 @@ primitive normalizer drops trailing zeros from a raw array, and
 
 {docstring Hex.DensePoly.ofList}
 
+For a coefficient literal, `#p[a₀, a₁, ...]` is the concise form of
+`ofCoeffs #[a₀, a₁, ...]`. Coefficients are listed in ascending degree
+order, so `aᵢ` is the coefficient of `xⁱ`. The literal uses the same
+normalization as `ofCoeffs`, including removal of trailing zeros.
+
 The remaining constructors build the common shapes directly. The zero
 polynomial is the empty array; a constant collapses to zero when its
 scalar is zero; a monomial collapses likewise.
@@ -180,9 +185,9 @@ open Hex Hex.DensePoly
 namespace HexPolyChapterArith
 
 -- a = 1 + 2x + 3x²
-private def a : DensePoly Int := ofCoeffs #[1, 2, 3]
+private def a : DensePoly Int := #p[1, 2, 3]
 -- b = x
-private def b : DensePoly Int := monomial 1 1
+private def b : DensePoly Int := .monomial 1 1
 
 -- The constructors normalize: trailing zeros are
 -- dropped, and a monomial stores its one nonzero
@@ -194,7 +199,7 @@ private def b : DensePoly Int := monomial 1 1
 #guard a.coeff 2 = 3
 
 -- A padded array collapses to the trimmed value.
-#guard ofCoeffs #[1, 2, 3, 0, 0] = a
+#guard #p[1, 2, 3, 0, 0] = a
 -- The zero constant is the zero polynomial.
 #guard C (0 : Int) = (0 : DensePoly Int)
 
@@ -265,8 +270,8 @@ open Hex Hex.DensePoly
 namespace HexPolyChapterEuclid
 
 -- p = x² - 1, q = x - 1
-private def p : DensePoly Rat := ofCoeffs #[-1, 0, 1]
-private def q : DensePoly Rat := ofCoeffs #[-1, 1]
+private def p : DensePoly Rat := #p[-1, 0, 1]
+private def q : DensePoly Rat := #p[-1, 1]
 
 -- x² - 1 = (x - 1)(x + 1), so the division is exact.
 -- Quotient x + 1, remainder 0.
@@ -284,7 +289,7 @@ private def q : DensePoly Rat := ofCoeffs #[-1, 1]
 #guard modByMonic p q (by rfl) = (0 : DensePoly Rat)
 
 -- gcd(x² - 1, x + 1) = x + 1: a monic gcd.
-#guard gcd p (ofCoeffs #[1, 1]) = ofCoeffs #[1, 1]
+#guard gcd p #p[1, 1] = #p[1, 1]
 
 end HexPolyChapterEuclid
 ```

--- a/HexManual/Chapters/HexPoly.lean
+++ b/HexManual/Chapters/HexPoly.lean
@@ -76,10 +76,12 @@ primitive normalizer drops trailing zeros from a raw array, and
 
 {docstring Hex.DensePoly.ofList}
 
-For a coefficient literal, `#p[a₀, a₁, ...]` is the concise form of
-`ofCoeffs #[a₀, a₁, ...]`. Coefficients are listed in ascending degree
-order, so `aᵢ` is the coefficient of `xⁱ`. The literal uses the same
-normalization as `ofCoeffs`, including removal of trailing zeros.
+For a coefficient literal, `#p[a₀, a₁, ...]` constructs the same value
+as {name}`Hex.DensePoly.ofCoeffs` applied to `#[a₀, a₁, ...]`. The
+expected dense-polynomial type determines the coefficient type.
+Coefficients are listed in ascending degree order, so `aᵢ` is the
+coefficient of `xⁱ`. The literal uses the same normalization as
+`ofCoeffs`, including removal of trailing zeros.
 
 The remaining constructors build the common shapes directly. The zero
 polynomial is the empty array; a constant collapses to zero when its
@@ -187,7 +189,7 @@ namespace HexPolyChapterArith
 -- a = 1 + 2x + 3x²
 private def a : DensePoly Int := #p[1, 2, 3]
 -- b = x
-private def b : DensePoly Int := .monomial 1 1
+private def b : DensePoly Int := monomial 1 1
 
 -- The constructors normalize: trailing zeros are
 -- dropped, and a monomial stores its one nonzero
@@ -198,7 +200,7 @@ private def b : DensePoly Int := .monomial 1 1
 #guard a.support = [0, 1, 2]
 #guard a.coeff 2 = 3
 
--- A padded array collapses to the trimmed value.
+-- A literal with padding collapses to the trimmed value.
 #guard #p[1, 2, 3, 0, 0] = a
 -- The zero constant is the zero polynomial.
 #guard C (0 : Int) = (0 : DensePoly Int)

--- a/HexManual/Chapters/HexPolyFp.lean
+++ b/HexManual/Chapters/HexPolyFp.lean
@@ -167,11 +167,6 @@ private theorem prime_five : Hex.Nat.Prime 5 := by
 private def coeffNats (f : FpPoly 5) : List Nat :=
   f.toArray.toList.map ZMod64.toNat
 
-private def sfFactorFive
-    (factor : FpPoly 5) (multiplicity : Nat) :
-    SquareFreeFactor 5 :=
-  { factor, multiplicity }
-
 private def sfSummary
     (d : SquareFreeDecomposition 5) :
     Nat × List (List Nat × Nat) :=
@@ -223,13 +218,14 @@ private theorem linearModulus_monic :
 -- Compose (3 + 2x + x²) with (1 + x) mod (x² + 2).
 #guard
   coeffNats
-    (composeModMonic #p[3, 2, 1]
-      #p[1, 1] quadModulus quadModulus_monic)
+    (composeModMonic #p[3, 2, 1] #p[1, 1]
+      quadModulus quadModulus_monic)
       = [4, 4]
 -- The weighted product of (x + 1)² is x² + 2x + 1.
 #guard
   coeffNats
-    (weightedProduct [sfFactorFive #p[1, 1] 2])
+    (weightedProduct
+      [{ factor := #p[1, 1], multiplicity := 2 }])
       = [1, 2, 1]
 -- The empty product is the constant 1.
 #guard

--- a/HexManual/Chapters/HexPolyFp.lean
+++ b/HexManual/Chapters/HexPolyFp.lean
@@ -146,13 +146,6 @@ namespace HexPolyFpChapterExample
 private instance : ZMod64.Bounds 5 :=
   ⟨by decide, by decide⟩
 
-private theorem one_ne_zero_five :
-    (1 : ZMod64 5) ≠ 0 := by
-  intro h
-  have hm :=
-    (ZMod64.natCast_eq_natCast_iff (p := 5) 1 0).mp h
-  simp at hm
-
 private theorem prime_five : Hex.Nat.Prime 5 := by
   constructor
   · decide
@@ -171,16 +164,13 @@ private theorem prime_five : Hex.Nat.Prime 5 := by
     · simp at hm
     · exact Or.inr rfl
 
-private def polyFive (coeffs : Array Nat) : FpPoly 5 :=
-  ofCoeffs (coeffs.map (fun n => ZMod64.ofNat 5 n))
-
 private def coeffNats (f : FpPoly 5) : List Nat :=
   f.toArray.toList.map ZMod64.toNat
 
 private def sfFactorFive
-    (coeffs : Array Nat) (multiplicity : Nat) :
+    (factor : FpPoly 5) (multiplicity : Nat) :
     SquareFreeFactor 5 :=
-  { factor := polyFive coeffs, multiplicity }
+  { factor, multiplicity }
 
 private def sfSummary
     (d : SquareFreeDecomposition 5) :
@@ -191,26 +181,16 @@ private def sfSummary
 
 private def sfReconstruction
     (d : SquareFreeDecomposition 5) : FpPoly 5 :=
-  DensePoly.C d.unit * weightedProduct d.factors
+  .C d.unit * weightedProduct d.factors
 
 -- Monic modulus x² + 2 over F₅, with x² ≡ 3.
-private def quadModulus : FpPoly 5 :=
-  { coeffs := #[(2 : ZMod64 5), 0, 1]
-    normalized := by
-      right
-      show some (1 : ZMod64 5) ≠ some 0
-      exact fun h => one_ne_zero_five (Option.some.inj h) }
+private def quadModulus : FpPoly 5 := #p[2, 0, 1]
 
 private theorem quadModulus_monic :
     DensePoly.Monic quadModulus := by rfl
 
 -- Monic linear modulus x + 3 over F₅.
-private def linearModulus : FpPoly 5 :=
-  { coeffs := #[(3 : ZMod64 5), 1]
-    normalized := by
-      right
-      show some (1 : ZMod64 5) ≠ some 0
-      exact fun h => one_ne_zero_five (Option.some.inj h) }
+private def linearModulus : FpPoly 5 := #p[3, 1]
 
 private theorem linearModulus_monic :
     DensePoly.Monic linearModulus := by rfl
@@ -218,12 +198,12 @@ private theorem linearModulus_monic :
 -- (x + 1)³ mod (x² + 2) ≡ x.
 #guard
   coeffNats
-    (powModMonic (polyFive #[1, 1]) quadModulus
+    (powModMonic #p[1, 1] quadModulus
       quadModulus_monic 3) = [0, 1]
 -- Exponent zero is the quotient-ring identity 1.
 #guard
   coeffNats
-    (powModMonic (polyFive #[0, 0, 1]) quadModulus
+    (powModMonic #p[0, 0, 1] quadModulus
       quadModulus_monic 0) = [1]
 -- Frobenius generator X⁵ mod (x² + 2) ≡ 4x.
 #guard
@@ -243,13 +223,13 @@ private theorem linearModulus_monic :
 -- Compose (3 + 2x + x²) with (1 + x) mod (x² + 2).
 #guard
   coeffNats
-    (composeModMonic (polyFive #[3, 2, 1])
-      (polyFive #[1, 1]) quadModulus quadModulus_monic)
+    (composeModMonic #p[3, 2, 1]
+      #p[1, 1] quadModulus quadModulus_monic)
       = [4, 4]
 -- The weighted product of (x + 1)² is x² + 2x + 1.
 #guard
   coeffNats
-    (weightedProduct [sfFactorFive #[1, 1] 2])
+    (weightedProduct [sfFactorFive #p[1, 1] 2])
       = [1, 2, 1]
 -- The empty product is the constant 1.
 #guard
@@ -261,11 +241,11 @@ private theorem linearModulus_monic :
 #guard
   sfSummary
     (squareFreeDecomposition prime_five
-      (polyFive #[1, 2, 1]))
+      #p[1, 2, 1])
       = (1, [([1, 1], 2)])
 -- The decomposition reconstructs its input.
 #guard
-  let f := polyFive #[1, 2, 1]
+  let f : FpPoly 5 := #p[1, 2, 1]
   coeffNats
     (sfReconstruction
       (squareFreeDecomposition prime_five f))

--- a/HexManual/Chapters/HexPolyZ.lean
+++ b/HexManual/Chapters/HexPolyZ.lean
@@ -274,11 +274,11 @@ integer-factorization libraries:
 
 * {ref "hex-poly"}[HexPoly] is the generic dense-polynomial library
   this one specializes. The constructors, arithmetic, and Euclidean
-  operations used throughout this chapter, including the `#p[...]`
-  literal and the rational division underlying the square-free
-  decomposition, are documented there. `HexPolyZ` only fixes the
-  coefficient type to `Int` and adds the content, congruence, and
-  Mignotte operations.
+  operations used throughout this chapter (the `#p[...]` literal,
+  {name}`Hex.DensePoly.scale`, and the rational division underlying
+  {name}`Hex.ZPoly.primitiveSquareFreeDecomposition`) are documented
+  there. `HexPolyZ` only fixes the coefficient type to `Int` and adds
+  the content, congruence, and Mignotte operations.
 * `HexPolyZMathlib` is the correspondence library: it identifies
   {name}`Hex.ZPoly` with Mathlib's `Polynomial ℤ` and proves the
   Mignotte bound as a theorem about the Mahler measure of the

--- a/HexManual/Chapters/HexPolyZ.lean
+++ b/HexManual/Chapters/HexPolyZ.lean
@@ -98,7 +98,7 @@ open Hex Hex.DensePoly
 namespace HexPolyZChapterContent
 
 -- f = 2 + 4x + 6x²
-private def f : ZPoly := ofCoeffs #[2, 4, 6]
+private def f : ZPoly := #p[2, 4, 6]
 
 -- The content is the nonnegative gcd of the
 -- coefficients; the primitive part divides it out.
@@ -111,10 +111,10 @@ private def f : ZPoly := ofCoeffs #[2, 4, 6]
 
 -- A polynomial whose coefficients are coprime is
 -- already primitive: its content is 1.
-#guard ZPoly.content (ofCoeffs #[1, 2, 3]) = 1
+#guard ZPoly.content #p[1, 2, 3] = 1
 
 -- Dilation X ↦ 2·X scales coefficient i by 2ⁱ.
-private def g : ZPoly := ofCoeffs #[1, 1, 1]
+private def g : ZPoly := #p[1, 1, 1]
 #guard (ZPoly.dilate 2 g).toArray.toList = [1, 2, 4]
 
 end HexPolyZChapterContent
@@ -216,7 +216,7 @@ open Hex Hex.DensePoly
 namespace HexPolyZChapterMignotte
 
 -- g = 1 + x + x² + x³ + x⁴
-private def g : ZPoly := ofCoeffs #[1, 1, 1, 1, 1]
+private def g : ZPoly := #p[1, 1, 1, 1, 1]
 
 -- Squared L2 norm of the coefficient vector is 5, and
 -- its conservative integer bound is ceilSqrt 5 = 3.
@@ -274,10 +274,11 @@ integer-factorization libraries:
 
 * {ref "hex-poly"}[HexPoly] is the generic dense-polynomial library
   this one specializes. The constructors, arithmetic, and Euclidean
-  operations used throughout this chapter (`ofCoeffs`, `scale`, the
-  rational division underlying `primitiveSquareFreeDecomposition`) are
-  documented there. `HexPolyZ` only fixes the coefficient type to
-  `Int` and adds the content, congruence, and Mignotte operations.
+  operations used throughout this chapter, including the `#p[...]`
+  literal and the rational division underlying the square-free
+  decomposition, are documented there. `HexPolyZ` only fixes the
+  coefficient type to `Int` and adds the content, congruence, and
+  Mignotte operations.
 * `HexPolyZMathlib` is the correspondence library: it identifies
   {name}`Hex.ZPoly` with Mathlib's `Polynomial ℤ` and proves the
   Mignotte bound as a theorem about the Mahler measure of the

--- a/HexManual/Chapters/HexRCF.lean
+++ b/HexManual/Chapters/HexRCF.lean
@@ -238,7 +238,8 @@ one quantifier supported by the decision procedure.
 
 {docstring Hex.RCF.Sentence.toProp}
 
-Coefficient arrays use ascending order. This direct construction represents
+The `#p[...]` literal lists coefficients in ascending degree order and
+normalizes away trailing zeros. This direct construction represents
 `∀ x : ℝ, x² + 1 > 0` and sends it through the same compiled decision
 procedure used by the tactic:
 
@@ -247,7 +248,7 @@ open Hex.RCF
 
 private def positiveQuadratic : Sentence :=
   .forallReal (.atom {
-    p := Hex.DensePoly.ofCoeffs #[1, 0, 1]
+    p := #p[1, 0, 1]
     cmp := .gt
   })
 
@@ -264,7 +265,7 @@ open Hex.RCF
 private def nonnegativeOnUnit : Sentence :=
   .forallIoc (Dyadic.ofInt 0) (Dyadic.ofInt 1)
     (.atom {
-      p := Hex.DensePoly.ofCoeffs #[0, 1]
+      p := #p[0, 1]
       cmp := .ge
     })
 

--- a/HexManual/Tutorials/Coppersmith.lean
+++ b/HexManual/Tutorials/Coppersmith.lean
@@ -247,7 +247,7 @@ private def rows : Array Poly := Id.run do
   return rs
 
 private def B : Matrix Int 9 9 :=
-  Matrix.ofFn fun i j => (rows.getD i.val #[]).getD j.val 0
+  .ofFn fun i j => (rows.getD i.val #[]).getD j.val 0
 
 private def reduced : Matrix Int 9 9 :=
   lllNative B (3 / 4) (by grind) (by grind) (by decide)
@@ -274,7 +274,7 @@ private def g : Poly := Id.run do
 -- the root of its linear factor x - x0. Scanning x below
 -- X ~ 2^400 is hopeless; factoring degree-8 g is instant.
 private def recovered : Option Int := Id.run do
-  let gz : ZPoly := DensePoly.ofCoeffs g
+  let gz : ZPoly := .ofCoeffs g
   for (fac, _) in gz.factors do
     -- Linear factor `p·x + q` has root `-q/p` when `p ∣ q`.
     match fac.toArray with

--- a/progress/20260728T052136Z.md
+++ b/progress/20260728T052136Z.md
@@ -19,12 +19,13 @@
 
 ## Current frontier
 
-- The implementation is locally complete and ready for pull-request review.
+- The implementation is published in PR #9037. Local aggregate builds and
+  rendered-manual checks are complete.
 
 ## Next step
 
-- Open the pull request, obtain the requested independent review, address any
-  findings, and monitor the required checks through merge.
+- Monitor the required checks, rebase if `main` moves, and merge once the PR is
+  green.
 
 ## Blockers
 

--- a/progress/20260728T052136Z.md
+++ b/progress/20260728T052136Z.md
@@ -1,0 +1,31 @@
+# Manual type-directed notation
+
+## Accomplished
+
+- Reviewed every chapter and tutorial under `HexManual/` for dense-polynomial
+  literals, leading-dot notation, and namespaces that should remain explicit.
+- Documented `#p[...]` in the HexPoly constructors section, including ascending
+  coefficient order and trailing-zero normalization.
+- Replaced literal coefficient arrays with `#p[...]` throughout the polynomial,
+  Hensel, quotient-ring, finite-field, and RCF examples.
+- Simplified the prime-field and quotient examples by passing typed
+  polynomials directly, removing hand-written normalization proofs that the
+  literal makes unnecessary.
+- Used leading-dot notation where the result type identifies the constructor,
+  while retaining explicit irreducibility propositions, Mathlib names, and API
+  ownership at explanatory boundaries.
+- Built `HexManual`, rendered the static site, and inspected the affected HTML
+  for code layout, syntax highlighting, declaration links, and hover metadata.
+
+## Current frontier
+
+- The implementation is locally complete and ready for pull-request review.
+
+## Next step
+
+- Open the pull request, obtain the requested independent review, address any
+  findings, and monitor the required checks through merge.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
## Summary

- document the dense-polynomial literal in HexPoly before its worked examples
- use #p literals throughout polynomial-consuming manual examples
- use expected-type constructor notation selectively while preserving API and Mathlib boundaries

## Verification

- lake build HexManual
- lake exe hexmanual --output _out
- git diff --check

Closes #9030