### PR TITLE
feat(resultant): add column transformations

### DIFF
--- a/HexManual/Chapters/HexResultant.lean
+++ b/HexManual/Chapters/HexResultant.lean
@@ -116,15 +116,21 @@ then have base-ring image witnesses.
 
 {docstring Hex.DensePoly.Subresultant.poly_size_le}
 
-The local Laplace determinant supplies column multilinearity and
-adjacent-column alternation without importing `hex-matrix` or
-`hex-determinant`. In particular, scaling either input polynomial scales the
-generalized subresultant by one scalar for each column in that input's
-Sylvester block.
+The local Laplace determinant supplies column multilinearity, arbitrary
+alternation and column updates, and the parity law for adjacent-transposition
+sequences without importing `hex-matrix` or `hex-determinant`. In particular,
+scaling either input polynomial scales the generalized subresultant by one
+scalar for each column in that input's Sylvester block.
 
 {docstring Hex.SubresultantMinor.det_setCol_add}
 
-{docstring Hex.SubresultantMinor.det_eq_zero_of_adjacent_col_eq}
+{docstring Hex.SubresultantMinor.det_swapAdjacent}
+
+{docstring Hex.SubresultantMinor.det_applySwaps}
+
+{docstring Hex.SubresultantMinor.det_eq_zero_of_col_eq}
+
+{docstring Hex.SubresultantMinor.det_addCol}
 
 {docstring Hex.SubresultantMinor.det_scaleRange}
 

--- a/HexResultant/DeterminantAlgebra.lean
+++ b/HexResultant/DeterminantAlgebra.lean
@@ -16,9 +16,9 @@ Local determinant algebra for generalized Sylvester minors.
 
 The proof-only determinant in `SubresultantMinor` deliberately avoids a
 dependency on `hex-matrix` or `hex-determinant`.  This module develops the
-column multilinearity, adjacent-column alternation, and block-scaling
-identities that begin the Brown--Traub proof directly from its first-row
-Laplace recursion.
+column multilinearity, arbitrary alternation and column-update, permutation,
+and block-scaling identities that begin the Brown--Traub proof directly from
+its first-row Laplace recursion.
 -/
 
 namespace Hex
@@ -47,6 +47,64 @@ theorem setCol_self {R : Type u} {n : Nat} (M : Square R n) (dst : Fin n) :
   · subst j
     simp [setCol]
   · simp [setCol, h]
+
+/-- Swap two adjacent columns of a proof-only square coefficient family. -/
+@[expose]
+def swapAdjacent {R : Type u} {n : Nat} (M : Square R (n + 1))
+    (left : Fin n) : Square R (n + 1) :=
+  fun i j =>
+    if j = left.castSucc then M i left.succ
+    else if j = left.succ then M i left.castSucc
+    else M i j
+
+@[simp, grind =]
+theorem swapAdjacent_apply {R : Type u} {n : Nat}
+    (M : Square R (n + 1)) (left : Fin n) (i j : Fin (n + 1)) :
+    swapAdjacent M left i j =
+      if j = left.castSucc then M i left.succ
+      else if j = left.succ then M i left.castSucc
+      else M i j := by
+  rfl
+
+@[simp, grind =]
+theorem swapAdjacent_left {R : Type u} {n : Nat}
+    (M : Square R (n + 1)) (left : Fin n) (i : Fin (n + 1)) :
+    swapAdjacent M left i left.castSucc = M i left.succ := by
+  simp [swapAdjacent]
+
+@[simp, grind =]
+theorem swapAdjacent_right {R : Type u} {n : Nat}
+    (M : Square R (n + 1)) (left : Fin n) (i : Fin (n + 1)) :
+    swapAdjacent M left i left.succ = M i left.castSucc := by
+  have hne : left.succ ≠ left.castSucc := by
+    intro h
+    have hval := congrArg Fin.val h
+    simp at hval
+  simp [swapAdjacent, hne]
+
+@[simp, grind =]
+theorem swapAdjacent_of_ne {R : Type u} {n : Nat}
+    (M : Square R (n + 1)) (left : Fin n) (i j : Fin (n + 1))
+    (hl : j ≠ left.castSucc) (hr : j ≠ left.succ) :
+    swapAdjacent M left i j = M i j := by
+  simp [swapAdjacent, hl, hr]
+
+@[simp, grind =]
+theorem swapAdjacent_swapAdjacent {R : Type u} {n : Nat}
+    (M : Square R (n + 1)) (left : Fin n) :
+    swapAdjacent (swapAdjacent M left) left = M := by
+  have hne : left.castSucc ≠ left.succ := by
+    intro h
+    have hval := congrArg Fin.val h
+    simp at hval
+  funext i j
+  by_cases hl : j = left.castSucc
+  · subst j
+    simp [swapAdjacent, hne.symm]
+  · by_cases hr : j = left.succ
+    · subst j
+      simp [swapAdjacent, hne.symm]
+    · simp [swapAdjacent, hl, hr]
 
 @[simp, grind =]
 theorem skipIndex_val_of_lt {n : Nat} (skip : Fin (n + 1)) (i : Fin n)
@@ -621,31 +679,224 @@ theorem det_eq_zero_of_adjacent_col_eq {R : Type u} [Lean.Grind.CommRing R]
       rw [foldl_finRange_adjacent left term hzero]
       exact hcancel
 
+/-- Swapping two adjacent columns negates the local determinant. -/
+theorem det_swapAdjacent {R : Type u} [Lean.Grind.CommRing R]
+    {n : Nat} (M : Square R (n + 1)) (left : Fin n) :
+    det (swapAdjacent M left) = 0 - det M := by
+  let a : Fin (n + 1) := left.castSucc
+  let b : Fin (n + 1) := left.succ
+  let va : Fin (n + 1) → R := fun i => M i a
+  let vb : Fin (n + 1) → R := fun i => M i b
+  let vsum : Fin (n + 1) → R := fun i => va i + vb i
+  have hab : a ≠ b := by
+    intro h
+    have hval := congrArg Fin.val h
+    simp [a, b] at hval
+  have hboth :
+      det (setCol (setCol M a vsum) b vsum) = 0 := by
+    apply det_eq_zero_of_adjacent_col_eq (left := left)
+    intro i
+    simp [setCol, a, b, hab, vsum]
+  have hcomm :
+      setCol (setCol M a vsum) b va =
+        setCol (setCol M b va) a vsum := by
+    funext i j
+    by_cases hja : j = a
+    · subst j
+      simp [setCol, hab]
+    · by_cases hjb : j = b
+      · subst j
+        simp [setCol, hja]
+      · simp [setCol, hja, hjb]
+  have hrestore :
+      setCol (setCol M a vsum) b vb = setCol M a vsum := by
+    funext i j
+    by_cases hjb : j = b
+    · subst j
+      simp [setCol, vb, hab.symm]
+    · simp [setCol, hjb]
+  have hswap :
+      setCol (setCol M b va) a vb = swapAdjacent M left := by
+    funext i j
+    by_cases hja : j = a
+    · subst j
+      simp [setCol, swapAdjacent, a, b, vb]
+    · by_cases hjb : j = b
+      · subst j
+        simp [setCol, swapAdjacent, a, b, va, vb, hja]
+      · simp [setCol, swapAdjacent, a, b, va, vb, hja, hjb]
+  have hdupA : det (setCol (setCol M b va) a va) = 0 := by
+    apply det_eq_zero_of_adjacent_col_eq (left := left)
+    intro i
+    simp [setCol, a, b, va]
+  have hdupB : det (setCol M a vb) = 0 := by
+    apply det_eq_zero_of_adjacent_col_eq (left := left)
+    intro i
+    simp [setCol, a, b, vb]
+  have houter := det_setCol_add (setCol M a vsum) b va vb
+  have hleft := det_setCol_add (setCol M b va) a va vb
+  have hright := det_setCol_add M a va vb
+  have hself : setCol M a va = M := setCol_self M a
+  rw [show (fun i => va i + vb i) = vsum by rfl] at houter hleft hright
+  rw [hboth, hcomm, hrestore, hleft, hright, hdupA, hdupB, hswap,
+    hself] at houter
+  grind
+
+/-- Apply a sequence of adjacent column transpositions. -/
+@[expose]
+def applySwaps {R : Type u} {n : Nat} (M : Square R (n + 1))
+    (swaps : List (Fin n)) : Square R (n + 1) :=
+  swaps.foldl swapAdjacent M
+
+@[simp, grind =]
+theorem applySwaps_nil {R : Type u} {n : Nat} (M : Square R (n + 1)) :
+    applySwaps M [] = M := by
+  rfl
+
+@[simp, grind =]
+theorem applySwaps_cons {R : Type u} {n : Nat} (M : Square R (n + 1))
+    (left : Fin n) (swaps : List (Fin n)) :
+    applySwaps M (left :: swaps) = applySwaps (swapAdjacent M left) swaps := by
+  rfl
+
+/-- Concatenating swap sequences composes their column actions. -/
+@[simp, grind =]
+theorem applySwaps_append {R : Type u} {n : Nat} (M : Square R (n + 1))
+    (xs ys : List (Fin n)) :
+    applySwaps M (xs ++ ys) = applySwaps (applySwaps M xs) ys := by
+  simp [applySwaps, List.foldl_append]
+
+/-- A sequence of adjacent column transpositions multiplies the local
+determinant by its parity sign. -/
+theorem det_applySwaps {R : Type u} [Lean.Grind.CommRing R]
+    {n : Nat} (M : Square R (n + 1)) (swaps : List (Fin n)) :
+    det (applySwaps M swaps) = sign (R := R) swaps.length * det M := by
+  induction swaps generalizing M with
+  | nil =>
+      simp [applySwaps, sign]
+      grind
+  | cons left swaps ih =>
+      rw [applySwaps_cons, ih, det_swapAdjacent]
+      have hsign := sign_succ (R := R) swaps.length
+      simp only [List.length_cons]
+      rw [hsign]
+      grind
+
+private theorem det_eq_zero_of_col_eq_of_lt {R : Type u}
+    [Lean.Grind.CommRing R] {n : Nat} (M : Square R (n + 1))
+    (a b : Fin (n + 1)) (hab : a.val < b.val)
+    (hcol : ∀ i, M i a = M i b) :
+    det M = 0 := by
+  by_cases hadj : b.val = a.val + 1
+  · let left : Fin n := ⟨a.val, by omega⟩
+    have ha : left.castSucc = a := by
+      apply Fin.ext
+      rfl
+    have hb : left.succ = b := by
+      apply Fin.ext
+      simp [left]
+      omega
+    apply det_eq_zero_of_adjacent_col_eq M left
+    intro i
+    rw [ha, hb]
+    exact hcol i
+  · let left : Fin n := ⟨b.val - 1, by omega⟩
+    have hbefore : a.val < left.val := by
+      simp [left]
+      omega
+    have haLeft : a ≠ left.castSucc := by
+      intro h
+      have hval := congrArg Fin.val h
+      simp at hval
+      omega
+    have haRight : a ≠ left.succ := by
+      intro h
+      have hval := congrArg Fin.val h
+      simp [left] at hval
+      omega
+    have hright : left.succ = b := by
+      apply Fin.ext
+      simp [left]
+      omega
+    let N := swapAdjacent M left
+    have hcolN (i : Fin (n + 1)) :
+        N i a = N i left.castSucc := by
+      rw [show N i a = M i a by
+        exact swapAdjacent_of_ne M left i a haLeft haRight]
+      rw [show N i left.castSucc = M i left.succ by
+        exact swapAdjacent_left M left i]
+      rw [hright]
+      exact hcol i
+    have hzero := det_eq_zero_of_col_eq_of_lt N a left.castSucc hbefore hcolN
+    have hswap := det_swapAdjacent M left
+    change det N = 0 at hzero
+    change det N = 0 - det M at hswap
+    rw [hzero] at hswap
+    grind
+termination_by b.val - a.val
+decreasing_by
+  simp_wf
+  omega
+
+/-- The local determinant vanishes when any two distinct columns agree. -/
+theorem det_eq_zero_of_col_eq {R : Type u} [Lean.Grind.CommRing R]
+    {n : Nat} (M : Square R n) (a b : Fin n)
+    (hab : a ≠ b) (hcol : ∀ i, M i a = M i b) :
+    det M = 0 := by
+  cases n with
+  | zero => exact Fin.elim0 a
+  | succ n =>
+      by_cases hlt : a.val < b.val
+      · exact det_eq_zero_of_col_eq_of_lt M a b hlt hcol
+      · have hgt : b.val < a.val := by
+          have hval : a.val ≠ b.val := by
+            intro h
+            exact hab (Fin.ext h)
+          omega
+        exact det_eq_zero_of_col_eq_of_lt M b a hgt (fun i => (hcol i).symm)
+
+/-- Add a scalar multiple of one column to another. -/
+@[expose]
+def addCol {R : Type u} [Add R] [Mul R] {n : Nat}
+    (M : Square R n) (src dst : Fin n) (c : R) : Square R n :=
+  setCol M dst (fun i => M i dst + c * M i src)
+
+@[simp, grind =]
+theorem addCol_apply {R : Type u} [Add R] [Mul R] {n : Nat}
+    (M : Square R n) (src dst : Fin n) (c : R) (i j : Fin n) :
+    addCol M src dst c i j =
+      if j = dst then M i dst + c * M i src else M i j := by
+  rfl
+
+/-- Adding a scalar multiple of one column to a distinct column preserves the
+local determinant. -/
+theorem det_addCol {R : Type u} [Lean.Grind.CommRing R]
+    {n : Nat} (M : Square R n) (src dst : Fin n)
+    (c : R) (h : src ≠ dst) :
+    det (addCol M src dst c) = det M := by
+  cases n with
+  | zero => exact Fin.elim0 src
+  | succ n =>
+      unfold addCol
+      rw [det_setCol_add, det_setCol_smul]
+      have hdup : det (setCol M dst (fun i => M i src)) = 0 := by
+        apply det_eq_zero_of_col_eq (a := src) (b := dst) (hab := h)
+        intro i
+        simp [setCol, h]
+      rw [hdup, setCol_self]
+      grind
+
 /-- Adding a scalar multiple of an adjacent column to its right neighbor
 preserves the local determinant. -/
 theorem det_setCol_add_adjacent {R : Type u} [Lean.Grind.CommRing R]
     {n : Nat} (M : Square R (n + 1)) (left : Fin n) (c : R) :
     det (setCol M left.succ
       (fun i => M i left.succ + c * M i left.castSucc)) = det M := by
-  rw [det_setCol_add]
-  rw [det_setCol_smul]
-  have hdup : det (setCol M left.succ (fun i => M i left.castSucc)) = 0 := by
-    apply det_eq_zero_of_adjacent_col_eq (left := left)
-    intro i
-    have hne : left.castSucc ≠ left.succ := by
-      intro h
-      have hval := congrArg Fin.val h
-      simp at hval
-    simp [setCol, hne]
-  rw [hdup]
-  have hself : setCol M left.succ (fun i => M i left.succ) = M := by
-    funext i j
-    by_cases h : j = left.succ
-    · subst j
-      simp [setCol]
-    · simp [setCol, h]
-  rw [hself]
-  grind
+  have hne : left.castSucc ≠ left.succ := by
+    intro h
+    have hval := congrArg Fin.val h
+    simp at hval
+  exact det_addCol M left.castSucc left.succ c hne
 
 end SubresultantMinor
 

--- a/HexResultant/SPEC/hex-resultant.md
+++ b/HexResultant/SPEC/hex-resultant.md
@@ -212,7 +212,8 @@ formal degrees explicit in the matrix core avoids dependent casts when the
 coefficient ring changes.  The construction is total through truncated
 natural subtraction; Brown identities use the meaningful range
 `J ≤ min (formalDegree f) (formalDegree g)`. The proof route derives the
-needed alternation, multilinearity, column-update, and block identities
+needed multilinearity, adjacent swaps, arbitrary duplicate-column vanishing,
+adjacent-transposition sequence parity, column updates, and block identities
 locally from the Laplace recursion rather than importing the matrix or
 determinant libraries. The theorems `coeffMinor_map`, `poly_map`, and
 `exists_coeff` prove that coefficient embedding commutes with the construction
@@ -368,9 +369,9 @@ quotient is exact over every stated exact-division domain.
   Sylvester determinant, generalized subresultant polynomials, and their
   fraction-embedding image certificates.
 - `HexResultant/DeterminantAlgebra.lean`: local column multilinearity,
-  adjacent-column alternation and update laws, consecutive-block scaling,
-  and the resulting left/right homogeneity laws for generalized
-  subresultants.
+  adjacent swaps and swap-sequence parity, arbitrary alternation and update
+  laws, consecutive-block scaling, and the resulting left/right homogeneity
+  laws for generalized subresultants.
 - `HexResultant/Subresultant.lean`: the Brown worker,
   `subresultantChain`, `resultant`, chain termination, and degree bounds.
 - `HexResultant/Discriminant.lean`: `disc` and the algebraic
@@ -412,7 +413,9 @@ Per [SPEC/testing.md](../../SPEC/testing.md), fixtures are tiered into
   - Small generalized-minor pins cover both Sylvester blocks, a repeated-row
     zero above index `J`, degree reversal, equal degrees, regular and defective
     Brown-chain terms, left/right homogeneity, and a bivariate `ZPoly`
-    coefficient ring. The local Laplace determinant is factorial proof
+    coefficient ring. Direct local-determinant checks cover adjacent swaps,
+    swap-sequence parity and action, arbitrary duplicate columns, and arbitrary
+    column updates. The local Laplace determinant is factorial proof
     infrastructure, so these checks stay deliberately small rather than
     joining the random degree-10 resultant sweep.
   - A bivariate case over `R = ZPoly`, exercising the

--- a/conformance/HexResultant/Conformance.lean
+++ b/conformance/HexResultant/Conformance.lean
@@ -27,8 +27,9 @@ Covered properties:
   and leaves a remainder smaller than the divisor; reconstruction plus that
   bound is unique, and nonzero input scaling obeys the two homogeneity laws;
 - coefficient-indexed Sylvester minors reproduce pinned scalar resultants and
-  the expected first nontrivial subresultant, and obey left/right
-  homogeneity;
+  the expected first nontrivial subresultant; their local determinant obeys
+  adjacent-transposition sequence parity, arbitrary alternation and column
+  updates, while the generalized polynomials obey left/right homogeneity;
 - Brown chains omit zero terms, order unequal-degree inputs, strictly decrease
   after their first two entries, obey the sharp length bound, and are stable
   under extra fuel;
@@ -283,6 +284,44 @@ example {c : Int} (hc : c ≠ 0) (J : Nat) (f g : DensePoly Int) :
       scale 27 resultantBase &&
     DensePoly.Subresultant.poly 2 (scale (-2) cubic) quadratic = topBase &&
     DensePoly.Subresultant.poly 2 cubic (scale 3 quadratic) = scale 3 topBase
+
+example (M : SubresultantMinor.Square Int 3) (left : Fin 2) :
+    SubresultantMinor.det (SubresultantMinor.swapAdjacent M left) =
+      0 - SubresultantMinor.det M :=
+  SubresultantMinor.det_swapAdjacent M left
+
+example (M : SubresultantMinor.Square Int 3) (swaps : List (Fin 2)) :
+    SubresultantMinor.det (SubresultantMinor.applySwaps M swaps) =
+      SubresultantMinor.sign (R := Int) swaps.length *
+        SubresultantMinor.det M :=
+  SubresultantMinor.det_applySwaps M swaps
+
+example (M : SubresultantMinor.Square Int 3) (a b : Fin 3)
+    (hab : a ≠ b) (hcol : ∀ i, M i a = M i b) :
+    SubresultantMinor.det M = 0 :=
+  SubresultantMinor.det_eq_zero_of_col_eq M a b hab hcol
+
+example (M : SubresultantMinor.Square Int 3) (src dst : Fin 3)
+    (c : Int) (h : src ≠ dst) :
+    SubresultantMinor.det (SubresultantMinor.addCol M src dst c) =
+      SubresultantMinor.det M :=
+  SubresultantMinor.det_addCol M src dst c h
+
+-- An asymmetric matrix pins the adjacent action, odd/even signs, arbitrary
+-- duplicate-column vanishing, and arbitrary column update.
+#guard
+  let rows : List (List Int) := [[1, 2, 3], [0, 1, 4], [5, 6, 0]]
+  let M : SubresultantMinor.Square Int 3 :=
+    fun i j => (rows.getD i.val []).getD j.val 0
+  let moved := SubresultantMinor.applySwaps M [0, 1]
+  SubresultantMinor.det M = 1 &&
+    SubresultantMinor.det (SubresultantMinor.swapAdjacent M 0) = -1 &&
+    SubresultantMinor.det (SubresultantMinor.applySwaps M [0]) = -1 &&
+    SubresultantMinor.det moved = 1 &&
+    moved 0 0 = 2 && moved 0 1 = 3 && moved 0 2 = 1 &&
+    SubresultantMinor.det
+      (SubresultantMinor.setCol M 1 (fun i => M i 2)) = 0 &&
+    SubresultantMinor.det (SubresultantMinor.addCol M 0 1 7) = 1
 
 /-! # Brown chain -/
 

--- a/progress/2026-07-28T20-20-46Z.md
+++ b/progress/2026-07-28T20-20-46Z.md
@@ -1,0 +1,35 @@
+# Resultant column transformations
+
+## Accomplished
+
+- Proved that swapping adjacent columns negates the local Laplace determinant
+  and that a sequence of adjacent swaps contributes its length-parity sign.
+- Generalized adjacent-column cancellation to arbitrary distinct equal
+  columns by a well-founded sequence of adjacent swaps.
+- Added a dimension-polymorphic column-update operation and proved that adding
+  a scalar multiple of one distinct column to another preserves determinant.
+- Added involution and sequence-composition laws, updated the Resultant SPEC
+  and manual, and strengthened conformance with an asymmetric executable
+  matrix pin for action, signs, duplication, and updates.
+- Completed full repository and conformance builds (9,565 and 9,171 jobs). An
+  independent proof audit found no correctness blockers or forbidden proof
+  primitives; its applicable API and testing feedback is incorporated.
+
+## Current frontier
+
+The local determinant layer now has the column multilinearity, homogeneity,
+adjacent swaps, swap-sequence parity, arbitrary alternation, and arbitrary
+column-update laws required for structured Sylvester transformations. The
+remaining Resultant correctness frontier is block reordering/factorization and
+the Brown--Traub pseudo-remainder identities.
+
+## Next step
+
+After this milestone PR is merged, construct the concrete adjacent-swap
+sequences for Sylvester column blocks, prove triangular/block determinant
+factorization, and use them to establish the first Brown--Traub transformation
+identity for generalized subresultants.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Summary

- prove adjacent column swaps negate the local Laplace determinant
- compose adjacent swaps with a sequence-parity determinant law, involution, and append composition
- derive arbitrary duplicate-column vanishing and dimension-polymorphic distinct-column update invariance
- update the Resultant SPEC/manual and add asymmetric executable conformance coverage for swap action, odd/even signs, duplicate columns, and updates

## Why

Brown–Traub generalized-subresultant transformations need arbitrary column alternation and updates, not only the adjacent cancellation law from the preceding determinant-algebra milestone. This keeps that proof infrastructure local to `hex-resultant`, preserving its `hex-poly`-only dependency boundary.

## Validation

- `lake build` — 9,565 jobs passed
- `lake build HexConformance` — 9,171 jobs passed
- focused Resultant conformance and manual targets passed
- fresh independent proof audit found no correctness blockers and confirmed the swap derivation, well-founded duplicate-column recursion, parity law, and column-update proof; applicable API/test feedback was incorporated
- no new `sorry`, `axiom`, or `native_decide`