### PR TITLE
resultant: certify pseudo-division transport

### DIFF
--- a/HexManual/Chapters/HexResultant.lean
+++ b/HexManual/Chapters/HexResultant.lean
@@ -49,6 +49,35 @@ nonzero polynomial.
 
 {docstring Hex.DensePoly.subresultantChain}
 
+# Certified pseudo-division algebra
+%%%
+tag := "hex-resultant-pseudo-division"
+%%%
+
+The coefficient recurrence is characterized independently of its array
+implementation: reconstruction and a remainder smaller than the divisor
+determine the quotient/remainder pair uniquely. Nonzero scaling of either
+input then follows from that characterization.
+
+{docstring Hex.DensePoly.pseudoDivMod_unique}
+
+{docstring Hex.DensePoly.pseudoDivMod_scale_left}
+
+{docstring Hex.DensePoly.pseudoDivMod_scale_right}
+
+The Mathlib companion transports the same step through the formal-degree
+Sylvester determinant. This is the resultant recurrence used by the later
+Brown correctness argument; the coefficientwise integrality of Brown's exact
+quotients remains its own subresultant theorem.
+
+{docstring Hex.DensePoly.PseudoDivMod.quotient_degree}
+
+{docstring Hex.DensePoly.PseudoDivMod.remainder_degree}
+
+{docstring Hex.DensePoly.PseudoDivMod.resultant_step}
+
+{docstring Hex.DensePoly.PseudoDivMod.resultant_step_degree}
+
 # Certified chain structure
 %%%
 tag := "hex-resultant-chain-structure"

--- a/HexPoly/Dense.lean
+++ b/HexPoly/Dense.lean
@@ -517,6 +517,20 @@ def degree? (p : DensePoly R) : Option Nat :=
 @[simp, grind =] theorem size_zero : (0 : DensePoly R).size = 0 := by
   rfl
 
+/-- A normalized dense polynomial has no stored coefficients exactly when it
+is the zero polynomial. -/
+@[simp]
+theorem size_eq_zero_iff (p : DensePoly R) : p.size = 0 ↔ p = 0 := by
+  constructor
+  · intro hp
+    apply ext_of_size_eq
+    · rw [hp, size_zero]
+    · intro i hi
+      omega
+  · intro hp
+    subst p
+    exact size_zero
+
 /-- The zero polynomial has no degree. -/
 @[simp, grind =] theorem degree?_zero : (0 : DensePoly R).degree? = none := by
   unfold degree?

--- a/HexPoly/Euclid/MulRing.lean
+++ b/HexPoly/Euclid/MulRing.lean
@@ -363,6 +363,49 @@ theorem mul_sub_zero_comm {S : Type _}
     diagonalSum_eq_degree_bound p (0 - q) n, diagonalSum_eq_degree_bound q p n,
     diagonalSum_neg_right p q n, fold_diagonal_comm p q n]
 
+/-- Pull a coefficient scalar through the left polynomial factor. -/
+theorem scale_mul {S : Type _} [Lean.Grind.CommRing S] [DecidableEq S]
+    (a : S) (p q : DensePoly S) :
+    scale a (p * q) = scale a p * q := by
+  apply ext_coeff
+  intro n
+  rw [coeff_scale_semiring, coeff_mul, coeff_mul,
+    mulCoeffSum_eq_diagonal, mulCoeffSum_eq_diagonal,
+    diagonalSum_eq_degree_bound (scale a p) q n,
+    diagonalSum_eq_degree_bound p q n]
+  let term : DensePoly S → Nat → S := fun r i =>
+    diagonalMulCoeffTerm r q n i
+  have hfold : ∀ m acc,
+      (List.range m).foldl (fun x i => x + term (scale a p) i) acc =
+        acc + a * (List.range m).foldl (fun x i => x + term p i) 0 := by
+    intro m
+    induction m with
+    | zero =>
+        intro acc
+        simp
+        grind
+    | succ m ih =>
+        intro acc
+        rw [List.range_succ, List.foldl_append, List.foldl_append]
+        simp only [List.foldl_cons, List.foldl_nil]
+        rw [ih]
+        have hterm : term (scale a p) m = a * term p m := by
+          unfold term diagonalMulCoeffTerm
+          by_cases hnm : n < m
+          · simp only [hnm, if_true]
+            grind
+          · simp only [hnm, if_false, coeff_scale_semiring]
+            grind
+        rw [hterm]
+        grind
+  have h := hfold (n + 1) 0
+  have hzero : (0 : S) +
+      a * (List.range (n + 1)).foldl (fun x i => x + term p i) 0 =
+        a * (List.range (n + 1)).foldl (fun x i => x + term p i) 0 := by
+    grind
+  rw [hzero] at h
+  simpa only [term] using h.symm
+
 /-- Commutativity of `DensePoly` multiplication. Hand-proved because `DensePoly`
 carries only `Lean.Grind.CommRing`, not Mathlib's `CommRing`, so `mul_comm`
 is unavailable. -/
@@ -374,6 +417,13 @@ theorem mul_comm_poly {S : Type _}
   intro n
   rw [coeff_mul, coeff_mul, mulCoeffSum_eq_diagonal p q n, mulCoeffSum_eq_diagonal q p n,
     diagonalSum_eq_degree_bound p q n, diagonalSum_eq_degree_bound q p n, fold_diagonal_comm p q n]
+
+/-- Pull a coefficient scalar through the right polynomial factor. -/
+theorem mul_scale {S : Type _} [Lean.Grind.CommRing S] [DecidableEq S]
+    (a : S) (p q : DensePoly S) :
+    scale a (p * q) = p * scale a q := by
+  rw [mul_comm_poly p q, scale_mul a q p,
+    mul_comm_poly (scale a q) p]
 
 /-- Cancellation rearrangement `(x + y) - (z + x) = y + (0 - z)`, used to
 simplify mixed add/sub combinations arising in the Euclidean update steps. -/

--- a/HexPoly/Operations.lean
+++ b/HexPoly/Operations.lean
@@ -174,6 +174,15 @@ rewrite because the required `c * 0 = 0` law is available from the semiring stru
     (scale c p).coeff n = c * p.coeff n :=
   coeff_scale c p n (Lean.Grind.Semiring.mul_zero c)
 
+/-- Scaling twice multiplies the two scalars. -/
+theorem scale_scale {S : Type u} [Lean.Grind.Semiring S] [DecidableEq S]
+    (a b : S) (p : DensePoly S) :
+    scale a (scale b p) = scale (a * b) p := by
+  apply ext_coeff
+  intro n
+  simp only [coeff_scale_semiring]
+  grind
+
 /-- Semiring-specialized left zero law for scalar multiplication. -/
 @[simp, grind =] theorem scale_zero_left_semiring {S : Type u}
     [Lean.Grind.Semiring S] [DecidableEq S]
@@ -1447,6 +1456,15 @@ theorem coeff_add [Add R] (p q : DensePoly R) (n : Nat)
     (hzero : AddZeroLaw S := by infer_instance) :
     (p + q).coeff n = p.coeff n + q.coeff n :=
   coeff_add p q n hzero.add_zero_zero
+
+/-- Scaling distributes over polynomial addition. -/
+theorem scale_add {S : Type u} [Lean.Grind.Semiring S] [DecidableEq S]
+    (a : S) (p q : DensePoly S) :
+    scale a (p + q) = scale a p + scale a q := by
+  apply ext_coeff
+  intro n
+  simp only [coeff_scale_semiring, coeff_add_semiring]
+  grind
 
 /-- Coefficient law for subtraction. The explicit zero law is needed because the generic
 `Sub`/`Zero` interface does not imply `0 - 0 = 0`. -/

--- a/HexPoly/SPEC/hex-poly.md
+++ b/HexPoly/SPEC/hex-poly.md
@@ -24,6 +24,8 @@ type. As with `ofCoeffs`, trailing zero coefficients are removed.
 
 **Operations:**
 - Addition, subtraction, multiplication (schoolbook, Karatsuba for large degree)
+- Coefficient scaling, with public composition, addition, and multiplication
+  transport laws (`scale_scale`, `scale_add`, `scale_mul`, `mul_scale`)
 - Division with remainder (for monic divisors; general division over fields)
 - Polynomial GCD (plain Euclidean remainder sequence — **not** the extended
   algorithm). `gcd` tracks only the remainders, so it is `O(deg²)`. The extended

--- a/HexResultant.lean
+++ b/HexResultant.lean
@@ -8,6 +8,7 @@ module
 
 public import HexResultant.Basic
 public import HexResultant.ExactDiv
+public import HexResultant.PseudoDivMod
 public import HexResultant.Subresultant
 public import HexResultant.Discriminant
 

--- a/HexResultant/Basic.lean
+++ b/HexResultant/Basic.lean
@@ -748,13 +748,8 @@ theorem pseudoDivMod_reconstruct {S : Type u}
     scale (g.leadingCoeff ^ (f.size - g.size + 1)) f =
       (pseudoDivMod f g).1 * g + (pseudoDivMod f g).2 := by
   have hgpos : 0 < g.size := by
-    apply Nat.pos_of_ne_zero
-    intro hsize
-    apply hg
-    apply ext_coeff
-    intro i
-    rw [coeff_zero]
-    exact coeff_eq_zero_of_size_le g (by omega)
+    exact Nat.pos_of_ne_zero fun hsize =>
+      hg ((size_eq_zero_iff g).mp hsize)
   have hfpos : 0 < f.size := Nat.lt_of_lt_of_le hgpos hfg
   have hgzero : g.isZero = false := (isZero_eq_false_iff g).2 hgpos
   let n := f.size - 1

--- a/HexResultant/ExactDiv.lean
+++ b/HexResultant/ExactDiv.lean
@@ -140,6 +140,38 @@ def divExp [Zero R] [DecidableEq R] [One R] [Mul R] [Div R]
 
 namespace DensePoly
 
+/-- A nonzero scalar does not change the normalized dense size. -/
+theorem size_scale [Lean.Grind.CommRing R] [DecidableEq R] [Div R]
+    [ExactDivLaws R] {a : R} (ha : a ≠ 0) (p : DensePoly R) :
+    (scale a p).size = p.size := by
+  have hle : (scale a p).size ≤ p.size := by
+    rw [scale_eq_scaleImpl]
+    exact size_scaleImpl_le a p
+  by_cases hp : p.size = 0
+  · omega
+  have hp_pos : 0 < p.size := Nat.pos_of_ne_zero hp
+  have hcoeff : (scale a p).coeff (p.size - 1) ≠ (0 : R) := by
+    rw [coeff_scale_semiring]
+    exact ExactDivLaws.mul_ne_zero ha
+      (coeff_last_ne_zero_of_pos_size p hp_pos)
+  apply Nat.le_antisymm hle
+  apply Nat.le_of_not_gt
+  intro hlt
+  exact hcoeff (coeff_eq_zero_of_size_le (scale a p) (by omega))
+
+/-- The leading coefficient scales with a nonzero coefficient scalar. -/
+theorem leadingCoeff_scale [Lean.Grind.CommRing R] [DecidableEq R] [Div R]
+    [ExactDivLaws R] {a : R} (ha : a ≠ 0) (p : DensePoly R) :
+    (scale a p).leadingCoeff = a * p.leadingCoeff := by
+  by_cases hp : p.size = 0
+  · have hp0 : p = 0 := (size_eq_zero_iff p).mp hp
+    subst p
+    simp [Lean.Grind.Semiring.mul_zero]
+  have hp_pos : 0 < p.size := Nat.pos_of_ne_zero hp
+  have hsize := size_scale ha p
+  rw [leadingCoeff_eq_coeff_last _ (hsize ▸ hp_pos), hsize,
+    coeff_scale_semiring, leadingCoeff_eq_coeff_last p hp_pos]
+
 /-- Divide every coefficient by the same scalar.
 
 Kernel-facing specification: one map over the coefficient list. Compiled code

--- a/HexResultant/PseudoDivMod.lean
+++ b/HexResultant/PseudoDivMod.lean
@@ -1,0 +1,211 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexResultant.Basic
+public import HexResultant.ExactDiv
+
+public section
+
+/-!
+Algebraic transport laws for fraction-free pseudo-division.
+
+The executable coefficient recurrence in `HexResultant.Basic` already proves
+reconstruction and the quotient/remainder size bounds.  This module adds the
+uniqueness theorem that characterizes those outputs and uses it to derive the
+two scalar homogeneity laws needed by the Brown--Traub development.
+-/
+namespace Hex.DensePoly
+
+universe u
+
+variable {S : Type u} [Lean.Grind.CommRing S] [DecidableEq S]
+
+variable [Div S] [ExactDivLaws S]
+
+/-- Powers distribute over multiplication in the lightweight commutative ring. -/
+private theorem mul_pow {T : Type u} [Lean.Grind.CommRing T]
+    (a b : T) : ∀ n : Nat, (a * b) ^ n = a ^ n * b ^ n
+  | 0 => by
+      rw [Lean.Grind.Semiring.pow_zero, Lean.Grind.Semiring.pow_zero,
+        Lean.Grind.Semiring.pow_zero]
+      exact (Lean.Grind.Semiring.mul_one 1).symm
+  | n + 1 => by
+      rw [Lean.Grind.Semiring.pow_succ, Lean.Grind.Semiring.pow_succ,
+        Lean.Grind.Semiring.pow_succ, mul_pow a b n]
+      grind
+
+/-- Below a positive-degree divisor, a strict dense-size bound gives the
+corresponding default-degree bound. -/
+private theorem degree_lt_of_size_lt {T : Type u} [Lean.Grind.CommRing T]
+    [DecidableEq T] (p g : DensePoly T)
+    (hg : 1 < g.size) (hp : p.size < g.size) :
+    p.degree?.getD 0 < g.degree?.getD 0 := by
+  rw [degree?_eq_some_of_pos_size g (by omega), Option.getD_some]
+  by_cases hp0 : p.size = 0
+  · rw [(degree?_eq_none_iff p).2 hp0, Option.getD_none]
+    omega
+  · rw [degree?_eq_some_of_pos_size p (Nat.pos_of_ne_zero hp0),
+      Option.getD_some]
+    omega
+
+/-- Reconstruction and the strict remainder bound uniquely characterize
+`pseudoDivMod` on an ordered nonzero input pair. -/
+theorem pseudoDivMod_unique (f g q r : DensePoly S) (hg : g ≠ 0)
+    (hgf : g.size ≤ f.size)
+    (hrec : scale (g.leadingCoeff ^ (f.size - g.size + 1)) f = q * g + r)
+    (hr : r.size < g.size) :
+    pseudoDivMod f g = (q, r) := by
+  rcases hqr : pseudoDivMod f g with ⟨q', r'⟩
+  have hrec' :
+      scale (g.leadingCoeff ^ (f.size - g.size + 1)) f = q' * g + r' := by
+    simpa only [hqr] using pseudoDivMod_reconstruct f g hg hgf
+  have hr' : r'.size < g.size := by
+    simpa only [hqr] using pseudoDivMod_remainder_lt f g hg
+  have hg_pos : 0 < g.size := by
+    exact Nat.pos_of_ne_zero fun hzero =>
+      hg ((size_eq_zero_iff g).mp hzero)
+  by_cases hg_const : g.size = 1
+  · have hr0 : r = 0 := (size_eq_zero_iff r).mp (by omega)
+    have hr'0 : r' = 0 := (size_eq_zero_iff r').mp (by omega)
+    have hmul : q' * g = q * g := by
+      rw [hr0, DensePoly.add_zero_poly] at hrec
+      rw [hr'0, DensePoly.add_zero_poly] at hrec'
+      exact hrec'.symm.trans hrec
+    have hq : q' = q :=
+      ExactDivLaws.mul_right_cancel (R := DensePoly S) hg hmul
+    exact Prod.ext hq (hr'0.trans hr0.symm)
+  · have hg_big : 1 < g.size := by omega
+    have hg_deg : 0 < g.degree?.getD 0 := by
+      rw [degree?_eq_some_of_pos_size g hg_pos, Option.getD_some]
+      omega
+    have hr_deg := degree_lt_of_size_lt r g hg_big hr
+    have hr'_deg := degree_lt_of_size_lt r' g hg_big hr'
+    have hmul : (q - q') * g = r' - r := by
+      rw [sub_mul_poly q q' g]
+      apply ext_coeff
+      intro n
+      have heq : (q * g).coeff n + r.coeff n =
+          (q' * g).coeff n + r'.coeff n := by
+        have h := congrArg (fun p : DensePoly S => p.coeff n)
+          (hrec.symm.trans hrec')
+        simpa only [coeff_add_semiring] using h
+      simp only [coeff_sub_ring]
+      grind
+    have hdeg : (r' - r).degree?.getD 0 < g.degree?.getD 0 :=
+      degree_getD_sub_lt r' r g hg_deg hr'_deg hr_deg
+    have hlc : g.leadingCoeff ≠ (0 : S) :=
+      leadingCoeff_ne_zero_of_pos_size g hg_pos
+    have hA : divMod (r' - r) g = (q - q', 0) :=
+      divMod_eq_of_polynomial_mul (r' - r) g (q - q') hg
+        (fun a => ExactDivLaws.mul_div_cancel_right a g.leadingCoeff hlc)
+        (fun _ ha => ExactDivLaws.mul_ne_zero ha hlc) hmul
+    have hB : divMod (r' - r) g = (0, r' - r) :=
+      divMod_eq_zero_self_of_degree_lt (r' - r) g hdeg
+    rw [hA] at hB
+    have hqq : q - q' = 0 := (Prod.mk.injEq _ _ _ _ ▸ hB).1
+    have hrr : (0 : DensePoly S) = r' - r :=
+      (Prod.mk.injEq _ _ _ _ ▸ hB).2
+    have hq : q' = q := by
+      apply ext_coeff
+      intro n
+      have h := congrArg (fun p : DensePoly S => p.coeff n) hqq
+      rw [coeff_sub_ring, coeff_zero] at h
+      grind
+    have hremainder : r' = r := by
+      apply ext_coeff
+      intro n
+      have h := congrArg (fun p : DensePoly S => p.coeff n) hrr.symm
+      rw [coeff_sub_ring, coeff_zero] at h
+      grind
+    exact Prod.ext hq hremainder
+
+/-- Scaling the dividend scales both pseudo-division outputs. -/
+theorem pseudoDivMod_scale_left (f g : DensePoly S) {a : S} (ha : a ≠ 0)
+    (hg : g ≠ 0) (hgf : g.size ≤ f.size) :
+    pseudoDivMod (scale a f) g =
+      (scale a (pseudoDivMod f g).1, scale a (pseudoDivMod f g).2) := by
+  let q := (pseudoDivMod f g).1
+  let r := (pseudoDivMod f g).2
+  have hfsize : (scale a f).size = f.size := size_scale ha f
+  have hrec := pseudoDivMod_reconstruct f g hg hgf
+  have hcandidate :
+      scale (g.leadingCoeff ^ ((scale a f).size - g.size + 1)) (scale a f) =
+        scale a q * g + scale a r := by
+    rw [hfsize, scale_scale, show g.leadingCoeff ^ (f.size - g.size + 1) * a =
+        a * g.leadingCoeff ^ (f.size - g.size + 1) by grind,
+      ← scale_mul a q g,
+      ← scale_add, ← hrec, scale_scale]
+  apply pseudoDivMod_unique (scale a f) g (scale a q) (scale a r) hg
+    (by omega) hcandidate
+  have hr : r.size < g.size := by
+    simpa only [r] using pseudoDivMod_remainder_lt f g hg
+  have hle : (scale a r).size ≤ r.size := by
+    rw [scale_eq_scaleImpl]
+    exact size_scaleImpl_le a r
+  omega
+
+/-- Scaling the divisor by `a` scales the pseudo-quotient by `a^(d-1)` and
+the pseudo-remainder by `a^d`, where `d` is the number of cancellation rounds. -/
+theorem pseudoDivMod_scale_right (f g : DensePoly S) {a : S} (ha : a ≠ 0)
+    (hg : g ≠ 0) (hgf : g.size ≤ f.size) :
+    let d := f.size - g.size + 1
+    pseudoDivMod f (scale a g) =
+      (scale (a ^ (d - 1)) (pseudoDivMod f g).1,
+        scale (a ^ d) (pseudoDivMod f g).2) := by
+  let d := f.size - g.size + 1
+  let q := (pseudoDivMod f g).1
+  let r := (pseudoDivMod f g).2
+  have hgscale : scale a g ≠ 0 := by
+    intro hzero
+    have hsize := congrArg DensePoly.size hzero
+    rw [size_scale ha g, size_zero] at hsize
+    exact hg ((size_eq_zero_iff g).mp hsize)
+  have hgsize : (scale a g).size = g.size := size_scale ha g
+  have hlc : (scale a g).leadingCoeff = a * g.leadingCoeff :=
+    leadingCoeff_scale ha g
+  have hrec := pseudoDivMod_reconstruct f g hg hgf
+  have hdpos : 0 < d := by
+    dsimp only [d]
+    omega
+  have hpow : a ^ (d - 1) * a = a ^ d := by
+    rw [← Lean.Grind.Semiring.pow_succ]
+    exact congrArg (fun n : Nat => a ^ n) (by omega)
+  have hcandidate :
+      scale ((scale a g).leadingCoeff ^ (f.size - (scale a g).size + 1)) f =
+        scale (a ^ (d - 1)) q * scale a g + scale (a ^ d) r := by
+    rw [hgsize, hlc]
+    change scale ((a * g.leadingCoeff) ^ d) f = _
+    calc
+      scale ((a * g.leadingCoeff) ^ d) f =
+          scale (a ^ d * g.leadingCoeff ^ d) f := by rw [mul_pow]
+      _ = scale (a ^ d) (scale (g.leadingCoeff ^ d) f) := by
+        rw [scale_scale]
+      _ = scale (a ^ d) (q * g + r) := by
+        have hrec' : scale (g.leadingCoeff ^ d) f = q * g + r := by
+          simpa only [d, q, r] using hrec
+        rw [hrec']
+      _ = scale (a ^ d) (q * g) + scale (a ^ d) r :=
+        scale_add (a ^ d) (q * g) r
+      _ = scale (a ^ (d - 1)) (scale a (q * g)) + scale (a ^ d) r := by
+        rw [scale_scale, hpow]
+      _ = scale (a ^ (d - 1)) (q * scale a g) + scale (a ^ d) r := by
+        rw [mul_scale a q g]
+      _ = scale (a ^ (d - 1)) q * scale a g + scale (a ^ d) r := by
+        rw [scale_mul (a ^ (d - 1)) q (scale a g)]
+  dsimp only
+  apply pseudoDivMod_unique f (scale a g)
+    (scale (a ^ (d - 1)) q) (scale (a ^ d) r) hgscale
+    (by omega) hcandidate
+  have hr : r.size < g.size := by
+    simpa only [r] using pseudoDivMod_remainder_lt f g hg
+  have hle : (scale (a ^ d) r).size ≤ r.size := by
+    rw [scale_eq_scaleImpl]
+    exact size_scaleImpl_le (a ^ d) r
+  omega
+
+end Hex.DensePoly

--- a/HexResultant/SPEC/hex-resultant.md
+++ b/HexResultant/SPEC/hex-resultant.md
@@ -130,6 +130,37 @@ A valid Brown run proves every denominator nonzero and every quotient exact.
 On an invalid coefficient implementation or unreachable junk state, the
 executable value remains deterministic but carries no algebraic claim.
 
+## Certified pseudo-remainder algebra
+
+For an ordered nonzero pair, reconstruction together with the strict
+remainder-size bound uniquely determines `pseudoDivMod`. The public
+`pseudoDivMod_unique` theorem packages that characterization; it lets the
+correctness development reason from the algebraic contract instead of the
+array folds implementing the quotient and remainder.
+
+The same API proves the two homogeneity laws used in polynomial remainder
+sequence arguments. For nonzero `a` and an ordered nonzero pair
+(`g ≠ 0`, `g.size ≤ f.size`), if `d = f.size - g.size + 1`, then
+
+```text
+pseudoDivMod (a·f) g = (a·q, a·r)
+pseudoDivMod f (a·g) = (a^(d-1)·q, a^d·r)
+```
+
+where `(q,r) = pseudoDivMod f g`. Nonzero scaling preserves dense size and
+leading coefficients scale by `a`; those facts are exposed separately as
+`size_scale` and `leadingCoeff_scale` under `[Div S] [ExactDivLaws S]`, whose
+no-zero-divisor consequence is exactly what makes size preservation valid.
+
+In the Mathlib adjunct, `PseudoDivMod.resultant_step` transports one reconstructed
+pseudo-division step through the formal-degree Sylvester determinant. It
+combines scalar homogeneity, the resultant row operation, and the swap sign.
+This is the value recurrence needed by Brown correctness. It deliberately does
+not claim the later coefficientwise exact divisions: their integrality is the
+separate Brown--Traub subresultant theorem recorded by `BrownLaw`.
+In particular, reversing `divScalar` by scaling requires the coefficientwise
+exactness certified by that law; the homogeneity API does not assume it.
+
 ## Ordered Brown run
 
 For nonzero `G₁, G₂` with `deg G₁ ≥ deg G₂`, write `nᵢ = deg Gᵢ`,
@@ -254,6 +285,8 @@ quotient is exact over every stated exact-division domain.
 - `HexResultant/ExactDiv.lean`: `ExactDivLaws`, the total exact-division
   wrappers, and the `Int`, field, and recursive dense-polynomial instances.
 - `HexResultant/Basic.lean`: `pseudoDivMod` and its computational properties.
+- `HexResultant/PseudoDivMod.lean`: uniqueness, nonzero scaling, and the
+  left/right pseudo-division homogeneity laws.
 - `HexResultant/Subresultant.lean`: the Brown worker,
   `subresultantChain`, `resultant`, chain termination, and degree bounds.
 - `HexResultant/Discriminant.lean`: `disc` and the algebraic

--- a/HexResultant/Subresultant.lean
+++ b/HexResultant/Subresultant.lean
@@ -6,8 +6,8 @@ Authors: Kim Morrison
 
 module
 
-public import HexResultant.Basic
 public import HexResultant.ExactDiv
+public import HexResultant.PseudoDivMod
 public meta import HexResultant.ExactDiv
 public meta import HexPoly.Dense
 public meta import HexPoly.Euclid.DivGcd
@@ -158,12 +158,8 @@ private theorem ne_zero_of_isZero_false (p : DensePoly R)
 zero. -/
 private theorem eq_zero_of_isZero_true (p : DensePoly R)
     (hp : p.isZero = true) : p = 0 := by
-  apply ext_coeff
-  intro i
-  rw [coeff_zero]
-  exact coeff_eq_zero_of_size_le p (by
-    have hsize := (isZero_eq_true_iff p).1 hp
-    omega)
+  apply (size_eq_zero_iff p).mp
+  exact (isZero_eq_true_iff p).1 hp
 
 /-- A propositionally nonzero polynomial is rejected by the executable zero
 test. -/
@@ -689,10 +685,7 @@ theorem subresultantChain_zero_right [One R] [Add R] [Sub R] [Mul R] [Div R]
     · exact hpos
     · exfalso
       apply hf
-      apply ext_coeff
-      intro i
-      rw [coeff_zero]
-      exact coeff_eq_zero_of_size_le f (by omega)
+      exact (size_eq_zero_iff f).mp (by omega)
   have hzz : (0 : DensePoly R).isZero = true := rfl
   simp [hfz, hzz]
 
@@ -706,10 +699,7 @@ theorem subresultantChain_zero_left [One R] [Add R] [Sub R] [Mul R] [Div R]
     · exact hpos
     · exfalso
       apply hg
-      apply ext_coeff
-      intro i
-      rw [coeff_zero]
-      exact coeff_eq_zero_of_size_le g (by omega)
+      exact (size_eq_zero_iff g).mp (by omega)
   have hzz : (0 : DensePoly R).isZero = true := rfl
   simp [hgz, hzz]
 

--- a/HexResultantMathlib.lean
+++ b/HexResultantMathlib.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexResultantMathlib.Basic
+public import HexResultantMathlib.PseudoDivMod
 public import HexResultantMathlib.Chain
 public import HexResultantMathlib.Sylvester
 public import HexResultantMathlib.Specialize

--- a/HexResultantMathlib/PseudoDivMod.lean
+++ b/HexResultantMathlib/PseudoDivMod.lean
@@ -1,0 +1,199 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexResultantMathlib.Basic
+
+public section
+
+/-!
+Mathlib transport for executable pseudo-division.
+
+The main identity is the determinant-resultant version of one pseudo-division
+step.  It is independent of Brown's later exact scalar quotients and is the
+value invariant used by the subresultant correspondence proof.
+-/
+namespace Hex.DensePoly.PseudoDivMod
+
+universe u
+
+variable {R : Type u}
+
+/-- The executable reconstruction identity transported to Mathlib
+polynomials. -/
+theorem reconstruct [CommRing R] [DecidableEq R]
+    (f g : DensePoly R) (hg : g ≠ 0) (hgf : g.size ≤ f.size) :
+    let q := (pseudoDivMod f g).1
+    let r := (pseudoDivMod f g).2
+    Polynomial.C (g.leadingCoeff ^ (f.size - g.size + 1)) *
+        HexPolyMathlib.toPolynomial f =
+      HexPolyMathlib.toPolynomial q * HexPolyMathlib.toPolynomial g +
+        HexPolyMathlib.toPolynomial r := by
+  have h := congrArg HexPolyMathlib.toPolynomial
+    (pseudoDivMod_reconstruct f g hg hgf)
+  simpa only [HexPolyMathlib.toPolynomial_scale,
+    HexPolyMathlib.toPolynomial_mul, HexPolyMathlib.toPolynomial_add] using h
+
+/-- A pseudo-quotient fits in the formal-degree gap required by Mathlib's
+resultant row-operation theorem. -/
+theorem quotient_degree [CommRing R] [DecidableEq R]
+    (f g : DensePoly R) (hg : g ≠ 0) (hgf : g.size ≤ f.size) :
+    (HexPolyMathlib.toPolynomial (pseudoDivMod f g).1).natDegree +
+        (HexPolyMathlib.toPolynomial g).natDegree ≤
+      (HexPolyMathlib.toPolynomial f).natDegree := by
+  rw [HexPolyMathlib.natDegree_toPolynomial,
+    HexPolyMathlib.natDegree_toPolynomial,
+    HexPolyMathlib.natDegree_toPolynomial]
+  have hq := pseudoDivMod_quotient_size_le f g
+  have hgpos : 0 < g.size := by
+    exact Nat.pos_of_ne_zero fun hg0 =>
+      hg ((size_eq_zero_iff g).mp hg0)
+  have hfpos : 0 < f.size := Nat.lt_of_lt_of_le hgpos hgf
+  have hgdeg : g.degree?.getD 0 = g.size - 1 := by
+    by_cases hg0 : g.size = 0
+    · rw [(degree?_eq_none_iff g).2 hg0, Option.getD_none]
+      omega
+    · rw [degree?_eq_some_of_pos_size g (Nat.pos_of_ne_zero hg0),
+        Option.getD_some]
+  have hfdeg : f.degree?.getD 0 = f.size - 1 := by
+    rw [degree?_eq_some_of_pos_size f hfpos, Option.getD_some]
+  rw [hgdeg, hfdeg]
+  by_cases hq0 : (pseudoDivMod f g).1.size = 0
+  · rw [(degree?_eq_none_iff (pseudoDivMod f g).1).2 hq0,
+      Option.getD_none]
+    omega
+  · rw [degree?_eq_some_of_pos_size (pseudoDivMod f g).1
+        (Nat.pos_of_ne_zero hq0), Option.getD_some]
+    omega
+
+/-- A pseudo-remainder is zero or has strictly smaller Mathlib degree than
+the nonzero divisor. The disjunction records Mathlib's default degree `0` for
+the zero polynomial, including the constant-divisor case. -/
+theorem remainder_degree [CommRing R] [DecidableEq R]
+    (f g : DensePoly R) (hg : g ≠ 0) :
+    HexPolyMathlib.toPolynomial (pseudoDivMod f g).2 = 0 ∨
+      (HexPolyMathlib.toPolynomial (pseudoDivMod f g).2).natDegree <
+        (HexPolyMathlib.toPolynomial g).natDegree := by
+  have hr := pseudoDivMod_remainder_lt f g hg
+  have hgpos : 0 < g.size := by
+    exact Nat.pos_of_ne_zero fun hg0 =>
+      hg ((size_eq_zero_iff g).mp hg0)
+  by_cases hr0 : (pseudoDivMod f g).2.size = 0
+  · left
+    rw [(size_eq_zero_iff (pseudoDivMod f g).2).mp hr0,
+      HexPolyMathlib.toPolynomial_zero]
+  · right
+    rw [HexPolyMathlib.natDegree_toPolynomial,
+      HexPolyMathlib.natDegree_toPolynomial,
+      degree?_eq_some_of_pos_size (pseudoDivMod f g).2
+        (Nat.pos_of_ne_zero hr0),
+      degree?_eq_some_of_pos_size g hgpos, Option.getD_some,
+      Option.getD_some]
+    omega
+
+/-- One fraction-free pseudo-division step transports the formal-degree
+resultant from `(f,g)` to `(g,r)`, including the Sylvester swap sign. -/
+theorem resultant_step [CommRing R] [DecidableEq R]
+    (f g : DensePoly R) (hg : g ≠ 0) (hgf : g.size ≤ f.size) :
+    let r := (pseudoDivMod f g).2
+    let F := HexPolyMathlib.toPolynomial f
+    let G := HexPolyMathlib.toPolynomial g
+    let P := HexPolyMathlib.toPolynomial r
+    let n := F.natDegree
+    let m := G.natDegree
+    (g.leadingCoeff ^ (f.size - g.size + 1)) ^ m *
+        Polynomial.resultant F G n m =
+      (-1 : R) ^ (n * m) * Polynomial.resultant G P m n := by
+  let q := (pseudoDivMod f g).1
+  let r := (pseudoDivMod f g).2
+  let F := HexPolyMathlib.toPolynomial f
+  let G := HexPolyMathlib.toPolynomial g
+  let P := HexPolyMathlib.toPolynomial r
+  let Q := HexPolyMathlib.toPolynomial q
+  let n := F.natDegree
+  let m := G.natDegree
+  let b := g.leadingCoeff ^ (f.size - g.size + 1)
+  have hrec : Polynomial.C b * F = Q * G + P := by
+    simpa only [b, F, G, P, Q, q, r] using reconstruct f g hg hgf
+  have hrow : Polynomial.resultant (P + G * Q) G n m =
+      Polynomial.resultant P G n m := by
+    apply Polynomial.resultant_add_mul_left
+    · simpa only [Q, G, n, m, q] using quotient_degree f g hg hgf
+    · exact (show G.natDegree ≤ m by rfl)
+  change b ^ m * Polynomial.resultant F G n m =
+    (-1 : R) ^ (n * m) * Polynomial.resultant G P m n
+  have hreorder : Q * G + P = P + G * Q := by ring
+  calc
+    b ^ m * Polynomial.resultant F G n m =
+        Polynomial.resultant (Polynomial.C b * F) G n m := by
+      rw [Polynomial.resultant_C_mul_left]
+    _ = Polynomial.resultant (P + G * Q) G n m := by
+      rw [hrec, hreorder]
+    _ = Polynomial.resultant P G n m := hrow
+    _ = (-1 : R) ^ (n * m) * Polynomial.resultant G P m n :=
+      Polynomial.resultant_comm P G n m
+
+/-- The pseudo-division resultant identity with the remainder returned to its
+actual default degree. The compensating leading-coefficient power records the
+formal-degree promotion explicitly. -/
+theorem resultant_step_degree [CommRing R] [DecidableEq R]
+    (f g : DensePoly R) (hg : g ≠ 0) (hgf : g.size ≤ f.size) :
+    let r := (pseudoDivMod f g).2
+    let F := HexPolyMathlib.toPolynomial f
+    let G := HexPolyMathlib.toPolynomial g
+    let P := HexPolyMathlib.toPolynomial r
+    let n := F.natDegree
+    let m := G.natDegree
+    let k := P.natDegree
+    (g.leadingCoeff ^ (f.size - g.size + 1)) ^ m *
+        Polynomial.resultant F G n m =
+      (-1 : R) ^ (n * m) *
+        (g.leadingCoeff ^ (n - k) * Polynomial.resultant G P m k) := by
+  let r := (pseudoDivMod f g).2
+  let F := HexPolyMathlib.toPolynomial f
+  let G := HexPolyMathlib.toPolynomial g
+  let P := HexPolyMathlib.toPolynomial r
+  let n := F.natDegree
+  let m := G.natDegree
+  let k := P.natDegree
+  have hr : r.size < g.size := by
+    simpa only [r] using pseudoDivMod_remainder_lt f g hg
+  have hgpos : 0 < g.size := by
+    exact Nat.pos_of_ne_zero fun hg0 =>
+      hg ((size_eq_zero_iff g).mp hg0)
+  have hfpos : 0 < f.size := Nat.lt_of_lt_of_le hgpos hgf
+  have hk : k ≤ n := by
+    change (HexPolyMathlib.toPolynomial r).natDegree ≤
+      (HexPolyMathlib.toPolynomial f).natDegree
+    rw [HexPolyMathlib.natDegree_toPolynomial,
+      HexPolyMathlib.natDegree_toPolynomial]
+    by_cases hr0 : r.size = 0
+    · rw [(degree?_eq_none_iff r).2 hr0, Option.getD_none,
+        degree?_eq_some_of_pos_size f hfpos, Option.getD_some]
+      omega
+    · rw [degree?_eq_some_of_pos_size r (Nat.pos_of_ne_zero hr0),
+        degree?_eq_some_of_pos_size f hfpos, Option.getD_some,
+        Option.getD_some]
+      omega
+  have hpromote : Polynomial.resultant G P m n =
+      g.leadingCoeff ^ (n - k) * Polynomial.resultant G P m k := by
+    have h := Polynomial.resultant_add_right_deg G P m k (n - k) le_rfl
+    rw [Nat.add_sub_of_le hk] at h
+    have hlc : G.coeff m = g.leadingCoeff := by
+      simpa only [G, m, Polynomial.leadingCoeff] using
+        HexPolyMathlib.leadingCoeff_toPolynomial g
+    simpa only [m, k, hlc] using h
+  calc
+    (g.leadingCoeff ^ (f.size - g.size + 1)) ^ m *
+          Polynomial.resultant F G n m =
+        (-1 : R) ^ (n * m) * Polynomial.resultant G P m n := by
+      simpa only [r, F, G, P, n, m] using resultant_step f g hg hgf
+    _ = (-1 : R) ^ (n * m) *
+          (g.leadingCoeff ^ (n - k) * Polynomial.resultant G P m k) := by
+      rw [hpromote]
+
+end Hex.DensePoly.PseudoDivMod

--- a/HexResultantMathlib/SPEC/hex-resultant-mathlib.md
+++ b/HexResultantMathlib/SPEC/hex-resultant-mathlib.md
@@ -13,7 +13,8 @@ resultant, including its units, powers, and signs.
 
 The exact typeclass assumptions follow the executable algorithm: `R` is a
 commutative integral domain with decidable equality, a quotient operation, and
-`Hex.ExactDivLaws R`.
+`Hex.ExactDivLaws R`. The `PseudoDivMod` transport theorems are deliberately
+more general and need only `[CommRing R] [DecidableEq R]`.
 
 ```lean
 namespace Hex.DensePoly
@@ -33,6 +34,67 @@ noncomputable def specialize [CommRing R] [DecidableEq R]
 noncomputable def evalBivariate [CommRing R] [DecidableEq R]
     (f : DensePoly (DensePoly R)) (a b : R) : R :=
   (specialize f a).eval b
+
+namespace PseudoDivMod
+
+/-- Transport the executable pseudo-division reconstruction to Mathlib
+    polynomials. -/
+theorem reconstruct [CommRing R] [DecidableEq R]
+    (f g : DensePoly R) (hg : g ≠ 0) (hgf : g.size ≤ f.size) :
+    let q := (pseudoDivMod f g).1
+    let r := (pseudoDivMod f g).2
+    Polynomial.C (g.leadingCoeff ^ (f.size - g.size + 1)) *
+        HexPolyMathlib.toPolynomial f =
+      HexPolyMathlib.toPolynomial q * HexPolyMathlib.toPolynomial g +
+        HexPolyMathlib.toPolynomial r
+
+/-- The pseudo-quotient fits the formal-degree gap used by the resultant row
+    operation. -/
+theorem quotient_degree [CommRing R] [DecidableEq R]
+    (f g : DensePoly R) (hg : g ≠ 0) (hgf : g.size ≤ f.size) :
+    (HexPolyMathlib.toPolynomial (pseudoDivMod f g).1).natDegree +
+        (HexPolyMathlib.toPolynomial g).natDegree ≤
+      (HexPolyMathlib.toPolynomial f).natDegree
+
+/-- The pseudo-remainder is zero or has strictly smaller Mathlib degree than
+    the nonzero divisor. -/
+theorem remainder_degree [CommRing R] [DecidableEq R]
+    (f g : DensePoly R) (hg : g ≠ 0) :
+    HexPolyMathlib.toPolynomial (pseudoDivMod f g).2 = 0 ∨
+      (HexPolyMathlib.toPolynomial (pseudoDivMod f g).2).natDegree <
+        (HexPolyMathlib.toPolynomial g).natDegree
+
+/-- Transport one pseudo-division step through the formal-degree Sylvester
+    resultant, including its scalar power and swap sign. -/
+theorem resultant_step [CommRing R] [DecidableEq R]
+    (f g : DensePoly R) (hg : g ≠ 0) (hgf : g.size ≤ f.size) :
+    let r := (pseudoDivMod f g).2
+    let F := HexPolyMathlib.toPolynomial f
+    let G := HexPolyMathlib.toPolynomial g
+    let P := HexPolyMathlib.toPolynomial r
+    let n := F.natDegree
+    let m := G.natDegree
+    (g.leadingCoeff ^ (f.size - g.size + 1)) ^ m *
+        Polynomial.resultant F G n m =
+      (-1 : R) ^ (n * m) * Polynomial.resultant G P m n
+
+/-- The same identity with the remainder returned to its actual default
+    degree and the compensating leading-coefficient power explicit. -/
+theorem resultant_step_degree [CommRing R] [DecidableEq R]
+    (f g : DensePoly R) (hg : g ≠ 0) (hgf : g.size ≤ f.size) :
+    let r := (pseudoDivMod f g).2
+    let F := HexPolyMathlib.toPolynomial f
+    let G := HexPolyMathlib.toPolynomial g
+    let P := HexPolyMathlib.toPolynomial r
+    let n := F.natDegree
+    let m := G.natDegree
+    let k := P.natDegree
+    (g.leadingCoeff ^ (f.size - g.size + 1)) ^ m *
+        Polynomial.resultant F G n m =
+      (-1 : R) ^ (n * m) *
+        (g.leadingCoeff ^ (n - k) * Polynomial.resultant G P m k)
+
+end PseudoDivMod
 
 /-- The executable and Mathlib resultants agree under the dense-polynomial
     correspondence. -/
@@ -129,8 +191,11 @@ multiplicity representation.
 Stage 1 is sufficient for `AlgebraicRoot` operation soundness and can land before
 the determinant correspondence.
 
-1. Define Mathlib polynomial pseudo-division and prove its quotient/remainder
-   identity and degree bound.
+1. Transport the executable pseudo-division reconstruction and degree bounds to
+   Mathlib polynomials. `PseudoDivMod.resultant_step` and
+   `resultant_step_degree` already
+   package the resulting Sylvester row operation, scalar power, swap sign, and
+   formal-degree promotion.
 2. Transfer the executable pseudo-remainder sequence through `toPolynomial`.
 3. Prove forward and backward preservation of common roots along the chain.
 4. Relate a positive-degree final gcd to executable resultant zero.
@@ -179,6 +244,7 @@ Sylvester-minor proof rather than retaining that obsolete total.
 ```text
 HexResultantMathlib/
   Basic.lean           : public theorem statements
+  PseudoDivMod.lean    : reconstruction and one-step resultant transport
   Chain.lean           : pseudo-division transfer and Stage 1
   Sylvester.lean       : subresultant minors and full agreement
   Specialize.lean      : bivariate specialization and norm corollaries

--- a/conformance/HexResultant/Conformance.lean
+++ b/conformance/HexResultant/Conformance.lean
@@ -24,7 +24,8 @@ Covered properties:
 - exact quotients, binary powers, and coefficientwise quotients obey their
   independently calculated integer values;
 - pseudo-division reconstructs the prescribed leading-coefficient multiple
-  and leaves a remainder smaller than the divisor;
+  and leaves a remainder smaller than the divisor; reconstruction plus that
+  bound is unique, and nonzero input scaling obeys the two homogeneity laws;
 - Brown chains omit zero terms, order unequal-degree inputs, strictly decrease
   after their first two entries, obey the sharp length bound, and are stable
   under extra fuel;
@@ -93,6 +94,25 @@ private def withinChainBound (f g : DensePoly Int) : Bool :=
 
 /-! # Pseudo-division -/
 
+example (f g q r : DensePoly Int) (hg : g ≠ 0) (hgf : g.size ≤ f.size)
+    (hrec : scale (g.leadingCoeff ^ (f.size - g.size + 1)) f = q * g + r)
+    (hr : r.size < g.size) : pseudoDivMod f g = (q, r) :=
+  pseudoDivMod_unique f g q r hg hgf hrec hr
+
+example (f g : DensePoly Int) {a : Int} (ha : a ≠ 0)
+    (hg : g ≠ 0) (hgf : g.size ≤ f.size) :
+    pseudoDivMod (scale a f) g =
+      (scale a (pseudoDivMod f g).1, scale a (pseudoDivMod f g).2) :=
+  pseudoDivMod_scale_left f g ha hg hgf
+
+example (f g : DensePoly Int) {a : Int} (ha : a ≠ 0)
+    (hg : g ≠ 0) (hgf : g.size ≤ f.size) :
+    let d := f.size - g.size + 1
+    pseudoDivMod f (scale a g) =
+      (scale (a ^ (d - 1)) (pseudoDivMod f g).1,
+        scale (a ^ d) (pseudoDivMod f g).2) :=
+  pseudoDivMod_scale_right f g ha hg hgf
+
 -- Typical nonmonic division: `4*(X^2+1) = (2X-1)*(2X+1)+5`.
 #guard
   let f := poly [1, 0, 1]
@@ -118,6 +138,49 @@ private def withinChainBound (f g : DensePoly Int) : Bool :=
   let f := poly [3]
   let g := poly [1, 1]
   pseudoDivMod f g = (0, f)
+
+-- Scaling the dividend scales both outputs by the same nonzero scalar.
+#guard
+  let f := poly [1, 0, 1]
+  let g := poly [1, 2]
+  let qr := pseudoDivMod (scale (-3) f) g
+  coeffs qr.1 = [3, -6] && coeffs qr.2 = [-15]
+
+-- Scaling the divisor by `a` scales quotient and remainder by `a^(d-1)`
+-- and `a^d`, respectively.
+#guard
+  let f := poly [1, 0, 1]
+  let g := poly [1, 2]
+  let qr := pseudoDivMod f (scale 3 g)
+  coeffs qr.1 = [-3, 6] && coeffs qr.2 = [45]
+
+-- The constant-divisor branch has `d = f.size` and zero remainder.
+#guard
+  let f := poly [1, 0, 1]
+  let g := poly [3]
+  let qr := pseudoDivMod f (scale 2 g)
+  coeffs qr.1 = [36, 0, 36] && coeffs qr.2 = []
+
+-- Equal-size inputs have `d = 1`, so scaling the divisor leaves the
+-- pseudo-quotient unchanged and scales only the remainder.
+#guard
+  let f := poly [1, 1]
+  let g := poly [3, 2]
+  let qr := pseudoDivMod f (scale 5 g)
+  coeffs qr.1 = [1] && coeffs qr.2 = [-5]
+
+-- Divisor scaling preserves the unused factor across a defective degree drop.
+#guard
+  let f := poly [0, 0, 0, 1]
+  let g := poly [1, 0, 2]
+  let qr := pseudoDivMod f (scale (-2) g)
+  coeffs qr.1 = [0, -4] && coeffs qr.2 = [0, -8]
+
+-- Nonzero scaling preserves normalized size and scales the leading coefficient.
+#guard
+  let p := poly [1, 0, -2]
+  let q := scale (-3) p
+  q.size = p.size && q.leadingCoeff = 6
 
 /-! # Brown chain -/
 

--- a/progress/2026-07-28T16-03-21Z.md
+++ b/progress/2026-07-28T16-03-21Z.md
@@ -1,0 +1,35 @@
+# Resultant pseudo-division transport
+
+## Accomplished
+
+- Added the algebraic characterization of executable pseudo-division and
+  proved left- and right-scaling laws, including the constant-divisor case.
+- Put generic dense-polynomial scaling laws in HexPoly, and kept the
+  exact-domain size and leading-coefficient laws in `HexResultant.ExactDiv`.
+- Transported pseudo-division reconstruction, quotient/remainder degree
+  bounds, and the signed formal-degree resultant step to Mathlib polynomials.
+- Updated the Resultant/HexPoly SPECs, manual chapter, umbrellas, and
+  conformance coverage for constant divisors, equal sizes, and defective
+  degree drops.
+- Verified all 9,561 build jobs, the Resultant conformance target, all four
+  Resultant benchmark registrations, byte-identical 128-line fixtures, and an
+  axiom audit with no `sorryAx` in the new theorem closure.
+
+## Current frontier
+
+`subresultantOrdered_brownLaw` remains the first unresolved Resultant theorem.
+The new homogeneity and one-step resultant APIs expose the algebraic transport
+needed around it without assuming Brown--Traub coefficientwise divisibility.
+
+## Next step
+
+Merge this milestone before beginning another one. Then develop the
+Sylvester-minor/fundamental-subresultant invariant that proves the corrected
+pseudo-remainders land in the base ring and makes every Brown scalar division
+exact.
+
+## Blockers
+
+No operational blocker. The mathematical blocker is the Brown--Traub
+integrality theorem itself; pseudo-remainder reconstruction and resultant
+value identities alone do not imply its coefficientwise divisibility claim.


### PR DESCRIPTION
## Summary

- characterize executable pseudo-division by reconstruction and strict remainder size, including constant divisors
- prove dividend/divisor homogeneity and place generic scaling laws in HexPoly
- transport reconstruction, degree bounds, the signed resultant step, and formal-degree promotion to Mathlib
- document the exact Brown integrality boundary and add conformance coverage for constant, equal-size, and defective cases

## Verification

- `lake build` (9,561 jobs)
- `lake build HexResultant.Conformance HexManual.Chapters.HexResultant HexResultantMathlib`
- `lake exe hexresultant_bench` (all four benchmarks registered)
- `lake exe hexresultant_emit_fixtures` (128 lines, byte-identical SHA-256)
- axiom audit of all new core and Mathlib theorems (only `propext`, `Classical.choice`, and `Quot.sound`)

A fresh independent source-level review found no theorem soundness issue. Its documentation, public-degree-bound, layering, naming, and corner-case coverage findings are incorporated here.