### PR TITLE
feat(resultant): prove generalized input swap

### DIFF
--- a/HexManual/Chapters/HexResultant.lean
+++ b/HexManual/Chapters/HexResultant.lean
@@ -120,13 +120,19 @@ The local Laplace determinant supplies column multilinearity, arbitrary
 alternation and column updates, and the parity law for adjacent-transposition
 sequences without importing `hex-matrix` or `hex-determinant`. In particular,
 scaling either input polynomial scales the generalized subresultant by one
-scalar for each column in that input's Sylvester block.
+scalar for each column in that input's Sylvester block. A consecutive-block
+rotation then exchanges those blocks, contributing one sign for every crossed
+pair of columns and yielding the generalized-subresultant input-swap law.
 
 {docstring Hex.SubresultantMinor.det_setCol_add}
 
 {docstring Hex.SubresultantMinor.det_swapAdjacent}
 
 {docstring Hex.SubresultantMinor.det_applySwaps}
+
+{docstring Hex.SubresultantMinor.rotateBlocks}
+
+{docstring Hex.SubresultantMinor.det_rotateBlocks}
 
 {docstring Hex.SubresultantMinor.det_eq_zero_of_col_eq}
 
@@ -137,6 +143,8 @@ scalar for each column in that input's Sylvester block.
 {docstring Hex.DensePoly.Subresultant.poly_scale_left}
 
 {docstring Hex.DensePoly.Subresultant.poly_scale_right}
+
+{docstring Hex.DensePoly.Subresultant.poly_swap}
 
 {docstring Hex.DensePoly.Subresultant.Fraction.poly_map}
 

--- a/HexResultant.lean
+++ b/HexResultant.lean
@@ -12,6 +12,7 @@ public import HexResultant.PseudoDivMod
 public import HexResultant.FractionPoly
 public import HexResultant.SubresultantMinor
 public import HexResultant.DeterminantAlgebra
+public import HexResultant.BlockDeterminant
 public import HexResultant.Subresultant
 public import HexResultant.Discriminant
 
@@ -31,3 +32,13 @@ formal derivative and an exact leading-coefficient quotient.
 Correctness and correspondence with Mathlib's `Polynomial.resultant` and
 `Polynomial.discr` live in the companion `HexResultantMathlib` library.
 -/
+
+namespace Hex.DensePoly
+
+/-- The executable Brown recurrence and the proof-only minor construction use
+the same alternating sign convention. -/
+theorem negOnePow_eq_sign {R : Type u} [Zero R] [One R] [Sub R] (n : Nat) :
+    negOnePow (R := R) n = SubresultantMinor.sign (R := R) n := by
+  rfl
+
+end Hex.DensePoly

--- a/HexResultant/BlockDeterminant.lean
+++ b/HexResultant/BlockDeterminant.lean
@@ -1,0 +1,442 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexResultant.DeterminantAlgebra
+import all HexResultant.DeterminantAlgebra
+
+public section
+
+/-!
+Consecutive-block transformations for the local resultant determinant.
+
+The generalized Sylvester swap law exchanges its two consecutive coefficient
+blocks.  This module realizes that exchange as adjacent column swaps, tracks
+the determinant sign, and keeps the construction independent of the matrix
+and determinant libraries.
+-/
+
+namespace Hex
+
+universe u
+
+namespace SubresultantMinor
+
+/-- Reindex a square coefficient family along an equality of dimensions. -/
+@[expose]
+def castSquare {R : Type u} {n m : Nat} (h : n = m)
+    (M : Square R n) : Square R m :=
+  fun i j => M (Fin.cast h.symm i) (Fin.cast h.symm j)
+
+@[simp, grind =]
+theorem castSquare_rfl {R : Type u} {n : Nat} (M : Square R n) :
+    castSquare rfl M = M := by
+  rfl
+
+@[simp, grind =]
+theorem castSquare_apply {R : Type u} {n m : Nat} (h : n = m)
+    (M : Square R n) (i j : Fin m) :
+    castSquare h M i j = M (Fin.cast h.symm i) (Fin.cast h.symm j) := by
+  rfl
+
+/-- Reindexing along a dimension equality does not change the local
+determinant. -/
+theorem det_castSquare {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
+    (h : n = m) (M : Square R n) :
+    det (castSquare h M) = det M := by
+  subst m
+  rfl
+
+/-- Swap the columns at numeric positions `left` and `left + 1`. -/
+@[expose]
+def swapAt {R : Type u} {n : Nat} (M : Square R n) (left : Nat)
+    (h : left + 1 < n) : Square R n :=
+  fun i j =>
+    if j.val = left then M i ⟨left + 1, h⟩
+    else if j.val = left + 1 then M i ⟨left, by omega⟩
+    else M i j
+
+@[simp, grind =]
+theorem swapAt_apply {R : Type u} {n : Nat} (M : Square R n)
+    (left : Nat) (h : left + 1 < n) (i j : Fin n) :
+    swapAt M left h i j =
+      if j.val = left then M i ⟨left + 1, h⟩
+      else if j.val = left + 1 then M i ⟨left, by omega⟩
+      else M i j := by
+  rfl
+
+/-- A numeric adjacent-column swap negates the local determinant. -/
+theorem det_swapAt {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (M : Square R n) (left : Nat) (h : left + 1 < n) :
+    det (swapAt M left h) = 0 - det M := by
+  cases n with
+  | zero => omega
+  | succ n =>
+      let left' : Fin n := ⟨left, by omega⟩
+      have hmatrix : swapAt M left h = swapAdjacent M left' := by
+        funext i j
+        simp only [swapAt, swapAdjacent]
+        by_cases hjl : j.val = left
+        · rw [if_pos hjl]
+          have hj : j = left'.castSucc := by
+            apply Fin.ext
+            exact hjl
+          rw [if_pos hj]
+          apply congrArg (M i)
+          apply Fin.ext
+          simp [left']
+        · rw [if_neg hjl]
+          have hjl' : j ≠ left'.castSucc := by
+            intro hj
+            exact hjl (congrArg Fin.val hj)
+          rw [if_neg hjl']
+          by_cases hjr : j.val = left + 1
+          · rw [if_pos hjr]
+            have hj : j = left'.succ := by
+              apply Fin.ext
+              simpa [left'] using hjr
+            rw [if_pos hj]
+            apply congrArg (M i)
+            apply Fin.ext
+            simp [left']
+          · rw [if_neg hjr]
+            have hjr' : j ≠ left'.succ := by
+              intro hj
+              apply hjr
+              simpa [left'] using congrArg Fin.val hj
+            rw [if_neg hjr']
+      rw [hmatrix, det_swapAdjacent]
+
+/-- Move the column at `start + count` to `start`, shifting the intervening
+columns one position to the right. -/
+@[expose]
+def moveLeft {R : Type u} {n : Nat} (M : Square R n) (start : Nat) :
+    (count : Nat) → start + count < n → Square R n
+  | 0, _ => M
+  | count + 1, h =>
+      moveLeft (swapAt M (start + count) (by omega)) start count (by omega)
+
+/-- Entrywise action of moving one column left across a consecutive range. -/
+theorem moveLeft_apply {R : Type u} {n : Nat} (M : Square R n)
+    (start count : Nat) (h : start + count < n) (i j : Fin n) :
+    moveLeft M start count h i j =
+      if j.val = start then M i ⟨start + count, h⟩
+      else if start < j.val ∧ j.val ≤ start + count then
+        M i ⟨j.val - 1, by omega⟩
+      else M i j := by
+  induction count generalizing M with
+  | zero =>
+      by_cases hs : j.val = start
+      · have hj : j = ⟨start, by omega⟩ := Fin.ext hs
+        subst j
+        simp [moveLeft]
+      · have hmid : ¬(start < j.val ∧ j.val ≤ start) := by omega
+        simp [moveLeft, hs, hmid]
+  | succ count ih =>
+      rw [moveLeft, ih]
+      by_cases hs : j.val = start
+      · simp [hs, swapAt]
+        apply congrArg (M i)
+        apply Fin.ext
+        simp [Nat.add_assoc]
+      · by_cases hmid : start < j.val ∧ j.val ≤ start + count
+        · have hnew : start < j.val ∧ j.val ≤ start + (count + 1) := by
+            omega
+          have hpredLeft : j.val - 1 ≠ start + count := by omega
+          have hpredRight : j.val - 1 ≠ start + count + 1 := by omega
+          simp [hs, hmid, hnew, swapAt, hpredLeft, hpredRight]
+        · by_cases hend : j.val = start + count + 1
+          · have hj : j = ⟨start + count + 1, by omega⟩ := Fin.ext hend
+            subst j
+            have hns : start + count + 1 ≠ start := by omega
+            have hpos : start < start + count + 1 := by omega
+            have hold : ¬(start + count + 1 ≤ start + count) := by omega
+            have hnew : start + count + 1 ≤ start + (count + 1) := by omega
+            simp [swapAt, hns, hpos, hold, hnew]
+          · have hnew : ¬(start < j.val ∧ j.val ≤ start + (count + 1)) := by
+              omega
+            have hleft : j.val ≠ start + count := by
+              intro heq
+              apply hmid
+              omega
+            simp [hs, hmid, hend, hnew, swapAt, hleft]
+
+/-- Moving a column left across `count` positions contributes the parity sign
+of `count`. -/
+theorem det_moveLeft {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (M : Square R n) (start count : Nat) (h : start + count < n) :
+    det (moveLeft M start count h) = sign (R := R) count * det M := by
+  induction count generalizing M with
+  | zero =>
+      simp [moveLeft, sign] <;> grind
+  | succ count ih =>
+      rw [moveLeft, ih, det_swapAt, sign_succ]
+      grind
+
+/-- Rotate consecutive blocks of lengths `left` and `right` beginning at
+`start`, changing `[A, B]` to `[B, A]`. -/
+@[expose]
+def rotateBlocks {R : Type u} {n : Nat} (M : Square R n)
+    (start left : Nat) : (right : Nat) → start + left + right ≤ n → Square R n
+  | 0, _ => M
+  | right + 1, h =>
+      rotateBlocks (moveLeft M start left (by omega)) (start + 1) left right
+        (by omega)
+
+/-- The column of the original matrix appearing at a given position after a
+consecutive-block rotation. -/
+@[expose]
+def rotateIndex {n : Nat} (start left right : Nat)
+    (h : start + left + right ≤ n) (j : Fin n) : Fin n :=
+  if hj : start ≤ j.val ∧ j.val < start + right then
+    ⟨j.val + left, by omega⟩
+  else if hk : start + right ≤ j.val ∧
+      j.val < start + right + left then
+    ⟨j.val - right, by
+      have := j.isLt
+      omega⟩
+  else j
+
+/-- Entrywise action of rotating two consecutive column blocks. -/
+theorem rotateBlocks_apply {R : Type u} {n : Nat} (M : Square R n)
+    (start left right : Nat) (h : start + left + right ≤ n)
+    (i j : Fin n) :
+    rotateBlocks M start left right h i j =
+      M i (rotateIndex start left right h j) := by
+  induction right generalizing M start with
+  | zero =>
+      have hfirst : ¬(start ≤ j.val ∧ j.val < start) := by omega
+      have hindex : rotateIndex start left 0 h j = j := by
+        apply Fin.ext
+        simp [rotateIndex, hfirst]
+      simp [rotateBlocks, hindex]
+  | succ right ih =>
+      rw [rotateBlocks, ih]
+      by_cases hstart : j.val = start
+      · have hrecFirst :
+            ¬(start + 1 ≤ j.val ∧ j.val < start + 1 + right) := by omega
+        have hrecSecond :
+            ¬(start + 1 + right ≤ j.val ∧
+              j.val < start + 1 + right + left) := by omega
+        have hfirst : start ≤ j.val ∧ j.val < start + (right + 1) := by
+          omega
+        have hrecIndex :
+            rotateIndex (start + 1) left right (by omega) j = j := by
+          apply Fin.ext
+          simp [rotateIndex, hrecFirst, hrecSecond]
+        let shifted : Fin n := ⟨start + left, by omega⟩
+        have hfinalIndex :
+            rotateIndex start left (right + 1) h j = shifted := by
+          apply Fin.ext
+          simp [rotateIndex, hstart, shifted]
+        rw [hrecIndex, hfinalIndex, moveLeft_apply]
+        rw [if_pos hstart]
+      · by_cases hfirst : start ≤ j.val ∧ j.val < start + (right + 1)
+        · have hrecFirst :
+              start + 1 ≤ j.val ∧ j.val < start + 1 + right := by omega
+          let shifted : Fin n := ⟨j.val + left, by omega⟩
+          have hrecIndex :
+              rotateIndex (start + 1) left right (by omega) j = shifted := by
+            apply Fin.ext
+            simp [rotateIndex, hrecFirst, shifted]
+          have hfinalIndex :
+              rotateIndex start left (right + 1) h j = shifted := by
+            apply Fin.ext
+            simp [rotateIndex, hfirst, shifted]
+          have hshiftStart : shifted.val ≠ start := by
+            simp [shifted]
+            omega
+          have hshiftMiddle :
+              ¬(start < shifted.val ∧ shifted.val ≤ start + left) := by
+            simp [shifted]
+            omega
+          rw [hrecIndex, hfinalIndex, moveLeft_apply]
+          rw [if_neg hshiftStart, if_neg hshiftMiddle]
+        · by_cases hsecond :
+            start + (right + 1) ≤ j.val ∧
+              j.val < start + (right + 1) + left
+          · have hrecSecond :
+                start + 1 + right ≤ j.val ∧
+                  j.val < start + 1 + right + left := by omega
+            have hrecFirst :
+                ¬(start + 1 ≤ j.val ∧ j.val < start + 1 + right) := by
+              omega
+            let middle : Fin n := ⟨j.val - right, by
+              have := j.isLt
+              omega⟩
+            let shifted : Fin n := ⟨j.val - (right + 1), by
+              have := j.isLt
+              omega⟩
+            have hrecIndex :
+                rotateIndex (start + 1) left right (by omega) j = middle := by
+              apply Fin.ext
+              simp [rotateIndex, hrecFirst, hrecSecond, middle]
+            have hfinalIndex :
+                rotateIndex start left (right + 1) h j = shifted := by
+              apply Fin.ext
+              simp [rotateIndex, hfirst, hsecond, shifted]
+            have hlookup :
+                start < j.val - right ∧
+                  j.val - right ≤ start + left := by omega
+            have hmiddleStart : middle.val ≠ start := by
+              simp [middle]
+              omega
+            rw [hrecIndex, hfinalIndex, moveLeft_apply]
+            rw [if_neg hmiddleStart, if_pos hlookup]
+            apply congrArg (M i)
+            apply Fin.ext
+            simp [middle, shifted]
+            omega
+          · have hrecFirst :
+                ¬(start + 1 ≤ j.val ∧
+                  j.val < start + 1 + right) := by omega
+            have hrecSecond :
+                ¬(start + 1 + right ≤ j.val ∧
+                  j.val < start + 1 + right + left) := by omega
+            have hlookup :
+                ¬(start < j.val ∧ j.val ≤ start + left) := by omega
+            have hrecIndex :
+                rotateIndex (start + 1) left right (by omega) j = j := by
+              apply Fin.ext
+              simp [rotateIndex, hrecFirst, hrecSecond]
+            have hfinalIndex :
+                rotateIndex start left (right + 1) h j = j := by
+              apply Fin.ext
+              simp [rotateIndex, hfirst, hsecond]
+            rw [hrecIndex, hfinalIndex, moveLeft_apply]
+            simp [hstart, hlookup]
+
+/-- Rotating consecutive blocks contributes one adjacent swap for each pair
+of columns drawn from opposite blocks. -/
+theorem det_rotateBlocks {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (M : Square R n) (start left right : Nat)
+    (h : start + left + right ≤ n) :
+    det (rotateBlocks M start left right h) =
+      sign (R := R) (left * right) * det M := by
+  induction right generalizing M start with
+  | zero =>
+      simp [rotateBlocks, sign] <;> grind
+  | succ right ih =>
+      rw [rotateBlocks, ih, det_moveLeft]
+      have hsign := sign_add (R := R) (left * right) left
+      rw [Nat.mul_succ, hsign]
+      grind
+
+end SubresultantMinor
+
+namespace DensePoly
+namespace Subresultant
+
+section Swap
+
+variable {R : Type u} [Lean.Grind.CommRing R] [DecidableEq R]
+
+/-- Rotating the two coefficient blocks of a generalized Sylvester matrix
+produces the matrix with its polynomial inputs exchanged. -/
+theorem coeffMatrixAt_rotate (df dg J l : Nat) (f g : DensePoly R) :
+    SubresultantMinor.castSquare (by omega)
+        (SubresultantMinor.rotateBlocks
+          (coeffMatrixAt df dg J l f g) 0 (dg - J) (df - J) (by omega)) =
+      coeffMatrixAt dg df J l g f := by
+  funext i j
+  simp only [SubresultantMinor.castSquare]
+  rw [SubresultantMinor.rotateBlocks_apply]
+  by_cases hj : j.val < df - J
+  · let source : Fin ((df - J) + (dg - J)) :=
+      ⟨j.val + (dg - J), by
+        have := j.isLt
+        omega⟩
+    have hindex :
+        SubresultantMinor.rotateIndex 0 (dg - J) (df - J)
+            (show 0 + (dg - J) + (df - J) ≤
+              (df - J) + (dg - J) by omega)
+            (Fin.cast (show (dg - J) + (df - J) =
+              (df - J) + (dg - J) by omega) j) = source := by
+      apply Fin.ext
+      simp [SubresultantMinor.rotateIndex, hj, source, Fin.cast]
+    rw [hindex]
+    have hright : ¬j.val + (dg - J) < dg - J := by omega
+    have hsub : j.val + (dg - J) - (dg - J) = j.val := by omega
+    have hrow :
+        i.val = (df - J) + (dg - J) - 1 ↔
+          i.val = (dg - J) + (df - J) - 1 := by omega
+    simp [coeffMatrixAt, source, hj, hright, hsub, hrow, Fin.cast]
+  · let source : Fin ((df - J) + (dg - J)) :=
+      ⟨j.val - (df - J), by
+        have := j.isLt
+        omega⟩
+    have hindex :
+        SubresultantMinor.rotateIndex 0 (dg - J) (df - J)
+            (show 0 + (dg - J) + (df - J) ≤
+              (df - J) + (dg - J) by omega)
+            (Fin.cast (show (dg - J) + (df - J) =
+              (df - J) + (dg - J) by omega) j) = source := by
+      apply Fin.ext
+      have hlower : df ≤ j.val + J := by omega
+      have hupper : j.val < (df - J) + (dg - J) := by
+        have := j.isLt
+        omega
+      simp [SubresultantMinor.rotateIndex, hj, hlower, hupper, source,
+        Fin.cast]
+    rw [hindex]
+    have hleft : j.val - (df - J) < dg - J := by omega
+    have hrow :
+        i.val = (df - J) + (dg - J) - 1 ↔
+          i.val = (dg - J) + (df - J) - 1 := by omega
+    simp [coeffMatrixAt, source, hj, hleft, hrow, Fin.cast]
+
+/-- Exchanging the inputs of a fixed-degree coefficient minor contributes
+the parity of the product of the two block lengths. -/
+theorem coeffMinorAt_swap (df dg J l : Nat) (f g : DensePoly R) :
+    coeffMinorAt df dg J l f g =
+      SubresultantMinor.sign (R := R) ((df - J) * (dg - J)) *
+        coeffMinorAt dg df J l g f := by
+  have hswap :
+      coeffMinorAt dg df J l g f =
+        SubresultantMinor.sign (R := R) ((df - J) * (dg - J)) *
+          coeffMinorAt df dg J l f g := by
+    unfold coeffMinorAt
+    rw [← coeffMatrixAt_rotate]
+    rw [SubresultantMinor.det_castSquare,
+      SubresultantMinor.det_rotateBlocks]
+    congr 2
+    exact Nat.mul_comm _ _
+  rw [hswap, ← Lean.Grind.Semiring.mul_assoc,
+    SubresultantMinor.sign_mul_self]
+  grind
+
+/-- Exchanging the inputs of a generalized coefficient minor contributes
+the standard degree-product sign. -/
+theorem coeffMinor_swap (J l : Nat) (f g : DensePoly R) :
+    coeffMinor J l f g =
+      SubresultantMinor.sign (R := R)
+          ((formalDegree f - J) * (formalDegree g - J)) *
+        coeffMinor J l g f := by
+  unfold coeffMinor
+  exact coeffMinorAt_swap (formalDegree f) (formalDegree g) J l f g
+
+/-- Generalized Sylvester subresultants obey the standard input-swap sign
+law. -/
+theorem poly_swap (J : Nat) (f g : DensePoly R) :
+    poly J f g =
+      scale
+        (SubresultantMinor.sign (R := R)
+          ((formalDegree f - J) * (formalDegree g - J)))
+        (poly J g f) := by
+  apply ext_coeff
+  intro l
+  rw [coeff_scale_semiring]
+  simp only [coeff_poly]
+  by_cases hl : l < J + 1
+  · rw [if_pos hl, if_pos hl, coeffMinor_swap]
+  · rw [if_neg hl, if_neg hl]
+    exact (Lean.Grind.Semiring.mul_zero _).symm
+
+end Swap
+end Subresultant
+end DensePoly
+end Hex

--- a/HexResultant/DeterminantAlgebra.lean
+++ b/HexResultant/DeterminantAlgebra.lean
@@ -613,6 +613,22 @@ theorem sign_succ {R : Type u} [Lean.Grind.CommRing R] (j : Nat) :
     rw [if_neg hj, if_pos hnext]
     grind
 
+/-- Alternating signs turn addition of exponents into multiplication. -/
+theorem sign_add {R : Type u} [Lean.Grind.CommRing R] (a b : Nat) :
+    sign (R := R) (a + b) = sign (R := R) a * sign (R := R) b := by
+  induction b with
+  | zero =>
+      simp [sign] <;> grind
+  | succ b ih =>
+      rw [Nat.add_succ, sign_succ, ih, sign_succ]
+      grind
+
+/-- Every alternating sign is its own multiplicative inverse. -/
+theorem sign_mul_self {R : Type u} [Lean.Grind.CommRing R] (n : Nat) :
+    sign (R := R) n * sign (R := R) n = 1 := by
+  unfold sign
+  split <;> grind
+
 /-- Deleting either member of an equal adjacent column pair gives the same
 minor. -/
 theorem deleteFirst_adjacent_eq {R : Type u} {n : Nat}

--- a/HexResultant/SPEC/hex-resultant.md
+++ b/HexResultant/SPEC/hex-resultant.md
@@ -220,7 +220,13 @@ determinant libraries. The theorems `coeffMinor_map`, `poly_map`, and
 and that every mapped minor coefficient has a base-ring image witness.
 The theorems `poly_scale_left` and `poly_scale_right` establish the first
 Brown--Traub transformation law: scaling an input contributes one scalar for
-each column in that input's generalized Sylvester block.
+each column in that input's generalized Sylvester block. The concrete
+`rotateBlocks` transformation moves two consecutive coefficient blocks using
+adjacent swaps and proves the determinant factor
+`(-1)^(left * right)`. Applied to the generalized Sylvester family,
+`poly_swap` gives
+`S_J(f, g) = (-1)^((deg f - J) * (deg g - J)) S_J(g, f)` without importing a
+matrix or determinant library.
 
 The injective coefficient map extends to dense polynomials and preserves
 normalized size, leading coefficients, constants, addition, subtraction,
@@ -372,6 +378,9 @@ quotient is exact over every stated exact-division domain.
   adjacent swaps and swap-sequence parity, arbitrary alternation and update
   laws, consecutive-block scaling, and the resulting left/right homogeneity
   laws for generalized subresultants.
+- `HexResultant/BlockDeterminant.lean`: dimension recasting, numeric adjacent
+  swaps, consecutive-block rotation with its parity law, and the resulting
+  generalized-subresultant input-swap law.
 - `HexResultant/Subresultant.lean`: the Brown worker,
   `subresultantChain`, `resultant`, chain termination, and degree bounds.
 - `HexResultant/Discriminant.lean`: `disc` and the algebraic

--- a/conformance/HexResultant/Conformance.lean
+++ b/conformance/HexResultant/Conformance.lean
@@ -29,7 +29,8 @@ Covered properties:
 - coefficient-indexed Sylvester minors reproduce pinned scalar resultants and
   the expected first nontrivial subresultant; their local determinant obeys
   adjacent-transposition sequence parity, arbitrary alternation and column
-  updates, while the generalized polynomials obey left/right homogeneity;
+  updates, consecutive-block rotation, and the generalized polynomials obey
+  left/right homogeneity and the input-swap sign law;
 - Brown chains omit zero terms, order unequal-degree inputs, strictly decrease
   after their first two entries, obey the sharp length bound, and are stable
   under extra fuel;
@@ -269,6 +270,29 @@ example {c : Int} (hc : c ≠ 0) (J : Nat) (f g : DensePoly Int) :
         (DensePoly.Subresultant.poly J f g) :=
   DensePoly.Subresultant.poly_scale_right hc J f g
 
+example (J : Nat) (f g : DensePoly Int) :
+    DensePoly.Subresultant.poly J f g =
+      scale
+        (SubresultantMinor.sign (R := Int)
+          ((DensePoly.Subresultant.formalDegree f - J) *
+            (DensePoly.Subresultant.formalDegree g - J)))
+        (DensePoly.Subresultant.poly J g f) :=
+  DensePoly.Subresultant.poly_swap J f g
+
+-- Two nonempty odd-length Sylvester blocks exercise the negative swap sign.
+#guard
+  let f := poly [1, 0, 1]
+  let g := poly [2, 1, 1]
+  DensePoly.Subresultant.poly 1 f g =
+    scale (-1) (DensePoly.Subresultant.poly 1 g f)
+
+-- Truncating one block to length zero makes input exchange sign-free.
+#guard
+  let f := poly [1, 1]
+  let g := poly [1, 0, 1]
+  DensePoly.Subresultant.poly 1 f g =
+    DensePoly.Subresultant.poly 1 g f
+
 -- Each input contributes one scalar for every column in its Sylvester block.
 #guard
   let cubic := poly [1, 1, 0, 1]
@@ -307,6 +331,12 @@ example (M : SubresultantMinor.Square Int 3) (src dst : Fin 3)
       SubresultantMinor.det M :=
   SubresultantMinor.det_addCol M src dst c h
 
+example (M : SubresultantMinor.Square Int 3) :
+    SubresultantMinor.det
+        (SubresultantMinor.rotateBlocks M 0 1 1 (by omega)) =
+      SubresultantMinor.sign (R := Int) 1 * SubresultantMinor.det M :=
+  SubresultantMinor.det_rotateBlocks M 0 1 1 (by omega)
+
 -- An asymmetric matrix pins the adjacent action, odd/even signs, arbitrary
 -- duplicate-column vanishing, and arbitrary column update.
 #guard
@@ -314,11 +344,14 @@ example (M : SubresultantMinor.Square Int 3) (src dst : Fin 3)
   let M : SubresultantMinor.Square Int 3 :=
     fun i j => (rows.getD i.val []).getD j.val 0
   let moved := SubresultantMinor.applySwaps M [0, 1]
+  let rotated := SubresultantMinor.rotateBlocks M 0 1 1 (by omega)
   SubresultantMinor.det M = 1 &&
     SubresultantMinor.det (SubresultantMinor.swapAdjacent M 0) = -1 &&
     SubresultantMinor.det (SubresultantMinor.applySwaps M [0]) = -1 &&
     SubresultantMinor.det moved = 1 &&
     moved 0 0 = 2 && moved 0 1 = 3 && moved 0 2 = 1 &&
+    SubresultantMinor.det rotated = -1 &&
+    rotated 0 0 = 2 && rotated 0 1 = 1 && rotated 0 2 = 3 &&
     SubresultantMinor.det
       (SubresultantMinor.setCol M 1 (fun i => M i 2)) = 0 &&
     SubresultantMinor.det (SubresultantMinor.addCol M 0 1 7) = 1

--- a/progress/2026-07-28T21-14-34Z.md
+++ b/progress/2026-07-28T21-14-34Z.md
@@ -1,0 +1,34 @@
+# Resultant block rotation and input swap
+
+## Accomplished
+
+- Added a proof-only consecutive-block rotation built from numeric adjacent
+  column swaps, with entrywise action and determinant parity
+  `(-1)^(left * right)`.
+- Identified the rotated generalized Sylvester coefficient matrix with the
+  matrix for exchanged polynomial inputs, including the dimension cast and
+  all total truncated-degree cases.
+- Proved fixed-degree minor, generalized coefficient-minor, and polynomial
+  input-swap laws with the standard degree-product sign.
+- Added the bridge between the executable Brown sign and the proof-side
+  determinant sign, updated the Resultant SPEC and manual, and extended
+  conformance with odd-sign and empty-block regressions.
+- Completed `lake build` (9,566 jobs), `lake build HexConformance` (9,172
+  jobs), and `lake build HexManual` (9,530 jobs) without introducing `sorry`,
+  `axiom`, or `native_decide`.
+
+## Current frontier
+
+The generalized Sylvester layer now has scalar homogeneity, arbitrary column
+updates, consecutive-block rotation, and the input-swap transformation law.
+This milestone is ready to publish and merge as one PR.
+
+## Next step
+
+After this milestone PR is merged, implement the unipotent triangular column
+transformation underlying the first Brown--Traub pseudo-remainder identity,
+then lift it coefficientwise to generalized subresultants.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Summary

- add numeric adjacent-column moves and consecutive block rotation for the local determinant
- identify rotated generalized Sylvester matrices and prove coefficient-minor and polynomial input-swap sign laws
- bridge proof and executable sign conventions, update the SPEC/manual, and add odd-sign plus truncated-block conformance coverage

## Why

Brown--Traub exactness needs concrete Sylvester block transformations without adding matrix-library dependencies. This establishes the block-exchange transformation and its exact parity factor as the next proof milestone.

## Validation

- `lake build` (9,566 jobs)
- `lake build HexConformance` (9,172 jobs)
- `lake build HexManual` (9,530 jobs)
- fresh independent proof audit found no merge-blocking correctness issues; applicable documentation and edge-case coverage feedback was incorporated
- no new `sorry`, `axiom`, or `native_decide`