### PR TITLE
bench: admit release evidence from chungus2 (#8972)

### DIFF
--- a/HexRealRootsMathlib/SPEC/hex-real-roots-mathlib.md
+++ b/HexRealRootsMathlib/SPEC/hex-real-roots-mathlib.md
@@ -413,9 +413,10 @@ not a LeanBench executable. Build-only modules below
 products at degrees 6, 8, and 10 and width-`2^(-20)` products at degrees 2, 4,
 and 6. Each case is adjacent to the same import-only baseline, and degree 6
 also has a direct natural-to-refined pair. Baseline and natural-degree-10
-same-module controls precede the substantive pairs, and the external runner
-uses six balanced rounds, exact generated-artifact invalidation, ordinary
-kernel checking, exact axiom validation, and complete source provenance.
+same-module controls are first in manifest `config.order`; execution order
+rotates by round. The external runner uses six balanced rounds, exact
+generated-artifact invalidation, ordinary kernel checking, exact axiom
+validation, and complete source provenance.
 `HexRealRootsMathlibReplayProbe` supplies the reduced CI coverage;
 `HexRealRootsMathlibReplayProbeScientific` owns the larger release arms and
 remains outside routine CI.
@@ -432,6 +433,9 @@ The runner enforces the designated-shared-host contract in
 `SPEC/benchmarking.md`; `--allow-busy` remains diagnostic-only. Executable
 isolation arithmetic belongs to the existing Mathlib-free `HexRealRoots`
 benchmark. The bridge declarations have no separable compiled runtime kernel.
+For the proof-emitting elaborator there is
+`no-comparable-surface-in-named-comparator`: no external tool emits and
+kernel-checks the same Lean proof term.
 
 A Mathlib-free variant (same meta core, emitting a
 `RealRootIsolations` value whose conclusions are the executable

--- a/HexRealRootsMathlib/SPEC/hex-real-roots-mathlib.md
+++ b/HexRealRootsMathlib/SPEC/hex-real-roots-mathlib.md
@@ -413,10 +413,25 @@ not a LeanBench executable. Build-only modules below
 products at degrees 6, 8, and 10 and width-`2^(-20)` products at degrees 2, 4,
 and 6. Each case is adjacent to the same import-only baseline, and degree 6
 also has a direct natural-to-refined pair. Baseline and natural-degree-10
-same-module controls precede the substantive pairs, and the sweep requires six
-balanced rounds. `HexRealRootsMathlibReplayProbe` supplies the reduced CI
-coverage; `HexRealRootsMathlibReplayProbeScientific` owns the larger release
-arms and remains outside routine CI.
+same-module controls precede the substantive pairs, and the external runner
+uses six balanced rounds, exact generated-artifact invalidation, ordinary
+kernel checking, exact axiom validation, and complete source provenance.
+`HexRealRootsMathlibReplayProbe` supplies the reduced CI coverage;
+`HexRealRootsMathlibReplayProbeScientific` owns the larger release arms and
+remains outside routine CI.
+
+On the named shared release machine the command is:
+
+```bash
+python3 scripts/bench/real_roots_mathlib_sweep.py --samples 6 \
+  --timeout 180 --warm-timeout 600 \
+  --shared-host --expected-host chungus2 --cpu 22
+```
+
+The runner enforces the designated-shared-host contract in
+`SPEC/benchmarking.md`; `--allow-busy` remains diagnostic-only. Executable
+isolation arithmetic belongs to the existing Mathlib-free `HexRealRoots`
+benchmark. The bridge declarations have no separable compiled runtime kernel.
 
 A Mathlib-free variant (same meta core, emitting a
 `RealRootIsolations` value whose conclusions are the executable

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -722,7 +722,11 @@ phase-attribution evidence only; the matching LeanBench target supplies the
 scientific asymptotic verdict, and the report neither substitutes nor adds the
 two. The headline report records source hashes, commit/toolchain/host/load
 state, raw samples, artifact sizes, timeout cleanup, and the theorem's axiom
-set, and refuses release claims from a dirty or busy host.
+set, and refuses release claims from a dirty or uncontrolled host. On the
+named shared release machine it uses the designated-shared-host protocol from
+`SPEC/benchmarking.md`: a preregistered hostname and logical CPU, runner-enforced
+affinity, six balanced rounds, both null controls, per-arm contention metadata,
+and the ordinary load ceiling.
 
 The committed implementation lives under `bench/HexRCF/ProofProbe/`.
 `Support.lean` owns the fixed source and reflected cases plus the precompiled
@@ -757,7 +761,8 @@ build-only Lake libraries; there is no proof-probe executable or in-process
 clock. The complete external sweep is:
 
 ```bash
-python3 scripts/bench/hexrcf_proof_sweep.py --samples 6
+python3 scripts/bench/hexrcf_proof_sweep.py --samples 6 \
+  --shared-host --expected-host chungus2 --cpu 47
 ```
 
 Only `Replay` and `Tactic` print an axiom report, fixed to
@@ -906,8 +911,10 @@ pipeline is dominated by elaboration overhead, not arithmetic.
 ## Time budgets (Phase 4 validation)
 
 These are fixed whole-tactic acceptance cases, measured as the preregistered
-paired `Tactic − Baseline` fresh-module delta on a clean, quiescent named host.
-Raw total wall times and every pair remain in the artifact. They are not
+paired `Tactic − Baseline` fresh-module delta on a clean named host, using
+either the quiescent-host or designated-shared-host protocol from
+`SPEC/benchmarking.md`. Raw total wall times and every pair remain in the
+artifact. They are not
 one-parameter ladders, complexity verdicts, or substitutes for the compiled
 LeanBench cases above.
 

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -701,7 +701,8 @@ distinct sign entries, and formula occurrences). The fixed
 quadratic/degree-10/degree-50 cases below do not participate in those
 complexity verdicts.
 
-The tactic track begins with same-module `Baseline − Baseline` and
+The tactic track begins with same-module `Baseline − Baseline`,
+`Degree10.Tactic − Degree10.Tactic`, and
 `Degree50.Tactic − Degree50.Tactic` null controls, then uses matched
 fresh-module variants for each fixed case:
 `Baseline` (identical imports), `Reify` (reify-only checksum), `Input`
@@ -709,15 +710,16 @@ fresh-module variants for each fixed case:
 compiled certificate construction, emitting no proof), `Literal` (input plus
 the pre-generated certificate), `Replay` (literal plus its kernel-checked
 theorem), and `Tactic` (the source goal closed by `rcf`). An external runner
-rotates fresh builds and reports both null calibrations followed by raw paired
+rotates fresh builds and reports all three null calibrations followed by raw paired
 deltas for reification, search, literal elaboration, replay, and the full
 tactic. Six rounds balance which role builds first. Each null's signed deltas,
 absolute and relative ranges, and median describe fresh-build noise only: they
 are reported before the substantive pairs in artifact `config.order` and are
 never subtracted, promoted to a significance test, or used to alter the fixed
-tactic budgets. A substantive delta is noise-sized only against a null with a
-comparable total build magnitude, or when its relative spread agrees with both
-controls; otherwise the sweep leaves it unresolved. `Search − Input` is
+tactic budgets. A substantive delta is noise-sized only against the selected
+null's zero-centred maximum-absolute envelope at a comparable total build
+magnitude; a cheaper selected envelope is scaled up by the magnitude ratio and
+is never scaled down. Otherwise the sweep leaves it unresolved. `Search − Input` is
 phase-attribution evidence only; the matching LeanBench target supplies the
 scientific asymptotic verdict, and the report neither substitutes nor adds the
 two. The headline report records source hashes, commit/toolchain/host/load
@@ -725,7 +727,7 @@ state, raw samples, artifact sizes, timeout cleanup, and the theorem's axiom
 set, and refuses release claims from a dirty or uncontrolled host. On the
 named shared release machine it uses the designated-shared-host protocol from
 `SPEC/benchmarking.md`: a preregistered hostname and logical CPU, runner-enforced
-affinity inherited by timed children, six balanced rounds, both null controls,
+affinity inherited by timed children, six balanced rounds, all null controls,
 and per-arm pinned-core/SMT scheduler accounting. Global load is recorded
 context; the scoped core-interference ceiling is the release gate.
 
@@ -739,9 +741,9 @@ independently rebuildable. All measured modules import the same generated
 support module and no measured module imports another measured module.
 
 There is one shared `Baseline` and six measured modules under each of
-`Quadratic/`, `Degree10/`, and `Degree50/`. The report contains seventeen
-pairs: the baseline and degree-50-tactic null controls first, then these five
-pairs for each of the three cases:
+`Quadratic/`, `Degree10/`, and `Degree50/`. The report contains eighteen
+pairs: baseline, degree-10-tactic, and degree-50-tactic null controls first,
+then these five pairs for each of the three cases:
 
 | Report component | Reference | Candidate |
 | --- | --- | --- |
@@ -763,7 +765,8 @@ clock. The complete external sweep is:
 
 ```bash
 python3 scripts/bench/hexrcf_proof_sweep.py --samples 6 \
-  --timeout 300 --shared-host --expected-host chungus2 --cpu 47
+  --timeout 300 --warm-timeout 600 \
+  --shared-host --expected-host chungus2 --cpu 22
 ```
 
 Only `Replay` and `Tactic` print an axiom report, fixed to

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -725,8 +725,9 @@ state, raw samples, artifact sizes, timeout cleanup, and the theorem's axiom
 set, and refuses release claims from a dirty or uncontrolled host. On the
 named shared release machine it uses the designated-shared-host protocol from
 `SPEC/benchmarking.md`: a preregistered hostname and logical CPU, runner-enforced
-affinity, six balanced rounds, both null controls, per-arm contention metadata,
-and the ordinary load ceiling.
+affinity inherited by timed children, six balanced rounds, both null controls,
+and per-arm pinned-core/SMT scheduler accounting. Global load is recorded
+context; the scoped core-interference ceiling is the release gate.
 
 The committed implementation lives under `bench/HexRCF/ProofProbe/`.
 `Support.lean` owns the fixed source and reflected cases plus the precompiled
@@ -762,7 +763,7 @@ clock. The complete external sweep is:
 
 ```bash
 python3 scripts/bench/hexrcf_proof_sweep.py --samples 6 \
-  --shared-host --expected-host chungus2 --cpu 47
+  --timeout 300 --shared-host --expected-host chungus2 --cpu 47
 ```
 
 Only `Replay` and `Tactic` print an axiom report, fixed to
@@ -912,9 +913,8 @@ pipeline is dominated by elaboration overhead, not arithmetic.
 
 These are fixed whole-tactic acceptance cases, measured as the preregistered
 paired `Tactic − Baseline` fresh-module delta on a clean named host, using
-either the quiescent-host or designated-shared-host protocol from
-`SPEC/benchmarking.md`. Raw total wall times and every pair remain in the
-artifact. They are not
+the designated-shared-host protocol from `SPEC/benchmarking.md`. Raw total wall
+times and every pair remain in the artifact. They are not
 one-parameter ladders, complexity verdicts, or substitutes for the compiled
 LeanBench cases above.
 

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -301,8 +301,9 @@ and concurrent Lake/Lean counts are retained around every measured arm.
 Scheduler counters on the pinned CPU and every SMT sibling are differenced
 across each arm and combined with child user/system time. Foreign work on the
 pinned CPU or excessive sibling utilisation above the preregistered ceiling
-invalidates release quality. Global load and unrelated Lake/Lean presence are
-context rather than automatic failures in this mode.
+invalidates release quality, as does a pinned-CPU frequency spread above its
+preregistered band. Global load and unrelated Lake/Lean presence are context
+rather than automatic failures in this mode.
 
 The artifact selects a magnitude-comparable control for every substantive
 pair and records `resolved`, `unresolved`, or `no-comparable-control`. A fixed

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -292,24 +292,37 @@ The default release protocol uses a quiescent host and rejects concurrent
 Lake/Lean processes. A named shared machine is also admissible through the
 explicit designated-shared-host protocol: the command preregisters the expected
 hostname and logical CPU, pins itself before warmup, and verifies its own
-affinity after every arm; every timed descendant inherits that affinity. The
+affinity after every arm; every timed descendant inherits that affinity, and
+the timed Lean processes use one worker thread. The
 manifest's `config.order` begins with at least two same-module null controls at
 distinct cheap and expensive build magnitudes, followed by substantive pairs.
 The preregistered sample count is even and at least six. Physical-core and SMT
-topology are recorded once; host load, frequency, CPU-pressure state, affinity,
-and concurrent Lake/Lean counts are retained around every measured arm.
+topology are recorded once; host load, CPU-pressure state, affinity, and
+concurrent Lake/Lean counts are retained around every measured arm. Cumulative
+CPU-frequency residency is differenced across the arm to retain its
+time-weighted mean frequency; idle snapshots before and after the build are
+context only.
 Scheduler counters on the pinned CPU and every SMT sibling are differenced
-across each arm and combined with child user/system time. Foreign work on the
-pinned CPU or excessive sibling utilisation above the preregistered ceiling
-invalidates release quality, as does a pinned-CPU frequency spread above its
-preregistered band. Global load and unrelated Lake/Lean presence are context
-rather than automatic failures in this mode.
+across each arm and combined with child user/system time and the harness's own
+CPU time inside that counter window. Foreign work on the
+pinned CPU or excessive sibling utilisation above the preregistered ratio or
+three scheduler ticks invalidates release quality. The effective quantized
+ceiling is recorded rather than represented as the nominal ratio. Child CPU
+time materially above the pinned CPU's busy time is an affinity/accounting
+failure. Missing frequency residency or a spread of arm means above the
+preregistered band also invalidates release quality. Global load and unrelated
+Lake/Lean presence are context rather than automatic failures in this mode.
 
 The artifact selects a magnitude-comparable control for every substantive
-pair and records `resolved`, `unresolved`, or `no-comparable-control`. A fixed
-tactic budget is release-quality only when its median passes and remains below
-the budget after the comparable null spread is applied as a conservative
-resolution check; the reported timing itself is never corrected. Artifact
+pair and records `resolved`, `unresolved`, or `no-comparable-control`. It
+retains both the null range and the zero-centred envelope given by the largest
+observed absolute signed null delta. A fixed tactic budget is release-quality
+only when its median passes and remains below the budget after that comparable
+null envelope is applied as a conservative resolution check. When the selected
+control is cheaper, its range and envelope are first scaled by the build-time
+magnitude ratio; they are never scaled down. The accepted worst-case
+core-interference allowance across both arms must also be smaller than the
+budget. The reported timing itself is never corrected. Artifact
 `release_quality` is derived from pristine provenance, complete scheduler
 accounting, the scoped interference ceiling, and every required budget
 conclusion. A diagnostic `--allow-busy` run remains non-release evidence and
@@ -326,8 +339,8 @@ range and median before interpreting a magnitude-comparable proof delta, but
 does not subtract a null median, widen a budget by a null range, assign
 significance, or use a control as scientific evidence. With the small
 preregistered sample counts used here, a substantive delta inside a comparable
-null spread is described only as noise-sized or unresolved; a cheap control
-does not resolve noise for a much more expensive build.
+zero-centred null envelope is described only as noise-sized or unresolved; a
+cheap control does not resolve noise for a much more expensive build.
 
 Phase attribution uses matched module variants, not clocks embedded in the
 probe. A tactic library may use a baseline; a reify-only module; an input module

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -279,13 +279,29 @@ in-process clock, or contain a timing loop. A probe also cannot root any
 - before each sample, remove only the measured module's generated artefacts
   and run `lake build +<module>:olean`, keeping imported dependency artefacts
   warm; build each matched reference/candidate pair adjacently, rotate pair
-  order, and alternate pair orientation between rounds;
+  order, and alternate pair orientation over an even preregistered number of
+  rounds;
 - retain every raw wall-time sample and paired delta, and identify the exact
   source hashes, repository commit, dirty-state decision, toolchain, command,
   host/CPU/OS, load state, and timeout/cleanup policy;
 - record emitted artefact sizes and the axiom set of the accepted theorem;
-- refuse a release-quality verdict on a dirty tree, a busy shared host, a
-  timed-out build, or a provenance mismatch.
+- refuse a release-quality verdict on a dirty tree, an uncontrolled or
+  saturated host, a timed-out build, or a provenance mismatch.
+
+The default release protocol uses a quiescent host and rejects concurrent
+Lake/Lean processes. A named shared machine is also admissible through the
+explicit designated-shared-host protocol: the command preregisters the expected
+hostname and logical CPU, and the runner itself pins and verifies its complete
+process tree before warmup; the manifest begins with at
+least two same-module null controls spanning cheap and expensive build
+magnitudes; the preregistered sample count is even and at least six; and host
+load, CPU-pressure state, physical-core topology, affinity, and
+concurrent-process counts are retained around every measured arm.
+Background Lake/Lean process presence is metadata rather than an automatic
+failure in this mode, but the ordinary load-per-CPU ceiling remains binding.
+The report must leave any required conclusion unresolved when a
+magnitude-comparable null spread could change it. A diagnostic `--allow-busy`
+run remains non-release evidence and is not this protocol.
 
 A proof-track sweep may precede its substantive pairs with one or more marked
 same-module null controls at representative build magnitudes. Each control uses

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -291,17 +291,28 @@ in-process clock, or contain a timing loop. A probe also cannot root any
 The default release protocol uses a quiescent host and rejects concurrent
 Lake/Lean processes. A named shared machine is also admissible through the
 explicit designated-shared-host protocol: the command preregisters the expected
-hostname and logical CPU, and the runner itself pins and verifies its complete
-process tree before warmup; the manifest begins with at
-least two same-module null controls spanning cheap and expensive build
-magnitudes; the preregistered sample count is even and at least six; and host
-load, CPU-pressure state, physical-core topology, affinity, and
-concurrent-process counts are retained around every measured arm.
-Background Lake/Lean process presence is metadata rather than an automatic
-failure in this mode, but the ordinary load-per-CPU ceiling remains binding.
-The report must leave any required conclusion unresolved when a
-magnitude-comparable null spread could change it. A diagnostic `--allow-busy`
-run remains non-release evidence and is not this protocol.
+hostname and logical CPU, pins itself before warmup, and verifies its own
+affinity after every arm; every timed descendant inherits that affinity. The
+manifest's `config.order` begins with at least two same-module null controls at
+distinct cheap and expensive build magnitudes, followed by substantive pairs.
+The preregistered sample count is even and at least six. Physical-core and SMT
+topology are recorded once; host load, frequency, CPU-pressure state, affinity,
+and concurrent Lake/Lean counts are retained around every measured arm.
+Scheduler counters on the pinned CPU and every SMT sibling are differenced
+across each arm and combined with child user/system time. Foreign work on the
+pinned CPU or excessive sibling utilisation above the preregistered ceiling
+invalidates release quality. Global load and unrelated Lake/Lean presence are
+context rather than automatic failures in this mode.
+
+The artifact selects a magnitude-comparable control for every substantive
+pair and records `resolved`, `unresolved`, or `no-comparable-control`. A fixed
+tactic budget is release-quality only when its median passes and remains below
+the budget after the comparable null spread is applied as a conservative
+resolution check; the reported timing itself is never corrected. Artifact
+`release_quality` is derived from pristine provenance, complete scheduler
+accounting, the scoped interference ceiling, and every required budget
+conclusion. A diagnostic `--allow-busy` run remains non-release evidence and
+is not this protocol.
 
 A proof-track sweep may precede its substantive pairs with one or more marked
 same-module null controls at representative build magnitudes. Each control uses

--- a/progress/20260728T071234Z_shared-host-protocol.md
+++ b/progress/20260728T071234Z_shared-host-protocol.md
@@ -1,0 +1,38 @@
+# Designated shared-host proof evidence
+
+## Accomplished
+
+- Replaced the categorical shared-machine exclusion with an explicit
+  designated-shared-host protocol for fresh-module proof evidence.
+- Added fail-closed hostname and logical-CPU preregistration. The runner pins
+  itself before warmup, timed children inherit that affinity, and every arm
+  verifies that the affinity has not changed.
+- Required at least two representative same-module null controls and six
+  balanced rounds for shared-host release evidence; all fresh-module sweeps
+  now require an even number of rounds.
+- Retained global load, CPU pressure, affinity, physical-core/SMT topology,
+  and concurrent Lake/Lean counts around every measured arm. Unrelated
+  Lake/Lean process presence is recorded context; saturation still aborts.
+- Added regression tests for host identity, affinity pinning, control/sample
+  admission, process-presence handling, saturation rejection, and universal
+  orientation balance.
+- Added normative RealRootsMathlib proof-evidence documentation and exact
+  release commands for both RealRootsMathlib and RCF on `chungus2`, CPU 47.
+
+## Current frontier
+
+- The protocol implementation and 45 related Python tests are green on the
+  stacked evidence branch.
+- The structural RealRootsMathlib probe fixes are separately published on PR
+  #8980 so this protocol can rebase cleanly after that milestone merges.
+
+## Next step
+
+- Obtain independent review of the protocol, merge PR #8980 after its own
+  corrected review/CI, rebase this branch, and run the six-round RealRoots
+  release sweep from a clean checkout.
+
+## Blockers
+
+- None. Current host activity is measured and bounded by the protocol rather
+  than treated as a categorical blocker.

--- a/progress/20260728T071234Z_shared-host-protocol.md
+++ b/progress/20260728T071234Z_shared-host-protocol.md
@@ -6,7 +6,7 @@
   designated-shared-host protocol for fresh-module proof evidence.
 - Added fail-closed hostname and logical-CPU preregistration. The runner pins
   itself before warmup, timed children inherit that affinity, and every arm
-  verifies that the affinity has not changed.
+  verifies that the runner affinity has not changed.
 - Required at least two representative same-module null controls and six
   balanced rounds for shared-host release evidence; all fresh-module sweeps
   now require an even number of rounds.

--- a/progress/20260728T073003Z_shared-host-v2.md
+++ b/progress/20260728T073003Z_shared-host-v2.md
@@ -5,9 +5,10 @@
 - Completed a six-round RealRootsMathlib calibration sweep on pinned CPU 47:
   all 108 builds and exact axiom checks passed, with natural degree 10 and
   refined degree 6 completing in seconds.
-- Used the calibration nulls to confirm that the direct degree-6 refinement
-  delta is noise-sized; it will be reported as unresolved rather than assigned
-  significance.
+- Used the calibration nulls to identify the direct degree-6 refinement delta
+  as the closest call; protocol v2 now selects the nearest magnitude control
+  and records the resolution mechanically instead of assigning significance
+  by inspection.
 - Reworked shared-host validity after an independent Claude review rejected
   the first protocol's optimistic `release_quality` field.
 - Added per-arm `/proc/stat` accounting for CPU 47 and SMT sibling 95,

--- a/progress/20260728T073003Z_shared-host-v2.md
+++ b/progress/20260728T073003Z_shared-host-v2.md
@@ -13,7 +13,8 @@
 - Added per-arm `/proc/stat` accounting for CPU 47 and SMT sibling 95,
   GNU-time child CPU/context-switch measurements, pressure/frequency/load
   metadata, a preregistered 2% scoped-interference ceiling, and evidence-derived
-  release validity.
+  release validity. Missing magnitude-comparable controls and pinned-frequency
+  spread above the preregistered 15% band also invalidate the artifact.
 - Added magnitude-comparable null selection and explicit
   resolved/unresolved/no-control classifications. RCF tactic budgets now fail
   release quality when the median fails or its margin is not larger than the

--- a/progress/20260728T073003Z_shared-host-v2.md
+++ b/progress/20260728T073003Z_shared-host-v2.md
@@ -1,0 +1,43 @@
+# Designated shared-host protocol v2
+
+## Accomplished
+
+- Completed a six-round RealRootsMathlib calibration sweep on pinned CPU 47:
+  all 108 builds and exact axiom checks passed, with natural degree 10 and
+  refined degree 6 completing in seconds.
+- Used the calibration nulls to confirm that the direct degree-6 refinement
+  delta is noise-sized; it will be reported as unresolved rather than assigned
+  significance.
+- Reworked shared-host validity after an independent Claude review rejected
+  the first protocol's optimistic `release_quality` field.
+- Added per-arm `/proc/stat` accounting for CPU 47 and SMT sibling 95,
+  GNU-time child CPU/context-switch measurements, pressure/frequency/load
+  metadata, a preregistered 2% scoped-interference ceiling, and evidence-derived
+  release validity.
+- Added magnitude-comparable null selection and explicit
+  resolved/unresolved/no-control classifications. RCF tactic budgets now fail
+  release quality when the median fails or its margin is not larger than the
+  comparable null spread.
+- Corrected the affinity, topology, ordering, and global-load claims in the
+  benchmark specifications; fixed RCF acceptance budgets to this one release
+  protocol and documented calibrated 180/300-second arm timeouts.
+- Added fail-closed provenance checks, argument validation, distinct-control
+  admission, host identity, machine identity, and 51 passing regression tests.
+- Exercised a real baseline arm: 5.51 s wall, 5.44 s child CPU, 0.04 s
+  unattributed CPU-47 time, and zero CPU-95 busy time, within the 2% gate.
+
+## Current frontier
+
+- Protocol v2 is implemented and locally green on the stacked branch.
+- The first calibration artifact is diagnostic only and will not be published
+  because it predates scoped-core accounting and null-resolution validity.
+
+## Next step
+
+- Obtain a fresh Claude review of protocol v2, address any verified findings,
+  rebase after PR #8980 merges, and run the clean six-round release sweep.
+
+## Blockers
+
+- None. The only release host is now measured at the actual pinned-core
+  boundary instead of rejected or trusted from global load alone.

--- a/progress/20260728T074858Z_shared-host-counters.md
+++ b/progress/20260728T074858Z_shared-host-counters.md
@@ -1,0 +1,43 @@
+# Shared-host counter hardening
+
+## Accomplished
+
+- Treated `chungus2` as the designated release host and replaced global
+  quiescence assumptions with pinned-core, SMT-sibling, null-control, and
+  fail-closed provenance checks.
+- Corrected null interpretation to use a zero-centred maximum-absolute
+  envelope, conservatively scaled when the selected control is cheaper.
+- Restricted HexRCF acceptance budgets to the three whole-tactic pairs and
+  added a check that each budget exceeds the admitted two-arm interference
+  ceiling.
+- Added an intermediate degree-10 tactic null control after independent review
+  identified a possible magnitude gap between the baseline and degree-50
+  controls; all controls are now required to precede substantive pairs.
+- Replaced idle frequency snapshots with per-arm time-weighted means from
+  `cpufreq/stats/time_in_state`; missing residency data fails release quality.
+- Preserved signed pinned-CPU residuals, included precise reaped-child and
+  harness CPU time, rejected impossible accounting, and set timed Lean work to
+  one worker thread.
+- Tightened the nominal core-interference ratio to 0.2%, with a recorded
+  three-tick quantization floor. A live pinned build on CPU 22 / sibling 70
+  produced complete frequency data and no violations.
+- Expanded the focused suite to 61 passing tests. Phase-4, DAG, trust-surface,
+  line-count, copyright, bench-boundary, Python compile, and diff checks pass.
+
+## Current frontier
+
+The protocol changes are ready for a final independent review. RealRoots
+structural PR #8980 is still green-in-progress in its final CI run; this branch
+must be rebased onto its merge before collecting release evidence.
+
+## Next step
+
+Obtain a fresh review of the exact protocol commit, fix any verified findings,
+then rebase onto merged `main` and run the clean six-round RealRoots sweep on
+`chungus2`, pinned to CPU 22.
+
+## Blockers
+
+No host blocker remains. Release evidence cannot be attached to the structural
+milestone until PR #8980 merges, but review and protocol validation continue in
+parallel.

--- a/scripts/bench/fresh_module_sweep.py
+++ b/scripts/bench/fresh_module_sweep.py
@@ -82,7 +82,7 @@ def parse_args(
     description: str, argv: Sequence[str] | None = None
 ) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=description)
-    parser.add_argument("--samples", type=int, default=3)
+    parser.add_argument("--samples", type=int, default=4)
     parser.add_argument("--timeout", type=float, default=60.0)
     parser.add_argument("--warm-timeout", type=float, default=600.0)
     parser.add_argument("--output", type=Path)
@@ -95,6 +95,24 @@ def parse_args(
         "--allow-busy",
         action="store_true",
         help="permit concurrent Lake/Lean work or a saturated host for diagnostics",
+    )
+    parser.add_argument(
+        "--shared-host",
+        action="store_true",
+        help=(
+            "use the release-quality designated-shared-host protocol; requires "
+            "single-CPU affinity, two null controls, and at least six balanced "
+            "samples"
+        ),
+    )
+    parser.add_argument(
+        "--expected-host",
+        help="required hostname for the designated-shared-host protocol",
+    )
+    parser.add_argument(
+        "--cpu",
+        type=int,
+        help="logical CPU to which the shared-host runner and children are pinned",
     )
     parser.add_argument(
         "--max-load-per-cpu",
@@ -111,6 +129,10 @@ def parse_args(
         parser.error("--warm-timeout must be positive")
     if args.max_load_per_cpu <= 0:
         parser.error("--max-load-per-cpu must be positive")
+    if args.allow_busy and args.shared_host:
+        parser.error("--allow-busy and --shared-host are mutually exclusive")
+    if args.cpu is not None and args.cpu < 0:
+        parser.error("--cpu must be nonnegative")
     return args
 
 
@@ -194,6 +216,64 @@ def lean_processes() -> list[dict[str, object]]:
     return processes
 
 
+def cpu_affinity() -> list[int] | None:
+    """Return the logical CPUs available to this runner, when supported."""
+    get_affinity = getattr(os, "sched_getaffinity", None)
+    if get_affinity is None:
+        return None
+    return sorted(get_affinity(0))
+
+
+def _read_optional(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+
+
+def cpu_topology(cpu: int) -> dict[str, object]:
+    """Describe the physical-core unit containing one logical CPU."""
+    root = Path(f"/sys/devices/system/cpu/cpu{cpu}")
+    topology = root / "topology"
+    return {
+        "logical_cpu": cpu,
+        "core_id": _read_optional(topology / "core_id"),
+        "physical_package_id": _read_optional(
+            topology / "physical_package_id"
+        ),
+        "thread_siblings_list": _read_optional(
+            topology / "thread_siblings_list"
+        ),
+        "scaling_governor": _read_optional(
+            root / "cpufreq" / "scaling_governor"
+        ),
+    }
+
+
+def configure_shared_host(args: argparse.Namespace) -> None:
+    """Pin this runner before warmup and verify the named release machine."""
+    if not args.shared_host:
+        if args.expected_host is not None or args.cpu is not None:
+            raise RuntimeError("--expected-host/--cpu require --shared-host")
+        return
+    if args.expected_host is None or args.cpu is None:
+        raise RuntimeError(
+            "--shared-host requires both --expected-host and --cpu"
+        )
+    actual_host = socket.gethostname()
+    if actual_host != args.expected_host:
+        raise RuntimeError(
+            f"expected host {args.expected_host!r}, got {actual_host!r}"
+        )
+    set_affinity = getattr(os, "sched_setaffinity", None)
+    if set_affinity is None:
+        raise RuntimeError("CPU affinity is unavailable")
+    try:
+        set_affinity(0, {args.cpu})
+    except OSError as exc:
+        raise RuntimeError(f"cannot pin runner to CPU {args.cpu}: {exc}") from exc
+
+
 def host_state() -> dict[str, object]:
     cpus = os.cpu_count() or 1
     try:
@@ -204,14 +284,21 @@ def host_state() -> dict[str, object]:
         "logical_cpus": cpus,
         "load_average": load,
         "load_1m_per_cpu": load[0] / cpus if load else None,
+        "cpu_affinity": cpu_affinity(),
+        "cpu_pressure": _read_optional(Path("/proc/pressure/cpu")),
         "concurrent_lake_lean": lean_processes(),
     }
 
 
-def host_issues(state: dict[str, object], max_load_per_cpu: float) -> list[str]:
+def host_issues(
+    state: dict[str, object],
+    max_load_per_cpu: float,
+    *,
+    concurrent_is_issue: bool = True,
+) -> list[str]:
     issues: list[str] = []
     processes = state["concurrent_lake_lean"]
-    if processes:
+    if concurrent_is_issue and processes:
         issues.append(f"{len(processes)} concurrent Lake/Lean process(es)")
     load = state["load_1m_per_cpu"]
     if load is not None and float(load) > max_load_per_cpu:
@@ -219,6 +306,51 @@ def host_issues(state: dict[str, object], max_load_per_cpu: float) -> list[str]:
             f"one-minute load/CPU {float(load):.3f} exceeds {max_load_per_cpu:.3f}"
         )
     return issues
+
+
+def shared_host_protocol_issues(
+    spec: SweepSpec, args: argparse.Namespace
+) -> list[str]:
+    """Check the preregistered controls for shared-host release evidence."""
+    if not args.shared_host:
+        return []
+    issues: list[str] = []
+    affinity = cpu_affinity()
+    if affinity is None:
+        issues.append("CPU affinity is unavailable")
+    elif len(affinity) != 1:
+        issues.append(
+            "shared-host evidence requires exactly one affinity CPU, "
+            f"got {affinity}"
+        )
+    elif args.cpu is not None and affinity != [args.cpu]:
+        issues.append(
+            f"observed affinity {affinity} does not match requested CPU {args.cpu}"
+        )
+    controls = [pair for pair in spec.pairs if pair.null_control]
+    if len(controls) < 2:
+        issues.append(
+            "shared-host evidence requires at least two same-module null controls"
+        )
+    if args.samples < 6 or args.samples % 2 != 0:
+        issues.append(
+            "shared-host evidence requires at least six and an even number "
+            "of samples"
+        )
+    return issues
+
+
+def sampled_host_state(state: dict[str, object]) -> dict[str, object]:
+    """Compact host metadata retained immediately before each measured pair."""
+    processes = list(state["concurrent_lake_lean"])
+    return {
+        "logical_cpus": state["logical_cpus"],
+        "load_average": state["load_average"],
+        "load_1m_per_cpu": state["load_1m_per_cpu"],
+        "cpu_affinity": state["cpu_affinity"],
+        "cpu_pressure": state["cpu_pressure"],
+        "concurrent_lake_lean_count": len(processes),
+    }
 
 
 def dirty_issues(repository: dict[str, object],
@@ -483,6 +615,7 @@ def parse_axioms(output: str) -> list[str] | None:
 
 
 def build_sample(module: str, timeout: float) -> dict[str, object]:
+    host_before = sampled_host_state(host_state())
     remove_module_outputs(module)
     command = ["lake", "build", f"+{module}:olean"]
     try:
@@ -497,11 +630,14 @@ def build_sample(module: str, timeout: float) -> dict[str, object]:
         raise RuntimeError(
             f"probe failed ({proc.returncode}): {' '.join(command)}"
         )
-    return {
+    result = {
         "wall_nanos": elapsed,
         "peak_rss_kb": rss,
         "axioms": parse_axioms(output),
+        "host_before": host_before,
+        "host_after": sampled_host_state(host_state()),
     }
+    return result
 
 
 def warm_imports(spec: SweepSpec, timeout: float) -> None:
@@ -621,15 +757,21 @@ def run_cli(
 ) -> int:
     validate_spec(spec)
     args = parse_args(spec.description, argv)
+    configure_shared_host(args)
     if spec.required_samples is not None and args.samples != spec.required_samples:
         raise RuntimeError(
             f"this sweep requires --samples {spec.required_samples}, "
             f"got {args.samples}"
         )
-    if any(pair.null_control for pair in spec.pairs) and args.samples % 2 != 0:
+    if args.samples % 2 != 0:
         raise RuntimeError(
-            "null-control sweeps require an even --samples so pair "
+            "fresh-module sweeps require an even --samples so pair "
             "orientation is balanced"
+        )
+    protocol_issues = shared_host_protocol_issues(spec, args)
+    if protocol_issues:
+        raise RuntimeError(
+            "invalid shared-host protocol: " + "; ".join(protocol_issues)
         )
     warm_imports(spec, args.warm_timeout)
     env = environment()
@@ -641,7 +783,11 @@ def run_cli(
         raise RuntimeError("dirty measurement environment: " + "; ".join(dirt))
     if dirt:
         validity_exceptions.extend(dirt)
-    busy = host_issues(dict(env["host_before"]), args.max_load_per_cpu)
+    busy = host_issues(
+        dict(env["host_before"]),
+        args.max_load_per_cpu,
+        concurrent_is_issue=not args.shared_host,
+    )
     if busy and not args.allow_busy:
         raise RuntimeError("busy measurement environment: " + "; ".join(busy))
     if busy:
@@ -655,7 +801,11 @@ def run_cli(
     for round_index in range(args.samples):
         for pair in rotate(pairs, round_index):
             state = host_state()
-            issues = host_issues(state, args.max_load_per_cpu)
+            issues = host_issues(
+                state,
+                args.max_load_per_cpu,
+                concurrent_is_issue=not args.shared_host,
+            )
             if issues and not args.allow_busy:
                 raise RuntimeError("host became busy: " + "; ".join(issues))
             validity_exceptions.extend(issue for issue in issues
@@ -670,12 +820,34 @@ def run_cli(
                 )
                 sample = build_sample(module.module, args.timeout)
                 validate_axioms(pair.name, role, module, sample)
+                arm_issues = host_issues(
+                    host_state(),
+                    args.max_load_per_cpu,
+                    concurrent_is_issue=not args.shared_host,
+                )
+                if arm_issues and not args.allow_busy:
+                    raise RuntimeError(
+                        "host became busy: " + "; ".join(arm_issues)
+                    )
+                validity_exceptions.extend(
+                    issue for issue in arm_issues
+                    if issue not in validity_exceptions
+                )
+                expected_affinity = [args.cpu] if args.shared_host else None
+                if (
+                    expected_affinity is not None
+                    and cpu_affinity() != expected_affinity
+                ):
+                    raise RuntimeError(
+                        "shared-host CPU affinity changed during the sweep"
+                    )
                 built[role] = sample
             reference = built["reference"]
             candidate = built["candidate"]
             rows[pair.name].append({
                 "round": round_index + 1,
                 "build_order": [role for role, _module in modules],
+                "host_before_pair": sampled_host_state(state),
                 "reference": reference,
                 "candidate": candidate,
                 "signed_wall_delta_nanos": (
@@ -697,7 +869,11 @@ def run_cli(
     if dependencies_after != env["dependency_checkouts"]:
         raise RuntimeError("dependency checkout changed during the sweep")
     host_after = host_state()
-    final_busy = host_issues(host_after, args.max_load_per_cpu)
+    final_busy = host_issues(
+        host_after,
+        args.max_load_per_cpu,
+        concurrent_is_issue=not args.shared_host,
+    )
     if final_busy and not args.allow_busy:
         raise RuntimeError("host became busy: " + "; ".join(final_busy))
     validity_exceptions.extend(issue for issue in final_busy
@@ -711,6 +887,11 @@ def run_cli(
         "validity": {
             "release_quality": not validity_exceptions,
             "exceptions": validity_exceptions,
+            "host_protocol": (
+                "designated-shared-host-v1"
+                if args.shared_host
+                else "quiescent-host-v1"
+            ),
         },
         "config": {
             "samples": args.samples,
@@ -724,6 +905,15 @@ def run_cli(
             "max_load_per_cpu": args.max_load_per_cpu,
             "allow_dirty": args.allow_dirty,
             "allow_busy": args.allow_busy,
+            "shared_host": args.shared_host,
+            "expected_host": args.expected_host,
+            "requested_cpu": args.cpu,
+            "cpu_affinity": cpu_affinity(),
+            "cpu_topology": (
+                cpu_topology(args.cpu)
+                if args.shared_host and args.cpu is not None
+                else None
+            ),
         },
         "results": summarize(spec, rows),
         "source_sha256": before,

--- a/scripts/bench/fresh_module_sweep.py
+++ b/scripts/bench/fresh_module_sweep.py
@@ -18,6 +18,7 @@ import json
 import os
 import platform
 import re
+import resource
 import signal
 import shutil
 import socket
@@ -39,9 +40,11 @@ CPU_PERCENT_MARKER = "__HEX_CPU_PERCENT__="
 INVOLUNTARY_CONTEXT_MARKER = "__HEX_INVOLUNTARY_CONTEXT__="
 VOLUNTARY_CONTEXT_MARKER = "__HEX_VOLUNTARY_CONTEXT__="
 DEFAULT_MAX_LOAD_PER_CPU = 0.5
-DEFAULT_MAX_CORE_INTERFERENCE_RATIO = 0.02
+DEFAULT_MAX_CORE_INTERFERENCE_RATIO = 0.002
 DEFAULT_MAX_FREQUENCY_SPREAD_RATIO = 0.15
 NULL_MAGNITUDE_FACTOR = 3.0
+MIN_CONTROL_MAGNITUDE_RATIO = 2.0
+ACCOUNTING_QUANTIZATION_TICKS = 3
 T = TypeVar("T")
 
 sys.path.insert(0, str(ROOT))
@@ -309,6 +312,7 @@ def configure_shared_host(args: argparse.Namespace) -> None:
         set_affinity(0, {args.cpu})
     except OSError as exc:
         raise RuntimeError(f"cannot pin runner to CPU {args.cpu}: {exc}") from exc
+    os.environ["LEAN_NUM_THREADS"] = "1"
 
 
 def parse_cpu_list(text: str | None) -> list[int]:
@@ -346,6 +350,67 @@ def cpu_ticks(cpus: Sequence[int]) -> dict[int, dict[str, int]]:
         values = [int(value) for value in columns[1:]]
         result[int(suffix)] = dict(zip(fields, values, strict=False))
     return result
+
+
+def frequency_residency(cpu: int | None) -> dict[int, int] | None:
+    """Read cumulative cpufreq residency counters for one logical CPU."""
+    if cpu is None:
+        return None
+    text = _read_optional(
+        Path(
+            f"/sys/devices/system/cpu/cpu{cpu}/cpufreq/stats/time_in_state"
+        )
+    )
+    if text is None:
+        return None
+    result: dict[int, int] = {}
+    try:
+        for line in text.splitlines():
+            frequency, ticks = line.split()
+            result[int(frequency)] = int(ticks)
+    except (TypeError, ValueError):
+        return None
+    return result or None
+
+
+def frequency_residency_delta(
+    before: dict[int, int] | None,
+    after: dict[int, int] | None,
+) -> dict[int, int] | None:
+    """Difference compatible cpufreq residency snapshots fail-closed."""
+    if before is None or after is None or set(before) != set(after):
+        return None
+    delta = {
+        frequency: after[frequency] - ticks
+        for frequency, ticks in before.items()
+    }
+    if any(ticks < 0 for ticks in delta.values()):
+        return None
+    return delta
+
+
+def mean_residency_frequency(
+    delta: dict[int, int] | None,
+) -> float | None:
+    """Time-weighted mean kHz from a cpufreq residency delta."""
+    if delta is None:
+        return None
+    total = sum(delta.values())
+    if total <= 0:
+        return None
+    return sum(frequency * ticks for frequency, ticks in delta.items()) / total
+
+
+def runner_cpu_seconds() -> float:
+    """CPU consumed by this harness process itself."""
+    usage = resource.getrusage(resource.RUSAGE_SELF)
+    return float(usage.ru_utime + usage.ru_stime)
+
+
+def reaped_children_cpu_seconds() -> tuple[float, float]:
+    """Cumulative CPU of child processes already reaped by this runner."""
+    usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+    return float(usage.ru_utime), float(usage.ru_stime)
 
 
 def cpu_tick_delta(
@@ -390,10 +455,17 @@ def host_state() -> dict[str, object]:
         fields = loadavg.split()
         runnable = fields[3] if len(fields) > 3 else None
     pressure = _read_optional(Path("/proc/pressure/cpu"))
+    available_cpus = len(affinity) if affinity is not None else None
     return {
         "logical_cpus": cpus,
+        "available_logical_cpus": available_cpus,
         "load_average": load,
         "load_1m_per_cpu": load[0] / cpus if load else None,
+        "load_1m_per_available_cpu": (
+            load[0] / available_cpus
+            if load and available_cpus is not None and available_cpus > 0
+            else None
+        ),
         "runnable_tasks": runnable,
         "cpu_affinity": affinity,
         "cpu_pressure": pressure,
@@ -450,10 +522,17 @@ def shared_host_protocol_issues(
         issues.append(
             "shared-host evidence requires at least two same-module null controls"
         )
-    elif not all(pair.null_control for pair in spec.pairs[:2]):
-        issues.append("the first two manifest pairs must be null controls")
-    elif controls[0].reference.module == controls[1].reference.module:
-        issues.append("the first two null controls must use distinct magnitudes")
+    elif len({pair.reference.module for pair in controls}) < 2:
+        issues.append("null controls must use at least two distinct magnitudes")
+    first_substantive = next(
+        (
+            index for index, pair in enumerate(spec.pairs)
+            if not pair.null_control
+        ),
+        len(spec.pairs),
+    )
+    if any(pair.null_control for pair in spec.pairs[first_substantive:]):
+        issues.append("all null controls must precede substantive pairs")
     if not any(not pair.null_control for pair in spec.pairs):
         issues.append("shared-host evidence requires a substantive pair")
     if args.samples < 6 or args.samples % 2 != 0:
@@ -465,12 +544,14 @@ def shared_host_protocol_issues(
 
 
 def sampled_host_state(state: dict[str, object]) -> dict[str, object]:
-    """Compact host metadata retained immediately before each measured pair."""
+    """Compact host metadata retained around measured pairs and arms."""
     processes = list(state["concurrent_lake_lean"])
     return {
         "logical_cpus": state["logical_cpus"],
+        "available_logical_cpus": state["available_logical_cpus"],
         "load_average": state["load_average"],
         "load_1m_per_cpu": state["load_1m_per_cpu"],
+        "load_1m_per_available_cpu": state["load_1m_per_available_cpu"],
         "runnable_tasks": state["runnable_tasks"],
         "cpu_affinity": state["cpu_affinity"],
         "cpu_pressure": state["cpu_pressure"],
@@ -704,6 +785,7 @@ def run_timed(
     wrapped = command if timer is None else [
         timer, "-f", timer_format, *command
     ]
+    children_cpu_before = reaped_children_cpu_seconds()
     start = time.perf_counter_ns()
     child = subprocess.Popen(
         wrapped,
@@ -719,6 +801,7 @@ def run_timed(
         terminate_process_group(child)
         raise
     elapsed = time.perf_counter_ns() - start
+    children_cpu_after = reaped_children_cpu_seconds()
     proc = subprocess.CompletedProcess(
         wrapped, child.returncode, stdout=stdout, stderr=stderr
     )
@@ -726,6 +809,12 @@ def run_timed(
         "peak_rss_kb": None,
         "user_seconds": None,
         "system_seconds": None,
+        "precise_child_user_seconds": (
+            children_cpu_after[0] - children_cpu_before[0]
+        ),
+        "precise_child_system_seconds": (
+            children_cpu_after[1] - children_cpu_before[1]
+        ),
         "cpu_percent": None,
         "involuntary_context_switches": None,
         "voluntary_context_switches": None,
@@ -790,6 +879,8 @@ def build_sample(
     remove_module_outputs(module)
     host_before = sampled_host_state(host_state())
     ticks_before = cpu_ticks(monitored_cpus)
+    runner_cpu_before = runner_cpu_seconds()
+    frequency_before = frequency_residency(measurement_cpu)
     command = ["lake", "build", f"+{module}:olean"]
     try:
         proc, elapsed, metrics = run_timed(command, timeout)
@@ -803,6 +894,8 @@ def build_sample(
         raise RuntimeError(
             f"probe failed ({proc.returncode}): {' '.join(command)}"
         )
+    frequency_after = frequency_residency(measurement_cpu)
+    runner_cpu_after = runner_cpu_seconds()
     ticks_after = cpu_ticks(monitored_cpus)
     host_after = sampled_host_state(host_state())
     tick_hz = int(os.sysconf("SC_CLK_TCK"))
@@ -818,22 +911,28 @@ def build_sample(
         }
     child_cpu_seconds = None
     if (
-        metrics["user_seconds"] is not None
-        and metrics["system_seconds"] is not None
+        metrics["precise_child_user_seconds"] is not None
+        and metrics["precise_child_system_seconds"] is not None
     ):
         child_cpu_seconds = (
-            float(metrics["user_seconds"])
-            + float(metrics["system_seconds"])
+            float(metrics["precise_child_user_seconds"])
+            + float(metrics["precise_child_system_seconds"])
         )
+    runner_seconds = runner_cpu_after - runner_cpu_before
     foreign_seconds = None
+    residual_seconds = None
     if measurement_cpu is not None and str(measurement_cpu) in per_cpu:
         target_busy = per_cpu[str(measurement_cpu)]["busy_seconds"]
         if target_busy is not None and child_cpu_seconds is not None:
-            foreign_seconds = max(
-                0.0, float(target_busy) - child_cpu_seconds
+            residual_seconds = (
+                float(target_busy) - child_cpu_seconds - runner_seconds
             )
+            foreign_seconds = max(0.0, residual_seconds)
     pressure_before = host_before["cpu_pressure_some_total_us"]
     pressure_after = host_after["cpu_pressure_some_total_us"]
+    frequency_delta = frequency_residency_delta(
+        frequency_before, frequency_after
+    )
     result = {
         "wall_nanos": elapsed,
         **metrics,
@@ -844,7 +943,14 @@ def build_sample(
             "clock_ticks_per_second": tick_hz,
             "per_cpu": per_cpu,
             "child_cpu_seconds": child_cpu_seconds,
+            "child_cpu_source": "getrusage-reaped-children",
+            "runner_cpu_seconds": runner_seconds,
+            "measurement_cpu_residual_seconds": residual_seconds,
             "measurement_cpu_foreign_seconds": foreign_seconds,
+            "frequency_time_in_state_ticks": frequency_delta,
+            "mean_frequency_khz": mean_residency_frequency(
+                frequency_delta
+            ),
             "pressure_some_delta_us": (
                 int(pressure_after) - int(pressure_before)
                 if pressure_before is not None and pressure_after is not None
@@ -952,40 +1058,45 @@ def summarize(
             "signed_wall_delta_nanos": deltas,
             "median_signed_wall_delta_nanos": int(statistics.median(deltas)),
         }
+        result["build_magnitude_wall_nanos"] = max(
+            int(result["median_reference_wall_nanos"]),
+            int(result["median_candidate_wall_nanos"]),
+        )
         summary[pair.name] = result
-    controls: list[tuple[str, int, int]] = []
+    controls: list[tuple[str, int, int, int]] = []
     for pair in spec.pairs:
         result = summary[pair.name]
         if not pair.null_control:
             continue
         deltas = list(result["signed_wall_delta_nanos"])
-        magnitude = max(
-            int(result["median_reference_wall_nanos"]),
-            int(result["median_candidate_wall_nanos"]),
-        )
+        magnitude = int(result["build_magnitude_wall_nanos"])
         spread = max(deltas) - min(deltas)
         result["null_spread_nanos"] = spread
         result["null_max_absolute_delta_nanos"] = max(
             abs(int(delta)) for delta in deltas
         )
-        controls.append((pair.name, magnitude, spread))
+        controls.append(
+            (
+                pair.name,
+                magnitude,
+                spread,
+                int(result["null_max_absolute_delta_nanos"]),
+            )
+        )
     for pair in spec.pairs:
         if pair.null_control:
             continue
         result = summary[pair.name]
-        magnitude = max(
-            int(result["median_reference_wall_nanos"]),
-            int(result["median_candidate_wall_nanos"]),
-        )
+        magnitude = int(result["build_magnitude_wall_nanos"])
         comparable = [
-            (name, control_magnitude, spread)
-            for name, control_magnitude, spread in controls
+            (name, control_magnitude, spread, envelope)
+            for name, control_magnitude, spread, envelope in controls
             if min(magnitude, control_magnitude) > 0
             and max(magnitude, control_magnitude)
             / min(magnitude, control_magnitude) <= NULL_MAGNITUDE_FACTOR
         ]
         if comparable:
-            name, control_magnitude, spread = min(
+            name, control_magnitude, spread, envelope = min(
                 comparable,
                 key=lambda item: abs(
                     magnitude - item[1]
@@ -996,27 +1107,46 @@ def summarize(
                 max(magnitude, control_magnitude)
                 / min(magnitude, control_magnitude)
             )
-            result["comparable_null_spread_nanos"] = spread
+            scale_numerator = max(magnitude, control_magnitude)
+            scale_denominator = control_magnitude
+            applied_spread = (
+                spread * scale_numerator + scale_denominator - 1
+            ) // scale_denominator
+            applied_envelope = (
+                envelope * scale_numerator + scale_denominator - 1
+            ) // scale_denominator
+            result["control_scale_factor"] = (
+                scale_numerator / scale_denominator
+            )
+            result["comparable_null_raw_spread_nanos"] = spread
+            result["comparable_null_raw_envelope_nanos"] = envelope
+            result["comparable_null_spread_nanos"] = applied_spread
+            result["comparable_null_envelope_nanos"] = applied_envelope
             result["resolution"] = (
                 "unresolved"
-                if abs(int(result["median_signed_wall_delta_nanos"])) <= spread
+                if abs(int(result["median_signed_wall_delta_nanos"]))
+                <= applied_envelope
                 else "resolved"
             )
         else:
             result["comparable_control"] = None
             result["control_magnitude_ratio"] = None
+            result["control_scale_factor"] = None
+            result["comparable_null_raw_spread_nanos"] = None
+            result["comparable_null_raw_envelope_nanos"] = None
             result["comparable_null_spread_nanos"] = None
+            result["comparable_null_envelope_nanos"] = None
             result["resolution"] = "no-comparable-control"
         budget_ms = pair.metadata.get("tactic_budget_ms")
         if budget_ms is not None:
             budget_nanos = int(budget_ms) * 1_000_000
             median_delta = int(result["median_signed_wall_delta_nanos"])
-            spread_value = result["comparable_null_spread_nanos"]
+            envelope_value = result["comparable_null_envelope_nanos"]
             if median_delta >= budget_nanos:
                 budget_status = "failed"
-            elif spread_value is None:
+            elif envelope_value is None:
                 budget_status = "no-comparable-control"
-            elif median_delta + int(spread_value) >= budget_nanos:
+            elif median_delta + int(envelope_value) >= budget_nanos:
                 budget_status = "unresolved"
             else:
                 budget_status = "passed"
@@ -1038,7 +1168,10 @@ def shared_host_observations(
     max_pressure_delta = 0
     max_concurrent = 0
     max_load = 0.0
-    frequencies: list[int] = []
+    frequencies: list[float] = []
+    expected_frequency_observations = 0
+    max_effective_interference_ratio = 0.0
+    max_interference_allowance_seconds = 0.0
     violations: list[str] = []
     missing_accounting = False
     tick_hz = int(os.sysconf("SC_CLK_TCK"))
@@ -1049,25 +1182,82 @@ def shared_host_observations(
                 arm = dict(sample[role])
                 wall_seconds = int(arm["wall_nanos"]) / 1_000_000_000
                 accounting = dict(arm["cpu_accounting"])
-                foreign = accounting["measurement_cpu_foreign_seconds"]
-                per_cpu = dict(accounting["per_cpu"])
-                if foreign is None or wall_seconds <= 0:
-                    missing_accounting = True
-                    continue
-                foreign_ratio = float(foreign) / wall_seconds
-                max_foreign_ratio = max(max_foreign_ratio, foreign_ratio)
-                allowance = max(2 / tick_hz, max_ratio * wall_seconds)
-                if float(foreign) > allowance:
-                    violations.append(
-                        f"{pair_name} round {round_index} {role}: "
-                        f"measurement CPU foreign time {float(foreign):.3f}s "
-                        f"exceeds {allowance:.3f}s"
+                expected_frequency_observations += 1
+                mean_frequency = accounting.get("mean_frequency_khz")
+                if (
+                    mean_frequency is not None
+                    and float(mean_frequency) > 0
+                ):
+                    frequencies.append(float(mean_frequency))
+                for state_key in ("host_before", "host_after"):
+                    state = dict(arm[state_key])
+                    max_concurrent = max(
+                        max_concurrent,
+                        int(state["concurrent_lake_lean_count"]),
                     )
+                    load = state.get("load_1m_per_cpu")
+                    if load is not None:
+                        max_load = max(max_load, float(load))
+                foreign = accounting["measurement_cpu_foreign_seconds"]
+                residual = accounting.get(
+                    "measurement_cpu_residual_seconds"
+                )
+                per_cpu = dict(accounting["per_cpu"])
+                quantization_allowance = (
+                    ACCOUNTING_QUANTIZATION_TICKS / tick_hz
+                )
+                allowance = max(
+                    quantization_allowance,
+                    max_ratio * wall_seconds,
+                )
+                if wall_seconds > 0:
+                    max_interference_allowance_seconds = max(
+                        max_interference_allowance_seconds, allowance
+                    )
+                    max_effective_interference_ratio = max(
+                        max_effective_interference_ratio,
+                        allowance / wall_seconds,
+                    )
+                if (
+                    foreign is None
+                    or residual is None
+                    or wall_seconds <= 0
+                ):
+                    missing_accounting = True
+                else:
+                    foreign_ratio = float(foreign) / wall_seconds
+                    max_foreign_ratio = max(
+                        max_foreign_ratio, foreign_ratio
+                    )
+                    if float(residual) < -quantization_allowance:
+                        violations.append(
+                            f"{pair_name} round {round_index} {role}: "
+                            "child CPU time exceeds pinned-CPU busy time by "
+                            f"{-float(residual):.3f}s (allowance "
+                            f"{quantization_allowance:.3f}s)"
+                        )
+                    if float(foreign) > allowance:
+                        violations.append(
+                            f"{pair_name} round {round_index} {role}: "
+                            "measurement CPU foreign time "
+                            f"{float(foreign):.3f}s exceeds "
+                            f"{allowance:.3f}s"
+                        )
+                    cpu_percent = arm.get("cpu_percent")
+                    if (
+                        cpu_percent is not None
+                        and float(cpu_percent) > 100 * (1 + max_ratio)
+                    ):
+                        violations.append(
+                            f"{pair_name} round {round_index} {role}: "
+                            f"child CPU utilisation {float(cpu_percent):.1f}% "
+                            "exceeds the single-CPU affinity ceiling"
+                        )
                 for sibling in sibling_cpus:
                     busy = dict(per_cpu.get(str(sibling), {})).get(
                         "busy_seconds"
                     )
-                    if busy is None:
+                    if busy is None or wall_seconds <= 0:
                         missing_accounting = True
                         continue
                     sibling_ratio = float(busy) / wall_seconds
@@ -1085,22 +1275,16 @@ def shared_host_observations(
                     max_pressure_delta = max(
                         max_pressure_delta, int(pressure)
                     )
-                for state_key in ("host_before", "host_after"):
-                    state = dict(arm[state_key])
-                    max_concurrent = max(
-                        max_concurrent,
-                        int(state["concurrent_lake_lean_count"]),
-                    )
-                    load = state.get("load_1m_per_cpu")
-                    if load is not None:
-                        max_load = max(max_load, float(load))
-                    frequency = state.get("affinity_cpu_frequency_khz")
-                    if frequency is not None:
-                        frequencies.append(int(frequency))
     if missing_accounting:
         violations.append("per-arm CPU accounting is incomplete")
+    if len(frequencies) != expected_frequency_observations:
+        violations.append(
+            "pinned-CPU frequency accounting is incomplete "
+            f"({len(frequencies)}/{expected_frequency_observations} "
+            "positive readings)"
+        )
     frequency_spread_ratio = None
-    if frequencies and min(frequencies) > 0:
+    if frequencies:
         frequency_spread_ratio = (
             max(frequencies) / min(frequencies) - 1
         )
@@ -1114,14 +1298,23 @@ def shared_host_observations(
         "measurement_cpu": measurement_cpu,
         "smt_sibling_cpus": list(sibling_cpus),
         "max_core_interference_ratio": max_ratio,
+        "accounting_quantization_ticks": ACCOUNTING_QUANTIZATION_TICKS,
+        "max_effective_core_interference_ratio":
+            max_effective_interference_ratio,
+        "max_interference_allowance_seconds":
+            max_interference_allowance_seconds,
         "max_frequency_spread_ratio": max_frequency_spread_ratio,
         "max_measurement_cpu_foreign_ratio": max_foreign_ratio,
         "max_smt_sibling_busy_ratio": max_sibling_ratio,
         "max_cpu_pressure_some_delta_us": max_pressure_delta,
         "max_concurrent_lake_lean_count": max_concurrent,
         "max_load_1m_per_cpu": max_load,
-        "min_frequency_khz": min(frequencies) if frequencies else None,
-        "max_frequency_khz": max(frequencies) if frequencies else None,
+        "min_arm_mean_frequency_khz":
+            min(frequencies) if frequencies else None,
+        "max_arm_mean_frequency_khz":
+            max(frequencies) if frequencies else None,
+        "expected_frequency_observations": expected_frequency_observations,
+        "observed_frequency_observations": len(frequencies),
         "frequency_spread_ratio": frequency_spread_ratio,
         "violations": violations,
     }
@@ -1141,15 +1334,63 @@ def validity_summary(
             issue for issue in observations["violations"]
             if issue not in issues
         )
+    if args.shared_host:
+        control_magnitudes = [
+            int(results[pair.name]["build_magnitude_wall_nanos"])
+            for pair in spec.pairs
+            if pair.null_control
+        ]
+        if (
+            control_magnitudes
+            and min(control_magnitudes) > 0
+            and max(control_magnitudes) / min(control_magnitudes)
+            < MIN_CONTROL_MAGNITUDE_RATIO
+        ):
+            issues.append(
+                "null-control build magnitudes are not sufficiently distinct"
+            )
     for pair in spec.pairs:
         if pair.null_control:
             continue
-        if results[pair.name].get("resolution") == "no-comparable-control":
+        if (
+            args.shared_host
+            and results[pair.name].get("resolution")
+            == "no-comparable-control"
+        ):
             issue = f"{pair.name}: no magnitude-comparable null control"
             if issue not in issues:
                 issues.append(issue)
         if "tactic_budget_ms" not in pair.metadata:
             continue
+        if args.shared_host:
+            tick_hz = int(os.sysconf("SC_CLK_TCK"))
+            quantization = ACCOUNTING_QUANTIZATION_TICKS / tick_hz
+            pair_allowances = [
+                sum(
+                    max(
+                        quantization,
+                        args.max_core_interference_ratio
+                        * int(sample[role]["wall_nanos"])
+                        / 1_000_000_000,
+                    )
+                    for role in ("reference", "candidate")
+                )
+                for sample in results[pair.name]["samples"]
+            ]
+            interference_ceiling_nanos = int(
+                max(pair_allowances, default=0.0) * 1_000_000_000
+            )
+            results[pair.name][
+                "budget_interference_ceiling_nanos"
+            ] = interference_ceiling_nanos
+            budget_nanos = int(results[pair.name]["budget_nanos"])
+            if interference_ceiling_nanos >= budget_nanos:
+                issue = (
+                    f"{pair.name}: tactic budget is not resolvable under "
+                    "the admitted core-interference ceiling"
+                )
+                if issue not in issues:
+                    issues.append(issue)
         status = results[pair.name].get("budget_status")
         if status != "passed":
             issue = f"{pair.name}: tactic budget {status}"
@@ -1382,8 +1623,16 @@ def run_cli(
             "max_load_per_cpu": args.max_load_per_cpu,
             "max_core_interference_ratio":
                 args.max_core_interference_ratio,
+            "accounting_quantization_ticks":
+                ACCOUNTING_QUANTIZATION_TICKS,
             "max_frequency_spread_ratio":
                 args.max_frequency_spread_ratio,
+            "minimum_control_magnitude_ratio":
+                MIN_CONTROL_MAGNITUDE_RATIO,
+            "null_magnitude_factor": NULL_MAGNITUDE_FACTOR,
+            "frequency_measurement":
+                "cpufreq-time-in-state-arm-mean",
+            "lean_num_threads": os.environ.get("LEAN_NUM_THREADS"),
             "allow_dirty": args.allow_dirty,
             "allow_busy": args.allow_busy,
             "shared_host": args.shared_host,

--- a/scripts/bench/fresh_module_sweep.py
+++ b/scripts/bench/fresh_module_sweep.py
@@ -33,7 +33,14 @@ from typing import Sequence, TypeVar
 ROOT = Path(__file__).resolve().parents[2]
 BUILD = ROOT / ".lake" / "build"
 RSS_MARKER = "__HEX_MAX_RSS_KB__="
+USER_MARKER = "__HEX_USER_SECONDS__="
+SYSTEM_MARKER = "__HEX_SYSTEM_SECONDS__="
+CPU_PERCENT_MARKER = "__HEX_CPU_PERCENT__="
+INVOLUNTARY_CONTEXT_MARKER = "__HEX_INVOLUNTARY_CONTEXT__="
+VOLUNTARY_CONTEXT_MARKER = "__HEX_VOLUNTARY_CONTEXT__="
 DEFAULT_MAX_LOAD_PER_CPU = 0.5
+DEFAULT_MAX_CORE_INTERFERENCE_RATIO = 0.02
+NULL_MAGNITUDE_FACTOR = 3.0
 T = TypeVar("T")
 
 sys.path.insert(0, str(ROOT))
@@ -79,10 +86,13 @@ class SweepSpec:
 
 
 def parse_args(
-    description: str, argv: Sequence[str] | None = None
+    description: str,
+    argv: Sequence[str] | None = None,
+    *,
+    default_samples: int = 4,
 ) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=description)
-    parser.add_argument("--samples", type=int, default=4)
+    parser.add_argument("--samples", type=int, default=default_samples)
     parser.add_argument("--timeout", type=float, default=60.0)
     parser.add_argument("--warm-timeout", type=float, default=600.0)
     parser.add_argument("--output", type=Path)
@@ -120,6 +130,15 @@ def parse_args(
         default=DEFAULT_MAX_LOAD_PER_CPU,
         help="maximum one-minute load average divided by logical CPU count",
     )
+    parser.add_argument(
+        "--max-core-interference-ratio",
+        type=float,
+        default=DEFAULT_MAX_CORE_INTERFERENCE_RATIO,
+        help=(
+            "maximum foreign busy-time fraction on the measurement CPU or "
+            "busy-time fraction on its SMT sibling"
+        ),
+    )
     args = parser.parse_args(argv)
     if args.samples < 1:
         parser.error("--samples must be positive")
@@ -129,10 +148,20 @@ def parse_args(
         parser.error("--warm-timeout must be positive")
     if args.max_load_per_cpu <= 0:
         parser.error("--max-load-per-cpu must be positive")
+    if not 0 < args.max_core_interference_ratio < 1:
+        parser.error("--max-core-interference-ratio must be between 0 and 1")
     if args.allow_busy and args.shared_host:
         parser.error("--allow-busy and --shared-host are mutually exclusive")
     if args.cpu is not None and args.cpu < 0:
         parser.error("--cpu must be nonnegative")
+    if args.shared_host and (
+        args.expected_host is None or args.cpu is None
+    ):
+        parser.error("--shared-host requires both --expected-host and --cpu")
+    if not args.shared_host and (
+        args.expected_host is not None or args.cpu is not None
+    ):
+        parser.error("--expected-host/--cpu require --shared-host")
     return args
 
 
@@ -247,19 +276,18 @@ def cpu_topology(cpu: int) -> dict[str, object]:
         "scaling_governor": _read_optional(
             root / "cpufreq" / "scaling_governor"
         ),
+        "scaling_cur_freq_khz": _read_optional(
+            root / "cpufreq" / "scaling_cur_freq"
+        ),
     }
 
 
 def configure_shared_host(args: argparse.Namespace) -> None:
     """Pin this runner before warmup and verify the named release machine."""
     if not args.shared_host:
-        if args.expected_host is not None or args.cpu is not None:
-            raise RuntimeError("--expected-host/--cpu require --shared-host")
         return
-    if args.expected_host is None or args.cpu is None:
-        raise RuntimeError(
-            "--shared-host requires both --expected-host and --cpu"
-        )
+    assert args.expected_host is not None
+    assert args.cpu is not None
     actual_host = socket.gethostname()
     if actual_host != args.expected_host:
         raise RuntimeError(
@@ -274,18 +302,98 @@ def configure_shared_host(args: argparse.Namespace) -> None:
         raise RuntimeError(f"cannot pin runner to CPU {args.cpu}: {exc}") from exc
 
 
+def parse_cpu_list(text: str | None) -> list[int]:
+    """Parse Linux cpulist syntax such as ``0-2,7``."""
+    if not text:
+        return []
+    cpus: list[int] = []
+    for part in text.split(","):
+        bounds = part.split("-", 1)
+        start = int(bounds[0])
+        stop = int(bounds[-1])
+        cpus.extend(range(start, stop + 1))
+    return sorted(set(cpus))
+
+
+def cpu_ticks(cpus: Sequence[int]) -> dict[int, dict[str, int]]:
+    """Read per-logical-CPU scheduler counters from ``/proc/stat``."""
+    wanted = set(cpus)
+    result: dict[int, dict[str, int]] = {}
+    fields = (
+        "user", "nice", "system", "idle", "iowait", "irq", "softirq",
+        "steal", "guest", "guest_nice",
+    )
+    try:
+        lines = Path("/proc/stat").read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return result
+    for line in lines:
+        columns = line.split()
+        if not columns or not columns[0].startswith("cpu"):
+            continue
+        suffix = columns[0][3:]
+        if not suffix.isdigit() or int(suffix) not in wanted:
+            continue
+        values = [int(value) for value in columns[1:]]
+        result[int(suffix)] = dict(zip(fields, values, strict=False))
+    return result
+
+
+def cpu_tick_delta(
+    before: dict[int, dict[str, int]],
+    after: dict[int, dict[str, int]],
+    cpu: int,
+) -> dict[str, int] | None:
+    if cpu not in before or cpu not in after:
+        return None
+    return {
+        field: after[cpu].get(field, 0) - value
+        for field, value in before[cpu].items()
+    }
+
+
+def busy_ticks(delta: dict[str, int] | None) -> int | None:
+    if delta is None:
+        return None
+    return sum(
+        delta.get(field, 0)
+        for field in ("user", "nice", "system", "irq", "softirq", "steal")
+    )
+
+
+def pressure_total_us(text: str | None) -> int | None:
+    if text is None:
+        return None
+    match = re.search(r"^some .*?\btotal=(\d+)", text, flags=re.MULTILINE)
+    return int(match.group(1)) if match else None
+
+
 def host_state() -> dict[str, object]:
     cpus = os.cpu_count() or 1
     try:
         load = list(os.getloadavg())
     except OSError:
         load = []
+    affinity = cpu_affinity()
+    loadavg = _read_optional(Path("/proc/loadavg"))
+    runnable = None
+    if loadavg is not None:
+        fields = loadavg.split()
+        runnable = fields[3] if len(fields) > 3 else None
+    pressure = _read_optional(Path("/proc/pressure/cpu"))
     return {
         "logical_cpus": cpus,
         "load_average": load,
         "load_1m_per_cpu": load[0] / cpus if load else None,
-        "cpu_affinity": cpu_affinity(),
-        "cpu_pressure": _read_optional(Path("/proc/pressure/cpu")),
+        "runnable_tasks": runnable,
+        "cpu_affinity": affinity,
+        "cpu_pressure": pressure,
+        "cpu_pressure_some_total_us": pressure_total_us(pressure),
+        "affinity_cpu_frequency_khz": (
+            cpu_topology(affinity[0])["scaling_cur_freq_khz"]
+            if affinity is not None and len(affinity) == 1
+            else None
+        ),
         "concurrent_lake_lean": lean_processes(),
     }
 
@@ -295,13 +403,14 @@ def host_issues(
     max_load_per_cpu: float,
     *,
     concurrent_is_issue: bool = True,
+    load_is_issue: bool = True,
 ) -> list[str]:
     issues: list[str] = []
     processes = state["concurrent_lake_lean"]
     if concurrent_is_issue and processes:
         issues.append(f"{len(processes)} concurrent Lake/Lean process(es)")
     load = state["load_1m_per_cpu"]
-    if load is not None and float(load) > max_load_per_cpu:
+    if load_is_issue and load is not None and float(load) > max_load_per_cpu:
         issues.append(
             f"one-minute load/CPU {float(load):.3f} exceeds {max_load_per_cpu:.3f}"
         )
@@ -332,6 +441,12 @@ def shared_host_protocol_issues(
         issues.append(
             "shared-host evidence requires at least two same-module null controls"
         )
+    elif not all(pair.null_control for pair in spec.pairs[:2]):
+        issues.append("the first two manifest pairs must be null controls")
+    elif controls[0].reference.module == controls[1].reference.module:
+        issues.append("the first two null controls must use distinct magnitudes")
+    if not any(not pair.null_control for pair in spec.pairs):
+        issues.append("shared-host evidence requires a substantive pair")
     if args.samples < 6 or args.samples % 2 != 0:
         issues.append(
             "shared-host evidence requires at least six and an even number "
@@ -347,8 +462,11 @@ def sampled_host_state(state: dict[str, object]) -> dict[str, object]:
         "logical_cpus": state["logical_cpus"],
         "load_average": state["load_average"],
         "load_1m_per_cpu": state["load_1m_per_cpu"],
+        "runnable_tasks": state["runnable_tasks"],
         "cpu_affinity": state["cpu_affinity"],
         "cpu_pressure": state["cpu_pressure"],
+        "cpu_pressure_some_total_us": state["cpu_pressure_some_total_us"],
+        "affinity_cpu_frequency_khz": state["affinity_cpu_frequency_khz"],
         "concurrent_lake_lean_count": len(processes),
     }
 
@@ -405,6 +523,7 @@ def environment() -> dict[str, object]:
         "dependency_checkouts": dependencies,
         "toolchain": (ROOT / "lean-toolchain").read_text(encoding="utf-8").strip(),
         "hostname": socket.gethostname(),
+        "machine_id": _read_optional(Path("/etc/machine-id")),
         "platform": platform.platform(),
         "architecture": platform.machine(),
         "cpu_model": cpu_model(),
@@ -509,10 +628,17 @@ def provenance_sources(spec: SweepSpec, caller_file: Path) -> list[Path]:
         caller_file.resolve(),
         ROOT / "scripts" / "ci" / "check_benches_mathlib_free.py",
     }
-    files.update(
+    extras = [
         path if path.is_absolute() else ROOT / path
         for path in spec.extra_sources
-    )
+    ]
+    missing = [path for path in extras if not path.is_file()]
+    if missing:
+        raise RuntimeError(
+            "missing declared provenance source(s): "
+            + ", ".join(str(path) for path in missing)
+        )
+    files.update(extras)
     return sorted(path for path in files if path.is_file())
 
 
@@ -556,10 +682,18 @@ def remove_module_outputs(module: str) -> None:
 
 def run_timed(
     command: list[str], timeout: float
-) -> tuple[subprocess.CompletedProcess[str], int, int | None]:
+) -> tuple[subprocess.CompletedProcess[str], int, dict[str, int | float | None]]:
     timer = time_binary()
+    timer_format = "\n".join((
+        RSS_MARKER + "%M",
+        USER_MARKER + "%U",
+        SYSTEM_MARKER + "%S",
+        CPU_PERCENT_MARKER + "%P",
+        INVOLUNTARY_CONTEXT_MARKER + "%c",
+        VOLUNTARY_CONTEXT_MARKER + "%w",
+    ))
     wrapped = command if timer is None else [
-        timer, "-f", RSS_MARKER + "%M", *command
+        timer, "-f", timer_format, *command
     ]
     start = time.perf_counter_ns()
     child = subprocess.Popen(
@@ -579,12 +713,36 @@ def run_timed(
     proc = subprocess.CompletedProcess(
         wrapped, child.returncode, stdout=stdout, stderr=stderr
     )
-    rss = None
+    metrics: dict[str, int | float | None] = {
+        "peak_rss_kb": None,
+        "user_seconds": None,
+        "system_seconds": None,
+        "cpu_percent": None,
+        "involuntary_context_switches": None,
+        "voluntary_context_switches": None,
+    }
     if timer is not None:
-        match = re.search(rf"{re.escape(RSS_MARKER)}(\d+)", proc.stderr)
-        if match:
-            rss = int(match.group(1))
-    return proc, elapsed, rss
+        integer_metrics = (
+            (RSS_MARKER, "peak_rss_kb"),
+            (INVOLUNTARY_CONTEXT_MARKER, "involuntary_context_switches"),
+            (VOLUNTARY_CONTEXT_MARKER, "voluntary_context_switches"),
+        )
+        for marker, key in integer_metrics:
+            match = re.search(rf"{re.escape(marker)}(\d+)", proc.stderr)
+            if match:
+                metrics[key] = int(match.group(1))
+        float_metrics = (
+            (USER_MARKER, "user_seconds"),
+            (SYSTEM_MARKER, "system_seconds"),
+            (CPU_PERCENT_MARKER, "cpu_percent"),
+        )
+        for marker, key in float_metrics:
+            match = re.search(
+                rf"{re.escape(marker)}([0-9]+(?:\.[0-9]+)?)", proc.stderr
+            )
+            if match:
+                metrics[key] = float(match.group(1))
+    return proc, elapsed, metrics
 
 
 def terminate_process_group(child: subprocess.Popen[str], grace: float = 5.0) -> None:
@@ -614,12 +772,18 @@ def parse_axioms(output: str) -> list[str] | None:
     return None
 
 
-def build_sample(module: str, timeout: float) -> dict[str, object]:
-    host_before = sampled_host_state(host_state())
+def build_sample(
+    module: str,
+    timeout: float,
+    measurement_cpu: int | None = None,
+    monitored_cpus: Sequence[int] = (),
+) -> dict[str, object]:
     remove_module_outputs(module)
+    host_before = sampled_host_state(host_state())
+    ticks_before = cpu_ticks(monitored_cpus)
     command = ["lake", "build", f"+{module}:olean"]
     try:
-        proc, elapsed, rss = run_timed(command, timeout)
+        proc, elapsed, metrics = run_timed(command, timeout)
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError(
             f"probe timed out after {timeout:g}s: {' '.join(command)}"
@@ -630,12 +794,54 @@ def build_sample(module: str, timeout: float) -> dict[str, object]:
         raise RuntimeError(
             f"probe failed ({proc.returncode}): {' '.join(command)}"
         )
+    ticks_after = cpu_ticks(monitored_cpus)
+    host_after = sampled_host_state(host_state())
+    tick_hz = int(os.sysconf("SC_CLK_TCK"))
+    per_cpu: dict[str, dict[str, object]] = {}
+    for cpu in monitored_cpus:
+        delta = cpu_tick_delta(ticks_before, ticks_after, cpu)
+        busy = busy_ticks(delta)
+        per_cpu[str(cpu)] = {
+            "ticks": delta,
+            "busy_seconds": (
+                float(busy) / tick_hz if busy is not None else None
+            ),
+        }
+    child_cpu_seconds = None
+    if (
+        metrics["user_seconds"] is not None
+        and metrics["system_seconds"] is not None
+    ):
+        child_cpu_seconds = (
+            float(metrics["user_seconds"])
+            + float(metrics["system_seconds"])
+        )
+    foreign_seconds = None
+    if measurement_cpu is not None and str(measurement_cpu) in per_cpu:
+        target_busy = per_cpu[str(measurement_cpu)]["busy_seconds"]
+        if target_busy is not None and child_cpu_seconds is not None:
+            foreign_seconds = max(
+                0.0, float(target_busy) - child_cpu_seconds
+            )
+    pressure_before = host_before["cpu_pressure_some_total_us"]
+    pressure_after = host_after["cpu_pressure_some_total_us"]
     result = {
         "wall_nanos": elapsed,
-        "peak_rss_kb": rss,
+        **metrics,
         "axioms": parse_axioms(output),
         "host_before": host_before,
-        "host_after": sampled_host_state(host_state()),
+        "host_after": host_after,
+        "cpu_accounting": {
+            "clock_ticks_per_second": tick_hz,
+            "per_cpu": per_cpu,
+            "child_cpu_seconds": child_cpu_seconds,
+            "measurement_cpu_foreign_seconds": foreign_seconds,
+            "pressure_some_delta_us": (
+                int(pressure_after) - int(pressure_before)
+                if pressure_before is not None and pressure_after is not None
+                else None
+            ),
+        },
     }
     return result
 
@@ -646,7 +852,7 @@ def warm_imports(spec: SweepSpec, timeout: float) -> None:
     command = ["lake", "build", *[f"+{module}:deps" for module in modules]]
     print(f"[warm] {' '.join(command)}", flush=True)
     try:
-        proc, _elapsed, _rss = run_timed(command, timeout)
+        proc, _elapsed, _metrics = run_timed(command, timeout)
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError(
             f"probe import warmup timed out after {timeout:g}s"
@@ -738,7 +944,194 @@ def summarize(
             "median_signed_wall_delta_nanos": int(statistics.median(deltas)),
         }
         summary[pair.name] = result
+    controls: list[tuple[str, int, int]] = []
+    for pair in spec.pairs:
+        result = summary[pair.name]
+        if not pair.null_control:
+            continue
+        deltas = list(result["signed_wall_delta_nanos"])
+        magnitude = max(
+            int(result["median_reference_wall_nanos"]),
+            int(result["median_candidate_wall_nanos"]),
+        )
+        spread = max(deltas) - min(deltas)
+        result["null_spread_nanos"] = spread
+        result["null_max_absolute_delta_nanos"] = max(
+            abs(int(delta)) for delta in deltas
+        )
+        controls.append((pair.name, magnitude, spread))
+    for pair in spec.pairs:
+        if pair.null_control:
+            continue
+        result = summary[pair.name]
+        magnitude = max(
+            int(result["median_reference_wall_nanos"]),
+            int(result["median_candidate_wall_nanos"]),
+        )
+        comparable = [
+            (name, control_magnitude, spread)
+            for name, control_magnitude, spread in controls
+            if min(magnitude, control_magnitude) > 0
+            and max(magnitude, control_magnitude)
+            / min(magnitude, control_magnitude) <= NULL_MAGNITUDE_FACTOR
+        ]
+        if comparable:
+            name, control_magnitude, spread = min(
+                comparable,
+                key=lambda item: abs(
+                    magnitude - item[1]
+                ) / max(magnitude, item[1]),
+            )
+            result["comparable_control"] = name
+            result["control_magnitude_ratio"] = (
+                max(magnitude, control_magnitude)
+                / min(magnitude, control_magnitude)
+            )
+            result["comparable_null_spread_nanos"] = spread
+            result["resolution"] = (
+                "unresolved"
+                if abs(int(result["median_signed_wall_delta_nanos"])) <= spread
+                else "resolved"
+            )
+        else:
+            result["comparable_control"] = None
+            result["control_magnitude_ratio"] = None
+            result["comparable_null_spread_nanos"] = None
+            result["resolution"] = "no-comparable-control"
+        budget_ms = pair.metadata.get("tactic_budget_ms")
+        if budget_ms is not None:
+            budget_nanos = int(budget_ms) * 1_000_000
+            median_delta = int(result["median_signed_wall_delta_nanos"])
+            spread_value = result["comparable_null_spread_nanos"]
+            if median_delta >= budget_nanos:
+                budget_status = "failed"
+            elif spread_value is None:
+                budget_status = "no-comparable-control"
+            elif median_delta + int(spread_value) >= budget_nanos:
+                budget_status = "unresolved"
+            else:
+                budget_status = "passed"
+            result["budget_nanos"] = budget_nanos
+            result["budget_status"] = budget_status
     return summary
+
+
+def shared_host_observations(
+    rows: dict[str, list[dict[str, object]]],
+    measurement_cpu: int,
+    sibling_cpus: Sequence[int],
+    max_ratio: float,
+) -> dict[str, object]:
+    """Aggregate auditable per-arm contention measurements."""
+    max_foreign_ratio = 0.0
+    max_sibling_ratio = 0.0
+    max_pressure_delta = 0
+    max_concurrent = 0
+    max_load = 0.0
+    frequencies: list[int] = []
+    violations: list[str] = []
+    missing_accounting = False
+    tick_hz = int(os.sysconf("SC_CLK_TCK"))
+    for pair_name, samples in rows.items():
+        for sample in samples:
+            round_index = int(sample["round"])
+            for role in ("reference", "candidate"):
+                arm = dict(sample[role])
+                wall_seconds = int(arm["wall_nanos"]) / 1_000_000_000
+                accounting = dict(arm["cpu_accounting"])
+                foreign = accounting["measurement_cpu_foreign_seconds"]
+                per_cpu = dict(accounting["per_cpu"])
+                if foreign is None or wall_seconds <= 0:
+                    missing_accounting = True
+                    continue
+                foreign_ratio = float(foreign) / wall_seconds
+                max_foreign_ratio = max(max_foreign_ratio, foreign_ratio)
+                allowance = max(2 / tick_hz, max_ratio * wall_seconds)
+                if float(foreign) > allowance:
+                    violations.append(
+                        f"{pair_name} round {round_index} {role}: "
+                        f"measurement CPU foreign time {float(foreign):.3f}s "
+                        f"exceeds {allowance:.3f}s"
+                    )
+                for sibling in sibling_cpus:
+                    busy = dict(per_cpu.get(str(sibling), {})).get(
+                        "busy_seconds"
+                    )
+                    if busy is None:
+                        missing_accounting = True
+                        continue
+                    sibling_ratio = float(busy) / wall_seconds
+                    max_sibling_ratio = max(
+                        max_sibling_ratio, sibling_ratio
+                    )
+                    if float(busy) > allowance:
+                        violations.append(
+                            f"{pair_name} round {round_index} {role}: "
+                            f"SMT sibling CPU {sibling} busy time "
+                            f"{float(busy):.3f}s exceeds {allowance:.3f}s"
+                        )
+                pressure = accounting.get("pressure_some_delta_us")
+                if pressure is not None:
+                    max_pressure_delta = max(
+                        max_pressure_delta, int(pressure)
+                    )
+                for state_key in ("host_before", "host_after"):
+                    state = dict(arm[state_key])
+                    max_concurrent = max(
+                        max_concurrent,
+                        int(state["concurrent_lake_lean_count"]),
+                    )
+                    load = state.get("load_1m_per_cpu")
+                    if load is not None:
+                        max_load = max(max_load, float(load))
+                    frequency = state.get("affinity_cpu_frequency_khz")
+                    if frequency is not None:
+                        frequencies.append(int(frequency))
+    if missing_accounting:
+        violations.append("per-arm CPU accounting is incomplete")
+    return {
+        "measurement_cpu": measurement_cpu,
+        "smt_sibling_cpus": list(sibling_cpus),
+        "max_core_interference_ratio": max_ratio,
+        "max_measurement_cpu_foreign_ratio": max_foreign_ratio,
+        "max_smt_sibling_busy_ratio": max_sibling_ratio,
+        "max_cpu_pressure_some_delta_us": max_pressure_delta,
+        "max_concurrent_lake_lean_count": max_concurrent,
+        "max_load_1m_per_cpu": max_load,
+        "min_frequency_khz": min(frequencies) if frequencies else None,
+        "max_frequency_khz": max(frequencies) if frequencies else None,
+        "violations": violations,
+    }
+
+
+def validity_summary(
+    spec: SweepSpec,
+    args: argparse.Namespace,
+    results: dict[str, dict[str, object]],
+    observations: dict[str, object] | None,
+    exceptions: Sequence[str],
+) -> tuple[bool, list[str]]:
+    """Derive release validity from provenance, contention, and conclusions."""
+    issues = list(exceptions)
+    if observations is not None:
+        issues.extend(
+            issue for issue in observations["violations"]
+            if issue not in issues
+        )
+    for pair in spec.pairs:
+        if pair.null_control or "tactic_budget_ms" not in pair.metadata:
+            continue
+        status = results[pair.name].get("budget_status")
+        if status != "passed":
+            issue = f"{pair.name}: tactic budget {status}"
+            if issue not in issues:
+                issues.append(issue)
+    release_quality = (
+        not args.allow_dirty
+        and not args.allow_busy
+        and not issues
+    )
+    return release_quality, issues
 
 
 def default_output(env: dict[str, object], output_stem: str) -> Path:
@@ -756,7 +1149,11 @@ def run_cli(
     argv: Sequence[str] | None = None,
 ) -> int:
     validate_spec(spec)
-    args = parse_args(spec.description, argv)
+    args = parse_args(
+        spec.description,
+        argv,
+        default_samples=spec.required_samples or 4,
+    )
     configure_shared_host(args)
     if spec.required_samples is not None and args.samples != spec.required_samples:
         raise RuntimeError(
@@ -773,7 +1170,6 @@ def run_cli(
         raise RuntimeError(
             "invalid shared-host protocol: " + "; ".join(protocol_issues)
         )
-    warm_imports(spec, args.warm_timeout)
     env = environment()
     validity_exceptions: list[str] = []
     dirt = dirty_issues(
@@ -787,24 +1183,64 @@ def run_cli(
         dict(env["host_before"]),
         args.max_load_per_cpu,
         concurrent_is_issue=not args.shared_host,
+        load_is_issue=not args.shared_host,
     )
     if busy and not args.allow_busy:
         raise RuntimeError("busy measurement environment: " + "; ".join(busy))
     if busy:
         validity_exceptions.extend(busy)
+    warm_imports(spec, args.warm_timeout)
+    post_warm = host_issues(
+        host_state(),
+        args.max_load_per_cpu,
+        concurrent_is_issue=not args.shared_host,
+        load_is_issue=False,
+    )
+    if post_warm and not args.allow_busy:
+        raise RuntimeError(
+            "busy measurement environment after warmup: "
+            + "; ".join(post_warm)
+        )
+    validity_exceptions.extend(
+        issue for issue in post_warm if issue not in validity_exceptions
+    )
     before = source_hashes(spec, caller_file)
     pairs = list(spec.pairs)
     rows: dict[str, list[dict[str, object]]] = {
         pair.name: [] for pair in pairs
     }
+    topology = (
+        cpu_topology(args.cpu)
+        if args.shared_host and args.cpu is not None
+        else None
+    )
+    monitored_cpus: list[int] = []
+    sibling_cpus: list[int] = []
+    if topology is not None and args.cpu is not None:
+        monitored_cpus = parse_cpu_list(
+            str(topology["thread_siblings_list"])
+            if topology["thread_siblings_list"] is not None
+            else None
+        )
+        if args.cpu not in monitored_cpus:
+            monitored_cpus.append(args.cpu)
+        monitored_cpus.sort()
+        sibling_cpus = [
+            cpu for cpu in monitored_cpus if cpu != args.cpu
+        ]
+        if not sibling_cpus:
+            raise RuntimeError(
+                "shared-host CPU topology has no recorded SMT sibling"
+            )
 
     for round_index in range(args.samples):
-        for pair in rotate(pairs, round_index):
+        for slot_index, pair in enumerate(rotate(pairs, round_index)):
             state = host_state()
             issues = host_issues(
                 state,
                 args.max_load_per_cpu,
                 concurrent_is_issue=not args.shared_host,
+                load_is_issue=not args.shared_host,
             )
             if issues and not args.allow_busy:
                 raise RuntimeError("host became busy: " + "; ".join(issues))
@@ -818,21 +1254,13 @@ def run_cli(
                     f"{role} ({module.module})",
                     flush=True,
                 )
-                sample = build_sample(module.module, args.timeout)
+                sample = build_sample(
+                    module.module,
+                    args.timeout,
+                    measurement_cpu=args.cpu if args.shared_host else None,
+                    monitored_cpus=monitored_cpus,
+                )
                 validate_axioms(pair.name, role, module, sample)
-                arm_issues = host_issues(
-                    host_state(),
-                    args.max_load_per_cpu,
-                    concurrent_is_issue=not args.shared_host,
-                )
-                if arm_issues and not args.allow_busy:
-                    raise RuntimeError(
-                        "host became busy: " + "; ".join(arm_issues)
-                    )
-                validity_exceptions.extend(
-                    issue for issue in arm_issues
-                    if issue not in validity_exceptions
-                )
                 expected_affinity = [args.cpu] if args.shared_host else None
                 if (
                     expected_affinity is not None
@@ -846,6 +1274,7 @@ def run_cli(
             candidate = built["candidate"]
             rows[pair.name].append({
                 "round": round_index + 1,
+                "slot_index": slot_index,
                 "build_order": [role for role, _module in modules],
                 "host_before_pair": sampled_host_state(state),
                 "reference": reference,
@@ -873,22 +1302,40 @@ def run_cli(
         host_after,
         args.max_load_per_cpu,
         concurrent_is_issue=not args.shared_host,
+        load_is_issue=not args.shared_host,
     )
     if final_busy and not args.allow_busy:
         raise RuntimeError("host became busy: " + "; ".join(final_busy))
     validity_exceptions.extend(issue for issue in final_busy
                                if issue not in validity_exceptions)
     env["host_after"] = host_after
+    results = summarize(spec, rows)
+    observations = None
+    if args.shared_host and args.cpu is not None:
+        observations = shared_host_observations(
+            rows,
+            args.cpu,
+            sibling_cpus,
+            args.max_core_interference_ratio,
+        )
+    release_quality, validity_exceptions = validity_summary(
+        spec,
+        args,
+        results,
+        observations,
+        validity_exceptions,
+    )
 
     record = {
         "schema": spec.schema,
         "measurement": spec.measurement,
         "environment": env,
         "validity": {
-            "release_quality": not validity_exceptions,
+            "release_quality": release_quality,
             "exceptions": validity_exceptions,
+            "observed": observations,
             "host_protocol": (
-                "designated-shared-host-v1"
+                "designated-shared-host-v2"
                 if args.shared_host
                 else "quiescent-host-v1"
             ),
@@ -903,19 +1350,17 @@ def run_cli(
             "rotation": "pairs left by round index; pair orientation alternates",
             "pairing": "adjacent measured reference and candidate fresh modules",
             "max_load_per_cpu": args.max_load_per_cpu,
+            "max_core_interference_ratio":
+                args.max_core_interference_ratio,
             "allow_dirty": args.allow_dirty,
             "allow_busy": args.allow_busy,
             "shared_host": args.shared_host,
             "expected_host": args.expected_host,
             "requested_cpu": args.cpu,
             "cpu_affinity": cpu_affinity(),
-            "cpu_topology": (
-                cpu_topology(args.cpu)
-                if args.shared_host and args.cpu is not None
-                else None
-            ),
+            "cpu_topology": topology,
         },
-        "results": summarize(spec, rows),
+        "results": results,
         "source_sha256": before,
     }
     output = args.output or default_output(env, spec.output_stem)
@@ -930,4 +1375,4 @@ def run_cli(
     except ValueError:
         display = output
     print(display)
-    return 0
+    return 0 if release_quality else 2

--- a/scripts/bench/fresh_module_sweep.py
+++ b/scripts/bench/fresh_module_sweep.py
@@ -40,6 +40,7 @@ INVOLUNTARY_CONTEXT_MARKER = "__HEX_INVOLUNTARY_CONTEXT__="
 VOLUNTARY_CONTEXT_MARKER = "__HEX_VOLUNTARY_CONTEXT__="
 DEFAULT_MAX_LOAD_PER_CPU = 0.5
 DEFAULT_MAX_CORE_INTERFERENCE_RATIO = 0.02
+DEFAULT_MAX_FREQUENCY_SPREAD_RATIO = 0.15
 NULL_MAGNITUDE_FACTOR = 3.0
 T = TypeVar("T")
 
@@ -139,6 +140,12 @@ def parse_args(
             "busy-time fraction on its SMT sibling"
         ),
     )
+    parser.add_argument(
+        "--max-frequency-spread-ratio",
+        type=float,
+        default=DEFAULT_MAX_FREQUENCY_SPREAD_RATIO,
+        help="maximum observed pinned-CPU frequency spread for shared-host evidence",
+    )
     args = parser.parse_args(argv)
     if args.samples < 1:
         parser.error("--samples must be positive")
@@ -150,6 +157,8 @@ def parse_args(
         parser.error("--max-load-per-cpu must be positive")
     if not 0 < args.max_core_interference_ratio < 1:
         parser.error("--max-core-interference-ratio must be between 0 and 1")
+    if not 0 < args.max_frequency_spread_ratio < 1:
+        parser.error("--max-frequency-spread-ratio must be between 0 and 1")
     if args.allow_busy and args.shared_host:
         parser.error("--allow-busy and --shared-host are mutually exclusive")
     if args.cpu is not None and args.cpu < 0:
@@ -1021,6 +1030,7 @@ def shared_host_observations(
     measurement_cpu: int,
     sibling_cpus: Sequence[int],
     max_ratio: float,
+    max_frequency_spread_ratio: float,
 ) -> dict[str, object]:
     """Aggregate auditable per-arm contention measurements."""
     max_foreign_ratio = 0.0
@@ -1089,10 +1099,22 @@ def shared_host_observations(
                         frequencies.append(int(frequency))
     if missing_accounting:
         violations.append("per-arm CPU accounting is incomplete")
+    frequency_spread_ratio = None
+    if frequencies and min(frequencies) > 0:
+        frequency_spread_ratio = (
+            max(frequencies) / min(frequencies) - 1
+        )
+        if frequency_spread_ratio > max_frequency_spread_ratio:
+            violations.append(
+                "pinned-CPU frequency spread "
+                f"{frequency_spread_ratio:.3f} exceeds "
+                f"{max_frequency_spread_ratio:.3f}"
+            )
     return {
         "measurement_cpu": measurement_cpu,
         "smt_sibling_cpus": list(sibling_cpus),
         "max_core_interference_ratio": max_ratio,
+        "max_frequency_spread_ratio": max_frequency_spread_ratio,
         "max_measurement_cpu_foreign_ratio": max_foreign_ratio,
         "max_smt_sibling_busy_ratio": max_sibling_ratio,
         "max_cpu_pressure_some_delta_us": max_pressure_delta,
@@ -1100,6 +1122,7 @@ def shared_host_observations(
         "max_load_1m_per_cpu": max_load,
         "min_frequency_khz": min(frequencies) if frequencies else None,
         "max_frequency_khz": max(frequencies) if frequencies else None,
+        "frequency_spread_ratio": frequency_spread_ratio,
         "violations": violations,
     }
 
@@ -1119,7 +1142,13 @@ def validity_summary(
             if issue not in issues
         )
     for pair in spec.pairs:
-        if pair.null_control or "tactic_budget_ms" not in pair.metadata:
+        if pair.null_control:
+            continue
+        if results[pair.name].get("resolution") == "no-comparable-control":
+            issue = f"{pair.name}: no magnitude-comparable null control"
+            if issue not in issues:
+                issues.append(issue)
+        if "tactic_budget_ms" not in pair.metadata:
             continue
         status = results[pair.name].get("budget_status")
         if status != "passed":
@@ -1317,6 +1346,7 @@ def run_cli(
             args.cpu,
             sibling_cpus,
             args.max_core_interference_ratio,
+            args.max_frequency_spread_ratio,
         )
     release_quality, validity_exceptions = validity_summary(
         spec,
@@ -1352,6 +1382,8 @@ def run_cli(
             "max_load_per_cpu": args.max_load_per_cpu,
             "max_core_interference_ratio":
                 args.max_core_interference_ratio,
+            "max_frequency_spread_ratio":
+                args.max_frequency_spread_ratio,
             "allow_dirty": args.allow_dirty,
             "allow_busy": args.allow_busy,
             "shared_host": args.shared_host,

--- a/scripts/bench/hexrcf_proof_sweep.py
+++ b/scripts/bench/hexrcf_proof_sweep.py
@@ -92,7 +92,7 @@ SPEC = SweepSpec(
         *case_pairs("degree50", "Degree50", 30_000),
     ),
     probe_target="HexRCFProofProbe",
-    schema="hexrcf-proof-probes-v2",
+    schema="hexrcf-proof-probes-v3",
     measurement="paired-fresh-module-olean-wall-v1",
     output_stem="hexrcf-proof-probes",
     extra_sources=(

--- a/scripts/bench/hexrcf_proof_sweep.py
+++ b/scripts/bench/hexrcf_proof_sweep.py
@@ -27,7 +27,7 @@ def case_pairs(case: str, module_case: str, budget_ms: int) -> tuple[ProbePair, 
     prefix = f"HexRCF.ProofProbe.{module_case}"
     input_module = ProbeModule(f"{prefix}.Input")
     literal_module = ProbeModule(f"{prefix}.Literal")
-    common = {"case": case, "tactic_budget_ms": budget_ms}
+    common = {"case": case}
     return (
         ProbePair(
             f"{case}-reify",
@@ -57,7 +57,11 @@ def case_pairs(case: str, module_case: str, budget_ms: int) -> tuple[ProbePair, 
             f"{case}-tactic",
             BASELINE,
             ProbeModule(f"{prefix}.Tactic", ALLOWED_AXIOMS),
-            {**common, "component": "end-to-end-tactic"},
+            {
+                **common,
+                "component": "end-to-end-tactic",
+                "tactic_budget_ms": budget_ms,
+            },
         ),
     )
 
@@ -77,6 +81,17 @@ SPEC = SweepSpec(
             null_control=True,
         ),
         ProbePair(
+            "degree10-tactic-null",
+            ProbeModule("HexRCF.ProofProbe.Degree10.Tactic", ALLOWED_AXIOMS),
+            ProbeModule("HexRCF.ProofProbe.Degree10.Tactic", ALLOWED_AXIOMS),
+            {
+                "component": "fresh-build-noise",
+                "interpretation": "calibration-only",
+                "magnitude": "degree10-tactic",
+            },
+            null_control=True,
+        ),
+        ProbePair(
             "degree50-tactic-null",
             ProbeModule("HexRCF.ProofProbe.Degree50.Tactic", ALLOWED_AXIOMS),
             ProbeModule("HexRCF.ProofProbe.Degree50.Tactic", ALLOWED_AXIOMS),
@@ -92,7 +107,7 @@ SPEC = SweepSpec(
         *case_pairs("degree50", "Degree50", 30_000),
     ),
     probe_target="HexRCFProofProbe",
-    schema="hexrcf-proof-probes-v3",
+    schema="hexrcf-proof-probes-v4",
     measurement="paired-fresh-module-olean-wall-v1",
     output_stem="hexrcf-proof-probes",
     extra_sources=(

--- a/scripts/bench/real_roots_mathlib_sweep.py
+++ b/scripts/bench/real_roots_mathlib_sweep.py
@@ -130,7 +130,7 @@ SPEC = SweepSpec(
         ),
     ),
     probe_target="HexRealRootsMathlibReplayProbe",
-    schema="hex-real-roots-mathlib-proof-probe-v2",
+    schema="hex-real-roots-mathlib-proof-probe-v3",
     measurement="paired-fresh-module-olean-wall-v1",
     extra_sources=(
         Path("libraries.yml"),

--- a/scripts/bench/test_fresh_module_sweep.py
+++ b/scripts/bench/test_fresh_module_sweep.py
@@ -316,6 +316,98 @@ class PairingTests(unittest.TestCase):
 
 
 class HarnessValidationTests(unittest.TestCase):
+    def test_shared_host_pins_named_machine(self) -> None:
+        args = sweep.parse_args(
+            SPEC.description,
+            [
+                "--shared-host",
+                "--expected-host", "bench-host",
+                "--cpu", "3",
+                "--samples", "6",
+            ],
+        )
+        with mock.patch.object(
+            sweep.socket, "gethostname", return_value="bench-host"
+        ), mock.patch.object(
+            sweep.os, "sched_setaffinity", create=True
+        ) as set_affinity:
+            sweep.configure_shared_host(args)
+        set_affinity.assert_called_once_with(0, {3})
+
+    def test_shared_host_rejects_wrong_machine(self) -> None:
+        args = sweep.parse_args(
+            SPEC.description,
+            [
+                "--shared-host",
+                "--expected-host", "bench-host",
+                "--cpu", "3",
+                "--samples", "6",
+            ],
+        )
+        with mock.patch.object(
+            sweep.socket, "gethostname", return_value="other-host"
+        ):
+            with self.assertRaisesRegex(RuntimeError, "expected host"):
+                sweep.configure_shared_host(args)
+
+    def test_shared_host_requires_single_cpu_affinity(self) -> None:
+        args = sweep.parse_args(SPEC.description, ["--shared-host", "--samples", "6"])
+        with mock.patch.object(
+            sweep, "cpu_affinity", return_value=[3, 4]
+        ):
+            self.assertRegex(
+                "; ".join(sweep.shared_host_protocol_issues(SPEC, args)),
+                "exactly one affinity CPU",
+            )
+
+    def test_shared_host_requires_two_controls(self) -> None:
+        args = sweep.parse_args(SPEC.description, ["--shared-host", "--samples", "6"])
+        with mock.patch.object(sweep, "cpu_affinity", return_value=[3]):
+            self.assertRegex(
+                "; ".join(sweep.shared_host_protocol_issues(SPEC, args)),
+                "at least two same-module null controls",
+            )
+
+    def test_shared_host_accepts_balanced_controlled_spec(self) -> None:
+        module = sweep.ProbeModule("Probe.Same")
+        controls = (
+            sweep.ProbePair("cheap", module, module, {}, null_control=True),
+            sweep.ProbePair("expensive", module, module, {}, null_control=True),
+        )
+        spec = sweep.SweepSpec(
+            description="shared",
+            pairs=controls,
+            probe_target="Probe",
+            schema="test",
+            measurement="test",
+            output_stem="test",
+            required_samples=6,
+        )
+        args = sweep.parse_args(
+            spec.description, ["--shared-host", "--samples", "6"]
+        )
+        with mock.patch.object(sweep, "cpu_affinity", return_value=[3]):
+            self.assertEqual(sweep.shared_host_protocol_issues(spec, args), [])
+
+    def test_shared_host_ignores_process_presence_but_not_saturation(self) -> None:
+        state = {
+            "concurrent_lake_lean": [{"pid": 1, "command": "lake build"}],
+            "load_1m_per_cpu": 0.25,
+        }
+        self.assertEqual(
+            sweep.host_issues(
+                state, 0.5, concurrent_is_issue=False
+            ),
+            [],
+        )
+        state["load_1m_per_cpu"] = 0.75
+        self.assertRegex(
+            "; ".join(sweep.host_issues(
+                state, 0.5, concurrent_is_issue=False
+            )),
+            "exceeds",
+        )
+
     def test_warmup_builds_every_unique_import_closure(self) -> None:
         completed = subprocess.CompletedProcess(
             ["lake", "build"], 0, stdout="", stderr=""
@@ -458,11 +550,16 @@ class HarnessValidationTests(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "requires --samples 6"):
                 sweep.run_cli(spec, CALLER, ["--samples", "4"])
 
-    def test_null_control_requires_even_sample_count(self) -> None:
+    def test_every_sweep_requires_even_sample_count(self) -> None:
         module = sweep.ProbeModule("Probe.Same")
-        pair = sweep.ProbePair("null", module, module, {}, null_control=True)
+        pair = sweep.ProbePair(
+            "ordinary",
+            module,
+            sweep.ProbeModule("Probe.Other"),
+            {},
+        )
         spec = sweep.SweepSpec(
-            description="balanced null",
+            description="balanced",
             pairs=(pair,),
             probe_target="Probe",
             schema="test",

--- a/scripts/bench/test_fresh_module_sweep.py
+++ b/scripts/bench/test_fresh_module_sweep.py
@@ -148,6 +148,8 @@ class ProcessGroupTests(unittest.TestCase):
             self.assertIsNotNone(metrics["user_seconds"])
             self.assertIsNotNone(metrics["system_seconds"])
             self.assertIsNotNone(metrics["cpu_percent"])
+        self.assertIsNotNone(metrics["precise_child_user_seconds"])
+        self.assertIsNotNone(metrics["precise_child_system_seconds"])
 
     @unittest.skipUnless(Path("/proc").is_dir(), "requires procfs")
     def test_run_timed_invokes_group_cleanup(self) -> None:
@@ -210,6 +212,16 @@ class ProcessGroupTests(unittest.TestCase):
 
 
 class PairingTests(unittest.TestCase):
+    def test_frequency_residency_uses_arm_weighted_mean(self) -> None:
+        delta = sweep.frequency_residency_delta(
+            {1_500_000: 10, 3_000_000: 20},
+            {1_500_000: 11, 3_000_000: 23},
+        )
+        self.assertEqual(delta, {1_500_000: 1, 3_000_000: 3})
+        self.assertEqual(
+            sweep.mean_residency_frequency(delta), 2_625_000
+        )
+
     def test_summary_uses_each_pairs_adjacent_measurements(self) -> None:
         rows: dict[str, list[dict[str, object]]] = {
             PAIR.name: [{
@@ -400,6 +412,44 @@ class PairingTests(unittest.TestCase):
         self.assertEqual(summary["tactic"]["resolution"], "resolved")
         self.assertEqual(summary["tactic"]["budget_status"], "unresolved")
 
+    def test_one_sided_null_uses_zero_centred_envelope(self) -> None:
+        module = sweep.ProbeModule("Probe.Baseline")
+        candidate = sweep.ProbeModule("Probe.Candidate")
+        pairs = (
+            sweep.ProbePair(
+                "null", module, module, {}, null_control=True
+            ),
+            sweep.ProbePair("effect", module, candidate, {}),
+        )
+        spec = sweep.SweepSpec(
+            description="one-sided null",
+            pairs=pairs,
+            probe_target="Probe",
+            schema="test",
+            measurement="test",
+            output_stem="test",
+        )
+
+        def rows(deltas: list[int]) -> list[dict[str, object]]:
+            return [{
+                "reference": {"wall_nanos": 1_000, "peak_rss_kb": None},
+                "candidate": {
+                    "wall_nanos": 1_000 + delta,
+                    "peak_rss_kb": None,
+                },
+                "signed_wall_delta_nanos": delta,
+            } for delta in deltas]
+
+        with mock.patch.object(sweep, "artifact_sizes", return_value={}):
+            summary = sweep.summarize(
+                spec, {"null": rows([90, 100]), "effect": rows([50, 50])}
+            )
+        self.assertEqual(summary["null"]["null_spread_nanos"], 10)
+        self.assertEqual(
+            summary["effect"]["comparable_null_envelope_nanos"], 100
+        )
+        self.assertEqual(summary["effect"]["resolution"], "unresolved")
+
     def test_shared_host_observations_reject_sibling_contention(self) -> None:
         def arm(sibling_busy: float) -> dict[str, object]:
             host = {
@@ -412,7 +462,9 @@ class PairingTests(unittest.TestCase):
                 "host_before": host,
                 "host_after": host,
                 "cpu_accounting": {
+                    "measurement_cpu_residual_seconds": 0.01,
                     "measurement_cpu_foreign_seconds": 0.01,
+                    "mean_frequency_khz": 2_500_000,
                     "pressure_some_delta_us": 5,
                     "per_cpu": {
                         "95": {"busy_seconds": sibling_busy},
@@ -433,6 +485,221 @@ class PairingTests(unittest.TestCase):
         self.assertEqual(observed["max_smt_sibling_busy_ratio"], 0.10)
         self.assertRegex(
             "; ".join(observed["violations"]), "SMT sibling CPU 95"
+        )
+
+    def test_shared_host_observations_reject_missing_frequency(self) -> None:
+        host = {
+            "concurrent_lake_lean_count": 0,
+            "load_1m_per_cpu": 0.0,
+            "affinity_cpu_frequency_khz": None,
+        }
+        arm = {
+            "wall_nanos": 1_000_000_000,
+            "host_before": host,
+            "host_after": host,
+            "cpu_accounting": {
+                "measurement_cpu_residual_seconds": 0.0,
+                "measurement_cpu_foreign_seconds": 0.0,
+                "mean_frequency_khz": None,
+                "pressure_some_delta_us": 0,
+                "per_cpu": {"95": {"busy_seconds": 0.0}},
+            },
+        }
+        rows = {
+            "pair": [{
+                "round": 1,
+                "reference": arm,
+                "candidate": arm,
+            }]
+        }
+        observed = sweep.shared_host_observations(
+            rows, 47, [95], 0.02, 0.15
+        )
+        self.assertEqual(observed["expected_frequency_observations"], 2)
+        self.assertEqual(observed["observed_frequency_observations"], 0)
+        self.assertRegex(
+            "; ".join(observed["violations"]),
+            "frequency accounting is incomplete",
+        )
+
+    def test_shared_host_observations_reject_impossible_cpu_total(self) -> None:
+        host = {
+            "concurrent_lake_lean_count": 0,
+            "load_1m_per_cpu": 0.0,
+            "affinity_cpu_frequency_khz": "2500000",
+        }
+        arm = {
+            "wall_nanos": 1_000_000_000,
+            "host_before": host,
+            "host_after": host,
+            "cpu_accounting": {
+                "measurement_cpu_residual_seconds": -0.5,
+                "measurement_cpu_foreign_seconds": 0.0,
+                "mean_frequency_khz": 2_500_000,
+                "pressure_some_delta_us": 0,
+                "per_cpu": {"95": {"busy_seconds": 0.0}},
+            },
+        }
+        rows = {
+            "pair": [{
+                "round": 1,
+                "reference": arm,
+                "candidate": arm,
+            }]
+        }
+        observed = sweep.shared_host_observations(
+            rows, 47, [95], 0.02, 0.15
+        )
+        self.assertRegex(
+            "; ".join(observed["violations"]),
+            "child CPU time exceeds pinned-CPU busy time",
+        )
+
+    def test_shared_host_observations_gate_arm_mean_frequency(self) -> None:
+        host = {
+            "concurrent_lake_lean_count": 0,
+            "load_1m_per_cpu": 0.0,
+            "affinity_cpu_frequency_khz": "1500000",
+        }
+
+        def arm(mean_frequency: int) -> dict[str, object]:
+            return {
+                "wall_nanos": 1_000_000_000,
+                "cpu_percent": 100.0,
+                "host_before": host,
+                "host_after": host,
+                "cpu_accounting": {
+                    "measurement_cpu_residual_seconds": 0.0,
+                    "measurement_cpu_foreign_seconds": 0.0,
+                    "mean_frequency_khz": mean_frequency,
+                    "pressure_some_delta_us": 0,
+                    "per_cpu": {"95": {"busy_seconds": 0.0}},
+                },
+            }
+
+        rows = {
+            "pair": [{
+                "round": 1,
+                "reference": arm(2_000_000),
+                "candidate": arm(2_500_000),
+            }]
+        }
+        observed = sweep.shared_host_observations(
+            rows, 47, [95], 0.002, 0.15
+        )
+        self.assertAlmostEqual(observed["frequency_spread_ratio"], 0.25)
+        self.assertRegex(
+            "; ".join(observed["violations"]),
+            "pinned-CPU frequency spread",
+        )
+
+    def test_nonshared_sweep_does_not_require_null_controls(self) -> None:
+        args = sweep.parse_args("validity", [])
+        quality, issues = sweep.validity_summary(
+            SPEC,
+            args,
+            {"center-direct": {"resolution": "no-comparable-control"}},
+            None,
+            [],
+        )
+        self.assertTrue(quality)
+        self.assertEqual(issues, [])
+
+    def test_shared_sweep_requires_measured_control_separation(self) -> None:
+        module = sweep.ProbeModule("Probe.Baseline")
+        pairs = (
+            sweep.ProbePair("cheap", module, module, {}, null_control=True),
+            sweep.ProbePair(
+                "expensive", module, module, {}, null_control=True
+            ),
+            sweep.ProbePair("effect", module, module, {}),
+        )
+        spec = sweep.SweepSpec(
+            description="control magnitudes",
+            pairs=pairs,
+            probe_target="Probe",
+            schema="test",
+            measurement="test",
+            output_stem="test",
+        )
+        args = sweep.parse_args(
+            "validity",
+            [
+                "--shared-host", "--expected-host", "bench",
+                "--cpu", "22", "--samples", "6",
+            ],
+        )
+        results = {
+            "cheap": {"build_magnitude_wall_nanos": 1_000},
+            "expensive": {"build_magnitude_wall_nanos": 1_500},
+            "effect": {
+                "build_magnitude_wall_nanos": 1_250,
+                "resolution": "resolved",
+            },
+        }
+        quality, issues = sweep.validity_summary(
+            spec, args, results, {"violations": []}, []
+        )
+        self.assertFalse(quality)
+        self.assertIn(
+            "null-control build magnitudes are not sufficiently distinct",
+            issues,
+        )
+
+    def test_shared_budget_must_exceed_interference_ceiling(self) -> None:
+        module = sweep.ProbeModule("Probe.Baseline")
+        pairs = (
+            sweep.ProbePair("cheap", module, module, {}, null_control=True),
+            sweep.ProbePair(
+                "expensive", module, module, {}, null_control=True
+            ),
+            sweep.ProbePair(
+                "tactic",
+                module,
+                module,
+                {"tactic_budget_ms": 100},
+            ),
+        )
+        spec = sweep.SweepSpec(
+            description="budget resolution",
+            pairs=pairs,
+            probe_target="Probe",
+            schema="test",
+            measurement="test",
+            output_stem="test",
+        )
+        args = sweep.parse_args(
+            "validity",
+            [
+                "--shared-host", "--expected-host", "bench",
+                "--cpu", "22", "--samples", "6",
+            ],
+        )
+        arm = {"wall_nanos": 30_000_000_000}
+        results = {
+            "cheap": {"build_magnitude_wall_nanos": 10_000_000_000},
+            "expensive": {"build_magnitude_wall_nanos": 30_000_000_000},
+            "tactic": {
+                "build_magnitude_wall_nanos": 30_000_000_000,
+                "resolution": "resolved",
+                "budget_nanos": 100_000_000,
+                "budget_status": "passed",
+                "samples": [
+                    {"reference": arm, "candidate": arm}
+                ],
+            },
+        }
+        quality, issues = sweep.validity_summary(
+            spec, args, results, {"violations": []}, []
+        )
+        self.assertFalse(quality)
+        self.assertGreater(
+            results["tactic"]["budget_interference_ceiling_nanos"],
+            results["tactic"]["budget_nanos"],
+        )
+        self.assertRegex(
+            "; ".join(issues),
+            "not resolvable under the admitted core-interference ceiling",
         )
 
     def test_contention_violation_makes_release_quality_false(self) -> None:
@@ -564,6 +831,45 @@ class HarnessValidationTests(unittest.TestCase):
         )
         with mock.patch.object(sweep, "cpu_affinity", return_value=[3]):
             self.assertEqual(sweep.shared_host_protocol_issues(spec, args), [])
+
+    def test_shared_host_requires_controls_before_substantive_pairs(self) -> None:
+        cheap = sweep.ProbeModule("Probe.Cheap")
+        expensive = sweep.ProbeModule("Probe.Expensive")
+        pairs = (
+            sweep.ProbePair("cheap", cheap, cheap, {}, null_control=True),
+            sweep.ProbePair(
+                "substantive",
+                cheap,
+                sweep.ProbeModule("Probe.Candidate"),
+                {},
+            ),
+            sweep.ProbePair(
+                "expensive", expensive, expensive, {}, null_control=True
+            ),
+        )
+        spec = sweep.SweepSpec(
+            description="misordered controls",
+            pairs=pairs,
+            probe_target="Probe",
+            schema="test",
+            measurement="test",
+            output_stem="test",
+            required_samples=6,
+        )
+        args = sweep.parse_args(
+            spec.description,
+            [
+                "--shared-host", "--expected-host", "bench-host",
+                "--cpu", "3", "--samples", "6",
+            ],
+        )
+        with mock.patch.object(sweep, "cpu_affinity", return_value=[3]):
+            self.assertRegex(
+                "; ".join(
+                    sweep.shared_host_protocol_issues(spec, args)
+                ),
+                "all null controls must precede substantive pairs",
+            )
 
     def test_shared_host_records_global_activity_without_rejecting_it(self) -> None:
         state = {

--- a/scripts/bench/test_fresh_module_sweep.py
+++ b/scripts/bench/test_fresh_module_sweep.py
@@ -428,7 +428,7 @@ class PairingTests(unittest.TestCase):
             }]
         }
         observed = sweep.shared_host_observations(
-            rows, 47, [95], 0.02
+            rows, 47, [95], 0.02, 0.15
         )
         self.assertEqual(observed["max_smt_sibling_busy_ratio"], 0.10)
         self.assertRegex(

--- a/scripts/bench/test_fresh_module_sweep.py
+++ b/scripts/bench/test_fresh_module_sweep.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import io
 import os
 import signal
 import subprocess
@@ -116,8 +117,38 @@ class ProvenanceTests(unittest.TestCase):
                     with self.assertRaisesRegex(RuntimeError, "forced failure"):
                         sweep.checkout_state(Path("/unused"))
 
+    def test_missing_declared_provenance_source_fails_closed(self) -> None:
+        spec = sweep.SweepSpec(
+            description="missing provenance",
+            pairs=(PAIR,),
+            probe_target="Probe",
+            schema="test",
+            measurement="test",
+            output_stem="test",
+            extra_sources=(Path("missing.md"),),
+        )
+        with tempfile.TemporaryDirectory() as directory, mock.patch.object(
+            sweep, "ROOT", Path(directory)
+        ), mock.patch.object(
+            sweep, "local_import_sources", return_value=set()
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError, "missing declared provenance"
+            ):
+                sweep.provenance_sources(spec, CALLER)
+
 
 class ProcessGroupTests(unittest.TestCase):
+    def test_run_timed_records_scheduler_metrics(self) -> None:
+        proc, elapsed, metrics = sweep.run_timed(["true"], 5)
+        self.assertEqual(proc.returncode, 0)
+        self.assertGreater(elapsed, 0)
+        if sweep.time_binary() is not None:
+            self.assertIsNotNone(metrics["peak_rss_kb"])
+            self.assertIsNotNone(metrics["user_seconds"])
+            self.assertIsNotNone(metrics["system_seconds"])
+            self.assertIsNotNone(metrics["cpu_percent"])
+
     @unittest.skipUnless(Path("/proc").is_dir(), "requires procfs")
     def test_run_timed_invokes_group_cleanup(self) -> None:
         with mock.patch.object(sweep, "time_binary", return_value=None), \
@@ -314,8 +345,128 @@ class PairingTests(unittest.TestCase):
             summary = sweep.summarize(spec, rows)[pair.name]
         self.assertTrue(summary["null_control"])
 
+    def test_summary_resolves_against_magnitude_comparable_control(self) -> None:
+        cheap = sweep.ProbeModule("Probe.Cheap")
+        expensive = sweep.ProbeModule("Probe.Expensive")
+        candidate = sweep.ProbeModule("Probe.Candidate")
+        pairs = (
+            sweep.ProbePair("cheap", cheap, cheap, {}, null_control=True),
+            sweep.ProbePair(
+                "expensive", expensive, expensive, {}, null_control=True
+            ),
+            sweep.ProbePair(
+                "tactic",
+                expensive,
+                candidate,
+                {"tactic_budget_ms": 100},
+            ),
+        )
+        spec = sweep.SweepSpec(
+            description="resolution",
+            pairs=pairs,
+            probe_target="Probe",
+            schema="test",
+            measurement="test",
+            output_stem="test",
+        )
+
+        def rows(wall: int, deltas: list[int]) -> list[dict[str, object]]:
+            return [{
+                "reference": {
+                    "wall_nanos": wall,
+                    "peak_rss_kb": None,
+                },
+                "candidate": {
+                    "wall_nanos": wall + delta,
+                    "peak_rss_kb": None,
+                },
+                "signed_wall_delta_nanos": delta,
+            } for delta in deltas]
+
+        samples = {
+            "cheap": rows(100_000_000, [-1_000_000, 1_000_000]),
+            "expensive": rows(
+                1_000_000_000, [-10_000_000, 10_000_000]
+            ),
+            "tactic": rows(
+                1_000_000_000, [85_000_000, 95_000_000]
+            ),
+        }
+        with mock.patch.object(sweep, "artifact_sizes", return_value={}):
+            summary = sweep.summarize(spec, samples)
+        self.assertEqual(
+            summary["tactic"]["comparable_control"], "expensive"
+        )
+        self.assertEqual(summary["tactic"]["resolution"], "resolved")
+        self.assertEqual(summary["tactic"]["budget_status"], "unresolved")
+
+    def test_shared_host_observations_reject_sibling_contention(self) -> None:
+        def arm(sibling_busy: float) -> dict[str, object]:
+            host = {
+                "concurrent_lake_lean_count": 2,
+                "load_1m_per_cpu": 0.25,
+                "affinity_cpu_frequency_khz": "2500000",
+            }
+            return {
+                "wall_nanos": 1_000_000_000,
+                "host_before": host,
+                "host_after": host,
+                "cpu_accounting": {
+                    "measurement_cpu_foreign_seconds": 0.01,
+                    "pressure_some_delta_us": 5,
+                    "per_cpu": {
+                        "95": {"busy_seconds": sibling_busy},
+                    },
+                },
+            }
+
+        rows = {
+            "pair": [{
+                "round": 1,
+                "reference": arm(0.01),
+                "candidate": arm(0.10),
+            }]
+        }
+        observed = sweep.shared_host_observations(
+            rows, 47, [95], 0.02
+        )
+        self.assertEqual(observed["max_smt_sibling_busy_ratio"], 0.10)
+        self.assertRegex(
+            "; ".join(observed["violations"]), "SMT sibling CPU 95"
+        )
+
+    def test_contention_violation_makes_release_quality_false(self) -> None:
+        args = sweep.parse_args("validity", [])
+        observations = {"violations": ["sibling contention"]}
+        quality, issues = sweep.validity_summary(
+            SPEC,
+            args,
+            {"center-direct": {}},
+            observations,
+            [],
+        )
+        self.assertFalse(quality)
+        self.assertEqual(issues, ["sibling contention"])
+
 
 class HarnessValidationTests(unittest.TestCase):
+    def test_shared_host_arguments_are_complete_and_exclusive(self) -> None:
+        with mock.patch.object(sys, "stderr", new=io.StringIO()):
+            with self.assertRaises(SystemExit):
+                sweep.parse_args("shared", ["--shared-host"])
+            with self.assertRaises(SystemExit):
+                sweep.parse_args(
+                    "shared", ["--expected-host", "bench-host", "--cpu", "3"]
+                )
+            with self.assertRaises(SystemExit):
+                sweep.parse_args(
+                    "shared",
+                    [
+                        "--shared-host", "--expected-host", "bench-host",
+                        "--cpu", "3", "--allow-busy",
+                    ],
+                )
+
     def test_shared_host_pins_named_machine(self) -> None:
         args = sweep.parse_args(
             SPEC.description,
@@ -351,7 +502,13 @@ class HarnessValidationTests(unittest.TestCase):
                 sweep.configure_shared_host(args)
 
     def test_shared_host_requires_single_cpu_affinity(self) -> None:
-        args = sweep.parse_args(SPEC.description, ["--shared-host", "--samples", "6"])
+        args = sweep.parse_args(
+            SPEC.description,
+            [
+                "--shared-host", "--expected-host", "bench-host",
+                "--cpu", "3", "--samples", "6",
+            ],
+        )
         with mock.patch.object(
             sweep, "cpu_affinity", return_value=[3, 4]
         ):
@@ -361,7 +518,13 @@ class HarnessValidationTests(unittest.TestCase):
             )
 
     def test_shared_host_requires_two_controls(self) -> None:
-        args = sweep.parse_args(SPEC.description, ["--shared-host", "--samples", "6"])
+        args = sweep.parse_args(
+            SPEC.description,
+            [
+                "--shared-host", "--expected-host", "bench-host",
+                "--cpu", "3", "--samples", "6",
+            ],
+        )
         with mock.patch.object(sweep, "cpu_affinity", return_value=[3]):
             self.assertRegex(
                 "; ".join(sweep.shared_host_protocol_issues(SPEC, args)),
@@ -369,10 +532,19 @@ class HarnessValidationTests(unittest.TestCase):
             )
 
     def test_shared_host_accepts_balanced_controlled_spec(self) -> None:
-        module = sweep.ProbeModule("Probe.Same")
+        cheap = sweep.ProbeModule("Probe.Cheap")
+        expensive = sweep.ProbeModule("Probe.Expensive")
         controls = (
-            sweep.ProbePair("cheap", module, module, {}, null_control=True),
-            sweep.ProbePair("expensive", module, module, {}, null_control=True),
+            sweep.ProbePair("cheap", cheap, cheap, {}, null_control=True),
+            sweep.ProbePair(
+                "expensive", expensive, expensive, {}, null_control=True
+            ),
+            sweep.ProbePair(
+                "substantive",
+                cheap,
+                sweep.ProbeModule("Probe.Candidate"),
+                {},
+            ),
         )
         spec = sweep.SweepSpec(
             description="shared",
@@ -384,28 +556,32 @@ class HarnessValidationTests(unittest.TestCase):
             required_samples=6,
         )
         args = sweep.parse_args(
-            spec.description, ["--shared-host", "--samples", "6"]
+            spec.description,
+            [
+                "--shared-host", "--expected-host", "bench-host",
+                "--cpu", "3", "--samples", "6",
+            ],
         )
         with mock.patch.object(sweep, "cpu_affinity", return_value=[3]):
             self.assertEqual(sweep.shared_host_protocol_issues(spec, args), [])
 
-    def test_shared_host_ignores_process_presence_but_not_saturation(self) -> None:
+    def test_shared_host_records_global_activity_without_rejecting_it(self) -> None:
         state = {
             "concurrent_lake_lean": [{"pid": 1, "command": "lake build"}],
             "load_1m_per_cpu": 0.25,
         }
         self.assertEqual(
             sweep.host_issues(
-                state, 0.5, concurrent_is_issue=False
+                state, 0.5, concurrent_is_issue=False, load_is_issue=False
             ),
             [],
         )
         state["load_1m_per_cpu"] = 0.75
-        self.assertRegex(
-            "; ".join(sweep.host_issues(
-                state, 0.5, concurrent_is_issue=False
-            )),
-            "exceeds",
+        self.assertEqual(
+            sweep.host_issues(
+                state, 0.5, concurrent_is_issue=False, load_is_issue=False
+            ),
+            [],
         )
 
     def test_warmup_builds_every_unique_import_closure(self) -> None:

--- a/scripts/bench/test_hexrcf_proof_sweep.py
+++ b/scripts/bench/test_hexrcf_proof_sweep.py
@@ -10,23 +10,36 @@ from scripts.bench import hexrcf_proof_sweep as rcf
 
 
 class ManifestTests(unittest.TestCase):
-    def test_manifest_is_two_nulls_plus_five_pairs_per_case(self) -> None:
-        self.assertEqual(len(rcf.SPEC.pairs), 17)
+    def test_manifest_is_three_nulls_plus_five_pairs_per_case(self) -> None:
+        self.assertEqual(len(rcf.SPEC.pairs), 18)
         self.assertEqual(
             [pair.name for pair in rcf.SPEC.pairs],
-            ["fresh-build-null", "degree50-tactic-null", *[
+            [
+                "fresh-build-null",
+                "degree10-tactic-null",
+                "degree50-tactic-null",
+                *[
                 f"{case}-{component}"
                 for case in ("quadratic", "degree10", "degree50")
                 for component in ("reify", "search", "literal", "replay", "tactic")
-            ]],
+                ],
+            ],
         )
 
     def test_null_controls_are_first_and_use_exact_module_identity(self) -> None:
-        baseline, expensive = rcf.SPEC.pairs[:2]
+        baseline, intermediate, expensive = rcf.SPEC.pairs[:3]
         self.assertTrue(baseline.null_control)
         self.assertIs(baseline.reference, rcf.BASELINE)
         self.assertIs(baseline.candidate, rcf.BASELINE)
         self.assertEqual(baseline.metadata["interpretation"], "calibration-only")
+        self.assertTrue(intermediate.null_control)
+        self.assertEqual(intermediate.reference, intermediate.candidate)
+        self.assertEqual(
+            intermediate.reference.expected_axioms, rcf.ALLOWED_AXIOMS
+        )
+        self.assertEqual(
+            intermediate.metadata["magnitude"], "degree10-tactic"
+        )
         self.assertTrue(expensive.null_control)
         self.assertEqual(expensive.reference, expensive.candidate)
         self.assertEqual(expensive.reference.expected_axioms, rcf.ALLOWED_AXIOMS)
@@ -42,6 +55,15 @@ class ManifestTests(unittest.TestCase):
             self.assertEqual(
                 len([pair for pair in substantive if pair.name.startswith(case)]),
                 5,
+            )
+
+    def test_only_whole_tactic_pairs_have_acceptance_budgets(self) -> None:
+        for pair in rcf.SPEC.pairs:
+            has_budget = "tactic_budget_ms" in pair.metadata
+            self.assertEqual(
+                has_budget,
+                not pair.null_control and pair.name.endswith("-tactic"),
+                pair.name,
             )
 
     def test_only_replay_and_tactic_report_axioms(self) -> None:


### PR DESCRIPTION
Milestone for #8972 after merged structural PR #8980.

This defines the designated shared-host proof-probe protocol used by both HexRealRootsMathlib and HexRCF: named-host and single-core pinning before warmup, SMT-sibling and pinned-core accounting, per-arm frequency residency, three magnitude-spanning null controls for RCF (two for RealRootsMathlib), fail-closed provenance, conservative null envelopes, and whole-tactic budget resolution. Timed Lean work is single-threaded. The preregistered release commands use chungus2 CPU 22.

Validation:
- 61 focused Python tests pass
- Phase 4, DAG, copyright, line-count, trust-surface, and Mathlib bench-boundary checks pass
- live pinned Baseline build on CPU 22 / sibling 70 produced complete counters and no protocol violations

The release artifact and report will follow as the next milestone after this protocol merges; this PR does not advance done_through.