### PR TITLE
perf(arith): stop trial primality at square root

### DIFF
--- a/HexArith/Nat/Prime.lean
+++ b/HexArith/Nat/Prime.lean
@@ -529,37 +529,111 @@ theorem pow_prime_mod {p : Nat} (hp : Prime p) (a : Nat) :
   exact pow_prime_mod_from_add_pow hp a (fun a b => add_pow_prime_mod hp a b)
 
 /--
-Executable trial-division primality test. Returns `true` only when `2 ≤ n`
-and no integer in `[2, n)` divides `n`. Used by downstream prime-search
-extensions to produce primality witnesses for candidates beyond any fixed
-list, without depending on `Mathlib` or `native_decide`.
+Balanced trial division over the `2 ^ fuel` candidates starting at `k`.
+The square guard is checked before descending into an interval, so no
+candidate with `n < k * k` is tested. Splitting the interval in half keeps
+kernel reduction depth logarithmic in the number of candidate divisors.
+-/
+@[expose] def isPrimeTrialAux (n : Nat) : Nat → Nat → Bool
+  | 0, k =>
+      if n < k * k then
+        true
+      else
+        decide (n % k ≠ 0)
+  | fuel + 1, k =>
+      if n < k * k then
+        true
+      else
+        isPrimeTrialAux n fuel k &&
+          isPrimeTrialAux n fuel (k + 2 ^ fuel)
+
+/--
+Executable bounded trial-division primality test. Returns `true` exactly when
+`n` is prime. Candidate divisors start at `2`, and the loop stops before
+testing the first `k` whose square exceeds `n`; thus it performs at most
+`⌊√n⌋ - 1` remainder tests. It remains pure Lean so emitted primality
+certificates can be replayed by the kernel without `Mathlib`, `native_decide`,
+or a fixed prime table.
 -/
 @[expose]
 def isPrimeTrial (n : Nat) : Bool :=
-  decide (2 ≤ n) &&
-    (List.range n).all (fun k => decide (k < 2) || decide (n % k ≠ 0))
-
-private theorem range_all_eq_true_of_isPrimeTrial {n : Nat}
-    (h : isPrimeTrial n = true) :
-    ∀ k, k < n → 2 ≤ k → n % k ≠ 0 := by
-  unfold isPrimeTrial at h
-  rw [Bool.and_eq_true] at h
-  obtain ⟨_, hall⟩ := h
-  rw [List.all_eq_true] at hall
-  intro k hk hk2
-  have hmem : k ∈ List.range n := List.mem_range.mpr hk
-  have := hall k hmem
-  rw [Bool.or_eq_true] at this
-  rcases this with hlt | hmod
-  · have : k < 2 := of_decide_eq_true hlt
-    omega
-  · exact of_decide_eq_true hmod
+  decide (2 ≤ n) && isPrimeTrialAux n (n.log2 + 1) 2
 
 private theorem two_le_of_isPrimeTrial {n : Nat} (h : isPrimeTrial n = true) :
     2 ≤ n := by
   unfold isPrimeTrial at h
   rw [Bool.and_eq_true] at h
   exact of_decide_eq_true h.1
+
+private theorem no_divisor_of_isPrimeTrialAux {n fuel k : Nat}
+    (h : isPrimeTrialAux n fuel k = true) :
+    ∀ d, k ≤ d → d < k + 2 ^ fuel → d * d ≤ n → n % d ≠ 0 := by
+  induction fuel generalizing k with
+  | zero =>
+      rw [isPrimeTrialAux] at h
+      by_cases hstop : n < k * k
+      · rw [if_pos hstop] at h
+        intro d hkd hd hsq
+        have hdk : d = k := by
+          simp only [Nat.pow_zero] at hd
+          omega
+        subst d
+        omega
+      · rw [if_neg hstop] at h
+        intro d hkd hd _
+        have hdk : d = k := by
+          simp only [Nat.pow_zero] at hd
+          omega
+        subst d
+        exact of_decide_eq_true h
+  | succ fuel ih =>
+      rw [isPrimeTrialAux] at h
+      by_cases hstop : n < k * k
+      · rw [if_pos hstop] at h
+        intro d hkd _ hsq
+        have hkk : k * k ≤ d * d := Nat.mul_le_mul hkd hkd
+        omega
+      · rw [if_neg hstop, Bool.and_eq_true] at h
+        intro d hkd hd hsq
+        have hpow : 2 ^ (fuel + 1) = 2 ^ fuel + 2 ^ fuel := by
+          rw [Nat.pow_succ]
+          omega
+        by_cases hleft : d < k + 2 ^ fuel
+        · exact ih h.1 d hkd hleft hsq
+        · apply ih h.2 d (by omega) ?_ hsq
+          rw [hpow] at hd
+          omega
+
+private theorem exists_trial_divisor {n m : Nat} (hn : 0 < n) (hm : m ∣ n)
+    (hm1 : m ≠ 1) (hmn : m ≠ n) :
+    ∃ d, 2 ≤ d ∧ d * d ≤ n ∧ d ∣ n := by
+  rcases hm with ⟨c, hc⟩
+  have hm0 : m ≠ 0 := by
+    intro h
+    subst m
+    simp at hc
+    omega
+  have hm2 : 2 ≤ m := by omega
+  have hc0 : c ≠ 0 := by
+    intro h
+    subst c
+    simp at hc
+    omega
+  have hc1 : c ≠ 1 := by
+    intro h
+    subst c
+    simp at hc
+    exact hmn hc.symm
+  have hc2 : 2 ≤ c := by omega
+  by_cases hmc : m ≤ c
+  · refine ⟨m, hm2, ?_, ⟨c, hc⟩⟩
+    rw [hc]
+    exact Nat.mul_le_mul_left m hmc
+  · have hcm : c ≤ m := Nat.le_of_not_ge hmc
+    refine ⟨c, hc2, ?_, ⟨m, ?_⟩⟩
+    · rw [hc]
+      simpa [Nat.mul_comm] using Nat.mul_le_mul_left c hcm
+    · simpa [Nat.mul_comm] using hc
 
 /--
 Soundness of the trial-division primality test against the project-local
@@ -572,30 +646,77 @@ theorem isPrimeTrial_isPrime {n : Nat} (h : isPrimeTrial n = true) :
   refine ⟨two_le_of_isPrimeTrial h, ?_⟩
   intro m hm
   have h2n : 2 ≤ n := two_le_of_isPrimeTrial h
-  have hno : ∀ k, k < n → 2 ≤ k → n % k ≠ 0 :=
-    range_all_eq_true_of_isPrimeTrial h
   have hn_pos : 0 < n := by omega
-  have hm_le_n : m ≤ n := Nat.le_of_dvd hn_pos hm
-  by_cases hm0 : m = 0
-  · subst hm0
-    have : n = 0 := Nat.eq_zero_of_zero_dvd hm
-    omega
   by_cases hm1 : m = 1
   · exact Or.inl hm1
   by_cases hmn : m = n
   · exact Or.inr hmn
   exfalso
-  have hm2 : 2 ≤ m := by
-    rcases m with _ | _ | m
-    · exact absurd rfl hm0
-    · exact absurd rfl hm1
-    · omega
-  have hmlt : m < n := Nat.lt_of_le_of_ne hm_le_n hmn
-  have hmod : n % m = 0 := by
-    rcases hm with ⟨k, hk⟩
-    rw [hk]
-    exact Nat.mul_mod_right m k
-  exact hno m hmlt hm2 hmod
+  obtain ⟨d, hd2, hdsq, hdvd⟩ :=
+    exists_trial_divisor hn_pos hm hm1 hmn
+  have hd_le_sq : d ≤ d * d := Nat.le_mul_of_pos_right d (by omega)
+  have hd_le_n : d ≤ n := Nat.le_trans hd_le_sq hdsq
+  have haux : isPrimeTrialAux n (n.log2 + 1) 2 = true := by
+    unfold isPrimeTrial at h
+    rw [Bool.and_eq_true] at h
+    exact h.2
+  have hn_lt_pow : n < 2 ^ (n.log2 + 1) := Nat.lt_log2_self
+  have hno : n % d ≠ 0 :=
+    no_divisor_of_isPrimeTrialAux haux d hd2 (by omega) hdsq
+  exact hno (Nat.mod_eq_zero_of_dvd hdvd)
+
+private theorem isPrimeTrialAux_of_prime {n : Nat} (hn : Prime n) :
+    ∀ fuel k, 2 ≤ k → isPrimeTrialAux n fuel k = true := by
+  intro fuel
+  induction fuel with
+  | zero =>
+      intro k hk2
+      rw [isPrimeTrialAux]
+      by_cases hstop : n < k * k
+      · rw [if_pos hstop]
+      · rw [if_neg hstop]
+        apply decide_eq_true
+        intro hmod
+        have hdvd : k ∣ n := Nat.dvd_of_mod_eq_zero hmod
+        rcases hn.2 k hdvd with hk1 | hkn
+        · omega
+        · subst k
+          have hnn : n * n ≤ n := Nat.le_of_not_gt hstop
+          have hn_lt_mul : n < n * n := by
+            simpa using (Nat.mul_lt_mul_left hn.pos).2 hn.one_lt
+          omega
+  | succ fuel ih =>
+      intro k hk2
+      rw [isPrimeTrialAux]
+      by_cases hstop : n < k * k
+      · rw [if_pos hstop]
+      · rw [if_neg hstop, Bool.and_eq_true]
+        exact ⟨ih k hk2,
+          ih (k + 2 ^ fuel) (Nat.le_trans hk2 (Nat.le_add_right k _))⟩
+
+/--
+Completeness of the executable trial-division test: every project-local prime
+witness makes the Boolean checker return `true`.
+-/
+theorem isPrimeTrial_of_prime {n : Nat} (h : Prime n) :
+    isPrimeTrial n = true := by
+  unfold isPrimeTrial
+  rw [Bool.and_eq_true]
+  exact ⟨decide_eq_true h.two_le,
+    isPrimeTrialAux_of_prime h (n.log2 + 1) 2 (by decide)⟩
+
+/-! Regression coverage for the bounded checker: small inputs, primes, perfect
+squares, and semiprimes whose least factor is close to the square root. -/
+
+#guard isPrimeTrial 0 = false
+#guard isPrimeTrial 1 = false
+#guard isPrimeTrial 2 = true
+#guard isPrimeTrial 3 = true
+#guard isPrimeTrial 4 = false
+#guard isPrimeTrial 97 = true
+#guard isPrimeTrial 49 = false
+#guard isPrimeTrial 121 = false
+#guard isPrimeTrial 899 = false
 
 end Nat
 

--- a/HexArith/Nat/Prime.lean
+++ b/HexArith/Nat/Prime.lean
@@ -533,6 +533,8 @@ Balanced trial division over the `2 ^ fuel` candidates starting at `k`.
 The square guard is checked before descending into an interval, so no
 candidate with `n < k * k` is tested. Splitting the interval in half keeps
 kernel reduction depth logarithmic in the number of candidate divisors.
+This helper is a primality test only with a range large enough to cover every
+small divisor; `isPrimeTrial` is the supported entry point.
 -/
 @[expose] def isPrimeTrialAux (n : Nat) : Nat → Nat → Bool
   | 0, k =>
@@ -717,6 +719,7 @@ squares, and semiprimes whose least factor is close to the square root. -/
 #guard isPrimeTrial 49 = false
 #guard isPrimeTrial 121 = false
 #guard isPrimeTrial 899 = false
+#guard ((List.range 1000).filter isPrimeTrial).length = 168
 
 end Nat
 

--- a/HexBerlekamp/TacticCore.lean
+++ b/HexBerlekamp/TacticCore.lean
@@ -170,12 +170,15 @@ is used only at elaboration time to budget the proof that the kernel will
 replay.
 -/
 meta def primeReplayCost (n : Nat) : Nat := Id.run do
-  let mut k := 2
-  let mut cost := 0
-  while k * k ≤ n do
-    cost := cost + 1
-    k := k + 1
-  return cost
+  let mut lo := 0
+  let mut hi := n + 1
+  while lo + 1 < hi do
+    let mid := (lo + hi) / 2
+    if mid * mid ≤ n then
+      lo := mid
+    else
+      hi := mid
+  return lo - 1
 
 /-- Fail fast when a Rabin replay for a degree-`deg` factor at modulus `p`
 would exceed `replayBudget`. -/

--- a/HexBerlekamp/TacticCore.lean
+++ b/HexBerlekamp/TacticCore.lean
@@ -158,6 +158,25 @@ replay. Inputs over budget fail at elaboration time with a clear message
 instead of emitting a proof the kernel cannot afford to check. -/
 meta def replayBudget : Nat := 1 <<< 26
 
+/-- Ceiling on candidate remainder tests in one kernel primality replay.
+`2^16` covers the full `ZMod64` modulus range, whose largest square-root scan
+tests fewer than `2^16` candidates. -/
+meta def primeReplayBudget : Nat := 1 <<< 16
+
+/--
+Worst-case number of remainder tests in `Hex.Nat.isPrimeTrial n`. This mirrors
+the checker's square stopping convention without performing any divisions, and
+is used only at elaboration time to budget the proof that the kernel will
+replay.
+-/
+meta def primeReplayCost (n : Nat) : Nat := Id.run do
+  let mut k := 2
+  let mut cost := 0
+  while k * k ≤ n do
+    cost := cost + 1
+    k := k + 1
+  return cost
+
 /-- Fail fast when a Rabin replay for a degree-`deg` factor at modulus `p`
 would exceed `replayBudget`. -/
 meta def checkReplayBudget (tactic : String) (p deg : Nat) : MetaM Unit := do

--- a/HexBerlekampMathlib/FactorPolyTests.lean
+++ b/HexBerlekampMathlib/FactorPolyTests.lean
@@ -90,6 +90,16 @@ is a nonzero constant, hence a unit over F_5, not irreducible
 #guard_msgs in
 example := irreducibility (3 : Polynomial (ZMod 5))
 
+/-! ## Bounded primality replay -/
+
+/--
+error: irreducibility: the polynomial
+  3
+is a nonzero constant, hence a unit over F_67108879, not irreducible
+-/
+#guard_msgs in
+example := irreducibility (3 : Polynomial (ZMod 67108879))
+
 /-! ## Composite modulus: the provider declines, the driver reports -/
 
 /--

--- a/HexBerlekampMathlib/FactorPolyTests.lean
+++ b/HexBerlekampMathlib/FactorPolyTests.lean
@@ -92,6 +92,10 @@ example := irreducibility (3 : Polynomial (ZMod 5))
 
 /-! ## Bounded primality replay -/
 
+/-- The former linear checker exceeded default recursion depth on this
+modulus; the balanced square-root scan kernel-replays directly. -/
+example : Hex.Nat.isPrimeTrial 67108879 = true := by decide
+
 /--
 error: irreducibility: the polynomial
   3

--- a/HexBerlekampMathlib/FactorProvider.lean
+++ b/HexBerlekampMathlib/FactorProvider.lean
@@ -328,12 +328,12 @@ meta def withZModInput (tactic : String) (ty : Expr)
       Expr → Term.TermElabM Expr) :
     Term.TermElabM ProviderResult := do
   let some (q, qE) ← zmodInput? ty | return .notApplicable
-  -- `isPrimeTrial` is Θ(q) at elaboration time, and its emitted slot
-  -- kernel-replays at the same cost, so check the `ZMod64` bound and the
-  -- replay budget before running it.
+  -- The emitted primality slot kernel-replays the bounded trial scan, so
+  -- budget its worst-case number of candidate remainder tests.
   if h1 : 0 < q then
     if h2 : q < 2 ^ 31 then
-      if q ≤ Hex.FactorTactic.replayBudget then
+      let primeCost := Hex.FactorTactic.primeReplayCost q
+      if primeCost ≤ Hex.FactorTactic.primeReplayBudget then
         if hpt : Hex.Nat.isPrimeTrial q = true then
           return .success (← k q ⟨h1, h2⟩ hpt qE)
         else
@@ -341,8 +341,8 @@ meta def withZModInput (tactic : String) (ty : Expr)
               prime modulus, but {q} is not prime"
       else
         return .declined m!"{tactic}: the modulus {q} needs a kernel \
-            primality replay of roughly {q} steps, over the supported \
-            budget ({Hex.FactorTactic.replayBudget})"
+            primality replay of {primeCost} candidate remainder tests, \
+            over the supported budget ({Hex.FactorTactic.primeReplayBudget})"
     else
       return .declined m!"{tactic}: the modulus {q} is over the ZMod64 \
           bound (2^31), so the Polynomial (ZMod q) provider cannot \

--- a/HexBerlekampZassenhaus/FactorProvider.lean
+++ b/HexBerlekampZassenhaus/FactorProvider.lean
@@ -94,17 +94,14 @@ meta def searchModPWitness (q : Hex.ZPoly) : Option Hex.ZPoly.ModPWitness := Id.
 meta def eisensteinShifts : List Int :=
   [0, 1, -1, 2, -2, 3, -3]
 
-/-- Ceiling on Eisenstein witness primes. The emitted certificate
-kernel-replays `Hex.Nat.isPrimeTrial q`, whose `List.range q` reduction is
-recursion-depth linear in `q` and hits the default `maxRecDepth` a little
-above 150, so a larger witness prime would elaborate to a proof the kernel
-cannot check. `128` leaves margin below that boundary (the boundary replay
-`checkIrredWitness (X² − 127) (.eisenstein 127 0)` is locked by a test). -/
+/-- Ceiling on Eisenstein witness primes. This keeps the auxiliary divisor
+search bounded; the boundary witness
+`checkIrredWitness (X² − 127) (.eisenstein 127 0)` is locked by a test. -/
 meta def eisensteinPrimeCap : Nat := 128
 
 /-- Prime divisors of `n` up to `eisensteinPrimeCap`, by trial division. Any
-cofactor above the cap is dropped: its `isPrimeTrial` replay would blow the
-kernel recursion depth. -/
+cofactor above the cap is dropped because the Eisenstein witness search is
+deliberately bounded. -/
 meta def smallPrimeDivisors (n : Nat) : List Nat := Id.run do
   let mut n := n
   let mut acc : List Nat := []

--- a/HexBerlekampZassenhaus/FactorProvider.lean
+++ b/HexBerlekampZassenhaus/FactorProvider.lean
@@ -94,8 +94,9 @@ meta def searchModPWitness (q : Hex.ZPoly) : Option Hex.ZPoly.ModPWitness := Id.
 meta def eisensteinShifts : List Int :=
   [0, 1, -1, 2, -2, 3, -3]
 
-/-- Ceiling on Eisenstein witness primes. This keeps the auxiliary divisor
-search bounded; the boundary witness
+/-- Fixed breadth limit for the auxiliary Eisenstein witness search. Raising
+it expands coefficient-divisor enumeration and should be benchmarked as a
+separate tactic-coverage change; the current boundary witness
 `checkIrredWitness (X² − 127) (.eisenstein 127 0)` is locked by a test. -/
 meta def eisensteinPrimeCap : Nat := 128
 
@@ -134,10 +135,10 @@ meta def searchEisenstein (f : Hex.ZPoly) : Option Hex.ZPoly.IrredWitness := Id.
 /-- Search for an irreducibility witness for `q`. -/
 meta def searchWitness (q : Hex.ZPoly) : Option Hex.ZPoly.IrredWitness := Id.run do
   if q.size = 1 then
-    -- The kernel replay of `isNatPrime c` costs roughly `c` steps
-    -- (`List.range c`), so budget-check before even computing it.
     let c := (q.coeff 0).natAbs
-    if c ≤ Hex.FactorTactic.replayBudget && Hex.ZPoly.isNatPrime c then
+    let primeCost := Hex.FactorTactic.primeReplayCost c
+    if primeCost ≤ Hex.FactorTactic.primeReplayBudget &&
+        Hex.ZPoly.isNatPrime c then
       return some .primeConst
     else
       return none
@@ -263,11 +264,15 @@ meta def irredProof (fE : Expr) (f : Hex.ZPoly) :
       return .ok (mkApp3 (mkConst ``Hex.ZPoly.irreducible_of_checkIrredWitness)
         fE (reifyWitness w) Hex.CertReify.reflTrue)
   | none =>
-      if f.size = 1 && (f.coeff 0).natAbs > Hex.FactorTactic.replayBudget then
-        throwError "irreducibility: deciding primality of the constant\
-            {indentExpr fE}\
-            \nneeds a kernel replay of roughly {(f.coeff 0).natAbs} steps, \
-            over the supported budget ({Hex.FactorTactic.replayBudget})"
+      if f.size = 1 then
+        let primeCost :=
+          Hex.FactorTactic.primeReplayCost (f.coeff 0).natAbs
+        if primeCost > Hex.FactorTactic.primeReplayBudget then
+          throwError "irreducibility: deciding primality of the constant\
+              {indentExpr fE}\
+              \nneeds a kernel replay of {primeCost} candidate remainder \
+              tests, over the supported budget \
+              ({Hex.FactorTactic.primeReplayBudget})"
       if Hex.ZPoly.isIrreducible f then
         return .error (← balancedDecline "irreducibility" f)
       else

--- a/HexBerlekampZassenhaus/FactorTacticTests.lean
+++ b/HexBerlekampZassenhaus/FactorTacticTests.lean
@@ -75,9 +75,7 @@ theorem x2m2_irred : ZPoly.Irreducible x2m2 :=
   ZPoly.irreducible_of_checkIrredWitness x2m2 (.eisenstein 2 0) rfl
 
 /-- The largest admissible Eisenstein prime (`eisensteinPrimeCap = 128`, so
-prime `127`) still kernel-replays within the default `maxRecDepth`: the
-`isPrimeTrial` reduction is depth-linear in the prime, and stalls a little
-above 150, which is why the search caps its candidates. -/
+prime `127`) still produces a replayable boundary witness. -/
 def x2m127 : ZPoly := DensePoly.ofCoeffs #[-127, 0, 1]
 
 example : ZPoly.checkIrredWitness x2m127 (.eisenstein 127 0) = true := rfl

--- a/HexBerlekampZassenhaus/FactorTacticTests.lean
+++ b/HexBerlekampZassenhaus/FactorTacticTests.lean
@@ -44,10 +44,13 @@ example : True := by
 def linZ : ZPoly := DensePoly.ofCoeffs #[3, 2]
 def quadZ : ZPoly := DensePoly.ofCoeffs #[1, 0, 1]
 def constZ : ZPoly := DensePoly.C (-7)
+def largeConstZ : ZPoly := DensePoly.C 10007
 
 theorem lin_irred : ZPoly.Irreducible linZ := irreducibility linZ
 theorem quad_irred : ZPoly.Irreducible quadZ := irreducibility quadZ
 theorem const_irred : ZPoly.Irreducible constZ := irreducibility constZ
+theorem large_const_irred : ZPoly.Irreducible largeConstZ :=
+  irreducibility largeConstZ
 
 example : ZPoly.Irreducible quadZ := by irreducibility
 
@@ -109,11 +112,11 @@ is a unit (±1), not irreducible -/
 
 /--
 info: irreducibility: deciding primality of the constant
-  DensePoly.C 67108879
-needs a kernel replay of roughly 67108879 steps, over the supported budget (67108864)
+  DensePoly.C 4295229444
+needs a kernel replay of 65537 candidate remainder tests, over the supported budget (65536)
 -/
 #guard_msgs in
-#check_failure (irreducibility (DensePoly.C (67108879 : Int)))
+#check_failure (irreducibility (DensePoly.C (4295229444 : Int)))
 
 /-! ## Axiom hygiene -/
 

--- a/HexBerlekampZassenhaus/IrreducibleCore.lean
+++ b/HexBerlekampZassenhaus/IrreducibleCore.lean
@@ -186,9 +186,11 @@ by the greedy expansion helper. -/
 def Associated (a b : ZPoly) : Prop :=
   ∃ u : ZPoly, ZPoly.IsUnit u ∧ b = a * u
 
+/-- Integer primality checker used by constant-polynomial irreducibility.
+This is the shared verified bounded checker from `HexArith`. -/
 @[expose]
 def isNatPrime (n : Nat) : Bool :=
-  2 ≤ n && !((List.range n).any fun d => 2 ≤ d && d * d ≤ n && n % d == 0)
+  Hex.Nat.isPrimeTrial n
 
 /--
 Computational irreducibility checker backed by the public factorization API.
@@ -259,36 +261,53 @@ private theorem isNatPrime_iff (n : Nat) :
     isNatPrime n = true ↔
       2 ≤ n ∧ ∀ d : Nat, 2 ≤ d → d * d ≤ n → ¬ d ∣ n := by
   unfold isNatPrime
-  rw [Bool.and_eq_true, decide_eq_true_iff, Bool.not_eq_true', List.any_eq_false]
-  refine Iff.intro ?fwd ?bwd
-  case fwd =>
-    rintro ⟨h2, hany⟩
-    refine ⟨h2, fun d hd2 hdd_le hdvd => ?_⟩
-    have hd_lt_n : d < n := by
-      have h2d_le_dd : 2 * d ≤ d * d := Nat.mul_le_mul_right d hd2
-      have h2d_le_n : 2 * d ≤ n := Nat.le_trans h2d_le_dd hdd_le
+  constructor
+  · intro h
+    have hp : Hex.Nat.Prime n := Hex.Nat.isPrimeTrial_isPrime h
+    refine ⟨hp.two_le, fun d hd2 hdd_le hdvd => ?_⟩
+    rcases hp.2 d hdvd with hd1 | hdn
+    · omega
+    · subst d
+      have hn_lt_mul : n < n * n := by
+        simpa using (Nat.mul_lt_mul_left hp.pos).2 hp.one_lt
       omega
-    have hmem : d ∈ List.range n := List.mem_range.mpr hd_lt_n
-    have hpred_ne_true : ¬
-        ((decide (2 ≤ d) && decide (d * d ≤ n) && (n % d == 0)) = true) :=
-      hany d hmem
-    apply hpred_ne_true
-    have h1 : (decide (2 ≤ d)) = true := decide_eq_true hd2
-    have h2 : (decide (d * d ≤ n)) = true := decide_eq_true hdd_le
-    have h3 : (n % d == 0) = true := by
-      rw [beq_iff_eq]
-      exact Nat.mod_eq_zero_of_dvd hdvd
-    rw [h1, h2, h3]
-    rfl
-  case bwd =>
-    rintro ⟨h2, hno⟩
-    refine ⟨h2, fun d hmem => ?_⟩
-    have hd_lt_n : d < n := List.mem_range.mp hmem
-    intro hpred_true
-    rw [Bool.and_eq_true, Bool.and_eq_true, decide_eq_true_iff,
-      decide_eq_true_iff, beq_iff_eq] at hpred_true
-    obtain ⟨⟨hd2, hdd_le⟩, hmod⟩ := hpred_true
-    exact hno d hd2 hdd_le (Nat.dvd_of_mod_eq_zero hmod)
+  · rintro ⟨h2, hno⟩
+    apply Hex.Nat.isPrimeTrial_of_prime
+    refine ⟨h2, ?_⟩
+    intro m hm
+    by_cases hm1 : m = 1
+    · exact Or.inl hm1
+    by_cases hmn : m = n
+    · exact Or.inr hmn
+    exfalso
+    rcases hm with ⟨c, hc⟩
+    have hm0 : m ≠ 0 := by
+      intro h
+      subst m
+      simp at hc
+      omega
+    have hm2 : 2 ≤ m := by omega
+    have hc0 : c ≠ 0 := by
+      intro h
+      subst c
+      simp at hc
+      omega
+    have hc1 : c ≠ 1 := by
+      intro h
+      subst c
+      simp at hc
+      exact hmn hc.symm
+    have hc2 : 2 ≤ c := by omega
+    by_cases hmc : m ≤ c
+    · apply hno m hm2
+      · rw [hc]
+        exact Nat.mul_le_mul_left m hmc
+      · exact ⟨c, hc⟩
+    · have hcm : c ≤ m := Nat.le_of_not_ge hmc
+      apply hno c hc2
+      · rw [hc]
+        simpa [Nat.mul_comm] using Nat.mul_le_mul_left c hcm
+      · exact ⟨m, by simpa [Nat.mul_comm] using hc⟩
 
 /-- `DensePoly.C` on integers commutes with multiplication: `C (a*b) = C a * C b`.
 Used by the constant-polynomial Irreducible characterisation to split integer

--- a/HexBerlekampZassenhaus/PrimeSelection.lean
+++ b/HexBerlekampZassenhaus/PrimeSelection.lean
@@ -631,31 +631,6 @@ def hotPathCandidates : List SmallPrimeCandidate :=
 #guard hotPathCandidates.length == 94
 
 /--
-Converse of `Hex.Nat.isPrimeTrial_isPrime`: a `Hex.Nat.Prime` witness
-implies the trial-division boolean test returns `true`. Used to bridge
-between the propositional prime predicate and the kernel-decidable
-boolean surface needed to enumerate primes in a bounded range.
--/
-private theorem isPrimeTrial_of_prime {n : Nat} (hn : Hex.Nat.Prime n) :
-    Hex.Nat.isPrimeTrial n = true := by
-  unfold Hex.Nat.isPrimeTrial
-  rw [Bool.and_eq_true]
-  refine ⟨decide_eq_true hn.two_le, ?_⟩
-  rw [List.all_eq_true]
-  intro k hk
-  have hkn : k < n := List.mem_range.mp hk
-  rw [Bool.or_eq_true]
-  by_cases hk2 : k < 2
-  · exact Or.inl (decide_eq_true hk2)
-  · refine Or.inr (decide_eq_true ?_)
-    have hk2' : 2 ≤ k := Nat.le_of_not_lt hk2
-    intro hmod
-    have hdvd : k ∣ n := Nat.dvd_of_mod_eq_zero hmod
-    rcases hn.2 k hdvd with hk1 | hkn'
-    · omega
-    · omega
-
-/--
 Soundness of the hot-path prime candidate list: every entry carries a
 prime in the closed range `[3, 500]`. The `Hex.Nat.Prime` conjunct is
 the structure field directly; the bounds follow by a decidable check
@@ -683,7 +658,8 @@ candidate fold over any prime in the admissible range.
 theorem exists_mem_hotPathCandidates_of_prime
     {p : Nat} (hprime : Hex.Nat.Prime p) (hge : 3 ≤ p) (hle : p ≤ 500) :
     ∃ c ∈ hotPathCandidates, c.p = p := by
-  have htrial : Hex.Nat.isPrimeTrial p = true := isPrimeTrial_of_prime hprime
+  have htrial : Hex.Nat.isPrimeTrial p = true :=
+    Hex.Nat.isPrimeTrial_of_prime hprime
   have key : ∀ q : Fin 501,
       3 ≤ q.val → Hex.Nat.isPrimeTrial q.val = true →
         q.val ∈ hotPathCandidates.map (fun x : SmallPrimeCandidate => x.p) := by

--- a/HexBerlekampZassenhaus/Records.lean
+++ b/HexBerlekampZassenhaus/Records.lean
@@ -299,7 +299,6 @@ def normalizeForFactor (f : ZPoly) : FactorNormalizationData :=
     squareFreeCore := sqData.squareFreeCore
     repeatedPart := sqData.repeatedPart }
 
-set_option maxRecDepth 4000 in
 /-- Certified probe prime for the modular square-free fast path.  `499` is a
 cheap fixed choice: it is large enough that a distinct-root input rarely reduces
 non-square-free at it, but it carries no guarantee (a rationally square-free

--- a/HexManual/Chapters/FactorTactics.lean
+++ b/HexManual/Chapters/FactorTactics.lean
@@ -348,13 +348,13 @@ content of the input.
 Finally, `Polynomial (ZMod q)` inputs reuse the prime-field pipeline
 through the parser-with-proof of `HexBerlekampMathlib`, producing the
 same {name}`Hex.FactoredPoly` shape as the integer case. The modulus
-must be a literal prime with `q ≤ 2²⁶`. The current primality checker tests
-every candidate divisor in `[2, q)`, so checking the emitted proof takes
-`Θ(q)` remainder tests. This is a limitation of the present checker, not of
-trial division in general: a conventional implementation stops at `√q`.
-The linear replay explains why larger moduli are declined even inside the
-`ZMod64` bound. The per-factor `(degree + 1) · q` replay budget of the
-{ref "factor-tactics-coverage"}[coverage section] applies as well:
+must be a literal prime inside the `ZMod64` bound (`q < 2³¹`). The
+primality checker tests candidates from `2` through `⌊√q⌋`, so checking
+the emitted proof takes `Θ(√q)` remainder tests. The provider budgets
+that exact worst-case candidate count; throughout the `ZMod64` range it
+is at most `46,339`, below the `2¹⁶` primality replay ceiling. The separate
+per-factor `(degree + 1) · q` Rabin-certificate replay budget of the
+{ref "factor-tactics-coverage"}[coverage section] still applies:
 
 ```lean
 open Polynomial
@@ -448,9 +448,9 @@ Eisenstein-after-shift. Each is found by a bounded search, so an
 input can lie inside a certificate language yet outside the
 implemented search: the single-prime search tries primes below `512`
 (those within the replay budget), the Eisenstein search tries shifts
-`0, ±1, ±2, ±3` with witness primes capped at `128` (a larger prime's
-trial-division replay would exceed the kernel's recursion depth), and
-a prime-constant witness must itself fit the replay budget. The
+`0, ±1, ±2, ±3` with witness primes capped at `128` to keep that
+auxiliary search bounded, and a prime-constant witness must itself fit
+the replay budget. The
 Eisenstein kind deserves a story: `x⁴ + 1` is irreducible over `ℤ`
 yet reducible modulo *every* prime, so no single-prime witness
 exists, but shifting by `1` gives

--- a/HexManual/Chapters/FactorTactics.lean
+++ b/HexManual/Chapters/FactorTactics.lean
@@ -348,13 +348,14 @@ content of the input.
 Finally, `Polynomial (ZMod q)` inputs reuse the prime-field pipeline
 through the parser-with-proof of `HexBerlekampMathlib`, producing the
 same {name}`Hex.FactoredPoly` shape as the integer case. The modulus
-must be a literal prime inside the `ZMod64` bound (`q < 2³¹`). The
-primality checker tests candidates from `2` through `⌊√q⌋`, so checking
-the emitted proof takes `Θ(√q)` remainder tests. The provider budgets
-that exact worst-case candidate count; throughout the `ZMod64` range it
-is at most `46,339`, below the `2¹⁶` primality replay ceiling. The separate
-per-factor `(degree + 1) · q` Rabin-certificate replay budget of the
-{ref "factor-tactics-coverage"}[coverage section] still applies:
+must be a literal prime inside the `ZMod64` bound (`q < 2³¹`), but the
+per-factor Rabin-certificate budget binds first for every nonconstant
+input: `(degree + 1) · q ≤ 2²⁶`, as described in the
+{ref "factor-tactics-coverage"}[coverage section]. The primality checker
+tests candidates from `2` through `⌊√q⌋`, so checking that part of the
+emitted proof takes `Θ(√q)` remainder tests. The provider budgets that
+exact worst-case candidate count against a separate `2¹⁶` ceiling;
+throughout the `ZMod64` range it is at most `46,339`.
 
 ```lean
 open Polynomial
@@ -447,7 +448,7 @@ certificate for a prime where the factor stays irreducible), and
 Eisenstein-after-shift. Each is found by a bounded search, so an
 input can lie inside a certificate language yet outside the
 implemented search: the single-prime search tries primes below `512`
-(those within the replay budget), the Eisenstein search tries shifts
+(with the Rabin budget enforced separately), the Eisenstein search tries shifts
 `0, ±1, ±2, ±3` with witness primes capped at `128` to keep that
 auxiliary search bounded, and a prime-constant witness must itself fit
 the replay budget. The

--- a/HexManual/Chapters/HexArith.lean
+++ b/HexManual/Chapters/HexArith.lean
@@ -216,12 +216,12 @@ stay canonical.
 tag := "hex-arith-prime"
 %%%
 
-`HexArith` supplies a self-contained primality test. It checks that no
-integer in `[2, n)` divides `n`, and its soundness theorem lifts a
-`true` result to the project-local {name}`Hex.Nat.Prime` predicate: a
-primality witness produced without `native_decide` or a fixed prime
-table, so downstream prime searches can certify candidates beyond any
-precomputed list.
+`HexArith` supplies a self-contained primality test. It checks candidate
+divisors from `2` through `⌊√n⌋`, stopping before the first candidate
+whose square exceeds `n`. Its soundness theorem lifts a `true` result to
+the project-local {name}`Hex.Nat.Prime` predicate: a primality witness
+produced without `native_decide` or a fixed prime table, so downstream
+prime searches can certify candidates beyond any precomputed list.
 
 {docstring Hex.Nat.Prime}
 

--- a/HexManual/Chapters/HexArith.lean
+++ b/HexManual/Chapters/HexArith.lean
@@ -229,6 +229,8 @@ prime searches can certify candidates beyond any precomputed list.
 
 {docstring Hex.Nat.isPrimeTrial_isPrime}
 
+{docstring Hex.Nat.isPrimeTrial_of_prime}
+
 # Worked example
 %%%
 tag := "hex-arith-worked"

--- a/progress/20260728T052946Z_issue-9029.md
+++ b/progress/20260728T052946Z_issue-9029.md
@@ -13,21 +13,30 @@
   semiprime, and a `Polynomial (ZMod q)` modulus above the former `2²⁶` gate.
 - Added an exact square-root candidate cost and a separate `2¹⁶` primality
   replay ceiling to the factor-tactic provider, and updated its diagnostic.
+- Consolidated the integer constant-polynomial primality path onto the same
+  verified bounded checker and budget, removing its duplicate linear scan.
 - Updated the Factor Tactics and HexArith manuals and removed stale
   linear-scan explanations.
 - Verified ordinary kernel replay at the largest supported modulus
   `2³¹ - 1` under the default recursion-depth setting.
+- Added committed kernel-replay regressions above the former modulus cutoff
+  and for a five-digit integer prime constant; removed the obsolete
+  `maxRecDepth` override around the fixed prime-499 certificate.
+- Incorporated independent review feedback by making replay-cost calculation
+  logarithmic, documenting the helper precondition, broadening differential
+  regression coverage, and leading the manual with the binding Rabin budget.
 - Ran the complete `lake build` successfully (9,510 jobs), including the
-  factor-tactic tests and manual.
+  factor-tactic tests and manual, both before and after review fixes.
 
 ## Current frontier
 
-- The implementation is locally complete and ready to publish as a PR.
+- PR #9039 contains the initial implementation; review fixes are locally
+  complete and ready to push.
 
 ## Next step
 
-- Open the PR, obtain the requested independent second opinion, address any
-  validated findings, and monitor CI through squash auto-merge.
+- Push the review fixes, then monitor conflicts and CI through squash
+  auto-merge.
 
 ## Blockers
 

--- a/progress/20260728T052946Z_issue-9029.md
+++ b/progress/20260728T052946Z_issue-9029.md
@@ -1,0 +1,34 @@
+# Issue #9029 bounded primality replay
+
+## Accomplished
+
+- Replaced the linear `List.range n` primality checker with a balanced
+  power-of-two interval scan that tests candidates only through `⌊√n⌋`.
+- Proved both soundness and completeness against `Hex.Nat.Prime`, using a
+  small-divisor lemma that selects the smaller member of a nontrivial factor
+  pair.
+- Migrated the BZ prime-selection caller to the new public completeness
+  theorem.
+- Added regressions for small inputs, primes, squares, a near-square
+  semiprime, and a `Polynomial (ZMod q)` modulus above the former `2²⁶` gate.
+- Added an exact square-root candidate cost and a separate `2¹⁶` primality
+  replay ceiling to the factor-tactic provider, and updated its diagnostic.
+- Updated the Factor Tactics and HexArith manuals and removed stale
+  linear-scan explanations.
+- Verified ordinary kernel replay at the largest supported modulus
+  `2³¹ - 1` under the default recursion-depth setting.
+- Ran the complete `lake build` successfully (9,510 jobs), including the
+  factor-tactic tests and manual.
+
+## Current frontier
+
+- The implementation is locally complete and ready to publish as a PR.
+
+## Next step
+
+- Open the PR, obtain the requested independent second opinion, address any
+  validated findings, and monitor CI through squash auto-merge.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
Closes #9029

## Summary
- replace the linear primality range with a balanced bounded scan through floor(sqrt n)
- prove soundness and completeness against Hex.Nat.Prime and migrate BZ callers, including integer prime constants
- budget primality replay by exact candidate-test cost and update diagnostics/manuals
- add small, square, near-square composite, former-cutoff kernel replay, and constant-prime regressions

## Verification
- lake build (9,510 jobs), repeated after independent review fixes
- direct kernel replay of isPrimeTrial (2^31 - 1) under default maxRecDepth
- committed kernel replay above the former 2^26 modulus cutoff