### PR TITLE
feat(resultant): add generalized Sylvester minors

### DIFF
--- a/HexManual/Chapters/HexResultant.lean
+++ b/HexManual/Chapters/HexResultant.lean
@@ -103,6 +103,23 @@ in its input coefficient ring.
 
 {docstring Hex.DensePoly.Fraction.divScalar_exact}
 
+The generalized subresultants are coefficient-indexed scalar determinants
+local to `HexResultant`; they do not introduce a dependency on the matrix
+libraries. Their explicit-degree core makes preservation under the fraction
+embedding type-stable. The Brown--Traub identities identify the later scalar
+and polynomial quotients with these mapped subresultants, whose coefficients
+then have base-ring image witnesses.
+
+{docstring Hex.DensePoly.Subresultant.coeffMinor}
+
+{docstring Hex.DensePoly.Subresultant.poly}
+
+{docstring Hex.DensePoly.Subresultant.poly_size_le}
+
+{docstring Hex.DensePoly.Subresultant.Fraction.poly_map}
+
+{docstring Hex.DensePoly.Subresultant.Fraction.exists_coeff}
+
 # Certified chain structure
 %%%
 tag := "hex-resultant-chain-structure"

--- a/HexResultant.lean
+++ b/HexResultant.lean
@@ -10,6 +10,7 @@ public import HexResultant.Basic
 public import HexResultant.ExactDiv
 public import HexResultant.PseudoDivMod
 public import HexResultant.FractionPoly
+public import HexResultant.SubresultantMinor
 public import HexResultant.Subresultant
 public import HexResultant.Discriminant
 

--- a/HexResultant/SPEC/hex-resultant.md
+++ b/HexResultant/SPEC/hex-resultant.md
@@ -60,12 +60,39 @@ def divExp [Zero R] [DecidableEq R] [One R] [Mul R] [Div R]
     (x y : R) (n : Nat) : R :=
   exactDiv (powNat x n) (powNat y (n - 1))
 
+namespace SubresultantMinor
+
+/-- Proof-only square coefficient family. -/
+abbrev Square (R : Type u) (n : Nat) := Fin n → Fin n → R
+
+/-- Local first-row Laplace determinant. -/
+def det [Zero R] [One R] [Add R] [Sub R] [Mul R] :
+    {n : Nat} → Square R n → R := ...
+
+end SubresultantMinor
+
 namespace DensePoly
 
 /-- Divide every coefficient by the same scalar through `exactDiv`. -/
 noncomputable def divScalar [Zero R] [DecidableEq R] [Div R]
     (p : DensePoly R) (b : R) : DensePoly R :=
   if b = 0 then 0 else ofCoeffs (p.toList.map (fun a => a / b)).toArray
+
+namespace Subresultant
+
+/-- Default formal degree, with zero and constants both at degree zero. -/
+def formalDegree [Zero R] [DecidableEq R] (p : DensePoly R) : Nat :=
+  p.size - 1
+
+/-- Scalar determinant giving coefficient `l` of subresultant index `J`. -/
+def coeffMinor [Zero R] [DecidableEq R] [One R] [Add R] [Sub R] [Mul R]
+    (J l : Nat) (f g : DensePoly R) : R := ...
+
+/-- Generalized Sylvester subresultant of index `J`. -/
+def poly [Zero R] [DecidableEq R] [One R] [Add R] [Sub R] [Mul R]
+    (J : Nat) (f g : DensePoly R) : DensePoly R := ...
+
+end Subresultant
 
 /-- Polynomial pseudo-division: for `f, g : DensePoly R` with `g ≠ 0`
     and `g.degree? ≤ f.degree?`, returns `(quotient, pseudoRemainder)`
@@ -175,6 +202,21 @@ coefficient-indexed proof objects with their finite-sum identities developed
 inside `hex-resultant`; they are not matrices from `hex-matrix` or
 `hex-determinant`. Consequently the released dependency graph remains the one
 stated at the top of this SPEC.
+
+Concretely, `DensePoly.Subresultant.coeffMatrixAt` is a finite scalar
+coefficient family at explicit formal degrees, and
+`DensePoly.Subresultant.coeffMinor` takes its local first-row Laplace
+determinant. `DensePoly.Subresultant.poly J f g` assembles the coefficient
+minors for indices `0, …, J`, so its dense degree is at most `J`.  Keeping the
+formal degrees explicit in the matrix core avoids dependent casts when the
+coefficient ring changes.  The construction is total through truncated
+natural subtraction; Brown identities use the meaningful range
+`J ≤ min (formalDegree f) (formalDegree g)`. The proof route derives the
+needed alternation, multilinearity, column-update, and block identities
+locally from the Laplace recursion rather than importing the matrix or
+determinant libraries. The theorems `coeffMinor_map`, `poly_map`, and
+`exists_coeff` prove that coefficient embedding commutes with the construction
+and that every mapped minor coefficient has a base-ring image witness.
 
 The injective coefficient map extends to dense polynomials and preserves
 normalized size, leading coefficients, constants, addition, subtraction,
@@ -319,6 +361,9 @@ quotient is exact over every stated exact-division domain.
 - `HexResultant/FractionPoly.lean`: the injective dense-polynomial embedding,
   its algebraic and pseudo-division transport laws, and coefficientwise
   quotient pullback.
+- `HexResultant/SubresultantMinor.lean`: the local coefficient-indexed
+  Sylvester determinant, generalized subresultant polynomials, and their
+  fraction-embedding image certificates.
 - `HexResultant/Subresultant.lean`: the Brown worker,
   `subresultantChain`, `resultant`, chain termination, and degree bounds.
 - `HexResultant/Discriminant.lean`: `disc` and the algebraic
@@ -357,6 +402,12 @@ Per [SPEC/testing.md](../../SPEC/testing.md), fixtures are tiered into
     `G₂ = 2X³+1`, whose final chain constant is `4` but resultant is
     `16`, and `G₁ = -X⁴`, `G₂ = 2X³-1`, which exercises both
     nonunit exact divisions and has resultant `-1`.
+  - Small generalized-minor pins cover both Sylvester blocks, a repeated-row
+    zero above index `J`, degree reversal, equal degrees, regular and defective
+    Brown-chain terms, and a bivariate `ZPoly` coefficient ring. The local
+    Laplace determinant is factorial proof infrastructure, so these checks stay
+    deliberately small rather than joining the random degree-10 resultant
+    sweep.
   - A bivariate case over `R = ZPoly`, exercising the
     `hex-number-field` instantiation: for example
     `resultant_y (y² − t) (y − t) = t² − t`.

--- a/HexResultant/SubresultantMinor.lean
+++ b/HexResultant/SubresultantMinor.lean
@@ -1,0 +1,277 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexResultant.FractionPoly
+
+public section
+
+/-!
+Coefficient-indexed generalized Sylvester minors.
+
+This module is proof infrastructure for Brown exactness.  It deliberately uses
+finite functions rather than `Hex.Matrix`: `hex-resultant` remains dependent
+only on `hex-poly`.  The determinant is a local Laplace recursion, and the
+subresultant polynomial is assembled from its scalar coefficient minors.
+-/
+
+namespace Hex
+
+universe u
+
+namespace SubresultantMinor
+
+/-- A proof-only square coefficient family. -/
+abbrev Square (R : Type u) (n : Nat) := Fin n → Fin n → R
+
+/-- Embed an index while skipping one position. -/
+@[expose]
+def skipIndex {n : Nat} (j : Fin (n + 1)) (k : Fin n) : Fin (n + 1) :=
+  if h : k.val < j.val then
+    ⟨k.val, by omega⟩
+  else
+    ⟨k.val + 1, by omega⟩
+
+/-- Remove the first row and one selected column. -/
+@[expose]
+def deleteFirst {R : Type u} {n : Nat} (M : Square R (n + 1))
+    (j : Fin (n + 1)) : Square R n :=
+  fun i k => M i.succ (skipIndex j k)
+
+/-- The alternating sign in a first-row Laplace expansion. -/
+@[expose]
+def sign {R : Type u} [Zero R] [One R] [Sub R] (j : Nat) : R :=
+  if j % 2 = 0 then 1 else 0 - 1
+
+/-- Local proof-only determinant, defined by first-row Laplace expansion.
+Its factorial recursion is not an executable resultant algorithm. -/
+@[expose]
+def det {R : Type u} [Zero R] [One R] [Add R] [Sub R] [Mul R] :
+    {n : Nat} → Square R n → R
+  | 0, _ => 1
+  | n + 1, M =>
+      (List.finRange (n + 1)).foldl
+        (fun acc j =>
+          acc + sign j.val * M ⟨0, by omega⟩ j * det (deleteFirst M j)) 0
+
+@[simp, grind =]
+theorem det_zero {R : Type u} [Zero R] [One R] [Add R] [Sub R] [Mul R]
+    (M : Square R 0) : det M = 1 := by
+  rfl
+
+namespace Fraction
+
+variable {R : Type u} [Lean.Grind.CommRing R] [DecidableEq R] [Div R]
+  [ExactDivLaws R] [Hex.Fraction.NonzeroOne R]
+
+omit [DecidableEq R] in
+private theorem sign_map (j : Nat) :
+    Hex.Fraction.ofCoeff (sign (R := R) j) =
+      sign (R := Hex.Fraction R) j := by
+  unfold sign
+  by_cases h : j % 2 = 0
+  · rw [if_pos h, if_pos h]
+    exact Hex.Fraction.ofCoeff_one
+  · rw [if_neg h, if_neg h, Hex.Fraction.ofCoeff_sub]
+    change Hex.Fraction.ofCoeff (Zero.zero : R) -
+        Hex.Fraction.ofCoeff (One.one : R) =
+      (Zero.zero : Hex.Fraction R) - (One.one : Hex.Fraction R)
+    rw [Hex.Fraction.ofCoeff_zero, Hex.Fraction.ofCoeff_one]
+
+omit [DecidableEq R] in
+/-- The coefficient embedding commutes with the local determinant. -/
+theorem det_map {n : Nat} (M : Square R n) :
+    det (fun i j => Hex.Fraction.ofCoeff (M i j)) =
+      Hex.Fraction.ofCoeff (det M) := by
+  induction n with
+  | zero =>
+      simp only [det]
+      exact Hex.Fraction.ofCoeff_one.symm
+  | succ n ih =>
+      simp only [det]
+      let row : Fin (n + 1) := ⟨0, by omega⟩
+      let stepR := fun (acc : R) (j : Fin (n + 1)) =>
+        acc + sign j.val * M row j * det (deleteFirst M j)
+      let stepF := fun (acc : Hex.Fraction R) (j : Fin (n + 1)) =>
+        acc + sign j.val * Hex.Fraction.ofCoeff (M row j) *
+          det (deleteFirst (fun i k => Hex.Fraction.ofCoeff (M i k)) j)
+      have hminor (j : Fin (n + 1)) :
+          det (deleteFirst (fun i k => Hex.Fraction.ofCoeff (M i k)) j) =
+            Hex.Fraction.ofCoeff (det (deleteFirst M j)) := by
+        change det (fun i k => Hex.Fraction.ofCoeff ((deleteFirst M j) i k)) = _
+        exact ih (deleteFirst M j)
+      have hstep (acc : R) (j : Fin (n + 1)) :
+          stepF (Hex.Fraction.ofCoeff acc) j =
+            Hex.Fraction.ofCoeff (stepR acc j) := by
+        unfold stepF stepR
+        rw [hminor, ← sign_map, ← Hex.Fraction.ofCoeff_mul,
+          ← Hex.Fraction.ofCoeff_mul, ← Hex.Fraction.ofCoeff_add]
+      have hfold (xs : List (Fin (n + 1))) (acc : R) :
+          xs.foldl stepF (Hex.Fraction.ofCoeff acc) =
+            Hex.Fraction.ofCoeff (xs.foldl stepR acc) := by
+        induction xs generalizing acc with
+        | nil => rfl
+        | cons j js hjs =>
+            simp only [List.foldl_cons]
+            rw [hstep, hjs]
+      change (List.finRange (n + 1)).foldl stepF
+          (Hex.Fraction.ofCoeff (Zero.zero : R)) = _
+      exact hfold (List.finRange (n + 1)) (Zero.zero : R)
+
+end Fraction
+end SubresultantMinor
+
+namespace DensePoly
+namespace Subresultant
+
+section Base
+
+variable {R : Type u} [Zero R] [DecidableEq R]
+
+/-- Read a coefficient at an integer index, returning zero below index zero. -/
+@[expose]
+def coeffInt (p : DensePoly R) (i : Int) : R :=
+  if i < 0 then 0 else p.coeff i.toNat
+
+/-- Default formal degree: zero and nonzero constants both have degree zero. -/
+@[expose]
+def formalDegree (p : DensePoly R) : Nat :=
+  p.size - 1
+
+/-- Scalar coefficient matrix at explicit formal degrees.  Keeping the degree
+parameters separate makes coefficient embeddings definitionally
+dimension-preserving. -/
+@[expose]
+def coeffMatrixAt (df dg J l : Nat) (f g : DensePoly R) :
+    SubresultantMinor.Square R ((df - J) + (dg - J)) :=
+  fun i j =>
+    let left := dg - J
+    let right := df - J
+    let n := right + left
+    if j.val < left then
+      if i.val = n - 1 then
+        coeffInt f (Int.ofNat l - Int.ofNat (left - 1) + Int.ofNat j.val)
+      else
+        coeffInt f (Int.ofNat df - Int.ofNat i.val + Int.ofNat j.val)
+    else
+      let jj := j.val - left
+      if i.val = n - 1 then
+        coeffInt g (Int.ofNat l - Int.ofNat (right - 1) + Int.ofNat jj)
+      else
+        coeffInt g (Int.ofNat dg - Int.ofNat i.val + Int.ofNat jj)
+
+/-- One scalar coefficient minor at explicit formal degrees. -/
+@[expose]
+def coeffMinorAt [One R] [Add R] [Sub R] [Mul R]
+    (df dg J l : Nat) (f g : DensePoly R) : R :=
+  SubresultantMinor.det (coeffMatrixAt df dg J l f g)
+
+/-- One scalar coefficient minor of the `J`-th generalized subresultant. -/
+@[expose]
+def coeffMinor [One R] [Add R] [Sub R] [Mul R]
+    (J l : Nat) (f g : DensePoly R) : R :=
+  coeffMinorAt (formalDegree f) (formalDegree g) J l f g
+
+/-- Generalized Sylvester subresultant, assembled coefficientwise from scalar
+minors.  Its degree is at most `J`. -/
+@[expose]
+def poly [One R] [Add R] [Sub R] [Mul R]
+    (J : Nat) (f g : DensePoly R) : DensePoly R :=
+  ofList ((List.range (J + 1)).map fun l => coeffMinor J l f g)
+
+@[simp, grind =]
+theorem coeff_poly [One R] [Add R] [Sub R] [Mul R]
+    (J : Nat) (f g : DensePoly R) (l : Nat) :
+    (poly J f g).coeff l =
+      if l < J + 1 then coeffMinor J l f g else Zero.zero := by
+  by_cases h : l < J + 1
+  · simp [poly, h]
+  · simp [poly, h]
+
+/-- The coefficient construction stores no terms above subresultant index
+`J`. -/
+theorem poly_size_le [One R] [Add R] [Sub R] [Mul R]
+    (J : Nat) (f g : DensePoly R) :
+    (poly J f g).size ≤ J + 1 := by
+  exact Nat.le_trans (size_ofList_le _)
+    (by simp)
+
+end Base
+
+namespace Fraction
+
+variable {R : Type u} [Lean.Grind.CommRing R] [DecidableEq R]
+  [Div R] [ExactDivLaws R]
+  [Hex.Fraction.NonzeroOne R]
+
+@[simp]
+theorem coeffInt_map (p : DensePoly R) (i : Int) :
+    coeffInt (DensePoly.Fraction.map p) i =
+      Hex.Fraction.ofCoeff (coeffInt p i) := by
+  unfold coeffInt
+  by_cases h : i < 0
+  · rw [if_pos h, if_pos h]
+    exact Hex.Fraction.ofCoeff_zero.symm
+  · simp [h, DensePoly.Fraction.coeff_map]
+
+@[simp]
+theorem formalDegree_map (p : DensePoly R) :
+    formalDegree (DensePoly.Fraction.map p) = formalDegree p := by
+  simp [formalDegree]
+
+/-- A coefficient minor at fixed formal degrees is preserved by the fraction
+embedding. -/
+theorem coeffMinorAt_map (df dg J l : Nat) (f g : DensePoly R) :
+    coeffMinorAt df dg J l (DensePoly.Fraction.map f)
+        (DensePoly.Fraction.map g) =
+      Hex.Fraction.ofCoeff (coeffMinorAt df dg J l f g) := by
+  unfold coeffMinorAt
+  have hmatrix :
+      coeffMatrixAt df dg J l (DensePoly.Fraction.map f)
+          (DensePoly.Fraction.map g) =
+        fun i j => Hex.Fraction.ofCoeff ((coeffMatrixAt df dg J l f g) i j) := by
+    funext i j
+    simp only [coeffMatrixAt]
+    split <;> split <;> simp
+  rw [hmatrix, SubresultantMinor.Fraction.det_map]
+
+/-- Every generalized subresultant coefficient is preserved by the fraction
+embedding. -/
+theorem coeffMinor_map (J l : Nat) (f g : DensePoly R) :
+    coeffMinor J l (DensePoly.Fraction.map f) (DensePoly.Fraction.map g) =
+      Hex.Fraction.ofCoeff (coeffMinor J l f g) := by
+  unfold coeffMinor
+  rw [formalDegree_map, formalDegree_map]
+  exact coeffMinorAt_map (formalDegree f) (formalDegree g) J l f g
+
+/-- Generalized Sylvester subresultants commute with the polynomial
+coefficient embedding.  In particular, every coefficient of the fraction
+construction has an explicit base-ring image witness. -/
+theorem poly_map (J : Nat) (f g : DensePoly R) :
+    poly J (DensePoly.Fraction.map f) (DensePoly.Fraction.map g) =
+      DensePoly.Fraction.map (poly J f g) := by
+  apply ext_coeff
+  intro l
+  simp only [coeff_poly, DensePoly.Fraction.coeff_map]
+  by_cases h : l < J + 1
+  · rw [if_pos h, if_pos h, coeffMinor_map]
+  · rw [if_neg h, if_neg h]
+    exact Hex.Fraction.ofCoeff_zero.symm
+
+/-- Coefficients of mapped generalized subresultants lie in the coefficient
+embedding image. -/
+theorem exists_coeff (J : Nat) (f g : DensePoly R) (l : Nat) :
+    ∃ c : R,
+      Hex.Fraction.ofCoeff c =
+        (poly J (DensePoly.Fraction.map f) (DensePoly.Fraction.map g)).coeff l := by
+  refine ⟨(poly J f g).coeff l, ?_⟩
+  rw [poly_map, DensePoly.Fraction.coeff_map]
+
+end Fraction
+end Subresultant
+end DensePoly
+end Hex

--- a/conformance/HexResultant/Conformance.lean
+++ b/conformance/HexResultant/Conformance.lean
@@ -26,6 +26,8 @@ Covered properties:
 - pseudo-division reconstructs the prescribed leading-coefficient multiple
   and leaves a remainder smaller than the divisor; reconstruction plus that
   bound is unique, and nonzero input scaling obeys the two homogeneity laws;
+- coefficient-indexed Sylvester minors reproduce pinned scalar resultants and
+  the expected first nontrivial subresultant;
 - Brown chains omit zero terms, order unequal-degree inputs, strictly decrease
   after their first two entries, obey the sharp length bound, and are stable
   under extra fuel;
@@ -181,6 +183,77 @@ example (f g : DensePoly Int) {a : Int} (ha : a ≠ 0)
   let p := poly [1, 0, -2]
   let q := scale (-3) p
   q.size = p.size && q.leadingCoeff = 6
+
+/-! # Generalized Sylvester minors -/
+
+#guard
+  let quadratic := poly [1, 0, 1]
+  let linear := poly [-1, 1]
+  DensePoly.Subresultant.coeffMinor 0 0 quadratic linear =
+      resultant quadratic linear &&
+    DensePoly.Subresultant.coeffMinor 1 0 quadratic linear = -1 &&
+    DensePoly.Subresultant.coeffMinor 1 1 quadratic linear = 1
+
+#guard
+  let cubic := poly [-1, 0, 0, 1]
+  let linear := poly [-2, 1]
+  let quadratic := poly [1, 0, 1]
+  DensePoly.Subresultant.coeffMinor 0 0 cubic linear =
+      resultant cubic linear &&
+    DensePoly.Subresultant.coeffMinor 0 0 cubic quadratic =
+      resultant cubic quadratic
+
+-- Both Sylvester blocks are nonempty and the determinant is genuinely 3×3.
+#guard
+  let cubic := poly [1, 1, 0, 1]
+  let quadratic := poly [-1, 0, 1]
+  DensePoly.Subresultant.coeffMinor 1 0 cubic quadratic = 1 &&
+    DensePoly.Subresultant.coeffMinor 1 1 cubic quadratic = 2 &&
+    DensePoly.Subresultant.coeffMinor 1 2 cubic quadratic = 0 &&
+    DensePoly.Subresultant.poly 1 cubic quadratic = poly [1, 2]
+
+-- Degree reversal and equal-degree inputs pin the caller-order convention.
+#guard
+  let linear := poly [-2, 1]
+  let cubic := poly [-1, 0, 0, 1]
+  let quadratic1 := poly [1, 0, 1]
+  let quadratic2 := poly [2, 1, 1]
+  DensePoly.Subresultant.coeffMinor 0 0 linear cubic =
+      resultant linear cubic &&
+    DensePoly.Subresultant.coeffMinor 0 0 quadratic1 quadratic2 =
+      resultant quadratic1 quadratic2
+
+-- The SPEC's two defective Brown examples also pin the scalar minor sign.
+#guard
+  let f1 := poly [2, 1, 0, 2, 2]
+  let g1 := poly [1, 0, 0, 2]
+  let f2 := poly [0, 0, 0, 0, -1]
+  let g2 := poly [-1, 0, 0, 2]
+  DensePoly.Subresultant.coeffMinor 0 0 f1 g1 = 16 &&
+    DensePoly.Subresultant.coeffMinor 0 0 f2 g2 = -1
+
+-- Standard subresultants agree with Brown's stored terms at the first regular
+-- and defective drops used by the executable regression suite.
+#guard
+  let quadratic := poly [1, 0, 1]
+  let linear := poly [-1, 1]
+  let regular := subresultantChain quadratic linear
+  let defectiveF := poly [0, 0, 0, 0, -1]
+  let defectiveG := poly [-1, 0, 0, 2]
+  let defective := subresultantChain defectiveF defectiveG
+  DensePoly.Subresultant.poly 0 quadratic linear = regular.getD 2 0 &&
+    DensePoly.Subresultant.poly 2 defectiveF defectiveG =
+      defective.getD 2 0 &&
+    DensePoly.Subresultant.poly 0 defectiveF defectiveG =
+      defective.getD 3 0
+
+-- The recursive dense-polynomial coefficient ring exercises bivariate minors.
+#guard
+  let t : DensePoly Int := poly [0, 1]
+  let one : DensePoly Int := 1
+  let ySqSubT : DensePoly (DensePoly Int) := ofList [0 - t, 0, one]
+  let ySubT : DensePoly (DensePoly Int) := ofList [0 - t, one]
+  DensePoly.Subresultant.coeffMinor 0 0 ySqSubT ySubT = t * t - t
 
 /-! # Brown chain -/
 

--- a/progress/2026-07-28T18-34-53Z.md
+++ b/progress/2026-07-28T18-34-53Z.md
@@ -1,0 +1,40 @@
+# Resultant generalized Sylvester minors
+
+## Accomplished
+
+- Added a Mathlib-free, coefficient-indexed square family and local first-row
+  Laplace determinant for proof-only generalized Sylvester constructions.
+- Defined scalar coefficient minors and assembled generalized subresultant
+  polynomials at explicit formal degrees, including the dense size bound.
+- Proved that the coefficient embedding into the local fraction field
+  preserves the determinant, scalar minors, and assembled subresultants, and
+  exposed base-ring image witnesses for every mapped coefficient.
+- Kept the proof infrastructure out of the executable Brown worker's direct
+  import closure and documented the local determinant strategy, meaningful
+  subresultant-index range, and factorial proof-only cost.
+- Added conformance pins covering both Sylvester blocks, repeated-row
+  vanishing, input-order signs, regular and defective Brown-chain terms, the
+  SPEC's defective resultants, and a bivariate coefficient ring.
+- Incorporated an independent source review, then verified the targeted
+  library/manual/conformance builds, all 9,564 repository build jobs, all
+  9,170 conformance jobs, and a theorem-dependency audit with no `sorryAx` in
+  the new theorem closure.
+
+## Current frontier
+
+`subresultantOrdered_brownLaw` remains the first unresolved Resultant theorem.
+The generalized subresultants now have concrete integral coefficient witnesses
+after fraction embedding, and executable tests pin their signs against both
+regular and defective Brown terms.
+
+## Next step
+
+Merge this milestone before starting another. Then derive the local
+determinant's alternation, multilinearity, column-update, and block identities,
+and use them to prove the Brown--Traub subresultant transformation formulas.
+
+## Blockers
+
+No operational blocker. The remaining work is the local determinant algebra
+and the fundamental subresultant identities connecting every Brown recurrence
+quotient to an integral generalized Sylvester minor.


### PR DESCRIPTION
## Summary

- add a Mathlib-free, coefficient-indexed local Laplace determinant and generalized Sylvester subresultant polynomials
- prove fraction-field embedding preservation and base-ring image witnesses for mapped coefficients
- document the meaningful Brown index range and local determinant proof strategy
- add conformance pins for both Sylvester blocks, repeated-row vanishing, input-order signs, regular and defective Brown terms, and bivariate coefficients

## Why

The fraction-field bridge can pull Brown quotients back only after generalized subresultant identities show that their coefficients lie in the base-ring image. This milestone supplies those concrete integral proof objects without adding matrix or determinant dependencies to `hex-resultant`.

## Validation

- independent source review, with findings incorporated
- `lake build` — 9,564 jobs
- `lake build HexConformance` — 9,170 jobs
- targeted Resultant/manual/conformance builds
- theorem-dependency audit: no `sorryAx` in the new theorem closure
- no new `sorry`, `axiom`, or `native_decide`