### PR TITLE
bench: extend RCF shared-host retry headroom

### DIFF
--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -778,8 +778,20 @@ in-process clock. The complete external sweep is:
 ```bash
 python3 scripts/bench/hexrcf_proof_sweep.py --samples 6 \
   --timeout 300 --warm-timeout 600 \
-  --shared-host --expected-host chungus2 --cpu 22
+  --shared-host --expected-host chungus2 --cpu 22 \
+  --max-pair-retries 32
 ```
+
+`DoubleDegree50` takes roughly 15 seconds per arm on the designated host, so
+this suite explicitly requests the 32-retry hard cap: at most 33 complete
+adjacent attempts for a pair. Every rejected attempt remains in the artifact,
+and the extra opportunities do not relax the per-arm interference gate. At
+the observed arm cost with immediate preflights, exhausting all 33 attempts is
+about 17 minutes for one required sample; the independent preflight and arm
+timeouts remain authoritative. Allowing every preflight and both arms to reach
+their configured limits gives a nominal per-sample envelope of 8 hours 15
+minutes, excluding bounded observation and process overhead, although an
+actual arm timeout aborts the run earlier.
 
 Only `Replay`, `Tactic`, and `DoubleDegree50` print an axiom report, fixed to
 `[propext, Classical.choice, Quot.sound]`. `Search` also checks stable

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -316,13 +316,18 @@ preregistered ratio or three scheduler ticks rejects the complete pair
 attempt.
 
 A rejected pair attempt is retained with both arms, their fixed orientation,
-and all counters. The runner then rebuilds both arms in the same order, up to
-eight retries; it never retry-warms one arm in isolation. Before each attempt,
-the runner waits up to five minutes for a two-second physical-core observation
-with at most two non-interrupt busy ticks on the pinned CPU and two busy ticks
-on each sibling. This preflight avoids spending the finite build-retry budget
-inside a sustained burst; every rejected preflight window and its counters are
-retained, and the unchanged per-arm admission gate remains authoritative.
+and all counters. The runner then rebuilds both arms in the same order; it
+never retry-warms one arm in isolation. The default is eight retries, while a
+suite with preregistered long arms may explicitly request at most 32. The
+requested value counts retries after the initial attempt. The chosen finite
+bound is recorded and changes only how many clean-pair opportunities are
+attempted, never the admission threshold. Before each
+attempt, the runner waits up to five minutes for a two-second physical-core
+observation with at most two non-interrupt busy ticks on the pinned CPU and two
+busy ticks on each sibling. This preflight avoids spending the finite
+build-retry budget inside a sustained burst; every rejected preflight window
+and its counters are retained, and the unchanged per-arm admission gate
+remains authoritative.
 Only a wholly clean, adjacent pair attempt enters the timing sample. Exhausting
 the build-retry bound or the preflight wait emits an explicit partial artifact,
 records every rejected attempt or window, and never places a contaminated arm

--- a/progress/20260728T133649Z_rcf-shared-retries.md
+++ b/progress/20260728T133649Z_rcf-shared-retries.md
@@ -1,0 +1,31 @@
+# Accomplished
+
+- Preserved the generic shared-host default of eight whole-pair retries while
+  raising the explicit hard cap to 32.
+- Opted only the HexRCF proof sweep into that cap because its preregistered
+  double-degree-50 magnitude control is the longest arm and exhausted all nine
+  attempts in the first schema-v6 collection attempt.
+- Kept every admission threshold, accounting identity, preflight gate, and
+  fail-closed partial-artifact rule unchanged.
+- Added a suite-level retry bound to `SweepSpec`, so a shared-host run must use
+  the exact preregistered value: 32 for HexRCF and the default 8 elsewhere.
+- Added parser tests for the default, canonical and alias forms of the hard
+  cap, rejection outside the valid range, exact 33-attempt exhaustion, and the
+  HexRCF canonical command.
+- Passed all 73 shared sweep tests plus Phase-4, DAG, and diff checks.
+- Obtained an independent exact-diff GO; the admission gates and audit trail
+  remain unchanged.
+
+# Current frontier
+
+The retry-headroom change is prepared as a separate milestone stacked after
+the schema-v6 contract correction.
+
+# Next step
+
+Review and validate the narrow change, merge it after the contract PR, then
+run the complete schema-v6 artifact from the resulting clean main commit.
+
+# Blockers
+
+None.

--- a/scripts/bench/fresh_module_sweep.py
+++ b/scripts/bench/fresh_module_sweep.py
@@ -43,7 +43,7 @@ DEFAULT_MAX_LOAD_PER_CPU = 0.5
 DEFAULT_MAX_CORE_INTERFERENCE_RATIO = 0.002
 DEFAULT_MAX_FREQUENCY_SPREAD_RATIO = 0.15
 DEFAULT_MAX_PAIR_RETRIES = 8
-MAX_PAIR_RETRIES = 8
+MAX_PAIR_RETRIES = 32
 DEFAULT_PREFLIGHT_WINDOW_SECONDS = 2.0
 DEFAULT_PREFLIGHT_TIMEOUT_SECONDS = 300.0
 PREFLIGHT_MAX_BUSY_TICKS = 2
@@ -92,6 +92,7 @@ class SweepSpec:
     src_dir: Path = Path("bench")
     extra_sources: tuple[Path, ...] = ()
     required_samples: int | None = None
+    max_pair_retries: int = DEFAULT_MAX_PAIR_RETRIES
 
 
 def parse_args(
@@ -162,7 +163,8 @@ def parse_args(
         default=DEFAULT_MAX_PAIR_RETRIES,
         help=(
             "maximum contaminated-pair retries under the shared-host "
-            "protocol (default 8)"
+            f"protocol (default {DEFAULT_MAX_PAIR_RETRIES}, hard cap "
+            f"{MAX_PAIR_RETRIES}; counts retries after the initial attempt)"
         ),
     )
     parser.add_argument(
@@ -1882,6 +1884,11 @@ def run_cli(
         raise RuntimeError(
             f"this sweep requires --samples {spec.required_samples}, "
             f"got {args.samples}"
+        )
+    if args.shared_host and args.max_pair_retries != spec.max_pair_retries:
+        raise RuntimeError(
+            "this sweep requires --max-pair-retries "
+            f"{spec.max_pair_retries}, got {args.max_pair_retries}"
         )
     if args.samples % 2 != 0:
         raise RuntimeError(

--- a/scripts/bench/hexrcf_proof_sweep.py
+++ b/scripts/bench/hexrcf_proof_sweep.py
@@ -131,6 +131,7 @@ SPEC = SweepSpec(
         Path("SPEC/Libraries/hex-rcf.md"),
     ),
     required_samples=6,
+    max_pair_retries=32,
 )
 
 

--- a/scripts/bench/test_fresh_module_sweep.py
+++ b/scripts/bench/test_fresh_module_sweep.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import io
 import json
 import os
@@ -352,6 +353,45 @@ class PairingTests(unittest.TestCase):
             "; ".join(rejected[-1]["issues"]),
             "aggregate measurement-CPU foreign",
         )
+
+    def test_shared_host_hard_cap_is_33_complete_attempts(self) -> None:
+        modules = (
+            ("reference", sweep.ProbeModule("Probe.Baseline")),
+            ("candidate", sweep.ProbeModule("Probe.Candidate")),
+        )
+        with (
+            mock.patch.object(
+                sweep,
+                "build_sample",
+                return_value=self.shared_arm(foreign=0.10),
+            ) as build,
+            mock.patch.object(sweep, "sampled_host_state", return_value={}),
+            mock.patch.object(sweep, "cpu_affinity", return_value=[47]),
+            mock.patch.object(sys, "stdout", new=io.StringIO()),
+            mock.patch.object(sys, "stderr", new=io.StringIO()),
+            mock.patch.object(
+                sweep,
+                "wait_for_shared_host_window",
+                return_value={
+                    "admitted": True,
+                    "elapsed_seconds": 2.0,
+                    "rejected_windows": [],
+                    "accepted_window": {},
+                },
+            ),
+        ):
+            accepted, rejected, preflight_failure = (
+                sweep.build_shared_host_pair(
+                    "pair", 1, 0, modules,
+                    60.0, 47, [47, 95], [95], 0.002,
+                    sweep.MAX_PAIR_RETRIES, 2.0, 300.0,
+                )
+            )
+        self.assertIsNone(accepted)
+        self.assertIsNone(preflight_failure)
+        self.assertEqual(len(rejected), 33)
+        self.assertEqual(build.call_count, 66)
+        self.assertEqual(rejected[-1]["measurement_attempt"], 33)
 
     def test_interrupt_cannot_mask_negative_cpu_accounting(self) -> None:
         arm = self.shared_arm(
@@ -1002,15 +1042,52 @@ class HarnessValidationTests(unittest.TestCase):
                     ],
                 )
 
-    def test_pair_retry_limit_is_capped_at_eight(self) -> None:
+    def test_pair_retry_default_and_hard_cap_are_distinct(self) -> None:
+        self.assertEqual(
+            sweep.parse_args("shared", []).max_pair_retries, 8
+        )
+        self.assertEqual(
+            sweep.parse_args(
+                "shared", ["--max-pair-retries", "32"]
+            ).max_pair_retries,
+            32,
+        )
+        self.assertEqual(
+            sweep.parse_args(
+                "shared", ["--max-arm-retries", "32"]
+            ).max_pair_retries,
+            32,
+        )
         with mock.patch.object(sys, "stderr", new=io.StringIO()):
             with self.assertRaises(SystemExit):
                 sweep.parse_args(
-                    "shared", ["--max-pair-retries", "9"]
+                    "shared", ["--max-pair-retries", "33"]
                 )
             with self.assertRaises(SystemExit):
                 sweep.parse_args(
-                    "shared", ["--max-arm-retries", "9"]
+                    "shared", ["--max-arm-retries", "33"]
+                )
+            with self.assertRaises(SystemExit):
+                sweep.parse_args(
+                    "shared", ["--max-pair-retries", "-1"]
+                )
+
+    def test_suite_preregisters_exact_shared_host_retry_bound(self) -> None:
+        spec = dataclasses.replace(SPEC, max_pair_retries=32)
+        with mock.patch.object(sweep, "configure_shared_host"):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "requires --max-pair-retries 32, got 8",
+            ):
+                sweep.run_cli(
+                    spec,
+                    CALLER,
+                    [
+                        "--samples", "6",
+                        "--shared-host",
+                        "--expected-host", "chungus2",
+                        "--cpu", "22",
+                    ],
                 )
 
     def test_exhausted_pair_emits_unsummarized_partial_artifact(self) -> None:

--- a/scripts/bench/test_hexrcf_proof_sweep.py
+++ b/scripts/bench/test_hexrcf_proof_sweep.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import re
+import shlex
 import unittest
 
 from scripts.bench import fresh_module_sweep as sweep
@@ -79,6 +80,30 @@ class ManifestTests(unittest.TestCase):
 
     def test_schema_tracks_contract_change(self) -> None:
         self.assertEqual(rcf.SPEC.schema, "hexrcf-proof-probes-v6")
+
+    def test_shared_host_recipe_requests_retry_headroom(self) -> None:
+        source = (sweep.ROOT / "SPEC/Libraries/hex-rcf.md").read_text(
+            encoding="utf-8"
+        )
+        match = re.search(
+            r"```bash\n(?P<command>python3 "
+            r"scripts/bench/hexrcf_proof_sweep\.py.*?\n)```",
+            source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(match)
+        assert match is not None
+        command = match.group("command").replace("\\\n", " ")
+        argv = shlex.split(command)[2:]
+        args = sweep.parse_args(rcf.SPEC.description, argv)
+        self.assertEqual(args.samples, rcf.SPEC.required_samples)
+        self.assertTrue(args.shared_host)
+        self.assertEqual(args.expected_host, "chungus2")
+        self.assertEqual(args.cpu, 22)
+        self.assertEqual(args.timeout, 300)
+        self.assertEqual(args.warm_timeout, 600)
+        self.assertEqual(args.max_pair_retries, rcf.SPEC.max_pair_retries)
+        self.assertEqual(rcf.SPEC.max_pair_retries, 32)
 
     def test_substantive_pairs_remain_five_per_case(self) -> None:
         substantive = [pair for pair in rcf.SPEC.pairs if not pair.null_control]


### PR DESCRIPTION
Updates #9025

The first schema-v6 collection attempt on the designated shared host exhausted all nine attempts for DoubleDegree50. Every 14.29-14.59 s arm was correctly rejected for 40-280 ms of audited aggregate foreign/sibling interference above the unchanged 30 ms allowance. This was strict filtering, not an inadmissible host or runner error.

This narrow follow-up:

- preserves the generic default of 8 whole-pair retries and raises only the hard cap to 32;
- adds an exact per-suite retry preregistration to SweepSpec, so HexRCF requires 32 while every other suite remains at 8;
- makes the canonical HexRCF command request 32 retries, meaning at most 33 same-order adjacent pair attempts;
- leaves preflight, orientation, accounting, frequency, interference, timeout, artifact, and release-quality gates unchanged;
- records every rejected attempt and still emits an incomplete non-release artifact on exhaustion;
- tests default/cap/alias/negative boundaries, exact 33-attempt/66-arm exhaustion, suite-to-CLI equality, and parses the documented command as executable argv.

Operational bounds are documented: about 17 minutes for one long-control sample at observed cost with immediate preflights; nominal configured envelope 8 h 15 min excluding bounded overhead. This is a manual scientific run, never CI.

Validation:

- PYTHONPATH=. python3 -m unittest scripts.bench.test_fresh_module_sweep scripts.bench.test_hexrcf_proof_sweep (73 tests)
- Phase-4, DAG, trust-surface, Mathlib-free bench, and diff checks
- independent Sol exact-head review: GO
- fresh high-effort Opus review: GO; its suite-enforcement, recipe-parser, help-text, and bound-qualification findings are included
- local validator/report helpers independently enforce retry config 32 and attempts 1-33