### PR TITLE
feat(resultant): prove Brown-Traub degree collapse

### DIFF
--- a/HexManual/Chapters/HexResultant.lean
+++ b/HexManual/Chapters/HexResultant.lean
@@ -132,8 +132,13 @@ upper-triangular update adds multiplier-weighted `G` columns into the later
 column by the matching `H` column. The target is the ordinary generalized
 Sylvester matrix for `G, H`, with `F`'s formal degree retained explicitly even
 when `H` drops in degree. The determinant is unchanged by these additions, so
-the only factor is the block-swap sign. The following degree-collapse step is
-what introduces the leading-coefficient power in the full Brown--Traub law.
+the only factor is the block-swap sign.
+
+Collapsing the retained formal degree then exposes one sparse first row per
+removed degree. Each expansion contributes `lc(G)`, while the final edge
+subresultant is `lc(H)^(deg G - deg H - 1) H`. Together these identities give the full
+Brown--Traub factorization, and a nonzero factor can be divided out
+coefficientwise by the executable exact-division operation.
 
 {docstring Hex.SubresultantMinor.det_setCol_add}
 
@@ -151,6 +156,8 @@ what introduces the leading-coefficient power in the full Brown--Traub law.
 
 {docstring Hex.SubresultantMinor.det_scaleRange}
 
+{docstring Hex.SubresultantMinor.det_firstRow}
+
 {docstring Hex.DensePoly.Subresultant.poly_scale_left}
 
 {docstring Hex.DensePoly.Subresultant.poly_scale_right}
@@ -164,6 +171,22 @@ what introduces the leading-coefficient power in the full Brown--Traub law.
 {docstring Hex.DensePoly.Subresultant.det_addMul}
 
 {docstring Hex.DensePoly.Subresultant.coeffMinorAt_addMul}
+
+{docstring Hex.DensePoly.Subresultant.coeffMinorAt_succRight}
+
+{docstring Hex.DensePoly.Subresultant.coeffMinorAt_raiseRight}
+
+{docstring Hex.DensePoly.Subresultant.coeffMinorAt_rightDegree}
+
+{docstring Hex.DensePoly.Subresultant.coeffMinorAt_brownTraub}
+
+{docstring Hex.DensePoly.Subresultant.poly_rightDegree}
+
+{docstring Hex.DensePoly.Subresultant.poly_brownTraub}
+
+{docstring Hex.DensePoly.Subresultant.poly_brownTraub_rightDegree}
+
+{docstring Hex.DensePoly.Subresultant.divScalar_brownTraub}
 
 {docstring Hex.DensePoly.Subresultant.Fraction.poly_map}
 

--- a/HexResultant/BrownTraub.lean
+++ b/HexResultant/BrownTraub.lean
@@ -500,6 +500,306 @@ theorem coeffMinorAt_addMul {R : Type u}
   unfold coeffMinorAt
   rw [det_addMul df dg db J l f g b h hJ hdeg hb hh]
 
+/-- Raising the retained formal degree of the right input by one contributes
+one leading coefficient of the left input, provided the right polynomial has
+no coefficient at the new degree. This is used in the opposite direction to
+collapse an artificially retained formal degree. -/
+theorem coeffMinorAt_succRight {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R]
+    (dg dh J l : Nat) (g h : DensePoly R)
+    (hpos : 0 < (dg - J) + (dh - J)) (hJh : J ≤ dh)
+    (hg : g.size = dg + 1) (hh : h.size ≤ dh + 1) :
+    coeffMinorAt dg (dh + 1) J l g h =
+      g.leadingCoeff * coeffMinorAt dg dh J l g h := by
+  let n := (dg - J) + (dh - J)
+  have hnpos : 0 < n := by
+    simpa [n] using hpos
+  have hdim : ((dg - J) + (dh + 1 - J)) = n + 1 := by
+    simp [n]
+    omega
+  let row : Fin (n + 1) := ⟨0, by omega⟩
+  let M : SubresultantMinor.Square R (n + 1) :=
+    SubresultantMinor.castSquare hdim
+      (coeffMatrixAt dg (dh + 1) J l g h)
+  have hleftPos : 0 < dh + 1 - J := by omega
+  have hnotLast : 0 ≠ (dg - J) + (dh + 1 - J) - 1 := by omega
+  have hfirst : M row row = g.leadingCoeff := by
+    have hcoeff : g.coeff dg = g.leadingCoeff := by
+      rw [leadingCoeff_eq_coeff_last g (by omega), hg]
+      congr
+    simpa [M, row, SubresultantMinor.castSquare, coeffMatrixAt,
+      Fin.cast, hleftPos, hnotLast, n]
+      using hcoeff
+  have hzero (j : Fin (n + 1)) (hj : 0 < j.val) : M row j = 0 := by
+    by_cases hleft : j.val < dh + 1 - J
+    · have hbound : g.size ≤ dg + j.val := by
+        rw [hg]
+        omega
+      simp only [M, row, SubresultantMinor.castSquare, coeffMatrixAt,
+        Fin.cast]
+      rw [if_pos hleft, if_neg hnotLast]
+      rw [show Int.ofNat dg - Int.ofNat 0 + Int.ofNat j.val =
+          ((dg + j.val : Nat) : Int) by
+        simp [Int.ofNat_eq_natCast, Int.natCast_add]]
+      rw [coeffInt_natCast]
+      exact coeff_eq_zero_of_size_le g hbound
+    · let jj := j.val - (dh + 1 - J)
+      have hbound : h.size ≤ dh + 1 + jj := by
+        simp [jj]
+        omega
+      simp only [M, row, SubresultantMinor.castSquare, coeffMatrixAt,
+        Fin.cast]
+      rw [if_neg hleft, if_neg hnotLast]
+      rw [show Int.ofNat (dh + 1) - Int.ofNat 0 + Int.ofNat jj =
+          ((dh + 1 + jj : Nat) : Int) by
+        simp [Int.ofNat_eq_natCast, Int.natCast_add]]
+      rw [coeffInt_natCast]
+      exact coeff_eq_zero_of_size_le h hbound
+  have hdelete : SubresultantMinor.deleteFirst M row =
+      coeffMatrixAt dg dh J l g h := by
+    funext i j
+    change coeffMatrixAt dg (dh + 1) J l g h
+        ⟨i.val + 1, by omega⟩ ⟨j.val + 1, by omega⟩ =
+      coeffMatrixAt dg dh J l g h i j
+    simp only [coeffMatrixAt]
+    by_cases hleft : j.val < dh - J
+    · rw [if_pos (by omega), if_pos hleft]
+      by_cases hlast : i.val = n - 1
+      · rw [if_pos (by omega), if_pos hlast]
+        congr 1
+        simp [n]
+        omega
+      · rw [if_neg (by omega), if_neg hlast]
+        congr 1
+        simp [Int.ofNat_eq_natCast, Int.natCast_add] <;> omega
+    · rw [if_neg (by omega), if_neg hleft]
+      by_cases hlast : i.val = n - 1
+      · rw [if_pos (by omega), if_pos hlast]
+        congr 1
+        simp [Int.ofNat_eq_natCast] <;> omega
+      · rw [if_neg (by omega), if_neg hlast]
+        congr 1
+        simp [Int.ofNat_eq_natCast, Int.natCast_add] <;> omega
+  unfold coeffMinorAt
+  rw [← SubresultantMinor.det_castSquare hdim]
+  change SubresultantMinor.det M = _
+  rw [SubresultantMinor.det_firstRow M hzero, hfirst, hdelete]
+
+/-- Raising the retained formal degree of the right input repeatedly
+contributes the corresponding power of the left leading coefficient. Reading
+the equality right-to-left collapses all retained degrees at once. -/
+theorem coeffMinorAt_raiseRight {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R]
+    (dg dh J l extra : Nat) (g h : DensePoly R)
+    (hpos : 0 < (dg - J) + (dh - J)) (hJh : J ≤ dh)
+    (hg : g.size = dg + 1) (hh : h.size ≤ dh + 1) :
+    coeffMinorAt dg (dh + extra) J l g h =
+      g.leadingCoeff ^ extra * coeffMinorAt dg dh J l g h := by
+  induction extra with
+  | zero =>
+      rw [Nat.add_zero, Lean.Grind.Semiring.pow_zero]
+      grind
+  | succ extra ih =>
+      rw [Nat.add_succ,
+        coeffMinorAt_succRight dg (dh + extra) J l g h (by omega)
+          (by omega) hg (by omega),
+        ih, Lean.Grind.Semiring.pow_succ]
+      grind
+
+/-- At the right input's formal degree, the left polynomial block is empty. -/
+private theorem coeffMinorAt_rightDegree_ignore {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R]
+    (dg dh l : Nat) (h g : DensePoly R) :
+    coeffMinorAt dh dg dh l h g =
+      coeffMinorAt dh dg dh l h 0 := by
+  unfold coeffMinorAt
+  apply congrArg SubresultantMinor.det
+  funext i j
+  have hj : j.val < dg - dh := by
+    have := j.isLt
+    omega
+  simp [coeffMatrixAt, hj]
+
+/-- The first nonempty edge minor is the selected coefficient of the right
+input. -/
+private theorem coeffMinorAt_unitRight {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R]
+    (dh l : Nat) (h : DensePoly R) :
+    coeffMinorAt dh (dh + 1) dh l h 0 = h.coeff l := by
+  unfold coeffMinorAt
+  have hdim : (dh - dh) + (dh + 1 - dh) = 1 := by omega
+  rw [← SubresultantMinor.det_castSquare hdim]
+  let M : SubresultantMinor.Square R 1 :=
+    SubresultantMinor.castSquare hdim
+      (coeffMatrixAt dh (dh + 1) dh l h 0)
+  change SubresultantMinor.det M = _
+  rw [SubresultantMinor.det_firstRow M (by
+    intro j hj
+    omega)]
+  have hentry : M ⟨0, by omega⟩ ⟨0, by omega⟩ = h.coeff l := by
+    simp [M, coeffMatrixAt, Fin.cast]
+  rw [hentry, SubresultantMinor.det_zero]
+  grind
+
+/-- The subresultant at the right input's degree is that input multiplied by
+the expected power of its leading coefficient. -/
+theorem coeffMinorAt_rightDegree {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R]
+    (dg dh l : Nat) (g h : DensePoly R)
+    (hdh : dh < dg) (hh : h.size = dh + 1) :
+    coeffMinorAt dg dh dh l g h =
+      h.leadingCoeff ^ (dg - dh - 1) * h.coeff l := by
+  rw [coeffMinorAt_swap]
+  simp only [Nat.sub_self, Nat.mul_zero, SubresultantMinor.sign]
+  rw [if_pos (by decide)]
+  rw [Lean.Grind.Semiring.one_mul,
+    coeffMinorAt_rightDegree_ignore dg dh l h g]
+  have hsum : dh + 1 + (dg - (dh + 1)) = dg := by omega
+  have hraise := coeffMinorAt_raiseRight dh (dh + 1) dh l
+    (dg - (dh + 1)) h (0 : DensePoly R) (by omega) (by omega) hh (by simp)
+  rw [hsum] at hraise
+  rw [hraise, coeffMinorAt_unitRight]
+  congr 2
+
+/-- Brown--Traub equation (12): if `H = F + B * G`, then the generalized
+Sylvester coefficient minor for `F, G` is the `G, H` minor at any formal degree
+bounding `H`, times the block-swap sign and one `lc(G)` for every collapsed
+formal degree. -/
+theorem coeffMinorAt_brownTraub {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R]
+    (df dg db dh J l : Nat) (f g b h : DensePoly R)
+    (hJh : J ≤ dh) (hdh : dh < dg)
+    (hdeg : df = db + dg) (hg : g.size = dg + 1)
+    (hb : b.size ≤ db + 1) (hhsize : h.size ≤ dh + 1)
+    (hh : h = f + b * g) :
+    coeffMinorAt df dg J l f g =
+      SubresultantMinor.sign (R := R) ((df - J) * (dg - J)) *
+        (g.leadingCoeff ^ (df - dh) * coeffMinorAt dg dh J l g h) := by
+  have hJg : J < dg := by omega
+  have hdhf : dh ≤ df := by omega
+  rw [coeffMinorAt_addMul df dg db J l f g b h hJg hdeg hb hh]
+  rw [← show dh + (df - dh) = df by omega]
+  rw [coeffMinorAt_raiseRight dg dh J l (df - dh) g h (by omega) hJh hg
+    hhsize]
+  simp
+
+/-- The generalized subresultant at the right input's degree is a scalar
+multiple of that input. -/
+theorem poly_rightDegree {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R]
+    (dg dh : Nat) (g h : DensePoly R)
+    (hdh : dh < dg) (hg : g.size = dg + 1) (hh : h.size = dh + 1) :
+    poly dh g h = scale (h.leadingCoeff ^ (dg - dh - 1)) h := by
+  have hfg : formalDegree g = dg := by simp [formalDegree, hg]
+  have hfh : formalDegree h = dh := by simp [formalDegree, hh]
+  apply ext_coeff
+  intro l
+  rw [coeff_scale_semiring]
+  simp only [coeff_poly]
+  by_cases hl : l < dh + 1
+  · rw [if_pos hl]
+    unfold coeffMinor
+    rw [hfg, hfh]
+    exact coeffMinorAt_rightDegree dg dh l g h hdh hh
+  · rw [if_neg hl, coeff_eq_zero_of_size_le h (by omega)]
+    change (0 : R) = h.leadingCoeff ^ (dg - dh - 1) * (0 : R)
+    rw [Lean.Grind.Semiring.mul_zero]
+
+/-- Polynomial form of the Brown--Traub transformation at or below the degree
+of `H`. -/
+theorem poly_brownTraub {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R]
+    (df dg db dh J : Nat) (f g b h : DensePoly R)
+    (hJh : J ≤ dh) (hdh : dh < dg) (hdeg : df = db + dg)
+    (hf : f.size = df + 1) (hg : g.size = dg + 1)
+    (hb : b.size ≤ db + 1) (hhsize : h.size = dh + 1)
+    (hh : h = f + b * g) :
+    poly J f g =
+      scale
+        (SubresultantMinor.sign (R := R) ((df - J) * (dg - J)) *
+          g.leadingCoeff ^ (df - dh))
+        (poly J g h) := by
+  have hff : formalDegree f = df := by simp [formalDegree, hf]
+  have hfg : formalDegree g = dg := by simp [formalDegree, hg]
+  have hfh : formalDegree h = dh := by simp [formalDegree, hhsize]
+  apply ext_coeff
+  intro l
+  rw [coeff_scale_semiring]
+  simp only [coeff_poly]
+  by_cases hl : l < J + 1
+  · rw [if_pos hl, if_pos hl]
+    unfold coeffMinor
+    rw [hff, hfg, hfh]
+    rw [coeffMinorAt_brownTraub df dg db dh J l f g b h hJh hdh hdeg
+      hg hb (by omega) hh]
+    grind
+  · rw [if_neg hl, if_neg hl]
+    change (0 : R) =
+      (SubresultantMinor.sign (R := R) ((df - J) * (dg - J)) *
+        g.leadingCoeff ^ (df - dh)) * (0 : R)
+    rw [Lean.Grind.Semiring.mul_zero]
+
+/-- Endpoint form of Brown--Traub equation (12), including both leading
+coefficient powers. -/
+theorem poly_brownTraub_rightDegree {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R]
+    (df dg db dh : Nat) (f g b h : DensePoly R)
+    (hdh : dh < dg) (hdeg : df = db + dg)
+    (hf : f.size = df + 1) (hg : g.size = dg + 1)
+    (hb : b.size ≤ db + 1) (hhsize : h.size = dh + 1)
+    (hh : h = f + b * g) :
+    poly dh f g =
+      scale
+        (SubresultantMinor.sign (R := R) ((df - dh) * (dg - dh)) *
+          g.leadingCoeff ^ (df - dh) * h.leadingCoeff ^ (dg - dh - 1)) h := by
+  rw [poly_brownTraub df dg db dh dh f g b h (Nat.le_refl _) hdh hdeg hf hg
+    hb hhsize hh]
+  rw [poly_rightDegree dg dh g h hdh hg hhsize, scale_scale]
+
+/-- The endpoint factorization makes its scalar quotient coefficientwise
+exact in every lawful exact-division domain. -/
+theorem divScalar_brownTraub {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R] [Div R] [ExactDivLaws R]
+    (df dg db dh : Nat) (f g b h : DensePoly R)
+    (hdh : dh < dg) (hdeg : df = db + dg)
+    (hf : f.size = df + 1) (hg : g.size = dg + 1)
+    (hb : b.size ≤ db + 1) (hhsize : h.size = dh + 1)
+    (hh : h = f + b * g)
+    (h1 : (1 : R) ≠ 0) :
+    divScalar (poly dh f g)
+        (SubresultantMinor.sign (R := R) ((df - dh) * (dg - dh)) *
+          g.leadingCoeff ^ (df - dh) * h.leadingCoeff ^ (dg - dh - 1)) = h := by
+  have hpow (a : R) (ha : a ≠ 0) : ∀ n : Nat, a ^ n ≠ 0 := by
+    intro n
+    induction n with
+    | zero =>
+        simpa only [Lean.Grind.Semiring.pow_zero] using h1
+    | succ n ih =>
+        rw [Lean.Grind.Semiring.pow_succ]
+        exact ExactDivLaws.mul_ne_zero ih ha
+  have hsign :
+      SubresultantMinor.sign (R := R) ((df - dh) * (dg - dh)) ≠ 0 := by
+    unfold SubresultantMinor.sign
+    split
+    · exact h1
+    · intro hzero
+      apply h1
+      calc
+        1 = 0 - (0 - (1 : R)) := by grind
+        _ = 0 - 0 := by rw [hzero]
+        _ = 0 := by grind
+  have hglc : g.leadingCoeff ≠ 0 :=
+    leadingCoeff_ne_zero_of_pos_size g (by omega)
+  have hhlc : h.leadingCoeff ≠ 0 :=
+    leadingCoeff_ne_zero_of_pos_size h (by omega)
+  have hc : SubresultantMinor.sign (R := R) ((df - dh) * (dg - dh)) *
+      g.leadingCoeff ^ (df - dh) * h.leadingCoeff ^ (dg - dh - 1) ≠ 0 :=
+    ExactDivLaws.mul_ne_zero
+      (ExactDivLaws.mul_ne_zero hsign (hpow _ hglc _)) (hpow _ hhlc _)
+  rw [poly_brownTraub_rightDegree df dg db dh f g b h hdh hdeg hf hg hb
+    hhsize hh]
+  exact divScalar_scale h hc
+
 end Subresultant
 end DensePoly
 end Hex

--- a/HexResultant/DeterminantAlgebra.lean
+++ b/HexResultant/DeterminantAlgebra.lean
@@ -366,6 +366,37 @@ private theorem nodup_finRange (n : Nat) : (List.finRange n).Nodup := by
       exact ⟨by simp [Fin.ext_iff],
         List.Pairwise.map _ (fun _ _ hne h => hne (Fin.succ_inj.mp h)) ih⟩
 
+/-- If the first row is supported only in its first column, the local
+determinant expands to that entry times the remaining first minor. -/
+theorem det_firstRow {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (M : Square R (n + 1))
+    (hzero : ∀ j : Fin (n + 1), 0 < j.val →
+      M ⟨0, by omega⟩ j = 0) :
+    det M = M ⟨0, by omega⟩ ⟨0, by omega⟩ *
+      det (deleteFirst M ⟨0, by omega⟩) := by
+  let row : Fin (n + 1) := ⟨0, by omega⟩
+  let term := fun j : Fin (n + 1) =>
+    sign j.val * M row j * det (deleteFirst M j)
+  have hterm (j : Fin (n + 1)) (_hjmem : j ∈ List.finRange (n + 1))
+      (hj : j ≠ row) : term j = 0 := by
+    have hjpos : 0 < j.val := by
+      by_cases hjzero : j.val = 0
+      · exfalso
+        apply hj
+        apply Fin.ext
+        simp [row, hjzero]
+      · omega
+    unfold term
+    rw [show M row j = 0 by exact hzero j hjpos]
+    grind
+  simp only [det]
+  change (List.finRange (n + 1)).foldl
+      (fun acc j => acc + term j) 0 = _
+  rw [foldl_add_single (List.finRange (n + 1)) row term 0
+    (nodup_finRange (n + 1)) (List.mem_finRange row) hterm]
+  simp [term, row, sign]
+  grind
+
 private theorem foldl_finRange_adjacent {R : Type u} [Lean.Grind.CommRing R]
     {n : Nat} (left : Fin (n + 1)) (f : Fin (n + 2) → R)
     (hzero : ∀ j, j ≠ left.castSucc → j ≠ left.succ → f j = 0) :

--- a/HexResultant/SPEC/hex-resultant.md
+++ b/HexResultant/SPEC/hex-resultant.md
@@ -241,8 +241,30 @@ includes negative and out-of-range indices, so the special coefficient row and
 every ordinary Sylvester row use the same proof. Consequently
 `coeffMinorAt_addMul` proves the column-operation form of Brown--Traub equation
 (18): the original minor is the `G, H` minor times only the usual block-swap
-sign. Collapsing the retained formal degree of `H` and producing the
-leading-coefficient power is the next transformation.
+sign.
+
+The retained formal degree is then collapsed internally, without changing the
+coefficient-matrix representation. `SubresultantMinor.det_firstRow` expands a
+matrix whose first row is supported only in its first column.
+`coeffMinorAt_succRight` identifies the remaining first minor with the matrix
+whose right formal degree is one lower, so each removed degree contributes one
+copy of `lc(G)`; `coeffMinorAt_raiseRight` iterates this to the full power.
+The edge case has a one-entry special row rather than another leading
+coefficient: `coeffMinorAt_rightDegree` and `poly_rightDegree` prove
+`S_deg(H)(G,H) = lc(H)^(deg G - deg H - 1) H`.
+
+Combining the column operation, formal-degree collapse, and edge
+factorization gives the scalar and polynomial forms of Brown--Traub Lemma 1:
+`coeffMinorAt_brownTraub`, `poly_brownTraub`, and
+`poly_brownTraub_rightDegree`. The final scalar contains the block-swap sign,
+`lc(G)^(deg F - deg H)`, and
+`lc(H)^(deg G - deg H - 1)`. In a lawful exact-division domain,
+`divScalar_brownTraub` immediately turns this factorization into an exact
+coefficientwise quotient. The remaining Brown correctness step specializes
+these identities to pseudo-remainders, composes their nonunit multiple of `F`
+with `poly_scale_left`, treats the defective range
+`deg(H) < J < deg(G)`, aligns accumulated scalar factors across recursive
+states, and discharges `subresultantOrdered_brownLaw`.
 
 The injective coefficient map extends to dense polynomials and preserves
 normalized size, leading coefficients, constants, addition, subtraction,
@@ -398,8 +420,9 @@ quotient is exact over every stated exact-division domain.
   swaps, consecutive-block rotation with its parity law, and the resulting
   generalized-subresultant input-swap law.
 - `HexResultant/BrownTraub.lean`: multiplier-convolution column updates, the
-  resulting `G, H` coefficient matrix, and the signed column-operation identity
-  of Brown--Traub equation (18).
+  resulting `G, H` coefficient matrix, formal-degree collapse,
+  leading-coefficient and endpoint factorizations, and the exact
+  coefficientwise Brown--Traub quotient.
 - `HexResultant/Subresultant.lean`: the Brown worker,
   `subresultantChain`, `resultant`, chain termination, and degree bounds.
 - `HexResultant/Discriminant.lean`: `disc` and the algebraic
@@ -445,9 +468,13 @@ Per [SPEC/testing.md](../../SPEC/testing.md), fixtures are tiered into
     swap-sequence parity and action, arbitrary duplicate columns, and arbitrary
     column updates. An equal-degree `H = F + B * G` pin with `J > 0`, odd swap
     parity, and `deg H < deg G` checks the multiplier transformation entrywise
-    and then checks equation (18). The local Laplace determinant is factorial
-    proof infrastructure, so these checks stay deliberately small rather than
-    joining the random degree-10 resultant sweep.
+    and then checks equation (18). A second pin drops four retained formal
+    degrees, checks the independently distinguishable leading-coefficient
+    factor `48`, and divides the endpoint subresultant back to `H`; a smaller
+    interior-index pin exercises the polynomial law with `J < deg H`. The local
+    Laplace determinant is factorial proof infrastructure, so these checks stay
+    deliberately small rather than joining the random degree-10 resultant
+    sweep.
   - A bivariate case over `R = ZPoly`, exercising the
     `hex-number-field` instantiation: for example
     `resultant_y (y² − t) (y − t) = t² − t`.
@@ -485,6 +512,10 @@ is faster by a factor of roughly `n+m`.
 
 - Collins, G. E. *Subresultants and reduced polynomial remainder
   sequences.* J. ACM 14 (1967), 128-142. The original.
+- Brown, W. S.; Traub, J. F.
+  [*On Euclid's Algorithm and the Theory of Subresultants*](https://iiif.library.cmu.edu/file/Traub_box00027_fld00059_bdl0001_doc0001/Traub_box00027_fld00059_bdl0001_doc0001.pdf).
+  J. ACM 18 (1971), 505-514. Lemma 1 gives the transformation and endpoint
+  factorization formalized here.
 - Brown, W. S. [*The subresultant PRS algorithm*](https://people.eecs.berkeley.edu/~fateman/282/readings/brown.pdf).
   ACM TOMS 4 (1978), 237-249. Algorithm 1 is the recurrence pinned above.
 - Eberl, M. [*Subresultants*](https://isa-afp.org/browser_info/current/AFP/Subresultants/Subresultant.html),

--- a/HexResultant/SubresultantMinor.lean
+++ b/HexResultant/SubresultantMinor.lean
@@ -137,6 +137,20 @@ variable {R : Type u} [Zero R] [DecidableEq R]
 def coeffInt (p : DensePoly R) (i : Int) : R :=
   if i < 0 then 0 else p.coeff i.toNat
 
+/-- A nonnegative integer-indexed lookup is the ordinary natural-indexed
+coefficient lookup. This explicit `Int.ofNat` form is useful for rewriting
+matrix indices before coercions have been normalized. -/
+theorem coeffInt_ofNat (p : DensePoly R) (i : Nat) :
+    coeffInt p (Int.ofNat i) = p.coeff i := by
+  cases i <;> rfl
+
+/-- Coercion notation for the nonnegative integer-indexed coefficient law. -/
+@[simp, grind =]
+theorem coeffInt_natCast (p : DensePoly R) (i : Nat) :
+    coeffInt p (i : Int) = p.coeff i := by
+  rw [← Int.ofNat_eq_natCast]
+  exact coeffInt_ofNat p i
+
 /-- Integer-indexed coefficient lookup distributes over polynomial addition. -/
 theorem coeffInt_add {S : Type u} [Lean.Grind.CommRing S] [DecidableEq S]
     (p q : DensePoly S) (t : Int) :

--- a/conformance/HexResultant/Conformance.lean
+++ b/conformance/HexResultant/Conformance.lean
@@ -31,7 +31,8 @@ Covered properties:
   adjacent-transposition sequence parity, arbitrary alternation and column
   updates, consecutive-block rotation, Brown multiplier updates, and the
   generalized polynomials obey left/right homogeneity, the input-swap sign law,
-  and Brown--Traub equation (18);
+  the Brown--Traub column identity, formal-degree collapse, endpoint
+  factorization, and exact scalar quotient;
 - Brown chains omit zero terms, order unequal-degree inputs, strictly decrease
   after their first two entries, obey the sharp length bound, and are stable
   under extra fuel;
@@ -382,6 +383,34 @@ example (f g b h : DensePoly Int) (hb : b.size ≤ 2)
     DensePoly.Subresultant.coeffMinorAt 2 2 1 0 f g =
       SubresultantMinor.sign (R := Int) 1 *
         DensePoly.Subresultant.coeffMinorAt 2 2 1 0 g h
+
+-- A four-degree formal collapse pins the full leading-coefficient power, the
+-- endpoint factorization, and the resulting exact coefficientwise quotient.
+#guard
+  let g := poly [1, 0, 0, 2]
+  let b := poly [1, 0, 3]
+  let h := poly [5, 3]
+  let f := h - b * g
+  let sub := DensePoly.Subresultant.poly 1 f g
+  f.size = 6 && g.size = 4 && b.size = 3 && h.size = 2 &&
+    h = f + b * g &&
+    sub = scale 48 h &&
+    DensePoly.divScalar (scale 48 h) 48 = h
+
+-- A smaller interior-index pin exercises the polynomial transformation before
+-- the endpoint, where `J < deg H` and the target remains a subresultant.
+#guard
+  let g := poly [1, 0, 1]
+  let b := poly [-1]
+  let h := poly [1, 1]
+  let f := h - b * g
+  f.size = 3 && g.size = 3 && b.size = 1 && h.size = 2 &&
+    h = f + b * g &&
+    DensePoly.Subresultant.poly 0 f g =
+      scale
+        (SubresultantMinor.sign (R := Int) ((2 - 0) * (2 - 0)) *
+          g.leadingCoeff ^ (2 - 1))
+        (DensePoly.Subresultant.poly 0 g h)
 
 /-! # Brown chain -/
 

--- a/progress/20260729T003301Z_resultant-brown-traub-collapse.md
+++ b/progress/20260729T003301Z_resultant-brown-traub-collapse.md
@@ -1,0 +1,31 @@
+# Resultant Brown--Traub degree collapse
+
+## Accomplished
+
+- Proved sparse-first-row determinant expansion for the local determinant.
+- Proved one-step and iterated retained-formal-degree collapse for generalized
+  Sylvester minors.
+- Proved the right-degree edge law, the full Brown--Traub factorization, and
+  its endpoint polynomial identity.
+- Derived the executable exact scalar quotient from the endpoint identity in
+  every nontrivial exact-division coefficient ring.
+- Added discriminating endpoint and interior-index conformance guards and
+  updated the Resultant SPEC and manual chapter.
+- Ran a fresh independent mathematical review, targeted builds, and the full
+  9,573-job `lake build` successfully.
+
+## Current frontier
+
+The formal-degree collapse and leading-coefficient factors are now available
+as reusable public lemmas. `subresultantOrdered_brownLaw` remains the principal
+Resultant proof obligation.
+
+## Next step
+
+Specialize the transformation laws to ordered pseudo-remainders, compose the
+nonunit multiple of the left input with `poly_scale_left`, cover the defective
+index range, and align the accumulated recursive scalar factors.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Summary

- add sparse-first-row determinant expansion to the local determinant API
- prove one-step and iterated retained-formal-degree collapse for generalized Sylvester minors
- derive the Brown--Traub coefficient and polynomial factorizations, endpoint law, and executable exact scalar quotient
- add discriminating endpoint and interior-index conformance guards
- update the Resultant SPEC, manual, and session progress record

## Why

The preceding column-transform milestone left the transformed `G, H` minor at `F`'s retained formal degree. These lemmas collapse that artificial degree, account for every leading-coefficient factor, and expose the exact endpoint quotient needed by the recursive Brown-law proof.

## Validation

- `lake build HexResultant.BrownTraub HexResultant.Conformance HexManual.Chapters.HexResultant`
- full `lake build` (9,573 jobs)
- `git diff --check`
- no new `sorry`, `axiom`, or `native_decide`
