### PR TITLE
feat(number-field): prove fixed-presentation field semantics

### DIFF
--- a/HexManual/Chapters/HexNumberField.lean
+++ b/HexManual/Chapters/HexNumberField.lean
@@ -164,11 +164,13 @@ rational `AdjoinRoot` quotient, their executable extended-GCD inverse is
 validated, and an opt-in `Field` instance preserves the existing computational
 operations and rational scalar action. Open the
 `Hex.QAdjoin.QAdjoinField` scope when Mathlib field notation and laws are
-wanted.
+wanted. Opening this scope makes that notation proof-bearing and
+noncomputable; executable code should continue to use the unscoped operations.
 
-The later approximation, exactification, lazy-arithmetic, and root-array
-contracts remain staged declarations for subsequent proof-completion
-milestones.
+Semantic equality and zero tests, together with the later approximation,
+exactification, lazy-arithmetic, and root-array contracts, remain staged
+declarations for subsequent proof-completion milestones. Some constructor
+certification in the Mathlib-free layer is likewise still staged.
 
 {docstring Hex.AlgebraicRoot.toComplex}
 

--- a/HexManual/Chapters/HexNumberField.lean
+++ b/HexManual/Chapters/HexNumberField.lean
@@ -158,15 +158,25 @@ finite root array carrying positive multiplicities.
 tag := "hex-number-field-correspondence"
 %%%
 
-`HexNumberFieldMathlib` currently exposes Phase-1 contract declarations; their
-proof bodies are not yet complete. Once discharged, they interpret selected
-roots in `ℂ`, establish the fixed-coordinate laws and approximation
-enclosure, make exactification and lazy arithmetic complete, and identify the
-returned arrays with Mathlib polynomial roots and multiplicities.
+`HexNumberFieldMathlib` interprets selected roots in `ℂ`. For a checked fixed
+presentation, the reduced coordinates are now ring-equivalent to the monic
+rational `AdjoinRoot` quotient, their executable extended-GCD inverse is
+validated, and an opt-in `Field` instance preserves the existing computational
+operations and rational scalar action. Open the
+`Hex.QAdjoin.QAdjoinField` scope when Mathlib field notation and laws are
+wanted.
+
+The later approximation, exactification, lazy-arithmetic, and root-array
+contracts remain staged declarations for subsequent proof-completion
+milestones.
 
 {docstring Hex.AlgebraicRoot.toComplex}
 
 {docstring Hex.QAdjoin.toComplex}
+
+{docstring Hex.QAdjoin.adjoinRootEquiv}
+
+{docstring Hex.QAdjoin.embedding}
 
 {docstring Hex.AlgebraicRoot.exact_toComplex}
 

--- a/HexNumberField/QAdjoin.lean
+++ b/HexNumberField/QAdjoin.lean
@@ -133,6 +133,24 @@ def div [ZPoly.CheckedIrreducible p] (a b : QAdjoin p x) : QAdjoin p x :=
 
 instance [ZPoly.CheckedIrreducible p] : Div (QAdjoin p x) := ⟨div⟩
 
+/-- Natural powers assembled from executable fixed-presentation
+multiplication. -/
+@[expose]
+def natPow (a : QAdjoin p x) : Nat → QAdjoin p x
+  | 0 => 1
+  | n + 1 => natPow a n * a
+
+instance : Pow (QAdjoin p x) Nat := ⟨natPow⟩
+
+/-- Integer powers assembled from executable multiplication and inversion. -/
+@[expose]
+def intPow [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) : Int → QAdjoin p x
+  | .ofNat n => natPow a n
+  | .negSucc n => (natPow a (n + 1))⁻¹
+
+instance [ZPoly.CheckedIrreducible p] : Pow (QAdjoin p x) Int := ⟨intPow⟩
+
 /-- Refine a fixed-field generator representative once and evaluate canonical
 coordinates on its disc. The checked driver's `none` fallback retains the
 original representative and therefore still returns a sound ball; the

--- a/HexNumberFieldMathlib/AdjoinRoot.lean
+++ b/HexNumberFieldMathlib/AdjoinRoot.lean
@@ -14,10 +14,10 @@ public section
 /-!
 # Fixed-presentation semantic laws
 
-These are the operation laws needed to transfer a field structure to
-`QAdjoin`.  The executable carrier deliberately supplies only its concrete
-operations; the eventual `AdjoinRoot` correspondence will package these laws
-without changing those operations or their rational scalar action.
+This module proves the operation laws needed to install a scoped field
+structure on `QAdjoin`. The executable carrier deliberately supplies only its
+concrete operations; the `AdjoinRoot` correspondence packages those laws
+without changing the operations or their rational scalar action.
 -/
 
 namespace Hex.QAdjoin
@@ -29,6 +29,62 @@ variable {p : ZPoly} {x : SimpleRoot p}
 noncomputable def definingPolynomial (p : ZPoly) : Polynomial Rat :=
   (p.leadingCoeff : Rat)⁻¹ • HexPolyZMathlib.toPolyℚ p
 
+/-- The rational defining polynomial is the monic associate of the checked
+integer polynomial. -/
+theorem definingPolynomial_monic (p : ZPoly) [ZPoly.CheckedIrreducible p] :
+    (definingPolynomial p).Monic := by
+  have hirr := ZPoly.CheckedIrreducible.irreducibleRat p
+  have hlc :
+      (HexPolyZMathlib.toPolyℚ p).leadingCoeff =
+        (p.leadingCoeff : Rat) := by
+    rw [HexPolyZMathlib.toPolyℚ,
+      Polynomial.leadingCoeff_map_of_injective
+        (RingHom.injective_int (Int.castRingHom Rat)),
+      HexPolyMathlib.leadingCoeff_toPolynomial]
+    rfl
+  rw [definingPolynomial, ← hlc, Polynomial.smul_eq_C_mul, mul_comm]
+  exact Polynomial.monic_mul_leadingCoeff_inv hirr.ne_zero
+
+/-- Monic normalization preserves the executable defining degree. -/
+theorem natDegree_definingPolynomial (p : ZPoly)
+    [ZPoly.CheckedIrreducible p] :
+    (definingPolynomial p).natDegree = p.degree?.getD 0 := by
+  have hirr := ZPoly.CheckedIrreducible.irreducibleRat p
+  have hlc :
+      (HexPolyZMathlib.toPolyℚ p).leadingCoeff =
+        (p.leadingCoeff : Rat) := by
+    rw [HexPolyZMathlib.toPolyℚ,
+      Polynomial.leadingCoeff_map_of_injective
+        (RingHom.injective_int (Int.castRingHom Rat)),
+      HexPolyMathlib.leadingCoeff_toPolynomial]
+    rfl
+  have hlc0 : (p.leadingCoeff : Rat) ≠ 0 := by
+    rw [← hlc]
+    exact Polynomial.leadingCoeff_ne_zero.mpr hirr.ne_zero
+  rw [definingPolynomial,
+    Polynomial.natDegree_smul _ (inv_ne_zero hlc0),
+    HexPolyZMathlib.toPolyℚ,
+    Polynomial.natDegree_map_eq_of_injective
+      (RingHom.injective_int (Int.castRingHom Rat)),
+    HexPolyMathlib.natDegree_toPolynomial]
+
+/-- The monic rational defining polynomial remains irreducible. -/
+theorem definingPolynomial_irreducible (p : ZPoly)
+    [ZPoly.CheckedIrreducible p] :
+    _root_.Irreducible (definingPolynomial p) := by
+  have hirr := ZPoly.CheckedIrreducible.irreducibleRat p
+  have hlc :
+      (HexPolyZMathlib.toPolyℚ p).leadingCoeff =
+        (p.leadingCoeff : Rat) := by
+    rw [HexPolyZMathlib.toPolyℚ,
+      Polynomial.leadingCoeff_map_of_injective
+        (RingHom.injective_int (Int.castRingHom Rat)),
+      HexPolyMathlib.leadingCoeff_toPolynomial]
+    rfl
+  rw [definingPolynomial, ← hlc, Polynomial.smul_eq_C_mul, mul_comm,
+    Polynomial.irreducible_mul_leadingCoeff_inv]
+  exact hirr
+
 /-- Send reduced executable coordinates to the corresponding `AdjoinRoot`
 class. This function is defined before a ring structure is installed on
 `QAdjoin`. -/
@@ -38,11 +94,166 @@ noncomputable def toAdjoinRoot (a : QAdjoin p x) :
   AdjoinRoot.mk (definingPolynomial p)
     (HexPolyMathlib.toPolynomial a.coeffs)
 
+/-- Recover the unique reduced executable coordinates of an `AdjoinRoot`
+class. -/
+@[expose]
+noncomputable def fromAdjoinRoot [ZPoly.CheckedIrreducible p]
+    (a : AdjoinRoot (definingPolynomial p)) : QAdjoin p x where
+  coeffs := HexPolyMathlib.ofPolynomial
+    (AdjoinRoot.modByMonicHom (definingPolynomial_monic p) a)
+  degree_lt := by
+    rw [← HexPolyMathlib.natDegree_toPolynomial,
+      HexPolyMathlib.toPolynomial_ofPolynomial,
+      ← natDegree_definingPolynomial p]
+    induction a using AdjoinRoot.induction_on with
+    | _ f =>
+        rw [AdjoinRoot.modByMonicHom_mk]
+        apply Polynomial.natDegree_modByMonic_lt _
+          (definingPolynomial_monic p)
+        intro hone
+        have hdegree := natDegree_definingPolynomial p
+        rw [hone, Polynomial.natDegree_one] at hdegree
+        exact (Nat.ne_of_gt
+          (ZPoly.CheckedIrreducible.pos_degree (p := p))) hdegree.symm
+
 /-- Reduced coordinates give a bijection with the quotient by the monic
 rational defining relation. -/
 theorem toAdjoinRoot_bijective [ZPoly.CheckedIrreducible p] :
     Function.Bijective (@toAdjoinRoot p x) := by
-  sorry
+  apply Function.bijective_iff_has_inverse.mpr
+  refine ⟨@fromAdjoinRoot p x _, ?_, ?_⟩
+  · intro a
+    apply QAdjoin.ext
+    apply (HexPolyMathlib.equiv (R := Rat)).injective
+    change HexPolyMathlib.toPolynomial
+        (HexPolyMathlib.ofPolynomial
+          (AdjoinRoot.modByMonicHom (definingPolynomial_monic p)
+            (toAdjoinRoot a))) =
+      HexPolyMathlib.toPolynomial a.coeffs
+    rw [HexPolyMathlib.toPolynomial_ofPolynomial, toAdjoinRoot,
+      AdjoinRoot.modByMonicHom_mk]
+    apply (Polynomial.modByMonic_eq_self_iff
+      (definingPolynomial_monic p)).mpr
+    apply Polynomial.degree_lt_degree
+    rw [HexPolyMathlib.natDegree_toPolynomial,
+      natDegree_definingPolynomial]
+    exact a.degree_lt
+  · intro a
+    change AdjoinRoot.mk (definingPolynomial p)
+      (HexPolyMathlib.toPolynomial
+        (HexPolyMathlib.ofPolynomial
+          (AdjoinRoot.modByMonicHom (definingPolynomial_monic p) a))) = a
+    rw [HexPolyMathlib.toPolynomial_ofPolynomial]
+    exact AdjoinRoot.mk_leftInverse (definingPolynomial_monic p) a
+
+/-- The selected complex root zeros the monic rational defining polynomial. -/
+theorem eval_definingPolynomial [ZPoly.CheckedIrreducible p]
+    (rep : RefinedIsolation p) :
+    (definingPolynomial p).eval₂ (algebraMap Rat ℂ) rep.root = 0 := by
+  have hp := eval_reduceCoeffs (p := p) (ZPoly.toRatPoly p) rep
+  rw [reduceCoeffs, HexPolyMathlib.toPolynomial_mod,
+    EuclideanDomain.mod_self,
+    Polynomial.eval₂_zero,
+    HexPolyZMathlib.toPolynomial_toRatPoly] at hp
+  rw [definingPolynomial, Polynomial.eval₂_smul, hp.symm, mul_zero]
+
+/-- Evaluate the quotient presentation at its selected complex root. -/
+@[expose]
+noncomputable def rootHom [ZPoly.CheckedIrreducible p]
+    (rep : RefinedIsolation p) :
+    AdjoinRoot (definingPolynomial p) →+* ℂ :=
+  AdjoinRoot.lift (algebraMap Rat ℂ) rep.root
+    (eval_definingPolynomial rep)
+
+/-- Quotient evaluation agrees with direct evaluation of executable
+coordinates. -/
+theorem rootHom_toAdjoinRoot [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) :
+    rootHom rep (toAdjoinRoot a) = toComplex a rep h := by
+  rw [rootHom, toAdjoinRoot, AdjoinRoot.lift_mk]
+  rfl
+
+/-- Evaluation at the selected root is injective for a checked irreducible
+presentation. -/
+theorem toComplex_injective [ZPoly.CheckedIrreducible p]
+    (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) :
+    Function.Injective (fun a : QAdjoin p x => toComplex a rep h) := by
+  letI : Fact (_root_.Irreducible (definingPolynomial p)) :=
+    ⟨definingPolynomial_irreducible p⟩
+  intro a b hab
+  apply toAdjoinRoot_bijective.1
+  apply (rootHom rep).injective
+  rw [rootHom_toAdjoinRoot a rep h, rootHom_toAdjoinRoot b rep h]
+  exact hab
+
+/-- The executable coordinate test recognizes precisely the zero element. -/
+theorem isZero_iff (a : QAdjoin p x) : a.isZero ↔ a = 0 := by
+  rw [QAdjoin.isZero, DensePoly.isZero_eq_true_iff]
+  constructor
+  · intro hsize
+    apply QAdjoin.ext
+    apply DensePoly.ext_coeff
+    intro n
+    change a.coeffs.coeff n = 0
+    exact DensePoly.coeff_eq_zero_of_size_le a.coeffs (by omega)
+  · intro ha
+    subst a
+    exact DensePoly.size_zero
+
+/-- Irreducibility and the reduced-degree invariant make the executable gcd
+guard in `QAdjoin.inv` succeed for every nonzero element. -/
+theorem inverse_gcd_size [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) (ha : a.isZero = false) :
+    (DensePoly.xgcdLeft a.coeffs (ZPoly.toRatPoly p)).gcd.size = 1 := by
+  let A := HexPolyMathlib.toPolynomial a.coeffs
+  let P := HexPolyMathlib.toPolynomial (ZPoly.toRatPoly p)
+  have ha0 : A ≠ 0 := by
+    intro hA
+    have hcoeffs : a.coeffs = 0 := by
+      apply (HexPolyMathlib.equiv (R := Rat)).injective
+      simpa [A] using hA
+    have hazero : a = 0 := QAdjoin.ext hcoeffs
+    have : a.isZero = true := (isZero_iff a).mpr hazero
+    simp [ha] at this
+  have hdeg : A.natDegree < P.natDegree := by
+    dsimp [A, P]
+    rw [HexPolyMathlib.natDegree_toPolynomial,
+      HexPolyZMathlib.toPolynomial_toRatPoly, HexPolyZMathlib.toPolyℚ,
+      Polynomial.natDegree_map_eq_of_injective
+        (RingHom.injective_int (Int.castRingHom Rat)),
+      HexPolyMathlib.natDegree_toPolynomial]
+    exact a.degree_lt
+  have hirr : _root_.Irreducible P := by
+    simpa [P, HexPolyZMathlib.toPolynomial_toRatPoly] using
+      ZPoly.CheckedIrreducible.irreducibleRat p
+  have hnotdvd : ¬ P ∣ A :=
+    Polynomial.not_dvd_of_natDegree_lt ha0 hdeg
+  have hnormUnit : IsUnit (EuclideanDomain.gcd A P) := by
+    apply EuclideanDomain.gcd_isUnit_iff.mpr
+    exact ((EuclideanDomain.dvd_or_coprime P A hirr).resolve_left
+      hnotdvd).symm
+  have hassoc :
+      Associated
+        (HexPolyMathlib.toPolynomial
+          (DensePoly.xgcdLeft a.coeffs (ZPoly.toRatPoly p)).gcd)
+        (EuclideanDomain.gcd A P) := by
+    rw [DensePoly.xgcdLeft_gcd_eq_xgcd]
+    simpa [A, P] using
+      (HexPolyMathlib.toPolynomial_xgcd_gcd_associated
+        (R := Rat) a.coeffs (ZPoly.toRatPoly p))
+  have hunit : IsUnit
+      (HexPolyMathlib.toPolynomial
+        (DensePoly.xgcdLeft a.coeffs (ZPoly.toRatPoly p)).gcd) :=
+    hassoc.isUnit_iff.mpr hnormUnit
+  obtain ⟨c, hc, hcPoly⟩ := Polynomial.isUnit_iff.mp hunit
+  have hgcdC :
+      (DensePoly.xgcdLeft a.coeffs (ZPoly.toRatPoly p)).gcd =
+        DensePoly.C c := by
+    apply (HexPolyMathlib.equiv (R := Rat)).injective
+    simpa only [HexPolyMathlib.equiv_apply,
+      HexPolyMathlib.toPolynomial_C] using hcPoly.symm
+  rw [hgcdC, DensePoly.size_C_of_ne_zero hc.ne_zero]
 
 /-- Fixed-presentation zero evaluates to complex zero. -/
 theorem map_zero (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) :
@@ -107,11 +318,313 @@ theorem map_smul (q : Rat) (a : QAdjoin p x) (rep : RefinedIsolation p)
         (algebraMap Rat ℂ) rep.root)
     (map_ratCast (algebraMap Rat ℂ) q)
 
+/-- Executable extended-GCD inversion agrees with complex inversion. -/
+theorem map_inv [ZPoly.CheckedIrreducible p] (a : QAdjoin p x)
+    (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) :
+    toComplex a⁻¹ rep h = (toComplex a rep h)⁻¹ := by
+  by_cases ha : a.isZero = true
+  · have hazero : a = 0 := (isZero_iff a).mp ha
+    change toComplex (QAdjoin.inv a) rep h = _
+    rw [QAdjoin.inv, if_pos ha, map_zero, hazero, map_zero, inv_zero]
+  · have haFalse : a.isZero = false := by
+      cases hzero : a.isZero <;> simp_all
+    let m := ZPoly.toRatPoly p
+    let r := DensePoly.xgcdLeft a.coeffs m
+    have hs : r.gcd.size = 1 := by
+      simpa [r, m] using inverse_gcd_size a haFalse
+    have hpos : 0 < r.gcd.size := by omega
+    have hlc0 : r.gcd.leadingCoeff ≠ 0 :=
+      DensePoly.leadingCoeff_ne_zero_of_pos_size r.gcd hpos
+    have hnat :
+        (HexPolyMathlib.toPolynomial r.gcd).natDegree = 0 := by
+      rw [HexPolyMathlib.natDegree_toPolynomial,
+        DensePoly.degree?_eq_some_of_pos_size _ hpos, hs]
+      rfl
+    have hcoeff :
+        (HexPolyMathlib.toPolynomial r.gcd).coeff 0 =
+          r.gcd.leadingCoeff := by
+      rw [HexPolyMathlib.coeff_toPolynomial,
+        DensePoly.leadingCoeff_eq_coeff_last _ hpos, hs]
+    have hgcdPoly :
+        HexPolyMathlib.toPolynomial r.gcd =
+          Polynomial.C r.gcd.leadingCoeff :=
+      (Polynomial.eq_C_of_natDegree_eq_zero hnat).trans
+        (congrArg Polynomial.C hcoeff)
+    have hp :
+        (HexPolyMathlib.toPolynomial m).eval₂
+          (algebraMap Rat ℂ) rep.root = 0 := by
+      have hp' := eval_reduceCoeffs (p := p) (ZPoly.toRatPoly p) rep
+      rw [reduceCoeffs, HexPolyMathlib.toPolynomial_mod,
+        EuclideanDomain.mod_self, Polynomial.eval₂_zero] at hp'
+      simpa [m] using hp'.symm
+    have hbez := HexPolyMathlib.toPolynomial_xgcd_bezout_raw
+      (R := Rat) a.coeffs m
+    rw [← DensePoly.xgcdLeft_left_eq_xgcd,
+      ← DensePoly.xgcdLeft_gcd_eq_xgcd] at hbez
+    have hbezEval := congrArg
+      (fun f : Polynomial Rat =>
+        f.eval₂ (algebraMap Rat ℂ) rep.root) hbez
+    rw [Polynomial.eval₂_add, Polynomial.eval₂_mul,
+      Polynomial.eval₂_mul] at hbezEval
+    change
+      (HexPolyMathlib.toPolynomial r.left).eval₂
+          (algebraMap Rat ℂ) rep.root *
+          toComplex a rep h +
+        (HexPolyMathlib.toPolynomial
+            (DensePoly.xgcd a.coeffs m).right).eval₂
+          (algebraMap Rat ℂ) rep.root *
+          (HexPolyMathlib.toPolynomial m).eval₂
+            (algebraMap Rat ℂ) rep.root =
+        (HexPolyMathlib.toPolynomial r.gcd).eval₂
+          (algebraMap Rat ℂ) rep.root at hbezEval
+    rw [hp, mul_zero, add_zero, hgcdPoly, Polynomial.eval₂_C] at hbezEval
+    have hcast :
+        (algebraMap Rat ℂ) r.gcd.leadingCoeff =
+          (r.gcd.leadingCoeff : ℂ) :=
+      map_ratCast (algebraMap Rat ℂ) r.gcd.leadingCoeff
+    have hlcC : (r.gcd.leadingCoeff : ℂ) ≠ 0 := by
+      rw [← hcast]
+      exact (map_ne_zero (algebraMap Rat ℂ)).mpr hlc0
+    rw [hcast] at hbezEval
+    have hvalue : toComplex a rep h ≠ 0 := by
+      intro hzero
+      apply ha
+      apply (isZero_iff a).mpr
+      apply toComplex_injective rep h
+      change toComplex a rep h = toComplex (0 : QAdjoin p x) rep h
+      rw [map_zero]
+      exact hzero
+    change toComplex (QAdjoin.inv a) rep h = _
+    simp only [QAdjoin.inv, haFalse, Bool.false_eq_true, if_false]
+    rw [hs, if_pos rfl, if_neg hlc0]
+    change
+      (HexPolyMathlib.toPolynomial
+        (reduceCoeffs p
+          (DensePoly.scale r.gcd.leadingCoeff⁻¹ r.left))).eval₂
+          (algebraMap Rat ℂ) rep.root = _
+    rw [eval_reduceCoeffs, HexPolyMathlib.toPolynomial_scale,
+      Polynomial.eval₂_mul, Polynomial.eval₂_C,
+      map_inv₀ (algebraMap Rat ℂ) r.gcd.leadingCoeff]
+    rw [mul_comm]
+    change
+      (HexPolyMathlib.toPolynomial r.left).eval₂
+          (algebraMap Rat ℂ) rep.root /
+        (r.gcd.leadingCoeff : ℂ) = (toComplex a rep h)⁻¹
+    apply mul_right_cancel₀ hvalue
+    rw [div_mul_eq_mul_div, hbezEval,
+      div_self hlcC,
+      mul_comm, Complex.mul_inv_cancel hvalue]
+
 /-- Fixed-presentation division agrees with complex division. -/
 theorem map_div [ZPoly.CheckedIrreducible p] (a b : QAdjoin p x)
     (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) :
     toComplex (a / b) rep h = toComplex a rep h / toComplex b rep h := by
-  sorry
+  change toComplex (a * b⁻¹) rep h = _
+  rw [map_mul, map_inv]
+  rfl
+
+/-- Natural powers assembled from executable fixed-presentation
+multiplication. -/
+@[expose]
+def natPow (a : QAdjoin p x) : Nat → QAdjoin p x
+  | 0 => 1
+  | n + 1 => natPow a n * a
+
+/-- Executable natural powers preserve the selected interpretation. -/
+theorem map_natPow (a : QAdjoin p x) (n : Nat)
+    (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) :
+    toComplex (natPow a n) rep h = toComplex a rep h ^ n := by
+  induction n with
+  | zero => simp [natPow, map_one]
+  | succ n ih => rw [natPow, map_mul, ih, pow_succ]
+
+/-- Integer powers assembled from executable multiplication and inversion. -/
+@[expose]
+def intPow [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) : Int → QAdjoin p x
+  | .ofNat n => natPow a n
+  | .negSucc n => (natPow a (n + 1))⁻¹
+
+/-- Executable integer powers preserve the selected interpretation. -/
+theorem map_intPow [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) (n : Int)
+    (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) :
+    toComplex (intPow a n) rep h = toComplex a rep h ^ n := by
+  cases n with
+  | ofNat n => exact map_natPow a n rep h
+  | negSucc n =>
+      rw [intPow, map_inv, map_natPow]
+      rfl
+
+/-- The law-bearing field whose operations are exactly the existing
+executable reduced-coordinate operations. -/
+@[expose, reducible]
+noncomputable def field (p : ZPoly) (x : SimpleRoot p)
+    [ZPoly.CheckedIrreducible p] : Field (QAdjoin p x) := by
+  let rep : RefinedIsolation p := Quot.out x
+  have hrep : SimpleRoot.mk rep = x := Quot.out_eq x
+  letI : SMul Nat (QAdjoin p x) :=
+    ⟨fun n a => (n : Rat) • a⟩
+  letI : SMul Int (QAdjoin p x) :=
+    ⟨fun n a => (n : Rat) • a⟩
+  letI : SMul ℚ≥0 (QAdjoin p x) :=
+    ⟨fun q a => (q : Rat) • a⟩
+  letI : Pow (QAdjoin p x) Nat :=
+    ⟨fun a n => natPow a n⟩
+  letI : Pow (QAdjoin p x) Int :=
+    ⟨fun a n => intPow a n⟩
+  letI : NatCast (QAdjoin p x) :=
+    ⟨fun n => (n : Rat) • (1 : QAdjoin p x)⟩
+  letI : IntCast (QAdjoin p x) :=
+    ⟨fun n => (n : Rat) • (1 : QAdjoin p x)⟩
+  letI : NNRatCast (QAdjoin p x) :=
+    ⟨fun q => (q : Rat) • (1 : QAdjoin p x)⟩
+  letI : RatCast (QAdjoin p x) :=
+    ⟨fun q => q • (1 : QAdjoin p x)⟩
+  apply Function.Injective.field
+    (fun a => toComplex a rep hrep) (toComplex_injective rep hrep)
+  · exact map_zero rep hrep
+  · exact map_one rep hrep
+  · exact fun a b => map_add a b rep hrep
+  · exact fun a b => map_mul a b rep hrep
+  · exact fun a => map_neg a rep hrep
+  · exact fun a b => map_sub a b rep hrep
+  · exact fun a => map_inv a rep hrep
+  · exact fun a b => map_div a b rep hrep
+  · intro n a
+    change toComplex ((n : Rat) • a) rep hrep = n • toComplex a rep hrep
+    rw [map_smul, nsmul_eq_mul]
+    rfl
+  · intro n a
+    change toComplex ((n : Rat) • a) rep hrep = n • toComplex a rep hrep
+    rw [map_smul, zsmul_eq_mul]
+    rfl
+  · intro q a
+    change toComplex ((q : Rat) • a) rep hrep = q • toComplex a rep hrep
+    rw [map_smul, NNRat.smul_def]
+    rfl
+  · intro q a
+    change toComplex (q • a) rep hrep = q • toComplex a rep hrep
+    rw [map_smul, Rat.smul_def]
+  · exact fun a n => map_natPow a n rep hrep
+  · exact fun a n => map_intPow a n rep hrep
+  · intro n
+    change toComplex ((n : Rat) • (1 : QAdjoin p x)) rep hrep = (n : ℂ)
+    rw [map_smul, map_one, mul_one]
+    norm_cast
+  · intro n
+    change toComplex ((n : Rat) • (1 : QAdjoin p x)) rep hrep = (n : ℂ)
+    rw [map_smul, map_one, mul_one]
+    norm_cast
+  · intro q
+    change toComplex ((q : Rat) • (1 : QAdjoin p x)) rep hrep = (q : ℂ)
+    rw [map_smul, map_one, mul_one]
+    norm_cast
+  · intro q
+    change toComplex (q • (1 : QAdjoin p x)) rep hrep = (q : ℂ)
+    rw [map_smul, map_one, mul_one]
+
+namespace QAdjoinField
+
+/-- Opt-in field instance for a checked fixed presentation. It is scoped so
+computational imports never acquire a noncomputable proof dictionary. -/
+noncomputable scoped instance (p : ZPoly) (x : SimpleRoot p)
+    [ZPoly.CheckedIrreducible p] : Field (QAdjoin p x) := field p x
+
+end QAdjoinField
+
+open scoped QAdjoinField
+
+/-- The quotient comparison preserves executable zero. -/
+theorem toAdjoinRoot_zero [ZPoly.CheckedIrreducible p] :
+    toAdjoinRoot (0 : QAdjoin p x) = 0 := by
+  let rep : RefinedIsolation p := Quot.out x
+  have hrep : SimpleRoot.mk rep = x := Quot.out_eq x
+  letI : Fact (_root_.Irreducible (definingPolynomial p)) :=
+    ⟨definingPolynomial_irreducible p⟩
+  apply (rootHom rep).injective
+  rw [rootHom_toAdjoinRoot, (rootHom rep).map_zero]
+  exact map_zero rep hrep
+
+/-- The quotient comparison preserves executable one. -/
+theorem toAdjoinRoot_one [ZPoly.CheckedIrreducible p] :
+    toAdjoinRoot (1 : QAdjoin p x) = 1 := by
+  let rep : RefinedIsolation p := Quot.out x
+  have hrep : SimpleRoot.mk rep = x := Quot.out_eq x
+  letI : Fact (_root_.Irreducible (definingPolynomial p)) :=
+    ⟨definingPolynomial_irreducible p⟩
+  apply (rootHom rep).injective
+  rw [rootHom_toAdjoinRoot, (rootHom rep).map_one]
+  exact map_one rep hrep
+
+/-- The quotient comparison preserves executable addition. -/
+theorem toAdjoinRoot_add [ZPoly.CheckedIrreducible p]
+    (a b : QAdjoin p x) :
+    toAdjoinRoot (a + b) = toAdjoinRoot a + toAdjoinRoot b := by
+  let rep : RefinedIsolation p := Quot.out x
+  have hrep : SimpleRoot.mk rep = x := Quot.out_eq x
+  letI : Fact (_root_.Irreducible (definingPolynomial p)) :=
+    ⟨definingPolynomial_irreducible p⟩
+  apply (rootHom rep).injective
+  rw [rootHom_toAdjoinRoot, (rootHom rep).map_add,
+    rootHom_toAdjoinRoot, rootHom_toAdjoinRoot]
+  exact map_add a b rep hrep
+
+/-- The quotient comparison preserves executable multiplication. -/
+theorem toAdjoinRoot_mul [ZPoly.CheckedIrreducible p]
+    (a b : QAdjoin p x) :
+    toAdjoinRoot (a * b) = toAdjoinRoot a * toAdjoinRoot b := by
+  let rep : RefinedIsolation p := Quot.out x
+  have hrep : SimpleRoot.mk rep = x := Quot.out_eq x
+  letI : Fact (_root_.Irreducible (definingPolynomial p)) :=
+    ⟨definingPolynomial_irreducible p⟩
+  apply (rootHom rep).injective
+  rw [rootHom_toAdjoinRoot, (rootHom rep).map_mul,
+    rootHom_toAdjoinRoot, rootHom_toAdjoinRoot]
+  exact map_mul a b rep hrep
+
+/-- The reduced-coordinate comparison as a ring homomorphism. -/
+@[expose]
+noncomputable def toAdjoinRootHom [ZPoly.CheckedIrreducible p] :
+    QAdjoin p x →+* AdjoinRoot (definingPolynomial p) where
+  toFun := toAdjoinRoot
+  map_zero' := toAdjoinRoot_zero
+  map_one' := toAdjoinRoot_one
+  map_add' := toAdjoinRoot_add
+  map_mul' := toAdjoinRoot_mul
+
+/-- Reduced executable coordinates are ring-equivalent to the monic rational
+`AdjoinRoot` presentation. -/
+@[expose]
+noncomputable def adjoinRootEquiv [ZPoly.CheckedIrreducible p] :
+    QAdjoin p x ≃+* AdjoinRoot (definingPolynomial p) :=
+  RingEquiv.ofBijective toAdjoinRootHom toAdjoinRoot_bijective
+
+@[simp]
+theorem adjoinRootEquiv_apply [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) : adjoinRootEquiv a = toAdjoinRoot a := rfl
+
+/-- Evaluation at the selected root as an injective ring homomorphism. -/
+@[expose]
+noncomputable def embedding [ZPoly.CheckedIrreducible p]
+    (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) :
+    QAdjoin p x →+* ℂ where
+  toFun := fun a => toComplex a rep h
+  map_zero' := map_zero rep h
+  map_one' := map_one rep h
+  map_add' := fun a b => map_add a b rep h
+  map_mul' := fun a b => map_mul a b rep h
+
+@[simp]
+theorem embedding_apply [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) :
+    embedding rep h a = toComplex a rep h := rfl
+
+/-- The selected-root ring homomorphism is an embedding. -/
+theorem embedding_injective [ZPoly.CheckedIrreducible p]
+    (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) :
+    Function.Injective (embedding rep h) := toComplex_injective rep h
 
 /-- Equality in a checked presentation is exactly equality of interpreted
 complex values. -/

--- a/HexNumberFieldMathlib/AdjoinRoot.lean
+++ b/HexNumberFieldMathlib/AdjoinRoot.lean
@@ -423,13 +423,6 @@ theorem map_div [ZPoly.CheckedIrreducible p] (a b : QAdjoin p x)
   rw [map_mul, map_inv]
   rfl
 
-/-- Natural powers assembled from executable fixed-presentation
-multiplication. -/
-@[expose]
-def natPow (a : QAdjoin p x) : Nat → QAdjoin p x
-  | 0 => 1
-  | n + 1 => natPow a n * a
-
 /-- Executable natural powers preserve the selected interpretation. -/
 theorem map_natPow (a : QAdjoin p x) (n : Nat)
     (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) :
@@ -437,13 +430,6 @@ theorem map_natPow (a : QAdjoin p x) (n : Nat)
   induction n with
   | zero => simp [natPow, map_one]
   | succ n ih => rw [natPow, map_mul, ih, pow_succ]
-
-/-- Integer powers assembled from executable multiplication and inversion. -/
-@[expose]
-def intPow [ZPoly.CheckedIrreducible p]
-    (a : QAdjoin p x) : Int → QAdjoin p x
-  | .ofNat n => natPow a n
-  | .negSucc n => (natPow a (n + 1))⁻¹
 
 /-- Executable integer powers preserve the selected interpretation. -/
 theorem map_intPow [ZPoly.CheckedIrreducible p]
@@ -469,10 +455,8 @@ noncomputable def field (p : ZPoly) (x : SimpleRoot p)
     ⟨fun n a => (n : Rat) • a⟩
   letI : SMul ℚ≥0 (QAdjoin p x) :=
     ⟨fun q a => (q : Rat) • a⟩
-  letI : Pow (QAdjoin p x) Nat :=
-    ⟨fun a n => natPow a n⟩
-  letI : Pow (QAdjoin p x) Int :=
-    ⟨fun a n => intPow a n⟩
+  -- Deliberately retain the executable `SMul Rat` and `Pow` instances. The
+  -- injected field must prove laws for those operations, not replace them.
   letI : NatCast (QAdjoin p x) :=
     ⟨fun n => (n : Rat) • (1 : QAdjoin p x)⟩
   letI : IntCast (QAdjoin p x) :=
@@ -526,14 +510,43 @@ noncomputable def field (p : ZPoly) (x : SimpleRoot p)
 
 namespace QAdjoinField
 
+/-- Opt-in irreducibility witness for the monic rational defining polynomial. -/
+scoped instance factIrreducible (p : ZPoly) [ZPoly.CheckedIrreducible p] :
+    Fact (_root_.Irreducible (definingPolynomial p)) :=
+  ⟨definingPolynomial_irreducible p⟩
+
 /-- Opt-in field instance for a checked fixed presentation. It is scoped so
-computational imports never acquire a noncomputable proof dictionary. -/
+computational imports never acquire a noncomputable proof dictionary. Opening
+the scope makes field notation proof-bearing and therefore noncomputable;
+executable code should use the unscoped operations instead. -/
 noncomputable scoped instance (p : ZPoly) (x : SimpleRoot p)
     [ZPoly.CheckedIrreducible p] : Field (QAdjoin p x) := field p x
 
 end QAdjoinField
 
 open scoped QAdjoinField
+
+/-! These examples pin the scoped field's data fields to the executable
+operations. They intentionally use definitional equality, so a future change
+that silently replaces an operation or the rational scalar action fails here. -/
+
+section OperationRegression
+
+variable (a b : QAdjoin p x) (q : Rat) [ZPoly.CheckedIrreducible p]
+
+example : (0 : QAdjoin p x) = QAdjoin.instZero.zero := rfl
+example : (1 : QAdjoin p x) = QAdjoin.instOne.one := rfl
+example : a + b = QAdjoin.add a b := rfl
+example : a - b = QAdjoin.sub a b := rfl
+example : a * b = QAdjoin.mul a b := rfl
+example : -a = QAdjoin.neg a := rfl
+example : a⁻¹ = QAdjoin.inv a := rfl
+example : a / b = QAdjoin.div a b := rfl
+example : a ^ (3 : Nat) = QAdjoin.natPow a 3 := rfl
+example : a ^ (-3 : Int) = QAdjoin.intPow a (-3) := rfl
+example : q • a = QAdjoin.smul q a := rfl
+
+end OperationRegression
 
 /-- The quotient comparison preserves executable zero. -/
 theorem toAdjoinRoot_zero [ZPoly.CheckedIrreducible p] :

--- a/HexNumberFieldMathlib/Basic.lean
+++ b/HexNumberFieldMathlib/Basic.lean
@@ -11,7 +11,7 @@ public import HexResultantMathlib
 public import HexBerlekampZassenhausMathlib
 public import HexRootsMathlib
 public import HexPolyZMathlib
-public import Mathlib.FieldTheory.Minpoly.Basic
+public import Mathlib.FieldTheory.Minpoly.Field
 
 public section
 
@@ -26,13 +26,31 @@ depend on the semantic boundary without importing one monolithic development.
 
 namespace Hex
 
+/-- A computationally checked irreducible integer polynomial remains
+irreducible after extension of coefficients to the rationals. -/
+theorem ZPoly.CheckedIrreducible.irreducibleRat (p : ZPoly)
+    [ZPoly.CheckedIrreducible p] :
+    _root_.Irreducible (HexPolyZMathlib.toPolyℚ p) := by
+  have hirrZ : _root_.Irreducible (HexPolyZMathlib.toPolynomial p) :=
+    (HexBerlekampZassenhausMathlib.Hex.ZPoly.Irreducible_iff_polynomialIrreducible p).mp <|
+      (HexBerlekampZassenhausMathlib.Hex.ZPoly.isIrreducible_iff p).mp
+        (ZPoly.CheckedIrreducible.is_true (p := p))
+  have hdegree : (HexPolyZMathlib.toPolynomial p).natDegree ≠ 0 := by
+    rw [HexPolyMathlib.natDegree_toPolynomial]
+    exact Nat.ne_of_gt (ZPoly.CheckedIrreducible.pos_degree (p := p))
+  have hprimitive : (HexPolyZMathlib.toPolynomial p).IsPrimitive :=
+    hirrZ.isPrimitive hdegree
+  exact
+    ((Polynomial.IsPrimitive.Int.irreducible_iff_irreducible_map_cast
+      hprimitive).mp hirrZ)
+
 /-- A computationally checked irreducible integer polynomial is separable over
 the rationals. The factorization correspondence supplies irreducibility; this
 is the semantic bridge used by quotient-root interpretation. -/
 theorem ZPoly.CheckedIrreducible.separable (p : ZPoly)
     [ZPoly.CheckedIrreducible p] :
     (HexPolyZMathlib.toPolyℚ p).Separable := by
-  sorry
+  exact (ZPoly.CheckedIrreducible.irreducibleRat p).separable
 
 namespace AlgebraicRoot
 
@@ -60,7 +78,32 @@ rational minimal polynomial. -/
 theorem p_eq_minpoly (a : AlgebraicNumber) :
     (a.p.leadingCoeff : Rat)⁻¹ • HexPolyZMathlib.toPolyℚ a.p =
       minpoly Rat a.toComplex := by
-  sorry
+  letI : ZPoly.CheckedIrreducible a.p := a.checked
+  have hroot :
+      Polynomial.aeval a.toComplex (HexPolyZMathlib.toPolyℚ a.p) = 0 := by
+    rw [Polynomial.aeval_def, Polynomial.eval₂_eq_eval_map]
+    have hcomp :
+        (algebraMap Rat ℂ).comp (Int.castRingHom Rat) =
+          Int.castRingHom ℂ :=
+      RingHom.ext_int _ _
+    rw [show
+        (HexPolyZMathlib.toPolyℚ a.p).map (algebraMap Rat ℂ) =
+          HexRootsMathlib.toPolyℂ a.p by
+      dsimp [HexPolyZMathlib.toPolyℚ, HexRootsMathlib.toPolyℂ]
+      rw [Polynomial.map_map, hcomp]]
+    exact AlgebraicRoot.toComplex_isRoot a.toRoot
+  have hmin := minpoly.eq_of_irreducible
+    (ZPoly.CheckedIrreducible.irreducibleRat a.p) hroot
+  have hlc :
+      (HexPolyZMathlib.toPolyℚ a.p).leadingCoeff =
+        (a.p.leadingCoeff : Rat) := by
+    rw [HexPolyZMathlib.toPolyℚ,
+      Polynomial.leadingCoeff_map_of_injective
+        (RingHom.injective_int (Int.castRingHom Rat)),
+      HexPolyMathlib.leadingCoeff_toPolynomial]
+    rfl
+  rw [hlc] at hmin
+  simpa [Polynomial.smul_eq_C_mul, mul_comm] using hmin
 
 end AlgebraicNumber
 
@@ -138,20 +181,6 @@ theorem map_mul (a b : QAdjoin p x) (rep : RefinedIsolation p)
           (algebraMap Rat ℂ) rep.root
   rw [eval_reduceCoeffs, HexPolyMathlib.toPolynomial_mul,
     Polynomial.eval₂_mul]
-
-/-- Fixed-presentation inversion agrees with complex inversion, including the
-computational convention `0⁻¹ = 0`. -/
-theorem map_inv [ZPoly.CheckedIrreducible p] (a : QAdjoin p x)
-    (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) :
-    toComplex a⁻¹ rep h = (toComplex a rep h)⁻¹ := by
-  sorry
-
-/-- Evaluation at the selected root is injective for a checked irreducible
-presentation. -/
-theorem toComplex_injective [ZPoly.CheckedIrreducible p]
-    (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) :
-    Function.Injective (fun a : QAdjoin p x => toComplex a rep h) := by
-  sorry
 
 end QAdjoin
 

--- a/progress/20260728T094933Z.md
+++ b/progress/20260728T094933Z.md
@@ -14,23 +14,27 @@
 - Installed an opt-in field structure that retains the executable arithmetic
   and existing rational scalar action, and bundled the `AdjoinRoot` ring
   equivalence and complex ring embedding.
+- Moved natural and integer powers into the Mathlib-free executable layer and
+  added definitional regressions pinning the scoped field to every executable
+  operation and the existing rational scalar action.
 - Updated the NumberField manual to distinguish the completed fixed-field
   foundation from later semantic stages.
 - Built `HexNumberFieldMathlib.AdjoinRoot`, `HexNumberFieldMathlib`,
   `HexManual`, and the full repository successfully. The touched modules close
   six existing `sorry`s and add none.
+- Audited the headline declarations with `#print axioms`; each depends only on
+  `propext`, `Classical.choice`, and `Quot.sound`, with no `sorryAx`.
 
 ## Current frontier
 
-The coherent fixed-presentation milestone is undergoing its independent
-pre-merge review. Upstream `main` advanced during implementation and will be
-incorporated before publication.
+The coherent fixed-presentation milestone passed independent mathematical and
+source review, is rebased onto current `main`, and has completed post-review
+validation. It is ready for its single publication PR.
 
 ## Next step
 
-Validate the review findings, rebase onto current `main`, rerun the focused
-builds, then publish and merge this single milestone PR before starting the
-next NumberField semantic slice.
+Publish and merge this single milestone PR before starting the next NumberField
+semantic slice.
 
 ## Blockers
 

--- a/progress/20260728T094933Z.md
+++ b/progress/20260728T094933Z.md
@@ -1,0 +1,37 @@
+# NumberField fixed-presentation semantics
+
+## Accomplished
+
+- Proved that checked integer irreducibility transfers to `ℚ`, hence gives
+  separability, and identified each canonical algebraic number's normalized
+  defining polynomial with its rational minimal polynomial.
+- Proved the monic rational defining polynomial's degree and irreducibility,
+  constructed the inverse reduced-coordinate map, and established the
+  `QAdjoin`/`AdjoinRoot` bijection.
+- Proved selected-root evaluation injective without an inverse/field cycle.
+- Proved both defensive extended-GCD branches in executable inversion
+  unreachable, then proved inversion and division correspondence.
+- Installed an opt-in field structure that retains the executable arithmetic
+  and existing rational scalar action, and bundled the `AdjoinRoot` ring
+  equivalence and complex ring embedding.
+- Updated the NumberField manual to distinguish the completed fixed-field
+  foundation from later semantic stages.
+- Built `HexNumberFieldMathlib.AdjoinRoot`, `HexNumberFieldMathlib`,
+  `HexManual`, and the full repository successfully. The touched modules close
+  six existing `sorry`s and add none.
+
+## Current frontier
+
+The coherent fixed-presentation milestone is undergoing its independent
+pre-merge review. Upstream `main` advanced during implementation and will be
+incorporated before publication.
+
+## Next step
+
+Validate the review findings, rebase onto current `main`, rerun the focused
+builds, then publish and merge this single milestone PR before starting the
+next NumberField semantic slice.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Summary

- transfer checked integer irreducibility to rational irreducibility and separability, and identify normalized defining polynomials with minimal polynomials
- prove the reduced-coordinate presentation equivalent to the monic rational AdjoinRoot quotient with an injective complex embedding
- validate executable extended-GCD inversion and division, then provide an opt-in field structure preserving every computational operation and the existing rational scalar action
- keep natural and integer powers in the Mathlib-free layer and document the completed fixed-presentation foundation

## Validation

- lake build HexNumberFieldMathlib.AdjoinRoot HexNumberFieldMathlib HexManual
- lake build (9,559 jobs)
- headline declaration axiom audit: propext, Classical.choice, and Quot.sound only; no sorryAx
- independent source and mathematical review completed; review hardening applied