### PR TITLE
bench: validate isolate_roots Phase 4

### DIFF
--- a/HexRealRootsMathlib/SPEC/hex-real-roots-mathlib.md
+++ b/HexRealRootsMathlib/SPEC/hex-real-roots-mathlib.md
@@ -421,13 +421,18 @@ validation, and complete source provenance.
 `HexRealRootsMathlibReplayProbeScientific` owns the larger release arms and
 remains outside routine CI.
 
-On the named shared release machine the command is:
+On the named shared release machine a canonical invocation is:
 
 ```bash
 python3 scripts/bench/real_roots_mathlib_sweep.py --samples 6 \
   --timeout 180 --warm-timeout 600 \
   --shared-host --expected-host chungus2 --cpu 22
 ```
+
+The release run preregisters its selected logical CPU and aggregate
+interference ratio on the command line; the artifact and headline report record
+those exact values. They govern that run rather than the illustrative CPU
+number above.
 
 The runner enforces the designated-shared-host contract in
 `SPEC/benchmarking.md`, including bounded retries of complete rejected pairs

--- a/libraries.yml
+++ b/libraries.yml
@@ -546,7 +546,7 @@ libraries:
   HexRealRootsMathlib:
     deps: [HexRealRoots, HexPolyZMathlib]
     mathlib: true
-    done_through: 3
+    done_through: 4
     status: active
     proof_probes: [bench/HexRealRootsMathlib/ProofProbe]
   HexRCF:

--- a/progress/20260728T110304Z_realroots-phase4.md
+++ b/progress/20260728T110304Z_realroots-phase4.md
@@ -1,0 +1,40 @@
+# Accomplished
+
+- Stopped a clean but stale pre-merge sweep after detecting that the array
+  module-boundary fix had changed `HexBasic`, `HexPoly`, and `HexRealRoots`
+  files in the proof probes' import closure.
+- Re-ran all six preregistered rounds from clean current-main commit
+  `980aa6cb35ca38f804e308c05aca3e1c98d1c8b6` on designated shared host
+  `chungus2`, logical CPU 19, with a 0.005 aggregate core-interference ratio.
+- Produced and independently validated the schema-v4 release artifact:
+  54 accepted adjacent pairs / 108 arms, 29 rejected complete-pair attempts,
+  56 rejected preflight windows, no exhaustion or preflight failure, and
+  maximum admitted aggregate interference 0.00485231.
+- Added the five-section `HexRealRootsMathlib` performance report with all raw
+  samples, null controls, practical-limit interpretation, emitted-artifact and
+  axiom evidence, exact provenance, comparator/profile treatment, and no open
+  Concern.
+- Clarified that the SPEC's shared-host command is canonical while the
+  artifact's preregistered CPU and interference ratio govern an actual run.
+- Advanced only `HexRealRootsMathlib.done_through` from 3 to 4.
+- Passed the artifact validator, Phase-4, DAG, status, Mathlib-free bench,
+  copyright, trust-surface, file-line, and diff checks.
+- Built `HexRealRootsMathlib`, `HexRealRootsMathlibReplayProbe`, and
+  `HexRealRootsMathlibReplayProbeScientific` successfully; theorem probes
+  reported exactly `[propext, Classical.choice, Quot.sound]`.
+- Obtained two independent Sol GO reviews after correcting three report-only
+  omissions found by the first review.
+
+# Current frontier
+
+The RealRootsMathlib Phase-4 milestone is ready to commit and open as a PR.
+
+# Next step
+
+Commit and push the milestone, obtain a fresh Claude second opinion and green
+CI on the exact head, merge it, then rebase and complete the HexRCF Phase-4
+evidence/report milestone.
+
+# Blockers
+
+None.

--- a/reports/bench-results/hex-real-roots-mathlib-980aa6cb-chungus2.json
+++ b/reports/bench-results/hex-real-roots-mathlib-980aa6cb-chungus2.json
@@ -1,0 +1,26263 @@
+{
+  "config": {
+    "accounting_quantization_ticks": 3,
+    "allow_busy": false,
+    "allow_dirty": false,
+    "command_template": "lake build +<module>:olean",
+    "core_interference_accounting": "measurement-cpu-foreign-plus-all-SMT-sibling-busy",
+    "cpu_affinity": [
+      19
+    ],
+    "cpu_topology": {
+      "core_id": "49",
+      "logical_cpu": 19,
+      "physical_package_id": "0",
+      "scaling_cur_freq_khz": "4447033",
+      "scaling_governor": "schedutil",
+      "thread_siblings_list": "19,67"
+    },
+    "expected_host": "chungus2",
+    "frequency_measurement": "cpufreq-time-in-state-arm-mean",
+    "lean_num_threads": "1",
+    "max_core_interference_ratio": 0.005,
+    "max_frequency_spread_ratio": 0.15,
+    "max_load_per_cpu": 0.5,
+    "max_pair_retries": 8,
+    "measurement_cpu_foreign_accounting": "busy-minus-child-minus-runner-minus-irq-softirq",
+    "minimum_control_magnitude_ratio": 2.0,
+    "null_magnitude_factor": 3.0,
+    "order": [
+      "fresh-build-null",
+      "natural-10-null",
+      "natural-6",
+      "natural-8",
+      "natural-10",
+      "refined-2",
+      "refined-4",
+      "refined-6",
+      "refine-6"
+    ],
+    "pairing": "adjacent measured reference and candidate fresh modules; contamination retries the complete oriented pair",
+    "preflight_max_busy_ticks": 2,
+    "preflight_timeout_seconds": 300.0,
+    "preflight_window_seconds": 2.0,
+    "requested_cpu": 19,
+    "rotation": "pairs left by round index; pair orientation alternates",
+    "samples": 6,
+    "shared_host": true,
+    "timeout_seconds": 180.0,
+    "warm_command_template": "lake build +<module>:deps",
+    "warm_timeout_seconds": 600.0
+  },
+  "environment": {
+    "architecture": "x86_64",
+    "cpu_model": "AMD EPYC 9455 48-Core Processor",
+    "dependency_checkouts": {
+      "Cli": {
+        "dirty": false,
+        "head": "406ebb8c8e2f7e852a1b47764b42494022ce652c",
+        "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/Cli",
+        "state_sha256": "fb2685089426172e1b49f64e334d41075b6e97d0252efe3d1df5a75814dd691f",
+        "status": "",
+        "tree": "11e883f1e68348ff48d70ea6d9a1585003ab637a"
+      },
+      "LeanSearchClient": {
+        "dirty": false,
+        "head": "c5d5b8fe6e5158def25cd28eb94e4141ad97c843",
+        "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/LeanSearchClient",
+        "state_sha256": "8b9080c6fd5f0b3dac562f7a58b88dec467e78a184f04bfa705c093472d80169",
+        "status": "",
+        "tree": "d0224b6df6c90cc0b4ed2db6218037d31bfd6f52"
+      },
+      "MD4Lean": {
+        "dirty": false,
+        "head": "6a3fb240133bcb7e1a066fdc784b3fdc304e3fc5",
+        "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/MD4Lean",
+        "state_sha256": "56401822ddb0ee856118cc0d88e47de19c48802beed7c54e082f8a8dcf0563ff",
+        "status": "",
+        "tree": "5d02fb3fef67944b3dd4242b7fc16170d258a260"
+      },
+      "Qq": {
+        "dirty": false,
+        "head": "7a62bd13860cd39ac98da16ffc8c24d601353f69",
+        "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/Qq",
+        "state_sha256": "8e892eae3878af5d430b1bbcafc17664658d4a2502e353e53aec776a911a9122",
+        "status": "",
+        "tree": "31d436cbc8e28daf7c850d80738cab0e25a47e35"
+      },
+      "aesop": {
+        "dirty": false,
+        "head": "b5b9e2bb45ce91e4bc44eaa738c3a8910404ab82",
+        "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/aesop",
+        "state_sha256": "07d9db85cd9e004c7ff5e9bb0d500f10675cac6579c00984aa2a60764623db99",
+        "status": "",
+        "tree": "7ba23c52c2f9919b48c85b15f1ea36d916336d0a"
+      },
+      "batteries": {
+        "dirty": false,
+        "head": "77d3cc514f987c1f42f2bbd8a8d56855012dc115",
+        "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/batteries",
+        "state_sha256": "7e4fba14b402b73d6dbdbc8dc24f856c5d2a4aba1486b5dec093e599d72fb3f0",
+        "status": "",
+        "tree": "bbe05462df1fbe6974b8c22012f3d6d5d40f3d07"
+      },
+      "illuminate": {
+        "dirty": false,
+        "head": "ae95e7e7d01c072421732d0b84cf63ff903f4f0e",
+        "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/illuminate",
+        "state_sha256": "4e09f250a3dbb90216dd81eac9cd81fa63bcc452c035007feee4cdee17360d0f",
+        "status": "",
+        "tree": "2ef0cbaea821858d59680c9f8cbbe3d63ba031b0"
+      },
+      "importGraph": {
+        "dirty": false,
+        "head": "41f407a8e85b0fdc00910633a8f14754139b63f4",
+        "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/importGraph",
+        "state_sha256": "1e52ae39caffca1f19a5659523096b1c89c6472be660b3e95e202baee1b14657",
+        "status": "",
+        "tree": "7f8fb8b03b5681128ed3b0351290c9a44b79215d"
+      },
+      "lean-bench": {
+        "dirty": false,
+        "head": "fa30c2763cf523f3ac8e46dc3a1dad0845a40098",
+        "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/lean-bench",
+        "state_sha256": "689f9504c42512f18b20bb58391f1b3026e7a114591037ba1c2e4400db003ff9",
+        "status": "",
+        "tree": "5e2c6d004439e19a8fc005e136fea4beb9f28c5b"
+      },
+      "mathlib": {
+        "dirty": false,
+        "head": "aaedc74a09fbe1da58b11cf4d27806a6fa1a86eb",
+        "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/mathlib",
+        "state_sha256": "22581931070b9bea48e4d573b0d7eb193825a874c7c225e6b993e58750244e59",
+        "status": "",
+        "tree": "64f34bbc25b6bf7dd3a36524438065214d0518a4"
+      },
+      "plausible": {
+        "dirty": false,
+        "head": "f3c7bd5061bd81b4480295c524d4f245c8b7e4e2",
+        "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/plausible",
+        "state_sha256": "770da451657fb96675011f952038b40e5c49a0e967bb841f2617a924e920a5c3",
+        "status": "",
+        "tree": "751b1c6d14208cb74ccbd501d3015ef6c1ee7fc9"
+      },
+      "proofwidgets": {
+        "dirty": false,
+        "head": "e6518a674e62de322b8f79eebeda7bcae2a36bc3",
+        "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/proofwidgets",
+        "state_sha256": "16a41a3fef265fc102fd81c2e0f1dd00a3f02df5d86b0baa9004116935633a4a",
+        "status": "",
+        "tree": "af612c47c0ddeea7a0bbaee7d3fd69ddab46a903"
+      },
+      "subverso": {
+        "dirty": false,
+        "head": "0bd508e8362f56d4a05cbf63614d4c97db954041",
+        "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/subverso",
+        "state_sha256": "e41d0e99844c299108a75ab96d2e988105f3792abf3664870f3a4692101214ef",
+        "status": "",
+        "tree": "f85ca946cf9618c87d4cf25a77089968e8504c4f"
+      },
+      "verso": {
+        "dirty": false,
+        "head": "8cb04559a9b9feb8efab43e135f662514561f668",
+        "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/verso",
+        "state_sha256": "7cd0b36c7bd143024db6539906d00ac9431a2b9a668099cbdc204734701465ee",
+        "status": "",
+        "tree": "1e41fb0014e5125403fb09290628faecfc37ed70"
+      }
+    },
+    "git_commit": "980aa6cb35ca38f804e308c05aca3e1c98d1c8b6",
+    "git_dirty": false,
+    "gnu_time": "/run/current-system/sw/bin/time",
+    "host_after": {
+      "affinity_cpu_frequency_khz": "4450066",
+      "available_logical_cpus": 1,
+      "concurrent_lake_lean": [
+        {
+          "command": "/home/kim/.elan/toolchains/leanprover--lean4---v4.32.0-rc1/bin/lake build HexBasic.OfFn HexBerlekampZassenhaus.BhksRecover HexBerlekampZassenhaus.FactorEntryPoints HexNumberFieldMathlib.AdjoinRoot HexManual.Chapters.HexNumberField",
+          "pid": 572320
+        },
+        {
+          "command": "/home/kim/.elan/toolchains/leanprover--lean4---v4.32.0-rc1/bin/lake build HexNumberField.Basic",
+          "pid": 583250
+        },
+        {
+          "command": "/home/kim/.elan/toolchains/leanprover--lean4---v4.32.0-rc1/bin/lean /home/kim/worktrees/hex-dev/hex-dev-NumberField/HexBerlekampZassenhaus/ProductProofs.lean -o /home/kim/worktrees/hex-dev/hex-dev-NumberField/.lake/build/lib/lean/HexBerlekampZassenhaus/ProductProofs.olean -i /home/kim/worktrees/hex-dev/hex-dev-NumberField/.lake/build/lib/lean/HexBerlekampZassenhaus/ProductProofs.ilean -c /home/kim/worktrees/hex-dev/hex-dev-NumberField/.lake/build/ir/HexBerlekampZassenhaus/ProductProofs.c --setup /home/kim/worktrees/hex-dev/hex-dev-NumberField/.lake/build/ir/HexBerlekampZassenhaus/ProductProofs.setup.json --json",
+          "pid": 583899
+        },
+        {
+          "command": "/home/kim/.elan/toolchains/leanprover--lean4---v4.32.0-rc1/bin/lean /home/kim/worktrees/hex-dev/hex-dev-issue-9022/HexBerlekampZassenhausMathlib/SmartSearchCoverage.lean -o /home/kim/worktrees/hex-dev/hex-dev-issue-9022/.lake/build/lib/lean/HexBerlekampZassenhausMathlib/SmartSearchCoverage.olean -i /home/kim/worktrees/hex-dev/hex-dev-issue-9022/.lake/build/lib/lean/HexBerlekampZassenhausMathlib/SmartSearchCoverage.ilean -c /home/kim/worktrees/hex-dev/hex-dev-issue-9022/.lake/build/ir/HexBerlekampZassenhausMathlib/SmartSearchCoverage.c --setup /home/kim/worktrees/hex-dev/hex-dev-issue-9022/.lake/build/ir/HexBerlekampZassenhausMathlib/SmartSearchCoverage.setup.json --json",
+          "pid": 583915
+        },
+        {
+          "command": "/home/kim/.elan/toolchains/leanprover--lean4---v4.32.0-rc1/bin/lake serve -- /home/kim/worktrees/hex-dev/hex-dev-RCF",
+          "pid": 1706269
+        },
+        {
+          "command": "/home/kim/.elan/toolchains/leanprover--lean4---v4.32.0-rc1/bin/lean --server /home/kim/worktrees/hex-dev/hex-dev-RCF",
+          "pid": 1706450
+        },
+        {
+          "command": "/home/kim/.elan/toolchains/leanprover--lean4---v4.32.0-rc1/bin/lean --worker file:///home/kim/worktrees/hex-dev/hex-dev-RCF/HexRCF/SignMatrixTests.lean",
+          "pid": 1706478
+        },
+        {
+          "command": "/home/kim/.elan/toolchains/leanprover--lean4---v4.32.0-rc1/bin/lake serve -- /home/kim/worktrees/hex-dev/hex-dev-future-work",
+          "pid": 3262175
+        },
+        {
+          "command": "/home/kim/.elan/toolchains/leanprover--lean4---v4.32.0-rc1/bin/lean --server /home/kim/worktrees/hex-dev/hex-dev-future-work",
+          "pid": 3263069
+        },
+        {
+          "command": "/home/kim/.elan/toolchains/leanprover--lean4---v4.32.0-rc1/bin/lean --worker file:///home/kim/worktrees/hex-dev/hex-dev-future-work/HexBasic/OfFn.lean",
+          "pid": 3263116
+        }
+      ],
+      "cpu_affinity": [
+        19
+      ],
+      "cpu_pressure": "some avg10=4.20 avg60=4.92 avg300=7.14 total=7717428938\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+      "cpu_pressure_some_total_us": 7717428938,
+      "load_1m_per_available_cpu": 5.193359375,
+      "load_1m_per_cpu": 0.054097493489583336,
+      "load_average": [
+        5.193359375,
+        5.404296875,
+        6.046875
+      ],
+      "logical_cpus": 96,
+      "runnable_tasks": "5/3545"
+    },
+    "host_before": {
+      "affinity_cpu_frequency_khz": "4457937",
+      "available_logical_cpus": 1,
+      "concurrent_lake_lean": [
+        {
+          "command": "/home/kim/.elan/toolchains/leanprover--lean4---v4.32.0-rc1/bin/lake serve -- /home/kim/worktrees/hex-dev/hex-dev-RCF",
+          "pid": 1706269
+        },
+        {
+          "command": "/home/kim/.elan/toolchains/leanprover--lean4---v4.32.0-rc1/bin/lean --server /home/kim/worktrees/hex-dev/hex-dev-RCF",
+          "pid": 1706450
+        },
+        {
+          "command": "/home/kim/.elan/toolchains/leanprover--lean4---v4.32.0-rc1/bin/lean --worker file:///home/kim/worktrees/hex-dev/hex-dev-RCF/HexRCF/SignMatrixTests.lean",
+          "pid": 1706478
+        },
+        {
+          "command": "/home/kim/.elan/toolchains/leanprover--lean4---v4.32.0-rc1/bin/lake serve -- /home/kim/worktrees/hex-dev/hex-dev-future-work",
+          "pid": 3262175
+        },
+        {
+          "command": "/home/kim/.elan/toolchains/leanprover--lean4---v4.32.0-rc1/bin/lean --server /home/kim/worktrees/hex-dev/hex-dev-future-work",
+          "pid": 3263069
+        },
+        {
+          "command": "/home/kim/.elan/toolchains/leanprover--lean4---v4.32.0-rc1/bin/lean --worker file:///home/kim/worktrees/hex-dev/hex-dev-future-work/HexBasic/OfFn.lean",
+          "pid": 3263116
+        }
+      ],
+      "cpu_affinity": [
+        19
+      ],
+      "cpu_pressure": "some avg10=1.26 avg60=4.40 avg300=5.13 total=7538308857\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+      "cpu_pressure_some_total_us": 7538308857,
+      "load_1m_per_available_cpu": 3.72216796875,
+      "load_1m_per_cpu": 0.0387725830078125,
+      "load_average": [
+        3.72216796875,
+        9.41455078125,
+        12.646484375
+      ],
+      "logical_cpus": 96,
+      "runnable_tasks": "1/3503"
+    },
+    "hostname": "chungus2",
+    "machine_id": "8be29815875342aeaae06e62d60f6b03",
+    "platform": "Linux-6.12.95-x86_64-with-glibc2.42",
+    "python": "3.13.13",
+    "repository": {
+      "dirty": false,
+      "head": "980aa6cb35ca38f804e308c05aca3e1c98d1c8b6",
+      "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2",
+      "state_sha256": "588ab971c00b5937815878498fd50d0a388cd0a4d238145f1ee355bb17759f73",
+      "status": "",
+      "tree": "544c1f111ae30d11b35769b66d652f469aaf6f9d"
+    },
+    "toolchain": "leanprover/lean4:v4.32.0-rc1"
+  },
+  "exhausted_pairs": [],
+  "measurement": "paired-fresh-module-olean-wall-v1",
+  "measurement_state": "complete",
+  "partial_samples": null,
+  "preflight_failures": [],
+  "rejected_pair_attempts": [
+    {
+      "attempt": 1,
+      "build_order": [
+        "reference",
+        "candidate"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.02592000000000409,
+          "child_cpu_seconds": 13.943026999999995,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 1401
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.005920000000004089,
+          "measurement_cpu_interrupt_seconds": 0.07,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.005920000000004089,
+          "measurement_cpu_residual_seconds": 0.0759200000000041,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 14.02,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 5,
+                "nice": 0,
+                "softirq": 2,
+                "steal": 0,
+                "system": 100,
+                "user": 1295
+              }
+            },
+            "67": {
+              "busy_seconds": 0.02,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 1398,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 2
+              }
+            }
+          },
+          "pressure_some_delta_us": 1403342,
+          "runner_cpu_seconds": 0.0010530000000000816
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4451618",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=8.37 avg60=10.09 avg300=7.21 total=7554289973\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7554289973,
+          "load_1m_per_available_cpu": 3.4091796875,
+          "load_1m_per_cpu": 0.035512288411458336,
+          "load_average": [
+            3.4091796875,
+            7.6064453125,
+            11.5283203125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3560"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4450200",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=15.87 avg60=10.43 avg300=7.10 total=7552886631\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7552886631,
+          "load_1m_per_available_cpu": 3.99267578125,
+          "load_1m_per_cpu": 0.041590372721354164,
+          "load_average": [
+            3.99267578125,
+            7.9296875,
+            11.6953125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3524"
+        },
+        "involuntary_context_switches": 21972,
+        "peak_rss_kb": 3954608,
+        "precise_child_system_seconds": 1.0038140000000002,
+        "precise_child_user_seconds": 12.939212999999995,
+        "system_seconds": 1.0,
+        "user_seconds": 12.93,
+        "voluntary_context_switches": 36722,
+        "wall_nanos": 14010027785
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "4286208",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 6,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=10.54 avg60=9.21 avg300=6.79 total=7551539686\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7551539686,
+        "load_1m_per_available_cpu": 4.25341796875,
+        "load_1m_per_cpu": 0.044306437174479164,
+        "load_average": [
+          4.25341796875,
+          8.046875,
+          11.75341796875
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "7/3561"
+      },
+      "issues": [
+        "natural-10 round 1 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.037s exceeds 0.030s"
+      ],
+      "measurement_attempt": 1,
+      "pair": "natural-10",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            },
+            "67": {
+              "busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 2.0009671861771494,
+        "rejected_windows": []
+      },
+      "reference": {
+        "axioms": null,
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.03654800000000672,
+          "child_cpu_seconds": 5.4324269999999935,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 546
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.006548000000006724,
+          "measurement_cpu_interrupt_seconds": 0.01,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.006548000000006724,
+          "measurement_cpu_residual_seconds": 0.016548000000006724,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 5.45,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 1,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 92,
+                "user": 452
+              }
+            },
+            "67": {
+              "busy_seconds": 0.03,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 543,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 2
+              }
+            }
+          },
+          "pressure_some_delta_us": 1346614,
+          "runner_cpu_seconds": 0.0010249999999999981
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4452661",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=15.87 avg60=10.43 avg300=7.10 total=7552886402\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7552886402,
+          "load_1m_per_available_cpu": 3.99267578125,
+          "load_1m_per_cpu": 0.041590372721354164,
+          "load_average": [
+            3.99267578125,
+            7.9296875,
+            11.6953125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3524"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4451264",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=10.54 avg60=9.21 avg300=6.79 total=7551539788\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7551539788,
+          "load_1m_per_available_cpu": 4.25341796875,
+          "load_1m_per_cpu": 0.044306437174479164,
+          "load_average": [
+            4.25341796875,
+            8.046875,
+            11.75341796875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "2/3561"
+        },
+        "involuntary_context_switches": 21078,
+        "peak_rss_kb": 3079400,
+        "precise_child_system_seconds": 0.9186510000000006,
+        "precise_child_user_seconds": 4.513775999999993,
+        "system_seconds": 0.91,
+        "user_seconds": 4.51,
+        "voluntary_context_switches": 35844,
+        "wall_nanos": 5460180643
+      },
+      "round": 1,
+      "signed_wall_delta_nanos": 8549847142,
+      "slot_index": 4
+    },
+    {
+      "attempt": 2,
+      "build_order": [
+        "reference",
+        "candidate"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.008250000000006572,
+          "child_cpu_seconds": 13.810667999999993,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 1388
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.008250000000006572,
+          "measurement_cpu_interrupt_seconds": 0.05,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.008250000000006572,
+          "measurement_cpu_residual_seconds": 0.058250000000006574,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 13.87,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 4,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 102,
+                "user": 1280
+              }
+            },
+            "67": {
+              "busy_seconds": 0.0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 1388,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "pressure_some_delta_us": 1410960,
+          "runner_cpu_seconds": 0.0010820000000000274
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4452128",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=7.00 avg60=9.36 avg300=7.31 total=7556969278\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7556969278,
+          "load_1m_per_available_cpu": 2.91259765625,
+          "load_1m_per_cpu": 0.030339558919270832,
+          "load_average": [
+            2.91259765625,
+            7.0849609375,
+            11.22900390625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "3/3536"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4454896",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=10.05 avg60=9.39 avg300=7.19 total=7555558318\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7555558318,
+          "load_1m_per_available_cpu": 3.1884765625,
+          "load_1m_per_cpu": 0.033213297526041664,
+          "load_average": [
+            3.1884765625,
+            7.34814453125,
+            11.38037109375
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3522"
+        },
+        "involuntary_context_switches": 23171,
+        "peak_rss_kb": 3890208,
+        "precise_child_system_seconds": 1.0205720000000014,
+        "precise_child_user_seconds": 12.790095999999991,
+        "system_seconds": 1.02,
+        "user_seconds": 12.78,
+        "voluntary_context_switches": 38020,
+        "wall_nanos": 13874534428
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "3082929",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 6,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=2.65 avg60=8.32 avg300=6.93 total=7554295056\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7554295056,
+        "load_1m_per_available_cpu": 3.205078125,
+        "load_1m_per_cpu": 0.03338623046875,
+        "load_average": [
+          3.205078125,
+          7.421875,
+          11.42578125
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "2/3524"
+      },
+      "issues": [
+        "natural-10 round 1 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.034s exceeds 0.030s"
+      ],
+      "measurement_attempt": 2,
+      "pair": "natural-10",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            },
+            "67": {
+              "busy_ticks": 1,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 198,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 1
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 12.007347926031798,
+        "rejected_windows": [
+          {
+            "issues": [
+              "SMT sibling CPU 67 had 3 busy ticks"
+            ],
+            "max_busy_ticks": 2,
+            "per_cpu": {
+              "19": {
+                "noninterrupt_busy_ticks": 1,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 198,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 1
+                }
+              },
+              "67": {
+                "busy_ticks": 3,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 196,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 3
+                }
+              }
+            },
+            "window_seconds": 2.0
+          },
+          {
+            "issues": [
+              "measurement CPU 19 had 5 non-interrupt busy ticks",
+              "SMT sibling CPU 67 had 3 busy ticks"
+            ],
+            "max_busy_ticks": 2,
+            "per_cpu": {
+              "19": {
+                "noninterrupt_busy_ticks": 5,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 194,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 1,
+                  "user": 4
+                }
+              },
+              "67": {
+                "busy_ticks": 3,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 198,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 3
+                }
+              }
+            },
+            "window_seconds": 2.0
+          },
+          {
+            "issues": [
+              "measurement CPU 19 had 6 non-interrupt busy ticks",
+              "SMT sibling CPU 67 had 4 busy ticks"
+            ],
+            "max_busy_ticks": 2,
+            "per_cpu": {
+              "19": {
+                "noninterrupt_busy_ticks": 6,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 194,
+                  "iowait": 0,
+                  "irq": 1,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 6
+                }
+              },
+              "67": {
+                "busy_ticks": 4,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 196,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 4
+                }
+              }
+            },
+            "window_seconds": 2.0
+          },
+          {
+            "issues": [
+              "measurement CPU 19 had 5 non-interrupt busy ticks",
+              "SMT sibling CPU 67 had 4 busy ticks"
+            ],
+            "max_busy_ticks": 2,
+            "per_cpu": {
+              "19": {
+                "noninterrupt_busy_ticks": 5,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 195,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 1,
+                  "user": 4
+                }
+              },
+              "67": {
+                "busy_ticks": 4,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 197,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 1,
+                  "steal": 0,
+                  "system": 2,
+                  "user": 1
+                }
+              }
+            },
+            "window_seconds": 2.0
+          },
+          {
+            "issues": [
+              "measurement CPU 19 had 4 non-interrupt busy ticks",
+              "SMT sibling CPU 67 had 5 busy ticks"
+            ],
+            "max_busy_ticks": 2,
+            "per_cpu": {
+              "19": {
+                "noninterrupt_busy_ticks": 4,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 198,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 2,
+                  "user": 2
+                }
+              },
+              "67": {
+                "busy_ticks": 5,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 197,
+                  "iowait": 0,
+                  "irq": 1,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 1,
+                  "user": 3
+                }
+              }
+            },
+            "window_seconds": 2.0
+          }
+        ]
+      },
+      "reference": {
+        "axioms": null,
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.03421299999999122,
+          "child_cpu_seconds": 5.384746000000009,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 541
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.004212999999991224,
+          "measurement_cpu_interrupt_seconds": 0.03,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.004212999999991224,
+          "measurement_cpu_residual_seconds": 0.03421299999999122,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 5.42,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 91,
+                "user": 448
+              }
+            },
+            "67": {
+              "busy_seconds": 0.03,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 538,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 3,
+                "user": 0
+              }
+            }
+          },
+          "pressure_some_delta_us": 1262727,
+          "runner_cpu_seconds": 0.0010410000000000141
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4453103",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=10.05 avg60=9.39 avg300=7.19 total=7555558042\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7555558042,
+          "load_1m_per_available_cpu": 3.1884765625,
+          "load_1m_per_cpu": 0.033213297526041664,
+          "load_average": [
+            3.1884765625,
+            7.34814453125,
+            11.38037109375
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3522"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4300050",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=2.65 avg60=8.32 avg300=6.93 total=7554295315\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7554295315,
+          "load_1m_per_available_cpu": 3.205078125,
+          "load_1m_per_cpu": 0.03338623046875,
+          "load_average": [
+            3.205078125,
+            7.421875,
+            11.42578125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "5/3524"
+        },
+        "involuntary_context_switches": 20803,
+        "peak_rss_kb": 3081532,
+        "precise_child_system_seconds": 0.9103590000000015,
+        "precise_child_user_seconds": 4.474387000000007,
+        "system_seconds": 0.91,
+        "user_seconds": 4.47,
+        "voluntary_context_switches": 35580,
+        "wall_nanos": 5412492614
+      },
+      "round": 1,
+      "signed_wall_delta_nanos": 8462041814,
+      "slot_index": 4
+    },
+    {
+      "attempt": 1,
+      "build_order": [
+        "reference",
+        "candidate"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.01655299999999995,
+          "child_cpu_seconds": 6.562396,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 659
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.006552999999999948,
+          "measurement_cpu_interrupt_seconds": 0.03,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.006552999999999948,
+          "measurement_cpu_residual_seconds": 0.03655299999999995,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 6.6,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 92,
+                "user": 565
+              }
+            },
+            "67": {
+              "busy_seconds": 0.01,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 659,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 1
+              }
+            }
+          },
+          "pressure_some_delta_us": 757672,
+          "runner_cpu_seconds": 0.0010510000000000241
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4452113",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 9,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=10.49 avg60=9.42 avg300=7.81 total=7563691344\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7563691344,
+          "load_1m_per_available_cpu": 2.673828125,
+          "load_1m_per_cpu": 0.027852376302083332,
+          "load_average": [
+            2.673828125,
+            6.2431640625,
+            10.65869140625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3550"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4449693",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 8,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=10.07 avg60=9.19 avg300=7.73 total=7562933672\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7562933672,
+          "load_1m_per_available_cpu": 2.73291015625,
+          "load_1m_per_cpu": 0.028467814127604168,
+          "load_average": [
+            2.73291015625,
+            6.31494140625,
+            10.70556640625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "3/3541"
+        },
+        "involuntary_context_switches": 22393,
+        "peak_rss_kb": 3240548,
+        "precise_child_system_seconds": 0.9189459999999983,
+        "precise_child_user_seconds": 5.643450000000001,
+        "system_seconds": 0.91,
+        "user_seconds": 5.64,
+        "voluntary_context_switches": 37440,
+        "wall_nanos": 6597253280
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "1691613",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 6,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=2.21 avg60=8.15 avg300=7.50 total=7561734931\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7561734931,
+        "load_1m_per_available_cpu": 2.88427734375,
+        "load_1m_per_cpu": 0.0300445556640625,
+        "load_average": [
+          2.88427734375,
+          6.40478515625,
+          10.75830078125
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "3/3531"
+      },
+      "issues": [
+        "refined-4 round 1 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.035s exceeds 0.030s"
+      ],
+      "measurement_attempt": 1,
+      "pair": "refined-4",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            },
+            "67": {
+              "busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 16.007267453009263,
+        "rejected_windows": [
+          {
+            "issues": [
+              "measurement CPU 19 had 5 non-interrupt busy ticks",
+              "SMT sibling CPU 67 had 3 busy ticks"
+            ],
+            "max_busy_ticks": 2,
+            "per_cpu": {
+              "19": {
+                "noninterrupt_busy_ticks": 5,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 196,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 5
+                }
+              },
+              "67": {
+                "busy_ticks": 3,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 198,
+                  "iowait": 0,
+                  "irq": 1,
+                  "nice": 0,
+                  "softirq": 1,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 1
+                }
+              }
+            },
+            "window_seconds": 2.0
+          },
+          {
+            "issues": [
+              "SMT sibling CPU 67 had 7 busy ticks"
+            ],
+            "max_busy_ticks": 2,
+            "per_cpu": {
+              "19": {
+                "noninterrupt_busy_ticks": 2,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 197,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 1,
+                  "user": 1
+                }
+              },
+              "67": {
+                "busy_ticks": 7,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 192,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 7
+                }
+              }
+            },
+            "window_seconds": 2.0
+          },
+          {
+            "issues": [
+              "SMT sibling CPU 67 had 3 busy ticks"
+            ],
+            "max_busy_ticks": 2,
+            "per_cpu": {
+              "19": {
+                "noninterrupt_busy_ticks": 1,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 200,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 1
+                }
+              },
+              "67": {
+                "busy_ticks": 3,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 197,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 3
+                }
+              }
+            },
+            "window_seconds": 2.0
+          },
+          {
+            "issues": [
+              "measurement CPU 19 had 5 non-interrupt busy ticks",
+              "SMT sibling CPU 67 had 5 busy ticks"
+            ],
+            "max_busy_ticks": 2,
+            "per_cpu": {
+              "19": {
+                "noninterrupt_busy_ticks": 5,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 193,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 5
+                }
+              },
+              "67": {
+                "busy_ticks": 5,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 195,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 1,
+                  "user": 4
+                }
+              }
+            },
+            "window_seconds": 2.0
+          },
+          {
+            "issues": [
+              "measurement CPU 19 had 4 non-interrupt busy ticks",
+              "SMT sibling CPU 67 had 6 busy ticks"
+            ],
+            "max_busy_ticks": 2,
+            "per_cpu": {
+              "19": {
+                "noninterrupt_busy_ticks": 4,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 196,
+                  "iowait": 0,
+                  "irq": 1,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 1,
+                  "user": 3
+                }
+              },
+              "67": {
+                "busy_ticks": 6,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 195,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 1,
+                  "user": 5
+                }
+              }
+            },
+            "window_seconds": 2.0
+          },
+          {
+            "issues": [
+              "measurement CPU 19 had 6 non-interrupt busy ticks",
+              "SMT sibling CPU 67 had 3 busy ticks"
+            ],
+            "max_busy_ticks": 2,
+            "per_cpu": {
+              "19": {
+                "noninterrupt_busy_ticks": 6,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 197,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 1,
+                  "steal": 0,
+                  "system": 3,
+                  "user": 3
+                }
+              },
+              "67": {
+                "busy_ticks": 3,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 194,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 3
+                }
+              }
+            },
+            "window_seconds": 2.0
+          },
+          {
+            "issues": [
+              "SMT sibling CPU 67 had 5 busy ticks"
+            ],
+            "max_busy_ticks": 2,
+            "per_cpu": {
+              "19": {
+                "noninterrupt_busy_ticks": 1,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 199,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 1
+                }
+              },
+              "67": {
+                "busy_ticks": 5,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 196,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 5
+                }
+              }
+            },
+            "window_seconds": 2.0
+          }
+        ]
+      },
+      "reference": {
+        "axioms": null,
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.03525999999998262,
+          "child_cpu_seconds": 5.383699000000018,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 541
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.005259999999982621,
+          "measurement_cpu_interrupt_seconds": 0.01,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.005259999999982621,
+          "measurement_cpu_residual_seconds": 0.01525999999998262,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 5.4,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 1,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 93,
+                "user": 446
+              }
+            },
+            "67": {
+              "busy_seconds": 0.03,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 538,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 3,
+                "user": 0
+              }
+            }
+          },
+          "pressure_some_delta_us": 1198339,
+          "runner_cpu_seconds": 0.0010409999999999586
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4452491",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 8,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=10.07 avg60=9.19 avg300=7.73 total=7562933548\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7562933548,
+          "load_1m_per_available_cpu": 2.73291015625,
+          "load_1m_per_cpu": 0.028467814127604168,
+          "load_average": [
+            2.73291015625,
+            6.31494140625,
+            10.70556640625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "4/3541"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4180463",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=2.21 avg60=8.15 avg300=7.50 total=7561735209\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7561735209,
+          "load_1m_per_available_cpu": 2.88427734375,
+          "load_1m_per_cpu": 0.0300445556640625,
+          "load_average": [
+            2.88427734375,
+            6.40478515625,
+            10.75830078125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "2/3531"
+        },
+        "involuntary_context_switches": 21052,
+        "peak_rss_kb": 3081328,
+        "precise_child_system_seconds": 0.9204389999999982,
+        "precise_child_user_seconds": 4.4632600000000195,
+        "system_seconds": 0.92,
+        "user_seconds": 4.46,
+        "voluntary_context_switches": 35972,
+        "wall_nanos": 5409936228
+      },
+      "round": 1,
+      "signed_wall_delta_nanos": 1187317052,
+      "slot_index": 6
+    },
+    {
+      "attempt": 2,
+      "build_order": [
+        "reference",
+        "candidate"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.1295129999999838,
+          "child_cpu_seconds": 6.549379000000016,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 658
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.009512999999983812,
+          "measurement_cpu_interrupt_seconds": 0.03,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.009512999999983812,
+          "measurement_cpu_residual_seconds": 0.03951299999998381,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 6.59,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 94,
+                "user": 562
+              }
+            },
+            "67": {
+              "busy_seconds": 0.12,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 645,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 12,
+                "user": 0
+              }
+            }
+          },
+          "pressure_some_delta_us": 1021951,
+          "runner_cpu_seconds": 0.0011079999999999979
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4452385",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=13.61 avg60=10.25 avg300=8.07 total=7565642814\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7565642814,
+          "load_1m_per_available_cpu": 9.29541015625,
+          "load_1m_per_cpu": 0.09682718912760417,
+          "load_average": [
+            9.29541015625,
+            7.53662109375,
+            11.01123046875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "4/3536"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4333301",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 9,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=11.65 avg60=9.68 avg300=7.91 total=7564620863\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7564620863,
+          "load_1m_per_available_cpu": 10.017578125,
+          "load_1m_per_cpu": 0.10434977213541667,
+          "load_average": [
+            10.017578125,
+            7.6474609375,
+            11.0654296875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "99/3643"
+        },
+        "involuntary_context_switches": 22454,
+        "peak_rss_kb": 3246920,
+        "precise_child_system_seconds": 0.9336619999999982,
+        "precise_child_user_seconds": 5.615717000000018,
+        "system_seconds": 0.93,
+        "user_seconds": 5.61,
+        "voluntary_context_switches": 37364,
+        "wall_nanos": 6584116512
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "4456994",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 9,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=8.95 avg60=9.17 avg300=7.77 total=7563694001\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7563694001,
+        "load_1m_per_available_cpu": 2.673828125,
+        "load_1m_per_cpu": 0.027852376302083332,
+        "load_average": [
+          2.673828125,
+          6.2431640625,
+          10.65869140625
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "1/3550"
+      },
+      "issues": [
+        "refined-4 round 1 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.370s exceeds 0.030s",
+        "refined-4 round 1 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.130s exceeds 0.033s"
+      ],
+      "measurement_attempt": 2,
+      "pair": "refined-4",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 1,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 1
+              }
+            },
+            "67": {
+              "busy_ticks": 2,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 1,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 1
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 2.0006845730822533,
+        "rejected_windows": []
+      },
+      "reference": {
+        "axioms": null,
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.37,
+          "child_cpu_seconds": 5.514729000000003,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 554
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.0,
+          "measurement_cpu_interrupt_seconds": 0.02,
+          "measurement_cpu_noninterrupt_residual_seconds": -0.005979000000002382,
+          "measurement_cpu_residual_seconds": 0.014020999999997619,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 5.53,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 95,
+                "user": 456
+              }
+            },
+            "67": {
+              "busy_seconds": 0.37,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 513,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 33,
+                "user": 4
+              }
+            }
+          },
+          "pressure_some_delta_us": 924635,
+          "runner_cpu_seconds": 0.0012499999999999734
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4345715",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 9,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=11.65 avg60=9.68 avg300=7.91 total=7564618814\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7564618814,
+          "load_1m_per_available_cpu": 10.017578125,
+          "load_1m_per_cpu": 0.10434977213541667,
+          "load_average": [
+            10.017578125,
+            7.6474609375,
+            11.0654296875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "98/3643"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4451677",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 9,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=8.95 avg60=9.17 avg300=7.77 total=7563694179\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7563694179,
+          "load_1m_per_available_cpu": 2.673828125,
+          "load_1m_per_cpu": 0.027852376302083332,
+          "load_average": [
+            2.673828125,
+            6.2431640625,
+            10.65869140625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3550"
+        },
+        "involuntary_context_switches": 20812,
+        "peak_rss_kb": 3081536,
+        "precise_child_system_seconds": 0.9514530000000008,
+        "precise_child_user_seconds": 4.563276000000002,
+        "system_seconds": 0.95,
+        "user_seconds": 4.56,
+        "voluntary_context_switches": 35572,
+        "wall_nanos": 5541730405
+      },
+      "round": 1,
+      "signed_wall_delta_nanos": 1042386107,
+      "slot_index": 6
+    },
+    {
+      "attempt": 3,
+      "build_order": [
+        "reference",
+        "candidate"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.036134999999982376,
+          "child_cpu_seconds": 6.522827000000017,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 656
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.006134999999982377,
+          "measurement_cpu_interrupt_seconds": 0.03,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.006134999999982377,
+          "measurement_cpu_residual_seconds": 0.036134999999982376,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 6.56,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 93,
+                "user": 560
+              }
+            },
+            "67": {
+              "busy_seconds": 0.03,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 652,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 3,
+                "user": 0
+              }
+            }
+          },
+          "pressure_some_delta_us": 909084,
+          "runner_cpu_seconds": 0.0010379999999999834
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4451824",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=14.05 avg60=10.95 avg300=8.32 total=7567580962\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7567580962,
+          "load_1m_per_available_cpu": 8.94189453125,
+          "load_1m_per_cpu": 0.09314473470052083,
+          "load_average": [
+            8.94189453125,
+            7.52978515625,
+            10.9521484375
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3571"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4449648",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 9,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=14.01 avg60=10.62 avg300=8.20 total=7566671878\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7566671878,
+          "load_1m_per_available_cpu": 8.791015625,
+          "load_1m_per_cpu": 0.09157307942708333,
+          "load_average": [
+            8.791015625,
+            7.4609375,
+            10.9677734375
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "8/3559"
+        },
+        "involuntary_context_switches": 22232,
+        "peak_rss_kb": 3230324,
+        "precise_child_system_seconds": 0.9279010000000021,
+        "precise_child_user_seconds": 5.594926000000015,
+        "system_seconds": 0.92,
+        "user_seconds": 5.59,
+        "voluntary_context_switches": 37129,
+        "wall_nanos": 6553556241
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "4192518",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 6,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=11.69 avg60=10.01 avg300=8.03 total=7565644443\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7565644443,
+        "load_1m_per_available_cpu": 9.29541015625,
+        "load_1m_per_cpu": 0.09682718912760417,
+        "load_average": [
+          9.29541015625,
+          7.53662109375,
+          11.01123046875
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "4/3536"
+      },
+      "issues": [
+        "refined-4 round 1 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.036s exceeds 0.033s"
+      ],
+      "measurement_attempt": 3,
+      "pair": "refined-4",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            },
+            "67": {
+              "busy_ticks": 1,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 1
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 2.0008691961411387,
+        "rejected_windows": []
+      },
+      "reference": {
+        "axioms": null,
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.012817999999986247,
+          "child_cpu_seconds": 5.336160000000014,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 536
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.012817999999986247,
+          "measurement_cpu_interrupt_seconds": 0.02,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.012817999999986247,
+          "measurement_cpu_residual_seconds": 0.03281799999998625,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 5.37,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 94,
+                "user": 441
+              }
+            },
+            "67": {
+              "busy_seconds": 0.0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 537,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "pressure_some_delta_us": 1027231,
+          "runner_cpu_seconds": 0.0010220000000000784
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4451844",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 9,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=14.01 avg60=10.62 avg300=8.20 total=7566671796\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7566671796,
+          "load_1m_per_available_cpu": 8.791015625,
+          "load_1m_per_cpu": 0.09157307942708333,
+          "load_average": [
+            8.791015625,
+            7.4609375,
+            10.9677734375
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "7/3559"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4449446",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=9.57 avg60=9.68 avg300=7.98 total=7565644565\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7565644565,
+          "load_1m_per_available_cpu": 9.29541015625,
+          "load_1m_per_cpu": 0.09682718912760417,
+          "load_average": [
+            9.29541015625,
+            7.53662109375,
+            11.01123046875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "4/3536"
+        },
+        "involuntary_context_switches": 21360,
+        "peak_rss_kb": 3079464,
+        "precise_child_system_seconds": 0.9322900000000018,
+        "precise_child_user_seconds": 4.403870000000012,
+        "system_seconds": 0.93,
+        "user_seconds": 4.4,
+        "voluntary_context_switches": 36237,
+        "wall_nanos": 5362941890
+      },
+      "round": 1,
+      "signed_wall_delta_nanos": 1190614351,
+      "slot_index": 6
+    },
+    {
+      "attempt": 1,
+      "build_order": [
+        "reference",
+        "candidate"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.06,
+          "child_cpu_seconds": 8.01099000000001,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 805
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.0,
+          "measurement_cpu_interrupt_seconds": 0.03,
+          "measurement_cpu_noninterrupt_residual_seconds": -0.002041000000011145,
+          "measurement_cpu_residual_seconds": 0.027958999999988854,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 8.04,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 94,
+                "user": 707
+              }
+            },
+            "67": {
+              "busy_seconds": 0.06,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 800,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 2,
+                "user": 3
+              }
+            }
+          },
+          "pressure_some_delta_us": 1409562,
+          "runner_cpu_seconds": 0.0010510000000000241
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4450121",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=16.08 avg60=12.88 avg300=9.04 total=7572436397\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7572436397,
+          "load_1m_per_available_cpu": 6.03662109375,
+          "load_1m_per_cpu": 0.0628814697265625,
+          "load_average": [
+            6.03662109375,
+            6.96630859375,
+            10.65576171875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3527"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4449948",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=17.16 avg60=12.33 avg300=8.82 total=7571026835\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7571026835,
+          "load_1m_per_available_cpu": 6.9521484375,
+          "load_1m_per_cpu": 0.072418212890625,
+          "load_average": [
+            6.9521484375,
+            7.169921875,
+            10.7607421875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "6/3528"
+        },
+        "involuntary_context_switches": 22965,
+        "peak_rss_kb": 3333976,
+        "precise_child_system_seconds": 0.9422120000000014,
+        "precise_child_user_seconds": 7.068778000000009,
+        "system_seconds": 0.94,
+        "user_seconds": 7.06,
+        "voluntary_context_switches": 37920,
+        "wall_nanos": 8050123063
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "4456502",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 6,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=9.85 avg60=10.89 avg300=8.48 total=7569609001\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7569609001,
+        "load_1m_per_available_cpu": 7.470703125,
+        "load_1m_per_cpu": 0.07781982421875,
+        "load_average": [
+          7.470703125,
+          7.2744140625,
+          10.8134765625
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "1/3531"
+      },
+      "issues": [
+        "refined-6 round 1 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.060s exceeds 0.040s"
+      ],
+      "measurement_attempt": 1,
+      "pair": "refined-6",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 2,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 1
+              }
+            },
+            "67": {
+              "busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 2.0008039788808674,
+        "rejected_windows": []
+      },
+      "reference": {
+        "axioms": null,
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.010538999999983995,
+          "child_cpu_seconds": 5.438400000000016,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 547
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.010538999999983995,
+          "measurement_cpu_interrupt_seconds": 0.02,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.010538999999983995,
+          "measurement_cpu_residual_seconds": 0.030538999999983996,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 5.47,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 1,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 93,
+                "user": 452
+              }
+            },
+            "67": {
+              "busy_seconds": 0.0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 546,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "pressure_some_delta_us": 1417435,
+          "runner_cpu_seconds": 0.0010610000000000896
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4452721",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=17.16 avg60=12.33 avg300=8.82 total=7571026577\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7571026577,
+          "load_1m_per_available_cpu": 6.9521484375,
+          "load_1m_per_cpu": 0.072418212890625,
+          "load_average": [
+            6.9521484375,
+            7.169921875,
+            10.7607421875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3528"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4451514",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=9.85 avg60=10.89 avg300=8.48 total=7569609142\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7569609142,
+          "load_1m_per_available_cpu": 7.470703125,
+          "load_1m_per_cpu": 0.07781982421875,
+          "load_average": [
+            7.470703125,
+            7.2744140625,
+            10.8134765625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3531"
+        },
+        "involuntary_context_switches": 20745,
+        "peak_rss_kb": 3077300,
+        "precise_child_system_seconds": 0.9215209999999985,
+        "precise_child_user_seconds": 4.516879000000017,
+        "system_seconds": 0.92,
+        "user_seconds": 4.51,
+        "voluntary_context_switches": 35598,
+        "wall_nanos": 5466354635
+      },
+      "round": 1,
+      "signed_wall_delta_nanos": 2583768428,
+      "slot_index": 7
+    },
+    {
+      "attempt": 2,
+      "build_order": [
+        "reference",
+        "candidate"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.08743499999997914,
+          "child_cpu_seconds": 7.99151400000002,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 804
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.017434999999979134,
+          "measurement_cpu_interrupt_seconds": 0.03,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.017434999999979134,
+          "measurement_cpu_residual_seconds": 0.04743499999997913,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 8.04,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 3,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 93,
+                "user": 708
+              }
+            },
+            "67": {
+              "busy_seconds": 0.07,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 794,
+                "iowait": 0,
+                "irq": 1,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 2,
+                "user": 4
+              }
+            }
+          },
+          "pressure_some_delta_us": 1406146,
+          "runner_cpu_seconds": 0.0010510000000000241
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4452007",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=16.00 avg60=13.85 avg300=9.47 total=7575258821\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7575258821,
+          "load_1m_per_available_cpu": 5.20263671875,
+          "load_1m_per_cpu": 0.054194132486979164,
+          "load_average": [
+            5.20263671875,
+            6.73828125,
+            10.521484375
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "2/3536"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4450955",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=17.85 avg60=13.50 avg300=9.27 total=7573852675\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7573852675,
+          "load_1m_per_available_cpu": 5.79296875,
+          "load_1m_per_cpu": 0.060343424479166664,
+          "load_average": [
+            5.79296875,
+            6.900390625,
+            10.6142578125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "2/3528"
+        },
+        "involuntary_context_switches": 22423,
+        "peak_rss_kb": 3338620,
+        "precise_child_system_seconds": 0.917427,
+        "precise_child_user_seconds": 7.07408700000002,
+        "system_seconds": 0.91,
+        "user_seconds": 7.07,
+        "voluntary_context_switches": 37209,
+        "wall_nanos": 8031384359
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "3989381",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 6,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=13.89 avg60=12.59 avg300=9.00 total=7572437205\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7572437205,
+        "load_1m_per_available_cpu": 6.03662109375,
+        "load_1m_per_cpu": 0.0628814697265625,
+        "load_average": [
+          6.03662109375,
+          6.96630859375,
+          10.65576171875
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "1/3527"
+      },
+      "issues": [
+        "refined-6 round 1 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.034s exceeds 0.030s",
+        "refined-6 round 1 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.087s exceeds 0.040s"
+      ],
+      "measurement_attempt": 2,
+      "pair": "refined-6",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            },
+            "67": {
+              "busy_ticks": 1,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 1
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 2.000937405973673,
+        "rejected_windows": []
+      },
+      "reference": {
+        "axioms": null,
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.03373900000000296,
+          "child_cpu_seconds": 5.385233999999997,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 541
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.01373900000000296,
+          "measurement_cpu_interrupt_seconds": 0.02,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.01373900000000296,
+          "measurement_cpu_residual_seconds": 0.03373900000000296,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 5.42,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 1,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 91,
+                "user": 449
+              }
+            },
+            "67": {
+              "busy_seconds": 0.02,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 538,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 2,
+                "user": 0
+              }
+            }
+          },
+          "pressure_some_delta_us": 1414944,
+          "runner_cpu_seconds": 0.0010270000000000001
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4451437",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=17.85 avg60=13.50 avg300=9.27 total=7573852396\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7573852396,
+          "load_1m_per_available_cpu": 5.79296875,
+          "load_1m_per_cpu": 0.060343424479166664,
+          "load_average": [
+            5.79296875,
+            6.900390625,
+            10.6142578125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3527"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4452683",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=13.89 avg60=12.59 avg300=9.00 total=7572437452\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7572437452,
+          "load_1m_per_available_cpu": 6.03662109375,
+          "load_1m_per_cpu": 0.0628814697265625,
+          "load_average": [
+            6.03662109375,
+            6.96630859375,
+            10.65576171875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3527"
+        },
+        "involuntary_context_switches": 21280,
+        "peak_rss_kb": 3079464,
+        "precise_child_system_seconds": 0.9030970000000025,
+        "precise_child_user_seconds": 4.4821369999999945,
+        "system_seconds": 0.9,
+        "user_seconds": 4.48,
+        "voluntary_context_switches": 36125,
+        "wall_nanos": 5412070217
+      },
+      "round": 1,
+      "signed_wall_delta_nanos": 2619314142,
+      "slot_index": 7
+    },
+    {
+      "attempt": 1,
+      "build_order": [
+        "reference",
+        "candidate"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.003565000000014397,
+          "child_cpu_seconds": 7.8353859999999855,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 787
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.003565000000014397,
+          "measurement_cpu_interrupt_seconds": 0.04,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.003565000000014397,
+          "measurement_cpu_residual_seconds": 0.0435650000000144,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 7.88,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 3,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 94,
+                "user": 690
+              }
+            },
+            "67": {
+              "busy_seconds": 0.0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 788,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "pressure_some_delta_us": 1531936,
+          "runner_cpu_seconds": 0.0010489999999999666
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4452166",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=14.00 avg60=14.32 avg300=10.08 total=7580562343\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7580562343,
+          "load_1m_per_available_cpu": 4.34228515625,
+          "load_1m_per_cpu": 0.045232137044270836,
+          "load_average": [
+            4.34228515625,
+            6.39306640625,
+            10.28564453125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3502"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4451013",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=12.35 avg60=13.77 avg300=9.84 total=7579030407\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7579030407,
+          "load_1m_per_available_cpu": 4.45947265625,
+          "load_1m_per_cpu": 0.046452840169270836,
+          "load_average": [
+            4.45947265625,
+            6.45068359375,
+            10.3251953125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3499"
+        },
+        "involuntary_context_switches": 22115,
+        "peak_rss_kb": 3390792,
+        "precise_child_system_seconds": 0.943404000000001,
+        "precise_child_user_seconds": 6.8919819999999845,
+        "system_seconds": 0.94,
+        "user_seconds": 6.89,
+        "voluntary_context_switches": 37101,
+        "wall_nanos": 7875161810
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "4452938",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 6,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=11.52 avg60=13.55 avg300=9.68 total=7577670128\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7577670128,
+        "load_1m_per_available_cpu": 4.81982421875,
+        "load_1m_per_cpu": 0.050206502278645836,
+        "load_average": [
+          4.81982421875,
+          6.58544921875,
+          10.41064453125
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "2/3501"
+      },
+      "issues": [
+        "refine-6 round 1 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.040s exceeds 0.039s"
+      ],
+      "measurement_attempt": 1,
+      "pair": "refine-6",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            },
+            "67": {
+              "busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 2.0007218359969556,
+        "rejected_windows": []
+      },
+      "reference": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.040058000000026246,
+          "child_cpu_seconds": 7.698927999999974,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 774
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.010058000000026247,
+          "measurement_cpu_interrupt_seconds": 0.04,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.010058000000026247,
+          "measurement_cpu_residual_seconds": 0.05005800000002625,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 7.75,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 3,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 94,
+                "user": 677
+              }
+            },
+            "67": {
+              "busy_seconds": 0.03,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 771,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 3,
+                "user": 0
+              }
+            }
+          },
+          "pressure_some_delta_us": 1359866,
+          "runner_cpu_seconds": 0.0010139999999999594
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4452533",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=12.35 avg60=13.77 avg300=9.84 total=7579030059\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7579030059,
+          "load_1m_per_available_cpu": 4.45947265625,
+          "load_1m_per_cpu": 0.046452840169270836,
+          "load_average": [
+            4.45947265625,
+            6.45068359375,
+            10.3251953125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3499"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4454406",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=11.52 avg60=13.55 avg300=9.68 total=7577670193\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7577670193,
+          "load_1m_per_available_cpu": 4.81982421875,
+          "load_1m_per_cpu": 0.050206502278645836,
+          "load_average": [
+            4.81982421875,
+            6.58544921875,
+            10.41064453125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "3/3504"
+        },
+        "involuntary_context_switches": 22477,
+        "peak_rss_kb": 3311836,
+        "precise_child_system_seconds": 0.9320439999999977,
+        "precise_child_user_seconds": 6.766883999999976,
+        "system_seconds": 0.93,
+        "user_seconds": 6.76,
+        "voluntary_context_switches": 37402,
+        "wall_nanos": 7743012979
+      },
+      "round": 1,
+      "signed_wall_delta_nanos": 132148831,
+      "slot_index": 8
+    },
+    {
+      "attempt": 1,
+      "build_order": [
+        "candidate",
+        "reference"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.02434999999998223,
+          "child_cpu_seconds": 6.584664000000018,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 662
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.004349999999982229,
+          "measurement_cpu_interrupt_seconds": 0.03,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.004349999999982229,
+          "measurement_cpu_residual_seconds": 0.03434999999998223,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 6.62,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 1,
+                "iowait": 0,
+                "irq": 3,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 89,
+                "user": 570
+              }
+            },
+            "67": {
+              "busy_seconds": 0.02,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 660,
+                "iowait": 0,
+                "irq": 1,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 0
+              }
+            }
+          },
+          "pressure_some_delta_us": 1515606,
+          "runner_cpu_seconds": 0.0009860000000000424
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4449493",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=16.97 avg60=13.51 avg300=10.83 total=7596727500\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7596727500,
+          "load_1m_per_available_cpu": 2.5927734375,
+          "load_1m_per_cpu": 0.027008056640625,
+          "load_average": [
+            2.5927734375,
+            5.0087890625,
+            9.26171875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "2/3495"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4453215",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=14.28 avg60=12.53 avg300=10.58 total=7595211894\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7595211894,
+          "load_1m_per_available_cpu": 2.64453125,
+          "load_1m_per_cpu": 0.027547200520833332,
+          "load_average": [
+            2.64453125,
+            5.06005859375,
+            9.30126953125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "3/3496"
+        },
+        "involuntary_context_switches": 22335,
+        "peak_rss_kb": 3238300,
+        "precise_child_system_seconds": 0.8884350000000012,
+        "precise_child_user_seconds": 5.696229000000017,
+        "system_seconds": 0.88,
+        "user_seconds": 5.69,
+        "voluntary_context_switches": 37209,
+        "wall_nanos": 6619600338
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "4453140",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 6,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=14.28 avg60=12.53 avg300=10.58 total=7595211777\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7595211777,
+        "load_1m_per_available_cpu": 2.64453125,
+        "load_1m_per_cpu": 0.027547200520833332,
+        "load_average": [
+          2.64453125,
+          5.06005859375,
+          9.30126953125
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "1/3496"
+      },
+      "issues": [
+        "refined-4 round 2 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.061s exceeds 0.030s"
+      ],
+      "measurement_attempt": 1,
+      "pair": "refined-4",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            },
+            "67": {
+              "busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 2.0007404410280287,
+        "rejected_windows": []
+      },
+      "reference": {
+        "axioms": null,
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.06101100000002577,
+          "child_cpu_seconds": 5.457986999999974,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 549
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.011011000000025768,
+          "measurement_cpu_interrupt_seconds": 0.02,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.011011000000025768,
+          "measurement_cpu_residual_seconds": 0.031011000000025768,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 5.49,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 1,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 88,
+                "user": 459
+              }
+            },
+            "67": {
+              "busy_seconds": 0.05,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 544,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 4
+              }
+            }
+          },
+          "pressure_some_delta_us": 1422218,
+          "runner_cpu_seconds": 0.0010020000000000584
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4450639",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 8,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=19.27 avg60=14.50 avg300=11.11 total=7598149882\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7598149882,
+          "load_1m_per_available_cpu": 2.5009765625,
+          "load_1m_per_cpu": 0.026051839192708332,
+          "load_average": [
+            2.5009765625,
+            4.9091796875,
+            9.18359375
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "4/3505"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4448632",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=16.97 avg60=13.51 avg300=10.83 total=7596727664\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7596727664,
+          "load_1m_per_available_cpu": 2.5927734375,
+          "load_1m_per_cpu": 0.027008056640625,
+          "load_average": [
+            2.5927734375,
+            5.0087890625,
+            9.26171875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3495"
+        },
+        "involuntary_context_switches": 21642,
+        "peak_rss_kb": 3081452,
+        "precise_child_system_seconds": 0.8797390000000007,
+        "precise_child_user_seconds": 4.578247999999974,
+        "system_seconds": 0.87,
+        "user_seconds": 4.57,
+        "voluntary_context_switches": 36392,
+        "wall_nanos": 5486887767
+      },
+      "round": 2,
+      "signed_wall_delta_nanos": 1132712571,
+      "slot_index": 5
+    },
+    {
+      "attempt": 1,
+      "build_order": [
+        "candidate",
+        "reference"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.006054000000025796,
+          "child_cpu_seconds": 7.942907999999974,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 798
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.006054000000025796,
+          "measurement_cpu_interrupt_seconds": 0.04,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.006054000000025796,
+          "measurement_cpu_residual_seconds": 0.046054000000025797,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 7.99,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 3,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 91,
+                "user": 704
+              }
+            },
+            "67": {
+              "busy_seconds": 0.0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 798,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "pressure_some_delta_us": 1367564,
+          "runner_cpu_seconds": 0.0010380000000000944
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4450808",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 8,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=12.66 avg60=13.96 avg300=11.26 total=7601658006\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7601658006,
+          "load_1m_per_available_cpu": 2.8037109375,
+          "load_1m_per_cpu": 0.029205322265625,
+          "load_average": [
+            2.8037109375,
+            4.7880859375,
+            9.0283203125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "2/3511"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4450345",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 8,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=12.47 avg60=13.75 avg300=11.13 total=7600290442\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7600290442,
+          "load_1m_per_available_cpu": 2.76025390625,
+          "load_1m_per_cpu": 0.028752644856770832,
+          "load_average": [
+            2.76025390625,
+            4.84912109375,
+            9.09423828125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "4/3513"
+        },
+        "involuntary_context_switches": 22527,
+        "peak_rss_kb": 3409588,
+        "precise_child_system_seconds": 0.9125939999999986,
+        "precise_child_user_seconds": 7.030313999999976,
+        "system_seconds": 0.91,
+        "user_seconds": 7.02,
+        "voluntary_context_switches": 37538,
+        "wall_nanos": 7984518837
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "4456985",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 8,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=12.47 avg60=13.75 avg300=11.13 total=7600290316\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7600290316,
+        "load_1m_per_available_cpu": 2.76025390625,
+        "load_1m_per_cpu": 0.028752644856770832,
+        "load_average": [
+          2.76025390625,
+          4.84912109375,
+          9.09423828125
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "8/3513"
+      },
+      "issues": [
+        "refined-6 round 2 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.042s exceeds 0.030s"
+      ],
+      "measurement_attempt": 1,
+      "pair": "refined-6",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 1,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 0
+              }
+            },
+            "67": {
+              "busy_ticks": 1,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 1
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 2.0008600580040365,
+        "rejected_windows": []
+      },
+      "reference": {
+        "axioms": null,
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.04228400000000552,
+          "child_cpu_seconds": 5.426652999999995,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 545
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.012284000000005521,
+          "measurement_cpu_interrupt_seconds": 0.01,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.012284000000005521,
+          "measurement_cpu_residual_seconds": 0.02228400000000552,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 5.45,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 1,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 91,
+                "user": 453
+              }
+            },
+            "67": {
+              "busy_seconds": 0.03,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 542,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 2
+              }
+            }
+          },
+          "pressure_some_delta_us": 803212,
+          "runner_cpu_seconds": 0.0010630000000000361
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4453447",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=14.59 avg60=14.28 avg300=11.37 total=7602461313\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7602461313,
+          "load_1m_per_available_cpu": 2.7392578125,
+          "load_1m_per_cpu": 0.028533935546875,
+          "load_average": [
+            2.7392578125,
+            4.74169921875,
+            8.990234375
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3483"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4448676",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 8,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=12.66 avg60=13.96 avg300=11.26 total=7601658101\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7601658101,
+          "load_1m_per_available_cpu": 2.8037109375,
+          "load_1m_per_cpu": 0.029205322265625,
+          "load_average": [
+            2.8037109375,
+            4.7880859375,
+            9.0283203125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "6/3511"
+        },
+        "involuntary_context_switches": 21359,
+        "peak_rss_kb": 3081664,
+        "precise_child_system_seconds": 0.9112960000000001,
+        "precise_child_user_seconds": 4.5153569999999945,
+        "system_seconds": 0.91,
+        "user_seconds": 4.51,
+        "voluntary_context_switches": 36233,
+        "wall_nanos": 5455252792
+      },
+      "round": 2,
+      "signed_wall_delta_nanos": 2529266045,
+      "slot_index": 6
+    },
+    {
+      "attempt": 1,
+      "build_order": [
+        "reference",
+        "candidate"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.0724250000000316,
+          "child_cpu_seconds": 13.936521999999968,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 1401
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.0024250000000315963,
+          "measurement_cpu_interrupt_seconds": 0.07,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.0024250000000315963,
+          "measurement_cpu_residual_seconds": 0.0724250000000316,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 14.01,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 5,
+                "nice": 0,
+                "softirq": 2,
+                "steal": 0,
+                "system": 102,
+                "user": 1292
+              }
+            },
+            "67": {
+              "busy_seconds": 0.07,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 1396,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 4,
+                "user": 3
+              }
+            }
+          },
+          "pressure_some_delta_us": 1413407,
+          "runner_cpu_seconds": 0.0010530000000000816
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4452691",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=7.91 avg60=14.59 avg300=12.67 total=7619373817\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7619373817,
+          "load_1m_per_available_cpu": 2.49462890625,
+          "load_1m_per_cpu": 0.0259857177734375,
+          "load_average": [
+            2.49462890625,
+            4.06298828125,
+            8.30810546875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3497"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4450255",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=14.52 avg60=16.03 avg300=12.82 total=7617960410\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7617960410,
+          "load_1m_per_available_cpu": 2.44482421875,
+          "load_1m_per_cpu": 0.0254669189453125,
+          "load_average": [
+            2.44482421875,
+            4.13525390625,
+            8.40087890625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3493"
+        },
+        "involuntary_context_switches": 23486,
+        "peak_rss_kb": 3880076,
+        "precise_child_system_seconds": 1.0257599999999911,
+        "precise_child_user_seconds": 12.910761999999977,
+        "system_seconds": 1.02,
+        "user_seconds": 12.91,
+        "voluntary_context_switches": 38385,
+        "wall_nanos": 14003532377
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "4452123",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 6,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=10.48 avg60=15.54 avg300=12.65 total=7616605257\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7616605257,
+        "load_1m_per_available_cpu": 2.48388671875,
+        "load_1m_per_cpu": 0.025873819986979168,
+        "load_average": [
+          2.48388671875,
+          4.17138671875,
+          8.435546875
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "1/3492"
+      },
+      "issues": [
+        "natural-10 round 3 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.072s exceeds 0.070s"
+      ],
+      "measurement_attempt": 1,
+      "pair": "natural-10",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 1,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 0
+              }
+            },
+            "67": {
+              "busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 2.000755581073463,
+        "rejected_windows": []
+      },
+      "reference": {
+        "axioms": null,
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.01139900000000039,
+          "child_cpu_seconds": 5.38758,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 542
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.01139900000000039,
+          "measurement_cpu_interrupt_seconds": 0.01,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.01139900000000039,
+          "measurement_cpu_residual_seconds": 0.02139900000000039,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 5.41,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 1,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 91,
+                "user": 449
+              }
+            },
+            "67": {
+              "busy_seconds": 0.0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 541,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "pressure_some_delta_us": 1354876,
+          "runner_cpu_seconds": 0.0010209999999999386
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4451392",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=14.52 avg60=16.03 avg300=12.82 total=7617960242\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7617960242,
+          "load_1m_per_available_cpu": 2.44482421875,
+          "load_1m_per_cpu": 0.0254669189453125,
+          "load_average": [
+            2.44482421875,
+            4.13525390625,
+            8.40087890625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "3/3493"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4449472",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=10.48 avg60=15.54 avg300=12.65 total=7616605366\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7616605366,
+          "load_1m_per_available_cpu": 2.48388671875,
+          "load_1m_per_cpu": 0.025873819986979168,
+          "load_average": [
+            2.48388671875,
+            4.17138671875,
+            8.435546875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3492"
+        },
+        "involuntary_context_switches": 21354,
+        "peak_rss_kb": 3081628,
+        "precise_child_system_seconds": 0.9109040000000022,
+        "precise_child_user_seconds": 4.476675999999998,
+        "system_seconds": 0.91,
+        "user_seconds": 4.47,
+        "voluntary_context_switches": 36253,
+        "wall_nanos": 5414674285
+      },
+      "round": 3,
+      "signed_wall_delta_nanos": 8588858092,
+      "slot_index": 2
+    },
+    {
+      "attempt": 1,
+      "build_order": [
+        "reference",
+        "candidate"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.04673400000000248,
+          "child_cpu_seconds": 5.902220999999997,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 593
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.006734000000002478,
+          "measurement_cpu_interrupt_seconds": 0.02,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.006734000000002478,
+          "measurement_cpu_residual_seconds": 0.026734000000002478,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 5.93,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 1,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 91,
+                "user": 500
+              }
+            },
+            "67": {
+              "busy_seconds": 0.04,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 589,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 3
+              }
+            }
+          },
+          "pressure_some_delta_us": 1421373,
+          "runner_cpu_seconds": 0.0010449999999999626
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4451945",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=18.21 avg60=15.49 avg300=13.10 total=7625207774\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7625207774,
+          "load_1m_per_available_cpu": 2.5009765625,
+          "load_1m_per_cpu": 0.026051839192708332,
+          "load_average": [
+            2.5009765625,
+            3.92041015625,
+            8.10400390625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "6/3495"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4450307",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=14.80 avg60=14.74 avg300=12.90 total=7623786401\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7623786401,
+          "load_1m_per_available_cpu": 2.544921875,
+          "load_1m_per_cpu": 0.026509602864583332,
+          "load_average": [
+            2.544921875,
+            3.953125,
+            8.13720703125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "2/3491"
+        },
+        "involuntary_context_switches": 22193,
+        "peak_rss_kb": 3169208,
+        "precise_child_system_seconds": 0.9098260000000096,
+        "precise_child_user_seconds": 4.992394999999988,
+        "system_seconds": 0.9,
+        "user_seconds": 4.99,
+        "voluntary_context_switches": 37082,
+        "wall_nanos": 5934923296
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "2112737",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 6,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=8.05 avg60=13.96 avg300=12.71 total=7622386682\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7622386682,
+        "load_1m_per_available_cpu": 2.6796875,
+        "load_1m_per_cpu": 0.027913411458333332,
+        "load_average": [
+          2.6796875,
+          4.00341796875,
+          8.17578125
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "9/3493"
+      },
+      "issues": [
+        "refined-2 round 3 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.047s exceeds 0.030s"
+      ],
+      "measurement_attempt": 1,
+      "pair": "refined-2",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            },
+            "67": {
+              "busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 2.0012670701835304,
+        "rejected_windows": []
+      },
+      "reference": {
+        "axioms": null,
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.013880999999970629,
+          "child_cpu_seconds": 5.4151090000000295,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 544
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.013880999999970629,
+          "measurement_cpu_interrupt_seconds": 0.02,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.013880999999970629,
+          "measurement_cpu_residual_seconds": 0.03388099999997063,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 5.45,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 94,
+                "user": 449
+              }
+            },
+            "67": {
+              "busy_seconds": 0.0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 544,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "pressure_some_delta_us": 1399184,
+          "runner_cpu_seconds": 0.0010100000000000664
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4449933",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=14.80 avg60=14.74 avg300=12.90 total=7623785967\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7623785967,
+          "load_1m_per_available_cpu": 2.544921875,
+          "load_1m_per_cpu": 0.026509602864583332,
+          "load_average": [
+            2.544921875,
+            3.953125,
+            8.13720703125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3491"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4120468",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=8.05 avg60=13.96 avg300=12.71 total=7622386783\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7622386783,
+          "load_1m_per_available_cpu": 2.6796875,
+          "load_1m_per_cpu": 0.027913411458333332,
+          "load_average": [
+            2.6796875,
+            4.00341796875,
+            8.17578125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3493"
+        },
+        "involuntary_context_switches": 21301,
+        "peak_rss_kb": 3081692,
+        "precise_child_system_seconds": 0.9342379999999935,
+        "precise_child_user_seconds": 4.480871000000036,
+        "system_seconds": 0.93,
+        "user_seconds": 4.48,
+        "voluntary_context_switches": 36224,
+        "wall_nanos": 5444043479
+      },
+      "round": 3,
+      "signed_wall_delta_nanos": 490879817,
+      "slot_index": 3
+    },
+    {
+      "attempt": 1,
+      "build_order": [
+        "reference",
+        "candidate"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.04088400000002735,
+          "child_cpu_seconds": 7.938067999999973,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 798
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.010884000000027351,
+          "measurement_cpu_interrupt_seconds": 0.04,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.010884000000027351,
+          "measurement_cpu_residual_seconds": 0.05088400000002735,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 7.99,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 3,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 97,
+                "user": 698
+              }
+            },
+            "67": {
+              "busy_seconds": 0.03,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 796,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 2
+              }
+            }
+          },
+          "pressure_some_delta_us": 1357782,
+          "runner_cpu_seconds": 0.001048000000000049
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4451304",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=13.45 avg60=16.48 avg300=13.96 total=7636487279\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7636487279,
+          "load_1m_per_available_cpu": 2.71630859375,
+          "load_1m_per_cpu": 0.028294881184895832,
+          "load_average": [
+            2.71630859375,
+            3.67041015625,
+            7.751953125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3523"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4448956",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=13.80 avg60=16.58 avg300=13.90 total=7635129497\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7635129497,
+          "load_1m_per_available_cpu": 2.1689453125,
+          "load_1m_per_cpu": 0.022593180338541668,
+          "load_average": [
+            2.1689453125,
+            3.580078125,
+            7.7451171875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "3/3518"
+        },
+        "involuntary_context_switches": 21943,
+        "peak_rss_kb": 3394584,
+        "precise_child_system_seconds": 0.9672540000000112,
+        "precise_child_user_seconds": 6.970813999999962,
+        "system_seconds": 0.96,
+        "user_seconds": 6.97,
+        "voluntary_context_switches": 37036,
+        "wall_nanos": 7978977630
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "1609345",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 6,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=13.11 avg60=16.53 avg300=13.81 total=7633676491\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7633676491,
+        "load_1m_per_available_cpu": 2.01708984375,
+        "load_1m_per_cpu": 0.0210113525390625,
+        "load_average": [
+          2.01708984375,
+          3.6005859375,
+          7.796875
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "2/3493"
+      },
+      "issues": [
+        "refine-6 round 3 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.041s exceeds 0.040s"
+      ],
+      "measurement_attempt": 1,
+      "pair": "refine-6",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            },
+            "67": {
+              "busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 2.001032192958519,
+        "rejected_windows": []
+      },
+      "reference": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.0160429999999794,
+          "child_cpu_seconds": 7.68294400000002,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 772
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.006042999999979398,
+          "measurement_cpu_interrupt_seconds": 0.03,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.006042999999979398,
+          "measurement_cpu_residual_seconds": 0.0360429999999794,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 7.72,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 1,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 93,
+                "user": 676
+              }
+            },
+            "67": {
+              "busy_seconds": 0.01,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 772,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "pressure_some_delta_us": 1451971,
+          "runner_cpu_seconds": 0.0010129999999999306
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4448515",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=13.80 avg60=16.58 avg300=13.90 total=7635129385\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7635129385,
+          "load_1m_per_available_cpu": 2.1689453125,
+          "load_1m_per_cpu": 0.022593180338541668,
+          "load_average": [
+            2.1689453125,
+            3.580078125,
+            7.7451171875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "6/3518"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4087596",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=13.11 avg60=16.53 avg300=13.81 total=7633677414\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7633677414,
+          "load_1m_per_available_cpu": 2.01708984375,
+          "load_1m_per_cpu": 0.0210113525390625,
+          "load_average": [
+            2.01708984375,
+            3.6005859375,
+            7.796875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "2/3493"
+        },
+        "involuntary_context_switches": 21705,
+        "peak_rss_kb": 3370188,
+        "precise_child_system_seconds": 0.9285639999999944,
+        "precise_child_user_seconds": 6.754380000000026,
+        "system_seconds": 0.92,
+        "user_seconds": 6.75,
+        "voluntary_context_switches": 36645,
+        "wall_nanos": 7723423088
+      },
+      "round": 3,
+      "signed_wall_delta_nanos": 255554542,
+      "slot_index": 6
+    },
+    {
+      "attempt": 2,
+      "build_order": [
+        "reference",
+        "candidate"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.08271600000005382,
+          "child_cpu_seconds": 8.086217999999946,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 812
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.0027160000000538143,
+          "measurement_cpu_interrupt_seconds": 0.03,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.0027160000000538143,
+          "measurement_cpu_residual_seconds": 0.03271600000005381,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 8.12,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 96,
+                "user": 713
+              }
+            },
+            "67": {
+              "busy_seconds": 0.08,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 801,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 8
+              }
+            }
+          },
+          "pressure_some_delta_us": 1567025,
+          "runner_cpu_seconds": 0.0010659999999999004
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4450009",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=13.69 avg60=16.22 avg300=14.07 total=7639531133\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7639531133,
+          "load_1m_per_available_cpu": 2.3017578125,
+          "load_1m_per_cpu": 0.023976643880208332,
+          "load_average": [
+            2.3017578125,
+            3.51318359375,
+            7.6123046875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3526"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4449829",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=12.44 avg60=16.00 avg300=13.95 total=7637964108\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7637964108,
+          "load_1m_per_available_cpu": 2.4521484375,
+          "load_1m_per_cpu": 0.025543212890625,
+          "load_average": [
+            2.4521484375,
+            3.58203125,
+            7.67919921875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3525"
+        },
+        "involuntary_context_switches": 22741,
+        "peak_rss_kb": 3367304,
+        "precise_child_system_seconds": 0.9611519999999985,
+        "precise_child_user_seconds": 7.125065999999947,
+        "system_seconds": 0.96,
+        "user_seconds": 7.12,
+        "voluntary_context_switches": 37527,
+        "wall_nanos": 8126134529
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "1497522",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 6,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=11.02 avg60=15.94 avg300=13.87 total=7636487964\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7636487964,
+        "load_1m_per_available_cpu": 2.57861328125,
+        "load_1m_per_cpu": 0.026860555013020832,
+        "load_average": [
+          2.57861328125,
+          3.6259765625,
+          7.71533203125
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "2/3523"
+      },
+      "issues": [
+        "refine-6 round 3 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.055s exceeds 0.040s",
+        "refine-6 round 3 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.083s exceeds 0.041s"
+      ],
+      "measurement_attempt": 2,
+      "pair": "refine-6",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 1,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 198,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 0
+              }
+            },
+            "67": {
+              "busy_ticks": 1,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 1
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 2.0013001149054617,
+        "rejected_windows": []
+      },
+      "reference": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.055235000000068306,
+          "child_cpu_seconds": 7.883728999999931,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 792
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.005235000000068303,
+          "measurement_cpu_interrupt_seconds": 0.04,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.005235000000068303,
+          "measurement_cpu_residual_seconds": 0.045235000000068304,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 7.93,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 3,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 97,
+                "user": 692
+              }
+            },
+            "67": {
+              "busy_seconds": 0.05,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 787,
+                "iowait": 0,
+                "irq": 1,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 3
+              }
+            }
+          },
+          "pressure_some_delta_us": 1475780,
+          "runner_cpu_seconds": 0.0010360000000000369
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4451215",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=12.44 avg60=16.00 avg300=13.95 total=7637963925\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7637963925,
+          "load_1m_per_available_cpu": 2.4521484375,
+          "load_1m_per_cpu": 0.025543212890625,
+          "load_average": [
+            2.4521484375,
+            3.58203125,
+            7.67919921875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3525"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4234201",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=11.02 avg60=15.94 avg300=13.87 total=7636488145\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7636488145,
+          "load_1m_per_available_cpu": 2.57861328125,
+          "load_1m_per_cpu": 0.026860555013020832,
+          "load_average": [
+            2.57861328125,
+            3.6259765625,
+            7.71533203125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "2/3523"
+        },
+        "involuntary_context_switches": 22959,
+        "peak_rss_kb": 3359696,
+        "precise_child_system_seconds": 0.9681779999999947,
+        "precise_child_user_seconds": 6.915550999999937,
+        "system_seconds": 0.96,
+        "user_seconds": 6.91,
+        "voluntary_context_switches": 37838,
+        "wall_nanos": 7922574595
+      },
+      "round": 3,
+      "signed_wall_delta_nanos": 203559934,
+      "slot_index": 6
+    },
+    {
+      "attempt": 1,
+      "build_order": [
+        "candidate",
+        "reference"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.16977599999999649,
+          "child_cpu_seconds": 13.999171000000004,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 1407
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.009775999999996496,
+          "measurement_cpu_interrupt_seconds": 0.05,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.009775999999996496,
+          "measurement_cpu_residual_seconds": 0.0597759999999965,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 14.06,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 4,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 110,
+                "user": 1291
+              }
+            },
+            "67": {
+              "busy_seconds": 0.16,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 1391,
+                "iowait": 0,
+                "irq": 1,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 3,
+                "user": 12
+              }
+            }
+          },
+          "pressure_some_delta_us": 832064,
+          "runner_cpu_seconds": 0.0010529999999999706
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4451424",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=5.36 avg60=11.16 avg300=13.18 total=7651254581\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7651254581,
+          "load_1m_per_available_cpu": 2.09228515625,
+          "load_1m_per_cpu": 0.021794637044270832,
+          "load_average": [
+            2.09228515625,
+            3.07275390625,
+            7.02978515625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3523"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4451776",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 9,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=11.52 avg60=12.80 avg300=13.57 total=7650422517\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7650422517,
+          "load_1m_per_available_cpu": 1.9677734375,
+          "load_1m_per_cpu": 0.020497639973958332,
+          "load_average": [
+            1.9677734375,
+            3.09521484375,
+            7.10205078125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "2/3547"
+        },
+        "involuntary_context_switches": 22533,
+        "peak_rss_kb": 3887928,
+        "precise_child_system_seconds": 1.0934669999999898,
+        "precise_child_user_seconds": 12.905704000000014,
+        "system_seconds": 1.09,
+        "user_seconds": 12.9,
+        "voluntary_context_switches": 37416,
+        "wall_nanos": 14063484534
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "4454131",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 9,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=11.52 avg60=12.80 avg300=13.57 total=7650422291\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7650422291,
+        "load_1m_per_available_cpu": 1.9677734375,
+        "load_1m_per_cpu": 0.020497639973958332,
+        "load_average": [
+          1.9677734375,
+          3.09521484375,
+          7.10205078125
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "4/3547"
+      },
+      "issues": [
+        "natural-10 round 4 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.170s exceeds 0.070s",
+        "natural-10 round 4 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.071s exceeds 0.030s"
+      ],
+      "measurement_attempt": 1,
+      "pair": "natural-10",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            },
+            "67": {
+              "busy_ticks": 2,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 198,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 2
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 2.000830759992823,
+        "rejected_windows": []
+      },
+      "reference": {
+        "axioms": null,
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.07051999999998967,
+          "child_cpu_seconds": 5.38840900000001,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 541
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.010519999999989676,
+          "measurement_cpu_interrupt_seconds": 0.03,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.010519999999989676,
+          "measurement_cpu_residual_seconds": 0.040519999999989675,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 5.43,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 90,
+                "user": 450
+              }
+            },
+            "67": {
+              "busy_seconds": 0.06,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 534,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 5
+              }
+            }
+          },
+          "pressure_some_delta_us": 1472796,
+          "runner_cpu_seconds": 0.0010710000000000441
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4452886",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=12.85 avg60=12.35 avg300=13.40 total=7652727564\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7652727564,
+          "load_1m_per_available_cpu": 2.4052734375,
+          "load_1m_per_cpu": 0.025054931640625,
+          "load_average": [
+            2.4052734375,
+            3.12158203125,
+            7.02392578125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "2/3522"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4451766",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=5.36 avg60=11.16 avg300=13.18 total=7651254768\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7651254768,
+          "load_1m_per_available_cpu": 2.09228515625,
+          "load_1m_per_cpu": 0.021794637044270832,
+          "load_average": [
+            2.09228515625,
+            3.07275390625,
+            7.02978515625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3523"
+        },
+        "involuntary_context_switches": 21406,
+        "peak_rss_kb": 3081512,
+        "precise_child_system_seconds": 0.8980499999999978,
+        "precise_child_user_seconds": 4.490359000000012,
+        "system_seconds": 0.89,
+        "user_seconds": 4.48,
+        "voluntary_context_switches": 36238,
+        "wall_nanos": 5414383772
+      },
+      "round": 4,
+      "signed_wall_delta_nanos": 8649100762,
+      "slot_index": 1
+    },
+    {
+      "attempt": 1,
+      "build_order": [
+        "reference",
+        "candidate"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.10062399999995583,
+          "child_cpu_seconds": 14.018315000000044,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 1409
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.010623999999955835,
+          "measurement_cpu_interrupt_seconds": 0.07,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.010623999999955835,
+          "measurement_cpu_residual_seconds": 0.08062399999995584,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 14.1,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 6,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 100,
+                "user": 1303
+              }
+            },
+            "67": {
+              "busy_seconds": 0.09,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 1401,
+                "iowait": 0,
+                "irq": 1,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 3,
+                "user": 4
+              }
+            }
+          },
+          "pressure_some_delta_us": 322364,
+          "runner_cpu_seconds": 0.0010609999999999786
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4450909",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 8,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=1.76 avg60=7.45 avg300=12.13 total=7675020951\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7675020951,
+          "load_1m_per_available_cpu": 4.44091796875,
+          "load_1m_per_cpu": 0.046259562174479164,
+          "load_average": [
+            4.44091796875,
+            3.22021484375,
+            6.3193359375
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "3/3571"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4450017",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 9,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=4.16 avg60=8.96 avg300=12.63 total=7674698587\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7674698587,
+          "load_1m_per_available_cpu": 3.75830078125,
+          "load_1m_per_cpu": 0.039148966471354164,
+          "load_average": [
+            3.75830078125,
+            3.04052734375,
+            6.31396484375
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "7/3575"
+        },
+        "involuntary_context_switches": 21855,
+        "peak_rss_kb": 3871388,
+        "precise_child_system_seconds": 0.999284000000003,
+        "precise_child_user_seconds": 13.01903100000004,
+        "system_seconds": 0.99,
+        "user_seconds": 13.01,
+        "voluntary_context_switches": 36927,
+        "wall_nanos": 14086630425
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "1500000",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 9,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=4.31 avg60=9.46 avg300=12.81 total=7674392661\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7674392661,
+        "load_1m_per_available_cpu": 3.4755859375,
+        "load_1m_per_cpu": 0.036204020182291664,
+        "load_average": [
+          3.4755859375,
+          2.9736328125,
+          6.31005859375
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "7/3582"
+      },
+      "issues": [
+        "natural-10 round 5 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.101s exceeds 0.070s"
+      ],
+      "measurement_attempt": 1,
+      "pair": "natural-10",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 1,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            },
+            "67": {
+              "busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 2.0009113720152527,
+        "rejected_windows": []
+      },
+      "reference": {
+        "axioms": null,
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.0066309999999869616,
+          "child_cpu_seconds": 5.392314000000013,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 542
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.0066309999999869616,
+          "measurement_cpu_interrupt_seconds": 0.01,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.0066309999999869616,
+          "measurement_cpu_residual_seconds": 0.016630999999986962,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 5.41,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 1,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 92,
+                "user": 448
+              }
+            },
+            "67": {
+              "busy_seconds": 0.0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 541,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "pressure_some_delta_us": 305846,
+          "runner_cpu_seconds": 0.0010550000000000281
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4450673",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 9,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=4.16 avg60=8.96 avg300=12.63 total=7674698548\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7674698548,
+          "load_1m_per_available_cpu": 3.75830078125,
+          "load_1m_per_cpu": 0.039148966471354164,
+          "load_average": [
+            3.75830078125,
+            3.04052734375,
+            6.31396484375
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "10/3578"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4448898",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 9,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=4.31 avg60=9.46 avg300=12.81 total=7674392702\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7674392702,
+          "load_1m_per_available_cpu": 3.4755859375,
+          "load_1m_per_cpu": 0.036204020182291664,
+          "load_average": [
+            3.4755859375,
+            2.9736328125,
+            6.31005859375
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "7/3582"
+        },
+        "involuntary_context_switches": 21110,
+        "peak_rss_kb": 3079596,
+        "precise_child_system_seconds": 0.9170850000000002,
+        "precise_child_user_seconds": 4.475229000000013,
+        "system_seconds": 0.91,
+        "user_seconds": 4.47,
+        "voluntary_context_switches": 36050,
+        "wall_nanos": 5419233561
+      },
+      "round": 5,
+      "signed_wall_delta_nanos": 8667396864,
+      "slot_index": 0
+    },
+    {
+      "attempt": 1,
+      "build_order": [
+        "reference",
+        "candidate"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.007991000000027643,
+          "child_cpu_seconds": 6.480963999999972,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 651
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.007991000000027643,
+          "measurement_cpu_interrupt_seconds": 0.03,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.007991000000027643,
+          "measurement_cpu_residual_seconds": 0.03799100000002764,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 6.52,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 92,
+                "user": 557
+              }
+            },
+            "67": {
+              "busy_seconds": 0.0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 651,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "pressure_some_delta_us": 516793,
+          "runner_cpu_seconds": 0.0010450000000001847
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4450891",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 8,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=6.71 avg60=6.01 avg300=10.85 total=7677681691\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7677681691,
+          "load_1m_per_available_cpu": 4.6806640625,
+          "load_1m_per_cpu": 0.048756917317708336,
+          "load_average": [
+            4.6806640625,
+            3.4775390625,
+            6.2265625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "5/3539"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4449254",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 8,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=5.82 avg60=5.80 avg300=10.91 total=7677164898\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7677164898,
+          "load_1m_per_available_cpu": 4.3916015625,
+          "load_1m_per_cpu": 0.045745849609375,
+          "load_average": [
+            4.3916015625,
+            3.40087890625,
+            6.216796875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "5/3534"
+        },
+        "involuntary_context_switches": 22324,
+        "peak_rss_kb": 3220372,
+        "precise_child_system_seconds": 0.9130910000000085,
+        "precise_child_user_seconds": 5.567872999999963,
+        "system_seconds": 0.91,
+        "user_seconds": 5.56,
+        "voluntary_context_switches": 37220,
+        "wall_nanos": 6512342639
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "4452113",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 8,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=5.54 avg60=5.78 avg300=11.01 total=7676750128\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7676750128,
+        "load_1m_per_available_cpu": 4.1142578125,
+        "load_1m_per_cpu": 0.042856852213541664,
+        "load_average": [
+          4.1142578125,
+          3.3125,
+          6.21923828125
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "6/3538"
+      },
+      "issues": [
+        "refined-4 round 5 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 1.274s exceeds 0.030s"
+      ],
+      "measurement_attempt": 1,
+      "pair": "refined-4",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            },
+            "67": {
+              "busy_ticks": 2,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 197,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 1
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 2.000956861069426,
+        "rejected_windows": []
+      },
+      "reference": {
+        "axioms": null,
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 1.2739780000000143,
+          "child_cpu_seconds": 5.764926999999986,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 579
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.003978000000014265,
+          "measurement_cpu_interrupt_seconds": 0.02,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.003978000000014265,
+          "measurement_cpu_residual_seconds": 0.023978000000014266,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 5.79,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 94,
+                "user": 483
+              }
+            },
+            "67": {
+              "busy_seconds": 1.27,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 453,
+                "iowait": 0,
+                "irq": 1,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 125
+              }
+            }
+          },
+          "pressure_some_delta_us": 414369,
+          "runner_cpu_seconds": 0.001094999999999846
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4451434",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 8,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=5.82 avg60=5.80 avg300=10.91 total=7677164852\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7677164852,
+          "load_1m_per_available_cpu": 4.3916015625,
+          "load_1m_per_cpu": 0.045745849609375,
+          "load_average": [
+            4.3916015625,
+            3.40087890625,
+            6.216796875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "4/3534"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4450709",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 8,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=5.54 avg60=5.78 avg300=11.01 total=7676750483\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7676750483,
+          "load_1m_per_available_cpu": 4.1142578125,
+          "load_1m_per_cpu": 0.042856852213541664,
+          "load_average": [
+            4.1142578125,
+            3.3125,
+            6.21923828125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "6/3538"
+        },
+        "involuntary_context_switches": 21067,
+        "peak_rss_kb": 3081488,
+        "precise_child_system_seconds": 0.9402170000000041,
+        "precise_child_user_seconds": 4.824709999999982,
+        "system_seconds": 0.93,
+        "user_seconds": 4.82,
+        "voluntary_context_switches": 35876,
+        "wall_nanos": 5795934650
+      },
+      "round": 5,
+      "signed_wall_delta_nanos": 716407989,
+      "slot_index": 2
+    },
+    {
+      "attempt": 1,
+      "build_order": [
+        "reference",
+        "candidate"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.0005609999999707412,
+          "child_cpu_seconds": 7.888407000000029,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 792
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.0005609999999707412,
+          "measurement_cpu_interrupt_seconds": 0.02,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.0005609999999707412,
+          "measurement_cpu_residual_seconds": 0.02056099999997074,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 7.91,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 91,
+                "user": 698
+              }
+            },
+            "67": {
+              "busy_seconds": 0.0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 792,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "pressure_some_delta_us": 208204,
+          "runner_cpu_seconds": 0.001032000000000144
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4449028",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 11,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=2.43 avg60=5.44 avg300=10.04 total=7680658920\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7680658920,
+          "load_1m_per_available_cpu": 6.85693359375,
+          "load_1m_per_cpu": 0.0714263916015625,
+          "load_average": [
+            6.85693359375,
+            4.18310546875,
+            6.33349609375
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "11/3595"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4447377",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 11,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=3.35 avg60=5.94 avg300=10.26 total=7680450716\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7680450716,
+          "load_1m_per_available_cpu": 6.49609375,
+          "load_1m_per_cpu": 0.06766764322916667,
+          "load_average": [
+            6.49609375,
+            4.06787109375,
+            6.30810546875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "11/3594"
+        },
+        "involuntary_context_switches": 22818,
+        "peak_rss_kb": 3376476,
+        "precise_child_system_seconds": 0.9155259999999998,
+        "precise_child_user_seconds": 6.972881000000029,
+        "system_seconds": 0.91,
+        "user_seconds": 6.97,
+        "voluntary_context_switches": 37829,
+        "wall_nanos": 7919966661
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "4447896",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 11,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=5.28 avg60=6.51 avg300=10.50 total=7680248410\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7680248410,
+        "load_1m_per_available_cpu": 5.40869140625,
+        "load_1m_per_cpu": 0.056340535481770836,
+        "load_average": [
+          5.40869140625,
+          3.7802734375,
+          6.24072265625
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "19/3594"
+      },
+      "issues": [
+        "refine-6 round 5 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.145s exceeds 0.039s"
+      ],
+      "measurement_attempt": 1,
+      "pair": "refine-6",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            },
+            "67": {
+              "busy_ticks": 1,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 198,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 1
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 2.000931886024773,
+        "rejected_windows": []
+      },
+      "reference": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.14482100000000778,
+          "child_cpu_seconds": 7.7541399999999925,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 779
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.004821000000007753,
+          "measurement_cpu_interrupt_seconds": 0.02,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.004821000000007753,
+          "measurement_cpu_residual_seconds": 0.024821000000007754,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 7.78,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 1,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 96,
+                "user": 680
+              }
+            },
+            "67": {
+              "busy_seconds": 0.14,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 765,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 13
+              }
+            }
+          },
+          "pressure_some_delta_us": 202253,
+          "runner_cpu_seconds": 0.0010390000000000121
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4449828",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 11,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=3.35 avg60=5.94 avg300=10.26 total=7680450696\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7680450696,
+          "load_1m_per_available_cpu": 6.49609375,
+          "load_1m_per_cpu": 0.06766764322916667,
+          "load_average": [
+            6.49609375,
+            4.06787109375,
+            6.30810546875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "11/3594"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4443522",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 11,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=5.28 avg60=6.51 avg300=10.50 total=7680248443\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7680248443,
+          "load_1m_per_available_cpu": 5.40869140625,
+          "load_1m_per_cpu": 0.056340535481770836,
+          "load_average": [
+            5.40869140625,
+            3.7802734375,
+            6.24072265625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "18/3594"
+        },
+        "involuntary_context_switches": 21647,
+        "peak_rss_kb": 3348108,
+        "precise_child_system_seconds": 0.96199399999999,
+        "precise_child_user_seconds": 6.7921460000000025,
+        "system_seconds": 0.96,
+        "user_seconds": 6.79,
+        "voluntary_context_switches": 36729,
+        "wall_nanos": 7788464672
+      },
+      "round": 5,
+      "signed_wall_delta_nanos": 131501989,
+      "slot_index": 4
+    },
+    {
+      "attempt": 1,
+      "build_order": [
+        "candidate",
+        "reference"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.016081999999966644,
+          "child_cpu_seconds": 7.852889000000033,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 789
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.006081999999966642,
+          "measurement_cpu_interrupt_seconds": 0.03,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.006081999999966642,
+          "measurement_cpu_residual_seconds": 0.03608199999996664,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 7.89,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 93,
+                "user": 693
+              }
+            },
+            "67": {
+              "busy_seconds": 0.01,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 787,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 1
+              }
+            }
+          },
+          "pressure_some_delta_us": 1023196,
+          "runner_cpu_seconds": 0.0010289999999999466
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4452480",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 9,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=8.26 avg60=8.66 avg300=9.52 total=7692979118\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7692979118,
+          "load_1m_per_available_cpu": 4.79052734375,
+          "load_1m_per_cpu": 0.049901326497395836,
+          "load_average": [
+            4.79052734375,
+            4.431640625,
+            6.13818359375
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "2/3555"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4455599",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 9,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=6.91 avg60=8.28 avg300=9.46 total=7691955922\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7691955922,
+          "load_1m_per_available_cpu": 4.8623046875,
+          "load_1m_per_cpu": 0.050649007161458336,
+          "load_average": [
+            4.8623046875,
+            4.43017578125,
+            6.15576171875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "2/3587"
+        },
+        "involuntary_context_switches": 22050,
+        "peak_rss_kb": 3368008,
+        "precise_child_system_seconds": 0.9279679999999928,
+        "precise_child_user_seconds": 6.92492100000004,
+        "system_seconds": 0.92,
+        "user_seconds": 6.92,
+        "voluntary_context_switches": 37066,
+        "wall_nanos": 7884711533
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "4420378",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 9,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=6.91 avg60=8.28 avg300=9.46 total=7691955778\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7691955778,
+        "load_1m_per_available_cpu": 4.8623046875,
+        "load_1m_per_cpu": 0.050649007161458336,
+        "load_average": [
+          4.8623046875,
+          4.43017578125,
+          6.15576171875
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "2/3587"
+      },
+      "issues": [
+        "refined-6 round 6 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.060s exceeds 0.030s"
+      ],
+      "measurement_attempt": 1,
+      "pair": "refined-6",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 1,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 1
+              }
+            },
+            "67": {
+              "busy_ticks": 2,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 198,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 1
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 2.0009843630250543,
+        "rejected_windows": []
+      },
+      "reference": {
+        "axioms": null,
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.06,
+          "child_cpu_seconds": 5.3793579999999395,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 541
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.0,
+          "measurement_cpu_interrupt_seconds": 0.02,
+          "measurement_cpu_noninterrupt_residual_seconds": -0.00043299999993927016,
+          "measurement_cpu_residual_seconds": 0.01956700000006073,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 5.4,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 1,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 88,
+                "user": 450
+              }
+            },
+            "67": {
+              "busy_seconds": 0.06,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 535,
+                "iowait": 0,
+                "irq": 1,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 4
+              }
+            }
+          },
+          "pressure_some_delta_us": 931684,
+          "runner_cpu_seconds": 0.0010750000000001592
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4450724",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 9,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=12.92 avg60=9.58 avg300=9.70 total=7693910959\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7693910959,
+          "load_1m_per_available_cpu": 4.56689453125,
+          "load_1m_per_cpu": 0.047571818033854164,
+          "load_average": [
+            4.56689453125,
+            4.39111328125,
+            6.11572265625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "2/3590"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4450620",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 9,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=8.26 avg60=8.66 avg300=9.52 total=7692979275\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7692979275,
+          "load_1m_per_available_cpu": 4.79052734375,
+          "load_1m_per_cpu": 0.049901326497395836,
+          "load_average": [
+            4.79052734375,
+            4.431640625,
+            6.13818359375
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "2/3555"
+        },
+        "involuntary_context_switches": 21261,
+        "peak_rss_kb": 3081668,
+        "precise_child_system_seconds": 0.8835229999999967,
+        "precise_child_user_seconds": 4.495834999999943,
+        "system_seconds": 0.88,
+        "user_seconds": 4.49,
+        "voluntary_context_switches": 36135,
+        "wall_nanos": 5406069776
+      },
+      "round": 6,
+      "signed_wall_delta_nanos": 2478641757,
+      "slot_index": 2
+    },
+    {
+      "attempt": 1,
+      "build_order": [
+        "candidate",
+        "reference"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.04169599999993712,
+          "child_cpu_seconds": 8.047278000000063,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 809
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.0016959999999371159,
+          "measurement_cpu_interrupt_seconds": 0.04,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.0016959999999371159,
+          "measurement_cpu_residual_seconds": 0.04169599999993712,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 8.09,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 3,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 96,
+                "user": 709
+              }
+            },
+            "67": {
+              "busy_seconds": 0.04,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 806,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 3,
+                "user": 1
+              }
+            }
+          },
+          "pressure_some_delta_us": 524479,
+          "runner_cpu_seconds": 0.0010260000000001934
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4451318",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 9,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=5.01 avg60=7.97 avg300=9.30 total=7695598450\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7695598450,
+          "load_1m_per_available_cpu": 4.51806640625,
+          "load_1m_per_cpu": 0.047063191731770836,
+          "load_average": [
+            4.51806640625,
+            4.404296875,
+            6.07421875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "2/3538"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4448452",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 10,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=5.26 avg60=8.34 avg300=9.41 total=7695073971\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7695073971,
+          "load_1m_per_available_cpu": 4.7373046875,
+          "load_1m_per_cpu": 0.049346923828125,
+          "load_average": [
+            4.7373046875,
+            4.4453125,
+            6.0966796875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "6/3536"
+        },
+        "involuntary_context_switches": 22564,
+        "peak_rss_kb": 3409308,
+        "precise_child_system_seconds": 0.9587419999999724,
+        "precise_child_user_seconds": 7.08853600000009,
+        "system_seconds": 0.95,
+        "user_seconds": 7.08,
+        "voluntary_context_switches": 37504,
+        "wall_nanos": 8088400921
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "4455732",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 10,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=5.26 avg60=8.34 avg300=9.41 total=7695073440\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7695073440,
+        "load_1m_per_available_cpu": 4.7373046875,
+        "load_1m_per_cpu": 0.049346923828125,
+        "load_average": [
+          4.7373046875,
+          4.4453125,
+          6.0966796875
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "7/3534"
+      },
+      "issues": [
+        "refine-6 round 6 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.042s exceeds 0.040s",
+        "refine-6 round 6 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.044s exceeds 0.039s"
+      ],
+      "measurement_attempt": 1,
+      "pair": "refine-6",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            },
+            "67": {
+              "busy_ticks": 2,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 2
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 4.001473575131968,
+        "rejected_windows": [
+          {
+            "issues": [
+              "SMT sibling CPU 67 had 63 busy ticks"
+            ],
+            "max_busy_ticks": 2,
+            "per_cpu": {
+              "19": {
+                "noninterrupt_busy_ticks": 0,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 200,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 0
+                }
+              },
+              "67": {
+                "busy_ticks": 63,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 136,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 1,
+                  "user": 62
+                }
+              }
+            },
+            "window_seconds": 2.0
+          }
+        ]
+      },
+      "reference": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.04426600000004811,
+          "child_cpu_seconds": 7.784679999999952,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 783
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.014266000000048108,
+          "measurement_cpu_interrupt_seconds": 0.04,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.014266000000048108,
+          "measurement_cpu_residual_seconds": 0.05426600000004811,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 7.84,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 3,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 92,
+                "user": 688
+              }
+            },
+            "67": {
+              "busy_seconds": 0.03,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 778,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 3
+              }
+            }
+          },
+          "pressure_some_delta_us": 996640,
+          "runner_cpu_seconds": 0.0010539999999998884
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4451484",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=7.89 avg60=8.41 avg300=9.37 total=7696595207\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7696595207,
+          "load_1m_per_available_cpu": 4.19775390625,
+          "load_1m_per_cpu": 0.043726603190104164,
+          "load_average": [
+            4.19775390625,
+            4.3408203125,
+            6.03564453125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3507"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4451570",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 9,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=5.01 avg60=7.97 avg300=9.30 total=7695598567\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7695598567,
+          "load_1m_per_available_cpu": 4.51806640625,
+          "load_1m_per_cpu": 0.047063191731770836,
+          "load_average": [
+            4.51806640625,
+            4.404296875,
+            6.07421875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "2/3538"
+        },
+        "involuntary_context_switches": 22413,
+        "peak_rss_kb": 3346560,
+        "precise_child_system_seconds": 0.9164990000000159,
+        "precise_child_user_seconds": 6.868180999999936,
+        "system_seconds": 0.91,
+        "user_seconds": 6.86,
+        "voluntary_context_switches": 37245,
+        "wall_nanos": 7823493725
+      },
+      "round": 6,
+      "signed_wall_delta_nanos": 264907196,
+      "slot_index": 3
+    },
+    {
+      "attempt": 2,
+      "build_order": [
+        "candidate",
+        "reference"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.01,
+          "child_cpu_seconds": 7.900355999999988,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 794
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.0,
+          "measurement_cpu_interrupt_seconds": 0.02,
+          "measurement_cpu_noninterrupt_residual_seconds": -0.0013829999999879043,
+          "measurement_cpu_residual_seconds": 0.018617000000012096,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 7.92,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 91,
+                "user": 699
+              }
+            },
+            "67": {
+              "busy_seconds": 0.01,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 793,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 1
+              }
+            }
+          },
+          "pressure_some_delta_us": 1111678,
+          "runner_cpu_seconds": 0.0010269999999998891
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4450035",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 9,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=9.17 avg60=8.78 avg300=9.42 total=7697707593\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7697707593,
+          "load_1m_per_available_cpu": 4.3017578125,
+          "load_1m_per_cpu": 0.044809977213541664,
+          "load_average": [
+            4.3017578125,
+            4.36181640625,
+            6.0244140625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "10/3519"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4358943",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=7.00 avg60=8.23 avg300=9.33 total=7696595915\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7696595915,
+          "load_1m_per_available_cpu": 4.19775390625,
+          "load_1m_per_cpu": 0.043726603190104164,
+          "load_average": [
+            4.19775390625,
+            4.3408203125,
+            6.03564453125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3474"
+        },
+        "involuntary_context_switches": 22509,
+        "peak_rss_kb": 3377852,
+        "precise_child_system_seconds": 0.9195829999999887,
+        "precise_child_user_seconds": 6.980772999999999,
+        "system_seconds": 0.91,
+        "user_seconds": 6.98,
+        "voluntary_context_switches": 37424,
+        "wall_nanos": 7938699228
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "1975623",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 6,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=7.00 avg60=8.23 avg300=9.33 total=7696595707\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7696595707,
+        "load_1m_per_available_cpu": 4.19775390625,
+        "load_1m_per_cpu": 0.043726603190104164,
+        "load_average": [
+          4.19775390625,
+          4.3408203125,
+          6.03564453125
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "1/3474"
+      },
+      "issues": [
+        "refine-6 round 6 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.055s exceeds 0.039s"
+      ],
+      "measurement_attempt": 2,
+      "pair": "refine-6",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 1,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 1
+              }
+            },
+            "67": {
+              "busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 2.001268651103601,
+        "rejected_windows": []
+      },
+      "reference": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.054554000000076375,
+          "child_cpu_seconds": 7.774401999999924,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 782
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.014554000000076374,
+          "measurement_cpu_interrupt_seconds": 0.04,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.014554000000076374,
+          "measurement_cpu_residual_seconds": 0.054554000000076375,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 7.83,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 3,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 95,
+                "user": 684
+              }
+            },
+            "67": {
+              "busy_seconds": 0.04,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 778,
+                "iowait": 0,
+                "irq": 1,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 2
+              }
+            }
+          },
+          "pressure_some_delta_us": 1524283,
+          "runner_cpu_seconds": 0.0010439999999998228
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4452324",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=12.73 avg60=9.86 avg300=9.65 total=7699231968\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7699231968,
+          "load_1m_per_available_cpu": 3.94091796875,
+          "load_1m_per_cpu": 0.041051228841145836,
+          "load_average": [
+            3.94091796875,
+            4.283203125,
+            5.98046875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3469"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4450934",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 9,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=9.17 avg60=8.78 avg300=9.42 total=7697707685\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7697707685,
+          "load_1m_per_available_cpu": 4.3017578125,
+          "load_1m_per_cpu": 0.044809977213541664,
+          "load_average": [
+            4.3017578125,
+            4.36181640625,
+            6.0244140625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "2/3519"
+        },
+        "involuntary_context_switches": 22032,
+        "peak_rss_kb": 3387516,
+        "precise_child_system_seconds": 0.9407980000000009,
+        "precise_child_user_seconds": 6.833603999999923,
+        "system_seconds": 0.94,
+        "user_seconds": 6.83,
+        "voluntary_context_switches": 36894,
+        "wall_nanos": 7812079202
+      },
+      "round": 6,
+      "signed_wall_delta_nanos": 126620026,
+      "slot_index": 3
+    },
+    {
+      "attempt": 3,
+      "build_order": [
+        "candidate",
+        "reference"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.09,
+          "child_cpu_seconds": 8.044388000000055,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 809
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.0,
+          "measurement_cpu_interrupt_seconds": 0.04,
+          "measurement_cpu_noninterrupt_residual_seconds": -0.005420000000054791,
+          "measurement_cpu_residual_seconds": 0.03457999999994521,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 8.08,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 3,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 94,
+                "user": 710
+              }
+            },
+            "67": {
+              "busy_seconds": 0.09,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 800,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 2,
+                "user": 6
+              }
+            }
+          },
+          "pressure_some_delta_us": 1659956,
+          "runner_cpu_seconds": 0.001032000000000144
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4453535",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=12.96 avg60=10.47 avg300=9.79 total=7700894649\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7700894649,
+          "load_1m_per_available_cpu": 4.03662109375,
+          "load_1m_per_cpu": 0.042048136393229164,
+          "load_average": [
+            4.03662109375,
+            4.291015625,
+            5.96484375
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3467"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4453637",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=8.98 avg60=9.32 avg300=9.54 total=7699234693\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7699234693,
+          "load_1m_per_available_cpu": 3.94091796875,
+          "load_1m_per_cpu": 0.041051228841145836,
+          "load_average": [
+            3.94091796875,
+            4.283203125,
+            5.98046875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3464"
+        },
+        "involuntary_context_switches": 22440,
+        "peak_rss_kb": 3380552,
+        "precise_child_system_seconds": 0.9416999999999973,
+        "precise_child_user_seconds": 7.102688000000057,
+        "system_seconds": 0.94,
+        "user_seconds": 7.1,
+        "voluntary_context_switches": 37297,
+        "wall_nanos": 8083610526
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "4454911",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 6,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=8.98 avg60=9.32 avg300=9.54 total=7699233523\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7699233523,
+        "load_1m_per_available_cpu": 3.94091796875,
+        "load_1m_per_cpu": 0.041051228841145836,
+        "load_average": [
+          3.94091796875,
+          4.283203125,
+          5.98046875
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "1/3464"
+      },
+      "issues": [
+        "refine-6 round 6 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.090s exceeds 0.040s",
+        "refine-6 round 6 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.085s exceeds 0.039s"
+      ],
+      "measurement_attempt": 3,
+      "pair": "refine-6",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 2,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 197,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 2
+              }
+            },
+            "67": {
+              "busy_ticks": 2,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 198,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 1
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 4.001572642009705,
+        "rejected_windows": [
+          {
+            "issues": [
+              "SMT sibling CPU 67 had 4 busy ticks"
+            ],
+            "max_busy_ticks": 2,
+            "per_cpu": {
+              "19": {
+                "noninterrupt_busy_ticks": 2,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 198,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 1,
+                  "user": 1
+                }
+              },
+              "67": {
+                "busy_ticks": 4,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 197,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 4
+                }
+              }
+            },
+            "window_seconds": 2.0
+          }
+        ]
+      },
+      "reference": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.08501700000004893,
+          "child_cpu_seconds": 7.843926999999951,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 788
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.005017000000048927,
+          "measurement_cpu_interrupt_seconds": 0.03,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.005017000000048927,
+          "measurement_cpu_residual_seconds": 0.035017000000048926,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 7.88,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 97,
+                "user": 688
+              }
+            },
+            "67": {
+              "busy_seconds": 0.08,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 779,
+                "iowait": 0,
+                "irq": 1,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 2,
+                "user": 5
+              }
+            }
+          },
+          "pressure_some_delta_us": 1673313,
+          "runner_cpu_seconds": 0.0010559999999999459
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4452171",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=15.34 avg60=11.60 avg300=10.06 total=7702568164\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7702568164,
+          "load_1m_per_available_cpu": 3.7900390625,
+          "load_1m_per_cpu": 0.039479573567708336,
+          "load_average": [
+            3.7900390625,
+            4.2314453125,
+            5.92724609375
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3461"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4451695",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=12.96 avg60=10.47 avg300=9.79 total=7700894851\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7700894851,
+          "load_1m_per_available_cpu": 4.03662109375,
+          "load_1m_per_cpu": 0.042048136393229164,
+          "load_average": [
+            4.03662109375,
+            4.291015625,
+            5.96484375
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "2/3467"
+        },
+        "involuntary_context_switches": 23413,
+        "peak_rss_kb": 3336712,
+        "precise_child_system_seconds": 0.9699899999999957,
+        "precise_child_user_seconds": 6.873936999999955,
+        "system_seconds": 0.96,
+        "user_seconds": 6.87,
+        "voluntary_context_switches": 38312,
+        "wall_nanos": 7879624957
+      },
+      "round": 6,
+      "signed_wall_delta_nanos": 203985569,
+      "slot_index": 3
+    },
+    {
+      "attempt": 4,
+      "build_order": [
+        "candidate",
+        "reference"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.051129000000054825,
+          "child_cpu_seconds": 7.997859999999946,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 804
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.011129000000054824,
+          "measurement_cpu_interrupt_seconds": 0.04,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.011129000000054824,
+          "measurement_cpu_residual_seconds": 0.051129000000054825,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 8.05,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 3,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 100,
+                "user": 701
+              }
+            },
+            "67": {
+              "busy_seconds": 0.04,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 801,
+                "iowait": 0,
+                "irq": 1,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 1,
+                "user": 1
+              }
+            }
+          },
+          "pressure_some_delta_us": 1288402,
+          "runner_cpu_seconds": 0.0010109999999998731
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4452075",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=9.63 avg60=10.47 avg300=9.87 total=7703862897\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7703862897,
+          "load_1m_per_available_cpu": 3.09765625,
+          "load_1m_per_cpu": 0.032267252604166664,
+          "load_average": [
+            3.09765625,
+            4.05615234375,
+            5.84228515625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3472"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4201089",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=5.89 avg60=9.91 avg300=9.74 total=7702574495\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7702574495,
+          "load_1m_per_available_cpu": 3.28076171875,
+          "load_1m_per_cpu": 0.034174601236979164,
+          "load_average": [
+            3.28076171875,
+            4.10791015625,
+            5.86865234375
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3465"
+        },
+        "involuntary_context_switches": 22653,
+        "peak_rss_kb": 3372176,
+        "precise_child_system_seconds": 0.993251999999984,
+        "precise_child_user_seconds": 7.004607999999962,
+        "system_seconds": 0.99,
+        "user_seconds": 7.0,
+        "voluntary_context_switches": 37593,
+        "wall_nanos": 8036305789
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "2585855",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 6,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=5.89 avg60=9.91 avg300=9.74 total=7702574200\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7702574200,
+        "load_1m_per_available_cpu": 3.28076171875,
+        "load_1m_per_cpu": 0.034174601236979164,
+        "load_average": [
+          3.28076171875,
+          4.10791015625,
+          5.86865234375
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "2/3465"
+      },
+      "issues": [
+        "refine-6 round 6 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.051s exceeds 0.040s"
+      ],
+      "measurement_attempt": 4,
+      "pair": "refine-6",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            },
+            "67": {
+              "busy_ticks": 1,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 1
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 10.005616602953523,
+        "rejected_windows": [
+          {
+            "issues": [
+              "measurement CPU 19 had 5 non-interrupt busy ticks"
+            ],
+            "max_busy_ticks": 2,
+            "per_cpu": {
+              "19": {
+                "noninterrupt_busy_ticks": 5,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 195,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 1,
+                  "user": 4
+                }
+              },
+              "67": {
+                "busy_ticks": 2,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 195,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 2
+                }
+              }
+            },
+            "window_seconds": 2.0
+          },
+          {
+            "issues": [
+              "measurement CPU 19 had 111 non-interrupt busy ticks"
+            ],
+            "max_busy_ticks": 2,
+            "per_cpu": {
+              "19": {
+                "noninterrupt_busy_ticks": 111,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 88,
+                  "iowait": 0,
+                  "irq": 1,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 2,
+                  "user": 109
+                }
+              },
+              "67": {
+                "busy_ticks": 2,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 196,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 2
+                }
+              }
+            },
+            "window_seconds": 2.0
+          },
+          {
+            "issues": [
+              "measurement CPU 19 had 3 non-interrupt busy ticks",
+              "SMT sibling CPU 67 had 5 busy ticks"
+            ],
+            "max_busy_ticks": 2,
+            "per_cpu": {
+              "19": {
+                "noninterrupt_busy_ticks": 3,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 195,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 3
+                }
+              },
+              "67": {
+                "busy_ticks": 5,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 196,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 1,
+                  "user": 4
+                }
+              }
+            },
+            "window_seconds": 2.0
+          },
+          {
+            "issues": [
+              "measurement CPU 19 had 19 non-interrupt busy ticks",
+              "SMT sibling CPU 67 had 3 busy ticks"
+            ],
+            "max_busy_ticks": 2,
+            "per_cpu": {
+              "19": {
+                "noninterrupt_busy_ticks": 19,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 182,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 2,
+                  "user": 17
+                }
+              },
+              "67": {
+                "busy_ticks": 3,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 197,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 3
+                }
+              }
+            },
+            "window_seconds": 2.0
+          }
+        ]
+      },
+      "reference": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.033209999999902276,
+          "child_cpu_seconds": 7.705743000000098,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 775
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.013209999999902272,
+          "measurement_cpu_interrupt_seconds": 0.03,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.013209999999902272,
+          "measurement_cpu_residual_seconds": 0.04320999999990227,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 7.75,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 1,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 96,
+                "user": 676
+              }
+            },
+            "67": {
+              "busy_seconds": 0.02,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 773,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 2
+              }
+            }
+          },
+          "pressure_some_delta_us": 1535145,
+          "runner_cpu_seconds": 0.0010470000000000201
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4452067",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 9,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=13.41 avg60=11.51 avg300=10.13 total=7705398352\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7705398352,
+          "load_1m_per_available_cpu": 3.08203125,
+          "load_1m_per_cpu": 0.0321044921875,
+          "load_average": [
+            3.08203125,
+            4.02099609375,
+            5.81103515625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "2/3491"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4448908",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=9.63 avg60=10.47 avg300=9.87 total=7703863207\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7703863207,
+          "load_1m_per_available_cpu": 3.09765625,
+          "load_1m_per_cpu": 0.032267252604166664,
+          "load_average": [
+            3.09765625,
+            4.05615234375,
+            5.84228515625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "3/3472"
+        },
+        "involuntary_context_switches": 22146,
+        "peak_rss_kb": 3336804,
+        "precise_child_system_seconds": 0.9560529999999972,
+        "precise_child_user_seconds": 6.7496900000001006,
+        "system_seconds": 0.95,
+        "user_seconds": 6.74,
+        "voluntary_context_switches": 37074,
+        "wall_nanos": 7748872016
+      },
+      "round": 6,
+      "signed_wall_delta_nanos": 287433773,
+      "slot_index": 3
+    },
+    {
+      "attempt": 5,
+      "build_order": [
+        "candidate",
+        "reference"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.06011599999998472,
+          "child_cpu_seconds": 8.008853000000016,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 805
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.01011599999998472,
+          "measurement_cpu_interrupt_seconds": 0.03,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.01011599999998472,
+          "measurement_cpu_residual_seconds": 0.04011599999998472,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 8.05,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 1,
+                "iowait": 0,
+                "irq": 3,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 93,
+                "user": 709
+              }
+            },
+            "67": {
+              "busy_seconds": 0.05,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 799,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 4
+              }
+            }
+          },
+          "pressure_some_delta_us": 1166400,
+          "runner_cpu_seconds": 0.001030999999999782
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4451061",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=11.47 avg60=11.42 avg300=10.15 total=7706565876\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7706565876,
+          "load_1m_per_available_cpu": 3.056640625,
+          "load_1m_per_cpu": 0.031840006510416664,
+          "load_average": [
+            3.056640625,
+            3.98681640625,
+            5.78076171875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3467"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4450099",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 9,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=11.34 avg60=11.20 avg300=10.07 total=7705399476\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7705399476,
+          "load_1m_per_available_cpu": 3.08203125,
+          "load_1m_per_cpu": 0.0321044921875,
+          "load_average": [
+            3.08203125,
+            4.02099609375,
+            5.81103515625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "2/3506"
+        },
+        "involuntary_context_switches": 22131,
+        "peak_rss_kb": 3392260,
+        "precise_child_system_seconds": 0.9296099999999967,
+        "precise_child_user_seconds": 7.0792430000000195,
+        "system_seconds": 0.92,
+        "user_seconds": 7.07,
+        "voluntary_context_switches": 36951,
+        "wall_nanos": 8047794727
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "1500000",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 9,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=11.34 avg60=11.20 avg300=10.07 total=7705399345\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7705399345,
+        "load_1m_per_available_cpu": 3.08203125,
+        "load_1m_per_cpu": 0.0321044921875,
+        "load_average": [
+          3.08203125,
+          4.02099609375,
+          5.81103515625
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "3/3506"
+      },
+      "issues": [
+        "refine-6 round 6 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.060s exceeds 0.040s",
+        "refine-6 round 6 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.060s exceeds 0.040s"
+      ],
+      "measurement_attempt": 5,
+      "pair": "refine-6",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            },
+            "67": {
+              "busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 2.000821301015094,
+        "rejected_windows": []
+      },
+      "reference": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.06,
+          "child_cpu_seconds": 8.033916000000062,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 807
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.0,
+          "measurement_cpu_interrupt_seconds": 0.04,
+          "measurement_cpu_noninterrupt_residual_seconds": -0.004987000000061546,
+          "measurement_cpu_residual_seconds": 0.035012999999938454,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 8.07,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 3,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 95,
+                "user": 708
+              }
+            },
+            "67": {
+              "busy_seconds": 0.06,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 798,
+                "iowait": 1,
+                "irq": 1,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 4
+              }
+            }
+          },
+          "pressure_some_delta_us": 652372,
+          "runner_cpu_seconds": 0.0010710000000000441
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4454178",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 13,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=8.91 avg60=11.02 avg300=10.11 total=7707219104\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7707219104,
+          "load_1m_per_available_cpu": 3.53271484375,
+          "load_1m_per_cpu": 0.036799112955729164,
+          "load_average": [
+            3.53271484375,
+            4.0703125,
+            5.79833984375
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "10/3558"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4451754",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 6,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=11.47 avg60=11.42 avg300=10.15 total=7706566732\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7706566732,
+          "load_1m_per_available_cpu": 3.056640625,
+          "load_1m_per_cpu": 0.031840006510416664,
+          "load_average": [
+            3.056640625,
+            3.98681640625,
+            5.78076171875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "1/3467"
+        },
+        "involuntary_context_switches": 22795,
+        "peak_rss_kb": 3346964,
+        "precise_child_system_seconds": 0.9519889999999975,
+        "precise_child_user_seconds": 7.081927000000064,
+        "system_seconds": 0.95,
+        "user_seconds": 7.08,
+        "voluntary_context_switches": 37760,
+        "wall_nanos": 8074776707
+      },
+      "round": 6,
+      "signed_wall_delta_nanos": -26981980,
+      "slot_index": 3
+    },
+    {
+      "attempt": 6,
+      "build_order": [
+        "candidate",
+        "reference"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.14,
+          "child_cpu_seconds": 8.152816000000001,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 819
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.0,
+          "measurement_cpu_interrupt_seconds": 0.03,
+          "measurement_cpu_noninterrupt_residual_seconds": -0.003901000000001681,
+          "measurement_cpu_residual_seconds": 0.026098999999998318,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 8.18,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 3,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 101,
+                "user": 714
+              }
+            },
+            "67": {
+              "busy_seconds": 0.14,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 806,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 3,
+                "user": 11
+              }
+            }
+          },
+          "pressure_some_delta_us": 211090,
+          "runner_cpu_seconds": 0.0010850000000000026
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4456109",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 11,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=3.00 avg60=8.94 avg300=9.68 total=7707432744\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7707432744,
+          "load_1m_per_available_cpu": 5.1953125,
+          "load_1m_per_cpu": 0.054117838541666664,
+          "load_average": [
+            5.1953125,
+            4.3974609375,
+            5.87744140625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "10/3531"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4449256",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 13,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=4.89 avg60=9.97 avg300=9.90 total=7707221654\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7707221654,
+          "load_1m_per_available_cpu": 3.90625,
+          "load_1m_per_cpu": 0.040690104166666664,
+          "load_average": [
+            3.90625,
+            4.1337890625,
+            5.80078125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "9/3609"
+        },
+        "involuntary_context_switches": 22865,
+        "peak_rss_kb": 3413412,
+        "precise_child_system_seconds": 1.0137160000000165,
+        "precise_child_user_seconds": 7.139099999999985,
+        "system_seconds": 1.01,
+        "user_seconds": 7.13,
+        "voluntary_context_switches": 37825,
+        "wall_nanos": 8190686831
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "4445986",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 12,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=4.89 avg60=9.97 avg300=9.90 total=7707221623\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7707221623,
+        "load_1m_per_available_cpu": 3.90625,
+        "load_1m_per_cpu": 0.040690104166666664,
+        "load_average": [
+          3.90625,
+          4.1337890625,
+          5.80078125
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "9/3605"
+      },
+      "issues": [
+        "refine-6 round 6 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.140s exceeds 0.041s"
+      ],
+      "measurement_attempt": 6,
+      "pair": "refine-6",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            },
+            "67": {
+              "busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 6.003320890944451,
+        "rejected_windows": [
+          {
+            "issues": [
+              "measurement CPU 19 had 4 non-interrupt busy ticks",
+              "SMT sibling CPU 67 had 32 busy ticks"
+            ],
+            "max_busy_ticks": 2,
+            "per_cpu": {
+              "19": {
+                "noninterrupt_busy_ticks": 4,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 194,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 1,
+                  "user": 3
+                }
+              },
+              "67": {
+                "busy_ticks": 32,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 166,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 1,
+                  "user": 31
+                }
+              }
+            },
+            "window_seconds": 2.0
+          },
+          {
+            "issues": [
+              "measurement CPU 19 had 12 non-interrupt busy ticks",
+              "SMT sibling CPU 67 had 4 busy ticks"
+            ],
+            "max_busy_ticks": 2,
+            "per_cpu": {
+              "19": {
+                "noninterrupt_busy_ticks": 12,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 188,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 2,
+                  "user": 10
+                }
+              },
+              "67": {
+                "busy_ticks": 4,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 196,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 4
+                }
+              }
+            },
+            "window_seconds": 2.0
+          }
+        ]
+      },
+      "reference": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.0025769999999918705,
+          "child_cpu_seconds": 7.726323000000008,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 777
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.0025769999999918705,
+          "measurement_cpu_interrupt_seconds": 0.04,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.0025769999999918705,
+          "measurement_cpu_residual_seconds": 0.04257699999999187,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 7.77,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 3,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 92,
+                "user": 681
+              }
+            },
+            "67": {
+              "busy_seconds": 0.0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 776,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "pressure_some_delta_us": 230290,
+          "runner_cpu_seconds": 0.0010999999999998789
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4452303",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 11,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=2.44 avg60=8.10 avg300=9.48 total=7707663111\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7707663111,
+          "load_1m_per_available_cpu": 6.14892578125,
+          "load_1m_per_cpu": 0.06405131022135417,
+          "load_average": [
+            6.14892578125,
+            4.63134765625,
+            5.93798828125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "13/3528"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4452640",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 11,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=3.00 avg60=8.94 avg300=9.68 total=7707432821\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7707432821,
+          "load_1m_per_available_cpu": 5.1953125,
+          "load_1m_per_cpu": 0.054117838541666664,
+          "load_average": [
+            5.1953125,
+            4.3974609375,
+            5.87744140625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "11/3531"
+        },
+        "involuntary_context_switches": 21793,
+        "peak_rss_kb": 3358012,
+        "precise_child_system_seconds": 0.9208069999999964,
+        "precise_child_user_seconds": 6.8055160000000114,
+        "system_seconds": 0.92,
+        "user_seconds": 6.8,
+        "voluntary_context_switches": 36729,
+        "wall_nanos": 7763064163
+      },
+      "round": 6,
+      "signed_wall_delta_nanos": 427622668,
+      "slot_index": 3
+    },
+    {
+      "attempt": 7,
+      "build_order": [
+        "candidate",
+        "reference"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.20877700000002228,
+          "child_cpu_seconds": 8.110182999999978,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 816
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.008777000000022267,
+          "measurement_cpu_interrupt_seconds": 0.03,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.008777000000022267,
+          "measurement_cpu_residual_seconds": 0.038777000000022266,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 8.15,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 3,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 102,
+                "user": 710
+              }
+            },
+            "67": {
+              "busy_seconds": 0.2,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 796,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 20
+              }
+            }
+          },
+          "pressure_some_delta_us": 177067,
+          "runner_cpu_seconds": 0.001040000000000152
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4453055",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 12,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=1.43 avg60=6.63 avg300=9.08 total=7707841839\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7707841839,
+          "load_1m_per_available_cpu": 8.8203125,
+          "load_1m_per_cpu": 0.09187825520833333,
+          "load_average": [
+            8.8203125,
+            5.2890625,
+            6.13232421875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "4/3578"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4451123",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 12,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=1.34 avg60=7.33 avg300=9.28 total=7707664772\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7707664772,
+          "load_1m_per_available_cpu": 6.21728515625,
+          "load_1m_per_cpu": 0.06476338704427083,
+          "load_average": [
+            6.21728515625,
+            4.6708984375,
+            5.94384765625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "8/3564"
+        },
+        "involuntary_context_switches": 21823,
+        "peak_rss_kb": 3354080,
+        "precise_child_system_seconds": 1.016604000000001,
+        "precise_child_user_seconds": 7.093578999999977,
+        "system_seconds": 1.01,
+        "user_seconds": 7.09,
+        "voluntary_context_switches": 36699,
+        "wall_nanos": 8151827552
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "4453427",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 12,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=1.34 avg60=7.33 avg300=9.28 total=7707664751\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7707664751,
+        "load_1m_per_available_cpu": 6.21728515625,
+        "load_1m_per_cpu": 0.06476338704427083,
+        "load_average": [
+          6.21728515625,
+          4.6708984375,
+          5.94384765625
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "10/3564"
+      },
+      "issues": [
+        "refine-6 round 6 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.209s exceeds 0.041s"
+      ],
+      "measurement_attempt": 7,
+      "pair": "refine-6",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            },
+            "67": {
+              "busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 6.002388793043792,
+        "rejected_windows": [
+          {
+            "issues": [
+              "measurement CPU 19 had 8 non-interrupt busy ticks",
+              "SMT sibling CPU 67 had 7 busy ticks"
+            ],
+            "max_busy_ticks": 2,
+            "per_cpu": {
+              "19": {
+                "noninterrupt_busy_ticks": 8,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 193,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 8
+                }
+              },
+              "67": {
+                "busy_ticks": 7,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 194,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 7
+                }
+              }
+            },
+            "window_seconds": 2.0
+          },
+          {
+            "issues": [
+              "SMT sibling CPU 67 had 95 busy ticks"
+            ],
+            "max_busy_ticks": 2,
+            "per_cpu": {
+              "19": {
+                "noninterrupt_busy_ticks": 0,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 200,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 0
+                }
+              },
+              "67": {
+                "busy_ticks": 95,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 105,
+                  "iowait": 0,
+                  "irq": 1,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 1,
+                  "user": 93
+                }
+              }
+            },
+            "window_seconds": 2.0
+          }
+        ]
+      },
+      "reference": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.0,
+          "child_cpu_seconds": 7.734948000000088,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 777
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.0,
+          "measurement_cpu_interrupt_seconds": 0.04,
+          "measurement_cpu_noninterrupt_residual_seconds": -0.005994000000088172,
+          "measurement_cpu_residual_seconds": 0.03400599999991183,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 7.77,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 3,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 88,
+                "user": 685
+              }
+            },
+            "67": {
+              "busy_seconds": 0.0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 778,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "pressure_some_delta_us": 282352,
+          "runner_cpu_seconds": 0.0010459999999996583
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4450377",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 8,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=1.99 avg60=6.14 avg300=8.91 total=7708124269\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7708124269,
+          "load_1m_per_available_cpu": 8.35400390625,
+          "load_1m_per_cpu": 0.0870208740234375,
+          "load_average": [
+            8.35400390625,
+            5.2509765625,
+            6.115234375
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "4/3514"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4449184",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 12,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=1.43 avg60=6.63 avg300=9.08 total=7707841917\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7707841917,
+          "load_1m_per_available_cpu": 8.8203125,
+          "load_1m_per_cpu": 0.09187825520833333,
+          "load_average": [
+            8.8203125,
+            5.2890625,
+            6.13232421875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "4/3578"
+        },
+        "involuntary_context_switches": 22296,
+        "peak_rss_kb": 3363932,
+        "precise_child_system_seconds": 0.8865490000000023,
+        "precise_child_user_seconds": 6.848399000000086,
+        "system_seconds": 0.88,
+        "user_seconds": 6.84,
+        "voluntary_context_switches": 37172,
+        "wall_nanos": 7772488609
+      },
+      "round": 6,
+      "signed_wall_delta_nanos": 379338943,
+      "slot_index": 3
+    },
+    {
+      "attempt": 1,
+      "build_order": [
+        "candidate",
+        "reference"
+      ],
+      "candidate": {
+        "axioms": null,
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.061485000000030404,
+          "child_cpu_seconds": 5.46753499999997,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 550
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.0014850000000304064,
+          "measurement_cpu_interrupt_seconds": 0.03,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.0014850000000304064,
+          "measurement_cpu_residual_seconds": 0.031485000000030405,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 5.5,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 92,
+                "user": 455
+              }
+            },
+            "67": {
+              "busy_seconds": 0.06,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 544,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 5
+              }
+            }
+          },
+          "pressure_some_delta_us": 770819,
+          "runner_cpu_seconds": 0.0009799999999999809
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4450401",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 11,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=7.18 avg60=6.48 avg300=8.75 total=7710087820\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7710087820,
+          "load_1m_per_available_cpu": 7.67333984375,
+          "load_1m_per_cpu": 0.07993062337239583,
+          "load_average": [
+            7.67333984375,
+            5.34375,
+            6.1220703125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "6/3533"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4450221",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 8,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=3.79 avg60=5.92 avg300=8.68 total=7709317001\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7709317001,
+          "load_1m_per_available_cpu": 7.9931640625,
+          "load_1m_per_cpu": 0.08326212565104167,
+          "load_average": [
+            7.9931640625,
+            5.36669921875,
+            6.1337890625
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "3/3511"
+        },
+        "involuntary_context_switches": 21754,
+        "peak_rss_kb": 3081452,
+        "precise_child_system_seconds": 0.9181279999999958,
+        "precise_child_user_seconds": 4.549406999999974,
+        "system_seconds": 0.91,
+        "user_seconds": 4.54,
+        "voluntary_context_switches": 36604,
+        "wall_nanos": 5493545269
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "1500000",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 8,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=3.79 avg60=5.92 avg300=8.68 total=7709316946\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7709316946,
+        "load_1m_per_available_cpu": 7.9931640625,
+        "load_1m_per_cpu": 0.08326212565104167,
+        "load_average": [
+          7.9931640625,
+          5.36669921875,
+          6.1337890625
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "3/3511"
+      },
+      "issues": [
+        "fresh-build-null round 6 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.061s exceeds 0.030s"
+      ],
+      "measurement_attempt": 1,
+      "pair": "fresh-build-null",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            },
+            "67": {
+              "busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 200,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 2.000952288042754,
+        "rejected_windows": []
+      },
+      "reference": {
+        "axioms": null,
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.022062999999986177,
+          "child_cpu_seconds": 5.5368620000000135,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 556
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.0020629999999861766,
+          "measurement_cpu_interrupt_seconds": 0.02,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.0020629999999861766,
+          "measurement_cpu_residual_seconds": 0.022062999999986177,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 5.56,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 93,
+                "user": 461
+              }
+            },
+            "67": {
+              "busy_seconds": 0.02,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 555,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 0,
+                "user": 1
+              }
+            }
+          },
+          "pressure_some_delta_us": 217416,
+          "runner_cpu_seconds": 0.0010749999999999371
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4450842",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 12,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=5.14 avg60=6.15 avg300=8.63 total=7710305272\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7710305272,
+          "load_1m_per_available_cpu": 8.10009765625,
+          "load_1m_per_cpu": 0.08437601725260417,
+          "load_average": [
+            8.10009765625,
+            5.47119140625,
+            6.1591796875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "5/3579"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4448994",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 11,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=7.18 avg60=6.48 avg300=8.75 total=7710087856\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7710087856,
+          "load_1m_per_available_cpu": 7.67333984375,
+          "load_1m_per_cpu": 0.07993062337239583,
+          "load_average": [
+            7.67333984375,
+            5.34375,
+            6.1220703125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "5/3534"
+        },
+        "involuntary_context_switches": 21451,
+        "peak_rss_kb": 3079972,
+        "precise_child_system_seconds": 0.9226779999999906,
+        "precise_child_user_seconds": 4.614184000000023,
+        "system_seconds": 0.92,
+        "user_seconds": 4.61,
+        "voluntary_context_switches": 36231,
+        "wall_nanos": 5563887405
+      },
+      "round": 6,
+      "signed_wall_delta_nanos": -70342136,
+      "slot_index": 4
+    },
+    {
+      "attempt": 2,
+      "build_order": [
+        "candidate",
+        "reference"
+      ],
+      "candidate": {
+        "axioms": null,
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.03261299999995114,
+          "child_cpu_seconds": 5.4563700000000495,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 548
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.002612999999951144,
+          "measurement_cpu_interrupt_seconds": 0.02,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.002612999999951144,
+          "measurement_cpu_residual_seconds": 0.022612999999951144,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 5.48,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 94,
+                "user": 452
+              }
+            },
+            "67": {
+              "busy_seconds": 0.03,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 545,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 2
+              }
+            }
+          },
+          "pressure_some_delta_us": 468377,
+          "runner_cpu_seconds": 0.0010169999999998236
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4452132",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 9,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=6.45 avg60=6.27 avg300=8.61 total=7710774311\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7710774311,
+          "load_1m_per_available_cpu": 7.462890625,
+          "load_1m_per_cpu": 0.07773844401041667,
+          "load_average": [
+            7.462890625,
+            5.421875,
+            6.1357421875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "3/3515"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4444483",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 13,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=4.21 avg60=5.94 avg300=8.57 total=7710305934\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7710305934,
+          "load_1m_per_available_cpu": 7.8515625,
+          "load_1m_per_cpu": 0.081787109375,
+          "load_average": [
+            7.8515625,
+            5.462890625,
+            6.15283203125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "8/3567"
+        },
+        "involuntary_context_switches": 22103,
+        "peak_rss_kb": 3079364,
+        "precise_child_system_seconds": 0.9390080000000012,
+        "precise_child_user_seconds": 4.517362000000048,
+        "system_seconds": 0.93,
+        "user_seconds": 4.51,
+        "voluntary_context_switches": 36870,
+        "wall_nanos": 5483627416
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "4448566",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 13,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=4.21 avg60=5.94 avg300=8.57 total=7710305795\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7710305795,
+        "load_1m_per_available_cpu": 7.8515625,
+        "load_1m_per_cpu": 0.081787109375,
+        "load_average": [
+          7.8515625,
+          5.462890625,
+          6.15283203125
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "5/3574"
+      },
+      "issues": [
+        "fresh-build-null round 6 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.033s exceeds 0.030s"
+      ],
+      "measurement_attempt": 2,
+      "pair": "fresh-build-null",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 2,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 1
+              }
+            },
+            "67": {
+              "busy_ticks": 1,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 1,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 2.000848572002724,
+        "rejected_windows": []
+      },
+      "reference": {
+        "axioms": null,
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.006383999999960671,
+          "child_cpu_seconds": 5.37256400000004,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 540
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.006383999999960671,
+          "measurement_cpu_interrupt_seconds": 0.03,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.006383999999960671,
+          "measurement_cpu_residual_seconds": 0.03638399999996067,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 5.41,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 1,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 1,
+                "steal": 0,
+                "system": 93,
+                "user": 445
+              }
+            },
+            "67": {
+              "busy_seconds": 0.0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 540,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "pressure_some_delta_us": 410535,
+          "runner_cpu_seconds": 0.0010519999999998308
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4451033",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 8,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=6.43 avg60=6.28 avg300=8.56 total=7711184950\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7711184950,
+          "load_1m_per_available_cpu": 7.66650390625,
+          "load_1m_per_cpu": 0.07985941569010417,
+          "load_average": [
+            7.66650390625,
+            5.498046875,
+            6.15673828125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "5/3536"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4450268",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 9,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=6.45 avg60=6.27 avg300=8.61 total=7710774415\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7710774415,
+          "load_1m_per_available_cpu": 7.462890625,
+          "load_1m_per_cpu": 0.07773844401041667,
+          "load_average": [
+            7.462890625,
+            5.421875,
+            6.1357421875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "3/3515"
+        },
+        "involuntary_context_switches": 21093,
+        "peak_rss_kb": 3077964,
+        "precise_child_system_seconds": 0.9289619999999843,
+        "precise_child_user_seconds": 4.443602000000055,
+        "system_seconds": 0.92,
+        "user_seconds": 4.44,
+        "voluntary_context_switches": 35924,
+        "wall_nanos": 5398746485
+      },
+      "round": 6,
+      "signed_wall_delta_nanos": 84880931,
+      "slot_index": 4
+    },
+    {
+      "attempt": 1,
+      "build_order": [
+        "candidate",
+        "reference"
+      ],
+      "candidate": {
+        "axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.4363710000001629,
+          "child_cpu_seconds": 7.882572999999837,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 792
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.006371000000162903,
+          "measurement_cpu_interrupt_seconds": 0.02,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.006371000000162903,
+          "measurement_cpu_residual_seconds": 0.026371000000162903,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 7.91,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 1,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 102,
+                "user": 687
+              }
+            },
+            "67": {
+              "busy_seconds": 0.43,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 749,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 1,
+                "user": 42
+              }
+            }
+          },
+          "pressure_some_delta_us": 268924,
+          "runner_cpu_seconds": 0.0010559999999999459
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4453996",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 11,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=1.67 avg60=4.14 avg300=7.56 total=7713458736\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7713458736,
+          "load_1m_per_available_cpu": 7.0263671875,
+          "load_1m_per_cpu": 0.07319132486979167,
+          "load_average": [
+            7.0263671875,
+            5.66162109375,
+            6.169921875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "7/3560"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4448829",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 9,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=0.98 avg60=4.35 avg300=7.70 total=7713189812\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7713189812,
+          "load_1m_per_available_cpu": 6.68310546875,
+          "load_1m_per_cpu": 0.06961568196614583,
+          "load_average": [
+            6.68310546875,
+            5.5478515625,
+            6.138671875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "8/3539"
+        },
+        "involuntary_context_switches": 22734,
+        "peak_rss_kb": 3362344,
+        "precise_child_system_seconds": 1.0148989999999856,
+        "precise_child_user_seconds": 6.867673999999852,
+        "system_seconds": 1.01,
+        "user_seconds": 6.86,
+        "voluntary_context_switches": 37685,
+        "wall_nanos": 7915919544
+      },
+      "host_before_pair": {
+        "affinity_cpu_frequency_khz": "1500000",
+        "available_logical_cpus": 1,
+        "concurrent_lake_lean_count": 9,
+        "cpu_affinity": [
+          19
+        ],
+        "cpu_pressure": "some avg10=0.98 avg60=4.35 avg300=7.70 total=7713189736\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+        "cpu_pressure_some_total_us": 7713189736,
+        "load_1m_per_available_cpu": 6.68310546875,
+        "load_1m_per_cpu": 0.06961568196614583,
+        "load_average": [
+          6.68310546875,
+          5.5478515625,
+          6.138671875
+        ],
+        "logical_cpus": 96,
+        "runnable_tasks": "9/3539"
+      },
+      "issues": [
+        "natural-6 round 6 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.436s exceeds 0.040s"
+      ],
+      "measurement_attempt": 1,
+      "pair": "natural-6",
+      "preflight": {
+        "accepted_window": {
+          "issues": [],
+          "max_busy_ticks": 2,
+          "per_cpu": {
+            "19": {
+              "noninterrupt_busy_ticks": 0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 199,
+                "iowait": 0,
+                "irq": 1,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            },
+            "67": {
+              "busy_ticks": 2,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 198,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 2
+              }
+            }
+          },
+          "window_seconds": 2.0
+        },
+        "admitted": true,
+        "elapsed_seconds": 4.001650230027735,
+        "rejected_windows": [
+          {
+            "issues": [
+              "SMT sibling CPU 67 had 3 busy ticks"
+            ],
+            "max_busy_ticks": 2,
+            "per_cpu": {
+              "19": {
+                "noninterrupt_busy_ticks": 1,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 198,
+                  "iowait": 0,
+                  "irq": 0,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 0,
+                  "user": 1
+                }
+              },
+              "67": {
+                "busy_ticks": 3,
+                "ticks": {
+                  "guest": 0,
+                  "guest_nice": 0,
+                  "idle": 197,
+                  "iowait": 0,
+                  "irq": 1,
+                  "nice": 0,
+                  "softirq": 0,
+                  "steal": 0,
+                  "system": 1,
+                  "user": 1
+                }
+              }
+            },
+            "window_seconds": 2.0
+          }
+        ]
+      },
+      "reference": {
+        "axioms": null,
+        "cpu_accounting": {
+          "aggregate_core_interference_seconds": 0.00894599999991132,
+          "child_cpu_seconds": 5.369989000000089,
+          "child_cpu_source": "getrusage-reaped-children",
+          "clock_ticks_per_second": 100,
+          "frequency_time_in_state_ticks": {
+            "1500000": 0,
+            "2300000": 0,
+            "3150000": 540
+          },
+          "mean_frequency_khz": 3150000.0,
+          "measurement_cpu_foreign_seconds": 0.00894599999991132,
+          "measurement_cpu_interrupt_seconds": 0.02,
+          "measurement_cpu_noninterrupt_residual_seconds": 0.00894599999991132,
+          "measurement_cpu_residual_seconds": 0.02894599999991132,
+          "per_cpu": {
+            "19": {
+              "busy_seconds": 5.4,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 0,
+                "iowait": 0,
+                "irq": 2,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 90,
+                "user": 448
+              }
+            },
+            "67": {
+              "busy_seconds": 0.0,
+              "ticks": {
+                "guest": 0,
+                "guest_nice": 0,
+                "idle": 540,
+                "iowait": 0,
+                "irq": 0,
+                "nice": 0,
+                "softirq": 0,
+                "steal": 0,
+                "system": 0,
+                "user": 0
+              }
+            }
+          },
+          "pressure_some_delta_us": 327529,
+          "runner_cpu_seconds": 0.0010649999999998716
+        },
+        "cpu_percent": 99.0,
+        "host_after": {
+          "affinity_cpu_frequency_khz": "4451169",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 8,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=3.57 avg60=4.35 avg300=7.56 total=7713786288\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7713786288,
+          "load_1m_per_available_cpu": 6.94384765625,
+          "load_1m_per_cpu": 0.07233174641927083,
+          "load_average": [
+            6.94384765625,
+            5.66748046875,
+            6.1689453125
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "7/3514"
+        },
+        "host_before": {
+          "affinity_cpu_frequency_khz": "4453195",
+          "available_logical_cpus": 1,
+          "concurrent_lake_lean_count": 11,
+          "cpu_affinity": [
+            19
+          ],
+          "cpu_pressure": "some avg10=1.67 avg60=4.14 avg300=7.56 total=7713458759\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+          "cpu_pressure_some_total_us": 7713458759,
+          "load_1m_per_available_cpu": 7.0263671875,
+          "load_1m_per_cpu": 0.07319132486979167,
+          "load_average": [
+            7.0263671875,
+            5.66162109375,
+            6.169921875
+          ],
+          "logical_cpus": 96,
+          "runnable_tasks": "7/3560"
+        },
+        "involuntary_context_switches": 21416,
+        "peak_rss_kb": 3082300,
+        "precise_child_system_seconds": 0.8983420000000137,
+        "precise_child_user_seconds": 4.471647000000075,
+        "system_seconds": 0.89,
+        "user_seconds": 4.47,
+        "voluntary_context_switches": 36149,
+        "wall_nanos": 5394804218
+      },
+      "round": 6,
+      "signed_wall_delta_nanos": 2521115326,
+      "slot_index": 6
+    }
+  ],
+  "results": {
+    "fresh-build-null": {
+      "build_magnitude_wall_nanos": 5431211402,
+      "candidate": {
+        "artifacts": {
+          "ilean_bytes": 168,
+          "olean_bytes": 1584,
+          "olean_private_bytes": 96,
+          "olean_server_bytes": 912,
+          "source_bytes": 422
+        },
+        "expected_axioms": null,
+        "module": "HexRealRootsMathlib.ProofProbe.Baseline"
+      },
+      "family": "fresh-build-noise",
+      "interpretation": "calibration-only",
+      "magnitude": "baseline",
+      "median_candidate_peak_rss_kb": 3081416,
+      "median_candidate_wall_nanos": 5409156145,
+      "median_reference_peak_rss_kb": 3080462,
+      "median_reference_wall_nanos": 5431211402,
+      "median_signed_wall_delta_nanos": -12558705,
+      "null_control": true,
+      "null_max_absolute_delta_nanos": 58751220,
+      "null_spread_nanos": 88945003,
+      "reference": {
+        "artifacts": {
+          "ilean_bytes": 168,
+          "olean_bytes": 1584,
+          "olean_private_bytes": 96,
+          "olean_server_bytes": 912,
+          "source_bytes": 422
+        },
+        "expected_axioms": null,
+        "module": "HexRealRootsMathlib.ProofProbe.Baseline"
+      },
+      "samples": [
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0033150000000008173,
+              "child_cpu_seconds": 5.505636999999999,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 553
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0033150000000008173,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.0033150000000008173,
+              "measurement_cpu_residual_seconds": 0.033315000000000816,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.54,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 91,
+                    "user": 460
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 553,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 298514,
+              "runner_cpu_seconds": 0.0010479999999999934
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4442495",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 24,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=3.62 avg60=7.34 avg300=6.17 total=7545131482\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7545131482,
+              "load_1m_per_available_cpu": 7.63134765625,
+              "load_1m_per_cpu": 0.07949320475260417,
+              "load_average": [
+                7.63134765625,
+                9.41015625,
+                12.4482421875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "21/3612"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451224",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 26,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=3.28 avg60=7.66 avg300=6.20 total=7544832968\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7544832968,
+              "load_1m_per_available_cpu": 7.4248046875,
+              "load_1m_per_cpu": 0.07734171549479167,
+              "load_average": [
+                7.4248046875,
+                9.39990234375,
+                12.4619140625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "9/3665"
+            },
+            "involuntary_context_switches": 20408,
+            "peak_rss_kb": 3081376,
+            "precise_child_system_seconds": 0.9074990000000005,
+            "precise_child_user_seconds": 4.598137999999999,
+            "system_seconds": 0.9,
+            "user_seconds": 4.59,
+            "voluntary_context_switches": 35340,
+            "wall_nanos": 5533458716
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4447859",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 24,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=4.19 avg60=8.23 avg300=6.29 total=7544636509\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7544636509,
+            "load_1m_per_available_cpu": 5.45947265625,
+            "load_1m_per_cpu": 0.0568695068359375,
+            "load_average": [
+              5.45947265625,
+              9.0517578125,
+              12.3671875
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "7/3645"
+          },
+          "measurement_attempt": 1,
+          "pair": "fresh-build-null",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 4.0016523487865925,
+            "rejected_windows": [
+              {
+                "issues": [
+                  "measurement CPU 19 had 81 non-interrupt busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 81,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 119,
+                      "iowait": 0,
+                      "irq": 1,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 2,
+                      "user": 79
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 0,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 200,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 0
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              }
+            ]
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.005925000000005138,
+              "child_cpu_seconds": 5.563027999999995,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 559
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.005925000000005138,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.005925000000005138,
+              "measurement_cpu_residual_seconds": 0.02592500000000514,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.59,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 95,
+                    "user": 462
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 559,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 196343,
+              "runner_cpu_seconds": 0.0010469999999999646
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4450479",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 26,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=3.28 avg60=7.66 avg300=6.20 total=7544832926\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7544832926,
+              "load_1m_per_available_cpu": 7.4248046875,
+              "load_1m_per_cpu": 0.07734171549479167,
+              "load_average": [
+                7.4248046875,
+                9.39990234375,
+                12.4619140625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "8/3665"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4448790",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 24,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=4.19 avg60=8.23 avg300=6.29 total=7544636583\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7544636583,
+              "load_1m_per_available_cpu": 5.45947265625,
+              "load_1m_per_cpu": 0.0568695068359375,
+              "load_average": [
+                5.45947265625,
+                9.0517578125,
+                12.3671875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "5/3645"
+            },
+            "involuntary_context_switches": 21077,
+            "peak_rss_kb": 3081332,
+            "precise_child_system_seconds": 0.9455009999999993,
+            "precise_child_user_seconds": 4.6175269999999955,
+            "system_seconds": 0.94,
+            "user_seconds": 4.61,
+            "voluntary_context_switches": 35990,
+            "wall_nanos": 5592209936
+          },
+          "round": 1,
+          "signed_wall_delta_nanos": -58751220,
+          "slot_index": 0
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.010404999999964387,
+              "child_cpu_seconds": 5.368558000000036,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 540
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.010404999999964387,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.010404999999964387,
+              "measurement_cpu_residual_seconds": 0.040404999999964386,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.41,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 94,
+                    "user": 444
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 540,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1355846,
+              "runner_cpu_seconds": 0.0010370000000000656
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452083",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=16.33 avg60=15.58 avg300=12.11 total=7609772546\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7609772546,
+              "load_1m_per_available_cpu": 2.75634765625,
+              "load_1m_per_cpu": 0.028711954752604168,
+              "load_average": [
+                2.75634765625,
+                4.4794921875,
+                8.72021484375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3483"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4272227",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=13.34 avg60=15.00 avg300=11.92 total=7608416700\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7608416700,
+              "load_1m_per_available_cpu": 2.73486328125,
+              "load_1m_per_cpu": 0.0284881591796875,
+              "load_average": [
+                2.73486328125,
+                4.5048828125,
+                8.75146484375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3486"
+            },
+            "involuntary_context_switches": 21775,
+            "peak_rss_kb": 3081456,
+            "precise_child_system_seconds": 0.9405050000000017,
+            "precise_child_user_seconds": 4.428053000000034,
+            "system_seconds": 0.94,
+            "user_seconds": 4.42,
+            "voluntary_context_switches": 36533,
+            "wall_nanos": 5396453762
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "1611646",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=13.34 avg60=15.00 avg300=11.92 total=7608415981\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7608415981,
+            "load_1m_per_available_cpu": 2.73486328125,
+            "load_1m_per_cpu": 0.0284881591796875,
+            "load_average": [
+              2.73486328125,
+              4.5048828125,
+              8.75146484375
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "2/3486"
+          },
+          "measurement_attempt": 1,
+          "pair": "fresh-build-null",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.001135465921834,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.013007000000000777,
+              "child_cpu_seconds": 5.415951,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 544
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0030070000000007764,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.0030070000000007764,
+              "measurement_cpu_residual_seconds": 0.023007000000000777,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.44,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1,
+                    "iowait": 0,
+                    "irq": 1,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 89,
+                    "user": 453
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.01,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 542,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1348430,
+              "runner_cpu_seconds": 0.0010419999999998764
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4450725",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=17.98 avg60=16.16 avg300=12.31 total=7611121173\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7611121173,
+              "load_1m_per_available_cpu": 2.85595703125,
+              "load_1m_per_cpu": 0.029749552408854168,
+              "load_average": [
+                2.85595703125,
+                4.47119140625,
+                8.69482421875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3487"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4449923",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=16.33 avg60=15.58 avg300=12.11 total=7609772743\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7609772743,
+              "load_1m_per_available_cpu": 2.75634765625,
+              "load_1m_per_cpu": 0.028711954752604168,
+              "load_average": [
+                2.75634765625,
+                4.4794921875,
+                8.72021484375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "4/3483"
+            },
+            "involuntary_context_switches": 21113,
+            "peak_rss_kb": 3079344,
+            "precise_child_system_seconds": 0.888099000000004,
+            "precise_child_user_seconds": 4.527851999999996,
+            "system_seconds": 0.88,
+            "user_seconds": 4.52,
+            "voluntary_context_switches": 36016,
+            "wall_nanos": 5444541821
+          },
+          "round": 2,
+          "signed_wall_delta_nanos": -48088059,
+          "slot_index": 8
+        },
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.01,
+              "child_cpu_seconds": 5.381073000000015,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 541
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.0021270000000147282,
+              "measurement_cpu_residual_seconds": 0.02787299999998527,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.41,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 88,
+                    "user": 450
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.01,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 540,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1514095,
+              "runner_cpu_seconds": 0.0010539999999999994
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452053",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=20.71 avg60=16.55 avg300=14.31 total=7645478052\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7645478052,
+              "load_1m_per_available_cpu": 2.17041015625,
+              "load_1m_per_cpu": 0.022608439127604168,
+              "load_average": [
+                2.17041015625,
+                3.33203125,
+                7.39794921875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3524"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4449239",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=17.49 avg60=15.70 avg300=14.10 total=7643963957\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7643963957,
+              "load_1m_per_available_cpu": 1.923828125,
+              "load_1m_per_cpu": 0.020039876302083332,
+              "load_average": [
+                1.923828125,
+                3.3037109375,
+                7.4111328125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3524"
+            },
+            "involuntary_context_switches": 21479,
+            "peak_rss_kb": 3079584,
+            "precise_child_system_seconds": 0.8806769999999915,
+            "precise_child_user_seconds": 4.500396000000023,
+            "system_seconds": 0.88,
+            "user_seconds": 4.5,
+            "voluntary_context_switches": 36228,
+            "wall_nanos": 5408055623
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "3089859",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=10.64 avg60=14.56 avg300=13.84 total=7642588668\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7642588668,
+            "load_1m_per_available_cpu": 2.00439453125,
+            "load_1m_per_cpu": 0.020879109700520832,
+            "load_average": [
+              2.00439453125,
+              3.3427734375,
+              7.44580078125
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "1/3520"
+          },
+          "measurement_attempt": 1,
+          "pair": "fresh-build-null",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 1,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 1,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.0009234219323844,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.007992999999965961,
+              "child_cpu_seconds": 5.350975000000034,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 538
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.007992999999965961,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.007992999999965961,
+              "measurement_cpu_residual_seconds": 0.027992999999965962,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.38,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 90,
+                    "user": 446
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 538,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1374788,
+              "runner_cpu_seconds": 0.001032000000000144
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452754",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=17.49 avg60=15.70 avg300=14.10 total=7643963867\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7643963867,
+              "load_1m_per_available_cpu": 1.923828125,
+              "load_1m_per_cpu": 0.020039876302083332,
+              "load_average": [
+                1.923828125,
+                3.3037109375,
+                7.4111328125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3524"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4455250",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=10.64 avg60=14.56 avg300=13.84 total=7642589079\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7642589079,
+              "load_1m_per_available_cpu": 2.00439453125,
+              "load_1m_per_cpu": 0.020879109700520832,
+              "load_average": [
+                2.00439453125,
+                3.3427734375,
+                7.44580078125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3520"
+            },
+            "involuntary_context_switches": 21646,
+            "peak_rss_kb": 3079592,
+            "precise_child_system_seconds": 0.9002509999999972,
+            "precise_child_user_seconds": 4.4507240000000365,
+            "system_seconds": 0.89,
+            "user_seconds": 4.45,
+            "voluntary_context_switches": 36514,
+            "wall_nanos": 5377861840
+          },
+          "round": 3,
+          "signed_wall_delta_nanos": 30193783,
+          "slot_index": 7
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.009155999999999082,
+              "child_cpu_seconds": 5.399816000000001,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 543
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.009155999999999082,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.009155999999999082,
+              "measurement_cpu_residual_seconds": 0.03915599999999908,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.44,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 93,
+                    "user": 448
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 543,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1309874,
+              "runner_cpu_seconds": 0.0010280000000000289
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451790",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=18.28 avg60=16.23 avg300=14.39 total=7668852967\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7668852967,
+              "load_1m_per_available_cpu": 1.849609375,
+              "load_1m_per_cpu": 0.019266764322916668,
+              "load_average": [
+                1.849609375,
+                2.79833984375,
+                6.529296875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3484"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4049593",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=11.98 avg60=15.15 avg300=14.15 total=7667543093\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7667543093,
+              "load_1m_per_available_cpu": 1.923828125,
+              "load_1m_per_cpu": 0.020039876302083332,
+              "load_average": [
+                1.923828125,
+                2.8291015625,
+                6.5595703125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3524"
+            },
+            "involuntary_context_switches": 21858,
+            "peak_rss_kb": 3081680,
+            "precise_child_system_seconds": 0.9237309999999894,
+            "precise_child_user_seconds": 4.476085000000012,
+            "system_seconds": 0.92,
+            "user_seconds": 4.47,
+            "voluntary_context_switches": 36737,
+            "wall_nanos": 5427048728
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "1497139",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=11.98 avg60=15.15 avg300=14.15 total=7667542950\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7667542950,
+            "load_1m_per_available_cpu": 1.923828125,
+            "load_1m_per_cpu": 0.020039876302083332,
+            "load_average": [
+              1.923828125,
+              2.8291015625,
+              6.5595703125
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "1/3524"
+          },
+          "measurement_attempt": 1,
+          "pair": "fresh-build-null",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.001064107986167,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.015039999999971316,
+              "child_cpu_seconds": 5.413916000000029,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 544
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.015039999999971316,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.015039999999971316,
+              "measurement_cpu_residual_seconds": 0.035039999999971316,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.45,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 89,
+                    "user": 454
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 543,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1337835,
+              "runner_cpu_seconds": 0.001044000000000045
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451727",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=19.94 avg60=16.73 avg300=14.53 total=7670191080\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7670191080,
+              "load_1m_per_available_cpu": 1.94189453125,
+              "load_1m_per_cpu": 0.020228068033854168,
+              "load_average": [
+                1.94189453125,
+                2.8017578125,
+                6.51025390625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3486"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451004",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=18.28 avg60=16.23 avg300=14.39 total=7668853245\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7668853245,
+              "load_1m_per_available_cpu": 1.849609375,
+              "load_1m_per_cpu": 0.019266764322916668,
+              "load_average": [
+                1.849609375,
+                2.79833984375,
+                6.529296875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3483"
+            },
+            "involuntary_context_switches": 21746,
+            "peak_rss_kb": 3079420,
+            "precise_child_system_seconds": 0.8827239999999961,
+            "precise_child_user_seconds": 4.531192000000033,
+            "system_seconds": 0.88,
+            "user_seconds": 4.53,
+            "voluntary_context_switches": 36508,
+            "wall_nanos": 5440203345
+          },
+          "round": 4,
+          "signed_wall_delta_nanos": -13154617,
+          "slot_index": 6
+        },
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.004790999999929841,
+              "child_cpu_seconds": 5.38415800000007,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 541
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.004790999999929841,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.004790999999929841,
+              "measurement_cpu_residual_seconds": 0.02479099999992984,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.41,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 1,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 93,
+                    "user": 446
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 541,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1001501,
+              "runner_cpu_seconds": 0.0010509999999999131
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452288",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=9.91 avg60=5.47 avg300=9.43 total=7682512246\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7682512246,
+              "load_1m_per_available_cpu": 7.30517578125,
+              "load_1m_per_cpu": 0.0760955810546875,
+              "load_average": [
+                7.30517578125,
+                4.70751953125,
+                6.42431640625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3531"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4449118",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=3.08 avg60=4.19 avg300=9.23 total=7681510745\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7681510745,
+              "load_1m_per_available_cpu": 7.8544921875,
+              "load_1m_per_cpu": 0.081817626953125,
+              "load_average": [
+                7.8544921875,
+                4.7705078125,
+                6.45361328125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3566"
+            },
+            "involuntary_context_switches": 22034,
+            "peak_rss_kb": 3079408,
+            "precise_child_system_seconds": 0.9244390000000067,
+            "precise_child_user_seconds": 4.459719000000064,
+            "system_seconds": 0.92,
+            "user_seconds": 4.45,
+            "voluntary_context_switches": 36953,
+            "wall_nanos": 5410256667
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "1500000",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 11,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=1.70 avg60=4.11 avg300=9.32 total=7681167680\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7681167680,
+            "load_1m_per_available_cpu": 8.3642578125,
+            "load_1m_per_cpu": 0.087127685546875,
+            "load_average": [
+              8.3642578125,
+              4.8173828125,
+              6.47802734375
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "7/3599"
+          },
+          "measurement_attempt": 1,
+          "pair": "fresh-build-null",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.0007637799717486,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.02,
+              "child_cpu_seconds": 5.399357999999978,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 543
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.00039499999997814547,
+              "measurement_cpu_residual_seconds": 0.019605000000021855,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.42,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 94,
+                    "user": 446
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.02,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 540,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 2
+                  }
+                }
+              },
+              "pressure_some_delta_us": 342871,
+              "runner_cpu_seconds": 0.0010369999999999546
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452189",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=3.08 avg60=4.19 avg300=9.23 total=7681510572\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7681510572,
+              "load_1m_per_available_cpu": 7.8544921875,
+              "load_1m_per_cpu": 0.081817626953125,
+              "load_average": [
+                7.8544921875,
+                4.7705078125,
+                6.45361328125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3566"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4446212",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 11,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=1.70 avg60=4.11 avg300=9.32 total=7681167701\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7681167701,
+              "load_1m_per_available_cpu": 8.3642578125,
+              "load_1m_per_cpu": 0.087127685546875,
+              "load_average": [
+                8.3642578125,
+                4.8173828125,
+                6.47802734375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "8/3599"
+            },
+            "involuntary_context_switches": 21236,
+            "peak_rss_kb": 3081968,
+            "precise_child_system_seconds": 0.9363229999999874,
+            "precise_child_user_seconds": 4.463034999999991,
+            "system_seconds": 0.93,
+            "user_seconds": 4.46,
+            "voluntary_context_switches": 36126,
+            "wall_nanos": 5422219460
+          },
+          "round": 5,
+          "signed_wall_delta_nanos": -11962793,
+          "slot_index": 5
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 5.380781000000127,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 541
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.001823000000126456,
+              "measurement_cpu_residual_seconds": 0.018176999999873544,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.4,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 91,
+                    "user": 447
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 540,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 427779,
+              "runner_cpu_seconds": 0.0010419999999999874
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452234",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=4.45 avg60=5.70 avg300=8.33 total=7711614138\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7711614138,
+              "load_1m_per_available_cpu": 7.58984375,
+              "load_1m_per_cpu": 0.07906087239583333,
+              "load_average": [
+                7.58984375,
+                5.548828125,
+                6.166015625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "5/3522"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4450793",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=3.53 avg60=5.68 avg300=8.38 total=7711186359\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7711186359,
+              "load_1m_per_available_cpu": 7.29248046875,
+              "load_1m_per_cpu": 0.07596333821614583,
+              "load_average": [
+                7.29248046875,
+                5.45654296875,
+                6.1396484375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3523"
+            },
+            "involuntary_context_switches": 21452,
+            "peak_rss_kb": 3082312,
+            "precise_child_system_seconds": 0.9115859999999998,
+            "precise_child_user_seconds": 4.469195000000127,
+            "system_seconds": 0.91,
+            "user_seconds": 4.46,
+            "voluntary_context_switches": 36266,
+            "wall_nanos": 5405701573
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "1500000",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 8,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=3.53 avg60=5.68 avg300=8.38 total=7711186202\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7711186202,
+            "load_1m_per_available_cpu": 7.29248046875,
+            "load_1m_per_cpu": 0.07596333821614583,
+            "load_average": [
+              7.29248046875,
+              5.45654296875,
+              6.1396484375
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "3/3523"
+          },
+          "measurement_attempt": 3,
+          "pair": "fresh-build-null",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 199,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 6.002425287151709,
+            "rejected_windows": [
+              {
+                "issues": [
+                  "SMT sibling CPU 67 had 5 busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 0,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 200,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 0
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 5,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 195,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 3,
+                      "user": 2
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              },
+              {
+                "issues": [
+                  "measurement CPU 19 had 61 non-interrupt busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 61,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 138,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 61
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 0,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 200,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 0
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              }
+            ]
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 5.389254999999906,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 542
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.0003059999999057532,
+              "measurement_cpu_residual_seconds": 0.019694000000094247,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.41,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 1,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 91,
+                    "user": 448
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 541,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 444290,
+              "runner_cpu_seconds": 0.001050999999999691
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4454104",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=5.41 avg60=5.82 avg300=8.31 total=7712058490\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7712058490,
+              "load_1m_per_available_cpu": 7.703125,
+              "load_1m_per_cpu": 0.08024088541666667,
+              "load_average": [
+                7.703125,
+                5.6064453125,
+                6.181640625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3538"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4449787",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=4.45 avg60=5.70 avg300=8.33 total=7711614200\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7711614200,
+              "load_1m_per_available_cpu": 7.58984375,
+              "load_1m_per_cpu": 0.07906087239583333,
+              "load_average": [
+                7.58984375,
+                5.548828125,
+                6.166015625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "6/3522"
+            },
+            "involuntary_context_switches": 21955,
+            "peak_rss_kb": 3081528,
+            "precise_child_system_seconds": 0.9074520000000064,
+            "precise_child_user_seconds": 4.4818029999999,
+            "system_seconds": 0.9,
+            "user_seconds": 4.48,
+            "voluntary_context_switches": 36780,
+            "wall_nanos": 5415899069
+          },
+          "round": 6,
+          "signed_wall_delta_nanos": -10197496,
+          "slot_index": 4
+        }
+      ],
+      "signed_wall_delta_nanos": [
+        -58751220,
+        -48088059,
+        30193783,
+        -13154617,
+        -11962793,
+        -10197496
+      ]
+    },
+    "natural-10": {
+      "build_magnitude_wall_nanos": 14080099064,
+      "candidate": {
+        "artifacts": {
+          "ilean_bytes": 2348,
+          "olean_bytes": 12528,
+          "olean_private_bytes": 684008,
+          "olean_server_bytes": 1200,
+          "source_bytes": 803
+        },
+        "expected_axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "module": "HexRealRootsMathlib.ProofProbe.Natural10"
+      },
+      "comparable_control": "natural-10-null",
+      "comparable_null_envelope_nanos": 262605822,
+      "comparable_null_raw_envelope_nanos": 262385607,
+      "comparable_null_raw_spread_nanos": 254141199,
+      "comparable_null_spread_nanos": 254354495,
+      "control_magnitude_ratio": 1.0008392794333272,
+      "control_scale_factor": 1.0008392794333272,
+      "degree": 10,
+      "family": "natural-width",
+      "median_candidate_peak_rss_kb": 3906008,
+      "median_candidate_wall_nanos": 14080099064,
+      "median_reference_peak_rss_kb": 3081680,
+      "median_reference_wall_nanos": 5404434129,
+      "median_signed_wall_delta_nanos": 8689746634,
+      "null_control": false,
+      "reference": {
+        "artifacts": {
+          "ilean_bytes": 168,
+          "olean_bytes": 1584,
+          "olean_private_bytes": 96,
+          "olean_server_bytes": 912,
+          "source_bytes": 422
+        },
+        "expected_axioms": null,
+        "module": "HexRealRootsMathlib.ProofProbe.Baseline"
+      },
+      "resolution": "resolved",
+      "samples": [
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.05,
+              "child_cpu_seconds": 14.08165700000001,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 1415
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.06,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.002712000000009984,
+              "measurement_cpu_residual_seconds": 0.057287999999990014,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 14.14,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1,
+                    "iowait": 0,
+                    "irq": 5,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 103,
+                    "user": 1305
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.05,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1406,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 3,
+                    "user": 2
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1535146,
+              "runner_cpu_seconds": 0.0010550000000000281
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452689",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=7.64 avg60=10.20 avg300=7.71 total=7559942851\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7559942851,
+              "load_1m_per_available_cpu": 2.7490234375,
+              "load_1m_per_cpu": 0.028635660807291668,
+              "load_average": [
+                2.7490234375,
+                6.78466796875,
+                11.04150390625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3525"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4452890",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=12.60 avg60=10.37 avg300=7.59 total=7558407705\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7558407705,
+              "load_1m_per_available_cpu": 3.16015625,
+              "load_1m_per_cpu": 0.032918294270833336,
+              "load_average": [
+                3.16015625,
+                7.06689453125,
+                11.20068359375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3540"
+            },
+            "involuntary_context_switches": 22859,
+            "peak_rss_kb": 3905136,
+            "precise_child_system_seconds": 1.0354509999999983,
+            "precise_child_user_seconds": 13.046206000000012,
+            "system_seconds": 1.03,
+            "user_seconds": 13.04,
+            "voluntary_context_switches": 37662,
+            "wall_nanos": 14148779516
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "1500000",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=5.91 avg60=9.08 avg300=7.27 total=7556971183\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7556971183,
+            "load_1m_per_available_cpu": 2.91259765625,
+            "load_1m_per_cpu": 0.030339558919270832,
+            "load_average": [
+              2.91259765625,
+              7.0849609375,
+              11.22900390625
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "1/3535"
+          },
+          "measurement_attempt": 3,
+          "pair": "natural-10",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 1,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 199,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 1,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.0008340768981725,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.01,
+              "child_cpu_seconds": 5.402243000000002,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 543
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.003263000000002375,
+              "measurement_cpu_residual_seconds": 0.026736999999997624,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.43,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 89,
+                    "user": 451
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.01,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 542,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1435686,
+              "runner_cpu_seconds": 0.0010199999999999654
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451178",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=12.60 avg60=10.37 avg300=7.59 total=7558406988\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7558406988,
+              "load_1m_per_available_cpu": 3.16015625,
+              "load_1m_per_cpu": 0.032918294270833336,
+              "load_average": [
+                3.16015625,
+                7.06689453125,
+                11.20068359375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3540"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451949",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=5.91 avg60=9.08 avg300=7.27 total=7556971302\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7556971302,
+              "load_1m_per_available_cpu": 2.91259765625,
+              "load_1m_per_cpu": 0.030339558919270832,
+              "load_average": [
+                2.91259765625,
+                7.0849609375,
+                11.22900390625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3535"
+            },
+            "involuntary_context_switches": 21285,
+            "peak_rss_kb": 3079292,
+            "precise_child_system_seconds": 0.8944769999999984,
+            "precise_child_user_seconds": 4.507766000000004,
+            "system_seconds": 0.89,
+            "user_seconds": 4.5,
+            "voluntary_context_switches": 36118,
+            "wall_nanos": 5430992041
+          },
+          "round": 1,
+          "signed_wall_delta_nanos": 8717787475,
+          "slot_index": 4
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.06,
+              "child_cpu_seconds": 14.011029999999998,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 1407
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.06,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.0021259999999979073,
+              "measurement_cpu_residual_seconds": 0.05787400000000209,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 14.07,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 5,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 103,
+                    "user": 1298
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.06,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1400,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 3,
+                    "user": 3
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1321039,
+              "runner_cpu_seconds": 0.001096000000000097
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452733",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=6.84 avg60=10.88 avg300=10.13 total=7591518433\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7591518433,
+              "load_1m_per_available_cpu": 3.03564453125,
+              "load_1m_per_cpu": 0.031621297200520836,
+              "load_average": [
+                3.03564453125,
+                5.29150390625,
+                9.466796875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3522"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4448308",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=10.93 avg60=11.60 avg300=10.20 total=7590197394\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7590197394,
+              "load_1m_per_available_cpu": 3.23583984375,
+              "load_1m_per_cpu": 0.0337066650390625,
+              "load_average": [
+                3.23583984375,
+                5.44482421875,
+                9.583984375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "6/3532"
+            },
+            "involuntary_context_switches": 23020,
+            "peak_rss_kb": 3837472,
+            "precise_child_system_seconds": 1.0367380000000068,
+            "precise_child_user_seconds": 12.974291999999991,
+            "system_seconds": 1.03,
+            "user_seconds": 12.97,
+            "voluntary_context_switches": 37803,
+            "wall_nanos": 14078188855
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4449990",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 9,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=10.93 avg60=11.60 avg300=10.20 total=7590197357\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7590197357,
+            "load_1m_per_available_cpu": 3.23583984375,
+            "load_1m_per_cpu": 0.0337066650390625,
+            "load_average": [
+              3.23583984375,
+              5.44482421875,
+              9.583984375
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "6/3532"
+          },
+          "measurement_attempt": 1,
+          "pair": "natural-10",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 2,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 197,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 1,
+                    "user": 1
+                  }
+                },
+                "67": {
+                  "busy_ticks": 2,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 197,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 2
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 4.001661411952227,
+            "rejected_windows": [
+              {
+                "issues": [
+                  "measurement CPU 19 had 3 non-interrupt busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 3,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 195,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 3
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 2,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 198,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 2
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              }
+            ]
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.007346999999966037,
+              "child_cpu_seconds": 5.371598000000034,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 540
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.007346999999966037,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.007346999999966037,
+              "measurement_cpu_residual_seconds": 0.027346999999966037,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.4,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 92,
+                    "user": 446
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 540,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 806330,
+              "runner_cpu_seconds": 0.0010550000000000281
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452531",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=9.17 avg60=11.02 avg300=10.17 total=7592324899\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7592324899,
+              "load_1m_per_available_cpu": 3.11328125,
+              "load_1m_per_cpu": 0.032430013020833336,
+              "load_average": [
+                3.11328125,
+                5.27001953125,
+                9.43701171875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3500"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451869",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=6.84 avg60=10.88 avg300=10.13 total=7591518569\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7591518569,
+              "load_1m_per_available_cpu": 3.03564453125,
+              "load_1m_per_cpu": 0.031621297200520836,
+              "load_average": [
+                3.03564453125,
+                5.29150390625,
+                9.466796875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3522"
+            },
+            "involuntary_context_switches": 21524,
+            "peak_rss_kb": 3081684,
+            "precise_child_system_seconds": 0.9192079999999976,
+            "precise_child_user_seconds": 4.452390000000037,
+            "system_seconds": 0.91,
+            "user_seconds": 4.45,
+            "voluntary_context_switches": 36384,
+            "wall_nanos": 5399323731
+          },
+          "round": 2,
+          "signed_wall_delta_nanos": 8678865124,
+          "slot_index": 3
+        },
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.020181999999978533,
+              "child_cpu_seconds": 13.918765000000022,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 1398
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.00018199999997853267,
+              "measurement_cpu_interrupt_seconds": 0.07,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.00018199999997853267,
+              "measurement_cpu_residual_seconds": 0.07018199999997854,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 13.99,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 5,
+                    "nice": 0,
+                    "softirq": 2,
+                    "steal": 0,
+                    "system": 99,
+                    "user": 1293
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.02,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1397,
+                    "iowait": 0,
+                    "irq": 1,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1556635,
+              "runner_cpu_seconds": 0.0010529999999998596
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4449414",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=9.38 avg60=14.37 avg300=12.79 total=7622385662\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7622385662,
+              "load_1m_per_available_cpu": 2.9130859375,
+              "load_1m_per_cpu": 0.030344645182291668,
+              "load_average": [
+                2.9130859375,
+                4.0712890625,
+                8.22021484375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "4/3498"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4450969",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=15.72 avg60=15.45 avg300=12.89 total=7620829027\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7620829027,
+              "load_1m_per_available_cpu": 2.935546875,
+              "load_1m_per_cpu": 0.03057861328125,
+              "load_average": [
+                2.935546875,
+                4.12841796875,
+                8.30615234375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3495"
+            },
+            "involuntary_context_switches": 23221,
+            "peak_rss_kb": 3993120,
+            "precise_child_system_seconds": 0.9908850000000058,
+            "precise_child_user_seconds": 12.927880000000016,
+            "system_seconds": 0.99,
+            "user_seconds": 12.92,
+            "voluntary_context_switches": 38185,
+            "wall_nanos": 13983664428
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4453447",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=6.66 avg60=14.14 avg300=12.59 total=7619374610\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7619374610,
+            "load_1m_per_available_cpu": 2.49462890625,
+            "load_1m_per_cpu": 0.0259857177734375,
+            "load_average": [
+              2.49462890625,
+              4.06298828125,
+              8.30810546875
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "1/3497"
+          },
+          "measurement_attempt": 2,
+          "pair": "natural-10",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 1,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.0007736990228295,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.005309000000022341,
+              "child_cpu_seconds": 5.363672999999977,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 539
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.005309000000022341,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.005309000000022341,
+              "measurement_cpu_residual_seconds": 0.02530900000002234,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.39,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 91,
+                    "user": 446
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 539,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1454073,
+              "runner_cpu_seconds": 0.0010180000000000744
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4454609",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=15.72 avg60=15.45 avg300=12.89 total=7620828813\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7620828813,
+              "load_1m_per_available_cpu": 2.935546875,
+              "load_1m_per_cpu": 0.03057861328125,
+              "load_average": [
+                2.935546875,
+                4.12841796875,
+                8.30615234375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3495"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4450904",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=6.66 avg60=14.14 avg300=12.59 total=7619374740\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7619374740,
+              "load_1m_per_available_cpu": 2.49462890625,
+              "load_1m_per_cpu": 0.0259857177734375,
+              "load_average": [
+                2.49462890625,
+                4.06298828125,
+                8.30810546875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3497"
+            },
+            "involuntary_context_switches": 21778,
+            "peak_rss_kb": 3081692,
+            "precise_child_system_seconds": 0.9002729999999985,
+            "precise_child_user_seconds": 4.463399999999979,
+            "system_seconds": 0.9,
+            "user_seconds": 4.46,
+            "voluntary_context_switches": 36380,
+            "wall_nanos": 5391809845
+          },
+          "round": 3,
+          "signed_wall_delta_nanos": 8591854583,
+          "slot_index": 2
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.02507900000002587,
+              "child_cpu_seconds": 13.843883999999974,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 1391
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.005079000000025868,
+              "measurement_cpu_interrupt_seconds": 0.06,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.005079000000025868,
+              "measurement_cpu_residual_seconds": 0.06507900000002587,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 13.91,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 5,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 101,
+                    "user": 1284
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.02,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1389,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 2
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1471339,
+              "runner_cpu_seconds": 0.0010369999999999546
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4450374",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=6.93 avg60=11.34 avg300=13.14 total=7654199806\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7654199806,
+              "load_1m_per_available_cpu": 2.376953125,
+              "load_1m_per_cpu": 0.024759928385416668,
+              "load_average": [
+                2.376953125,
+                3.08203125,
+                6.94775390625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3526"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4453666",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=10.70 avg60=11.97 avg300=13.31 total=7652728467\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7652728467,
+              "load_1m_per_available_cpu": 2.4052734375,
+              "load_1m_per_cpu": 0.025054931640625,
+              "load_average": [
+                2.4052734375,
+                3.12158203125,
+                7.02392578125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3521"
+            },
+            "involuntary_context_switches": 22120,
+            "peak_rss_kb": 3865600,
+            "precise_child_system_seconds": 1.0083209999999951,
+            "precise_child_user_seconds": 12.83556299999998,
+            "system_seconds": 1.0,
+            "user_seconds": 12.83,
+            "voluntary_context_switches": 37083,
+            "wall_nanos": 13910004293
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4196136",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=10.70 avg60=11.97 avg300=13.31 total=7652728330\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7652728330,
+            "load_1m_per_available_cpu": 2.4052734375,
+            "load_1m_per_cpu": 0.025054931640625,
+            "load_average": [
+              2.4052734375,
+              3.12158203125,
+              7.02392578125
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "1/3521"
+          },
+          "measurement_attempt": 2,
+          "pair": "natural-10",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 198,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.000876093050465,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.011775999999918083,
+              "child_cpu_seconds": 5.407152000000082,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 544
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0017759999999180827,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.0017759999999180827,
+              "measurement_cpu_residual_seconds": 0.021775999999918083,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.43,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 1,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 88,
+                    "user": 453
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.01,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 542,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1513229,
+              "runner_cpu_seconds": 0.0010719999999999619
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452355",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=16.72 avg60=13.02 avg300=13.47 total=7655713375\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7655713375,
+              "load_1m_per_available_cpu": 2.42724609375,
+              "load_1m_per_cpu": 0.0252838134765625,
+              "load_average": [
+                2.42724609375,
+                3.08056640625,
+                6.92626953125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3524"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4448560",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=6.93 avg60=11.34 avg300=13.14 total=7654200146\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7654200146,
+              "load_1m_per_available_cpu": 2.376953125,
+              "load_1m_per_cpu": 0.024759928385416668,
+              "load_average": [
+                2.376953125,
+                3.08203125,
+                6.94775390625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3526"
+            },
+            "involuntary_context_switches": 20835,
+            "peak_rss_kb": 3081624,
+            "precise_child_system_seconds": 0.8777819999999963,
+            "precise_child_user_seconds": 4.529370000000085,
+            "system_seconds": 0.87,
+            "user_seconds": 4.52,
+            "voluntary_context_switches": 35570,
+            "wall_nanos": 5437915920
+          },
+          "round": 4,
+          "signed_wall_delta_nanos": 8472088373,
+          "slot_index": 1
+        },
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.030578000000006225,
+              "child_cpu_seconds": 14.018390999999994,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 1408
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0005780000000062263,
+              "measurement_cpu_interrupt_seconds": 0.05,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.0005780000000062263,
+              "measurement_cpu_residual_seconds": 0.05057800000000623,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 14.07,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 5,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 103,
+                    "user": 1299
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.03,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1405,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 1,
+                    "user": 2
+                  }
+                }
+              },
+              "pressure_some_delta_us": 294907,
+              "runner_cpu_seconds": 0.0010310000000000041
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451597",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=1.77 avg60=5.67 avg300=11.30 total=7675752039\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7675752039,
+              "load_1m_per_available_cpu": 4.60595703125,
+              "load_1m_per_cpu": 0.047978719075520836,
+              "load_average": [
+                4.60595703125,
+                3.36279296875,
+                6.283203125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3555"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4449515",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=3.66 avg60=6.74 avg300=11.77 total=7675457132\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7675457132,
+              "load_1m_per_available_cpu": 4.533203125,
+              "load_1m_per_cpu": 0.047220865885416664,
+              "load_average": [
+                4.533203125,
+                3.27978515625,
+                6.3046875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "6/3569"
+            },
+            "involuntary_context_switches": 22795,
+            "peak_rss_kb": 3939892,
+            "precise_child_system_seconds": 1.0354050000000115,
+            "precise_child_user_seconds": 12.982985999999983,
+            "system_seconds": 1.03,
+            "user_seconds": 12.98,
+            "voluntary_context_switches": 37841,
+            "wall_nanos": 14082009273
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "1500000",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 8,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=0.79 avg60=6.52 avg300=11.80 total=7675023684\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7675023684,
+            "load_1m_per_available_cpu": 4.4052734375,
+            "load_1m_per_cpu": 0.045888264973958336,
+            "load_average": [
+              4.4052734375,
+              3.2333984375,
+              6.306640625
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "3/3567"
+          },
+          "measurement_attempt": 2,
+          "pair": "natural-10",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 8.003064068034291,
+            "rejected_windows": [
+              {
+                "issues": [
+                  "measurement CPU 19 had 4 non-interrupt busy ticks",
+                  "SMT sibling CPU 67 had 3 busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 4,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 195,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 4
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 3,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 196,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 1,
+                      "user": 2
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              },
+              {
+                "issues": [
+                  "measurement CPU 19 had 3 non-interrupt busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 3,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 198,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 1,
+                      "user": 2
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 2,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 197,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 2
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              },
+              {
+                "issues": [
+                  "SMT sibling CPU 67 had 3 busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 1,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 198,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 1
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 3,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 198,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 1,
+                      "user": 2
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              }
+            ]
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.003501999999985711,
+              "child_cpu_seconds": 5.355497000000014,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 538
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.003501999999985711,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.003501999999985711,
+              "measurement_cpu_residual_seconds": 0.03350199999998571,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.39,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 89,
+                    "user": 447
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 538,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 432946,
+              "runner_cpu_seconds": 0.0010010000000000296
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4450957",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=3.66 avg60=6.74 avg300=11.77 total=7675457083\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7675457083,
+              "load_1m_per_available_cpu": 4.533203125,
+              "load_1m_per_cpu": 0.047220865885416664,
+              "load_average": [
+                4.533203125,
+                3.27978515625,
+                6.3046875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "7/3569"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451811",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=0.79 avg60=6.52 avg300=11.80 total=7675024137\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7675024137,
+              "load_1m_per_available_cpu": 4.4052734375,
+              "load_1m_per_cpu": 0.045888264973958336,
+              "load_average": [
+                4.4052734375,
+                3.2333984375,
+                6.306640625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3567"
+            },
+            "involuntary_context_switches": 21509,
+            "peak_rss_kb": 3081676,
+            "precise_child_system_seconds": 0.8798600000000079,
+            "precise_child_user_seconds": 4.475637000000006,
+            "system_seconds": 0.87,
+            "user_seconds": 4.47,
+            "voluntary_context_switches": 36340,
+            "wall_nanos": 5381381128
+          },
+          "round": 5,
+          "signed_wall_delta_nanos": 8700628145,
+          "slot_index": 0
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.03435300000002964,
+              "child_cpu_seconds": 14.08458699999997,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 1415
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.004353000000029639,
+              "measurement_cpu_interrupt_seconds": 0.06,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.004353000000029639,
+              "measurement_cpu_residual_seconds": 0.06435300000002964,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 14.15,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 5,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 104,
+                    "user": 1305
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.03,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1410,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 1,
+                    "user": 2
+                  }
+                }
+              },
+              "pressure_some_delta_us": 833466,
+              "runner_cpu_seconds": 0.001060000000000061
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451201",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 10,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=3.35 avg60=4.85 avg300=7.17 total=7717047793\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7717047793,
+              "load_1m_per_available_cpu": 5.123046875,
+              "load_1m_per_cpu": 0.053365071614583336,
+              "load_average": [
+                5.123046875,
+                5.39404296875,
+                6.04736328125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "6/3534"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4450563",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=3.79 avg60=4.78 avg300=7.26 total=7716214327\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7716214327,
+              "load_1m_per_available_cpu": 5.53076171875,
+              "load_1m_per_cpu": 0.057612101236979164,
+              "load_average": [
+                5.53076171875,
+                5.48291015625,
+                6.08642578125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "6/3523"
+            },
+            "involuntary_context_switches": 22251,
+            "peak_rss_kb": 3906880,
+            "precise_child_system_seconds": 1.0418870000000027,
+            "precise_child_user_seconds": 13.042699999999968,
+            "system_seconds": 1.04,
+            "user_seconds": 13.04,
+            "voluntary_context_switches": 37366,
+            "wall_nanos": 14146734419
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "1500000",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 8,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=3.79 avg60=4.78 avg300=7.26 total=7716214263\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7716214263,
+            "load_1m_per_available_cpu": 5.53076171875,
+            "load_1m_per_cpu": 0.057612101236979164,
+            "load_average": [
+              5.53076171875,
+              5.48291015625,
+              6.08642578125
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "3/3523"
+          },
+          "measurement_attempt": 1,
+          "pair": "natural-10",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 8.003123535076156,
+            "rejected_windows": [
+              {
+                "issues": [
+                  "SMT sibling CPU 67 had 20 busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 0,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 200,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 0
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 20,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 179,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 20
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              },
+              {
+                "issues": [
+                  "measurement CPU 19 had 12 non-interrupt busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 12,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 187,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 5,
+                      "user": 7
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 0,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 200,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 0
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              },
+              {
+                "issues": [
+                  "measurement CPU 19 had 18 non-interrupt busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 18,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 182,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 18
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 1,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 200,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 1
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              }
+            ]
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.005046000000058299,
+              "child_cpu_seconds": 5.383904999999942,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 541
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.005046000000058299,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.005046000000058299,
+              "measurement_cpu_residual_seconds": 0.0250460000000583,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.41,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 92,
+                    "user": 447
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 541,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 373378,
+              "runner_cpu_seconds": 0.0010490000000000776
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451041",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 10,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=4.20 avg60=4.92 avg300=7.14 total=7717421205\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7717421205,
+              "load_1m_per_available_cpu": 5.193359375,
+              "load_1m_per_cpu": 0.054097493489583336,
+              "load_average": [
+                5.193359375,
+                5.404296875,
+                6.046875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "4/3545"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4449969",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 10,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=3.35 avg60=4.85 avg300=7.17 total=7717047827\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7717047827,
+              "load_1m_per_available_cpu": 5.123046875,
+              "load_1m_per_cpu": 0.053365071614583336,
+              "load_average": [
+                5.123046875,
+                5.39404296875,
+                6.04736328125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "6/3534"
+            },
+            "involuntary_context_switches": 21135,
+            "peak_rss_kb": 3082308,
+            "precise_child_system_seconds": 0.9186039999999878,
+            "precise_child_user_seconds": 4.465300999999954,
+            "system_seconds": 0.91,
+            "user_seconds": 4.46,
+            "voluntary_context_switches": 35958,
+            "wall_nanos": 5409544528
+          },
+          "round": 6,
+          "signed_wall_delta_nanos": 8737189891,
+          "slot_index": 8
+        }
+      ],
+      "signed_wall_delta_nanos": [
+        8717787475,
+        8678865124,
+        8591854583,
+        8472088373,
+        8700628145,
+        8737189891
+      ],
+      "width_bits": null
+    },
+    "natural-10-null": {
+      "build_magnitude_wall_nanos": 14068291836,
+      "candidate": {
+        "artifacts": {
+          "ilean_bytes": 2348,
+          "olean_bytes": 12528,
+          "olean_private_bytes": 684008,
+          "olean_server_bytes": 1200,
+          "source_bytes": 803
+        },
+        "expected_axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "module": "HexRealRootsMathlib.ProofProbe.Natural10"
+      },
+      "family": "fresh-build-noise",
+      "interpretation": "calibration-only",
+      "magnitude": "natural-10",
+      "median_candidate_peak_rss_kb": 3924794,
+      "median_candidate_wall_nanos": 13950387336,
+      "median_reference_peak_rss_kb": 3873656,
+      "median_reference_wall_nanos": 14068291836,
+      "median_signed_wall_delta_nanos": -69242577,
+      "null_control": true,
+      "null_max_absolute_delta_nanos": 262385607,
+      "null_spread_nanos": 254141199,
+      "reference": {
+        "artifacts": {
+          "ilean_bytes": 2348,
+          "olean_bytes": 12528,
+          "olean_private_bytes": 684008,
+          "olean_server_bytes": 1200,
+          "source_bytes": 803
+        },
+        "expected_axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "module": "HexRealRootsMathlib.ProofProbe.Natural10"
+      },
+      "samples": [
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.024599999999992444,
+              "child_cpu_seconds": 13.944345000000007,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 1401
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0045999999999924435,
+              "measurement_cpu_interrupt_seconds": 0.06,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.0045999999999924435,
+              "measurement_cpu_residual_seconds": 0.06459999999999244,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 14.01,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 5,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 105,
+                    "user": 1290
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.02,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1401,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 1,
+                    "user": 1
+                  }
+                }
+              },
+              "pressure_some_delta_us": 917786,
+              "runner_cpu_seconds": 0.0010550000000000281
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4455882",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=3.32 avg60=5.91 avg300=5.93 total=7546556276\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7546556276,
+              "load_1m_per_available_cpu": 5.6875,
+              "load_1m_per_cpu": 0.059244791666666664,
+              "load_average": [
+                5.6875,
+                8.77880859375,
+                12.14111328125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3523"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451654",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=2.12 avg60=6.00 avg300=5.93 total=7545638490\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7545638490,
+              "load_1m_per_available_cpu": 6.45263671875,
+              "load_1m_per_cpu": 0.0672149658203125,
+              "load_average": [
+                6.45263671875,
+                9.02685546875,
+                12.2568359375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3562"
+            },
+            "involuntary_context_switches": 22641,
+            "peak_rss_kb": 3928232,
+            "precise_child_system_seconds": 1.04425,
+            "precise_child_user_seconds": 12.900095000000007,
+            "system_seconds": 1.04,
+            "user_seconds": 12.89,
+            "voluntary_context_switches": 37547,
+            "wall_nanos": 14009825989
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4453243",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 24,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=2.43 avg60=6.87 avg300=6.08 total=7545132359\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7545132359,
+            "load_1m_per_available_cpu": 7.34033203125,
+            "load_1m_per_cpu": 0.0764617919921875,
+            "load_average": [
+              7.34033203125,
+              9.3203125,
+              12.40283203125
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "11/3608"
+          },
+          "measurement_attempt": 1,
+          "pair": "natural-10-null",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 1,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 4.00168484589085,
+            "rejected_windows": [
+              {
+                "issues": [
+                  "measurement CPU 19 had 65 non-interrupt busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 65,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 135,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 1,
+                      "user": 64
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 0,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 199,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 0
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              }
+            ]
+          },
+          "reference": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 13.964940999999996,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 1403
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.06,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.005957999999996466,
+              "measurement_cpu_residual_seconds": 0.05404200000000353,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 14.02,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 5,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 106,
+                    "user": 1290
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1403,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 505217,
+              "runner_cpu_seconds": 0.0010169999999999901
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452455",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=2.12 avg60=6.00 avg300=5.93 total=7545637610\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7545637610,
+              "load_1m_per_available_cpu": 6.45263671875,
+              "load_1m_per_cpu": 0.0672149658203125,
+              "load_average": [
+                6.45263671875,
+                9.02685546875,
+                12.2568359375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3562"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4452352",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 24,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=2.43 avg60=6.87 avg300=6.08 total=7545132393\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7545132393,
+              "load_1m_per_available_cpu": 7.34033203125,
+              "load_1m_per_cpu": 0.0764617919921875,
+              "load_average": [
+                7.34033203125,
+                9.3203125,
+                12.40283203125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "5/3608"
+            },
+            "involuntary_context_switches": 23734,
+            "peak_rss_kb": 3887948,
+            "precise_child_system_seconds": 1.0641969999999992,
+            "precise_child_user_seconds": 12.900743999999996,
+            "system_seconds": 1.06,
+            "user_seconds": 12.9,
+            "voluntary_context_switches": 38631,
+            "wall_nanos": 14029235500
+          },
+          "round": 1,
+          "signed_wall_delta_nanos": -19409511,
+          "slot_index": 1
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.03,
+              "child_cpu_seconds": 13.840654000000029,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 1391
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.06,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.0016780000000287676,
+              "measurement_cpu_residual_seconds": 0.05832199999997123,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 13.9,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 5,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 103,
+                    "user": 1281
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.03,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1388,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 3,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1254518,
+              "runner_cpu_seconds": 0.0010240000000000249
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452183",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=6.34 avg60=12.05 avg300=10.01 total=7583964357\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7583964357,
+              "load_1m_per_available_cpu": 3.4150390625,
+              "load_1m_per_cpu": 0.035573323567708336,
+              "load_average": [
+                3.4150390625,
+                5.93701171875,
+                9.98779296875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3505"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4452282",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=9.33 avg60=13.15 avg300=10.09 total=7582709839\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7582709839,
+              "load_1m_per_available_cpu": 3.84130859375,
+              "load_1m_per_cpu": 0.040013631184895836,
+              "load_average": [
+                3.84130859375,
+                6.14111328125,
+                10.11865234375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "5/3532"
+            },
+            "involuntary_context_switches": 22618,
+            "peak_rss_kb": 4004816,
+            "precise_child_system_seconds": 1.035618999999997,
+            "precise_child_user_seconds": 12.805035000000032,
+            "system_seconds": 1.03,
+            "user_seconds": 12.8,
+            "voluntary_context_switches": 37497,
+            "wall_nanos": 13905708794
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4360408",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 9,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=9.33 avg60=13.15 avg300=10.09 total=7582709552\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7582709552,
+            "load_1m_per_available_cpu": 3.84130859375,
+            "load_1m_per_cpu": 0.040013631184895836,
+            "load_average": [
+              3.84130859375,
+              6.14111328125,
+              10.11865234375
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "3/3532"
+          },
+          "measurement_attempt": 1,
+          "pair": "natural-10-null",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.000878707971424,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.06,
+              "child_cpu_seconds": 14.101136999999994,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 1417
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.06,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.002196999999994176,
+              "measurement_cpu_residual_seconds": 0.05780300000000582,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 14.16,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 5,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 99,
+                    "user": 1311
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.06,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1411,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 1,
+                    "user": 5
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1396500,
+              "runner_cpu_seconds": 0.001060000000000061
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451940",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=5.64 avg60=11.32 avg300=9.97 total=7585361022\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7585361022,
+              "load_1m_per_available_cpu": 3.42724609375,
+              "load_1m_per_cpu": 0.035700480143229164,
+              "load_average": [
+                3.42724609375,
+                5.810546875,
+                9.880859375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3504"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451323",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=6.34 avg60=12.05 avg300=10.01 total=7583964522\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7583964522,
+              "load_1m_per_available_cpu": 3.4150390625,
+              "load_1m_per_cpu": 0.035573323567708336,
+              "load_average": [
+                3.4150390625,
+                5.93701171875,
+                9.98779296875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3505"
+            },
+            "involuntary_context_switches": 22267,
+            "peak_rss_kb": 3846308,
+            "precise_child_system_seconds": 0.9929309999999987,
+            "precise_child_user_seconds": 13.108205999999996,
+            "system_seconds": 0.99,
+            "user_seconds": 13.1,
+            "voluntary_context_switches": 37141,
+            "wall_nanos": 14168094401
+          },
+          "round": 2,
+          "signed_wall_delta_nanos": -262385607,
+          "slot_index": 0
+        },
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.028524999999982852,
+              "child_cpu_seconds": 13.920416000000017,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 1399
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.008524999999982852,
+              "measurement_cpu_interrupt_seconds": 0.07,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.008524999999982852,
+              "measurement_cpu_residual_seconds": 0.07852499999998286,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 14.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 5,
+                    "nice": 0,
+                    "softirq": 2,
+                    "steal": 0,
+                    "system": 106,
+                    "user": 1287
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.02,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1396,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 2
+                  }
+                }
+              },
+              "pressure_some_delta_us": 830637,
+              "runner_cpu_seconds": 0.0010589999999999211
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451825",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=4.81 avg60=12.57 avg300=13.58 total=7647665911\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7647665911,
+              "load_1m_per_available_cpu": 2.32763671875,
+              "load_1m_per_cpu": 0.0242462158203125,
+              "load_average": [
+                2.32763671875,
+                3.24072265625,
+                7.23583984375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3526"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4447283",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=8.59 avg60=14.53 avg300=13.99 total=7646835274\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7646835274,
+              "load_1m_per_available_cpu": 1.8427734375,
+              "load_1m_per_cpu": 0.019195556640625,
+              "load_average": [
+                1.8427734375,
+                3.20068359375,
+                7.28955078125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3546"
+            },
+            "involuntary_context_switches": 22430,
+            "peak_rss_kb": 3866792,
+            "precise_child_system_seconds": 1.0580730000000074,
+            "precise_child_user_seconds": 12.86234300000001,
+            "system_seconds": 1.05,
+            "user_seconds": 12.86,
+            "voluntary_context_switches": 37328,
+            "wall_nanos": 13988265522
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "2050481",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=17.32 avg60=16.08 avg300=14.23 total=7645479200\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7645479200,
+            "load_1m_per_available_cpu": 2.17041015625,
+            "load_1m_per_cpu": 0.022608439127604168,
+            "load_average": [
+              2.17041015625,
+              3.33203125,
+              7.39794921875
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "2/3523"
+          },
+          "measurement_attempt": 1,
+          "pair": "natural-10-null",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.000971945002675,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.01,
+              "child_cpu_seconds": 13.929763000000023,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 1400
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.05,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.0007800000000219437,
+              "measurement_cpu_residual_seconds": 0.04921999999997806,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 13.98,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 4,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 103,
+                    "user": 1290
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.01,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1400,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1355701,
+              "runner_cpu_seconds": 0.0010169999999998236
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4450437",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=8.59 avg60=14.53 avg300=13.99 total=7646835152\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7646835152,
+              "load_1m_per_available_cpu": 1.8427734375,
+              "load_1m_per_cpu": 0.019195556640625,
+              "load_average": [
+                1.8427734375,
+                3.20068359375,
+                7.28955078125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "4/3546"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4396501",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=17.32 avg60=16.08 avg300=14.23 total=7645479451\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7645479451,
+              "load_1m_per_available_cpu": 1.99658203125,
+              "load_1m_per_cpu": 0.0207977294921875,
+              "load_average": [
+                1.99658203125,
+                3.2763671875,
+                7.35791015625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3523"
+            },
+            "involuntary_context_switches": 22503,
+            "peak_rss_kb": 3896924,
+            "precise_child_system_seconds": 1.0287420000000083,
+            "precise_child_user_seconds": 12.901021000000014,
+            "system_seconds": 1.02,
+            "user_seconds": 12.9,
+            "voluntary_context_switches": 37344,
+            "wall_nanos": 13996509930
+          },
+          "round": 3,
+          "signed_wall_delta_nanos": -8244408,
+          "slot_index": 8
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.012184999999993285,
+              "child_cpu_seconds": 13.826760000000007,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 1390
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.012184999999993285,
+              "measurement_cpu_interrupt_seconds": 0.06,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.012184999999993285,
+              "measurement_cpu_residual_seconds": 0.07218499999999328,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 13.9,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 5,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 103,
+                    "user": 1281
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1389,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1463955,
+              "runner_cpu_seconds": 0.001054999999999806
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452131",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=6.10 avg60=12.75 avg300=13.75 total=7671660793\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7671660793,
+              "load_1m_per_available_cpu": 1.802734375,
+              "load_1m_per_cpu": 0.018778483072916668,
+              "load_average": [
+                1.802734375,
+                2.6904296875,
+                6.37353515625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3486"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451896",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=6.14 avg60=13.75 avg300=13.96 total=7670196838\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7670196838,
+              "load_1m_per_available_cpu": 1.64306640625,
+              "load_1m_per_cpu": 0.017115275065104168,
+              "load_average": [
+                1.64306640625,
+                2.708984375,
+                6.43994140625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3486"
+            },
+            "involuntary_context_switches": 22516,
+            "peak_rss_kb": 3921356,
+            "precise_child_system_seconds": 1.0282660000000021,
+            "precise_child_user_seconds": 12.798494000000005,
+            "system_seconds": 1.02,
+            "user_seconds": 12.79,
+            "voluntary_context_switches": 37433,
+            "wall_nanos": 13892291469
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "1500000",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=6.14 avg60=13.75 avg300=13.96 total=7670196547\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7670196547,
+            "load_1m_per_available_cpu": 1.64306640625,
+            "load_1m_per_cpu": 0.017115275065104168,
+            "load_average": [
+              1.64306640625,
+              2.708984375,
+              6.43994140625
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "1/3486"
+          },
+          "measurement_attempt": 1,
+          "pair": "natural-10-null",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 1,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                },
+                "67": {
+                  "busy_ticks": 1,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 1,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 12.006141687976196,
+            "rejected_windows": [
+              {
+                "issues": [
+                  "SMT sibling CPU 67 had 4 busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 2,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 196,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 2
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 4,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 194,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 4
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              },
+              {
+                "issues": [
+                  "SMT sibling CPU 67 had 4 busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 1,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 199,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 1,
+                      "user": 0
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 4,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 195,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 4
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              },
+              {
+                "issues": [
+                  "measurement CPU 19 had 5 non-interrupt busy ticks",
+                  "SMT sibling CPU 67 had 7 busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 5,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 195,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 1,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 5
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 7,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 192,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 1,
+                      "user": 6
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              },
+              {
+                "issues": [
+                  "measurement CPU 19 had 5 non-interrupt busy ticks",
+                  "SMT sibling CPU 67 had 3 busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 5,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 196,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 1,
+                      "user": 4
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 3,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 197,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 1,
+                      "user": 2
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              },
+              {
+                "issues": [
+                  "SMT sibling CPU 67 had 4 busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 0,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 200,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 0
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 4,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 197,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 1,
+                      "user": 3
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              }
+            ]
+          },
+          "reference": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.03,
+              "child_cpu_seconds": 14.03995599999999,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 1411
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.06,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.0009829999999896866,
+              "measurement_cpu_residual_seconds": 0.05901700000001031,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 14.1,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 5,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 105,
+                    "user": 1299
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.03,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1407,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 1,
+                    "user": 2
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1572218,
+              "runner_cpu_seconds": 0.0010269999999998891
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452333",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=6.70 avg60=12.21 avg300=13.60 total=7673233310\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7673233310,
+              "load_1m_per_available_cpu": 1.828125,
+              "load_1m_per_cpu": 0.01904296875,
+              "load_average": [
+                1.828125,
+                2.6552734375,
+                6.302734375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3487"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4450267",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=6.10 avg60=12.75 avg300=13.75 total=7671661092\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7671661092,
+              "load_1m_per_available_cpu": 1.802734375,
+              "load_1m_per_cpu": 0.018778483072916668,
+              "load_average": [
+                1.802734375,
+                2.6904296875,
+                6.37353515625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3486"
+            },
+            "involuntary_context_switches": 22736,
+            "peak_rss_kb": 3864356,
+            "precise_child_system_seconds": 1.050893000000002,
+            "precise_child_user_seconds": 12.989062999999987,
+            "system_seconds": 1.05,
+            "user_seconds": 12.98,
+            "voluntary_context_switches": 37740,
+            "wall_nanos": 14107348172
+          },
+          "round": 4,
+          "signed_wall_delta_nanos": -215056703,
+          "slot_index": 7
+        },
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.02102300000001405,
+              "child_cpu_seconds": 13.847948999999986,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 1391
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.01102300000001405,
+              "measurement_cpu_interrupt_seconds": 0.07,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.01102300000001405,
+              "measurement_cpu_residual_seconds": 0.08102300000001406,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 13.93,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 5,
+                    "nice": 0,
+                    "softirq": 2,
+                    "steal": 0,
+                    "system": 105,
+                    "user": 1281
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.01,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1391,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1560440,
+              "runner_cpu_seconds": 0.0010280000000000289
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451601",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=7.24 avg60=7.02 avg300=9.46 total=7685582574\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7685582574,
+              "load_1m_per_available_cpu": 4.81982421875,
+              "load_1m_per_cpu": 0.050206502278645836,
+              "load_average": [
+                4.81982421875,
+                4.3525390625,
+                6.25
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3525"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4449228",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=7.15 avg60=6.18 avg300=9.40 total=7684022134\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7684022134,
+              "load_1m_per_available_cpu": 5.90771484375,
+              "load_1m_per_cpu": 0.0615386962890625,
+              "load_average": [
+                5.90771484375,
+                4.525390625,
+                6.33642578125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3529"
+            },
+            "involuntary_context_switches": 22895,
+            "peak_rss_kb": 3842696,
+            "precise_child_system_seconds": 1.0475550000000027,
+            "precise_child_user_seconds": 12.800393999999983,
+            "system_seconds": 1.04,
+            "user_seconds": 12.8,
+            "voluntary_context_switches": 37908,
+            "wall_nanos": 13912509150
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "2599148",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=8.47 avg60=5.35 avg300=9.38 total=7682513208\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7682513208,
+            "load_1m_per_available_cpu": 7.30517578125,
+            "load_1m_per_cpu": 0.0760955810546875,
+            "load_average": [
+              7.30517578125,
+              4.70751953125,
+              6.42431640625
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "2/3529"
+          },
+          "measurement_attempt": 1,
+          "pair": "natural-10-null",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.0008305739611387,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.012336000000021274,
+              "child_cpu_seconds": 13.926633999999979,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 1400
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.012336000000021274,
+              "measurement_cpu_interrupt_seconds": 0.06,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.012336000000021274,
+              "measurement_cpu_residual_seconds": 0.07233600000002127,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 14.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 5,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 106,
+                    "user": 1288
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1398,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1508591,
+              "runner_cpu_seconds": 0.0010300000000000864
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451866",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=7.15 avg60=6.18 avg300=9.40 total=7684021948\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7684021948,
+              "load_1m_per_available_cpu": 5.90771484375,
+              "load_1m_per_cpu": 0.0615386962890625,
+              "load_average": [
+                5.90771484375,
+                4.525390625,
+                6.33642578125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3529"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4450464",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=8.47 avg60=5.35 avg300=9.38 total=7682513357\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7682513357,
+              "load_1m_per_available_cpu": 7.30517578125,
+              "load_1m_per_cpu": 0.0760955810546875,
+              "load_average": [
+                7.30517578125,
+                4.70751953125,
+                6.42431640625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3529"
+            },
+            "involuntary_context_switches": 21826,
+            "peak_rss_kb": 3821784,
+            "precise_child_system_seconds": 1.0585590000000025,
+            "precise_child_user_seconds": 12.868074999999976,
+            "system_seconds": 1.05,
+            "user_seconds": 12.86,
+            "voluntary_context_switches": 36796,
+            "wall_nanos": 13995542233
+          },
+          "round": 5,
+          "signed_wall_delta_nanos": -83033083,
+          "slot_index": 6
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.028259000000003833,
+              "child_cpu_seconds": 14.030699999999996,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 1410
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.008259000000003833,
+              "measurement_cpu_interrupt_seconds": 0.05,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.008259000000003833,
+              "measurement_cpu_residual_seconds": 0.058259000000003835,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 14.09,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 5,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 104,
+                    "user": 1300
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.02,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1407,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 1,
+                    "user": 1
+                  }
+                }
+              },
+              "pressure_some_delta_us": 828154,
+              "runner_cpu_seconds": 0.0010410000000000696
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4454054",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 10,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=3.40 avg60=5.49 avg300=8.11 total=7712888339\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7712888339,
+              "load_1m_per_available_cpu": 6.40234375,
+              "load_1m_per_cpu": 0.06669108072916667,
+              "load_average": [
+                6.40234375,
+                5.43798828125,
+                6.11328125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "8/3552"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4456032",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=4.43 avg60=5.63 avg300=8.25 total=7712060185\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7712060185,
+              "load_1m_per_available_cpu": 7.166015625,
+              "load_1m_per_cpu": 0.07464599609375,
+              "load_average": [
+                7.166015625,
+                5.52978515625,
+                6.15380859375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3540"
+            },
+            "involuntary_context_switches": 23445,
+            "peak_rss_kb": 3936312,
+            "precise_child_system_seconds": 1.0429479999999955,
+            "precise_child_user_seconds": 12.987752,
+            "system_seconds": 1.04,
+            "user_seconds": 12.98,
+            "voluntary_context_switches": 38379,
+            "wall_nanos": 14092522261
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "1508708",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 8,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=4.43 avg60=5.63 avg300=8.25 total=7712059830\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7712059830,
+            "load_1m_per_available_cpu": 7.166015625,
+            "load_1m_per_cpu": 0.07464599609375,
+            "load_average": [
+              7.166015625,
+              5.52978515625,
+              6.15380859375
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "4/3538"
+          },
+          "measurement_attempt": 1,
+          "pair": "natural-10-null",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.0011642740573734,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.01203099999995976,
+              "child_cpu_seconds": 14.08691200000004,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 1415
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0020309999999597594,
+              "measurement_cpu_interrupt_seconds": 0.06,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.0020309999999597594,
+              "measurement_cpu_residual_seconds": 0.06203099999995976,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 14.15,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 5,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 102,
+                    "user": 1307
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.01,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1413,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                }
+              },
+              "pressure_some_delta_us": 300848,
+              "runner_cpu_seconds": 0.0010569999999998636
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4450294",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 10,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=1.47 avg60=4.64 avg300=7.80 total=7713189212\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7713189212,
+              "load_1m_per_available_cpu": 6.568359375,
+              "load_1m_per_cpu": 0.06842041015625,
+              "load_average": [
+                6.568359375,
+                5.50634765625,
+                6.12841796875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "12/3561"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451960",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 10,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=3.40 avg60=5.49 avg300=8.11 total=7712888364\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7712888364,
+              "load_1m_per_available_cpu": 6.40234375,
+              "load_1m_per_cpu": 0.06669108072916667,
+              "load_average": [
+                6.40234375,
+                5.43798828125,
+                6.11328125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "8/3552"
+            },
+            "involuntary_context_switches": 22456,
+            "peak_rss_kb": 3882956,
+            "precise_child_system_seconds": 1.0196070000000077,
+            "precise_child_user_seconds": 13.067305000000033,
+            "system_seconds": 1.01,
+            "user_seconds": 13.06,
+            "voluntary_context_switches": 37347,
+            "wall_nanos": 14147974333
+          },
+          "round": 6,
+          "signed_wall_delta_nanos": -55452072,
+          "slot_index": 5
+        }
+      ],
+      "signed_wall_delta_nanos": [
+        -19409511,
+        -262385607,
+        -8244408,
+        -215056703,
+        -83033083,
+        -55452072
+      ]
+    },
+    "natural-6": {
+      "build_magnitude_wall_nanos": 7725483932,
+      "candidate": {
+        "artifacts": {
+          "ilean_bytes": 1872,
+          "olean_bytes": 10576,
+          "olean_private_bytes": 393360,
+          "olean_server_bytes": 1200,
+          "source_bytes": 717
+        },
+        "expected_axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "module": "HexRealRootsMathlib.ProofProbe.Natural6"
+      },
+      "comparable_control": "fresh-build-null",
+      "comparable_null_envelope_nanos": 83569129,
+      "comparable_null_raw_envelope_nanos": 58751220,
+      "comparable_null_raw_spread_nanos": 88945003,
+      "comparable_null_spread_nanos": 126517483,
+      "control_magnitude_ratio": 1.4224237210054376,
+      "control_scale_factor": 1.4224237210054376,
+      "degree": 6,
+      "family": "natural-width",
+      "median_candidate_peak_rss_kb": 3379886,
+      "median_candidate_wall_nanos": 7725483932,
+      "median_reference_peak_rss_kb": 3081574,
+      "median_reference_wall_nanos": 5420120188,
+      "median_signed_wall_delta_nanos": 2303891226,
+      "null_control": false,
+      "reference": {
+        "artifacts": {
+          "ilean_bytes": 168,
+          "olean_bytes": 1584,
+          "olean_private_bytes": 96,
+          "olean_server_bytes": 912,
+          "source_bytes": 422
+        },
+        "expected_axioms": null,
+        "module": "HexRealRootsMathlib.ProofProbe.Baseline"
+      },
+      "resolution": "resolved",
+      "samples": [
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.006703000000004927,
+              "child_cpu_seconds": 7.682220999999995,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 772
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.006703000000004927,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.006703000000004927,
+              "measurement_cpu_residual_seconds": 0.036703000000004926,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.72,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 93,
+                    "user": 676
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 772,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 934891,
+              "runner_cpu_seconds": 0.0010759999999999659
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452607",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=11.28 avg60=7.67 avg300=6.32 total=7548814754\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7548814754,
+              "load_1m_per_available_cpu": 5.28515625,
+              "load_1m_per_cpu": 0.0550537109375,
+              "load_average": [
+                5.28515625,
+                8.4853515625,
+                11.97216796875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3522"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4450338",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=9.95 avg60=7.00 avg300=6.16 total=7547879863\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7547879863,
+              "load_1m_per_available_cpu": 5.53369140625,
+              "load_1m_per_cpu": 0.057642618815104164,
+              "load_average": [
+                5.53369140625,
+                8.63916015625,
+                12.05908203125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3551"
+            },
+            "involuntary_context_switches": 21682,
+            "peak_rss_kb": 3376848,
+            "precise_child_system_seconds": 0.9234669999999987,
+            "precise_child_user_seconds": 6.758753999999996,
+            "system_seconds": 0.92,
+            "user_seconds": 6.75,
+            "voluntary_context_switches": 36657,
+            "wall_nanos": 7719611977
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4453661",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=2.37 avg60=5.56 avg300=5.85 total=7546557954\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7546557954,
+            "load_1m_per_available_cpu": 5.23193359375,
+            "load_1m_per_cpu": 0.054499308268229164,
+            "load_average": [
+              5.23193359375,
+              8.6328125,
+              12.07568359375
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "1/3526"
+          },
+          "measurement_attempt": 1,
+          "pair": "natural-6",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 2,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 198,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 1,
+                    "user": 1
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 4.0017178719863296,
+            "rejected_windows": [
+              {
+                "issues": [
+                  "SMT sibling CPU 67 had 4 busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 1,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 200,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 1
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 4,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 195,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 1,
+                      "user": 3
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              }
+            ]
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0024180000000001596,
+              "child_cpu_seconds": 5.376533,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 541
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0024180000000001596,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.0024180000000001596,
+              "measurement_cpu_residual_seconds": 0.02241800000000016,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.4,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 91,
+                    "user": 447
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 541,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1321670,
+              "runner_cpu_seconds": 0.0010489999999999666
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4449919",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=9.95 avg60=7.00 avg300=6.16 total=7547879753\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7547879753,
+              "load_1m_per_available_cpu": 5.53369140625,
+              "load_1m_per_cpu": 0.057642618815104164,
+              "load_average": [
+                5.53369140625,
+                8.63916015625,
+                12.05908203125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "6/3551"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4452267",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=2.37 avg60=5.56 avg300=5.85 total=7546558083\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7546558083,
+              "load_1m_per_available_cpu": 5.23193359375,
+              "load_1m_per_cpu": 0.054499308268229164,
+              "load_average": [
+                5.23193359375,
+                8.6328125,
+                12.07568359375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3526"
+            },
+            "involuntary_context_switches": 21119,
+            "peak_rss_kb": 3081504,
+            "precise_child_system_seconds": 0.9051150000000003,
+            "precise_child_user_seconds": 4.471418,
+            "system_seconds": 0.9,
+            "user_seconds": 4.47,
+            "voluntary_context_switches": 36022,
+            "wall_nanos": 5406263264
+          },
+          "round": 1,
+          "signed_wall_delta_nanos": 2313348713,
+          "slot_index": 2
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.03,
+              "child_cpu_seconds": 7.689948000000022,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 773
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.04,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.0009750000000220069,
+              "measurement_cpu_residual_seconds": 0.039024999999977994,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.73,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1,
+                    "iowait": 0,
+                    "irq": 3,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 93,
+                    "user": 676
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.03,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 770,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 3,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1238066,
+              "runner_cpu_seconds": 0.0010270000000000001
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452801",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=8.33 avg60=10.88 avg300=9.93 total=7586601716\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7586601716,
+              "load_1m_per_available_cpu": 3.1162109375,
+              "load_1m_per_cpu": 0.032460530598958336,
+              "load_average": [
+                3.1162109375,
+                5.62353515625,
+                9.75390625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3523"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4456551",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=3.34 avg60=10.30 avg300=9.78 total=7585363650\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7585363650,
+              "load_1m_per_available_cpu": 3.232421875,
+              "load_1m_per_cpu": 0.033671061197916664,
+              "load_average": [
+                3.232421875,
+                5.73046875,
+                9.8330078125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3500"
+            },
+            "involuntary_context_switches": 22159,
+            "peak_rss_kb": 3377556,
+            "precise_child_system_seconds": 0.929667000000002,
+            "precise_child_user_seconds": 6.76028100000002,
+            "system_seconds": 0.92,
+            "user_seconds": 6.75,
+            "voluntary_context_switches": 37140,
+            "wall_nanos": 7730131454
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "2842586",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=3.34 avg60=10.30 avg300=9.78 total=7585363580\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7585363580,
+            "load_1m_per_available_cpu": 3.232421875,
+            "load_1m_per_cpu": 0.033671061197916664,
+            "load_average": [
+              3.232421875,
+              5.73046875,
+              9.8330078125
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "2/3501"
+          },
+          "measurement_attempt": 1,
+          "pair": "natural-6",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 199,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 6.0030158450827,
+            "rejected_windows": [
+              {
+                "issues": [
+                  "measurement CPU 19 had 8 non-interrupt busy ticks",
+                  "SMT sibling CPU 67 had 7 busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 8,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 194,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 3,
+                      "user": 5
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 7,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 194,
+                      "iowait": 0,
+                      "irq": 1,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 1,
+                      "user": 5
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              },
+              {
+                "issues": [
+                  "measurement CPU 19 had 6 non-interrupt busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 6,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 194,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 6
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 2,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 198,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 2
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              }
+            ]
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.012658000000012179,
+              "child_cpu_seconds": 5.416298999999988,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 545
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0026580000000121784,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.0026580000000121784,
+              "measurement_cpu_residual_seconds": 0.03265800000001218,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.45,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 89,
+                    "user": 453
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.01,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 545,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 769806,
+              "runner_cpu_seconds": 0.0010430000000000161
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451624",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=11.39 avg60=11.34 avg300=10.04 total=7587371620\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7587371620,
+              "load_1m_per_available_cpu": 3.1064453125,
+              "load_1m_per_cpu": 0.032358805338541664,
+              "load_average": [
+                3.1064453125,
+                5.57958984375,
+                9.71728515625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3506"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4450430",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=8.33 avg60=10.88 avg300=9.93 total=7586601814\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7586601814,
+              "load_1m_per_available_cpu": 3.1162109375,
+              "load_1m_per_cpu": 0.032460530598958336,
+              "load_average": [
+                3.1162109375,
+                5.62353515625,
+                9.75390625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3523"
+            },
+            "involuntary_context_switches": 20867,
+            "peak_rss_kb": 3081644,
+            "precise_child_system_seconds": 0.892474,
+            "precise_child_user_seconds": 4.523824999999988,
+            "system_seconds": 0.89,
+            "user_seconds": 4.52,
+            "voluntary_context_switches": 35646,
+            "wall_nanos": 5445058923
+          },
+          "round": 2,
+          "signed_wall_delta_nanos": 2285072531,
+          "slot_index": 1
+        },
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 7.70080599999995,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 774
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.0018369999999498787,
+              "measurement_cpu_residual_seconds": 0.02816300000005012,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.73,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 96,
+                    "user": 674
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 773,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1516848,
+              "runner_cpu_seconds": 0.0010310000000000041
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452032",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=18.28 avg60=16.92 avg300=12.67 total=7614061146\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7614061146,
+              "load_1m_per_available_cpu": 2.37646484375,
+              "load_1m_per_cpu": 0.024754842122395832,
+              "load_average": [
+                2.37646484375,
+                4.2841796875,
+                8.5654296875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3490"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4448563",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=20.71 avg60=16.80 avg300=12.52 total=7612544298\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7612544298,
+              "load_1m_per_available_cpu": 2.49658203125,
+              "load_1m_per_cpu": 0.026006062825520832,
+              "load_average": [
+                2.49658203125,
+                4.33984375,
+                8.6064453125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3486"
+            },
+            "involuntary_context_switches": 23620,
+            "peak_rss_kb": 3357676,
+            "precise_child_system_seconds": 0.9651500000000013,
+            "precise_child_user_seconds": 6.735655999999949,
+            "system_seconds": 0.96,
+            "user_seconds": 6.73,
+            "voluntary_context_switches": 38408,
+            "wall_nanos": 7739279478
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4326917",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=14.72 avg60=15.63 avg300=12.23 total=7611122125\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7611122125,
+            "load_1m_per_available_cpu": 2.626953125,
+            "load_1m_per_cpu": 0.027364095052083332,
+            "load_average": [
+              2.626953125,
+              4.396484375,
+              8.64794921875
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "1/3487"
+          },
+          "measurement_attempt": 1,
+          "pair": "natural-6",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 1,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.0008671581745148,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 5.384785000000008,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 542
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.005789000000007576,
+              "measurement_cpu_residual_seconds": 0.014210999999992424,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.4,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 88,
+                    "user": 450
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 542,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1421935,
+              "runner_cpu_seconds": 0.0010040000000000049
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451250",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=20.71 avg60=16.80 avg300=12.52 total=7612544203\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7612544203,
+              "load_1m_per_available_cpu": 2.49658203125,
+              "load_1m_per_cpu": 0.026006062825520832,
+              "load_average": [
+                2.49658203125,
+                4.33984375,
+                8.6064453125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3486"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451336",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=14.72 avg60=15.63 avg300=12.23 total=7611122268\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7611122268,
+              "load_1m_per_available_cpu": 2.626953125,
+              "load_1m_per_cpu": 0.027364095052083332,
+              "load_average": [
+                2.626953125,
+                4.396484375,
+                8.64794921875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3487"
+            },
+            "involuntary_context_switches": 21036,
+            "peak_rss_kb": 3079568,
+            "precise_child_system_seconds": 0.8880079999999992,
+            "precise_child_user_seconds": 4.496777000000009,
+            "system_seconds": 0.88,
+            "user_seconds": 4.49,
+            "voluntary_context_switches": 35951,
+            "wall_nanos": 5413837706
+          },
+          "round": 3,
+          "signed_wall_delta_nanos": 2325441772,
+          "slot_index": 0
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.020771999999916323,
+              "child_cpu_seconds": 7.688204000000084,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 773
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.01077199999991632,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.01077199999991632,
+              "measurement_cpu_residual_seconds": 0.04077199999991632,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.73,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 3,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 89,
+                    "user": 681
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.01,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 772,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 1,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 854523,
+              "runner_cpu_seconds": 0.0010239999999999139
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452305",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=6.04 avg60=10.32 avg300=13.07 total=7674092663\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7674092663,
+              "load_1m_per_available_cpu": 2.41455078125,
+              "load_1m_per_cpu": 0.025151570638020832,
+              "load_average": [
+                2.41455078125,
+                2.751953125,
+                6.27587890625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "6/3604"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4320134",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=2.63 avg60=10.39 avg300=13.16 total=7673238140\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7673238140,
+              "load_1m_per_available_cpu": 2.45068359375,
+              "load_1m_per_cpu": 0.0255279541015625,
+              "load_average": [
+                2.45068359375,
+                2.76513671875,
+                6.29931640625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "5/3551"
+            },
+            "involuntary_context_switches": 22540,
+            "peak_rss_kb": 3395624,
+            "precise_child_system_seconds": 0.8898319999999984,
+            "precise_child_user_seconds": 6.798372000000086,
+            "system_seconds": 0.88,
+            "user_seconds": 6.79,
+            "voluntary_context_switches": 37541,
+            "wall_nanos": 7720836410
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "1868561",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 8,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=2.63 avg60=10.39 avg300=13.16 total=7673237979\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7673237979,
+            "load_1m_per_available_cpu": 2.45068359375,
+            "load_1m_per_cpu": 0.0255279541015625,
+            "load_average": [
+              2.45068359375,
+              2.76513671875,
+              6.29931640625
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "2/3551"
+          },
+          "measurement_attempt": 1,
+          "pair": "natural-6",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 10.00421595084481,
+            "rejected_windows": [
+              {
+                "issues": [
+                  "measurement CPU 19 had 4 non-interrupt busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 4,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 196,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 1,
+                      "user": 3
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 2,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 198,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 2
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              },
+              {
+                "issues": [
+                  "measurement CPU 19 had 27 non-interrupt busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 27,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 172,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 8,
+                      "user": 19
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 1,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 200,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 1,
+                      "user": 0
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              },
+              {
+                "issues": [
+                  "measurement CPU 19 had 40 non-interrupt busy ticks",
+                  "SMT sibling CPU 67 had 28 busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 40,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 160,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 1,
+                      "steal": 0,
+                      "system": 5,
+                      "user": 35
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 28,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 170,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 28
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              },
+              {
+                "issues": [
+                  "measurement CPU 19 had 13 non-interrupt busy ticks",
+                  "SMT sibling CPU 67 had 6 busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 13,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 188,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 4,
+                      "user": 9
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 6,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 194,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 6
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              }
+            ]
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 5.401034999999979,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 543
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.01,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.002082999999978732,
+              "measurement_cpu_residual_seconds": 0.007917000000021268,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.41,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 1,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 92,
+                    "user": 448
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 543,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 299662,
+              "runner_cpu_seconds": 0.0010479999999999379
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4446126",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=5.26 avg60=9.78 avg300=12.90 total=7674392378\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7674392378,
+              "load_1m_per_available_cpu": 3.3427734375,
+              "load_1m_per_cpu": 0.034820556640625,
+              "load_average": [
+                3.3427734375,
+                2.93896484375,
+                6.3173828125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "4/3583"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4449563",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=6.04 avg60=10.32 avg300=13.07 total=7674092716\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7674092716,
+              "load_1m_per_available_cpu": 2.41455078125,
+              "load_1m_per_cpu": 0.025151570638020832,
+              "load_average": [
+                2.41455078125,
+                2.751953125,
+                6.27587890625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "5/3603"
+            },
+            "involuntary_context_switches": 21104,
+            "peak_rss_kb": 3079428,
+            "precise_child_system_seconds": 0.9221860000000106,
+            "precise_child_user_seconds": 4.478848999999968,
+            "system_seconds": 0.92,
+            "user_seconds": 4.47,
+            "voluntary_context_switches": 35938,
+            "wall_nanos": 5426402671
+          },
+          "round": 4,
+          "signed_wall_delta_nanos": 2294433739,
+          "slot_index": 8
+        },
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.03,
+              "child_cpu_seconds": 7.792306999999909,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 783
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.04,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.0033489999999085293,
+              "measurement_cpu_residual_seconds": 0.03665100000009147,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.83,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 3,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 99,
+                    "user": 680
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.03,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 779,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 1,
+                    "user": 2
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1218416,
+              "runner_cpu_seconds": 0.0010419999999999874
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451062",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=13.32 avg60=9.10 avg300=9.81 total=7688188687\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7688188687,
+              "load_1m_per_available_cpu": 4.46630859375,
+              "load_1m_per_cpu": 0.0465240478515625,
+              "load_average": [
+                4.46630859375,
+                4.3017578125,
+                6.20263671875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "4/3587"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451518",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=13.93 avg60=8.31 avg300=9.66 total=7686970271\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7686970271,
+              "load_1m_per_available_cpu": 4.91455078125,
+              "load_1m_per_cpu": 0.0511932373046875,
+              "load_average": [
+                4.91455078125,
+                4.38037109375,
+                6.24853515625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3529"
+            },
+            "involuntary_context_switches": 22557,
+            "peak_rss_kb": 3395500,
+            "precise_child_system_seconds": 0.989453999999995,
+            "precise_child_user_seconds": 6.802852999999914,
+            "system_seconds": 0.98,
+            "user_seconds": 6.8,
+            "voluntary_context_switches": 37432,
+            "wall_nanos": 7829473694
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4318487",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 7,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=6.29 avg60=6.85 avg300=9.41 total=7685583748\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7685583748,
+            "load_1m_per_available_cpu": 4.81982421875,
+            "load_1m_per_cpu": 0.050206502278645836,
+            "load_average": [
+              4.81982421875,
+              4.3525390625,
+              6.25
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "8/3531"
+          },
+          "measurement_attempt": 1,
+          "pair": "natural-6",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.0006860999856144,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.012072000000008529,
+              "child_cpu_seconds": 5.426898999999992,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 546
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.012072000000008529,
+              "measurement_cpu_interrupt_seconds": 0.01,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.012072000000008529,
+              "measurement_cpu_residual_seconds": 0.02207200000000853,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.45,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1,
+                    "iowait": 0,
+                    "irq": 1,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 93,
+                    "user": 451
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 545,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1385195,
+              "runner_cpu_seconds": 0.0010289999999999466
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452270",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=13.93 avg60=8.31 avg300=9.66 total=7686968987\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7686968987,
+              "load_1m_per_available_cpu": 4.91455078125,
+              "load_1m_per_cpu": 0.0511932373046875,
+              "load_average": [
+                4.91455078125,
+                4.38037109375,
+                6.24853515625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3529"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4452267",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 7,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=6.29 avg60=6.85 avg300=9.41 total=7685583792\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7685583792,
+              "load_1m_per_available_cpu": 4.81982421875,
+              "load_1m_per_cpu": 0.050206502278645836,
+              "load_average": [
+                4.81982421875,
+                4.3525390625,
+                6.25
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3531"
+            },
+            "involuntary_context_switches": 21121,
+            "peak_rss_kb": 3081712,
+            "precise_child_system_seconds": 0.9284279999999967,
+            "precise_child_user_seconds": 4.498470999999995,
+            "system_seconds": 0.92,
+            "user_seconds": 4.49,
+            "voluntary_context_switches": 35989,
+            "wall_nanos": 5454486095
+          },
+          "round": 5,
+          "signed_wall_delta_nanos": 2374987599,
+          "slot_index": 7
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.006551999999980823,
+              "child_cpu_seconds": 7.672419000000019,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 770
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.006551999999980823,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.006551999999980823,
+              "measurement_cpu_residual_seconds": 0.03655199999998082,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.71,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 93,
+                    "user": 675
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 770,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 366294,
+              "runner_cpu_seconds": 0.0010289999999999466
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451134",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=3.36 avg60=4.18 avg300=7.41 total=7714153141\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7714153141,
+              "load_1m_per_available_cpu": 6.9462890625,
+              "load_1m_per_cpu": 0.072357177734375,
+              "load_average": [
+                6.9462890625,
+                5.71142578125,
+                6.17822265625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "4/3511"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4448185",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=2.92 avg60=4.21 avg300=7.51 total=7713786847\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7713786847,
+              "load_1m_per_available_cpu": 6.94384765625,
+              "load_1m_per_cpu": 0.07233174641927083,
+              "load_average": [
+                6.94384765625,
+                5.66748046875,
+                6.1689453125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "6/3513"
+            },
+            "involuntary_context_switches": 22328,
+            "peak_rss_kb": 3382216,
+            "precise_child_system_seconds": 0.9291280000000199,
+            "precise_child_user_seconds": 6.743290999999999,
+            "system_seconds": 0.92,
+            "user_seconds": 6.74,
+            "voluntary_context_switches": 37199,
+            "wall_nanos": 7700949318
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4451860",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 8,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=2.92 avg60=4.21 avg300=7.51 total=7713786801\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7713786801,
+            "load_1m_per_available_cpu": 6.94384765625,
+            "load_1m_per_cpu": 0.07233174641927083,
+            "load_average": [
+              6.94384765625,
+              5.66748046875,
+              6.1689453125
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "6/3513"
+          },
+          "measurement_attempt": 2,
+          "pair": "natural-6",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.0008016081992537,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.005921999999833236,
+              "child_cpu_seconds": 5.383039000000167,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 540
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.005921999999833236,
+              "measurement_cpu_interrupt_seconds": 0.01,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.005921999999833236,
+              "measurement_cpu_residual_seconds": 0.015921999999833236,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.4,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 1,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 93,
+                    "user": 446
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 541,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 716938,
+              "runner_cpu_seconds": 0.0010390000000000121
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4453144",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=7.16 avg60=4.86 avg300=7.49 total=7714870157\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7714870157,
+              "load_1m_per_available_cpu": 6.6298828125,
+              "load_1m_per_cpu": 0.069061279296875,
+              "load_average": [
+                6.6298828125,
+                5.666015625,
+                6.1611328125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3510"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4448883",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=3.36 avg60=4.18 avg300=7.41 total=7714153219\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7714153219,
+              "load_1m_per_available_cpu": 6.9462890625,
+              "load_1m_per_cpu": 0.072357177734375,
+              "load_average": [
+                6.9462890625,
+                5.71142578125,
+                6.17822265625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "4/3511"
+            },
+            "involuntary_context_switches": 21830,
+            "peak_rss_kb": 3082276,
+            "precise_child_system_seconds": 0.9242980000000216,
+            "precise_child_user_seconds": 4.4587410000001455,
+            "system_seconds": 0.92,
+            "user_seconds": 4.45,
+            "voluntary_context_switches": 36494,
+            "wall_nanos": 5407957685
+          },
+          "round": 6,
+          "signed_wall_delta_nanos": 2292991633,
+          "slot_index": 6
+        }
+      ],
+      "signed_wall_delta_nanos": [
+        2313348713,
+        2285072531,
+        2325441772,
+        2294433739,
+        2374987599,
+        2292991633
+      ],
+      "width_bits": null
+    },
+    "natural-8": {
+      "build_magnitude_wall_nanos": 10029913046,
+      "candidate": {
+        "artifacts": {
+          "ilean_bytes": 2095,
+          "olean_bytes": 11552,
+          "olean_private_bytes": 529280,
+          "olean_server_bytes": 1200,
+          "source_bytes": 757
+        },
+        "expected_axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "module": "HexRealRootsMathlib.ProofProbe.Natural8"
+      },
+      "comparable_control": "natural-10-null",
+      "comparable_null_envelope_nanos": 262385607,
+      "comparable_null_raw_envelope_nanos": 262385607,
+      "comparable_null_raw_spread_nanos": 254141199,
+      "comparable_null_spread_nanos": 254141199,
+      "control_magnitude_ratio": 1.4026334796202977,
+      "control_scale_factor": 1.0,
+      "degree": 8,
+      "family": "natural-width",
+      "median_candidate_peak_rss_kb": 3582048,
+      "median_candidate_wall_nanos": 10029913046,
+      "median_reference_peak_rss_kb": 3081408,
+      "median_reference_wall_nanos": 5413339703,
+      "median_signed_wall_delta_nanos": 4619915173,
+      "null_control": false,
+      "reference": {
+        "artifacts": {
+          "ilean_bytes": 168,
+          "olean_bytes": 1584,
+          "olean_private_bytes": 96,
+          "olean_server_bytes": 912,
+          "source_bytes": 422
+        },
+        "expected_axioms": null,
+        "module": "HexRealRootsMathlib.ProofProbe.Baseline"
+      },
+      "resolution": "resolved",
+      "samples": [
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.03,
+              "child_cpu_seconds": 10.042554000000003,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 1009
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.05,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.0036130000000027668,
+              "measurement_cpu_residual_seconds": 0.046386999999997236,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 10.09,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 4,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 97,
+                    "user": 907
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.03,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1007,
+                    "iowait": 0,
+                    "irq": 1,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 1,
+                    "user": 1
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1391008,
+              "runner_cpu_seconds": 0.0010589999999999766
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4435655",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=12.43 avg60=9.45 avg300=6.83 total=7551538572\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7551538572,
+              "load_1m_per_available_cpu": 4.6240234375,
+              "load_1m_per_cpu": 0.048166910807291664,
+              "load_average": [
+                4.6240234375,
+                8.18310546875,
+                11.81689453125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3559"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451354",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=15.73 avg60=8.89 avg300=6.61 total=7550147564\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7550147564,
+              "load_1m_per_available_cpu": 5.02197265625,
+              "load_1m_per_cpu": 0.052312215169270836,
+              "load_average": [
+                5.02197265625,
+                8.37744140625,
+                11.91845703125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3560"
+            },
+            "involuntary_context_switches": 22031,
+            "peak_rss_kb": 3573164,
+            "precise_child_system_seconds": 0.9705149999999989,
+            "precise_child_user_seconds": 9.072039000000004,
+            "system_seconds": 0.96,
+            "user_seconds": 9.07,
+            "voluntary_context_switches": 37024,
+            "wall_nanos": 10090289348
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "2132226",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=9.78 avg60=7.52 avg300=6.30 total=7548816258\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7548816258,
+            "load_1m_per_available_cpu": 5.28515625,
+            "load_1m_per_cpu": 0.0550537109375,
+            "load_average": [
+              5.28515625,
+              8.4853515625,
+              11.97216796875
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "3/3558"
+          },
+          "measurement_attempt": 1,
+          "pair": "natural-8",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 1,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.0010931128636003,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0064039999999992055,
+              "child_cpu_seconds": 5.382587000000001,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 541
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0064039999999992055,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.0064039999999992055,
+              "measurement_cpu_residual_seconds": 0.026403999999999206,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.41,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 88,
+                    "user": 451
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 541,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1330847,
+              "runner_cpu_seconds": 0.0010090000000000376
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4453179",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=15.73 avg60=8.89 avg300=6.61 total=7550147257\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7550147257,
+              "load_1m_per_available_cpu": 5.02197265625,
+              "load_1m_per_cpu": 0.052312215169270836,
+              "load_average": [
+                5.02197265625,
+                8.37744140625,
+                11.91845703125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3560"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4458612",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=9.78 avg60=7.52 avg300=6.30 total=7548816410\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7548816410,
+              "load_1m_per_available_cpu": 5.28515625,
+              "load_1m_per_cpu": 0.0550537109375,
+              "load_average": [
+                5.28515625,
+                8.4853515625,
+                11.97216796875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3558"
+            },
+            "involuntary_context_switches": 20987,
+            "peak_rss_kb": 3081500,
+            "precise_child_system_seconds": 0.8754279999999994,
+            "precise_child_user_seconds": 4.5071590000000015,
+            "system_seconds": 0.87,
+            "user_seconds": 4.5,
+            "voluntary_context_switches": 35832,
+            "wall_nanos": 5408429304
+          },
+          "round": 1,
+          "signed_wall_delta_nanos": 4681860044,
+          "slot_index": 3
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0050179999999844585,
+              "child_cpu_seconds": 9.943916000000016,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 1000
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0050179999999844585,
+              "measurement_cpu_interrupt_seconds": 0.04,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.0050179999999844585,
+              "measurement_cpu_residual_seconds": 0.04501799999998446,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 9.99,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 3,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 92,
+                    "user": 903
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1000,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1441689,
+              "runner_cpu_seconds": 0.0010660000000000114
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451793",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=10.23 avg60=11.25 avg300=10.08 total=7588814498\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7588814498,
+              "load_1m_per_available_cpu": 3.00927734375,
+              "load_1m_per_cpu": 0.031346638997395836,
+              "load_average": [
+                3.00927734375,
+                5.4775390625,
+                9.6396484375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3499"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451841",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=9.50 avg60=11.00 avg300=9.98 total=7587372809\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7587372809,
+              "load_1m_per_available_cpu": 3.1064453125,
+              "load_1m_per_cpu": 0.032358805338541664,
+              "load_average": [
+                3.1064453125,
+                5.57958984375,
+                9.71728515625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3503"
+            },
+            "involuntary_context_switches": 22380,
+            "peak_rss_kb": 3611456,
+            "precise_child_system_seconds": 0.9271940000000001,
+            "precise_child_user_seconds": 9.016722000000016,
+            "system_seconds": 0.92,
+            "user_seconds": 9.01,
+            "voluntary_context_switches": 37331,
+            "wall_nanos": 9994418987
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4320522",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=9.50 avg60=11.00 avg300=9.98 total=7587372458\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7587372458,
+            "load_1m_per_available_cpu": 3.1064453125,
+            "load_1m_per_cpu": 0.032358805338541664,
+            "load_average": [
+              3.1064453125,
+              5.57958984375,
+              9.71728515625
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "2/3503"
+          },
+          "measurement_attempt": 1,
+          "pair": "natural-8",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 1,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 199,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 1,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.000791837926954,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0026170000000274203,
+              "child_cpu_seconds": 5.386343999999973,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 542
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0026170000000274203,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.0026170000000274203,
+              "measurement_cpu_residual_seconds": 0.02261700000002742,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.41,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 95,
+                    "user": 444
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 541,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1379699,
+              "runner_cpu_seconds": 0.0010390000000000121
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451858",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=16.09 avg60=12.37 avg300=10.34 total=7590194322\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7590194322,
+              "load_1m_per_available_cpu": 3.1689453125,
+              "load_1m_per_cpu": 0.033009847005208336,
+              "load_average": [
+                3.1689453125,
+                5.46923828125,
+                9.6142578125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3520"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451806",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=10.23 avg60=11.25 avg300=10.08 total=7588814623\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7588814623,
+              "load_1m_per_available_cpu": 3.00927734375,
+              "load_1m_per_cpu": 0.031346638997395836,
+              "load_average": [
+                3.00927734375,
+                5.4775390625,
+                9.6396484375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3499"
+            },
+            "involuntary_context_switches": 20766,
+            "peak_rss_kb": 3079536,
+            "precise_child_system_seconds": 0.9499369999999985,
+            "precise_child_user_seconds": 4.436406999999974,
+            "system_seconds": 0.94,
+            "user_seconds": 4.43,
+            "voluntary_context_switches": 35739,
+            "wall_nanos": 5415701786
+          },
+          "round": 2,
+          "signed_wall_delta_nanos": 4578717201,
+          "slot_index": 2
+        },
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.016280000000050296,
+              "child_cpu_seconds": 9.95266099999995,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 1000
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.016280000000050296,
+              "measurement_cpu_interrupt_seconds": 0.05,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.016280000000050296,
+              "measurement_cpu_residual_seconds": 0.0662800000000503,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 10.02,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 4,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 98,
+                    "user": 899
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1000,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1370088,
+              "runner_cpu_seconds": 0.0010589999999999211
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4450179",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=12.35 avg60=16.00 avg300=12.72 total=7616604312\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7616604312,
+              "load_1m_per_available_cpu": 2.48388671875,
+              "load_1m_per_cpu": 0.025873819986979168,
+              "load_average": [
+                2.48388671875,
+                4.17138671875,
+                8.435546875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3493"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4450113",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=16.59 avg60=16.61 avg300=12.71 total=7615234224\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7615234224,
+              "load_1m_per_available_cpu": 2.0908203125,
+              "load_1m_per_cpu": 0.021779378255208332,
+              "load_average": [
+                2.0908203125,
+                4.1591796875,
+                8.478515625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3495"
+            },
+            "involuntary_context_switches": 22382,
+            "peak_rss_kb": 3590932,
+            "precise_child_system_seconds": 0.9786220000000014,
+            "precise_child_user_seconds": 8.974038999999948,
+            "system_seconds": 0.97,
+            "user_seconds": 8.97,
+            "voluntary_context_switches": 37284,
+            "wall_nanos": 10003936595
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "1771252",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=15.33 avg60=16.43 avg300=12.60 total=7614061901\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7614061901,
+            "load_1m_per_available_cpu": 2.18603515625,
+            "load_1m_per_cpu": 0.022771199544270832,
+            "load_average": [
+              2.18603515625,
+              4.212890625,
+              8.51904296875
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "2/3492"
+          },
+          "measurement_attempt": 1,
+          "pair": "natural-8",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 1,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 201,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.0011710980907083,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 5.360139000000004,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 539
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.001157000000003721,
+              "measurement_cpu_residual_seconds": 0.01884299999999628,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.38,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 1,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 90,
+                    "user": 446
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 539,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1170573,
+              "runner_cpu_seconds": 0.0010179999999998524
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4450518",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=16.59 avg60=16.61 avg300=12.71 total=7615234026\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7615234026,
+              "load_1m_per_available_cpu": 2.0908203125,
+              "load_1m_per_cpu": 0.021779378255208332,
+              "load_average": [
+                2.0908203125,
+                4.1591796875,
+                8.478515625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3495"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4057435",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=15.33 avg60=16.43 avg300=12.60 total=7614063453\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7614063453,
+              "load_1m_per_available_cpu": 2.18603515625,
+              "load_1m_per_cpu": 0.022771199544270832,
+              "load_average": [
+                2.18603515625,
+                4.212890625,
+                8.51904296875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3492"
+            },
+            "involuntary_context_switches": 21755,
+            "peak_rss_kb": 3081644,
+            "precise_child_system_seconds": 0.9035269999999969,
+            "precise_child_user_seconds": 4.456612000000007,
+            "system_seconds": 0.9,
+            "user_seconds": 4.45,
+            "voluntary_context_switches": 36512,
+            "wall_nanos": 5388675369
+          },
+          "round": 3,
+          "signed_wall_delta_nanos": 4615261226,
+          "slot_index": 1
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.032674999999944956,
+              "child_cpu_seconds": 10.036294000000055,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 1008
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0026749999999449575,
+              "measurement_cpu_interrupt_seconds": 0.05,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.0026749999999449575,
+              "measurement_cpu_residual_seconds": 0.05267499999994496,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 10.09,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 4,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 98,
+                    "user": 906
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.03,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1006,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 1,
+                    "user": 2
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1437590,
+              "runner_cpu_seconds": 0.0010310000000000041
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452337",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=8.11 avg60=12.32 avg300=13.49 total=7649104690\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7649104690,
+              "load_1m_per_available_cpu": 1.96484375,
+              "load_1m_per_cpu": 0.020467122395833332,
+              "load_average": [
+                1.96484375,
+                3.11376953125,
+                7.1298828125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3524"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451931",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=4.12 avg60=12.19 avg300=13.49 total=7647667100\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7647667100,
+              "load_1m_per_available_cpu": 2.14111328125,
+              "load_1m_per_cpu": 0.022303263346354168,
+              "load_average": [
+                2.14111328125,
+                3.1865234375,
+                7.19677734375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3525"
+            },
+            "involuntary_context_switches": 22054,
+            "peak_rss_kb": 3596304,
+            "precise_child_system_seconds": 0.9826439999999934,
+            "precise_child_user_seconds": 9.053650000000061,
+            "system_seconds": 0.98,
+            "user_seconds": 9.05,
+            "voluntary_context_switches": 36960,
+            "wall_nanos": 10087155971
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4174002",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=4.12 avg60=12.19 avg300=13.49 total=7647666985\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7647666985,
+            "load_1m_per_available_cpu": 2.14111328125,
+            "load_1m_per_cpu": 0.022303263346354168,
+            "load_average": [
+              2.14111328125,
+              3.1865234375,
+              7.19677734375
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "1/3525"
+          },
+          "measurement_attempt": 1,
+          "pair": "natural-8",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.000711956061423,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.01606199999996006,
+              "child_cpu_seconds": 5.38288100000004,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 541
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.006061999999960061,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.006061999999960061,
+              "measurement_cpu_residual_seconds": 0.02606199999996006,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.41,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 87,
+                    "user": 452
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.01,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 541,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1315026,
+              "runner_cpu_seconds": 0.0010569999999998636
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4453825",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=13.85 avg60=13.20 avg300=13.66 total=7650419934\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7650419934,
+              "load_1m_per_available_cpu": 1.9677734375,
+              "load_1m_per_cpu": 0.020497639973958332,
+              "load_average": [
+                1.9677734375,
+                3.09521484375,
+                7.10205078125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3543"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4450755",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=8.11 avg60=12.32 avg300=13.49 total=7649104908\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7649104908,
+              "load_1m_per_available_cpu": 1.96484375,
+              "load_1m_per_cpu": 0.020467122395833332,
+              "load_average": [
+                1.96484375,
+                3.11376953125,
+                7.1298828125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3524"
+            },
+            "involuntary_context_switches": 20982,
+            "peak_rss_kb": 3079596,
+            "precise_child_system_seconds": 0.863578000000004,
+            "precise_child_user_seconds": 4.519303000000036,
+            "system_seconds": 0.86,
+            "user_seconds": 4.51,
+            "voluntary_context_switches": 35914,
+            "wall_nanos": 5410977621
+          },
+          "round": 4,
+          "signed_wall_delta_nanos": 4676178350,
+          "slot_index": 0
+        },
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.003979999999982588,
+              "child_cpu_seconds": 9.924941000000018,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 996
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.003979999999982588,
+              "measurement_cpu_interrupt_seconds": 0.04,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.003979999999982588,
+              "measurement_cpu_residual_seconds": 0.04397999999998259,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 9.97,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1,
+                    "iowait": 0,
+                    "irq": 3,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 96,
+                    "user": 897
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 997,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 550537,
+              "runner_cpu_seconds": 0.00107899999999983
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451665",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 10,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=5.89 avg60=8.07 avg300=9.53 total=7689163362\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7689163362,
+              "load_1m_per_available_cpu": 4.62158203125,
+              "load_1m_per_cpu": 0.0481414794921875,
+              "load_average": [
+                4.62158203125,
+                4.3505859375,
+                6.18798828125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "5/3569"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4449340",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=8.97 avg60=8.63 avg300=9.68 total=7688612825\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7688612825,
+              "load_1m_per_available_cpu": 4.74951171875,
+              "load_1m_per_cpu": 0.049474080403645836,
+              "load_average": [
+                4.74951171875,
+                4.36328125,
+                6.21240234375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3560"
+            },
+            "involuntary_context_switches": 22481,
+            "peak_rss_kb": 3551780,
+            "precise_child_system_seconds": 0.952194999999989,
+            "precise_child_user_seconds": 8.97274600000003,
+            "system_seconds": 0.95,
+            "user_seconds": 8.97,
+            "voluntary_context_switches": 37404,
+            "wall_nanos": 9967137423
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "1500000",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 9,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=11.27 avg60=8.87 avg300=9.75 total=7688189376\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7688189376,
+            "load_1m_per_available_cpu": 4.46630859375,
+            "load_1m_per_cpu": 0.0465240478515625,
+            "load_average": [
+              4.46630859375,
+              4.3017578125,
+              6.20263671875
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "2/3581"
+          },
+          "measurement_attempt": 1,
+          "pair": "natural-8",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 199,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.000904429005459,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 5.392299999999921,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 542
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.0033309999999204636,
+              "measurement_cpu_residual_seconds": 0.016669000000079537,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.41,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 91,
+                    "user": 448
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 542,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 423197,
+              "runner_cpu_seconds": 0.0010310000000000041
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451764",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=8.97 avg60=8.63 avg300=9.68 total=7688612685\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7688612685,
+              "load_1m_per_available_cpu": 4.74951171875,
+              "load_1m_per_cpu": 0.049474080403645836,
+              "load_average": [
+                4.74951171875,
+                4.36328125,
+                6.21240234375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3560"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4453693",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=11.27 avg60=8.87 avg300=9.75 total=7688189488\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7688189488,
+              "load_1m_per_available_cpu": 4.46630859375,
+              "load_1m_per_cpu": 0.0465240478515625,
+              "load_average": [
+                4.46630859375,
+                4.3017578125,
+                6.20263671875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "4/3581"
+            },
+            "involuntary_context_switches": 20977,
+            "peak_rss_kb": 3081672,
+            "precise_child_system_seconds": 0.9156380000000013,
+            "precise_child_user_seconds": 4.476661999999919,
+            "system_seconds": 0.91,
+            "user_seconds": 4.47,
+            "voluntary_context_switches": 35913,
+            "wall_nanos": 5420620375
+          },
+          "round": 5,
+          "signed_wall_delta_nanos": 4546517048,
+          "slot_index": 8
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.01816600000007699,
+              "child_cpu_seconds": 10.010780999999923,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 1006
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.008166000000076987,
+              "measurement_cpu_interrupt_seconds": 0.05,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.008166000000076987,
+              "measurement_cpu_residual_seconds": 0.05816600000007699,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 10.07,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 4,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 96,
+                    "user": 906
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.01,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1005,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                }
+              },
+              "pressure_some_delta_us": 479943,
+              "runner_cpu_seconds": 0.0010529999999999706
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452736",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 7,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=4.03 avg60=4.57 avg300=7.32 total=7715351733\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7715351733,
+              "load_1m_per_available_cpu": 5.9912109375,
+              "load_1m_per_cpu": 0.062408447265625,
+              "load_average": [
+                5.9912109375,
+                5.56103515625,
+                6.12158203125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3495"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4457412",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=6.04 avg60=4.74 avg300=7.45 total=7714871790\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7714871790,
+              "load_1m_per_available_cpu": 6.6298828125,
+              "load_1m_per_cpu": 0.069061279296875,
+              "load_average": [
+                6.6298828125,
+                5.666015625,
+                6.1611328125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3519"
+            },
+            "involuntary_context_switches": 22083,
+            "peak_rss_kb": 3567208,
+            "precise_child_system_seconds": 0.9620290000000011,
+            "precise_child_user_seconds": 9.048751999999922,
+            "system_seconds": 0.96,
+            "user_seconds": 9.04,
+            "voluntary_context_switches": 36928,
+            "wall_nanos": 10055889497
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4455123",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 8,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=6.04 avg60=4.74 avg300=7.45 total=7714871598\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7714871598,
+            "load_1m_per_available_cpu": 6.6298828125,
+            "load_1m_per_cpu": 0.069061279296875,
+            "load_average": [
+              6.6298828125,
+              5.666015625,
+              6.1611328125
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "3/3519"
+          },
+          "measurement_attempt": 1,
+          "pair": "natural-8",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.000880202045664,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0037770000000154798,
+              "child_cpu_seconds": 5.405197999999984,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 543
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0037770000000154798,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.0037770000000154798,
+              "measurement_cpu_residual_seconds": 0.02377700000001548,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.43,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 92,
+                    "user": 449
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 543,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 857433,
+              "runner_cpu_seconds": 0.0010249999999998316
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452380",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 10,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=8.21 avg60=5.43 avg300=7.45 total=7716209437\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7716209437,
+              "load_1m_per_available_cpu": 5.91162109375,
+              "load_1m_per_cpu": 0.061579386393229164,
+              "load_average": [
+                5.91162109375,
+                5.55126953125,
+                6.115234375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "5/3514"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451594",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=4.03 avg60=4.57 avg300=7.32 total=7715352004\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7715352004,
+              "load_1m_per_available_cpu": 5.9912109375,
+              "load_1m_per_cpu": 0.062408447265625,
+              "load_average": [
+                5.9912109375,
+                5.56103515625,
+                6.12158203125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3492"
+            },
+            "involuntary_context_switches": 21678,
+            "peak_rss_kb": 3081316,
+            "precise_child_system_seconds": 0.9187450000000013,
+            "precise_child_user_seconds": 4.486452999999983,
+            "system_seconds": 0.91,
+            "user_seconds": 4.48,
+            "voluntary_context_switches": 36562,
+            "wall_nanos": 5431320377
+          },
+          "round": 6,
+          "signed_wall_delta_nanos": 4624569120,
+          "slot_index": 7
+        }
+      ],
+      "signed_wall_delta_nanos": [
+        4681860044,
+        4578717201,
+        4615261226,
+        4676178350,
+        4546517048,
+        4624569120
+      ],
+      "width_bits": null
+    },
+    "refine-6": {
+      "build_magnitude_wall_nanos": 7922791943,
+      "candidate": {
+        "artifacts": {
+          "ilean_bytes": 1928,
+          "olean_bytes": 10576,
+          "olean_private_bytes": 442928,
+          "olean_server_bytes": 1184,
+          "source_bytes": 732
+        },
+        "expected_axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "module": "HexRealRootsMathlib.ProofProbe.Refined6"
+      },
+      "comparable_control": "fresh-build-null",
+      "comparable_null_envelope_nanos": 85703476,
+      "comparable_null_raw_envelope_nanos": 58751220,
+      "comparable_null_raw_spread_nanos": 88945003,
+      "comparable_null_spread_nanos": 129748725,
+      "control_magnitude_ratio": 1.4587522665905612,
+      "control_scale_factor": 1.4587522665905612,
+      "degree": 6,
+      "family": "refinement-attribution",
+      "median_candidate_peak_rss_kb": 3373058,
+      "median_candidate_wall_nanos": 7922791943,
+      "median_reference_peak_rss_kb": 3387814,
+      "median_reference_wall_nanos": 7725914622,
+      "median_signed_wall_delta_nanos": 193347398,
+      "null_control": false,
+      "reference": {
+        "artifacts": {
+          "ilean_bytes": 1872,
+          "olean_bytes": 10576,
+          "olean_private_bytes": 393360,
+          "olean_server_bytes": 1200,
+          "source_bytes": 717
+        },
+        "expected_axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "module": "HexRealRootsMathlib.ProofProbe.Natural6"
+      },
+      "resolution": "resolved",
+      "samples": [
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 7.871727999999997,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 791
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.04,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.002776999999997219,
+              "measurement_cpu_residual_seconds": 0.03722300000000278,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.91,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1,
+                    "iowait": 0,
+                    "irq": 3,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 91,
+                    "user": 696
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 791,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1297168,
+              "runner_cpu_seconds": 0.0010489999999999666
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4453798",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=11.39 avg60=13.60 avg300=10.16 total=7582708698\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7582708698,
+              "load_1m_per_available_cpu": 3.84130859375,
+              "load_1m_per_cpu": 0.040013631184895836,
+              "load_average": [
+                3.84130859375,
+                6.14111328125,
+                10.11865234375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3520"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451841",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=9.57 avg60=13.30 avg300=10.00 total=7581411530\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7581411530,
+              "load_1m_per_available_cpu": 3.99462890625,
+              "load_1m_per_cpu": 0.0416107177734375,
+              "load_average": [
+                3.99462890625,
+                6.24853515625,
+                10.1962890625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3502"
+            },
+            "involuntary_context_switches": 22453,
+            "peak_rss_kb": 3364004,
+            "precise_child_system_seconds": 0.9075680000000048,
+            "precise_child_user_seconds": 6.964159999999993,
+            "system_seconds": 0.9,
+            "user_seconds": 6.96,
+            "voluntary_context_switches": 37541,
+            "wall_nanos": 7912982704
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4191785",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 8,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=11.65 avg60=13.88 avg300=10.01 total=7580563883\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7580563883,
+            "load_1m_per_available_cpu": 3.994140625,
+            "load_1m_per_cpu": 0.041605631510416664,
+            "load_average": [
+              3.994140625,
+              6.28662109375,
+              10.22998046875
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "5/3524"
+          },
+          "measurement_attempt": 2,
+          "pair": "refine-6",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.0008373470045626,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0022820000000066953,
+              "child_cpu_seconds": 7.6666879999999935,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 771
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0022820000000066953,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.0022820000000066953,
+              "measurement_cpu_residual_seconds": 0.032282000000006694,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.7,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 97,
+                    "user": 670
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 770,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 847258,
+              "runner_cpu_seconds": 0.0010299999999999754
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452543",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=9.57 avg60=13.30 avg300=10.00 total=7581411241\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7581411241,
+              "load_1m_per_available_cpu": 3.99462890625,
+              "load_1m_per_cpu": 0.0416107177734375,
+              "load_average": [
+                3.99462890625,
+                6.24853515625,
+                10.1962890625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3502"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4454257",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=11.65 avg60=13.88 avg300=10.01 total=7580563983\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7580563983,
+              "load_1m_per_available_cpu": 3.994140625,
+              "load_1m_per_cpu": 0.041605631510416664,
+              "load_average": [
+                3.994140625,
+                6.28662109375,
+                10.22998046875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "5/3524"
+            },
+            "involuntary_context_switches": 22797,
+            "peak_rss_kb": 3355548,
+            "precise_child_system_seconds": 0.9705510000000004,
+            "precise_child_user_seconds": 6.696136999999993,
+            "system_seconds": 0.97,
+            "user_seconds": 6.69,
+            "voluntary_context_switches": 37603,
+            "wall_nanos": 7706459520
+          },
+          "round": 1,
+          "signed_wall_delta_nanos": 206523184,
+          "slot_index": 8
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.01167900000003432,
+              "child_cpu_seconds": 7.897302999999965,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 794
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0016790000000343197,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.0016790000000343197,
+              "measurement_cpu_residual_seconds": 0.03167900000003432,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.93,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 92,
+                    "user": 698
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.01,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 794,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1460259,
+              "runner_cpu_seconds": 0.0010180000000000744
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4449334",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=15.55 avg60=15.09 avg300=11.82 total=7606946676\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7606946676,
+              "load_1m_per_available_cpu": 2.4970703125,
+              "load_1m_per_cpu": 0.026011149088541668,
+              "load_average": [
+                2.4970703125,
+                4.521484375,
+                8.80322265625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3483"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4455576",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=15.96 avg60=14.83 avg300=11.67 total=7605486417\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7605486417,
+              "load_1m_per_available_cpu": 2.4208984375,
+              "load_1m_per_cpu": 0.025217692057291668,
+              "load_average": [
+                2.4208984375,
+                4.57373046875,
+                8.86669921875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3483"
+            },
+            "involuntary_context_switches": 22218,
+            "peak_rss_kb": 3402936,
+            "precise_child_system_seconds": 0.9260629999999992,
+            "precise_child_user_seconds": 6.971239999999966,
+            "system_seconds": 0.92,
+            "user_seconds": 6.97,
+            "voluntary_context_switches": 37173,
+            "wall_nanos": 7935257549
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "1500000",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=15.96 avg60=14.83 avg300=11.67 total=7605486335\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7605486335,
+            "load_1m_per_available_cpu": 2.4208984375,
+            "load_1m_per_cpu": 0.025217692057291668,
+            "load_average": [
+              2.4208984375,
+              4.57373046875,
+              8.86669921875
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "6/3483"
+          },
+          "measurement_attempt": 1,
+          "pair": "refine-6",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.000716994982213,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.02228899999999102,
+              "child_cpu_seconds": 7.736654000000009,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 778
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0022889999999910204,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.0022889999999910204,
+              "measurement_cpu_residual_seconds": 0.03228899999999102,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.77,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 3,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 96,
+                    "user": 678
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.02,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 774,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 1,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1467353,
+              "runner_cpu_seconds": 0.0010569999999999746
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452703",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=15.63 avg60=15.41 avg300=11.98 total=7608414212\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7608414212,
+              "load_1m_per_available_cpu": 2.73486328125,
+              "load_1m_per_cpu": 0.0284881591796875,
+              "load_average": [
+                2.73486328125,
+                4.5048828125,
+                8.75146484375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3485"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4449725",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=15.55 avg60=15.09 avg300=11.82 total=7606946859\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7606946859,
+              "load_1m_per_available_cpu": 2.4970703125,
+              "load_1m_per_cpu": 0.026011149088541668,
+              "load_average": [
+                2.4970703125,
+                4.521484375,
+                8.80322265625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3483"
+            },
+            "involuntary_context_switches": 23123,
+            "peak_rss_kb": 3399868,
+            "precise_child_system_seconds": 0.9607899999999958,
+            "precise_child_user_seconds": 6.775864000000013,
+            "system_seconds": 0.96,
+            "user_seconds": 6.77,
+            "voluntary_context_switches": 37992,
+            "wall_nanos": 7775535234
+          },
+          "round": 2,
+          "signed_wall_delta_nanos": 159722315,
+          "slot_index": 7
+        },
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.020628000000003553,
+              "child_cpu_seconds": 7.8783109999999965,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 792
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.010628000000003551,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.010628000000003551,
+              "measurement_cpu_residual_seconds": 0.04062800000000355,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.92,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 93,
+                    "user": 696
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.01,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 791,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1488238,
+              "runner_cpu_seconds": 0.0010609999999998676
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4453005",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=14.76 avg60=15.39 avg300=14.00 total=7642587632\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7642587632,
+              "load_1m_per_available_cpu": 2.00439453125,
+              "load_1m_per_cpu": 0.020879109700520832,
+              "load_average": [
+                2.00439453125,
+                3.3427734375,
+                7.44580078125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3523"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4450014",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=11.31 avg60=14.75 avg300=13.83 total=7641099394\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7641099394,
+              "load_1m_per_available_cpu": 2.0927734375,
+              "load_1m_per_cpu": 0.021799723307291668,
+              "load_average": [
+                2.0927734375,
+                3.40576171875,
+                7.5107421875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3527"
+            },
+            "involuntary_context_switches": 22120,
+            "peak_rss_kb": 3364476,
+            "precise_child_system_seconds": 0.9195970000000102,
+            "precise_child_user_seconds": 6.958713999999986,
+            "system_seconds": 0.91,
+            "user_seconds": 6.95,
+            "voluntary_context_switches": 37062,
+            "wall_nanos": 7919626520
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4455581",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=6.25 avg60=14.23 avg300=13.69 total=7639533930\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7639533930,
+            "load_1m_per_available_cpu": 2.1171875,
+            "load_1m_per_cpu": 0.022054036458333332,
+            "load_average": [
+              2.1171875,
+              3.45458984375,
+              7.5712890625
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "1/3523"
+          },
+          "measurement_attempt": 3,
+          "pair": "refine-6",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 1,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 199,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                },
+                "67": {
+                  "busy_ticks": 1,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 199,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 8.004716680850834,
+            "rejected_windows": [
+              {
+                "issues": [
+                  "measurement CPU 19 had 3 non-interrupt busy ticks",
+                  "SMT sibling CPU 67 had 5 busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 3,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 198,
+                      "iowait": 0,
+                      "irq": 1,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 1,
+                      "user": 2
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 5,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 195,
+                      "iowait": 0,
+                      "irq": 1,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 1,
+                      "user": 3
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              },
+              {
+                "issues": [
+                  "measurement CPU 19 had 10 non-interrupt busy ticks",
+                  "SMT sibling CPU 67 had 4 busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 10,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 190,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 1,
+                      "user": 9
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 4,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 195,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 1,
+                      "user": 3
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              },
+              {
+                "issues": [
+                  "measurement CPU 19 had 4 non-interrupt busy ticks",
+                  "SMT sibling CPU 67 had 3 busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 4,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 196,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 4
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 3,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 196,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 3
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              }
+            ]
+          },
+          "reference": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 7.700000005687185e-05,
+              "child_cpu_seconds": 7.698880999999943,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 774
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 7.700000005687185e-05,
+              "measurement_cpu_interrupt_seconds": 0.04,
+              "measurement_cpu_noninterrupt_residual_seconds": 7.700000005687185e-05,
+              "measurement_cpu_residual_seconds": 0.04007700000005687,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.74,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 3,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 89,
+                    "user": 681
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 773,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1565030,
+              "runner_cpu_seconds": 0.0010420000000000984
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4450962",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=11.31 avg60=14.75 avg300=13.83 total=7641099107\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7641099107,
+              "load_1m_per_available_cpu": 2.0927734375,
+              "load_1m_per_cpu": 0.021799723307291668,
+              "load_average": [
+                2.0927734375,
+                3.40576171875,
+                7.5107421875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3527"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451487",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=6.25 avg60=14.23 avg300=13.69 total=7639534077\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7639534077,
+              "load_1m_per_available_cpu": 2.1171875,
+              "load_1m_per_cpu": 0.022054036458333332,
+              "load_average": [
+                2.1171875,
+                3.45458984375,
+                7.5712890625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3523"
+            },
+            "involuntary_context_switches": 21818,
+            "peak_rss_kb": 3411988,
+            "precise_child_system_seconds": 0.8910459999999887,
+            "precise_child_user_seconds": 6.807834999999955,
+            "system_seconds": 0.89,
+            "user_seconds": 6.8,
+            "voluntary_context_switches": 36724,
+            "wall_nanos": 7739454907
+          },
+          "round": 3,
+          "signed_wall_delta_nanos": 180171613,
+          "slot_index": 6
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.014776999999943205,
+              "child_cpu_seconds": 7.884214000000057,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 793
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.004776999999943205,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.004776999999943205,
+              "measurement_cpu_residual_seconds": 0.024776999999943206,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.91,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 93,
+                    "user": 696
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.01,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 792,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 1,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1465742,
+              "runner_cpu_seconds": 0.0010090000000000376
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451075",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=14.66 avg60=15.45 avg300=14.15 total=7666061968\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7666061968,
+              "load_1m_per_available_cpu": 2.1865234375,
+              "load_1m_per_cpu": 0.022776285807291668,
+              "load_average": [
+                2.1865234375,
+                2.90869140625,
+                6.62548828125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3521"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451224",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=15.51 avg60=15.27 avg300=14.07 total=7664596226\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7664596226,
+              "load_1m_per_available_cpu": 2.22802734375,
+              "load_1m_per_cpu": 0.0232086181640625,
+              "load_average": [
+                2.22802734375,
+                2.93994140625,
+                6.67626953125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3522"
+            },
+            "involuntary_context_switches": 22246,
+            "peak_rss_kb": 3357184,
+            "precise_child_system_seconds": 0.9238649999999922,
+            "precise_child_user_seconds": 6.960349000000065,
+            "system_seconds": 0.92,
+            "user_seconds": 6.95,
+            "voluntary_context_switches": 37283,
+            "wall_nanos": 7925957366
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "1500000",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=15.51 avg60=15.27 avg300=14.07 total=7664595157\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7664595157,
+            "load_1m_per_available_cpu": 2.22802734375,
+            "load_1m_per_cpu": 0.0232086181640625,
+            "load_average": [
+              2.22802734375,
+              2.93994140625,
+              6.67626953125
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "1/3522"
+          },
+          "measurement_attempt": 1,
+          "pair": "refine-6",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.00068785995245,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.007322999999919623,
+              "child_cpu_seconds": 7.67163500000008,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 772
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.007322999999919623,
+              "measurement_cpu_interrupt_seconds": 0.04,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.007322999999919623,
+              "measurement_cpu_residual_seconds": 0.047322999999919624,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.72,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 3,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 93,
+                    "user": 675
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 771,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1480148,
+              "runner_cpu_seconds": 0.0010419999999999874
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451935",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=14.18 avg60=15.60 avg300=14.23 total=7667542341\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7667542341,
+              "load_1m_per_available_cpu": 2.09130859375,
+              "load_1m_per_cpu": 0.021784464518229168,
+              "load_average": [
+                2.09130859375,
+                2.876953125,
+                6.59521484375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3524"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4449558",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=14.66 avg60=15.45 avg300=14.15 total=7666062193\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7666062193,
+              "load_1m_per_available_cpu": 2.1865234375,
+              "load_1m_per_cpu": 0.022776285807291668,
+              "load_average": [
+                2.1865234375,
+                2.90869140625,
+                6.62548828125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3521"
+            },
+            "involuntary_context_switches": 21664,
+            "peak_rss_kb": 3390496,
+            "precise_child_system_seconds": 0.9257610000000085,
+            "precise_child_user_seconds": 6.745874000000072,
+            "system_seconds": 0.92,
+            "user_seconds": 6.74,
+            "voluntary_context_switches": 36711,
+            "wall_nanos": 7712374337
+          },
+          "round": 4,
+          "signed_wall_delta_nanos": 213583029,
+          "slot_index": 5
+        },
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0020299999999238427,
+              "child_cpu_seconds": 7.9069120000000765,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 795
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0020299999999238427,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.0020299999999238427,
+              "measurement_cpu_residual_seconds": 0.03202999999992384,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.94,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 3,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 92,
+                    "user": 699
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 794,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 288807,
+              "runner_cpu_seconds": 0.0010580000000000034
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4455930",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 11,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=2.08 avg60=4.25 avg300=9.38 total=7681167466\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7681167466,
+              "load_1m_per_available_cpu": 8.396484375,
+              "load_1m_per_cpu": 0.08746337890625,
+              "load_average": [
+                8.396484375,
+                4.76318359375,
+                6.4697265625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "9/3617"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4446427",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 11,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=1.41 avg60=4.41 avg300=9.56 total=7680878659\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7680878659,
+              "load_1m_per_available_cpu": 8.08251953125,
+              "load_1m_per_cpu": 0.08419291178385417,
+              "load_average": [
+                8.08251953125,
+                4.640625,
+                6.439453125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "7/3612"
+            },
+            "involuntary_context_switches": 22244,
+            "peak_rss_kb": 3412860,
+            "precise_child_system_seconds": 0.9198180000000065,
+            "precise_child_user_seconds": 6.98709400000007,
+            "system_seconds": 0.91,
+            "user_seconds": 6.98,
+            "voluntary_context_switches": 37183,
+            "wall_nanos": 7941502349
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4451980",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 11,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=1.09 avg60=4.76 avg300=9.77 total=7680659707\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7680659707,
+            "load_1m_per_available_cpu": 7.7412109375,
+            "load_1m_per_cpu": 0.08063761393229167,
+            "load_average": [
+              7.7412109375,
+              4.4580078125,
+              6.400390625
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "11/3597"
+          },
+          "measurement_attempt": 2,
+          "pair": "refine-6",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 1,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 199,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 8.003290251130238,
+            "rejected_windows": [
+              {
+                "issues": [
+                  "measurement CPU 19 had 3 non-interrupt busy ticks",
+                  "SMT sibling CPU 67 had 4 busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 3,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 195,
+                      "iowait": 0,
+                      "irq": 1,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 1,
+                      "user": 2
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 4,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 196,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 4
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              },
+              {
+                "issues": [
+                  "measurement CPU 19 had 3 non-interrupt busy ticks",
+                  "SMT sibling CPU 67 had 5 busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 3,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 196,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 1,
+                      "user": 2
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 5,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 195,
+                      "iowait": 0,
+                      "irq": 1,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 4
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              },
+              {
+                "issues": [
+                  "measurement CPU 19 had 3 non-interrupt busy ticks",
+                  "SMT sibling CPU 67 had 3 busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 3,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 196,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 1,
+                      "steal": 0,
+                      "system": 1,
+                      "user": 2
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 3,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 196,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 3
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              }
+            ]
+          },
+          "reference": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.008197000000035554,
+              "child_cpu_seconds": 7.6807709999999645,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 771
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.008197000000035554,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.008197000000035554,
+              "measurement_cpu_residual_seconds": 0.028197000000035555,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.71,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 89,
+                    "user": 680
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 771,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 218906,
+              "runner_cpu_seconds": 0.0010319999999999219
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4453849",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 11,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=1.41 avg60=4.41 avg300=9.56 total=7680878629\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7680878629,
+              "load_1m_per_available_cpu": 8.00244140625,
+              "load_1m_per_cpu": 0.0833587646484375,
+              "load_average": [
+                8.00244140625,
+                4.56689453125,
+                6.42529296875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "7/3612"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4448100",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 11,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=1.09 avg60=4.76 avg300=9.77 total=7680659723\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7680659723,
+              "load_1m_per_available_cpu": 7.7412109375,
+              "load_1m_per_cpu": 0.08063761393229167,
+              "load_average": [
+                7.7412109375,
+                4.4580078125,
+                6.400390625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "13/3597"
+            },
+            "involuntary_context_switches": 21808,
+            "peak_rss_kb": 3385132,
+            "precise_child_system_seconds": 0.8829389999999933,
+            "precise_child_user_seconds": 6.797831999999971,
+            "system_seconds": 0.88,
+            "user_seconds": 6.79,
+            "voluntary_context_switches": 36800,
+            "wall_nanos": 7711063227
+          },
+          "round": 5,
+          "signed_wall_delta_nanos": 230439122,
+          "slot_index": 4
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 3.699999988907021e-05,
+              "child_cpu_seconds": 7.878941000000111,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 792
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 3.699999988907021e-05,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": 3.699999988907021e-05,
+              "measurement_cpu_residual_seconds": 0.03003699999988907,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.91,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 3,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 94,
+                    "user": 694
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 791,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 724988,
+              "runner_cpu_seconds": 0.0010219999999998564
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4449104",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 10,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=4.77 avg60=6.26 avg300=8.84 total=7708850052\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7708850052,
+              "load_1m_per_available_cpu": 8.0712890625,
+              "load_1m_per_cpu": 0.084075927734375,
+              "load_average": [
+                8.0712890625,
+                5.29296875,
+                6.119140625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "6/3540"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4449975",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=1.81 avg60=5.97 avg300=8.85 total=7708125064\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7708125064,
+              "load_1m_per_available_cpu": 8.1650390625,
+              "load_1m_per_cpu": 0.085052490234375,
+              "load_average": [
+                8.1650390625,
+                5.263671875,
+                6.1142578125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "4/3524"
+            },
+            "involuntary_context_switches": 22052,
+            "peak_rss_kb": 3381640,
+            "precise_child_system_seconds": 0.9440910000000144,
+            "precise_child_user_seconds": 6.934850000000097,
+            "system_seconds": 0.94,
+            "user_seconds": 6.93,
+            "voluntary_context_switches": 36963,
+            "wall_nanos": 7914290969
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "1500000",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 8,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=1.81 avg60=5.97 avg300=8.85 total=7708125010\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7708125010,
+            "load_1m_per_available_cpu": 8.1650390625,
+            "load_1m_per_cpu": 0.085052490234375,
+            "load_average": [
+              8.1650390625,
+              5.263671875,
+              6.1142578125
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "3/3524"
+          },
+          "measurement_attempt": 8,
+          "pair": "refine-6",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.000722460914403,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.002367000000047765,
+              "child_cpu_seconds": 7.716584999999952,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 776
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.002367000000047765,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.002367000000047765,
+              "measurement_cpu_residual_seconds": 0.022367000000047765,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.74,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 93,
+                    "user": 679
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 775,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 465752,
+              "runner_cpu_seconds": 0.00104800000000016
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4457203",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=4.63 avg60=6.12 avg300=8.74 total=7709315859\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7709315859,
+              "load_1m_per_available_cpu": 7.9931640625,
+              "load_1m_per_cpu": 0.08326212565104167,
+              "load_average": [
+                7.9931640625,
+                5.36669921875,
+                6.1337890625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "5/3537"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4445455",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 10,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=4.77 avg60=6.26 avg300=8.84 total=7708850107\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7708850107,
+              "load_1m_per_available_cpu": 8.0712890625,
+              "load_1m_per_cpu": 0.084075927734375,
+              "load_average": [
+                8.0712890625,
+                5.29296875,
+                6.119140625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "15/3548"
+            },
+            "involuntary_context_switches": 21894,
+            "peak_rss_kb": 3373700,
+            "precise_child_system_seconds": 0.931808999999987,
+            "precise_child_user_seconds": 6.784775999999965,
+            "system_seconds": 0.93,
+            "user_seconds": 6.78,
+            "voluntary_context_switches": 36864,
+            "wall_nanos": 7752394631
+          },
+          "round": 6,
+          "signed_wall_delta_nanos": 161896338,
+          "slot_index": 3
+        }
+      ],
+      "signed_wall_delta_nanos": [
+        206523184,
+        159722315,
+        180171613,
+        213583029,
+        230439122,
+        161896338
+      ],
+      "width_bits": 20
+    },
+    "refined-2": {
+      "build_magnitude_wall_nanos": 5868958606,
+      "candidate": {
+        "artifacts": {
+          "ilean_bytes": 1486,
+          "olean_bytes": 8624,
+          "olean_private_bytes": 203792,
+          "olean_server_bytes": 1184,
+          "source_bytes": 628
+        },
+        "expected_axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "module": "HexRealRootsMathlib.ProofProbe.Refined2"
+      },
+      "comparable_control": "fresh-build-null",
+      "comparable_null_envelope_nanos": 63486478,
+      "comparable_null_raw_envelope_nanos": 58751220,
+      "comparable_null_raw_spread_nanos": 88945003,
+      "comparable_null_spread_nanos": 96113833,
+      "control_magnitude_ratio": 1.0805984469392598,
+      "control_scale_factor": 1.0805984469392598,
+      "degree": 2,
+      "family": "width-2^-20",
+      "median_candidate_peak_rss_kb": 3167262,
+      "median_candidate_wall_nanos": 5868958606,
+      "median_reference_peak_rss_kb": 3081670,
+      "median_reference_wall_nanos": 5395055554,
+      "median_signed_wall_delta_nanos": 471833392,
+      "null_control": false,
+      "reference": {
+        "artifacts": {
+          "ilean_bytes": 168,
+          "olean_bytes": 1584,
+          "olean_private_bytes": 96,
+          "olean_server_bytes": 912,
+          "source_bytes": 422
+        },
+        "expected_axioms": null,
+        "module": "HexRealRootsMathlib.ProofProbe.Baseline"
+      },
+      "resolution": "resolved",
+      "samples": [
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 5.830418000000012,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 586
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.0014410000000126648,
+              "measurement_cpu_residual_seconds": 0.018558999999987336,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.85,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 88,
+                    "user": 495
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 586,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 440040,
+              "runner_cpu_seconds": 0.0010229999999999961
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4450363",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=10.54 avg60=10.57 avg300=7.91 total=7561727878\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7561727878,
+              "load_1m_per_available_cpu": 3.8388671875,
+              "load_1m_per_cpu": 0.039988199869791664,
+              "load_average": [
+                3.8388671875,
+                6.81494140625,
+                10.982421875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3570"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4452104",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=13.81 avg60=11.01 avg300=7.94 total=7561287838\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7561287838,
+              "load_1m_per_available_cpu": 3.041015625,
+              "load_1m_per_cpu": 0.03167724609375,
+              "load_average": [
+                3.041015625,
+                6.71044921875,
+                10.97119140625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3583"
+            },
+            "involuntary_context_switches": 22740,
+            "peak_rss_kb": 3163076,
+            "precise_child_system_seconds": 0.8869330000000026,
+            "precise_child_user_seconds": 4.94348500000001,
+            "system_seconds": 0.88,
+            "user_seconds": 4.94,
+            "voluntary_context_switches": 37627,
+            "wall_nanos": 5860059392
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "3816581",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=5.27 avg60=9.58 avg300=7.61 total=7559944591\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7559944591,
+            "load_1m_per_available_cpu": 2.60888671875,
+            "load_1m_per_cpu": 0.0271759033203125,
+            "load_average": [
+              2.60888671875,
+              6.6884765625,
+              10.9873046875
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "3/3525"
+          },
+          "measurement_attempt": 1,
+          "pair": "refined-2",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 199,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 2,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 198,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 2,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 4.001732486998662,
+            "rejected_windows": [
+              {
+                "issues": [
+                  "measurement CPU 19 had 3 non-interrupt busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 3,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 198,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 1,
+                      "user": 2
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 2,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 197,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 2
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              }
+            ]
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.014712000000014066,
+              "child_cpu_seconds": 5.364251999999986,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 539
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.004712000000014066,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.004712000000014066,
+              "measurement_cpu_residual_seconds": 0.034712000000014065,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.4,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 93,
+                    "user": 444
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.01,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 539,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 1,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1342681,
+              "runner_cpu_seconds": 0.0010360000000000369
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452875",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=13.81 avg60=11.01 avg300=7.94 total=7561287729\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7561287729,
+              "load_1m_per_available_cpu": 3.041015625,
+              "load_1m_per_cpu": 0.03167724609375,
+              "load_average": [
+                3.041015625,
+                6.71044921875,
+                10.97119140625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "4/3583"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451681",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=5.27 avg60=9.58 avg300=7.61 total=7559945048\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7559945048,
+              "load_1m_per_available_cpu": 2.60888671875,
+              "load_1m_per_cpu": 0.0271759033203125,
+              "load_average": [
+                2.60888671875,
+                6.6884765625,
+                10.9873046875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3525"
+            },
+            "involuntary_context_switches": 21852,
+            "peak_rss_kb": 3079428,
+            "precise_child_system_seconds": 0.929392,
+            "precise_child_user_seconds": 4.434859999999986,
+            "system_seconds": 0.92,
+            "user_seconds": 4.43,
+            "voluntary_context_switches": 36593,
+            "wall_nanos": 5392219433
+          },
+          "round": 1,
+          "signed_wall_delta_nanos": 467839959,
+          "slot_index": 5
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 5.796400000000027,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 583
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.007438000000027239,
+              "measurement_cpu_residual_seconds": 0.012561999999972762,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.81,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 88,
+                    "user": 491
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 583,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1428379,
+              "runner_cpu_seconds": 0.0010379999999999834
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4454178",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=13.47 avg60=11.77 avg300=10.36 total=7593754661\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7593754661,
+              "load_1m_per_available_cpu": 2.7880859375,
+              "load_1m_per_cpu": 0.029042561848958332,
+              "load_average": [
+                2.7880859375,
+                5.12890625,
+                9.34619140625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3497"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4456451",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=7.87 avg60=10.72 avg300=10.12 total=7592326282\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7592326282,
+              "load_1m_per_available_cpu": 3.11328125,
+              "load_1m_per_cpu": 0.032430013020833336,
+              "load_average": [
+                3.11328125,
+                5.27001953125,
+                9.43701171875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3502"
+            },
+            "involuntary_context_switches": 22441,
+            "peak_rss_kb": 3167236,
+            "precise_child_system_seconds": 0.8834060000000008,
+            "precise_child_user_seconds": 4.912994000000026,
+            "system_seconds": 0.88,
+            "user_seconds": 4.91,
+            "voluntary_context_switches": 37355,
+            "wall_nanos": 5826010272
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "2963926",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=7.87 avg60=10.72 avg300=10.12 total=7592326173\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7592326173,
+            "load_1m_per_available_cpu": 3.11328125,
+            "load_1m_per_cpu": 0.032430013020833336,
+            "load_average": [
+              3.11328125,
+              5.27001953125,
+              9.43701171875
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "1/3502"
+          },
+          "measurement_attempt": 1,
+          "pair": "refined-2",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.0008493531495333,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 5.357543000000007,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 538
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.008592000000006799,
+              "measurement_cpu_residual_seconds": 0.011407999999993201,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.37,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 1,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 90,
+                    "user": 445
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 538,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1455890,
+              "runner_cpu_seconds": 0.0010490000000000776
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452189",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=20.86 avg60=13.33 avg300=10.71 total=7595210810\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7595210810,
+              "load_1m_per_available_cpu": 2.64453125,
+              "load_1m_per_cpu": 0.027547200520833332,
+              "load_average": [
+                2.64453125,
+                5.06005859375,
+                9.30126953125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3495"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4455232",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=13.47 avg60=11.77 avg300=10.36 total=7593754920\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7593754920,
+              "load_1m_per_available_cpu": 2.7880859375,
+              "load_1m_per_cpu": 0.029042561848958332,
+              "load_average": [
+                2.7880859375,
+                5.12890625,
+                9.34619140625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3497"
+            },
+            "involuntary_context_switches": 21160,
+            "peak_rss_kb": 3081456,
+            "precise_child_system_seconds": 0.9071220000000011,
+            "precise_child_user_seconds": 4.450421000000006,
+            "system_seconds": 0.9,
+            "user_seconds": 4.44,
+            "voluntary_context_switches": 36067,
+            "wall_nanos": 5385903783
+          },
+          "round": 2,
+          "signed_wall_delta_nanos": 440106489,
+          "slot_index": 4
+        },
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.024278999999949424,
+              "child_cpu_seconds": 5.86464600000005,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 589
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.004278999999949424,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.004278999999949424,
+              "measurement_cpu_residual_seconds": 0.024278999999949424,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.89,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 89,
+                    "user": 498
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.02,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 588,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 1,
+                    "user": 1
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1529736,
+              "runner_cpu_seconds": 0.0010750000000000481
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452293",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=19.99 avg60=16.44 avg300=13.42 total=7628024598\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7628024598,
+              "load_1m_per_available_cpu": 2.3837890625,
+              "load_1m_per_cpu": 0.024831136067708332,
+              "load_average": [
+                2.3837890625,
+                3.8251953125,
+                8.00537109375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3487"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451089",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=17.65 avg60=15.61 avg300=13.19 total=7626494862\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7626494862,
+              "load_1m_per_available_cpu": 2.541015625,
+              "load_1m_per_cpu": 0.026468912760416668,
+              "load_average": [
+                2.541015625,
+                3.90478515625,
+                8.076171875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3490"
+            },
+            "involuntary_context_switches": 22217,
+            "peak_rss_kb": 3167140,
+            "precise_child_system_seconds": 0.8893380000000093,
+            "precise_child_user_seconds": 4.975308000000041,
+            "system_seconds": 0.88,
+            "user_seconds": 4.97,
+            "voluntary_context_switches": 37135,
+            "wall_nanos": 5895317954
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4413729",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=15.45 avg60=15.08 avg300=13.03 total=7625208285\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7625208285,
+            "load_1m_per_available_cpu": 2.5009765625,
+            "load_1m_per_cpu": 0.026051839192708332,
+            "load_average": [
+              2.5009765625,
+              3.92041015625,
+              8.10400390625
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "1/3495"
+          },
+          "measurement_attempt": 2,
+          "pair": "refined-2",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 1,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 199,
+                    "iowait": 0,
+                    "irq": 1,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                },
+                "67": {
+                  "busy_ticks": 1,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 198,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.000929197994992,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.02110600000001229,
+              "child_cpu_seconds": 5.447866999999988,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 547
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.01110600000001229,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.01110600000001229,
+              "measurement_cpu_residual_seconds": 0.03110600000001229,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.48,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 1,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 93,
+                    "user": 453
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.01,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 546,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1286271,
+              "runner_cpu_seconds": 0.0010270000000001112
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4453009",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=17.65 avg60=15.61 avg300=13.19 total=7626494700\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7626494700,
+              "load_1m_per_available_cpu": 2.541015625,
+              "load_1m_per_cpu": 0.026468912760416668,
+              "load_average": [
+                2.541015625,
+                3.90478515625,
+                8.076171875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3490"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4452832",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=15.45 avg60=15.08 avg300=13.03 total=7625208429\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7625208429,
+              "load_1m_per_available_cpu": 2.5009765625,
+              "load_1m_per_cpu": 0.026051839192708332,
+              "load_average": [
+                2.5009765625,
+                3.92041015625,
+                8.10400390625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3495"
+            },
+            "involuntary_context_switches": 21198,
+            "peak_rss_kb": 3082172,
+            "precise_child_system_seconds": 0.9199459999999959,
+            "precise_child_user_seconds": 4.527920999999992,
+            "system_seconds": 0.91,
+            "user_seconds": 4.52,
+            "voluntary_context_switches": 36059,
+            "wall_nanos": 5475259330
+          },
+          "round": 3,
+          "signed_wall_delta_nanos": 420058624,
+          "slot_index": 3
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.008812999999964016,
+              "child_cpu_seconds": 5.840156000000036,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 587
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.008812999999964016,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.008812999999964016,
+              "measurement_cpu_residual_seconds": 0.038812999999964015,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.88,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 93,
+                    "user": 492
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 587,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1547850,
+              "runner_cpu_seconds": 0.0010310000000000041
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4450471",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=18.68 avg60=13.72 avg300=13.60 total=7657262521\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7657262521,
+              "load_1m_per_available_cpu": 2.6142578125,
+              "load_1m_per_cpu": 0.027231852213541668,
+              "load_average": [
+                2.6142578125,
+                3.095703125,
+                6.8896484375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3525"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451527",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=14.05 avg60=12.66 avg300=13.39 total=7655714671\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7655714671,
+              "load_1m_per_available_cpu": 2.232421875,
+              "load_1m_per_cpu": 0.02325439453125,
+              "load_average": [
+                2.232421875,
+                3.029296875,
+                6.888671875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3524"
+            },
+            "involuntary_context_switches": 22457,
+            "peak_rss_kb": 3167288,
+            "precise_child_system_seconds": 0.9244640000000004,
+            "precise_child_user_seconds": 4.9156920000000355,
+            "system_seconds": 0.92,
+            "user_seconds": 4.91,
+            "voluntary_context_switches": 37345,
+            "wall_nanos": 5873718502
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "1500000",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=14.05 avg60=12.66 avg300=13.39 total=7655714551\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7655714551,
+            "load_1m_per_available_cpu": 2.232421875,
+            "load_1m_per_cpu": 0.02325439453125,
+            "load_average": [
+              2.232421875,
+              3.029296875,
+              6.888671875
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "1/3524"
+          },
+          "measurement_attempt": 1,
+          "pair": "refined-2",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 2,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 198,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 2
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.0007631110493094,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 5.3669390000000305,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 540
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.008006000000030794,
+              "measurement_cpu_residual_seconds": 0.021993999999969205,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.39,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 90,
+                    "user": 446
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 539,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1413578,
+              "runner_cpu_seconds": 0.0010669999999999291
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451556",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=21.02 avg60=14.67 avg300=13.80 total=7658676295\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7658676295,
+              "load_1m_per_available_cpu": 2.48486328125,
+              "load_1m_per_cpu": 0.025883992513020832,
+              "load_average": [
+                2.48486328125,
+                3.060546875,
+                6.85791015625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3524"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451079",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=18.68 avg60=13.72 avg300=13.60 total=7657262717\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7657262717,
+              "load_1m_per_available_cpu": 2.6142578125,
+              "load_1m_per_cpu": 0.027231852213541668,
+              "load_average": [
+                2.6142578125,
+                3.095703125,
+                6.8896484375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3525"
+            },
+            "involuntary_context_switches": 21734,
+            "peak_rss_kb": 3081676,
+            "precise_child_system_seconds": 0.9050919999999962,
+            "precise_child_user_seconds": 4.461847000000034,
+            "system_seconds": 0.9,
+            "user_seconds": 4.46,
+            "voluntary_context_switches": 36431,
+            "wall_nanos": 5397891676
+          },
+          "round": 4,
+          "signed_wall_delta_nanos": 475826826,
+          "slot_index": 2
+        },
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.01,
+              "child_cpu_seconds": 5.900896999999972,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 594
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.001921999999972418,
+              "measurement_cpu_residual_seconds": 0.02807800000002758,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.93,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 95,
+                    "user": 495
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.01,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 592,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                }
+              },
+              "pressure_some_delta_us": 692176,
+              "runner_cpu_seconds": 0.0010250000000000536
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4449340",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=6.33 avg60=5.91 avg300=11.08 total=7676749726\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7676749726,
+              "load_1m_per_available_cpu": 4.1142578125,
+              "load_1m_per_cpu": 0.042856852213541664,
+              "load_average": [
+                4.1142578125,
+                3.3125,
+                6.21923828125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3571"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4450806",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=2.99 avg60=5.41 avg300=11.09 total=7676057550\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7676057550,
+              "load_1m_per_available_cpu": 4.21142578125,
+              "load_1m_per_cpu": 0.0438690185546875,
+              "load_average": [
+                4.21142578125,
+                3.31787109375,
+                6.23681640625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3573"
+            },
+            "involuntary_context_switches": 21630,
+            "peak_rss_kb": 3169404,
+            "precise_child_system_seconds": 0.9438899999999961,
+            "precise_child_user_seconds": 4.957006999999976,
+            "system_seconds": 0.94,
+            "user_seconds": 4.95,
+            "voluntary_context_switches": 36464,
+            "wall_nanos": 5932320495
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4450110",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 8,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=1.63 avg60=5.52 avg300=11.23 total=7675753218\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7675753218,
+            "load_1m_per_available_cpu": 4.31689453125,
+            "load_1m_per_cpu": 0.0449676513671875,
+            "load_average": [
+              4.31689453125,
+              3.3232421875,
+              6.25439453125
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "3/3563"
+          },
+          "measurement_attempt": 1,
+          "pair": "refined-2",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 1,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 199,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.0008308589458466,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 5.3989250000000055,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 543
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.0002460000000059359,
+              "measurement_cpu_residual_seconds": 0.029753999999994063,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.43,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 92,
+                    "user": 448
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 542,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 304146,
+              "runner_cpu_seconds": 0.0013210000000001276
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451753",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=2.99 avg60=5.41 avg300=11.09 total=7676057472\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7676057472,
+              "load_1m_per_available_cpu": 4.21142578125,
+              "load_1m_per_cpu": 0.0438690185546875,
+              "load_average": [
+                4.21142578125,
+                3.31787109375,
+                6.23681640625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3573"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4448597",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=1.63 avg60=5.52 avg300=11.23 total=7675753326\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7675753326,
+              "load_1m_per_available_cpu": 4.31689453125,
+              "load_1m_per_cpu": 0.0449676513671875,
+              "load_average": [
+                4.31689453125,
+                3.3232421875,
+                6.25439453125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3563"
+            },
+            "involuntary_context_switches": 21037,
+            "peak_rss_kb": 3081672,
+            "precise_child_system_seconds": 0.9217080000000095,
+            "precise_child_user_seconds": 4.477216999999996,
+            "system_seconds": 0.92,
+            "user_seconds": 4.47,
+            "voluntary_context_switches": 35907,
+            "wall_nanos": 5427142718
+          },
+          "round": 5,
+          "signed_wall_delta_nanos": 505177777,
+          "slot_index": 1
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.00587599999994361,
+              "child_cpu_seconds": 5.833067000000057,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 587
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.00587599999994361,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.00587599999994361,
+              "measurement_cpu_residual_seconds": 0.02587599999994361,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.86,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 88,
+                    "user": 496
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 586,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 767391,
+              "runner_cpu_seconds": 0.0010570000000000856
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4450930",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=7.77 avg60=8.22 avg300=9.52 total=7689932350\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7689932350,
+              "load_1m_per_available_cpu": 4.54541015625,
+              "load_1m_per_cpu": 0.0473480224609375,
+              "load_average": [
+                4.54541015625,
+                4.33984375,
+                6.16455078125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3585"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451939",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=5.00 avg60=7.84 avg300=9.47 total=7689164959\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7689164959,
+              "load_1m_per_available_cpu": 4.33154296875,
+              "load_1m_per_cpu": 0.0451202392578125,
+              "load_average": [
+                4.33154296875,
+                4.294921875,
+                6.15966796875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3564"
+            },
+            "involuntary_context_switches": 22474,
+            "peak_rss_kb": 3169336,
+            "precise_child_system_seconds": 0.8846900000000062,
+            "precise_child_user_seconds": 4.94837700000005,
+            "system_seconds": 0.88,
+            "user_seconds": 4.94,
+            "voluntary_context_switches": 37280,
+            "wall_nanos": 5864198710
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "2378744",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 9,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=5.00 avg60=7.84 avg300=9.47 total=7689164877\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7689164877,
+            "load_1m_per_available_cpu": 4.33154296875,
+            "load_1m_per_cpu": 0.0451202392578125,
+            "load_average": [
+              4.33154296875,
+              4.294921875,
+              6.15966796875
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "4/3564"
+          },
+          "measurement_attempt": 1,
+          "pair": "refined-2",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 201,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.001093663973734,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.003422000000035591,
+              "child_cpu_seconds": 5.355527999999964,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 539
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.003422000000035591,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.003422000000035591,
+              "measurement_cpu_residual_seconds": 0.03342200000003559,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.39,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 86,
+                    "user": 450
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 538,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 660999,
+              "runner_cpu_seconds": 0.0010499999999999954
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452182",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=8.56 avg60=8.43 avg300=9.54 total=7690593438\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7690593438,
+              "load_1m_per_available_cpu": 4.90234375,
+              "load_1m_per_cpu": 0.051066080729166664,
+              "load_average": [
+                4.90234375,
+                4.41748046875,
+                6.18017578125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "10/3580"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4450177",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=7.77 avg60=8.22 avg300=9.52 total=7689932439\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7689932439,
+              "load_1m_per_available_cpu": 4.54541015625,
+              "load_1m_per_cpu": 0.0473480224609375,
+              "load_average": [
+                4.54541015625,
+                4.33984375,
+                6.16455078125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3585"
+            },
+            "involuntary_context_switches": 20944,
+            "peak_rss_kb": 3081668,
+            "precise_child_system_seconds": 0.8572699999999998,
+            "precise_child_user_seconds": 4.498257999999964,
+            "system_seconds": 0.85,
+            "user_seconds": 4.49,
+            "voluntary_context_switches": 35795,
+            "wall_nanos": 5385626497
+          },
+          "round": 6,
+          "signed_wall_delta_nanos": 478572213,
+          "slot_index": 0
+        }
+      ],
+      "signed_wall_delta_nanos": [
+        467839959,
+        440106489,
+        420058624,
+        475826826,
+        505177777,
+        478572213
+      ],
+      "width_bits": 20
+    },
+    "refined-4": {
+      "build_magnitude_wall_nanos": 6550729920,
+      "candidate": {
+        "artifacts": {
+          "ilean_bytes": 1706,
+          "olean_bytes": 9600,
+          "olean_private_bytes": 313536,
+          "olean_server_bytes": 1184,
+          "source_bytes": 678
+        },
+        "expected_axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "module": "HexRealRootsMathlib.ProofProbe.Refined4"
+      },
+      "comparable_control": "fresh-build-null",
+      "comparable_null_envelope_nanos": 70861425,
+      "comparable_null_raw_envelope_nanos": 58751220,
+      "comparable_null_raw_spread_nanos": 88945003,
+      "comparable_null_spread_nanos": 107278957,
+      "control_magnitude_ratio": 1.2061268536864072,
+      "control_scale_factor": 1.2061268536864072,
+      "degree": 4,
+      "family": "width-2^-20",
+      "median_candidate_peak_rss_kb": 3237574,
+      "median_candidate_wall_nanos": 6550729920,
+      "median_reference_peak_rss_kb": 3081562,
+      "median_reference_wall_nanos": 5398203754,
+      "median_signed_wall_delta_nanos": 1134463075,
+      "null_control": false,
+      "reference": {
+        "artifacts": {
+          "ilean_bytes": 168,
+          "olean_bytes": 1584,
+          "olean_private_bytes": 96,
+          "olean_server_bytes": 912,
+          "source_bytes": 422
+        },
+        "expected_axioms": null,
+        "module": "HexRealRootsMathlib.ProofProbe.Baseline"
+      },
+      "resolution": "resolved",
+      "samples": [
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.014219000000011658,
+              "child_cpu_seconds": 6.504726999999988,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 654
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.004219000000011658,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.004219000000011658,
+              "measurement_cpu_residual_seconds": 0.03421900000001166,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 6.54,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 89,
+                    "user": 562
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.01,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 653,
+                    "iowait": 0,
+                    "irq": 1,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 809217,
+              "runner_cpu_seconds": 0.0010539999999999994
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451363",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=12.03 avg60=11.26 avg300=8.54 total=7569607947\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7569607947,
+              "load_1m_per_available_cpu": 8.0341796875,
+              "load_1m_per_cpu": 0.08368937174479167,
+              "load_average": [
+                8.0341796875,
+                7.38037109375,
+                10.86669921875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3531"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451739",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=15.69 avg60=11.49 avg300=8.50 total=7568798730\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7568798730,
+              "load_1m_per_available_cpu": 8.3857421875,
+              "load_1m_per_cpu": 0.08735148111979167,
+              "load_average": [
+                8.3857421875,
+                7.4375,
+                10.90380859375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "4/3548"
+            },
+            "involuntary_context_switches": 22146,
+            "peak_rss_kb": 3230260,
+            "precise_child_system_seconds": 0.8898200000000003,
+            "precise_child_user_seconds": 5.614906999999988,
+            "system_seconds": 0.88,
+            "user_seconds": 5.61,
+            "voluntary_context_switches": 37126,
+            "wall_nanos": 6537041473
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4428165",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=12.05 avg60=10.68 avg300=8.28 total=7567581657\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7567581657,
+            "load_1m_per_available_cpu": 8.94189453125,
+            "load_1m_per_cpu": 0.09314473470052083,
+            "load_average": [
+              8.94189453125,
+              7.52978515625,
+              10.9521484375
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "2/3533"
+          },
+          "measurement_attempt": 4,
+          "pair": "refined-4",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.000733786029741,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 5.374793999999991,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 540
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.0058109999999911115,
+              "measurement_cpu_residual_seconds": 0.014189000000008889,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.39,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 91,
+                    "user": 446
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 540,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1214801,
+              "runner_cpu_seconds": 0.0010170000000000456
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452745",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=15.69 avg60=11.49 avg300=8.50 total=7568798580\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7568798580,
+              "load_1m_per_available_cpu": 8.3857421875,
+              "load_1m_per_cpu": 0.08735148111979167,
+              "load_average": [
+                8.3857421875,
+                7.4375,
+                10.90380859375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3548"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4456434",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=9.87 avg60=10.33 avg300=8.23 total=7567583779\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7567583779,
+              "load_1m_per_available_cpu": 8.94189453125,
+              "load_1m_per_cpu": 0.09314473470052083,
+              "load_average": [
+                8.94189453125,
+                7.52978515625,
+                10.9521484375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3533"
+            },
+            "involuntary_context_switches": 21235,
+            "peak_rss_kb": 3081528,
+            "precise_child_system_seconds": 0.9091589999999989,
+            "precise_child_user_seconds": 4.465634999999992,
+            "system_seconds": 0.9,
+            "user_seconds": 4.46,
+            "voluntary_context_switches": 36186,
+            "wall_nanos": 5400468358
+          },
+          "round": 1,
+          "signed_wall_delta_nanos": 1136573115,
+          "slot_index": 6
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 6.547234000000046,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 659
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.008286000000045507,
+              "measurement_cpu_residual_seconds": 0.021713999999954492,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 6.57,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 93,
+                    "user": 561
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 658,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1018647,
+              "runner_cpu_seconds": 0.001052000000000053
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452968",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=13.51 avg60=13.74 avg300=11.05 total=7599173330\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7599173330,
+              "load_1m_per_available_cpu": 2.56494140625,
+              "load_1m_per_cpu": 0.0267181396484375,
+              "load_average": [
+                2.56494140625,
+                4.84619140625,
+                9.11669921875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3494"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4450048",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=13.07 avg60=13.60 avg300=10.96 total=7598154683\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7598154683,
+              "load_1m_per_available_cpu": 2.5009765625,
+              "load_1m_per_cpu": 0.026051839192708332,
+              "load_average": [
+                2.5009765625,
+                4.9091796875,
+                9.18359375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3520"
+            },
+            "involuntary_context_switches": 22585,
+            "peak_rss_kb": 3242668,
+            "precise_child_system_seconds": 0.9381470000000007,
+            "precise_child_user_seconds": 5.609087000000045,
+            "system_seconds": 0.93,
+            "user_seconds": 5.6,
+            "voluntary_context_switches": 37438,
+            "wall_nanos": 6582755167
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4449558",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 9,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=13.07 avg60=13.60 avg300=10.96 total=7598154538\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7598154538,
+            "load_1m_per_available_cpu": 2.5009765625,
+            "load_1m_per_cpu": 0.026051839192708332,
+            "load_average": [
+              2.5009765625,
+              4.9091796875,
+              9.18359375
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "6/3512"
+          },
+          "measurement_attempt": 2,
+          "pair": "refined-4",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 1,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 199,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                },
+                "67": {
+                  "busy_ticks": 1,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 198,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 4.001624335069209,
+            "rejected_windows": [
+              {
+                "issues": [
+                  "measurement CPU 19 had 18 non-interrupt busy ticks",
+                  "SMT sibling CPU 67 had 4 busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 18,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 180,
+                      "iowait": 0,
+                      "irq": 1,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 5,
+                      "user": 13
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 4,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 197,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 4
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              }
+            ]
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.003244000000023478,
+              "child_cpu_seconds": 5.365690999999977,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 540
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.003244000000023478,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.003244000000023478,
+              "measurement_cpu_residual_seconds": 0.03324400000002348,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.4,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 94,
+                    "user": 443
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 539,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1115850,
+              "runner_cpu_seconds": 0.0010649999999999826
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4450863",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=15.00 avg60=14.18 avg300=11.20 total=7600289371\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7600289371,
+              "load_1m_per_available_cpu": 2.76025390625,
+              "load_1m_per_cpu": 0.028752644856770832,
+              "load_average": [
+                2.76025390625,
+                4.84912109375,
+                9.09423828125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3518"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4450516",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=13.51 avg60=13.74 avg300=11.05 total=7599173521\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7599173521,
+              "load_1m_per_available_cpu": 2.56494140625,
+              "load_1m_per_cpu": 0.0267181396484375,
+              "load_average": [
+                2.56494140625,
+                4.84619140625,
+                9.11669921875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3494"
+            },
+            "involuntary_context_switches": 21836,
+            "peak_rss_kb": 3079444,
+            "precise_child_system_seconds": 0.9300969999999964,
+            "precise_child_user_seconds": 4.4355939999999805,
+            "system_seconds": 0.93,
+            "user_seconds": 4.43,
+            "voluntary_context_switches": 36616,
+            "wall_nanos": 5395939151
+          },
+          "round": 2,
+          "signed_wall_delta_nanos": 1186816016,
+          "slot_index": 5
+        },
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 6.493332000000038,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 653
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.0043970000000380476,
+              "measurement_cpu_residual_seconds": 0.015602999999961953,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 6.51,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 93,
+                    "user": 556
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 653,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1391918,
+              "runner_cpu_seconds": 0.0010649999999999826
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4453730",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=18.78 avg60=17.02 avg300=13.70 total=7630835330\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7630835330,
+              "load_1m_per_available_cpu": 2.4052734375,
+              "load_1m_per_cpu": 0.025054931640625,
+              "load_average": [
+                2.4052734375,
+                3.78076171875,
+                7.94580078125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3483"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4450982",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=18.65 avg60=16.58 avg300=13.53 total=7629443412\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7629443412,
+              "load_1m_per_available_cpu": 2.35302734375,
+              "load_1m_per_cpu": 0.024510701497395832,
+              "load_average": [
+                2.35302734375,
+                3.79443359375,
+                7.97265625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "4/3492"
+            },
+            "involuntary_context_switches": 22589,
+            "peak_rss_kb": 3230320,
+            "precise_child_system_seconds": 0.9302419999999927,
+            "precise_child_user_seconds": 5.563090000000045,
+            "system_seconds": 0.93,
+            "user_seconds": 5.56,
+            "voluntary_context_switches": 37598,
+            "wall_nanos": 6527139042
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4006425",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=16.91 avg60=16.00 avg300=13.35 total=7628025635\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7628025635,
+            "load_1m_per_available_cpu": 2.3837890625,
+            "load_1m_per_cpu": 0.024831136067708332,
+            "load_average": [
+              2.3837890625,
+              3.8251953125,
+              8.00537109375
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "2/3488"
+          },
+          "measurement_attempt": 1,
+          "pair": "refined-4",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.000752286054194,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 5.36618100000004,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 540
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.007213000000040298,
+              "measurement_cpu_residual_seconds": 0.0227869999999597,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.39,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 94,
+                    "user": 442
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 539,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1417356,
+              "runner_cpu_seconds": 0.0010319999999999219
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4453171",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=18.65 avg60=16.58 avg300=13.53 total=7629443109\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7629443109,
+              "load_1m_per_available_cpu": 2.35302734375,
+              "load_1m_per_cpu": 0.024510701497395832,
+              "load_average": [
+                2.35302734375,
+                3.79443359375,
+                7.97265625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3492"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4454857",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=16.91 avg60=16.00 avg300=13.35 total=7628025753\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7628025753,
+              "load_1m_per_available_cpu": 2.3837890625,
+              "load_1m_per_cpu": 0.024831136067708332,
+              "load_average": [
+                2.3837890625,
+                3.8251953125,
+                8.00537109375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3488"
+            },
+            "involuntary_context_switches": 21226,
+            "peak_rss_kb": 3081596,
+            "precise_child_system_seconds": 0.9482140000000072,
+            "precise_child_user_seconds": 4.417967000000033,
+            "system_seconds": 0.94,
+            "user_seconds": 4.41,
+            "voluntary_context_switches": 36053,
+            "wall_nanos": 5394786006
+          },
+          "round": 3,
+          "signed_wall_delta_nanos": 1132353036,
+          "slot_index": 4
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.01,
+              "child_cpu_seconds": 6.479594000000006,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 651
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.010610000000005542,
+              "measurement_cpu_residual_seconds": 0.009389999999994458,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 6.49,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 89,
+                    "user": 558
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.01,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 651,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 1,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1505528,
+              "runner_cpu_seconds": 0.0010159999999999059
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4445290",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=19.30 avg60=15.03 avg300=13.90 total=7660183006\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7660183006,
+              "load_1m_per_available_cpu": 2.4775390625,
+              "load_1m_per_cpu": 0.025807698567708332,
+              "load_average": [
+                2.4775390625,
+                3.04150390625,
+                6.810546875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3521"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4452989",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=17.58 avg60=14.25 avg300=13.72 total=7658677478\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7658677478,
+              "load_1m_per_available_cpu": 2.48486328125,
+              "load_1m_per_cpu": 0.025883992513020832,
+              "load_average": [
+                2.48486328125,
+                3.060546875,
+                6.85791015625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3522"
+            },
+            "involuntary_context_switches": 21995,
+            "peak_rss_kb": 3244824,
+            "precise_child_system_seconds": 0.8972380000000015,
+            "precise_child_user_seconds": 5.582356000000004,
+            "system_seconds": 0.89,
+            "user_seconds": 5.58,
+            "voluntary_context_switches": 37088,
+            "wall_nanos": 6512718804
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "1500000",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=17.58 avg60=14.25 avg300=13.72 total=7658677246\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7658677246,
+            "load_1m_per_available_cpu": 2.48486328125,
+            "load_1m_per_cpu": 0.025883992513020832,
+            "load_average": [
+              2.48486328125,
+              3.060546875,
+              6.85791015625
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "1/3522"
+          },
+          "measurement_attempt": 1,
+          "pair": "refined-4",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 1,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.0007419399917126,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 5.362369999999956,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 539
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.0034069999999561673,
+              "measurement_cpu_residual_seconds": 0.02659300000004383,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.39,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 93,
+                    "user": 443
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 538,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1399187,
+              "runner_cpu_seconds": 0.0010369999999999546
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4453779",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=21.04 avg60=15.79 avg300=14.09 total=7661582380\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7661582380,
+              "load_1m_per_available_cpu": 2.51953125,
+              "load_1m_per_cpu": 0.0262451171875,
+              "load_average": [
+                2.51953125,
+                3.04052734375,
+                6.7900390625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3520"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4452910",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=19.30 avg60=15.03 avg300=13.90 total=7660183193\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7660183193,
+              "load_1m_per_available_cpu": 2.4775390625,
+              "load_1m_per_cpu": 0.025807698567708332,
+              "load_average": [
+                2.4775390625,
+                3.04150390625,
+                6.810546875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3521"
+            },
+            "involuntary_context_switches": 21352,
+            "peak_rss_kb": 3081668,
+            "precise_child_system_seconds": 0.9325500000000062,
+            "precise_child_user_seconds": 4.42981999999995,
+            "system_seconds": 0.93,
+            "user_seconds": 4.42,
+            "voluntary_context_switches": 36215,
+            "wall_nanos": 5389144171
+          },
+          "round": 4,
+          "signed_wall_delta_nanos": 1123574633,
+          "slot_index": 3
+        },
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.011581000000002756,
+              "child_cpu_seconds": 6.557367999999997,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 659
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.011581000000002756,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.011581000000002756,
+              "measurement_cpu_residual_seconds": 0.041581000000002755,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 6.6,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 87,
+                    "user": 570
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 659,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 856785,
+              "runner_cpu_seconds": 0.0010510000000001352
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451217",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=9.82 avg60=6.80 avg300=10.79 total=7679092463\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7679092463,
+              "load_1m_per_available_cpu": 5.224609375,
+              "load_1m_per_cpu": 0.054423014322916664,
+              "load_average": [
+                5.224609375,
+                3.66455078125,
+                6.24462890625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3527"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4450880",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=7.12 avg60=6.09 avg300=10.73 total=7678235678\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7678235678,
+              "load_1m_per_available_cpu": 5.02685546875,
+              "load_1m_per_cpu": 0.052363077799479164,
+              "load_average": [
+                5.02685546875,
+                3.5693359375,
+                6.24169921875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3569"
+            },
+            "involuntary_context_switches": 23824,
+            "peak_rss_kb": 3232480,
+            "precise_child_system_seconds": 0.8623890000000074,
+            "precise_child_user_seconds": 5.694978999999989,
+            "system_seconds": 0.86,
+            "user_seconds": 5.69,
+            "voluntary_context_switches": 38704,
+            "wall_nanos": 6590521033
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4456714",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 8,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=5.68 avg60=5.84 avg300=10.78 total=7677682079\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7677682079,
+            "load_1m_per_available_cpu": 4.6806640625,
+            "load_1m_per_cpu": 0.048756917317708336,
+            "load_average": [
+              4.6806640625,
+              3.4775390625,
+              6.2265625
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "6/3540"
+          },
+          "measurement_attempt": 2,
+          "pair": "refined-4",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.000853942008689,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.004267000000005811,
+              "child_cpu_seconds": 5.384705999999994,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 541
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.004267000000005811,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.004267000000005811,
+              "measurement_cpu_residual_seconds": 0.02426700000000581,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.41,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 91,
+                    "user": 448
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 541,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 553404,
+              "runner_cpu_seconds": 0.0010270000000001112
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451306",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=7.12 avg60=6.09 avg300=10.73 total=7678235584\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7678235584,
+              "load_1m_per_available_cpu": 5.02685546875,
+              "load_1m_per_cpu": 0.052363077799479164,
+              "load_average": [
+                5.02685546875,
+                3.5693359375,
+                6.24169921875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3569"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4449995",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=5.68 avg60=5.84 avg300=10.78 total=7677682180\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7677682180,
+              "load_1m_per_available_cpu": 4.6806640625,
+              "load_1m_per_cpu": 0.048756917317708336,
+              "load_average": [
+                4.6806640625,
+                3.4775390625,
+                6.2265625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "5/3540"
+            },
+            "involuntary_context_switches": 21527,
+            "peak_rss_kb": 3081676,
+            "precise_child_system_seconds": 0.9100540000000024,
+            "precise_child_user_seconds": 4.474651999999992,
+            "system_seconds": 0.91,
+            "user_seconds": 4.47,
+            "voluntary_context_switches": 36364,
+            "wall_nanos": 5411283028
+          },
+          "round": 5,
+          "signed_wall_delta_nanos": 1179238005,
+          "slot_index": 2
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 6.5305800000001,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 656
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.0016040000001007193,
+              "measurement_cpu_residual_seconds": 0.02839599999989928,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 6.56,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 92,
+                    "user": 561
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 657,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 766269,
+              "runner_cpu_seconds": 0.001024000000000358
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452236",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=8.31 avg60=8.46 avg300=9.52 total=7691360673\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7691360673,
+              "load_1m_per_available_cpu": 4.76318359375,
+              "load_1m_per_cpu": 0.049616495768229164,
+              "load_average": [
+                4.76318359375,
+                4.4033203125,
+                6.15673828125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3572"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4450092",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=7.01 avg60=8.16 avg300=9.48 total=7690594404\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7690594404,
+              "load_1m_per_available_cpu": 4.90234375,
+              "load_1m_per_cpu": 0.051066080729166664,
+              "load_average": [
+                4.90234375,
+                4.41748046875,
+                6.18017578125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3577"
+            },
+            "involuntary_context_switches": 21756,
+            "peak_rss_kb": 3251036,
+            "precise_child_system_seconds": 0.9282690000000002,
+            "precise_child_user_seconds": 5.6023110000001,
+            "system_seconds": 0.92,
+            "user_seconds": 5.6,
+            "voluntary_context_switches": 36561,
+            "wall_nanos": 6564418368
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4456735",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 9,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=7.01 avg60=8.16 avg300=9.48 total=7690594290\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7690594290,
+            "load_1m_per_available_cpu": 4.90234375,
+            "load_1m_per_cpu": 0.051066080729166664,
+            "load_average": [
+              4.90234375,
+              4.41748046875,
+              6.18017578125
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "2/3577"
+          },
+          "measurement_attempt": 1,
+          "pair": "refined-4",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 199,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 199,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.0008131738286465,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.026546999999905507,
+              "child_cpu_seconds": 5.442382000000094,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 547
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.006546999999905507,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.006546999999905507,
+              "measurement_cpu_residual_seconds": 0.026546999999905507,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.47,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 90,
+                    "user": 455
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.02,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 546,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 1
+                  }
+                }
+              },
+              "pressure_some_delta_us": 594124,
+              "runner_cpu_seconds": 0.001070999999999822
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452075",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=8.44 avg60=8.56 avg300=9.52 total=7691954902\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7691954902,
+              "load_1m_per_available_cpu": 4.8623046875,
+              "load_1m_per_cpu": 0.050649007161458336,
+              "load_average": [
+                4.8623046875,
+                4.43017578125,
+                6.15576171875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3588"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4449445",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=8.31 avg60=8.46 avg300=9.52 total=7691360778\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7691360778,
+              "load_1m_per_available_cpu": 4.76318359375,
+              "load_1m_per_cpu": 0.049616495768229164,
+              "load_average": [
+                4.76318359375,
+                4.4033203125,
+                6.15673828125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "4/3572"
+            },
+            "involuntary_context_switches": 21726,
+            "peak_rss_kb": 3079436,
+            "precise_child_system_seconds": 0.9022940000000119,
+            "precise_child_user_seconds": 4.5400880000000825,
+            "system_seconds": 0.9,
+            "user_seconds": 4.54,
+            "voluntary_context_switches": 36620,
+            "wall_nanos": 5471002770
+          },
+          "round": 6,
+          "signed_wall_delta_nanos": 1093415598,
+          "slot_index": 1
+        }
+      ],
+      "signed_wall_delta_nanos": [
+        1136573115,
+        1186816016,
+        1132353036,
+        1123574633,
+        1179238005,
+        1093415598
+      ],
+      "width_bits": 20
+    },
+    "refined-6": {
+      "build_magnitude_wall_nanos": 7915650921,
+      "candidate": {
+        "artifacts": {
+          "ilean_bytes": 1928,
+          "olean_bytes": 10576,
+          "olean_private_bytes": 442928,
+          "olean_server_bytes": 1184,
+          "source_bytes": 732
+        },
+        "expected_axioms": [
+          "propext",
+          "Classical.choice",
+          "Quot.sound"
+        ],
+        "module": "HexRealRootsMathlib.ProofProbe.Refined6"
+      },
+      "comparable_control": "fresh-build-null",
+      "comparable_null_envelope_nanos": 85626229,
+      "comparable_null_raw_envelope_nanos": 58751220,
+      "comparable_null_raw_spread_nanos": 88945003,
+      "comparable_null_spread_nanos": 129631779,
+      "control_magnitude_ratio": 1.4574374545769153,
+      "control_scale_factor": 1.4574374545769153,
+      "degree": 6,
+      "family": "width-2^-20",
+      "median_candidate_peak_rss_kb": 3372436,
+      "median_candidate_wall_nanos": 7915650921,
+      "median_reference_peak_rss_kb": 3080608,
+      "median_reference_wall_nanos": 5397484245,
+      "median_signed_wall_delta_nanos": 2521630854,
+      "null_control": false,
+      "reference": {
+        "artifacts": {
+          "ilean_bytes": 168,
+          "olean_bytes": 1584,
+          "olean_private_bytes": 96,
+          "olean_server_bytes": 912,
+          "source_bytes": 422
+        },
+        "expected_axioms": null,
+        "module": "HexRealRootsMathlib.ProofProbe.Baseline"
+      },
+      "resolution": "resolved",
+      "samples": [
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0038900000000083035,
+              "child_cpu_seconds": 7.885055999999992,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 793
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0038900000000083035,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.0038900000000083035,
+              "measurement_cpu_residual_seconds": 0.0338900000000083,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.92,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 90,
+                    "user": 699
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 792,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1402517,
+              "runner_cpu_seconds": 0.0010539999999999994
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452872",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=13.63 avg60=13.95 avg300=9.73 total=7577669064\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7577669064,
+              "load_1m_per_available_cpu": 4.81982421875,
+              "load_1m_per_cpu": 0.050206502278645836,
+              "load_average": [
+                4.81982421875,
+                6.58544921875,
+                10.41064453125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3506"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4450072",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=13.86 avg60=13.63 avg300=9.54 total=7576266547\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7576266547,
+              "load_1m_per_available_cpu": 5.4267578125,
+              "load_1m_per_cpu": 0.056528727213541664,
+              "load_average": [
+                5.4267578125,
+                6.75927734375,
+                10.5078125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "6/3531"
+            },
+            "involuntary_context_switches": 22651,
+            "peak_rss_kb": 3409232,
+            "precise_child_system_seconds": 0.892156,
+            "precise_child_user_seconds": 6.992899999999992,
+            "system_seconds": 0.89,
+            "user_seconds": 6.99,
+            "voluntary_context_switches": 37536,
+            "wall_nanos": 7924665729
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "1804195",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=13.64 avg60=13.50 avg300=9.42 total=7575259364\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7575259364,
+            "load_1m_per_available_cpu": 5.20263671875,
+            "load_1m_per_cpu": 0.054194132486979164,
+            "load_average": [
+              5.20263671875,
+              6.73828125,
+              10.521484375
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "4/3530"
+          },
+          "measurement_attempt": 3,
+          "pair": "refined-6",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 199,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.001317478949204,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 5.34705300000001,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 538
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.008095000000009483,
+              "measurement_cpu_residual_seconds": 0.021904999999990515,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.37,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 88,
+                    "user": 446
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 537,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1006917,
+              "runner_cpu_seconds": 0.0010419999999999874
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452893",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=13.86 avg60=13.63 avg300=9.54 total=7576266468\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7576266468,
+              "load_1m_per_available_cpu": 5.4267578125,
+              "load_1m_per_cpu": 0.056528727213541664,
+              "load_average": [
+                5.4267578125,
+                6.75927734375,
+                10.5078125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3531"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4306342",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=13.64 avg60=13.50 avg300=9.42 total=7575259551\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7575259551,
+              "load_1m_per_available_cpu": 5.20263671875,
+              "load_1m_per_cpu": 0.054194132486979164,
+              "load_average": [
+                5.20263671875,
+                6.73828125,
+                10.521484375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "7/3530"
+            },
+            "involuntary_context_switches": 21415,
+            "peak_rss_kb": 3081648,
+            "precise_child_system_seconds": 0.8866700000000023,
+            "precise_child_user_seconds": 4.460383000000007,
+            "system_seconds": 0.88,
+            "user_seconds": 4.45,
+            "voluntary_context_switches": 36290,
+            "wall_nanos": 5375350914
+          },
+          "round": 1,
+          "signed_wall_delta_nanos": 2549314815,
+          "slot_index": 7
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 7.867266999999977,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 791
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.008305999999977248,
+              "measurement_cpu_residual_seconds": 0.02169400000002275,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.89,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 3,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 90,
+                    "user": 696
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 790,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1568021,
+              "runner_cpu_seconds": 0.0010390000000000121
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451732",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=14.69 avg60=14.34 avg300=11.48 total=7604030252\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7604030252,
+              "load_1m_per_available_cpu": 2.544921875,
+              "load_1m_per_cpu": 0.026509602864583332,
+              "load_average": [
+                2.544921875,
+                4.63427734375,
+                8.90966796875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "4/3483"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4455547",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=12.31 avg60=13.88 avg300=11.30 total=7602462231\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7602462231,
+              "load_1m_per_available_cpu": 2.7392578125,
+              "load_1m_per_cpu": 0.028533935546875,
+              "load_average": [
+                2.7392578125,
+                4.74169921875,
+                8.990234375
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3482"
+            },
+            "involuntary_context_switches": 22196,
+            "peak_rss_kb": 3374532,
+            "precise_child_system_seconds": 0.9022000000000006,
+            "precise_child_user_seconds": 6.965066999999976,
+            "system_seconds": 0.9,
+            "user_seconds": 6.96,
+            "voluntary_context_switches": 37161,
+            "wall_nanos": 7906636114
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4060102",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=12.31 avg60=13.88 avg300=11.30 total=7602461894\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7602461894,
+            "load_1m_per_available_cpu": 2.7392578125,
+            "load_1m_per_cpu": 0.028533935546875,
+            "load_average": [
+              2.7392578125,
+              4.74169921875,
+              8.990234375
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "3/3482"
+          },
+          "measurement_attempt": 2,
+          "pair": "refined-6",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.0008136888500303,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.01,
+              "child_cpu_seconds": 5.36250500000002,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 539
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.03,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.0035250000000205117,
+              "measurement_cpu_residual_seconds": 0.026474999999979487,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.39,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 88,
+                    "user": 448
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.01,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 539,
+                    "iowait": 0,
+                    "irq": 1,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1454990,
+              "runner_cpu_seconds": 0.001020000000000132
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452529",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=19.28 avg60=15.30 avg300=11.74 total=7605485626\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7605485626,
+              "load_1m_per_available_cpu": 2.4208984375,
+              "load_1m_per_cpu": 0.025217692057291668,
+              "load_average": [
+                2.4208984375,
+                4.57373046875,
+                8.86669921875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3483"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4450394",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=14.69 avg60=14.34 avg300=11.48 total=7604030636\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7604030636,
+              "load_1m_per_available_cpu": 2.544921875,
+              "load_1m_per_cpu": 0.026509602864583332,
+              "load_average": [
+                2.544921875,
+                4.63427734375,
+                8.90966796875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "4/3483"
+            },
+            "involuntary_context_switches": 21565,
+            "peak_rss_kb": 3079568,
+            "precise_child_system_seconds": 0.8814029999999988,
+            "precise_child_user_seconds": 4.481102000000021,
+            "system_seconds": 0.88,
+            "user_seconds": 4.48,
+            "voluntary_context_switches": 36483,
+            "wall_nanos": 5390052662
+          },
+          "round": 2,
+          "signed_wall_delta_nanos": 2516583452,
+          "slot_index": 6
+        },
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.005513000000041658,
+              "child_cpu_seconds": 7.883436999999958,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 793
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.005513000000041658,
+              "measurement_cpu_interrupt_seconds": 0.04,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.005513000000041658,
+              "measurement_cpu_residual_seconds": 0.04551300000004166,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.93,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1,
+                    "iowait": 0,
+                    "irq": 3,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 95,
+                    "user": 694
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 793,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1448123,
+              "runner_cpu_seconds": 0.0010499999999999954
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4453567",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=15.80 avg60=17.06 avg300=13.90 total=7633675508\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7633675508,
+              "load_1m_per_available_cpu": 2.01708984375,
+              "load_1m_per_cpu": 0.0210113525390625,
+              "load_average": [
+                2.01708984375,
+                3.6005859375,
+                7.796875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3494"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4453999",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=18.02 avg60=17.08 avg300=13.80 total=7632227385\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7632227385,
+              "load_1m_per_available_cpu": 2.115234375,
+              "load_1m_per_cpu": 0.02203369140625,
+              "load_average": [
+                2.115234375,
+                3.67236328125,
+                7.86572265625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3497"
+            },
+            "involuntary_context_switches": 22969,
+            "peak_rss_kb": 3370340,
+            "precise_child_system_seconds": 0.9495229999999992,
+            "precise_child_user_seconds": 6.933913999999959,
+            "system_seconds": 0.94,
+            "user_seconds": 6.93,
+            "voluntary_context_switches": 37845,
+            "wall_nanos": 7926537386
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "2303625",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=15.92 avg60=16.56 avg300=13.62 total=7630836495\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7630836495,
+            "load_1m_per_available_cpu": 2.21240234375,
+            "load_1m_per_cpu": 0.023045857747395832,
+            "load_average": [
+              2.21240234375,
+              3.7177734375,
+              7.90283203125
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "2/3489"
+          },
+          "measurement_attempt": 1,
+          "pair": "refined-6",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.000943686114624,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 5.370845000000031,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 540
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.0018520000000314778,
+              "measurement_cpu_residual_seconds": 0.018147999999968523,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.39,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 88,
+                    "user": 449
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 540,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1390636,
+              "runner_cpu_seconds": 0.0010069999999999801
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451610",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=18.02 avg60=17.08 avg300=13.80 total=7632227211\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7632227211,
+              "load_1m_per_available_cpu": 2.115234375,
+              "load_1m_per_cpu": 0.02203369140625,
+              "load_average": [
+                2.115234375,
+                3.67236328125,
+                7.86572265625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3497"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4455384",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=15.92 avg60=16.56 avg300=13.62 total=7630836575\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7630836575,
+              "load_1m_per_available_cpu": 2.21240234375,
+              "load_1m_per_cpu": 0.023045857747395832,
+              "load_average": [
+                2.21240234375,
+                3.7177734375,
+                7.90283203125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3489"
+            },
+            "involuntary_context_switches": 21361,
+            "peak_rss_kb": 3081688,
+            "precise_child_system_seconds": 0.8876980000000003,
+            "precise_child_user_seconds": 4.483147000000031,
+            "system_seconds": 0.88,
+            "user_seconds": 4.48,
+            "voluntary_context_switches": 36284,
+            "wall_nanos": 5399859130
+          },
+          "round": 3,
+          "signed_wall_delta_nanos": 2526678256,
+          "slot_index": 5
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.001528000000052411,
+              "child_cpu_seconds": 7.857464999999948,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 789
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.001528000000052411,
+              "measurement_cpu_interrupt_seconds": 0.04,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.001528000000052411,
+              "measurement_cpu_residual_seconds": 0.04152800000005241,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.9,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 3,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 89,
+                    "user": 697
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 789,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1439501,
+              "runner_cpu_seconds": 0.0010069999999999801
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451593",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=13.38 avg60=14.64 avg300=13.90 total=7663024466\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7663024466,
+              "load_1m_per_available_cpu": 2.33544921875,
+              "load_1m_per_cpu": 0.024327596028645832,
+              "load_average": [
+                2.33544921875,
+                2.97314453125,
+                6.70703125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3521"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4100736",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=11.79 avg60=14.35 avg300=13.82 total=7661584965\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7661584965,
+              "load_1m_per_available_cpu": 2.3173828125,
+              "load_1m_per_cpu": 0.024139404296875,
+              "load_average": [
+                2.3173828125,
+                2.98974609375,
+                6.75341796875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3523"
+            },
+            "involuntary_context_switches": 22494,
+            "peak_rss_kb": 3353380,
+            "precise_child_system_seconds": 0.8880610000000075,
+            "precise_child_user_seconds": 6.96940399999994,
+            "system_seconds": 0.88,
+            "user_seconds": 6.96,
+            "voluntary_context_switches": 37502,
+            "wall_nanos": 7895242957
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "1534631",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 6,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=11.79 avg60=14.35 avg300=13.82 total=7661584875\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7661584875,
+            "load_1m_per_available_cpu": 2.3173828125,
+            "load_1m_per_cpu": 0.024139404296875,
+            "load_average": [
+              2.3173828125,
+              2.98974609375,
+              6.75341796875
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "1/3523"
+          },
+          "measurement_attempt": 1,
+          "pair": "refined-6",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 199,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 6.0035228449851274,
+            "rejected_windows": [
+              {
+                "issues": [
+                  "measurement CPU 19 had 3 non-interrupt busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 3,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 196,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 1,
+                      "user": 2
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 2,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 198,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 2
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              },
+              {
+                "issues": [
+                  "SMT sibling CPU 67 had 6 busy ticks"
+                ],
+                "max_busy_ticks": 2,
+                "per_cpu": {
+                  "19": {
+                    "noninterrupt_busy_ticks": 2,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 196,
+                      "iowait": 0,
+                      "irq": 0,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 2
+                    }
+                  },
+                  "67": {
+                    "busy_ticks": 6,
+                    "ticks": {
+                      "guest": 0,
+                      "guest_nice": 0,
+                      "idle": 194,
+                      "iowait": 0,
+                      "irq": 1,
+                      "nice": 0,
+                      "softirq": 0,
+                      "steal": 0,
+                      "system": 0,
+                      "user": 5
+                    }
+                  }
+                },
+                "window_seconds": 2.0
+              }
+            ]
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 5.3735650000000135,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 541
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.004623000000013793,
+              "measurement_cpu_residual_seconds": 0.015376999999986207,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.39,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 94,
+                    "user": 443
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 540,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 1569431,
+              "runner_cpu_seconds": 0.0010580000000000034
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4452754",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=18.50 avg60=15.72 avg300=14.15 total=7664594245\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7664594245,
+              "load_1m_per_available_cpu": 2.22802734375,
+              "load_1m_per_cpu": 0.0232086181640625,
+              "load_average": [
+                2.22802734375,
+                2.93994140625,
+                6.67626953125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3524"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4451117",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 6,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=13.38 avg60=14.64 avg300=13.90 total=7663024814\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7663024814,
+              "load_1m_per_available_cpu": 2.33544921875,
+              "load_1m_per_cpu": 0.024327596028645832,
+              "load_average": [
+                2.33544921875,
+                2.97314453125,
+                6.70703125
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "1/3521"
+            },
+            "involuntary_context_switches": 21415,
+            "peak_rss_kb": 3079564,
+            "precise_child_system_seconds": 0.9389070000000004,
+            "precise_child_user_seconds": 4.434658000000013,
+            "system_seconds": 0.93,
+            "user_seconds": 4.43,
+            "voluntary_context_switches": 36284,
+            "wall_nanos": 5401521213
+          },
+          "round": 4,
+          "signed_wall_delta_nanos": 2493721744,
+          "slot_index": 4
+        },
+        {
+          "build_order": [
+            "reference",
+            "candidate"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 7.889324000000016,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 793
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.04,
+              "measurement_cpu_noninterrupt_residual_seconds": -0.00039400000001640206,
+              "measurement_cpu_residual_seconds": 0.0396059999999836,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.93,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 3,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 91,
+                    "user": 698
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 793,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 372480,
+              "runner_cpu_seconds": 0.0010699999999999044
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4453341",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=6.45 avg60=6.73 avg300=10.57 total=7680248132\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7680248132,
+              "load_1m_per_available_cpu": 5.40869140625,
+              "load_1m_per_cpu": 0.056340535481770836,
+              "load_average": [
+                5.40869140625,
+                3.7802734375,
+                6.24072265625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "6/3562"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4447575",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=10.05 avg60=7.13 avg300=10.75 total=7679875652\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7679875652,
+              "load_1m_per_available_cpu": 5.12646484375,
+              "load_1m_per_cpu": 0.053400675455729164,
+              "load_average": [
+                5.12646484375,
+                3.67041015625,
+                6.232421875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "7/3568"
+            },
+            "involuntary_context_switches": 21664,
+            "peak_rss_kb": 3349064,
+            "precise_child_system_seconds": 0.9068919999999991,
+            "precise_child_user_seconds": 6.982432000000017,
+            "system_seconds": 0.9,
+            "user_seconds": 6.98,
+            "voluntary_context_switches": 36590,
+            "wall_nanos": 7928253526
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4456994",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 8,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=8.22 avg60=6.61 avg300=10.73 total=7679093713\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7679093713,
+            "load_1m_per_available_cpu": 5.224609375,
+            "load_1m_per_cpu": 0.054423014322916664,
+            "load_average": [
+              5.224609375,
+              3.66455078125,
+              6.24462890625
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "4/3563"
+          },
+          "measurement_attempt": 1,
+          "pair": "refined-6",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.000879533821717,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.0,
+              "child_cpu_seconds": 5.369047000000023,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 539
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.0,
+              "measurement_cpu_interrupt_seconds": 0.02,
+              "measurement_cpu_noninterrupt_residual_seconds": -9.500000002325357e-05,
+              "measurement_cpu_residual_seconds": 0.019904999999976747,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.39,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 1,
+                    "iowait": 0,
+                    "irq": 2,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 89,
+                    "user": 448
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 540,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 781395,
+              "runner_cpu_seconds": 0.0010479999999997158
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4448572",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=10.05 avg60=7.13 avg300=10.75 total=7679875210\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7679875210,
+              "load_1m_per_available_cpu": 5.12646484375,
+              "load_1m_per_cpu": 0.053400675455729164,
+              "load_average": [
+                5.12646484375,
+                3.67041015625,
+                6.232421875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "15/3568"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4450524",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 8,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=8.22 avg60=6.61 avg300=10.73 total=7679093815\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7679093815,
+              "load_1m_per_available_cpu": 5.224609375,
+              "load_1m_per_cpu": 0.054423014322916664,
+              "load_average": [
+                5.224609375,
+                3.66455078125,
+                6.24462890625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "7/3562"
+            },
+            "involuntary_context_switches": 21719,
+            "peak_rss_kb": 3079364,
+            "precise_child_system_seconds": 0.8913450000000012,
+            "precise_child_user_seconds": 4.477702000000022,
+            "system_seconds": 0.89,
+            "user_seconds": 4.47,
+            "voluntary_context_switches": 36499,
+            "wall_nanos": 5395109360
+          },
+          "round": 5,
+          "signed_wall_delta_nanos": 2533144166,
+          "slot_index": 3
+        },
+        {
+          "build_order": [
+            "candidate",
+            "reference"
+          ],
+          "candidate": {
+            "axioms": [
+              "propext",
+              "Classical.choice",
+              "Quot.sound"
+            ],
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.001694000000019437,
+              "child_cpu_seconds": 7.84726999999998,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 788
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.001694000000019437,
+              "measurement_cpu_interrupt_seconds": 0.04,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.001694000000019437,
+              "measurement_cpu_residual_seconds": 0.04169400000001944,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 7.89,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 3,
+                    "nice": 0,
+                    "softirq": 1,
+                    "steal": 0,
+                    "system": 90,
+                    "user": 695
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 789,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 766002,
+              "runner_cpu_seconds": 0.0010359999999998148
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4450319",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 10,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=9.08 avg60=9.18 avg300=9.61 total=7694677969\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7694677969,
+              "load_1m_per_available_cpu": 4.72021484375,
+              "load_1m_per_cpu": 0.049168904622395836,
+              "load_average": [
+                4.72021484375,
+                4.427734375,
+                6.10888671875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3535"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4450902",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 9,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=10.76 avg60=9.30 avg300=9.64 total=7693911967\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7693911967,
+              "load_1m_per_available_cpu": 4.56689453125,
+              "load_1m_per_cpu": 0.047571818033854164,
+              "load_average": [
+                4.56689453125,
+                4.39111328125,
+                6.11572265625
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "2/3552"
+            },
+            "involuntary_context_switches": 22419,
+            "peak_rss_kb": 3404308,
+            "precise_child_system_seconds": 0.8932810000000018,
+            "precise_child_user_seconds": 6.953988999999979,
+            "system_seconds": 0.89,
+            "user_seconds": 6.95,
+            "voluntary_context_switches": 37427,
+            "wall_nanos": 7882223476
+          },
+          "host_before_pair": {
+            "affinity_cpu_frequency_khz": "4452676",
+            "available_logical_cpus": 1,
+            "concurrent_lake_lean_count": 9,
+            "cpu_affinity": [
+              19
+            ],
+            "cpu_pressure": "some avg10=10.76 avg60=9.30 avg300=9.64 total=7693911846\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+            "cpu_pressure_some_total_us": 7693911846,
+            "load_1m_per_available_cpu": 4.56689453125,
+            "load_1m_per_cpu": 0.047571818033854164,
+            "load_average": [
+              4.56689453125,
+              4.39111328125,
+              6.11572265625
+            ],
+            "logical_cpus": 96,
+            "runnable_tasks": "3/3552"
+          },
+          "measurement_attempt": 2,
+          "pair": "refined-6",
+          "preflight": {
+            "accepted_window": {
+              "issues": [],
+              "max_busy_ticks": 2,
+              "per_cpu": {
+                "19": {
+                  "noninterrupt_busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                },
+                "67": {
+                  "busy_ticks": 0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 200,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "window_seconds": 2.0
+            },
+            "admitted": true,
+            "elapsed_seconds": 2.0010201218537986,
+            "rejected_windows": []
+          },
+          "reference": {
+            "axioms": null,
+            "cpu_accounting": {
+              "aggregate_core_interference_seconds": 0.009336999999899795,
+              "child_cpu_seconds": 5.4296140000001,
+              "child_cpu_source": "getrusage-reaped-children",
+              "clock_ticks_per_second": 100,
+              "frequency_time_in_state_ticks": {
+                "1500000": 0,
+                "2300000": 0,
+                "3150000": 545
+              },
+              "mean_frequency_khz": 3150000.0,
+              "measurement_cpu_foreign_seconds": 0.009336999999899795,
+              "measurement_cpu_interrupt_seconds": 0.01,
+              "measurement_cpu_noninterrupt_residual_seconds": 0.009336999999899795,
+              "measurement_cpu_residual_seconds": 0.019336999999899795,
+              "per_cpu": {
+                "19": {
+                  "busy_seconds": 5.45,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 0,
+                    "iowait": 0,
+                    "irq": 1,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 88,
+                    "user": 456
+                  }
+                },
+                "67": {
+                  "busy_seconds": 0.0,
+                  "ticks": {
+                    "guest": 0,
+                    "guest_nice": 0,
+                    "idle": 545,
+                    "iowait": 0,
+                    "irq": 0,
+                    "nice": 0,
+                    "softirq": 0,
+                    "steal": 0,
+                    "system": 0,
+                    "user": 0
+                  }
+                }
+              },
+              "pressure_some_delta_us": 393634,
+              "runner_cpu_seconds": 0.0010490000000000776
+            },
+            "cpu_percent": 99.0,
+            "host_after": {
+              "affinity_cpu_frequency_khz": "4451997",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 10,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=7.85 avg60=8.91 avg300=9.54 total=7695071791\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7695071791,
+              "load_1m_per_available_cpu": 5.06298828125,
+              "load_1m_per_cpu": 0.052739461263020836,
+              "load_average": [
+                5.06298828125,
+                4.50390625,
+                6.12451171875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "4/3575"
+            },
+            "host_before": {
+              "affinity_cpu_frequency_khz": "4449247",
+              "available_logical_cpus": 1,
+              "concurrent_lake_lean_count": 10,
+              "cpu_affinity": [
+                19
+              ],
+              "cpu_pressure": "some avg10=9.08 avg60=9.18 avg300=9.61 total=7694678157\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0",
+              "cpu_pressure_some_total_us": 7694678157,
+              "load_1m_per_available_cpu": 4.72021484375,
+              "load_1m_per_cpu": 0.049168904622395836,
+              "load_average": [
+                4.72021484375,
+                4.427734375,
+                6.10888671875
+              ],
+              "logical_cpus": 96,
+              "runnable_tasks": "3/3535"
+            },
+            "involuntary_context_switches": 21732,
+            "peak_rss_kb": 3081660,
+            "precise_child_system_seconds": 0.8701160000000243,
+            "precise_child_user_seconds": 4.559498000000076,
+            "system_seconds": 0.86,
+            "user_seconds": 4.55,
+            "voluntary_context_switches": 36562,
+            "wall_nanos": 5454379478
+          },
+          "round": 6,
+          "signed_wall_delta_nanos": 2427843998,
+          "slot_index": 2
+        }
+      ],
+      "signed_wall_delta_nanos": [
+        2549314815,
+        2516583452,
+        2526678256,
+        2493721744,
+        2533144166,
+        2427843998
+      ],
+      "width_bits": 20
+    }
+  },
+  "schema": "hex-real-roots-mathlib-proof-probe-v4",
+  "source_sha256": {
+    "HexArith/Barrett/Context.lean": "4c2f02160593b1e5d5039419a514de92460c87ffd6b31c6314aa26ed5e74b251",
+    "HexArith/Barrett/Reduce.lean": "cbd8636dfd24ef347eb906761359e649dcbbea54f6f06b4b42ac109ae972e66d",
+    "HexArith/Barrett/ReduceNat.lean": "0fded93eb3e4127009e1133fceaf954e0142fcf0e56ffbe08665501a7c9f0bbf",
+    "HexArith/ExtGcd.lean": "8dc204af962c022e33ab36b73231efa3d674f07585ddbd25a61b6f244853b5f6",
+    "HexArith/Montgomery/Context.lean": "a835bceb22dcb48baeef3c112d4ae9bd6ee0feacb45730f0652e34a3b28a4974",
+    "HexArith/Montgomery/InvNat.lean": "aea19a3bb6068e652456e9ec7b615a9379bf06a88c82538f961600a66b321e52",
+    "HexArith/Montgomery/Redc.lean": "391ed6511367a612eef1e054699c60064e28fba8ae68bfb67c7f25ad228cdea2",
+    "HexArith/Montgomery/RedcNat.lean": "a386bbf1ca24d507759aacc31ac8bbbf483f978bcd48d40407da3ae8ea8f016b",
+    "HexArith/Nat/ModArith.lean": "25e3156a04d2b3bfbd8a9be455baf17099193b1d753ae866d564e8531d9d0e83",
+    "HexArith/Nat/Prime.lean": "8c78ad43ff77a87a7846acc3daca6667ef74bc3a4f1f1e93584d4c0128db6ab3",
+    "HexArith/UInt64/Wide.lean": "f024ce31df73b33a770b7bba2a849cc156d8f0407ae099babe5f4552ba590d5c",
+    "HexBasic.lean": "f14ef808be6797a958f0d9684e5e24b712ff5b22a4910fadfd53b1795c6ad70b",
+    "HexBasic/ArrayDecEq.lean": "3401d0c2138929f5c95d4de1527fd9056875dee60505b693f40f65c9108cc4c8",
+    "HexBasic/Fold.lean": "ac12f3163f3d35b9cb16356bb7ddfc59f3f56a030f54eef3db854fe176c50f8d",
+    "HexBasic/ListShim.lean": "7e622eac33f0e4f89e5055217c9f8f807827b2cf4e4ba8150648c4702475c8d1",
+    "HexBasic/ModuleBoundaryTests.lean": "843dcaadf3a2a764b39b09bb149de96dda9005e44442e7162fe9e2fa55f68cb3",
+    "HexBasic/OfFn.lean": "f6759234abfc02a07a83141dbd068a7d2da7b3bf2d3395a2cd1d0098adbd3f38",
+    "HexBasic/Vector/Modify.lean": "a60c484f4d875213bb35cc0f93946e818e4beaf242c4b3f2bcb4db88bb8c8af2",
+    "HexHensel/Basic.lean": "7b7bb4a223ba53585906eb7bc16e0c7cd808d45c2712201d73b21bd089779435",
+    "HexModArith.lean": "cd48384495d507320178431d8af0a40b4bedd9cd4b0e3e512bcf725a1e8a1887",
+    "HexModArith/Basic.lean": "17907ba0fa6dbfd382a168c519ac3c997a8a635ba5fc70707ac252e8d7faa66a",
+    "HexModArith/HotLoop.lean": "9be44bfa8f8449a2dad18f7683436d42297a5dce4ec5dedd799bb2d2ef264215",
+    "HexModArith/Prime.lean": "a60a8b89719834d9227fcd3f1aca0c36199e9e22886289343e92afced224948c",
+    "HexModArith/Ring.lean": "97f17c64dd1cdbc64920357f36de3d2ca6e271707054293ee4d57a396fe3af62",
+    "HexModArith/WordMod.lean": "367944e38a4f184bdd273e81e5353c1f19c3b21b4a9946c02e09cfb3faedf802",
+    "HexModArithMathlib.lean": "18e681f9fc979e5a0a85a227547d738ef503fb2d93da84eb2d2de40aa43ecf41",
+    "HexModArithMathlib/Basic.lean": "021d787bb5091ef1c46ef99e67fd0317892b5f3e7efe78b8018b3eea82971993",
+    "HexModArithMathlib/WordMod.lean": "42787a21e10cebaa2edc5dca414a653de0ce204fd13738ba2d2ea8a7edf64439",
+    "HexPoly.lean": "8d55ba3432fae6b4460cae93e12386809720b89037a5ec46cc4131c93c524abb",
+    "HexPoly/Dense.lean": "e2421b24388e6e97ad2cee3d6cd2978ef2b0701ee260b479c914ed0b033de480",
+    "HexPoly/Euclid.lean": "7210a7790b63c2e54f4c0ea65470b8d53005aa0ddc7010a4470569a9c7b3020c",
+    "HexPoly/Euclid/Content.lean": "8531b03295550cf245dc034984268361bbb456ef5c1c94c2bc54ae678798eaf3",
+    "HexPoly/Euclid/DivGcd.lean": "a5bec9ea75cc08cb28eebe9aae2d5dd81d76f53493483eb9cd69362923c2266a",
+    "HexPoly/Euclid/MonicUnique.lean": "aebf877937c4f27465c89186086e82d054b40352a5e6cc4ad522ffdf09c3ba1c",
+    "HexPoly/Euclid/MulRing.lean": "0d7e57ca2f07dc56706c860dfd355911283da240947c46b4c10d6250b4fdcbc6",
+    "HexPoly/Euclid/Reconstruction.lean": "54a880d2f60f7441f880ee352e00336f6d3b3ff415c4396d8f5fae2e471d7adf",
+    "HexPoly/Operations.lean": "8276babbafa8288257413770857c38ac646dde295283fdd603d6fab46d122756",
+    "HexPolyFp.lean": "58698a3d85dc77b7ccfe0d63a0a30f09422511a5f44aafbb267597226f102179",
+    "HexPolyFp/Compose.lean": "2eab4d7c3ed1328ed9c98af30524406a8dd5965f3f6fd86319b06e54fa39b5c8",
+    "HexPolyFp/Degree.lean": "e845103442ec3a8c06ff1f4faa6c96edcf514d8891a28bafb8c7fcf3a03a15a9",
+    "HexPolyFp/Enumeration.lean": "185a457481c5d0e14fc08a0b7ca0b242c1640d33befaee9807c610901c9cc4af",
+    "HexPolyFp/Field.lean": "03d915708d1cd59bc5f5a4514c26fdadb63fa06eeb98d825ab44a29e15936833",
+    "HexPolyFp/Frobenius.lean": "23594cd190ea93ec47ca6a02127106629c8295e808997319016921479eb0ce16",
+    "HexPolyFp/ModCompose.lean": "2cad99bdf73154c2ee91b2a0f3320c24076b940faf9d744c8d551233f3383f1b",
+    "HexPolyFp/Packed.lean": "442bc676392d15129015669a22f8ebdb2b6f5585d4744f67cf0de40655b9da88",
+    "HexPolyFp/PackedMul.lean": "0f4c0859140a3de03bc46047dd5c376d450ce0e8442b1864ab7d14a4835077c5",
+    "HexPolyFp/PrimeField.lean": "5fc229cea6842b7087c5753ba50e8e4c57376c6f4601bd2e59fe3a24fc7c0288",
+    "HexPolyFp/Quotient.lean": "0a1cb0aa9252ec50f4d705f02f2de27d9d4a6e46f903c00c8ffb86cadae51b14",
+    "HexPolyFp/Quotient/Ring.lean": "f74b8891309113ea63ec0e51e616630e2711a322b91de65fa279ca1e58944bba",
+    "HexPolyFp/QuotientFrobenius.lean": "27914abbbc5a14a2526bd4265f98dd6b8d32bfb2b275feffe0625e256d127641",
+    "HexPolyFp/Ring.lean": "8eccb7a0641a913dc84d2ac0cb886e2daefbae80bf56ad7400aaa29a7456b1d1",
+    "HexPolyFp/SquareFree.lean": "d4f7142e3a6aa8309439b520b1c92dd3360325bb0a7954d64b4b64652aadf094",
+    "HexPolyFp/SquareFree/Algebra.lean": "3f5f2667ce6302f79a67a7ec47ff0728fff59259eb637105b442e61a083b33d1",
+    "HexPolyFp/SquareFree/YunContribution.lean": "d6170fba2189f91b130adf7159963a512ea2702be08c5f2f00701e28e1a1f994",
+    "HexPolyFp/SquareFree/YunCorrect.lean": "a685674a66a2a58fac77e6ceaa28a2ae2e2eb1431ac959390ee7e9939c78785a",
+    "HexPolyFp/SquareFree/YunMeasure.lean": "84218f872dcc195cde41711c92a248d17c6d174705dcc718a9fbe6269dcaa974",
+    "HexPolyFp/SquareFree/YunReduce.lean": "64e0d0311c91373d3ae60cd17b5724a1a076fb73d31dc6b6c76b481ac19f245f",
+    "HexPolyMathlib/Basic.lean": "7ec6801dd41ccf6c87ec63077c6c5cb800bada6cd764b0597c6f74790d1e8821",
+    "HexPolyMathlib/Euclid.lean": "6d97a180e3114dadd71c6f13d5ee3481e6d360203585b21c597cb86e730487e7",
+    "HexPolyZ.lean": "5764f48df0d3e9a807841fa995f44cc8067719135ee9bce27840727daab3584f",
+    "HexPolyZ/Core.lean": "2e40375eb1275c83ca760db00fc551c29f8fdfee060f1e504aafd903fba7aa0f",
+    "HexPolyZ/Decomposition.lean": "6a6dfbf97e313fc0f3377e01ea0b94a985549a6a4ec95b10ee466767144738cf",
+    "HexPolyZ/Mignotte.lean": "1c78842fa3047a8796485ee68d464fbeaf6aa2802fb3a982294d0e62c96d5b54",
+    "HexPolyZ/Rational.lean": "7b9acea41698ac622050152caf10d784b90caa4d04f1cd6bd513d5eeef3b4bda",
+    "HexPolyZMathlib/Basic.lean": "1655922d465a47f8bbb89daf49478f6a403150e312a31be797e21fc35d9e88d0",
+    "HexPolyZMathlib/Discriminant.lean": "31f3490708222e5a919eb246dc7cb0cbbf97bbb8b00c2fa8e62dcc30e33dd203",
+    "HexPolyZMathlib/Hadamard.lean": "98226b0abddabdc3d706bbda7b0775650c5b03893948e04e69fef32b59ef52a2",
+    "HexPolyZMathlib/MahlerSeparation.lean": "84a35af5e74c3c7ba977ae0aa3a1f8bed6b638622d09f753e27c6a958a7eaf2c",
+    "HexPolyZMathlib/Mignotte.lean": "d90665494a875f77ab3a662a3fd16655352d027bdebca9c30a76b0b22c0141ec",
+    "HexPolyZMathlib/PolyParse.lean": "556828eb212a68f0c95bcbc17c237d2a056019a31ef26d4fc1540d29a9f5bd33",
+    "HexPolyZMathlib/Squarefree.lean": "c4b24b1bce83f63f793bcbf578d306c87955203e9a991ce473fb438aea1b08c8",
+    "HexRealRoots/Basic.lean": "287870a529ab2d9690f42f7051b8ea861a1e648f7a561465131b3538515c174f",
+    "HexRealRoots/Cert.lean": "2fd9ef2c8bf17752db901af11dcf6cb36a8e80f2508b09d37c0ef8f6a555cd61",
+    "HexRealRoots/Chain.lean": "e67fbaa17bd5deec18afb46deeaee3d85a89b17b971daf19015d348f39729788",
+    "HexRealRoots/Isolate.lean": "80c4147e1d601f10e6607cf173a38611ebc2e0b8c3d2abfe48b04d9ef042424b",
+    "HexRealRoots/IsolateDescartes.lean": "fc1684c3b3c801a5e122edf9f3480c112e84f6110ef2fb302c7a6abacac2790b",
+    "HexRealRoots/IsolateSturm.lean": "620f05ff630a50fb5410b69fab6ef231f3306ee1729ba5196459a3f8d7771637",
+    "HexRealRoots/Mobius.lean": "06e839dd677386ceeb749855b05df13ba7418d2673f4fdaa9df2bbbcd81501b8",
+    "HexRealRoots/Prec.lean": "753a04a832a15894650fc363545817fa62c4d6619173bd03a6f230a16fd57346",
+    "HexRealRoots/Refine.lean": "16aa07ce0a2ef2ac34d9c8fe8aab707f15a294b73aedfd38f61b16f4aa3c6098",
+    "HexRealRoots/Var.lean": "b6a9be04c719aa1e59f65b706233c99df6efaa50b3264cbccfe62ed367be7004",
+    "HexRealRootsMathlib/ChainCorrespond.lean": "cc30f30eced93fdfb1ab39cb3e9cab2dc1dffac48aa777872b44cc2527506a5e",
+    "HexRealRootsMathlib/IsolateRoots.lean": "209fabedbd179cdd0573c23a9beec57a60edc17fe1fdea1599d10c5f26750563",
+    "HexRealRootsMathlib/IsolateRootsElab.lean": "c30f907b02fef7bac939139ba940153b58e7a0f00e0f100b01e2f11872c5103b",
+    "HexRealRootsMathlib/Isolations.lean": "d1160f2f5c2ca551ebd24fe5599b781be2f2f4edfb401201cf924bfa3daa154d",
+    "HexRealRootsMathlib/SPEC/hex-real-roots-mathlib.md": "9d629085c82d296479aad39aef821fed958e18e254f7ceb6dc675b23a24afe6b",
+    "HexRealRootsMathlib/Separation.lean": "ee74ae5daa9aebee72d830a17f4336644bab7306f254447f61fb0fa2bf1eaff6",
+    "HexRealRootsMathlib/SquareFreeCore.lean": "ec79eeda6c63c70c7495b940d08b42dc5eb3dd3d24e16bdffa2d49b01d81d21a",
+    "HexRealRootsMathlib/SturmChainDefs.lean": "cca39031c83b262fcc3e2fbd9b46581c1d9afba74150bc2d8e0a3cebe6d2a3eb",
+    "HexRealRootsMathlib/SturmTheorem.lean": "f945773356a095a3781dec50100bf92cc5fd2829a9bc68daa01d24fd33ad57a4",
+    "PLAN/Phase4.md": "2a082f817a29d886f75e90905c8a3bae43e2ee1629b6ff2f84f6d9c2cebd3cb0",
+    "SPEC/benchmarking.md": "1a9cd00863863ba6a8880cdab8cce15d936985e1b305625fa4dd97b2e9baf5f4",
+    "bench/HexRealRootsMathlib/ProofProbe/Baseline.lean": "0da4d9e6d999b77ecb7a8c79a6ec29670bc8c0f7eed1cbd9b5f082d6a6eed73e",
+    "bench/HexRealRootsMathlib/ProofProbe/Natural10.lean": "292b10798652f7c8f78cfd6a4e7c50c9245a1d276bd9d37053acdb906ff9e49b",
+    "bench/HexRealRootsMathlib/ProofProbe/Natural6.lean": "96c0c8e3114b03f0d9f6581b42ad4c1d431fd33d26aa72d485678ce7b1a4d279",
+    "bench/HexRealRootsMathlib/ProofProbe/Natural8.lean": "0c3f7848a1b514c3c70df9f1455c83cc6d11aeffd2db7170e15950e34a5ba90b",
+    "bench/HexRealRootsMathlib/ProofProbe/Refined2.lean": "84a77fda9b14a5ede6055992f5710b6c64ae0edf289e7e1511fa863626c6b6df",
+    "bench/HexRealRootsMathlib/ProofProbe/Refined4.lean": "10a01033dc9d90af0032be224110b5ccba6fd8a3799b28f9090583c7ef141c6a",
+    "bench/HexRealRootsMathlib/ProofProbe/Refined6.lean": "ecab8d2d4515089f21b9dab57b7d09f59aa2242181e499c459dc2b4824cb848e",
+    "lake-manifest.json": "5315ef9d575b3b13138a8e10e222cec2b7cf16a96069f550a79d2fe6d20e3264",
+    "lakefile.lean": "02a483134d53b46377c1eb8e937e884dbd13d464d869e78bab4585c84450700d",
+    "lean-toolchain": "72681913b978b3f7c2f48229836771f736f6e97d833917726b2263afbc6108ed",
+    "libraries.yml": "2bf014e8caad9d34fe7d511cf941ed2b60e805f5fa5184bff36e4d406b1b41b8",
+    "scripts/bench/fresh_module_sweep.py": "6c64fcfed9475f0232fb7dc81da48ecd87e751ce7d0ebfb1c9857418590861e3",
+    "scripts/bench/real_roots_mathlib_sweep.py": "8b4ea00d345148e31f7a46b8b19e7e489dc092227fc31715cbdbd9d64bbe6bd4",
+    "scripts/ci/check_benches_mathlib_free.py": "ad01bd8d9edd2f111fcc30d90b3a427a7b3301fc45d4a33bf8e59a9081008cad"
+  },
+  "validity": {
+    "exceptions": [],
+    "host_protocol": "designated-shared-host-v3",
+    "observed": {
+      "accounting_quantization_ticks": 3,
+      "expected_frequency_observations": 108,
+      "frequency_spread_ratio": 0.0,
+      "max_aggregate_core_interference_ratio": 0.004852309734784782,
+      "max_arm_mean_frequency_khz": 3150000.0,
+      "max_attempts_per_pair": 8,
+      "max_concurrent_lake_lean_count": 26,
+      "max_core_interference_ratio": 0.005,
+      "max_cpu_pressure_some_delta_us": 1572218,
+      "max_effective_core_interference_ratio": 0.005581030983831318,
+      "max_frequency_spread_ratio": 0.15,
+      "max_interference_allowance_seconds": 0.070840472005,
+      "max_load_1m_per_cpu": 0.09314473470052083,
+      "max_measurement_cpu_foreign_ratio": 0.002764602542622663,
+      "max_measurement_cpu_interrupt_ratio": 0.005581030983831318,
+      "max_preflight_wait_seconds": 16.007267453009263,
+      "max_smt_sibling_busy_ratio": 0.004261911856558909,
+      "measurement_cpu": 19,
+      "min_arm_mean_frequency_khz": 3150000.0,
+      "observed_frequency_observations": 108,
+      "smt_sibling_cpus": [
+        67
+      ],
+      "total_exhausted_pairs": 0,
+      "total_preflight_failures": 0,
+      "total_rejected_pair_attempts": 29,
+      "total_rejected_preflight_windows": 56,
+      "violations": []
+    },
+    "release_quality": true
+  }
+}

--- a/reports/hex-real-roots-mathlib-performance.md
+++ b/reports/hex-real-roots-mathlib-performance.md
@@ -1,0 +1,411 @@
+# HexRealRootsMathlib Performance Report
+
+## Bench Targets
+
+`HexRealRootsMathlib` is proof-only: it has no LeanBench executable or compiled runtime benchmark surface. These build-only fresh-module probes replace a compiled complexity registration for `isolate_roots` elaboration, proof emission, certificate replay, and ordinary kernel checking.
+Accordingly, this surface has no LeanBench registration, executable,
+`list`/`verify` entry, complexity verdict, or timed-region sampling profile.
+
+| probe | reference | candidate | case |
+|---|---|---|---|
+| `fresh-build-null` | `HexRealRootsMathlib.ProofProbe.Baseline` | `HexRealRootsMathlib.ProofProbe.Baseline` | baseline, calibration-only |
+| `natural-10-null` | `HexRealRootsMathlib.ProofProbe.Natural10` | `HexRealRootsMathlib.ProofProbe.Natural10` | natural-10, calibration-only |
+| `natural-6` | `HexRealRootsMathlib.ProofProbe.Baseline` | `HexRealRootsMathlib.ProofProbe.Natural6` | natural-width, degree 6 |
+| `natural-8` | `HexRealRootsMathlib.ProofProbe.Baseline` | `HexRealRootsMathlib.ProofProbe.Natural8` | natural-width, degree 8 |
+| `natural-10` | `HexRealRootsMathlib.ProofProbe.Baseline` | `HexRealRootsMathlib.ProofProbe.Natural10` | natural-width, degree 10 |
+| `refined-2` | `HexRealRootsMathlib.ProofProbe.Baseline` | `HexRealRootsMathlib.ProofProbe.Refined2` | width-2^-20, degree 2, width bits 20 |
+| `refined-4` | `HexRealRootsMathlib.ProofProbe.Baseline` | `HexRealRootsMathlib.ProofProbe.Refined4` | width-2^-20, degree 4, width bits 20 |
+| `refined-6` | `HexRealRootsMathlib.ProofProbe.Baseline` | `HexRealRootsMathlib.ProofProbe.Refined6` | width-2^-20, degree 6, width bits 20 |
+| `refine-6` | `HexRealRootsMathlib.ProofProbe.Natural6` | `HexRealRootsMathlib.ProofProbe.Refined6` | refinement-attribution, degree 6, width bits 20 |
+
+`HexRealRootsMathlibReplayProbe` supplies reduced CI coverage; `HexRealRootsMathlibReplayProbeScientific` owns the larger release arms.
+
+## Verdicts
+
+Scientific fresh-module run at commit `980aa6cb35ca38f804e308c05aca3e1c98d1c8b6` on designated host `chungus2`, logical CPU `19`.
+
+Exact command invoked:
+
+```sh
+python3 scripts/bench/real_roots_mathlib_sweep.py --samples 6 \
+  --timeout 180 --warm-timeout 600 \
+  --shared-host --expected-host chungus2 --cpu 19 \
+  --max-core-interference-ratio 0.005 \
+  --output /tmp/real-roots-mathlib-shared-980aa6cb-cpu19-r005.json
+```
+
+The artifact below is the byte-for-byte committed copy of that `/tmp` output.
+
+| field | artifact value |
+|---|---|
+| artifact | `reports/bench-results/hex-real-roots-mathlib-980aa6cb-chungus2.json` |
+| artifact SHA-256 | `599a14c3971313d86ae23005d96b3484b963ef17535205a7012cd3be672cec3c` |
+| embedded source-hash map | `source_sha256` in the cited artifact |
+| schema | `hex-real-roots-mathlib-proof-probe-v4` |
+| measurement | `paired-fresh-module-olean-wall-v1` |
+| measurement state | `complete` |
+| release quality | `True` |
+| host protocol | `designated-shared-host-v3` |
+| accepted paired samples | 54 |
+| rejected pair attempts | 29 |
+| rejected preflight windows | 56 |
+| preflight failures | 0 |
+| exhausted pairs | 0 |
+| maximum admitted aggregate core-interference ratio | 0.004852 |
+| maximum effective quantized core-interference ratio | 0.005581 |
+| maximum core-interference allowance | 0.070840472 s |
+| maximum preflight wait | 16.007267453 s |
+
+Every sample cell is `reference / candidate / signed candidate−reference`; wall times are exact nanosecond values rendered as seconds. `R→C` and `C→R` record build orientation, and `aN` records the admitted complete-pair attempt.
+
+Null controls are descriptive only: their medians are not subtracted, their ranges do not widen a budget, and they are neither significance tests nor scientific evidence.
+
+### Null-control raw samples
+
+| control | round 1 | round 2 | round 3 | round 4 | round 5 | round 6 |
+|---|---|---|---|---|---|---|
+| `fresh-build-null` | a1, R→C; 5.592209936 s / 5.533458716 s / -0.058751220 s | a1, C→R; 5.444541821 s / 5.396453762 s / -0.048088059 s | a1, R→C; 5.377861840 s / 5.408055623 s / +0.030193783 s | a1, C→R; 5.440203345 s / 5.427048728 s / -0.013154617 s | a1, R→C; 5.422219460 s / 5.410256667 s / -0.011962793 s | a3, C→R; 5.415899069 s / 5.405701573 s / -0.010197496 s |
+| `natural-10-null` | a1, R→C; 14.029235500 s / 14.009825989 s / -0.019409511 s | a1, C→R; 14.168094401 s / 13.905708794 s / -0.262385607 s | a1, R→C; 13.996509930 s / 13.988265522 s / -0.008244408 s | a1, C→R; 14.107348172 s / 13.892291469 s / -0.215056703 s | a1, R→C; 13.995542233 s / 13.912509150 s / -0.083033083 s | a1, C→R; 14.147974333 s / 14.092522261 s / -0.055452072 s |
+
+### Null-control ranges and medians
+
+| control | signed range | absolute span | per-sample Δ/reference relative range | median relative delta | median signed delta | zero-centred envelope | build magnitude |
+|---|---|---|---|---|---|---|---|
+| `fresh-build-null` | -0.058751220 s … +0.030193783 s | 0.088945003 s | -1.050590% … +0.561446%; span 1.612036% | -0.231215% | -0.012558705 s | 0.058751220 s | 5.431211402 s |
+| `natural-10-null` | -0.262385607 s … -0.008244408 s | 0.254141199 s | -1.851947% … -0.058903%; span 1.793044% | -0.492613% | -0.069242577 s | 0.262385607 s | 14.068291836 s |
+
+### Substantive raw samples
+
+| proof pair | round 1 | round 2 | round 3 | round 4 | round 5 | round 6 |
+|---|---|---|---|---|---|---|
+| `natural-6` | a1, R→C; 5.406263264 s / 7.719611977 s / +2.313348713 s | a1, C→R; 5.445058923 s / 7.730131454 s / +2.285072531 s | a1, R→C; 5.413837706 s / 7.739279478 s / +2.325441772 s | a1, C→R; 5.426402671 s / 7.720836410 s / +2.294433739 s | a1, R→C; 5.454486095 s / 7.829473694 s / +2.374987599 s | a2, C→R; 5.407957685 s / 7.700949318 s / +2.292991633 s |
+| `natural-8` | a1, R→C; 5.408429304 s / 10.090289348 s / +4.681860044 s | a1, C→R; 5.415701786 s / 9.994418987 s / +4.578717201 s | a1, R→C; 5.388675369 s / 10.003936595 s / +4.615261226 s | a1, C→R; 5.410977621 s / 10.087155971 s / +4.676178350 s | a1, R→C; 5.420620375 s / 9.967137423 s / +4.546517048 s | a1, C→R; 5.431320377 s / 10.055889497 s / +4.624569120 s |
+| `natural-10` | a3, R→C; 5.430992041 s / 14.148779516 s / +8.717787475 s | a1, C→R; 5.399323731 s / 14.078188855 s / +8.678865124 s | a2, R→C; 5.391809845 s / 13.983664428 s / +8.591854583 s | a2, C→R; 5.437915920 s / 13.910004293 s / +8.472088373 s | a2, R→C; 5.381381128 s / 14.082009273 s / +8.700628145 s | a1, C→R; 5.409544528 s / 14.146734419 s / +8.737189891 s |
+| `refined-2` | a1, R→C; 5.392219433 s / 5.860059392 s / +0.467839959 s | a1, C→R; 5.385903783 s / 5.826010272 s / +0.440106489 s | a2, R→C; 5.475259330 s / 5.895317954 s / +0.420058624 s | a1, C→R; 5.397891676 s / 5.873718502 s / +0.475826826 s | a1, R→C; 5.427142718 s / 5.932320495 s / +0.505177777 s | a1, C→R; 5.385626497 s / 5.864198710 s / +0.478572213 s |
+| `refined-4` | a4, R→C; 5.400468358 s / 6.537041473 s / +1.136573115 s | a2, C→R; 5.395939151 s / 6.582755167 s / +1.186816016 s | a1, R→C; 5.394786006 s / 6.527139042 s / +1.132353036 s | a1, C→R; 5.389144171 s / 6.512718804 s / +1.123574633 s | a2, R→C; 5.411283028 s / 6.590521033 s / +1.179238005 s | a1, C→R; 5.471002770 s / 6.564418368 s / +1.093415598 s |
+| `refined-6` | a3, R→C; 5.375350914 s / 7.924665729 s / +2.549314815 s | a2, C→R; 5.390052662 s / 7.906636114 s / +2.516583452 s | a1, R→C; 5.399859130 s / 7.926537386 s / +2.526678256 s | a1, C→R; 5.401521213 s / 7.895242957 s / +2.493721744 s | a1, R→C; 5.395109360 s / 7.928253526 s / +2.533144166 s | a2, C→R; 5.454379478 s / 7.882223476 s / +2.427843998 s |
+| `refine-6` | a2, R→C; 7.706459520 s / 7.912982704 s / +0.206523184 s | a1, C→R; 7.775535234 s / 7.935257549 s / +0.159722315 s | a3, R→C; 7.739454907 s / 7.919626520 s / +0.180171613 s | a1, C→R; 7.712374337 s / 7.925957366 s / +0.213583029 s | a2, R→C; 7.711063227 s / 7.941502349 s / +0.230439122 s | a8, C→R; 7.752394631 s / 7.914290969 s / +0.161896338 s |
+
+### Substantive summaries
+
+| proof pair | median reference | median candidate | median signed delta | control | magnitude ratio | raw control span | raw control envelope | scaled span | scaled envelope | resolution |
+|---|---|---|---|---|---|---|---|---|---|---|
+| `natural-6` | 5.420120188 s | 7.725483932 s | +2.303891226 s | fresh-build-null | 1.422424 | 0.088945003 s | 0.058751220 s | 0.126517483 s | 0.083569129 s | resolved |
+| `natural-8` | 5.413339703 s | 10.029913046 s | +4.619915173 s | natural-10-null | 1.402633 | 0.254141199 s | 0.262385607 s | 0.254141199 s | 0.262385607 s | resolved |
+| `natural-10` | 5.404434129 s | 14.080099064 s | +8.689746634 s | natural-10-null | 1.000839 | 0.254141199 s | 0.262385607 s | 0.254354495 s | 0.262605822 s | resolved |
+| `refined-2` | 5.395055554 s | 5.868958606 s | +0.471833392 s | fresh-build-null | 1.080598 | 0.088945003 s | 0.058751220 s | 0.096113833 s | 0.063486478 s | resolved |
+| `refined-4` | 5.398203754 s | 6.550729920 s | +1.134463075 s | fresh-build-null | 1.206127 | 0.088945003 s | 0.058751220 s | 0.107278957 s | 0.070861425 s | resolved |
+| `refined-6` | 5.397484245 s | 7.915650921 s | +2.521630854 s | fresh-build-null | 1.457437 | 0.088945003 s | 0.058751220 s | 0.129631779 s | 0.085626229 s | resolved |
+| `refine-6` | 7.725914622 s | 7.922791943 s | +0.193347398 s | fresh-build-null | 1.458752 | 0.088945003 s | 0.058751220 s | 0.129748725 s | 0.085703476 s | resolved |
+
+Every practical-limit case in the SPEC completed well below the 180 s arm
+timeout. The `natural-6`, `natural-8`, and `natural-10` candidate medians are
+7.725483932 s, 10.029913046 s, and 14.080099064 s. At width `2^-20`, the
+`refined-2`, `refined-4`, and `refined-6` candidate medians are 5.868958606 s,
+6.550729920 s, and 7.915650921 s. The direct degree-6 refinement attribution is
++0.193347398 s. These results support the stated “cost seconds” practical
+limits through natural degree 10 and refined degree 6; they do not extrapolate
+beyond those cases or constitute an asymptotic verdict.
+
+These are raw proof-track timings, never complexity verdicts. The reported timing is not corrected. Only wholly clean adjacent pair attempts enter the tables; rejected attempts and preflight windows remain in the cited artifact.
+
+### Axiom validation and emitted artifact sizes
+
+| module | expected axioms | observed axioms | ilean_bytes | olean_bytes | olean_private_bytes | olean_server_bytes | source_bytes |
+|---|---|---|---|---|---|---|---|
+| `HexRealRootsMathlib.ProofProbe.Baseline` | null | null | 168 | 1584 | 96 | 912 | 422 |
+| `HexRealRootsMathlib.ProofProbe.Natural10` | [propext, Classical.choice, Quot.sound] | [propext, Classical.choice, Quot.sound] | 2348 | 12528 | 684008 | 1200 | 803 |
+| `HexRealRootsMathlib.ProofProbe.Natural6` | [propext, Classical.choice, Quot.sound] | [propext, Classical.choice, Quot.sound] | 1872 | 10576 | 393360 | 1200 | 717 |
+| `HexRealRootsMathlib.ProofProbe.Natural8` | [propext, Classical.choice, Quot.sound] | [propext, Classical.choice, Quot.sound] | 2095 | 11552 | 529280 | 1200 | 757 |
+| `HexRealRootsMathlib.ProofProbe.Refined2` | [propext, Classical.choice, Quot.sound] | [propext, Classical.choice, Quot.sound] | 1486 | 8624 | 203792 | 1184 | 628 |
+| `HexRealRootsMathlib.ProofProbe.Refined4` | [propext, Classical.choice, Quot.sound] | [propext, Classical.choice, Quot.sound] | 1706 | 9600 | 313536 | 1184 | 678 |
+| `HexRealRootsMathlib.ProofProbe.Refined6` | [propext, Classical.choice, Quot.sound] | [propext, Classical.choice, Quot.sound] | 1928 | 10576 | 442928 | 1184 | 732 |
+
+### Provenance and configuration
+
+| environment field | artifact value |
+|---|---|
+| git commit | 980aa6cb35ca38f804e308c05aca3e1c98d1c8b6 |
+| git dirty | False |
+| toolchain | leanprover/lean4:v4.32.0-rc1 |
+| hostname | chungus2 |
+| platform | Linux-6.12.95-x86_64-with-glibc2.42 |
+| machine ID | 8be29815875342aeaae06e62d60f6b03 |
+| architecture | x86_64 |
+| CPU model | AMD EPYC 9455 48-Core Processor |
+| Python | 3.13.13 |
+| GNU time | /run/current-system/sw/bin/time |
+
+Repository checkout:
+
+```json
+{
+  "dirty": false,
+  "head": "980aa6cb35ca38f804e308c05aca3e1c98d1c8b6",
+  "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2",
+  "state_sha256": "588ab971c00b5937815878498fd50d0a388cd0a4d238145f1ee355bb17759f73",
+  "status": "",
+  "tree": "544c1f111ae30d11b35769b66d652f469aaf6f9d"
+}
+```
+
+Dependency checkouts:
+
+```json
+{
+  "Cli": {
+    "dirty": false,
+    "head": "406ebb8c8e2f7e852a1b47764b42494022ce652c",
+    "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/Cli",
+    "state_sha256": "fb2685089426172e1b49f64e334d41075b6e97d0252efe3d1df5a75814dd691f",
+    "status": "",
+    "tree": "11e883f1e68348ff48d70ea6d9a1585003ab637a"
+  },
+  "LeanSearchClient": {
+    "dirty": false,
+    "head": "c5d5b8fe6e5158def25cd28eb94e4141ad97c843",
+    "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/LeanSearchClient",
+    "state_sha256": "8b9080c6fd5f0b3dac562f7a58b88dec467e78a184f04bfa705c093472d80169",
+    "status": "",
+    "tree": "d0224b6df6c90cc0b4ed2db6218037d31bfd6f52"
+  },
+  "MD4Lean": {
+    "dirty": false,
+    "head": "6a3fb240133bcb7e1a066fdc784b3fdc304e3fc5",
+    "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/MD4Lean",
+    "state_sha256": "56401822ddb0ee856118cc0d88e47de19c48802beed7c54e082f8a8dcf0563ff",
+    "status": "",
+    "tree": "5d02fb3fef67944b3dd4242b7fc16170d258a260"
+  },
+  "Qq": {
+    "dirty": false,
+    "head": "7a62bd13860cd39ac98da16ffc8c24d601353f69",
+    "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/Qq",
+    "state_sha256": "8e892eae3878af5d430b1bbcafc17664658d4a2502e353e53aec776a911a9122",
+    "status": "",
+    "tree": "31d436cbc8e28daf7c850d80738cab0e25a47e35"
+  },
+  "aesop": {
+    "dirty": false,
+    "head": "b5b9e2bb45ce91e4bc44eaa738c3a8910404ab82",
+    "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/aesop",
+    "state_sha256": "07d9db85cd9e004c7ff5e9bb0d500f10675cac6579c00984aa2a60764623db99",
+    "status": "",
+    "tree": "7ba23c52c2f9919b48c85b15f1ea36d916336d0a"
+  },
+  "batteries": {
+    "dirty": false,
+    "head": "77d3cc514f987c1f42f2bbd8a8d56855012dc115",
+    "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/batteries",
+    "state_sha256": "7e4fba14b402b73d6dbdbc8dc24f856c5d2a4aba1486b5dec093e599d72fb3f0",
+    "status": "",
+    "tree": "bbe05462df1fbe6974b8c22012f3d6d5d40f3d07"
+  },
+  "illuminate": {
+    "dirty": false,
+    "head": "ae95e7e7d01c072421732d0b84cf63ff903f4f0e",
+    "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/illuminate",
+    "state_sha256": "4e09f250a3dbb90216dd81eac9cd81fa63bcc452c035007feee4cdee17360d0f",
+    "status": "",
+    "tree": "2ef0cbaea821858d59680c9f8cbbe3d63ba031b0"
+  },
+  "importGraph": {
+    "dirty": false,
+    "head": "41f407a8e85b0fdc00910633a8f14754139b63f4",
+    "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/importGraph",
+    "state_sha256": "1e52ae39caffca1f19a5659523096b1c89c6472be660b3e95e202baee1b14657",
+    "status": "",
+    "tree": "7f8fb8b03b5681128ed3b0351290c9a44b79215d"
+  },
+  "lean-bench": {
+    "dirty": false,
+    "head": "fa30c2763cf523f3ac8e46dc3a1dad0845a40098",
+    "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/lean-bench",
+    "state_sha256": "689f9504c42512f18b20bb58391f1b3026e7a114591037ba1c2e4400db003ff9",
+    "status": "",
+    "tree": "5e2c6d004439e19a8fc005e136fea4beb9f28c5b"
+  },
+  "mathlib": {
+    "dirty": false,
+    "head": "aaedc74a09fbe1da58b11cf4d27806a6fa1a86eb",
+    "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/mathlib",
+    "state_sha256": "22581931070b9bea48e4d573b0d7eb193825a874c7c225e6b993e58750244e59",
+    "status": "",
+    "tree": "64f34bbc25b6bf7dd3a36524438065214d0518a4"
+  },
+  "plausible": {
+    "dirty": false,
+    "head": "f3c7bd5061bd81b4480295c524d4f245c8b7e4e2",
+    "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/plausible",
+    "state_sha256": "770da451657fb96675011f952038b40e5c49a0e967bb841f2617a924e920a5c3",
+    "status": "",
+    "tree": "751b1c6d14208cb74ccbd501d3015ef6c1ee7fc9"
+  },
+  "proofwidgets": {
+    "dirty": false,
+    "head": "e6518a674e62de322b8f79eebeda7bcae2a36bc3",
+    "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/proofwidgets",
+    "state_sha256": "16a41a3fef265fc102fd81c2e0f1dd00a3f02df5d86b0baa9004116935633a4a",
+    "status": "",
+    "tree": "af612c47c0ddeea7a0bbaee7d3fd69ddab46a903"
+  },
+  "subverso": {
+    "dirty": false,
+    "head": "0bd508e8362f56d4a05cbf63614d4c97db954041",
+    "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/subverso",
+    "state_sha256": "e41d0e99844c299108a75ab96d2e988105f3792abf3664870f3a4692101214ef",
+    "status": "",
+    "tree": "f85ca946cf9618c87d4cf25a77089968e8504c4f"
+  },
+  "verso": {
+    "dirty": false,
+    "head": "8cb04559a9b9feb8efab43e135f662514561f668",
+    "path": "/home/kim/worktrees/hex-dev/hex-dev-shared-host-v2/.lake/packages/verso",
+    "state_sha256": "7cd0b36c7bd143024db6539906d00ac9431a2b9a668099cbdc204734701465ee",
+    "status": "",
+    "tree": "1e41fb0014e5125403fb09290628faecfc37ed70"
+  }
+}
+```
+
+The complete per-source SHA-256 map is retained under `source_sha256` in the cited artifact; the artifact file itself is anchored above by SHA-256 `599a14c3971313d86ae23005d96b3484b963ef17535205a7012cd3be672cec3c`.
+
+Recorded configuration:
+
+```json
+{
+  "accounting_quantization_ticks": 3,
+  "allow_busy": false,
+  "allow_dirty": false,
+  "command_template": "lake build +<module>:olean",
+  "core_interference_accounting": "measurement-cpu-foreign-plus-all-SMT-sibling-busy",
+  "cpu_affinity": [
+    19
+  ],
+  "cpu_topology": {
+    "core_id": "49",
+    "logical_cpu": 19,
+    "physical_package_id": "0",
+    "scaling_cur_freq_khz": "4447033",
+    "scaling_governor": "schedutil",
+    "thread_siblings_list": "19,67"
+  },
+  "expected_host": "chungus2",
+  "frequency_measurement": "cpufreq-time-in-state-arm-mean",
+  "lean_num_threads": "1",
+  "max_core_interference_ratio": 0.005,
+  "max_frequency_spread_ratio": 0.15,
+  "max_load_per_cpu": 0.5,
+  "max_pair_retries": 8,
+  "measurement_cpu_foreign_accounting": "busy-minus-child-minus-runner-minus-irq-softirq",
+  "minimum_control_magnitude_ratio": 2.0,
+  "null_magnitude_factor": 3.0,
+  "order": [
+    "fresh-build-null",
+    "natural-10-null",
+    "natural-6",
+    "natural-8",
+    "natural-10",
+    "refined-2",
+    "refined-4",
+    "refined-6",
+    "refine-6"
+  ],
+  "pairing": "adjacent measured reference and candidate fresh modules; contamination retries the complete oriented pair",
+  "preflight_max_busy_ticks": 2,
+  "preflight_timeout_seconds": 300.0,
+  "preflight_window_seconds": 2.0,
+  "requested_cpu": 19,
+  "rotation": "pairs left by round index; pair orientation alternates",
+  "samples": 6,
+  "shared_host": true,
+  "timeout_seconds": 180.0,
+  "warm_command_template": "lake build +<module>:deps",
+  "warm_timeout_seconds": 600.0
+}
+```
+
+### Shared-host interference observations
+
+```json
+{
+  "accounting_quantization_ticks": 3,
+  "expected_frequency_observations": 108,
+  "frequency_spread_ratio": 0.0,
+  "max_aggregate_core_interference_ratio": 0.004852309734784782,
+  "max_arm_mean_frequency_khz": 3150000.0,
+  "max_attempts_per_pair": 8,
+  "max_concurrent_lake_lean_count": 26,
+  "max_core_interference_ratio": 0.005,
+  "max_cpu_pressure_some_delta_us": 1572218,
+  "max_effective_core_interference_ratio": 0.005581030983831318,
+  "max_frequency_spread_ratio": 0.15,
+  "max_interference_allowance_seconds": 0.070840472005,
+  "max_load_1m_per_cpu": 0.09314473470052083,
+  "max_measurement_cpu_foreign_ratio": 0.002764602542622663,
+  "max_measurement_cpu_interrupt_ratio": 0.005581030983831318,
+  "max_preflight_wait_seconds": 16.007267453009263,
+  "max_smt_sibling_busy_ratio": 0.004261911856558909,
+  "measurement_cpu": 19,
+  "min_arm_mean_frequency_khz": 3150000.0,
+  "observed_frequency_observations": 108,
+  "smt_sibling_cpus": [
+    67
+  ],
+  "total_exhausted_pairs": 0,
+  "total_preflight_failures": 0,
+  "total_rejected_pair_attempts": 29,
+  "total_rejected_preflight_windows": 56,
+  "violations": []
+}
+```
+
+Rejected pair-attempt index:
+
+| pair | round | slot | attempt | issues | rejected preflight windows |
+|---|---|---|---|---|---|
+| natural-10 | 1 | 4 | 1 | natural-10 round 1 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.037s exceeds 0.030s | 0 |
+| natural-10 | 1 | 4 | 2 | natural-10 round 1 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.034s exceeds 0.030s | 5 |
+| refined-4 | 1 | 6 | 1 | refined-4 round 1 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.035s exceeds 0.030s | 7 |
+| refined-4 | 1 | 6 | 2 | refined-4 round 1 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.370s exceeds 0.030s; refined-4 round 1 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.130s exceeds 0.033s | 0 |
+| refined-4 | 1 | 6 | 3 | refined-4 round 1 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.036s exceeds 0.033s | 0 |
+| refined-6 | 1 | 7 | 1 | refined-6 round 1 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.060s exceeds 0.040s | 0 |
+| refined-6 | 1 | 7 | 2 | refined-6 round 1 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.034s exceeds 0.030s; refined-6 round 1 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.087s exceeds 0.040s | 0 |
+| refine-6 | 1 | 8 | 1 | refine-6 round 1 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.040s exceeds 0.039s | 0 |
+| refined-4 | 2 | 5 | 1 | refined-4 round 2 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.061s exceeds 0.030s | 0 |
+| refined-6 | 2 | 6 | 1 | refined-6 round 2 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.042s exceeds 0.030s | 0 |
+| natural-10 | 3 | 2 | 1 | natural-10 round 3 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.072s exceeds 0.070s | 0 |
+| refined-2 | 3 | 3 | 1 | refined-2 round 3 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.047s exceeds 0.030s | 0 |
+| refine-6 | 3 | 6 | 1 | refine-6 round 3 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.041s exceeds 0.040s | 0 |
+| refine-6 | 3 | 6 | 2 | refine-6 round 3 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.055s exceeds 0.040s; refine-6 round 3 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.083s exceeds 0.041s | 0 |
+| natural-10 | 4 | 1 | 1 | natural-10 round 4 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.170s exceeds 0.070s; natural-10 round 4 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.071s exceeds 0.030s | 0 |
+| natural-10 | 5 | 0 | 1 | natural-10 round 5 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.101s exceeds 0.070s | 0 |
+| refined-4 | 5 | 2 | 1 | refined-4 round 5 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 1.274s exceeds 0.030s | 0 |
+| refine-6 | 5 | 4 | 1 | refine-6 round 5 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.145s exceeds 0.039s | 0 |
+| refined-6 | 6 | 2 | 1 | refined-6 round 6 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.060s exceeds 0.030s | 0 |
+| refine-6 | 6 | 3 | 1 | refine-6 round 6 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.042s exceeds 0.040s; refine-6 round 6 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.044s exceeds 0.039s | 1 |
+| refine-6 | 6 | 3 | 2 | refine-6 round 6 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.055s exceeds 0.039s | 0 |
+| refine-6 | 6 | 3 | 3 | refine-6 round 6 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.090s exceeds 0.040s; refine-6 round 6 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.085s exceeds 0.039s | 1 |
+| refine-6 | 6 | 3 | 4 | refine-6 round 6 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.051s exceeds 0.040s | 4 |
+| refine-6 | 6 | 3 | 5 | refine-6 round 6 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.060s exceeds 0.040s; refine-6 round 6 reference: aggregate measurement-CPU foreign and SMT-sibling busy time 0.060s exceeds 0.040s | 0 |
+| refine-6 | 6 | 3 | 6 | refine-6 round 6 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.140s exceeds 0.041s | 2 |
+| refine-6 | 6 | 3 | 7 | refine-6 round 6 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.209s exceeds 0.041s | 2 |
+| fresh-build-null | 6 | 4 | 1 | fresh-build-null round 6 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.061s exceeds 0.030s | 0 |
+| fresh-build-null | 6 | 4 | 2 | fresh-build-null round 6 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.033s exceeds 0.030s | 0 |
+| natural-6 | 6 | 6 | 1 | natural-6 round 6 candidate: aggregate measurement-CPU foreign and SMT-sibling busy time 0.436s exceeds 0.040s | 1 |
+
+## Comparator Ratios
+
+`no-comparable-surface-in-named-comparator`: no external tool emits and kernel-checks the same Lean proof term.
+
+Executable isolation arithmetic belongs to the Mathlib-free `HexRealRoots` benchmark. The `HexRealRootsMathlib` bridge declarations have no separable compiled runtime kernel, so there are no external comparator ratios for this proof-emitting elaborator.
+
+## Profile
+
+Fresh-module elaboration, tactic, emitted-proof, and kernel-checking probes have no LeanBench timed region and therefore no sampling-profile obligation. Timed-region sampling does not apply.
+
+The replacement evidence is the raw rotated fresh-build artifact cited above, including compiler/proof artifact sizes, exact source hashes, repository and dependency provenance, axiom validation, host accounting, rejected attempts, and accepted adjacent pairs.
+
+## Concerns
+
+None.


### PR DESCRIPTION
Closes #8972.

## Summary

- commits a clean schema-v4 six-round fresh-module artifact from designated shared host `chungus2` using the merged shared-host-v3 protocol
- reports all 54 accepted adjacent pairs, 29 rejected complete-pair attempts, 56 rejected preflight windows, null controls, exact axioms/artifact sizes, provenance, and practical-limit interpretation
- documents that each run preregisters its actual logical CPU and interference ratio
- advances only `HexRealRootsMathlib.done_through` from 3 to 4

The artifact is release-quality with no exceptions, exhaustion, preflight failure, or Concern. All seven substantive proof deltas are resolved against magnitude-comparable null controls. This is proof-track evidence only: no LeanBench registration, executable, `list`/`verify` entry, asymptotic verdict, or timed-region profile is claimed.

## SPEC-edit rationale

The prior clause in `HexRealRootsMathlib/SPEC/hex-real-roots-mathlib.md` said that, on the named shared release machine, “the command is” a command pinned to literal CPU 22. That conflicts with the governing designated-shared-host protocol in `SPEC/benchmarking.md`, whose project goal is reproducible release evidence from a shared machine by preregistering an available logical CPU and its interference ceiling for each run. A permanently fixed busy core can make valid evidence impossible even when another core is admissible. The edit resolves that internal contradiction by making the invocation canonical while requiring the artifact’s actual preregistered CPU and ratio to govern.

## Performance rationale

No complexity declaration changes. The user-facing surface is elaboration/proof emission/kernel replay, so the governing evidence is fixed fresh-module builds rather than a compiled asymptotic benchmark.

## Validation

- independent artifact validator: 54 pairs / 108 arms, 106 source hashes, axioms, controls, retry/interference invariants: OK
- `lake build HexRealRootsMathlib HexRealRootsMathlibReplayProbe HexRealRootsMathlibReplayProbeScientific`
- `python3 scripts/check_phase4.py`
- `python3 scripts/check_dag.py`
- `python3 scripts/status.py HexRealRootsMathlib`
- `python3 scripts/ci/check_benches_mathlib_free.py`
- copyright, trust-surface, file-line, and diff checks
- two independent Sol audits: GO
- fresh Claude Opus review: GO
