### PR TITLE
resultant: add fraction-field proof bridge

### DIFF
--- a/HexManual/Chapters/HexResultant.lean
+++ b/HexManual/Chapters/HexResultant.lean
@@ -78,6 +78,31 @@ quotients remains its own subresultant theorem.
 
 {docstring Hex.DensePoly.PseudoDivMod.resultant_step_degree}
 
+# Fraction-field proof bridge
+
+Brown--Traub exactness is proved first after embedding coefficients in a
+Mathlib-free fraction field. The embedding is injective, commutes with ordered
+pseudo-division, and turns an embedding-image certificate into the scalar and
+coefficientwise reconstruction equations required by the Brown recurrence.
+This bridge is proof-only; the executable chain continues to operate entirely
+in its input coefficient ring.
+
+{docstring Hex.Fraction.ofCoeff}
+
+{docstring Hex.Fraction.ofCoeff_injective}
+
+{docstring Hex.DensePoly.Fraction.map}
+
+{docstring Hex.Fraction.div_pullback}
+
+{docstring Hex.Fraction.divExp_exact}
+
+{docstring Hex.DensePoly.Fraction.map_pseudoDivMod}
+
+{docstring Hex.DensePoly.Fraction.divScalar_pullback}
+
+{docstring Hex.DensePoly.Fraction.divScalar_exact}
+
 # Certified chain structure
 %%%
 tag := "hex-resultant-chain-structure"

--- a/HexResultant.lean
+++ b/HexResultant.lean
@@ -9,6 +9,7 @@ module
 public import HexResultant.Basic
 public import HexResultant.ExactDiv
 public import HexResultant.PseudoDivMod
+public import HexResultant.FractionPoly
 public import HexResultant.Subresultant
 public import HexResultant.Discriminant
 

--- a/HexResultant/Fraction.lean
+++ b/HexResultant/Fraction.lean
@@ -1,0 +1,704 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexResultant.ExactDiv
+
+public section
+
+/-!
+The fraction field used internally by the Mathlib-free subresultant proof.
+
+The executable resultant never constructs these values.  They provide the
+classical quotient-field setting in which the Brown--Traub scale identities
+can be proved before exact quotients are pulled back to the coefficient ring.
+-/
+
+namespace Hex
+
+universe u
+
+namespace Fraction
+
+/-- The nontriviality needed to use `1` as a fraction denominator. Brown's
+nonzero input hypothesis supplies this locally even though the lightweight
+commutative-ring hierarchy itself permits the trivial ring. -/
+class NonzeroOne (R : Type u) [Zero R] [One R] : Prop where
+  one_ne_zero : (1 : R) ≠ 0
+
+namespace NonzeroOne
+
+/-- Any nonzero element of a commutative ring witnesses its nontriviality. -/
+theorem of_ne_zero {R : Type u} [Lean.Grind.CommRing R] {a : R} (ha : a ≠ 0) :
+    NonzeroOne R := by
+  refine ⟨?_⟩
+  intro hone
+  apply ha
+  calc
+    a = a * 1 := (Lean.Grind.Semiring.mul_one a).symm
+    _ = a * 0 := by rw [hone]
+    _ = 0 := Lean.Grind.Semiring.mul_zero a
+
+end NonzeroOne
+end Fraction
+
+/-- A numerator and a certified nonzero denominator. -/
+structure Fraction.Rep (R : Type u) [Zero R] where
+  num : R
+  den : R
+  den_ne : den ≠ 0
+
+namespace Fraction.Rep
+
+variable {R : Type u} [Lean.Grind.CommRing R] [Div R] [ExactDivLaws R]
+
+/-- Cross-multiplication equivalence on fraction representatives. -/
+@[expose]
+def Rel (a b : Fraction.Rep R) : Prop :=
+  a.num * b.den = b.num * a.den
+
+omit [Div R] [ExactDivLaws R] in
+theorem rel_refl (a : Fraction.Rep R) : Rel a a := by
+  exact rfl
+
+omit [Div R] [ExactDivLaws R] in
+theorem rel_symm {a b : Fraction.Rep R} (h : Rel a b) : Rel b a := by
+  exact h.symm
+
+theorem rel_trans {a b c : Fraction.Rep R}
+    (hab : Rel a b) (hbc : Rel b c) : Rel a c := by
+  apply ExactDivLaws.mul_right_cancel b.den_ne
+  unfold Rel at hab hbc
+  calc
+    a.num * c.den * b.den = (a.num * b.den) * c.den := by grind
+    _ = (b.num * a.den) * c.den := by rw [hab]
+    _ = (b.num * c.den) * a.den := by grind
+    _ = (c.num * b.den) * a.den := by rw [hbc]
+    _ = c.num * a.den * b.den := by grind
+
+instance : Setoid (Fraction.Rep R) where
+  r := Rel
+  iseqv := ⟨rel_refl, rel_symm, rel_trans⟩
+
+instance [DecidableEq R] (a b : Fraction.Rep R) : Decidable (Rel a b) :=
+  by
+    unfold Rel
+    infer_instance
+
+/-- Product of two representatives. -/
+def mul (a b : Fraction.Rep R) : Fraction.Rep R :=
+  ⟨a.num * b.num, a.den * b.den,
+    ExactDivLaws.mul_ne_zero a.den_ne b.den_ne⟩
+
+/-- Sum of two representatives. -/
+def add (a b : Fraction.Rep R) : Fraction.Rep R :=
+  ⟨a.num * b.den + b.num * a.den, a.den * b.den,
+    ExactDivLaws.mul_ne_zero a.den_ne b.den_ne⟩
+
+/-- Additive inverse of a representative. -/
+def neg (a : Fraction.Rep R) : Fraction.Rep R :=
+  ⟨-a.num, a.den, a.den_ne⟩
+
+theorem mul_rel {a b c d : Fraction.Rep R}
+    (hac : Rel a c) (hbd : Rel b d) : Rel (mul a b) (mul c d) := by
+  unfold Rel at hac hbd
+  unfold Rel mul
+  calc
+    a.num * b.num * (c.den * d.den) =
+        (a.num * c.den) * (b.num * d.den) := by grind
+    _ = (c.num * a.den) * (d.num * b.den) := by rw [hac, hbd]
+    _ = c.num * d.num * (a.den * b.den) := by grind
+
+theorem add_rel {a b c d : Fraction.Rep R}
+    (hac : Rel a c) (hbd : Rel b d) : Rel (add a b) (add c d) := by
+  unfold Rel at hac hbd
+  unfold Rel add
+  calc
+    (a.num * b.den + b.num * a.den) * (c.den * d.den) =
+        (a.num * c.den) * (b.den * d.den) +
+          (b.num * d.den) * (a.den * c.den) := by grind
+    _ = (c.num * a.den) * (b.den * d.den) +
+          (d.num * b.den) * (a.den * c.den) := by rw [hac, hbd]
+    _ = (c.num * d.den + d.num * c.den) * (a.den * b.den) := by grind
+
+omit [Div R] [ExactDivLaws R] in
+theorem neg_rel {a b : Fraction.Rep R} (hab : Rel a b) :
+    Rel (neg a) (neg b) := by
+  unfold Rel at hab
+  unfold Rel neg
+  rw [Lean.Grind.Ring.neg_mul, Lean.Grind.Ring.neg_mul, hab]
+
+end Fraction.Rep
+
+/-- The quotient field of a commutative exact-division domain. -/
+@[expose]
+def Fraction (R : Type u) [Lean.Grind.CommRing R] [Div R] [ExactDivLaws R] :=
+  Quotient (Fraction.Rep.instSetoid (R := R))
+
+namespace Fraction
+
+variable {R : Type u} [Lean.Grind.CommRing R] [Div R] [ExactDivLaws R]
+
+/-- Decidable equality inherited from cross multiplication of representatives. -/
+instance [DecidableEq R] : DecidableEq (Fraction R) :=
+  fun q₁ q₂ =>
+    Quotient.recOnSubsingleton₂ q₁ q₂ fun a b =>
+      if h : Fraction.Rep.Rel a b then
+        isTrue (Quotient.sound h)
+      else
+        isFalse fun hab => h (Quotient.exact hab)
+
+variable [NonzeroOne R]
+
+attribute [local instance] Lean.Grind.Semiring.natCast Lean.Grind.Ring.intCast
+
+/-- Inject a representative into its quotient. -/
+@[expose]
+def ofRep (a : Fraction.Rep R) : Fraction R :=
+  Quotient.mk _ a
+
+/-- Embed a coefficient as a fraction with denominator one. -/
+@[expose]
+def ofCoeff (a : R) : Fraction R :=
+  ofRep ⟨a, 1, NonzeroOne.one_ne_zero⟩
+
+omit [Div R] [ExactDivLaws R] in
+private theorem one_ne_zero : (1 : R) ≠ 0 := by
+  exact NonzeroOne.one_ne_zero
+
+omit [NonzeroOne R] in
+private theorem ofRep_eq {a b : Fraction.Rep R}
+    (h : Fraction.Rep.Rel a b) : ofRep a = ofRep b :=
+  Quotient.sound h
+
+/-- Multiplication of fractions. -/
+@[expose]
+protected def mul : Fraction R → Fraction R → Fraction R :=
+  Quotient.lift₂ (fun a b => ofRep (Fraction.Rep.mul a b)) (by
+    intro a b c d hac hbd
+    exact ofRep_eq (Fraction.Rep.mul_rel hac hbd))
+
+/-- Addition of fractions. -/
+@[expose]
+protected def add : Fraction R → Fraction R → Fraction R :=
+  Quotient.lift₂ (fun a b => ofRep (Fraction.Rep.add a b)) (by
+    intro a b c d hac hbd
+    exact ofRep_eq (Fraction.Rep.add_rel hac hbd))
+
+/-- Negation of fractions. -/
+@[expose]
+protected def neg : Fraction R → Fraction R :=
+  Quotient.lift (fun a => ofRep (Fraction.Rep.neg a)) (by
+    intro a b hab
+    exact ofRep_eq (Fraction.Rep.neg_rel hab))
+
+instance : Zero (Fraction R) := ⟨ofCoeff 0⟩
+instance : One (Fraction R) := ⟨ofCoeff 1⟩
+instance : Add (Fraction R) := ⟨Fraction.add⟩
+instance : Mul (Fraction R) := ⟨Fraction.mul⟩
+instance : Neg (Fraction R) := ⟨Fraction.neg⟩
+instance : Sub (Fraction R) := ⟨fun a b => a + -b⟩
+
+omit [NonzeroOne R] in
+private theorem rep_eq (a b : Fraction.Rep R) (h : Fraction.Rep.Rel a b) :
+    (ofRep a : Fraction R) = ofRep b :=
+  Quotient.sound h
+
+theorem add_zero (a : Fraction R) : a + 0 = a := by
+  induction a using Quotient.inductionOn with
+  | _ a =>
+      apply rep_eq
+      unfold Fraction.Rep.Rel Fraction.Rep.add
+      simp only [Lean.Grind.Semiring.zero_mul, Lean.Grind.Semiring.add_zero,
+        Lean.Grind.Semiring.mul_one]
+
+omit [NonzeroOne R] in
+theorem add_comm (a b : Fraction R) : a + b = b + a := by
+  induction a, b using Quotient.inductionOn₂ with
+  | _ a b =>
+      apply rep_eq
+      unfold Fraction.Rep.Rel Fraction.Rep.add
+      grind
+
+omit [NonzeroOne R] in
+theorem add_assoc (a b c : Fraction R) : a + b + c = a + (b + c) := by
+  induction a, b, c using Quotient.inductionOn₃ with
+  | _ a b c =>
+      apply rep_eq
+      unfold Fraction.Rep.Rel Fraction.Rep.add
+      grind
+
+omit [NonzeroOne R] in
+theorem mul_assoc (a b c : Fraction R) : a * b * c = a * (b * c) := by
+  induction a, b, c using Quotient.inductionOn₃ with
+  | _ a b c =>
+      apply rep_eq
+      unfold Fraction.Rep.Rel Fraction.Rep.mul
+      grind
+
+theorem mul_one (a : Fraction R) : a * 1 = a := by
+  induction a using Quotient.inductionOn with
+  | _ a =>
+      apply rep_eq
+      unfold Fraction.Rep.Rel Fraction.Rep.mul
+      simp only [Lean.Grind.Semiring.mul_one]
+
+theorem one_mul (a : Fraction R) : 1 * a = a := by
+  induction a using Quotient.inductionOn with
+  | _ a =>
+      apply rep_eq
+      unfold Fraction.Rep.Rel Fraction.Rep.mul
+      simp only [Lean.Grind.Semiring.one_mul]
+
+omit [NonzeroOne R] in
+theorem left_distrib (a b c : Fraction R) : a * (b + c) = a * b + a * c := by
+  induction a, b, c using Quotient.inductionOn₃ with
+  | _ a b c =>
+      apply rep_eq
+      unfold Fraction.Rep.Rel Fraction.Rep.mul Fraction.Rep.add
+      grind
+
+omit [NonzeroOne R] in
+theorem right_distrib (a b c : Fraction R) : (a + b) * c = a * c + b * c := by
+  induction a, b, c using Quotient.inductionOn₃ with
+  | _ a b c =>
+      apply rep_eq
+      unfold Fraction.Rep.Rel Fraction.Rep.mul Fraction.Rep.add
+      grind
+
+theorem zero_mul (a : Fraction R) : 0 * a = 0 := by
+  induction a using Quotient.inductionOn with
+  | _ a =>
+      apply rep_eq
+      unfold Fraction.Rep.Rel Fraction.Rep.mul
+      simp only [Lean.Grind.Semiring.zero_mul]
+
+theorem mul_zero (a : Fraction R) : a * 0 = 0 := by
+  induction a using Quotient.inductionOn with
+  | _ a =>
+      apply rep_eq
+      unfold Fraction.Rep.Rel Fraction.Rep.mul
+      simp only [Lean.Grind.Semiring.mul_zero, Lean.Grind.Semiring.zero_mul]
+
+theorem neg_add_cancel (a : Fraction R) : -a + a = 0 := by
+  induction a using Quotient.inductionOn with
+  | _ a =>
+      apply rep_eq
+      unfold Fraction.Rep.Rel Fraction.Rep.neg Fraction.Rep.add
+      grind
+
+omit [NonzeroOne R] in
+theorem neg_neg (a : Fraction R) : -(-a) = a := by
+  induction a using Quotient.inductionOn with
+  | _ a =>
+      apply rep_eq
+      unfold Fraction.Rep.Rel Fraction.Rep.neg
+      rw [Lean.Grind.AddCommGroup.neg_neg]
+
+omit [NonzeroOne R] in
+theorem mul_comm (a b : Fraction R) : a * b = b * a := by
+  induction a, b using Quotient.inductionOn₂ with
+  | _ a b =>
+      apply rep_eq
+      unfold Fraction.Rep.Rel Fraction.Rep.mul
+      grind
+
+omit [NonzeroOne R] in
+theorem neg_mul (a b : Fraction R) : (-a) * b = -(a * b) := by
+  induction a, b using Quotient.inductionOn₂ with
+  | _ a b =>
+      apply rep_eq
+      unfold Fraction.Rep.Rel Fraction.Rep.neg Fraction.Rep.mul
+      grind
+
+/-- The coefficient embedding preserves zero. -/
+@[simp]
+theorem ofCoeff_zero :
+    ofCoeff (Zero.zero : R) = (Zero.zero : Fraction R) := rfl
+
+/-- The coefficient embedding preserves one. -/
+@[simp]
+theorem ofCoeff_one :
+    ofCoeff (One.one : R) = (One.one : Fraction R) := rfl
+
+/-- The coefficient embedding preserves addition. -/
+@[simp]
+theorem ofCoeff_add (a b : R) : ofCoeff (a + b) = ofCoeff a + ofCoeff b := by
+  apply rep_eq
+  unfold Fraction.Rep.Rel Fraction.Rep.add
+  grind
+
+/-- The coefficient embedding preserves multiplication. -/
+@[simp]
+theorem ofCoeff_mul (a b : R) : ofCoeff (a * b) = ofCoeff a * ofCoeff b := by
+  apply rep_eq
+  unfold Fraction.Rep.Rel Fraction.Rep.mul
+  grind
+
+/-- The coefficient embedding preserves negation. -/
+@[simp]
+theorem ofCoeff_neg (a : R) : ofCoeff (-a) = -ofCoeff a := by
+  apply rep_eq
+  unfold Fraction.Rep.Rel Fraction.Rep.neg
+  grind
+
+/-- The coefficient embedding preserves subtraction. -/
+@[simp]
+theorem ofCoeff_sub (a b : R) : ofCoeff (a - b) = ofCoeff a - ofCoeff b := by
+  rw [Lean.Grind.Ring.sub_eq_add_neg (α := R)]
+  change ofCoeff (a + -b) = ofCoeff a + -ofCoeff b
+  rw [ofCoeff_add, ofCoeff_neg]
+
+/-- The coefficient embedding is injective. -/
+theorem ofCoeff_injective {a b : R} (h : ofCoeff a = ofCoeff b) : a = b := by
+  have hrel : a * 1 = b * 1 := Quotient.exact h
+  simpa only [Lean.Grind.Semiring.mul_one] using hrel
+
+/-- Natural powers of fractions. -/
+@[expose]
+def natPow (a : Fraction R) : Nat → Fraction R
+  | 0 => 1
+  | n + 1 => natPow a n * a
+
+instance : NatCast (Fraction R) :=
+  ⟨fun n => ofCoeff (Nat.cast n)⟩
+
+instance (n : Nat) : OfNat (Fraction R) n :=
+  ⟨match n with
+    | 0 => Zero.zero
+    | 1 => One.one
+    | n + 2 => ofCoeff (OfNat.ofNat (α := R) (n + 2))⟩
+
+/-- Fraction numerals agree with embedded coefficient numerals. -/
+theorem ofNat_eq_ofCoeff (n : Nat) :
+    OfNat.ofNat (α := Fraction R) n = ofCoeff (OfNat.ofNat (α := R) n) := by
+  cases n with
+  | zero => rfl
+  | succ n =>
+      cases n with
+      | zero => rfl
+      | succ n => rfl
+
+instance : SMul Nat (Fraction R) :=
+  ⟨fun n a => (Nat.cast n : Fraction R) * a⟩
+
+instance : HPow (Fraction R) Nat (Fraction R) :=
+  ⟨natPow⟩
+
+instance : IntCast (Fraction R) :=
+  ⟨fun i => ofCoeff (Int.cast i)⟩
+
+instance : SMul Int (Fraction R) :=
+  ⟨fun i a => (Int.cast i : Fraction R) * a⟩
+
+instance : Lean.Grind.Semiring (Fraction R) := by
+  refine Lean.Grind.Semiring.mk ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_ ?_
+  · exact add_zero
+  · exact add_comm
+  · exact add_assoc
+  · exact mul_assoc
+  · exact mul_one
+  · exact one_mul
+  · exact left_distrib
+  · exact right_distrib
+  · exact zero_mul
+  · exact mul_zero
+  · intro a
+    change natPow a 0 = 1
+    rw [natPow]
+  · intro a n
+    change natPow a (n + 1) = natPow a n * a
+    rw [natPow]
+  · intro n
+    rw [ofNat_eq_ofCoeff, ofNat_eq_ofCoeff, ofNat_eq_ofCoeff]
+    rw [← ofCoeff_add]
+    exact congrArg (ofCoeff (R := R))
+      (Lean.Grind.Semiring.ofNat_succ (α := R) n)
+  · intro n
+    rw [ofNat_eq_ofCoeff]
+    exact congrArg (ofCoeff (R := R))
+      (Lean.Grind.Semiring.ofNat_eq_natCast (α := R) n)
+  · intro _ _
+    rfl
+
+instance : Lean.Grind.Ring (Fraction R) := by
+  refine Lean.Grind.Ring.mk ?_ ?_ ?_ ?_ ?_ ?_
+  · exact neg_add_cancel
+  · intro _ _
+    rfl
+  · intro i a
+    change ofCoeff (R := R) (Int.cast (-i)) * a =
+      -(ofCoeff (R := R) (Int.cast i) * a)
+    rw [Lean.Grind.Ring.intCast_neg, ofCoeff_neg, neg_mul]
+  · intro n a
+    change ofCoeff (R := R) (Int.cast (Int.ofNat n)) * a =
+      ofCoeff (R := R) (Nat.cast n) * a
+    have hcast : Int.cast (R := R) (Int.ofNat n) = Nat.cast n :=
+      Lean.Grind.Ring.intCast_natCast n
+    exact congrArg (fun x : Fraction R => x * a)
+      (congrArg (ofCoeff (R := R)) hcast)
+  · intro n
+    rw [ofNat_eq_ofCoeff]
+    exact congrArg (ofCoeff (R := R))
+      (Lean.Grind.Ring.intCast_ofNat (α := R) n)
+  · intro i
+    change ofCoeff (R := R) (Int.cast (-i)) =
+      -ofCoeff (R := R) (Int.cast i)
+    rw [Lean.Grind.Ring.intCast_neg, ofCoeff_neg]
+
+instance : Lean.Grind.CommRing (Fraction R) := by
+  refine Lean.Grind.CommRing.mk ?_
+  exact mul_comm
+
+omit [NonzeroOne R] in
+/-- Related representatives have zero numerators simultaneously. -/
+private theorem num_eq_zero_iff {a b : Fraction.Rep R}
+    (hab : Fraction.Rep.Rel a b) : a.num = 0 ↔ b.num = 0 := by
+  constructor
+  · intro ha
+    apply ExactDivLaws.mul_right_cancel a.den_ne
+    unfold Fraction.Rep.Rel at hab
+    calc
+      b.num * a.den = 0 := by simpa [ha, Lean.Grind.Semiring.zero_mul] using hab.symm
+      _ = 0 * a.den := by rw [Lean.Grind.Semiring.zero_mul]
+  · intro hb
+    apply ExactDivLaws.mul_right_cancel b.den_ne
+    unfold Fraction.Rep.Rel at hab
+    calc
+      a.num * b.den = 0 := by simpa [hb, Lean.Grind.Semiring.zero_mul] using hab
+      _ = 0 * b.den := by rw [Lean.Grind.Semiring.zero_mul]
+
+variable [DecidableEq R]
+
+/-- Reciprocal of a fraction representative, with zero sent to zero. -/
+@[expose]
+def invRep (a : Fraction.Rep R) : Fraction R :=
+  if h : a.num = 0 then 0 else ofRep ⟨a.den, a.num, h⟩
+
+private theorem invRep_rel {a b : Fraction.Rep R}
+    (hab : Fraction.Rep.Rel a b) : invRep a = invRep b := by
+  by_cases ha : a.num = 0
+  · have hb : b.num = 0 := (num_eq_zero_iff hab).mp ha
+    simp [invRep, ha, hb]
+  · have hb : b.num ≠ 0 := by
+      intro hb
+      exact ha ((num_eq_zero_iff hab).mpr hb)
+    unfold invRep
+    rw [dif_neg ha, dif_neg hb]
+    apply rep_eq
+    unfold Fraction.Rep.Rel at hab ⊢
+    grind
+
+/-- Multiplicative inverse in the fraction field. -/
+@[expose]
+protected def inv : Fraction R → Fraction R :=
+  Quotient.lift invRep (by
+    intro a b hab
+    exact invRep_rel hab)
+
+instance : Inv (Fraction R) := ⟨Fraction.inv⟩
+instance : Div (Fraction R) := ⟨fun a b => a * b⁻¹⟩
+
+omit [NonzeroOne R] [DecidableEq R] in
+@[simp]
+theorem mul_ofRep (a b : Fraction.Rep R) :
+    ofRep a * ofRep b = ofRep (Fraction.Rep.mul a b) := rfl
+
+@[simp]
+theorem inv_ofRep (a : Fraction.Rep R) : (ofRep a)⁻¹ = invRep a := rfl
+
+omit [DecidableEq R] in
+/-- A representative is zero exactly when its numerator is zero. -/
+theorem ofRep_eq_zero_iff (a : Fraction.Rep R) : ofRep a = 0 ↔ a.num = 0 := by
+  constructor
+  · intro h
+    have hrel : a.num * 1 = 0 * a.den := Quotient.exact h
+    simpa only [Lean.Grind.Semiring.mul_one, Lean.Grind.Semiring.zero_mul] using hrel
+  · intro h
+    apply rep_eq
+    unfold Fraction.Rep.Rel
+    simp [h, Lean.Grind.Semiring.zero_mul]
+
+omit [DecidableEq R] in
+/-- The coefficient embedding reflects zero. -/
+@[simp]
+theorem ofCoeff_eq_zero_iff (a : R) : ofCoeff a = 0 ↔ a = 0 := by
+  exact ofRep_eq_zero_iff ⟨a, 1, one_ne_zero⟩
+
+/-- Fraction inversion uses the stable zero branch. -/
+@[simp]
+theorem inv_zero : (0 : Fraction R)⁻¹ = 0 := by
+  change invRep ⟨0, 1, one_ne_zero⟩ = 0
+  simp [invRep]
+
+/-- Every nonzero fraction has the expected multiplicative inverse. -/
+theorem mul_inv_cancel {a : Fraction R} (ha : a ≠ 0) : a * a⁻¹ = 1 := by
+  induction a using Quotient.inductionOn with
+  | _ a =>
+      change ofRep a * (ofRep a)⁻¹ = 1
+      have hnum : a.num ≠ 0 := by
+        intro hnum
+        exact ha ((ofRep_eq_zero_iff a).mpr hnum)
+      rw [inv_ofRep]
+      have hinv : invRep a = ofRep ⟨a.den, a.num, hnum⟩ := by
+        simp [invRep, hnum]
+      rw [hinv, mul_ofRep]
+      apply rep_eq
+      unfold Fraction.Rep.Rel Fraction.Rep.mul
+      grind
+
+omit [DecidableEq R] in
+/-- Zero and one are distinct in the fraction field. -/
+theorem zero_ne_one : (0 : Fraction R) ≠ 1 := by
+  intro h
+  have hcoeff : (0 : R) = 1 := ofCoeff_injective h
+  exact one_ne_zero hcoeff.symm
+
+/-- Inversion is involutive. -/
+theorem inv_inv (a : Fraction R) : a⁻¹⁻¹ = a := by
+  induction a using Quotient.inductionOn with
+  | _ a =>
+      change (ofRep a)⁻¹⁻¹ = ofRep a
+      rw [inv_ofRep]
+      by_cases hnum : a.num = 0
+      · have hzero : ofRep a = 0 := (ofRep_eq_zero_iff a).mpr hnum
+        rw [show invRep a = 0 by simp [invRep, hnum], inv_zero, hzero]
+      · rw [show invRep a = ofRep ⟨a.den, a.num, hnum⟩ by simp [invRep, hnum],
+          inv_ofRep]
+        unfold invRep
+        rw [dif_neg a.den_ne]
+
+/-- The inverse of one is one. -/
+theorem inv_one : (1 : Fraction R)⁻¹ = 1 := by
+  have hone : (1 : Fraction R) ≠ 0 := fun h => zero_ne_one h.symm
+  have h := mul_inv_cancel hone
+  rw [one_mul] at h
+  exact h
+
+/-- Integer powers of fractions use natural powers and total inversion. -/
+@[expose]
+def intPow (a : Fraction R) : Int → Fraction R
+  | .ofNat n => a ^ n
+  | .negSucc n => (a ^ (n + 1))⁻¹
+
+instance : HPow (Fraction R) Int (Fraction R) := ⟨intPow⟩
+
+/-- Division is multiplication by the fraction inverse. -/
+theorem div_eq_mul_inv (a b : Fraction R) : a / b = a * b⁻¹ := rfl
+
+/-- A nonzero denominator cancels on the right of fraction division. -/
+theorem div_mul_cancel (a : Fraction R) {b : Fraction R} (hb : b ≠ 0) :
+    a / b * b = a := by
+  rw [div_eq_mul_inv, mul_assoc, mul_comm b⁻¹ b, mul_inv_cancel hb, mul_one]
+
+/-- Fraction division satisfies the exact-division law. -/
+instance : ExactDivLaws (Fraction R) where
+  mul_div_cancel_right a b hb := by
+    rw [div_eq_mul_inv, mul_assoc, mul_inv_cancel hb, mul_one]
+
+/-- The quotient construction is a field in the lightweight Grind hierarchy. -/
+instance : Lean.Grind.Field (Fraction R) := by
+  refine Lean.Grind.Field.mk ?_ ?_ ?_ ?_ ?_ ?_ ?_
+  · exact div_eq_mul_inv
+  · exact zero_ne_one
+  · exact inv_zero
+  · exact mul_inv_cancel
+  · intro a
+    change natPow a 0 = 1
+    rw [natPow]
+  · intro a n
+    change natPow a (n + 1) = natPow a n * a
+    rw [natPow]
+  · intro a n
+    cases n with
+    | ofNat m =>
+        cases m with
+        | zero =>
+            change intPow a (-Int.ofNat 0) = (intPow a (Int.ofNat 0))⁻¹
+            rw [show -Int.ofNat 0 = Int.ofNat 0 by rfl]
+            change (1 : Fraction R) = 1⁻¹
+            exact inv_one.symm
+        | succ m => rfl
+    | negSucc m =>
+        simp only [Int.neg_negSucc]
+        change a ^ (m + 1) = ((a ^ (m + 1))⁻¹)⁻¹
+        exact (inv_inv _).symm
+
+omit [DecidableEq R] in
+/-- The coefficient embedding preserves natural powers. -/
+@[simp]
+theorem ofCoeff_pow (a : R) (n : Nat) : ofCoeff (a ^ n) = ofCoeff a ^ n := by
+  induction n with
+  | zero =>
+      rw [Lean.Grind.Semiring.pow_zero, Lean.Grind.Semiring.pow_zero]
+      exact ofCoeff_one
+  | succ n ih =>
+      rw [Lean.Grind.Semiring.pow_succ, Lean.Grind.Semiring.pow_succ,
+        ofCoeff_mul, ih]
+
+/-- Pull an exact scalar quotient back through the coefficient embedding.
+
+The hypothesis that the fraction quotient lies in the image is the
+integrality fact supplied by generalized subresultants. -/
+theorem div_pullback {a b c : R} (hb : b ≠ 0)
+    (h : ofCoeff c = ofCoeff a / ofCoeff b) : a / b = c := by
+  have hb' : ofCoeff b ≠ (0 : Fraction R) := by
+    intro hzero
+    exact hb ((ofCoeff_eq_zero_iff b).mp hzero)
+  have hmul := congrArg (fun x : Fraction R => x * ofCoeff b) h
+  rw [div_mul_cancel _ hb', ← ofCoeff_mul] at hmul
+  have hbase : c * b = a := ofCoeff_injective hmul
+  rw [← hbase]
+  exact ExactDivLaws.mul_div_cancel_right c b hb
+
+/-- An integral fraction quotient reconstructs its numerator in the original
+coefficient ring. -/
+theorem div_exact {a b : R} (hb : b ≠ 0)
+    (h : ∃ c : R, ofCoeff c = ofCoeff a / ofCoeff b) : a / b * b = a := by
+  rcases h with ⟨c, hc⟩
+  have hb' : ofCoeff b ≠ (0 : Fraction R) := by
+    intro hzero
+    exact hb ((ofCoeff_eq_zero_iff b).mp hzero)
+  have hmul := congrArg (fun x : Fraction R => x * ofCoeff b) hc
+  rw [div_mul_cancel _ hb', ← ofCoeff_mul] at hmul
+  have hbase : c * b = a := ofCoeff_injective hmul
+  rw [div_pullback hb hc, hbase]
+
+/-- The total exact-division wrapper reconstructs a nonzero-denominator
+numerator whenever its fraction quotient is integral. -/
+theorem exactDiv_exact {a b : R} (hb : b ≠ 0)
+    (h : ∃ c : R, ofCoeff c = ofCoeff a / ofCoeff b) :
+    exactDiv a b * b = a := by
+  rw [exactDiv_eq_div_of_ne a hb]
+  exact div_exact hb h
+
+/-- A Brown scalar quotient in the embedding image satisfies the exact scale
+recurrence used by `BrownLaw`. -/
+theorem divExp_exact (x y : R) (n : Nat)
+    (hden : powNat y (n - 1) ≠ 0)
+    (h : ∃ c : R,
+      ofCoeff c =
+        ofCoeff (powNat x n) / ofCoeff (powNat y (n - 1))) :
+    powNat x n = powNat y (n - 1) * divExp x y n := by
+  have hexact := exactDiv_exact hden h
+  unfold divExp
+  calc
+    powNat x n = exactDiv (powNat x n) (powNat y (n - 1)) *
+        powNat y (n - 1) := hexact.symm
+    _ = powNat y (n - 1) *
+        exactDiv (powNat x n) (powNat y (n - 1)) := by grind
+
+/-! Compile-time checks for the concrete fraction-field instance graph. -/
+
+private instance : NonzeroOne Int := ⟨by decide⟩
+
+example : Lean.Grind.Field (Fraction Int) := inferInstance
+example : ExactDivLaws (Fraction Int) := inferInstance
+example : DecidableEq (Fraction Int) := inferInstance
+
+end Fraction
+end Hex

--- a/HexResultant/FractionPoly.lean
+++ b/HexResultant/FractionPoly.lean
@@ -1,0 +1,273 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexResultant.Fraction
+public import HexResultant.PseudoDivMod
+
+public section
+
+/-!
+Coefficient embedding from dense polynomials over an exact-division domain to
+dense polynomials over its fraction field.
+-/
+
+namespace Hex
+
+namespace Fraction.NonzeroOne
+
+universe u
+
+/-- A nonzero dense polynomial supplies a nonzero coefficient and hence a
+nontrivial coefficient ring. -/
+theorem of_poly_ne_zero {R : Type u} [Lean.Grind.CommRing R] [DecidableEq R]
+    (p : DensePoly R) (hp : p ≠ 0) : Hex.Fraction.NonzeroOne R := by
+  have hpos : 0 < p.size := Nat.pos_of_ne_zero fun hzero =>
+    hp ((DensePoly.size_eq_zero_iff p).mp hzero)
+  exact of_ne_zero (DensePoly.leadingCoeff_ne_zero_of_pos_size p hpos)
+
+end Fraction.NonzeroOne
+
+namespace DensePoly
+namespace Fraction
+
+universe u
+
+variable {R : Type u} [Lean.Grind.CommRing R] [DecidableEq R] [Div R]
+  [ExactDivLaws R] [Hex.Fraction.NonzeroOne R]
+
+/-- Embed every coefficient of a dense polynomial into the fraction field. -/
+@[expose]
+noncomputable def map (p : DensePoly R) : DensePoly (Hex.Fraction R) :=
+  ofList (p.toList.map Hex.Fraction.ofCoeff)
+
+omit [DecidableEq R] in
+private theorem list_getD_map (xs : List R) (n : Nat) :
+    (xs.map Hex.Fraction.ofCoeff).getD n (Hex.Fraction.ofCoeff (0 : R)) =
+      Hex.Fraction.ofCoeff (xs.getD n (0 : R)) := by
+  induction xs generalizing n with
+  | nil => simp
+  | cons x xs ih =>
+      cases n with
+      | zero => simp
+      | succ n => exact ih n
+
+/-- Coefficients commute with the fraction-field embedding. -/
+@[simp]
+theorem coeff_map (p : DensePoly R) (n : Nat) :
+    (map p).coeff n = Hex.Fraction.ofCoeff (p.coeff n) := by
+  rw [map, coeff_ofList]
+  change (p.toList.map Hex.Fraction.ofCoeff).getD n
+      (Hex.Fraction.ofCoeff (0 : R)) = Hex.Fraction.ofCoeff (p.coeff n)
+  rw [list_getD_map]
+  exact congrArg Hex.Fraction.ofCoeff (toList_getD_eq_coeff p n)
+
+/-- Fraction embedding preserves the normalized dense size. -/
+@[simp]
+theorem size_map (p : DensePoly R) : (map p).size = p.size := by
+  have hle : (map p).size ≤ p.size := by
+    exact Nat.le_trans (size_ofList_le _)
+      (by simp [length_toList])
+  by_cases hp : p.size = 0
+  · omega
+  have hpos : 0 < p.size := Nat.pos_of_ne_zero hp
+  have hcoeff : (map p).coeff (p.size - 1) ≠ (0 : Hex.Fraction R) := by
+    rw [coeff_map]
+    intro hzero
+    have hz := (Hex.Fraction.ofCoeff_eq_zero_iff _).mp hzero
+    exact (coeff_last_ne_zero_of_pos_size p hpos) hz
+  apply Nat.le_antisymm hle
+  apply Nat.le_of_not_gt
+  intro hlt
+  exact hcoeff (coeff_eq_zero_of_size_le (map p) (by omega))
+
+/-- Fraction embedding preserves the leading coefficient. -/
+@[simp]
+theorem leadingCoeff_map (p : DensePoly R) :
+    (map p).leadingCoeff = Hex.Fraction.ofCoeff p.leadingCoeff := by
+  by_cases hp : p.size = 0
+  · have hp0 : p = 0 := (size_eq_zero_iff p).mp hp
+    have hmap0 : map p = 0 := (size_eq_zero_iff (map p)).mp (by
+      rw [size_map, hp])
+    rw [hmap0, hp0,
+      show (0 : DensePoly (Hex.Fraction R)).leadingCoeff = 0 from
+        leadingCoeff_zero,
+      show (0 : DensePoly R).leadingCoeff = 0 from leadingCoeff_zero]
+    exact Hex.Fraction.ofCoeff_zero.symm
+  · have hpos : 0 < p.size := Nat.pos_of_ne_zero hp
+    rw [leadingCoeff_eq_coeff_last (map p) (by simpa using hpos), size_map,
+      coeff_map, leadingCoeff_eq_coeff_last p hpos]
+
+/-- Fraction embedding reflects polynomial zero. -/
+theorem map_eq_zero_iff (p : DensePoly R) : map p = 0 ↔ p = 0 := by
+  rw [← size_eq_zero_iff, size_map, size_eq_zero_iff]
+
+/-- Fraction embedding is injective. -/
+theorem map_injective {p q : DensePoly R} (h : map p = map q) : p = q := by
+  apply ext_coeff
+  intro n
+  apply Hex.Fraction.ofCoeff_injective
+  simpa only [coeff_map] using congrArg (fun x => x.coeff n) h
+
+/-- Fraction embedding preserves zero. -/
+@[simp]
+theorem map_zero : map (0 : DensePoly R) = 0 := by
+  exact (map_eq_zero_iff 0).mpr rfl
+
+/-- Fraction embedding preserves constants. -/
+@[simp]
+theorem map_C (a : R) : map (C a) = C (Hex.Fraction.ofCoeff a) := by
+  apply ext_coeff
+  intro n
+  rw [coeff_map, coeff_C, coeff_C]
+  by_cases hn : n = 0
+  · simp [hn]
+  · simp only [hn, if_false]
+    exact Hex.Fraction.ofCoeff_zero
+
+/-- Fraction embedding preserves addition. -/
+@[simp]
+theorem map_add (p q : DensePoly R) : map (p + q) = map p + map q := by
+  apply ext_coeff
+  intro n
+  simp only [coeff_map, coeff_add_semiring, Hex.Fraction.ofCoeff_add]
+
+/-- Fraction embedding preserves negation. -/
+@[simp]
+theorem map_neg (p : DensePoly R) : map (-p) = -map p := by
+  apply ext_coeff
+  intro n
+  simp only [coeff_map, coeff_neg_ring, Hex.Fraction.ofCoeff_neg]
+
+/-- Fraction embedding preserves subtraction. -/
+@[simp]
+theorem map_sub (p q : DensePoly R) : map (p - q) = map p - map q := by
+  apply ext_coeff
+  intro n
+  simp only [coeff_map, coeff_sub_ring, Hex.Fraction.ofCoeff_sub]
+
+/-- Fraction embedding preserves scalar multiplication. -/
+@[simp]
+theorem map_scale (a : R) (p : DensePoly R) :
+    map (scale a p) = scale (Hex.Fraction.ofCoeff a) (map p) := by
+  apply ext_coeff
+  intro n
+  simp only [coeff_map, coeff_scale_semiring, Hex.Fraction.ofCoeff_mul]
+
+private theorem step_map (p q : DensePoly R) (n i j : Nat) (acc : R) :
+    Hex.Fraction.ofCoeff (mulCoeffStep p q n i acc j) =
+      mulCoeffStep (map p) (map q) n i (Hex.Fraction.ofCoeff acc) j := by
+  unfold mulCoeffStep
+  by_cases h : i + j = n
+  · simp only [h, if_true, coeff_map, Hex.Fraction.ofCoeff_add,
+      Hex.Fraction.ofCoeff_mul]
+  · simp only [h, if_false]
+
+private theorem inner_map (p q : DensePoly R) (n i : Nat) (xs : List Nat)
+    (acc : R) :
+    Hex.Fraction.ofCoeff (xs.foldl (mulCoeffStep p q n i) acc) =
+      xs.foldl (mulCoeffStep (map p) (map q) n i)
+        (Hex.Fraction.ofCoeff acc) := by
+  induction xs generalizing acc with
+  | nil => rfl
+  | cons j js ih =>
+      simp only [List.foldl_cons]
+      rw [ih, ← step_map]
+
+private theorem outer_map (p q : DensePoly R) (n : Nat) (xs : List Nat)
+    (acc : R) :
+    Hex.Fraction.ofCoeff
+        (xs.foldl
+          (fun acc i => (List.range q.size).foldl (mulCoeffStep p q n i) acc)
+          acc) =
+      xs.foldl
+        (fun acc i =>
+          (List.range (map q).size).foldl
+            (mulCoeffStep (map p) (map q) n i) acc)
+        (Hex.Fraction.ofCoeff acc) := by
+  rw [size_map]
+  induction xs generalizing acc with
+  | nil => rfl
+  | cons i is ih =>
+      simp only [List.foldl_cons]
+      rw [ih, ← inner_map]
+
+private theorem sum_map (p q : DensePoly R) (n : Nat) :
+    Hex.Fraction.ofCoeff (mulCoeffSum p q n) =
+      mulCoeffSum (map p) (map q) n := by
+  unfold mulCoeffSum
+  simpa only [size_map, Hex.Fraction.ofCoeff_zero] using
+    outer_map p q n (List.range p.size) (Zero.zero : R)
+
+/-- Fraction embedding preserves polynomial multiplication. -/
+@[simp]
+theorem map_mul (p q : DensePoly R) : map (p * q) = map p * map q := by
+  apply ext_coeff
+  intro n
+  rw [coeff_map, coeff_mul, coeff_mul, sum_map]
+
+/-- Pseudo-division commutes with the fraction-field embedding on an ordered
+nonzero input pair. -/
+theorem map_pseudoDivMod (f g : DensePoly R) (hg : g ≠ 0)
+    (hgf : g.size ≤ f.size) :
+    pseudoDivMod (map f) (map g) =
+      (map (pseudoDivMod f g).1, map (pseudoDivMod f g).2) := by
+  have hgmap : map g ≠ 0 := by
+    intro hzero
+    exact hg ((map_eq_zero_iff g).mp hzero)
+  have hrec := pseudoDivMod_reconstruct f g hg hgf
+  have hrecMap := congrArg map hrec
+  have hcandidate :
+      scale ((map g).leadingCoeff ^ ((map f).size - (map g).size + 1))
+          (map f) =
+        map (pseudoDivMod f g).1 * map g + map (pseudoDivMod f g).2 := by
+    simpa only [size_map, leadingCoeff_map, map_scale, map_mul, map_add,
+      Hex.Fraction.ofCoeff_pow] using hrecMap
+  apply pseudoDivMod_unique (map f) (map g) (map (pseudoDivMod f g).1)
+    (map (pseudoDivMod f g).2) hgmap (by simpa only [size_map] using hgf)
+    hcandidate
+  simpa only [size_map] using pseudoDivMod_remainder_lt f g hg
+
+/-- Pull coefficientwise exact scalar division back from the fraction field.
+
+The image hypothesis is the integrality certificate later supplied by a
+generalized subresultant minor. -/
+theorem divScalar_pullback (p q : DensePoly R) {b : R} (hb : b ≠ 0)
+    (h : map q = divScalar (map p) (Hex.Fraction.ofCoeff b)) :
+    divScalar p b = q := by
+  have hbmap : Hex.Fraction.ofCoeff b ≠ (0 : Hex.Fraction R) := by
+    intro hzero
+    exact hb ((Hex.Fraction.ofCoeff_eq_zero_iff b).mp hzero)
+  apply ext_coeff
+  intro n
+  rw [coeff_divScalar p hb]
+  apply Hex.Fraction.div_pullback hb
+  have hcoeff := congrArg (fun r : DensePoly (Hex.Fraction R) => r.coeff n) h
+  simpa only [coeff_map, coeff_divScalar _ hbmap] using hcoeff
+
+/-- Coefficientwise integrality in the fraction field proves that executable
+scalar division reconstructs the original polynomial. -/
+theorem divScalar_exact (p : DensePoly R) {b : R} (hb : b ≠ 0)
+    (h : ∀ n, ∃ c : R,
+      Hex.Fraction.ofCoeff c =
+        Hex.Fraction.ofCoeff (p.coeff n) / Hex.Fraction.ofCoeff b) :
+    p = scale b (divScalar p b) := by
+  apply ext_coeff
+  intro n
+  rw [coeff_scale_semiring, coeff_divScalar p hb]
+  have hexact := Hex.Fraction.div_exact hb (h n)
+  simpa only [Lean.Grind.CommRing.mul_comm] using hexact.symm
+
+/-! Compile-time check for the concrete polynomial instance graph. -/
+
+private instance : Hex.Fraction.NonzeroOne Int := ⟨by decide⟩
+
+example : Lean.Grind.CommRing (DensePoly (Hex.Fraction Int)) := inferInstance
+
+end Fraction
+end DensePoly
+end Hex

--- a/HexResultant/SPEC/hex-resultant.md
+++ b/HexResultant/SPEC/hex-resultant.md
@@ -161,6 +161,33 @@ separate Brown--Traub subresultant theorem recorded by `BrownLaw`.
 In particular, reversing `divScalar` by scaling requires the coefficientwise
 exactness certified by that law; the homogeneity API does not assume it.
 
+## Fraction-field proof bridge
+
+The Brown--Traub integrality proof works first in a Mathlib-free fraction
+field constructed locally from cross-multiplication classes. This is proof
+infrastructure only: the executable recurrence never constructs a fraction,
+and `hex-resultant` still has no matrix or Mathlib dependency. A nonzero Brown
+input supplies the local `1 ≠ 0` witness needed by the coefficient embedding;
+`ExactDivLaws` supplies cancellation and rules out zero products.
+
+The generalized Sylvester constructions in this proof are local,
+coefficient-indexed proof objects with their finite-sum identities developed
+inside `hex-resultant`; they are not matrices from `hex-matrix` or
+`hex-determinant`. Consequently the released dependency graph remains the one
+stated at the top of this SPEC.
+
+The injective coefficient map extends to dense polynomials and preserves
+normalized size, leading coefficients, constants, addition, subtraction,
+scaling, multiplication, and ordered pseudo-division. Generalized Sylvester
+subresultants can therefore establish the Brown scale identities in the
+fraction field. Once a scalar or coefficientwise quotient is shown to lie in
+the embedding image, `Fraction.divExp_exact` and
+`DensePoly.Fraction.divScalar_exact` prove exactly the two reconstruction
+equalities recorded by `BrownLaw`; the corresponding pullback lemmas identify
+the quotient returned by the original coefficient ring. Thus the
+fraction-field argument proves integrality instead of changing the executable
+algorithm's coefficient type.
+
 ## Ordered Brown run
 
 For nonzero `G₁, G₂` with `deg G₁ ≥ deg G₂`, write `nᵢ = deg Gᵢ`,
@@ -287,6 +314,11 @@ quotient is exact over every stated exact-division domain.
 - `HexResultant/Basic.lean`: `pseudoDivMod` and its computational properties.
 - `HexResultant/PseudoDivMod.lean`: uniqueness, nonzero scaling, and the
   left/right pseudo-division homogeneity laws.
+- `HexResultant/Fraction.lean`: the proof-only Mathlib-free fraction field,
+  injective coefficient embedding, and exact scalar quotient pullback.
+- `HexResultant/FractionPoly.lean`: the injective dense-polynomial embedding,
+  its algebraic and pseudo-division transport laws, and coefficientwise
+  quotient pullback.
 - `HexResultant/Subresultant.lean`: the Brown worker,
   `subresultantChain`, `resultant`, chain termination, and degree bounds.
 - `HexResultant/Discriminant.lean`: `disc` and the algebraic

--- a/progress/2026-07-28T17-40-53Z.md
+++ b/progress/2026-07-28T17-40-53Z.md
@@ -1,0 +1,39 @@
+# Resultant fraction-field proof bridge
+
+## Accomplished
+
+- Added a Mathlib-free quotient field for exact-division domains, including
+  injective coefficient embedding, coherent numeral instances, inversion,
+  lightweight field laws, and concrete `Int` instance checks.
+- Extended the embedding to normalized dense polynomials and proved
+  preservation of size, leading coefficients, ring operations, scaling,
+  multiplication, and ordered pseudo-division.
+- Added scalar and coefficientwise integrality interfaces that turn
+  fraction-field image certificates into the exact `divExp` and `divScalar`
+  reconstruction equations required by `BrownLaw`.
+- Scoped proof-only representatives and nontriviality evidence under
+  `Hex.Fraction`, documented the local coefficient-indexed Sylvester strategy,
+  and updated the Resultant umbrella, SPEC, and manual.
+- Incorporated an independent source-level review, then verified the targeted
+  Resultant/manual/conformance builds, all 9,563 repository build jobs, and an
+  axiom audit with no `sorryAx` in the new theorem closure.
+
+## Current frontier
+
+`subresultantOrdered_brownLaw` remains the first unresolved Resultant theorem.
+Its two executable reconstruction obligations now have exact image-certificate
+elimination lemmas; what remains is to construct those certificates from
+generalized subresultant identities.
+
+## Next step
+
+Merge this milestone before starting another. Then define the local
+coefficient-indexed generalized Sylvester subresultants and prove the
+fundamental identities that place every Brown scalar and polynomial quotient
+in the coefficient embedding image.
+
+## Blockers
+
+No operational blocker. The remaining mathematical work is the Brown--Traub
+fundamental subresultant theorem; the current bridge isolates its required
+integrality output without changing the executable recurrence.


### PR DESCRIPTION
## Summary

- construct a Mathlib-free quotient field over exact-division domains, with coherent lightweight field instances and an injective coefficient embedding
- transport normalized dense-polynomial operations and ordered pseudo-division into that field
- turn scalar and coefficientwise embedding-image certificates into the exact reconstruction equations required by BrownLaw
- document the local coefficient-indexed Sylvester strategy without adding matrix or Mathlib dependencies

## Verification

- lake build (9,563 jobs)
- lake build HexResultant HexResultant.Conformance HexManual.Chapters.HexResultant (2,186 jobs)
- axiom audit of the new theorem closure (only propext, Classical.choice, and Quot.sound)
- fresh independent source-level review; quotient soundness, ring/field packaging, injectivity, polynomial normalization, multiplication transport, and pseudo-division transport verified, with integrality APIs, instance checks, numeral coherence, namespacing, and documentation findings incorporated