### PR TITLE
number-field: prove semantic equality and zero tests

### DIFF
--- a/HexBerlekampZassenhaus/ProductProofs.lean
+++ b/HexBerlekampZassenhaus/ProductProofs.lean
@@ -411,6 +411,152 @@ theorem factorize_entries_primitive_of_ne_zero
     exact ⟨raw, hraw_mem, by simp only [hrecord, if_true]⟩
   exact hmem_filtered entry.1 hentry_in
 
+/-- Every recorded entry of a nonzero default factorization has positive
+degree.
+
+The recording filter alone does not exclude nonunit constants. Primitivity is
+the essential extra fact: a primitive constant is a unit, while recorded
+factors are nonunits. -/
+theorem factorize_entries_degree_pos
+    (f : ZPoly) (hf : f ≠ 0) :
+    ∀ entry ∈ (ZPoly.factorize f).factors, 0 < entry.1.degree?.getD 0 := by
+  intro entry hentry
+  have hmem := Array.mem_toList_iff.mpr hentry
+  exact degree_pos_of_primitive_norm_record entry.1
+    (factorize_entries_primitive_of_ne_zero f hf entry hentry)
+    (factorize_entry_normalizeFactorSign_id f entry hmem)
+    (factorize_entry_shouldRecord f entry hmem)
+
+private theorem factorPower_size (q : ZPoly) (hq : 0 < q.size) (n : Nat) :
+    (Factorization.factorPower q n).size = n * (q.size - 1) + 1 := by
+  induction n with
+  | zero =>
+      rw [Factorization.factorPower_zero]
+      simpa using DensePoly.size_one (R := Int) (by decide : (1 : Int) ≠ 0)
+  | succ n ih =>
+      rw [Factorization.factorPower_succ]
+      have hpow : 0 < (Factorization.factorPower q n).size := by
+        rw [ih]
+        omega
+      rw [ZPoly.mul_size_eq_top_succ_of_nonzero _ _ hpow hq, ih]
+      rw [Nat.add_mul]
+      omega
+
+private theorem length_le_sum_of_pos (xs : List Nat)
+    (hpos : ∀ x ∈ xs, 0 < x) : xs.length ≤ xs.sum := by
+  induction xs with
+  | nil => simp
+  | cons x xs ih =>
+      simp only [List.length_cons, List.sum_cons]
+      have hx := hpos x (by simp)
+      have htail : ∀ y ∈ xs, 0 < y := by
+        intro y hy
+        exact hpos y (by simp [hy])
+      have := ih htail
+      omega
+
+private theorem foldl_factorPower_size
+    (entries : List (ZPoly × Nat)) (acc : ZPoly) (hacc : 0 < acc.size)
+    (hentries : ∀ entry ∈ entries, 0 < entry.1.size) :
+    (entries.foldl
+      (fun product entry => product * Factorization.factorPower entry.1 entry.2)
+      acc).size =
+      acc.size + (entries.map fun entry => entry.2 * (entry.1.size - 1)).sum := by
+  induction entries generalizing acc with
+  | nil => simp
+  | cons entry entries ih =>
+      have hentry : 0 < entry.1.size := hentries entry (by simp)
+      have hpow_size := factorPower_size entry.1 hentry entry.2
+      have hpow : 0 < (Factorization.factorPower entry.1 entry.2).size := by
+        rw [hpow_size]
+        omega
+      have hproduct := ZPoly.mul_size_eq_top_succ_of_nonzero acc
+        (Factorization.factorPower entry.1 entry.2) hacc hpow
+      rw [List.foldl_cons,
+        ih (acc := acc * Factorization.factorPower entry.1 entry.2)]
+      · rw [hproduct, hpow_size]
+        simp only [List.map_cons, List.sum_cons]
+        omega
+      · rw [hproduct]
+        omega
+      · intro tailEntry htail
+        exact hentries tailEntry (by simp [htail])
+
+/-- The factorization-backed executable irreducibility checker accepts the
+indeterminate `X`. This follows from product preservation: positive-degree
+factors with positive multiplicities can contribute total degree one only as
+one factor of multiplicity one. -/
+theorem ZPoly.isIrreducible_X : ZPoly.isIrreducible ZPoly.X = true := by
+  have hx0 : ZPoly.X ≠ (0 : ZPoly) := by decide
+  have hxdeg : ZPoly.X.degree?.getD 0 ≠ 0 := by decide
+  rw [ZPoly.isIrreducible, if_neg hx0, if_neg hxdeg]
+  dsimp only
+  let φ := ZPoly.factorize ZPoly.X
+  have hscalar : φ.scalar = 1 := by
+    dsimp [φ]
+    rw [factorize_scalar_of_leadingCoeff_pos hx0 (by decide)]
+    decide
+  have hentry_size : ∀ entry ∈ φ.factors.toList, 0 < entry.1.size := by
+    intro entry hentry
+    have hdegree := factorize_entries_degree_pos ZPoly.X hx0 entry
+      (Array.mem_toList_iff.mp hentry)
+    by_cases hsize : entry.1.size = 0
+    · simp [DensePoly.degree?, hsize] at hdegree
+    · omega
+  have hfold := foldl_factorPower_size φ.factors.toList (DensePoly.C φ.scalar)
+    (by simp [hscalar, DensePoly.size_C_of_ne_zero]) hentry_size
+  have hproduct : φ.product = ZPoly.X := by
+    exact factorize_product ZPoly.X
+  have hsum :
+      (φ.factors.toList.map fun entry => entry.2 * (entry.1.size - 1)).sum = 1 := by
+    rw [Factorization.product_eq_foldl_factorPower, ← Array.foldl_toList] at hproduct
+    rw [hproduct] at hfold
+    have hXsize : ZPoly.X.size = 2 := by decide
+    have hCsize : (DensePoly.C φ.scalar : ZPoly).size = 1 := by
+      rw [hscalar]
+      exact DensePoly.size_C_of_ne_zero (R := Int) (by decide)
+    rw [hXsize, hCsize] at hfold
+    omega
+  have hterm_pos : ∀ n ∈
+      (φ.factors.toList.map fun entry => entry.2 * (entry.1.size - 1)), 0 < n := by
+    intro n hn
+    rw [List.mem_map] at hn
+    obtain ⟨entry, hentry, rfl⟩ := hn
+    have hmult := factorize_entry_multiplicity_pos ZPoly.X entry hentry
+    have hdegree := factorize_entries_degree_pos ZPoly.X hx0 entry
+      (Array.mem_toList_iff.mp hentry)
+    have hsize := hentry_size entry hentry
+    have hdegree_size : entry.1.degree?.getD 0 = entry.1.size - 1 := by
+      rw [DensePoly.degree?_eq_some_of_pos_size entry.1 hsize]
+      rfl
+    rw [hdegree_size] at hdegree
+    exact Nat.mul_pos hmult hdegree
+  have hlength_le : φ.factors.toList.length ≤
+      (φ.factors.toList.map fun entry => entry.2 * (entry.1.size - 1)).sum := by
+    simpa only [List.length_map] using length_le_sum_of_pos _ hterm_pos
+  have hlength : φ.factors.toList.length = 1 := by
+    rw [hsum] at hlength_le
+    by_cases hzero : φ.factors.toList.length = 0
+    · have : φ.factors.toList = [] := List.eq_nil_of_length_eq_zero hzero
+      rw [this] at hsum
+      simp at hsum
+    · omega
+  obtain ⟨entry, hentry⟩ := List.length_eq_one_iff.mp hlength
+  have hmult : entry.2 = 1 := by
+    rw [hentry] at hsum
+    simp only [List.map_cons, List.map_nil, List.sum_cons, List.sum_nil,
+      Nat.add_zero] at hsum
+    have hdvd : entry.2 ∣ 1 := ⟨entry.1.size - 1, hsum.symm⟩
+    have hle := Nat.le_of_dvd (by decide : 0 < (1 : Nat)) hdvd
+    have hentry_mem : entry ∈ φ.factors.toList := by simp [hentry]
+    have hpos := factorize_entry_multiplicity_pos ZPoly.X entry hentry_mem
+    omega
+  change (decide (φ.scalar.natAbs = 1) && φ.factors.size == 1 &&
+    match φ.factors.toList with
+    | [entry] => decide (entry.2 = 1)
+    | _ => false) = true
+  simp [hscalar, ← Array.length_toList, hentry, hmult]
+
 /--
 A successful integer certificate exposes the per-prime polynomial check fact:
 every recorded `PrimeFactorData` block satisfies `checkForPolynomial f` —

--- a/HexBerlekampZassenhausMathlib/FactorSoundness.lean
+++ b/HexBerlekampZassenhausMathlib/FactorSoundness.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexBerlekampZassenhaus.ProductProofs
 public import HexBerlekampZassenhausMathlib.IntReductionMod
 public import HexBerlekampZassenhausMathlib.LatticeTier
 
@@ -130,13 +131,8 @@ leading coefficient, and is sign-normalized. The constant case is excluded by
 -/
 theorem factorize_entries_degree_pos
     (f : Hex.ZPoly) (hf : f ≠ 0) :
-    ∀ entry ∈ (Hex.ZPoly.factorize f).factors, 0 < entry.1.degree?.getD 0 := by
-  intro entry hentry
-  have hmem := Array.mem_toList_iff.mpr hentry
-  exact Hex.degree_pos_of_primitive_norm_record entry.1
-    (Hex.factorize_entries_primitive_of_ne_zero f hf entry hentry)
-    (Hex.factorize_entry_normalizeFactorSign_id f entry hmem)
-    (Hex.factorize_entry_shouldRecord f entry hmem)
+    ∀ entry ∈ (Hex.ZPoly.factorize f).factors, 0 < entry.1.degree?.getD 0 :=
+  Hex.factorize_entries_degree_pos f hf
 
 /--
 Uniqueness specialised against the default executable factorization, so callers

--- a/HexNumberField/Basic.lean
+++ b/HexNumberField/Basic.lean
@@ -21,7 +21,8 @@ Core representations for exact algebraic numbers.
 `AlgebraicRoot` stores a squarefree factorization-lazy root, and
 `AlgebraicNumber` seals the canonical irreducible representation behind a
 private constructor. The only constructor exposed to later implementation
-modules re-runs the fixed root isolator and selects its canonical disc.
+modules uses the fixed representative of zero for `X`; all other inputs run
+the fixed root isolator and select its canonical disc.
 -/
 namespace Hex
 
@@ -48,8 +49,8 @@ structure AlgebraicRoot where
   rep : RefinedIsolation p
   rep_mk : SimpleRoot.mk rep = x
 
-/-- A canonical algebraic number. Construction is sealed so every value can
-be normalized and re-isolated through the fixed deterministic strategy. -/
+/-- A canonical algebraic number. Construction is sealed so each normalized
+polynomial/root pair receives one fixed representative. -/
 structure AlgebraicNumber where
   private mk ::
   p : ZPoly
@@ -64,22 +65,99 @@ structure AlgebraicNumber where
 
 namespace AlgebraicNumber
 
+private def zeroSquare : DyadicSquare :=
+  ⟨0, 0, (separationDepth ZPoly.X : Int)⟩
+
+/-- The fixed explicit representative of the root of `X`. -/
+private def zeroRep : RefinedIsolation ZPoly.X :=
+  ⟨⟨zeroSquare, by
+      left
+      decide⟩,
+    by
+      simp only [zeroSquare, separationDepth]
+      omega⟩
+
+private theorem zero_isIrreducible : ZPoly.isIrreducible ZPoly.X = true := by
+  exact ZPoly.isIrreducible_X
+
+private theorem zero_squarefree : HasOnlySimpleRoots ZPoly.X := by
+  -- Kernel reduction stops inside rational-polynomial gcd, so this cannot be
+  -- replaced by `by decide` under the module system.
+  have hX : ZPoly.toRatPoly ZPoly.X =
+      DensePoly.monomial 1 (1 : Rat) := by
+    apply DensePoly.ext_coeff
+    intro n
+    rw [ZPoly.coeff_toRatPoly, DensePoly.coeff_monomial]
+    by_cases hn : n = 1
+    · subst n
+      simp [ZPoly.X]
+    · rw [if_neg hn]
+      rw [ZPoly.X, DensePoly.coeff_monomial, if_neg hn]
+      change ((0 : Int) : Rat) = 0
+      simp
+  have hderiv : DensePoly.derivative (ZPoly.toRatPoly ZPoly.X) =
+      DensePoly.C (1 : Rat) := by
+    rw [hX]
+    apply DensePoly.ext_coeff
+    intro n
+    rw [DensePoly.coeff_derivative_semiring, DensePoly.coeff_C,
+      DensePoly.coeff_monomial]
+    by_cases hn : n = 0
+    · simp [hn]
+    · rw [if_neg hn, if_neg (by omega : n + 1 ≠ 1)]
+      change ((n + 1 : Nat) : Rat) * 0 = 0
+      exact Rat.mul_zero _
+  unfold HasOnlySimpleRoots ZPoly.SquareFreeRat
+  rw [hderiv]
+  by_cases hg : (DensePoly.gcd (ZPoly.toRatPoly ZPoly.X)
+      (DensePoly.C (1 : Rat))).size = 0
+  · omega
+  · exact ZPoly.rat_size_le_of_dvd_nonzero hg (by decide)
+      (DensePoly.gcd_dvd_right _ _)
+
+private def zeroRaw : AlgebraicNumber :=
+  .mk ZPoly.X (by rfl) (by decide) (by decide)
+    ⟨zero_isIrreducible, by decide⟩ zero_squarefree (SimpleRoot.mk zeroRep)
+    zeroRep rfl
+
+-- Keep executable evidence that the ordinary isolator also meets its stated
+-- completeness bound on `X`; the explicit zero path makes totality independent
+-- of this bounded computation.
+#guard (isolate ZPoly.X zero_squarefree
+  (separationDepth ZPoly.X : Int)).isSome
+
+/-- The canonical algebraic number zero, represented by the fixed explicit
+isolation of the normalized polynomial `X`. -/
+def zero : AlgebraicNumber :=
+  zeroRaw
+
+instance : Zero AlgebraicNumber := ⟨zero⟩
+
+/-- The canonical zero retains `X` as its normalized polynomial. -/
+@[simp] theorem zero_p : (0 : AlgebraicNumber).p = ZPoly.X := by
+  rfl
+
 /-- Re-isolate an already normalized irreducible polynomial with the fixed
 default strategy and retain the unique canonical disc matching `rep`.
 
-This is the implementation boundary used by later smart constructors. It is
-checked because failure of the bounded isolation driver is retired only by the
-Mathlib companion's completeness proof. -/
+The normalized polynomial `X` takes the explicit canonical-zero fast path, so
+the total `Zero` instance does not depend on success of a bounded driver. For
+all other inputs this is the implementation boundary used by later smart
+constructors. It is checked because failure of the bounded isolation driver is
+retired only by the Mathlib companion's completeness proof. -/
 def ofNormalized?
     (p : ZPoly) (prim : ZPoly.Primitive p) (pos_lc : 0 < p.leadingCoeff)
     (pos_degree : 0 < p.degree?.getD 0)
     (checked : ZPoly.CheckedIrreducible p) (squarefree : HasOnlySimpleRoots p)
-    (rep : RefinedIsolation p) : Option AlgebraicNumber := do
-  let isolations ← isolate p squarefree (separationDepth p : Int)
-  let refined ← isolations.mapM DyadicRootIsolation.toRefined?
-  let canonical ← refined.toList.find? fun r => r.sameRoot rep
-  some (.mk p prim pos_lc pos_degree checked squarefree (SimpleRoot.mk canonical)
-    canonical rfl)
+    (rep : RefinedIsolation p) : Option AlgebraicNumber :=
+  if _hzero : p = ZPoly.X then
+    some zeroRaw
+  else do
+    let isolations ← isolate p squarefree (separationDepth p : Int)
+    let refined ← isolations.mapM DyadicRootIsolation.toRefined?
+    let canonical ← refined.toList.find? fun r => r.sameRoot rep
+    some (.mk p prim pos_lc pos_degree checked squarefree (SimpleRoot.mk canonical)
+      canonical rfl)
 
 /-- Successful canonicalization retains the supplied normalized polynomial. -/
 theorem ofNormalized?_p
@@ -90,52 +168,43 @@ theorem ofNormalized?_p
     (h : ofNormalized? p prim pos_lc pos_degree checked squarefree rep = some a) :
     a.p = p := by
   unfold ofNormalized? at h
-  obtain ⟨isolations, _, h⟩ := Option.bind_eq_some_iff.mp h
-  obtain ⟨refined, _, h⟩ := Option.bind_eq_some_iff.mp h
-  obtain ⟨canonical, _, h⟩ := Option.bind_eq_some_iff.mp h
-  cases h
-  rfl
+  split at h
+  · next hp =>
+    cases h
+    simp [zeroRaw, hp]
+  · obtain ⟨isolations, _, h⟩ := Option.bind_eq_some_iff.mp h
+    obtain ⟨refined, _, h⟩ := Option.bind_eq_some_iff.mp h
+    obtain ⟨canonical, _, h⟩ := Option.bind_eq_some_iff.mp h
+    cases h
+    rfl
 
-private def zeroSquare : DyadicSquare :=
-  ⟨0, 0, (mahlerPrec ZPoly.X : Int)⟩
-
-/-- A small explicit representative of the root of `X`, used only to select
-the default isolator's canonical representative. -/
-private def zeroRep : RefinedIsolation ZPoly.X :=
-  ⟨⟨zeroSquare, by
-      left
-      decide⟩,
-    by simp [zeroSquare]⟩
-
-private theorem zero_isIrreducible : ZPoly.isIrreducible ZPoly.X = true := by
-  sorry
-
-private theorem zero_squarefree : HasOnlySimpleRoots ZPoly.X := by
-  sorry
-
-private def zeroCandidate : Option AlgebraicNumber :=
-  ofNormalized? ZPoly.X (by rfl) (by decide) (by decide)
-    ⟨zero_isIrreducible, by decide⟩ zero_squarefree zeroRep
-
-#guard ZPoly.isIrreducible ZPoly.X
-#guard decide (HasOnlySimpleRoots ZPoly.X)
-#guard zeroCandidate.isSome
-
-private theorem zeroCandidate_isSome : zeroCandidate.isSome := by
-  sorry
-
-/-- The canonical algebraic number zero, represented by the default isolated
-root of the normalized polynomial `X`. -/
-def zero : AlgebraicNumber :=
-  Option.get zeroCandidate zeroCandidate_isSome
-
-/-- The canonical zero retains `X` as its normalized polynomial. -/
-theorem zero_p : zero.p = ZPoly.X := by
-  apply ofNormalized?_p ZPoly.X (by rfl) (by decide) (by decide)
-    ⟨zero_isIrreducible, by decide⟩ zero_squarefree zeroRep
-  exact (Option.some_get zeroCandidate_isSome).symm
-
-instance : Zero AlgebraicNumber := ⟨zero⟩
+/-- A successful canonicalization either takes the explicit zero path or
+stores a representative intersecting the supplied isolation. This is the
+Mathlib-free behavioral boundary used by semantic soundness proofs. -/
+theorem ofNormalized?_spec
+    (p : ZPoly) (prim : ZPoly.Primitive p) (pos_lc : 0 < p.leadingCoeff)
+    (pos_degree : 0 < p.degree?.getD 0)
+    (checked : ZPoly.CheckedIrreducible p) (squarefree : HasOnlySimpleRoots p)
+    (rep : RefinedIsolation p) {a : AlgebraicNumber}
+    (h : ofNormalized? p prim pos_lc pos_degree checked squarefree rep = some a) :
+    (p = ZPoly.X ∧ a = 0) ∨
+      ∃ hp : a.p = p, Intersects (hp ▸ a.rep) rep := by
+  unfold ofNormalized? at h
+  split at h
+  · next hp =>
+    left
+    refine ⟨hp, ?_⟩
+    cases h
+    rfl
+  · right
+    obtain ⟨isolations, _, h⟩ := Option.bind_eq_some_iff.mp h
+    obtain ⟨refined, _, h⟩ := Option.bind_eq_some_iff.mp h
+    obtain ⟨canonical, hcanonical, h⟩ := Option.bind_eq_some_iff.mp h
+    have hsame : canonical.sameRoot rep = true :=
+      List.find?_some (p := fun r : RefinedIsolation p => r.sameRoot rep)
+        hcanonical
+    cases h
+    exact ⟨rfl, hsame⟩
 
 instance : Inhabited AlgebraicNumber := ⟨zero⟩
 

--- a/HexNumberField/SPEC/hex-number-field.md
+++ b/HexNumberField/SPEC/hex-number-field.md
@@ -104,12 +104,14 @@ requirement that the implementation literally use an `opaque` Lean declaration.
 Implementations use representation-private structures where constructors or
 recursors are needed internally.
 
-Every `AlgebraicNumber` smart constructor normalizes the primitive polynomial,
-then re-isolates with the fixed default strategy at `separationDepth` and stores
-the unique matching disc. Thus equal complex values have identical hidden data,
-not merely a semantic `BEq`; this representation can support field laws stated
-with Lean equality. User-supplied alternative refined discs cannot enter the
-private constructor.
+Every `AlgebraicNumber` smart constructor normalizes the primitive polynomial.
+The normalized polynomial `X` uses one fixed explicit certified representative;
+this makes canonical zero total without depending on success of the bounded
+isolation driver. Every other polynomial is re-isolated with the fixed default
+strategy at `separationDepth`, storing the unique matching disc. Thus equal
+complex values have identical hidden data, not merely a semantic `BEq`; this
+representation can support field laws stated with Lean equality. User-supplied
+alternative refined discs cannot enter the private constructor.
 
 Do not instantiate `DensePoly AlgebraicNumber` in the Mathlib-free layer.
 `DensePoly` requires a kernel `DecidableEq` on coefficients so trailing-zero

--- a/HexNumberFieldMathlib/Basic.lean
+++ b/HexNumberFieldMathlib/Basic.lean
@@ -183,19 +183,203 @@ theorem map_mul (a b : QAdjoin p x) (rep : RefinedIsolation p)
 
 end QAdjoin
 
+private def RefinedIsolation.castPoly {p q : ZPoly} (h : p = q)
+    (r : RefinedIsolation q) : RefinedIsolation p :=
+  h.symm ▸ r
+
+private theorem RefinedIsolation.castPoly_square {p q : ZPoly} (h : p = q)
+    (r : RefinedIsolation q) :
+    (r.castPoly h).1.square = r.1.square := by
+  cases h
+  rfl
+
+private theorem RefinedIsolation.castPoly_root {p q : ZPoly} (h : p = q)
+    (r : RefinedIsolation q) :
+    (r.castPoly h).root = r.root := by
+  cases h
+  rfl
+
+private theorem AlgebraicNumber.eq_polynomial {a b : AlgebraicNumber}
+    (h : a.toComplex = b.toComplex) : a.p = b.p := by
+  have hscaled :
+      Polynomial.C (a.p.leadingCoeff : Rat)⁻¹ *
+          HexPolyZMathlib.toPolyℚ a.p =
+        Polynomial.C (b.p.leadingCoeff : Rat)⁻¹ *
+          HexPolyZMathlib.toPolyℚ b.p := by
+    simpa [Polynomial.smul_eq_C_mul] using
+      (AlgebraicNumber.p_eq_minpoly a).trans
+        ((congrArg (minpoly Rat) h).trans
+          (AlgebraicNumber.p_eq_minpoly b).symm)
+  have halc : (a.p.leadingCoeff : Rat) ≠ 0 := by
+    exact_mod_cast (ne_of_gt a.pos_lc)
+  have hblc : (b.p.leadingCoeff : Rat) ≠ 0 := by
+    exact_mod_cast (ne_of_gt b.pos_lc)
+  have haunit : IsUnit (Polynomial.C (a.p.leadingCoeff : Rat)⁻¹) :=
+    Polynomial.isUnit_C.mpr (isUnit_iff_ne_zero.mpr (inv_ne_zero halc))
+  have hbunit : IsUnit (Polynomial.C (b.p.leadingCoeff : Rat)⁻¹) :=
+    Polynomial.isUnit_C.mpr (isUnit_iff_ne_zero.mpr (inv_ne_zero hblc))
+  have hrat : Associated (HexPolyZMathlib.toPolyℚ a.p)
+      (HexPolyZMathlib.toPolyℚ b.p) :=
+    (associated_unit_mul_left _ _ haunit).symm |>.trans <|
+      (Associated.of_eq hscaled).trans (associated_unit_mul_left _ _ hbunit)
+  have haprim := HexPolyZMathlib.isPrimitive_toPolynomial_of_primitive a.p a.prim
+  have hbprim := HexPolyZMathlib.isPrimitive_toPolynomial_of_primitive b.p b.prim
+  have hint : Associated (HexPolyZMathlib.toPolynomial a.p)
+      (HexPolyZMathlib.toPolynomial b.p) :=
+    dvd_dvd_iff_associated.mp ⟨
+      (Polynomial.IsPrimitive.Int.dvd_iff_map_cast_dvd_map_cast _ _ haprim hbprim).mpr
+        hrat.dvd,
+      (Polynomial.IsPrimitive.Int.dvd_iff_map_cast_dvd_map_cast _ _ hbprim haprim).mpr
+        hrat.symm.dvd⟩
+  exact
+    HexBerlekampZassenhausMathlib.zpoly_eq_of_toPolynomial_associated_of_primitive_pos_leading
+        a.prim b.prim a.pos_lc b.pos_lc hint
+
+/-- Canonical zero denotes complex zero. -/
+@[simp] theorem AlgebraicNumber.zero_toComplex :
+    (0 : AlgebraicNumber).toComplex = 0 := by
+  have hroot := AlgebraicRoot.toComplex_isRoot
+    (0 : AlgebraicNumber).toRoot
+  change (HexRootsMathlib.toPolyℂ (0 : AlgebraicNumber).p).eval
+    (0 : AlgebraicNumber).toComplex = 0 at hroot
+  rw [AlgebraicNumber.zero_p] at hroot
+  simpa [HexRootsMathlib.toPolyℂ, ZPoly.X] using hroot
+
+/-- Successful canonicalization preserves the complex root selected by the
+supplied refined isolation, including the explicit canonical-zero path. -/
+theorem AlgebraicNumber.ofNormalized?_toComplex
+    (p : ZPoly) (prim : ZPoly.Primitive p) (pos_lc : 0 < p.leadingCoeff)
+    (pos_degree : 0 < p.degree?.getD 0)
+    (checked : ZPoly.CheckedIrreducible p) (squarefree : HasOnlySimpleRoots p)
+    (rep : RefinedIsolation p) {a : AlgebraicNumber}
+    (h : AlgebraicNumber.ofNormalized? p prim pos_lc pos_degree checked
+      squarefree rep = some a) :
+    a.toComplex = rep.root := by
+  rcases AlgebraicNumber.ofNormalized?_spec p prim pos_lc pos_degree checked
+      squarefree rep h with hzero | hinter
+  · rcases hzero with ⟨hp, rfl⟩
+    subst p
+    rw [AlgebraicNumber.zero_toComplex]
+    have hroot : rep.root = 0 := by
+      simpa [HexRootsMathlib.toPolyℂ, ZPoly.X] using
+        HexRootsMathlib.RefinedIsolation.isRoot rep
+    exact hroot.symm
+  · obtain ⟨hp, hinter⟩ := hinter
+    let arep : RefinedIsolation p := hp ▸ a.rep
+    have haroot : arep.root = a.rep.root := by
+      cases hp
+      rfl
+    have hpne : p ≠ 0 := by
+      intro hp0
+      rw [hp0] at pos_degree
+      simp at pos_degree
+    have hroot :=
+      (HexRootsMathlib.RefinedIsolation.intersects_iff_root_eq_of_simple
+        squarefree hpne arep rep).mp hinter
+    change a.rep.root = rep.root
+    rw [← haroot]
+    exact hroot
+
 /-- Canonical Boolean equality is equality of represented complex values. -/
 theorem AlgebraicNumber.beq_iff (a b : AlgebraicNumber) :
     (a == b) ↔ a.toComplex = b.toComplex := by
-  sorry
+  change AlgebraicNumber.beq a b = true ↔ a.toComplex = b.toComplex
+  rw [AlgebraicNumber.beq]
+  rw [Bool.and_eq_true, beq_iff_eq]
+  constructor
+  · rintro ⟨hp, hmeet⟩
+    let brep : RefinedIsolation a.p := b.rep.castPoly hp
+    letI : ZPoly.CheckedIrreducible a.p := a.checked
+    have hinter : Intersects a.rep brep := by
+      change a.rep.1.square.discsMeet brep.1.square = true
+      rw [show brep.1.square = b.rep.1.square by
+        exact RefinedIsolation.castPoly_square hp b.rep]
+      exact hmeet
+    have hroot :=
+      (HexRootsMathlib.RefinedIsolation.intersects_iff_root_eq
+        (ZPoly.CheckedIrreducible.separable a.p) a.rep brep).mp hinter
+    change a.rep.root = b.rep.root
+    rw [← RefinedIsolation.castPoly_root hp b.rep]
+    exact hroot
+  · intro hroot
+    have hp := AlgebraicNumber.eq_polynomial hroot
+    refine ⟨hp, ?_⟩
+    let brep : RefinedIsolation a.p := b.rep.castPoly hp
+    letI : ZPoly.CheckedIrreducible a.p := a.checked
+    have hroot' : a.rep.root = brep.root := by
+      rw [show brep.root = b.rep.root by
+        exact RefinedIsolation.castPoly_root hp b.rep]
+      exact hroot
+    have hinter : Intersects a.rep brep :=
+      (HexRootsMathlib.RefinedIsolation.intersects_iff_root_eq
+        (ZPoly.CheckedIrreducible.separable a.p) a.rep brep).mpr hroot'
+    change a.rep.1.square.discsMeet b.rep.1.square = true
+    change a.rep.1.square.discsMeet brep.1.square = true at hinter
+    rw [show brep.1.square = b.rep.1.square by
+      exact RefinedIsolation.castPoly_square hp b.rep] at hinter
+    exact hinter
 
 /-- The executable zero predicate recognizes exactly the complex value zero. -/
 theorem AlgebraicRoot.isZero_iff (a : AlgebraicRoot) :
     a.isZero ↔ a.toComplex = 0 := by
-  sorry
+  rw [AlgebraicRoot.isZero, Bool.and_eq_true, beq_iff_eq]
+  constructor
+  · rintro ⟨hcoeff, hcontains⟩
+    have hzeroRoot : (HexRootsMathlib.toPolyℂ a.p).IsRoot 0 := by
+      change (HexRootsMathlib.toPolyℂ a.p).eval 0 = 0
+      rw [← Polynomial.coeff_zero_eq_eval_zero,
+        HexRootsMathlib.coeff_toPolyℂ, hcoeff]
+      simp
+    have hzeroMem :
+        (0 : ℂ) ∈ HexRootsMathlib.DyadicSquare.closedDisc a.rep.1.square := by
+      have hmem :=
+        (HexRootsMathlib.DyadicSquare.discContains_iff_mem_closedDisc
+          a.rep.1.square (0, 0)).mp hcontains
+      simp at hmem
+      exact hmem
+    have hpne : a.p ≠ 0 := by
+      intro hp
+      have hpos := a.pos_degree
+      rw [hp] at hpos
+      simp at hpos
+    have hroot :=
+      HexRootsMathlib.RefinedIsolation.eq_root_of_mem_closedDisc
+        (HexRootsMathlib.HasOnlySimpleRoots.separable a.squarefree hpne)
+        a.rep hzeroRoot hzeroMem
+    exact hroot.symm
+  · intro hroot
+    have hpolyRoot := AlgebraicRoot.toComplex_isRoot a
+    have hcoeffComplex : (a.p.coeff 0 : ℂ) = 0 := by
+      rw [hroot] at hpolyRoot
+      rw [← Polynomial.coeff_zero_eq_eval_zero,
+        HexRootsMathlib.coeff_toPolyℂ] at hpolyRoot
+      exact hpolyRoot
+    have hcoeff : a.p.coeff 0 = 0 := by
+      exact_mod_cast hcoeffComplex
+    refine ⟨hcoeff, ?_⟩
+    have hmem := HexRootsMathlib.RefinedIsolation.root_mem_closedDisc a.rep
+    change a.toComplex ∈
+      HexRootsMathlib.DyadicSquare.closedDisc a.rep.1.square at hmem
+    rw [hroot] at hmem
+    apply
+      (HexRootsMathlib.DyadicSquare.discContains_iff_mem_closedDisc
+        a.rep.1.square (0, 0)).mpr
+    simp
+    exact hmem
 
 /-- The canonical algebraic-number zero test recognizes exactly complex zero. -/
 theorem AlgebraicNumber.isZero_iff (a : AlgebraicNumber) :
     a.isZero ↔ a.toComplex = 0 := by
-  sorry
+  rw [AlgebraicNumber.isZero, beq_iff_eq]
+  constructor
+  · intro hp
+    have hroot := AlgebraicRoot.toComplex_isRoot a.toRoot
+    change (HexRootsMathlib.toPolyℂ a.p).eval a.toComplex = 0 at hroot
+    rw [hp] at hroot
+    simpa [HexRootsMathlib.toPolyℂ, ZPoly.X] using hroot
+  · intro hroot
+    have hp := AlgebraicNumber.eq_polynomial
+      (hroot.trans AlgebraicNumber.zero_toComplex.symm)
+    simpa [AlgebraicNumber.zero_p] using hp
 
 end Hex

--- a/HexNumberFieldMathlib/Lazy.lean
+++ b/HexNumberFieldMathlib/Lazy.lean
@@ -152,17 +152,6 @@ end AlgebraicRoot
 
 namespace AlgebraicNumber
 
-/-- Canonical zero denotes complex zero. -/
-theorem zero_toComplex : (0 : AlgebraicNumber).toComplex = 0 := by
-  have hroot := AlgebraicRoot.toComplex_isRoot
-    (0 : AlgebraicNumber).toRoot
-  change (HexRootsMathlib.toPolyℂ (0 : AlgebraicNumber).p).eval
-    (0 : AlgebraicNumber).toComplex = 0 at hroot
-  have hp : (0 : AlgebraicNumber).p = ZPoly.X :=
-    AlgebraicNumber.zero_p
-  rw [hp] at hroot
-  simpa [HexRootsMathlib.toPolyℂ, ZPoly.X] using hroot
-
 /-- Canonical addition computes complex addition. -/
 theorem add_toComplex (a b : AlgebraicNumber) :
     (a + b).toComplex = a.toComplex + b.toComplex := by

--- a/HexPoly/Euclid/DivGcd.lean
+++ b/HexPoly/Euclid/DivGcd.lean
@@ -68,6 +68,13 @@ division and gcd routines rely on. -/
   change (C (1 : R)).leadingCoeff = 1
   rw [leadingCoeff_C]
 
+/-- The constant polynomial `1` stores one coefficient when the coefficient
+ring's `1` is nonzero. -/
+theorem size_one [One R] (hone : (1 : R) ≠ 0) :
+    (1 : DensePoly R).size = 1 := by
+  change (C (1 : R)).size = 1
+  exact size_C_of_ne_zero hone
+
 /-- A polynomial is monic when its leading coefficient is `1`. -/
 @[expose]
 def Monic [One R] (p : DensePoly R) : Prop :=

--- a/HexRootsMathlib/Geometry.lean
+++ b/HexRootsMathlib/Geometry.lean
@@ -24,6 +24,12 @@ noncomputable section
 
 namespace GaussDyadic
 
+/-- The zero Gaussian dyadic embeds as complex zero. -/
+@[simp] theorem toComplex_zero :
+    toComplex ((0, 0) : Hex.GaussDyadic) = 0 := by
+  apply Complex.ext <;>
+    simp [toComplex, Dyadic.toReal_zero]
+
 /-- The real value of the executable lower modulus bound. -/
 @[simp] theorem toReal_lo (z : Hex.GaussDyadic) :
     Dyadic.toReal (Hex.GaussDyadic.lo z) =
@@ -294,6 +300,50 @@ Euclidean distance. -/
     Dyadic.toReal (Hex.GaussDyadic.distSq z w) =
       dist (GaussDyadic.toComplex z) (GaussDyadic.toComplex w) ^ 2 := by
   simp [Hex.GaussDyadic.distSq, Complex.dist_eq, Complex.sq_norm]
+
+/-- The exact executable point-in-disc test is membership in the represented
+closed circumscribed disc. -/
+theorem discContains_iff_mem_closedDisc (s : Hex.DyadicSquare)
+    (z : Hex.GaussDyadic) :
+    s.discContains z = true ↔ GaussDyadic.toComplex z ∈ closedDisc s := by
+  have hs : (2 : ℝ) ^ (-(2 * s.prec)) = ((2 : ℝ) ^ (-s.prec)) ^ 2 := by
+    rw [show -(2 * s.prec) = (-s.prec) * 2 by ring, zpow_mul]
+    rfl
+  have htwo : Dyadic.toReal (2 : _root_.Dyadic) = (2 : ℝ) :=
+    Dyadic.toReal_two
+  have hradius :
+      Dyadic.toReal
+          ((2 : _root_.Dyadic) * .ofIntWithPrec 1 (2 * s.prec)) =
+        radius s ^ 2 := by
+    rw [Dyadic.toReal_mul, htwo, Dyadic.toReal_ofIntWithPrec, radius_eq, hs]
+    simp only [Int.cast_one, one_mul, mul_pow,
+      Real.sq_sqrt (by norm_num : (0 : ℝ) ≤ 2)]
+    ring
+  have hrnonneg : 0 ≤ radius s := by
+    rw [radius_eq]
+    exact mul_nonneg (zpow_pos (by norm_num : (0 : ℝ) < 2) _).le
+      (Real.sqrt_nonneg _)
+  constructor
+  · intro h
+    change decide (Hex.GaussDyadic.distSq s.center z ≤
+      (2 : _root_.Dyadic) * .ofIntWithPrec 1 (2 * s.prec)) = true at h
+    have hreal := Dyadic.toReal_le_toReal_iff.mpr (of_decide_eq_true h)
+    rw [toReal_distSq, hradius] at hreal
+    rw [closedDisc, Metric.mem_closedBall, dist_comm]
+    exact (sq_le_sq₀ dist_nonneg hrnonneg).mp hreal
+  · intro h
+    rw [closedDisc, Metric.mem_closedBall, dist_comm] at h
+    have hsq :
+        dist (center s) (GaussDyadic.toComplex z) ^ 2 ≤ radius s ^ 2 :=
+      (sq_le_sq₀ dist_nonneg hrnonneg).mpr h
+    have hreal :
+        Dyadic.toReal (Hex.GaussDyadic.distSq s.center z) ≤
+          Dyadic.toReal
+            ((2 : _root_.Dyadic) * .ofIntWithPrec 1 (2 * s.prec)) := by
+      simpa only [toReal_distSq, center_eq, hradius] using hsq
+    change decide (Hex.GaussDyadic.distSq s.center z ≤
+      (2 : _root_.Dyadic) * .ofIntWithPrec 1 (2 * s.prec)) = true
+    exact decide_eq_true (Dyadic.toReal_le_toReal_iff.mp hreal)
 
 /-- A negative executable disc-intersection test certifies disjoint closed
 circumscribed discs. -/

--- a/HexRootsMathlib/SimpleRoot.lean
+++ b/HexRootsMathlib/SimpleRoot.lean
@@ -83,6 +83,39 @@ private theorem radius_lt_quarter {p : Hex.ZPoly}
     _ < ‖root i - z‖ / 4 :=
       mahlerPrec_separates p hsep (root i) z (isRoot i) hz hne
 
+/-- A polynomial root in the closed circumscribed disc of a refined isolation
+is the isolation's selected root. -/
+theorem eq_root_of_mem_closedDisc {p : Hex.ZPoly}
+    (hsep : (HexPolyZMathlib.toPolyℚ p).Separable)
+    (i : Hex.RefinedIsolation p) {z : ℂ}
+    (hzroot : (toPolyℂ p).IsRoot z)
+    (hzmem : z ∈ DyadicSquare.closedDisc i.1.square) :
+    z = root i := by
+  by_contra hne
+  have hne' : root i ≠ z := Ne.symm hne
+  have hradius := radius_lt_quarter hsep i hzroot hne'
+  have hrootmem :
+      dist (root i) (DyadicSquare.center i.1.square) ≤
+        DyadicSquare.radius i.1.square := by
+    simpa only [DyadicSquare.closedDisc, Metric.mem_closedBall] using
+      root_mem_closedDisc i
+  have hzmem' :
+      dist (DyadicSquare.center i.1.square) z ≤
+        DyadicSquare.radius i.1.square := by
+    rw [dist_comm]
+    simpa only [DyadicSquare.closedDisc, Metric.mem_closedBall] using hzmem
+  have hdist : dist (root i) z ≤ 2 * DyadicSquare.radius i.1.square := by
+    calc
+      dist (root i) z ≤
+          dist (root i) (DyadicSquare.center i.1.square) +
+            dist (DyadicSquare.center i.1.square) z := dist_triangle _ _ _
+      _ ≤ DyadicSquare.radius i.1.square +
+          DyadicSquare.radius i.1.square := add_le_add hrootmem hzmem'
+      _ = 2 * DyadicSquare.radius i.1.square := by ring
+  rw [Complex.dist_eq] at hdist
+  have hnorm : 0 ≤ ‖root i - z‖ := norm_nonneg _
+  linarith
+
 /-- At separation precision, executable disc intersection is exactly semantic
 root equality. Global separability is explicit because a local atom witness
 does not imply that every root of the polynomial is simple. -/

--- a/progress/20260728T124611Z_number-field-semantic-equality.md
+++ b/progress/20260728T124611Z_number-field-semantic-equality.md
@@ -1,0 +1,38 @@
+# Number-field semantic equality and zero certification
+
+## Accomplished
+
+- Proved the Mathlib-free executable irreducibility and squarefreeness facts
+  needed for the canonical representation of zero, without evaluating the
+  opaque factorizer in the kernel.
+- Replaced the fallible zero construction with one explicit certified
+  representative at `separationDepth`, while retaining an executable guard
+  that the ordinary root isolator succeeds on `X`.
+- Proved semantic correctness of successful canonicalization, Boolean
+  equality, and both zero predicates, adding the required complex-geometry and
+  root-uniqueness bridges.
+- Preserved the published Mathlib factorization API while moving its
+  Mathlib-free positive-degree proof to the computational library.
+- Updated the number-field SPEC to document the explicit canonical-zero path.
+- Passed focused builds, the full 9,559-job build, number-field conformance,
+  all eight number-field benchmark smoke cases, `git diff --check`, and an
+  explicit axiom audit with no `sorryAx` in the new theorems.
+- Addressed the substantive independent-review findings: canonical precision,
+  isolator evidence, fast-path semantic preservation, public API compatibility,
+  and explicit dependent transport.
+
+## Current frontier
+
+The semantic equality and zero-certification milestone is complete locally and
+ready to be rebased onto current `origin/main`, published as the sole task PR,
+and merged before any further implementation begins.
+
+## Next step
+
+Commit this milestone, rebase it over current main, rerun integration checks,
+push and open one PR, inspect the underlying GitHub Actions jobs, and merge once
+green.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Summary

- prove the executable irreducibility and squarefreeness facts needed for canonical zero
- make zero total through one explicit certified representative at separationDepth while retaining an isolation success guard
- prove canonicalization soundness, semantic Boolean equality, and both zero predicates
- add the required complex-geometry and root-uniqueness bridges, preserve the published factorization API, and update the SPEC

## Verification

- lake build (9559 jobs)
- lake build HexNumberField.Conformance (377 jobs)
- lake exe hexnumberfield_bench verify (8 of 8 passed)
- explicit print-axioms audit: no sorryAx in the new theorems
- git diff --check

## Review

Independent Claude Opus review found the main proofs sound. Addressed its substantive findings by retaining the X-isolator guard, proving the zero fast path preserves the supplied root, storing zero at separationDepth, preserving the moved public theorem name, and making dependent transport explicit.