### PR TITLE
Prove recursive Brown exactness

### DIFF
--- a/HexManual/Chapters/HexResultant.lean
+++ b/HexManual/Chapters/HexResultant.lean
@@ -78,14 +78,18 @@ quotients remains its own subresultant theorem.
 
 {docstring Hex.DensePoly.PseudoDivMod.resultant_step_degree}
 
-# Fraction-field proof bridge
+# Integral proof and coefficient embeddings
 
-Brown--Traub exactness is proved first after embedding coefficients in a
-Mathlib-free fraction field. The embedding is injective, commutes with ordered
-pseudo-division, and turns an embedding-image certificate into the scalar and
-coefficientwise reconstruction equations required by the Brown recurrence.
-This bridge is proof-only; the executable chain continues to operate entirely
-in its input coefficient ring.
+Brown--Traub exactness is proved directly in the input coefficient ring. The
+recursive invariant keeps every leading-coefficient and Brown-scale factor
+cross-multiplied, then cancels only factors already proved nonzero. This gives
+the scalar and coefficientwise reconstruction equations required by the Brown
+recurrence without changing coefficient types.
+
+The Mathlib-free fraction field remains available as general proof
+infrastructure. Its embedding is injective, commutes with ordered
+pseudo-division, and supports pulling exact quotients back to the coefficient
+ring, but the Brown recurrence does not depend on that detour.
 
 {docstring Hex.Fraction.ofCoeff}
 
@@ -187,6 +191,19 @@ coefficientwise by the executable exact-division operation.
 {docstring Hex.DensePoly.Subresultant.poly_brownTraub_rightDegree}
 
 {docstring Hex.DensePoly.Subresultant.divScalar_brownTraub}
+
+The pseudo-remainder specialization covers defective degree drops as well as
+regular steps. It identifies the subresultant immediately below the divisor
+degree, transports every lower subresultant across the step, and feeds the
+cross-multiplied family invariant used by the recursive proof.
+
+{docstring Hex.DensePoly.Subresultant.poly_prem}
+
+{docstring Hex.DensePoly.Subresultant.poly_descent}
+
+{docstring Hex.DensePoly.BrownLaw}
+
+{docstring Hex.DensePoly.subresultantOrdered_brownLaw}
 
 {docstring Hex.DensePoly.Subresultant.Fraction.poly_map}
 

--- a/HexResultant.lean
+++ b/HexResultant.lean
@@ -33,13 +33,3 @@ formal derivative and an exact leading-coefficient quotient.
 Correctness and correspondence with Mathlib's `Polynomial.resultant` and
 `Polynomial.discr` live in the companion `HexResultantMathlib` library.
 -/
-
-namespace Hex.DensePoly
-
-/-- The executable Brown recurrence and the proof-only minor construction use
-the same alternating sign convention. -/
-theorem negOnePow_eq_sign {R : Type u} [Zero R] [One R] [Sub R] (n : Nat) :
-    negOnePow (R := R) n = SubresultantMinor.sign (R := R) n := by
-  rfl
-
-end Hex.DensePoly

--- a/HexResultant/BrownTraub.lean
+++ b/HexResultant/BrownTraub.lean
@@ -641,6 +641,115 @@ private theorem coeffMinorAt_unitRight {R : Type u}
   rw [hentry, SubresultantMinor.det_zero]
   grind
 
+/-- When the right formal degree is one below the left and the subresultant
+index equals it, the one-entry coefficient minor selects the right input. -/
+theorem coeffMinorAt_leftSucc {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R]
+    (dh l : Nat) (g h : DensePoly R) :
+    coeffMinorAt (dh + 1) dh dh l g h = h.coeff l := by
+  rw [coeffMinorAt_swap]
+  simp only [Nat.sub_self, Nat.mul_zero, SubresultantMinor.sign]
+  rw [if_pos (by decide), Lean.Grind.Semiring.one_mul,
+    coeffMinorAt_rightDegree_ignore, coeffMinorAt_unitRight]
+
+/-- The subresultant immediately below the divisor degree is the signed
+pseudo-remainder. This includes defective remainders: no exact degree is
+assumed for the remainder. -/
+theorem poly_prem {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R] [Div R] [ExactDivLaws R]
+    (f g : DensePoly R) (hgsize : 2 ≤ g.size) (hgf : g.size ≤ f.size) :
+    poly (g.size - 2) f g =
+      scale
+        (SubresultantMinor.sign (R := R) (f.size - g.size + 1))
+        (pseudoDivMod f g).2 := by
+  let df := f.size - 1
+  let dg := g.size - 1
+  let db := f.size - g.size
+  let J := g.size - 2
+  let a := g.leadingCoeff ^ (db + 1)
+  let q := (pseudoDivMod f g).1
+  let r := (pseudoDivMod f g).2
+  let b := scale (0 - 1) q
+  have hg : g ≠ 0 := by
+    intro hzero
+    subst g
+    simp at hgsize
+  have hglc : g.leadingCoeff ≠ 0 :=
+    leadingCoeff_ne_zero_of_pos_size g (by omega)
+  have h1 : (1 : R) ≠ 0 := one_ne_zero_of_nonzero hglc
+  have hneg : (0 - 1 : R) ≠ 0 := negOne_ne_zero_of_one h1
+  have ha : a ≠ 0 := pow_ne_zero h1 hglc (db + 1)
+  have hqsize : q.size ≤ db + 1 := by
+    simpa only [q, db] using pseudoDivMod_quotient_size_le f g
+  have hbsize : b.size ≤ db + 1 := by
+    rw [size_scale hneg]
+    exact hqsize
+  have hrsize : r.size ≤ J + 1 := by
+    have hrlt : r.size < g.size := by
+      simpa only [r] using pseudoDivMod_remainder_lt f g hg
+    dsimp only [J]
+    omega
+  have hrec : scale a f = q * g + r := by
+    simpa only [a, db, q, r] using pseudoDivMod_reconstruct f g hg hgf
+  have hbneg : b = -q := by
+    apply ext_coeff
+    intro i
+    simp only [b, coeff_scale_semiring, coeff_neg_ring]
+    grind
+  have hr : r = scale a f + b * g := by
+    rw [hbneg]
+    grind
+  have hdf : df = db + dg := by
+    dsimp only [df, db, dg]
+    omega
+  have hfg : g.size = dg + 1 := by
+    dsimp only [dg]
+    omega
+  have hff : formalDegree f = df := by
+    simp [formalDegree, df]
+  have hgg : formalDegree g = dg := by
+    simp [formalDegree, dg]
+  apply ext_coeff
+  intro l
+  rw [coeff_scale_semiring]
+  simp only [coeff_poly]
+  by_cases hl : l < J + 1
+  · rw [if_pos hl]
+    unfold coeffMinor
+    rw [hff, hgg]
+    have hscale := coeffMinorAt_scale_left df dg J l a f g
+    have hadd := coeffMinorAt_addMul df dg db J l (scale a f) g b r
+      (by dsimp only [dg, J]; omega) hdf hbsize hr
+    have hraise := coeffMinorAt_raiseRight dg J J l (df - J) g r
+      (by dsimp only [dg, J]; omega) (Nat.le_refl _) hfg hrsize
+    rw [show J + (df - J) = df by dsimp only [df, J]; omega] at hraise
+    have hedge : coeffMinorAt dg J J l g r = r.coeff l := by
+      rw [show dg = J + 1 by dsimp only [dg, J]; omega]
+      exact coeffMinorAt_leftSucc J l g r
+    rw [hadd, hraise, hedge] at hscale
+    have hdfJ : df - J = db + 1 := by
+      dsimp only [df, J, db]
+      omega
+    have hdgJ : dg - J = 1 := by
+      dsimp only [dg, J]
+      omega
+    have hpow : g.leadingCoeff ^ (df - J) = a := by
+      rw [hdfJ]
+    have hunit : a ^ (dg - J) = a := by
+      rw [hdgJ, Lean.Grind.Semiring.pow_one]
+    have hsign :
+        SubresultantMinor.sign (R := R) ((df - J) * (dg - J)) =
+          SubresultantMinor.sign (db + 1) := by
+      rw [hdfJ, hdgJ, Nat.mul_one]
+    rw [hpow, hunit, hsign] at hscale
+    apply ExactDivLaws.mul_right_cancel ha
+    grind
+  · rw [if_neg hl]
+    have hrzero : r.coeff l = 0 :=
+      coeff_eq_zero_of_size_le r (by omega)
+    rw [hrzero, Lean.Grind.Semiring.mul_zero]
+    rfl
+
 /-- The subresultant at the right input's degree is that input multiplied by
 the expected power of its leading coefficient. -/
 theorem coeffMinorAt_rightDegree {R : Type u}
@@ -739,6 +848,97 @@ theorem poly_brownTraub {R : Type u}
         g.leadingCoeff ^ (df - dh)) * (0 : R)
     rw [Lean.Grind.Semiring.mul_zero]
 
+/-- Transport a generalized subresultant family across one scaled
+pseudo-remainder step. The identity stays cross-multiplied, so every scalar
+remains in the base ring even across defective degree drops. -/
+theorem poly_descent {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R] [Div R] [ExactDivLaws R]
+    (f g h : DensePoly R) {c : R} (hc : c ≠ 0)
+    (hg : g ≠ 0) (hh : h ≠ 0) (hgf : g.size ≤ f.size)
+    (hp : (pseudoDivMod f g).2 = scale c h)
+    (J : Nat) (hJ : J < h.size) :
+    scale
+        (g.leadingCoeff ^
+          ((f.size - g.size + 1) * (g.size - 1 - J)))
+        (poly J f g) =
+      scale
+        (SubresultantMinor.sign (R := R)
+            ((f.size - 1 - J) * (g.size - 1 - J)) *
+          g.leadingCoeff ^ (f.size - h.size) *
+          c ^ (g.size - 1 - J))
+        (poly J g h) := by
+  let df := f.size - 1
+  let dg := g.size - 1
+  let db := f.size - g.size
+  let dh := h.size - 1
+  let a := g.leadingCoeff ^ (db + 1)
+  let q := (pseudoDivMod f g).1
+  let b := scale (0 - 1) q
+  have hgpos : 0 < g.size := Nat.pos_of_ne_zero fun hzero =>
+    hg ((size_eq_zero_iff g).mp hzero)
+  have hhpos : 0 < h.size := Nat.pos_of_ne_zero fun hzero =>
+    hh ((size_eq_zero_iff h).mp hzero)
+  have hglc : g.leadingCoeff ≠ 0 :=
+    leadingCoeff_ne_zero_of_pos_size g hgpos
+  have h1 : (1 : R) ≠ 0 := one_ne_zero_of_nonzero hglc
+  have hneg : (0 - 1 : R) ≠ 0 := negOne_ne_zero_of_one h1
+  have ha : a ≠ 0 := pow_ne_zero h1 hglc (db + 1)
+  have hbsize : b.size ≤ db + 1 := by
+    rw [size_scale hneg]
+    simpa only [q, db] using pseudoDivMod_quotient_size_le f g
+  have hrec := pseudoDivMod_reconstruct f g hg hgf
+  have hbneg : b = -q := by
+    apply ext_coeff
+    intro i
+    simp only [b, coeff_scale_semiring, coeff_neg_ring]
+    grind
+  have hrem : scale c h = scale a f + b * g := by
+    rw [hbneg, ← hp]
+    simpa only [a, db, q] using (show
+      (pseudoDivMod f g).2 =
+        scale (g.leadingCoeff ^ (f.size - g.size + 1)) f +
+          -(pseudoDivMod f g).1 * g by
+      grind)
+  have hdf : df = db + dg := by
+    dsimp only [df, db, dg]
+    omega
+  have hdhg : dh < dg := by
+    have hremSize : (pseudoDivMod f g).2.size < g.size :=
+      pseudoDivMod_remainder_lt f g hg
+    rw [hp, size_scale hc] at hremSize
+    dsimp only [dh, dg]
+    omega
+  have hJh : J ≤ dh := by
+    dsimp only [dh]
+    omega
+  have hfsize : (scale a f).size = df + 1 := by
+    rw [size_scale ha]
+    dsimp only [df]
+    omega
+  have hgsize : g.size = dg + 1 := by
+    dsimp only [dg]
+    omega
+  have hhsize : (scale c h).size = dh + 1 := by
+    rw [size_scale hc]
+    dsimp only [dh]
+    omega
+  have hBT := poly_brownTraub df dg db dh J (scale a f) g b (scale c h)
+    hJh hdhg hdf hfsize hgsize hbsize hhsize hrem
+  have hleft := poly_scale_left ha J f g
+  have hright := poly_scale_right hc J g h
+  have hfgdeg : formalDegree g = dg := by simp [formalDegree, dg]
+  rw [hleft, hright, scale_scale] at hBT
+  rw [hfgdeg] at hBT
+  have haPow : a ^ (dg - J) =
+      g.leadingCoeff ^ ((db + 1) * (dg - J)) := by
+    exact (pow_mul g.leadingCoeff (db + 1) (dg - J)).symm
+  rw [haPow] at hBT
+  have hdiff : df - dh = f.size - h.size := by
+    dsimp only [df, dh]
+    omega
+  rw [hdiff] at hBT
+  simpa only [df, dg, db, dh, Nat.add_comm] using hBT
+
 /-- Endpoint form of Brown--Traub equation (12), including both leading
 coefficient powers. -/
 theorem poly_brownTraub_rightDegree {R : Type u}
@@ -769,25 +969,9 @@ theorem divScalar_brownTraub {R : Type u}
     divScalar (poly dh f g)
         (SubresultantMinor.sign (R := R) ((df - dh) * (dg - dh)) *
           g.leadingCoeff ^ (df - dh) * h.leadingCoeff ^ (dg - dh - 1)) = h := by
-  have hpow (a : R) (ha : a ≠ 0) : ∀ n : Nat, a ^ n ≠ 0 := by
-    intro n
-    induction n with
-    | zero =>
-        simpa only [Lean.Grind.Semiring.pow_zero] using h1
-    | succ n ih =>
-        rw [Lean.Grind.Semiring.pow_succ]
-        exact ExactDivLaws.mul_ne_zero ih ha
   have hsign :
-      SubresultantMinor.sign (R := R) ((df - dh) * (dg - dh)) ≠ 0 := by
-    unfold SubresultantMinor.sign
-    split
-    · exact h1
-    · intro hzero
-      apply h1
-      calc
-        1 = 0 - (0 - (1 : R)) := by grind
-        _ = 0 - 0 := by rw [hzero]
-        _ = 0 := by grind
+      SubresultantMinor.sign (R := R) ((df - dh) * (dg - dh)) ≠ 0 :=
+    SubresultantMinor.sign_ne_zero h1 _
   have hglc : g.leadingCoeff ≠ 0 :=
     leadingCoeff_ne_zero_of_pos_size g (by omega)
   have hhlc : h.leadingCoeff ≠ 0 :=
@@ -795,7 +979,8 @@ theorem divScalar_brownTraub {R : Type u}
   have hc : SubresultantMinor.sign (R := R) ((df - dh) * (dg - dh)) *
       g.leadingCoeff ^ (df - dh) * h.leadingCoeff ^ (dg - dh - 1) ≠ 0 :=
     ExactDivLaws.mul_ne_zero
-      (ExactDivLaws.mul_ne_zero hsign (hpow _ hglc _)) (hpow _ hhlc _)
+      (ExactDivLaws.mul_ne_zero hsign (pow_ne_zero h1 hglc _))
+      (pow_ne_zero h1 hhlc _)
   rw [poly_brownTraub_rightDegree df dg db dh f g b h hdh hdeg hf hg hb
     hhsize hh]
   exact divScalar_scale h hc

--- a/HexResultant/DeterminantAlgebra.lean
+++ b/HexResultant/DeterminantAlgebra.lean
@@ -654,11 +654,29 @@ theorem sign_add {R : Type u} [Lean.Grind.CommRing R] (a b : Nat) :
       rw [Nat.add_succ, sign_succ, ih, sign_succ]
       grind
 
+/-- A multiplied sign exponent is repeated multiplication of the sign. -/
+theorem sign_mul {R : Type u} [Lean.Grind.CommRing R] (a : Nat) :
+    ∀ b : Nat, sign (R := R) (a * b) = sign (R := R) a ^ b
+  | 0 => by
+      rw [Nat.mul_zero, Lean.Grind.Semiring.pow_zero]
+      simp [sign]
+  | b + 1 => by
+      rw [Nat.mul_succ, sign_add, sign_mul a b,
+        Lean.Grind.Semiring.pow_succ]
+
 /-- Every alternating sign is its own multiplicative inverse. -/
 theorem sign_mul_self {R : Type u} [Lean.Grind.CommRing R] (n : Nat) :
     sign (R := R) n * sign (R := R) n = 1 := by
   unfold sign
   split <;> grind
+
+/-- Every alternating sign is nonzero in a nontrivial ring. -/
+theorem sign_ne_zero {R : Type u} [Lean.Grind.CommRing R]
+    (h1 : (1 : R) ≠ 0) (n : Nat) : sign (R := R) n ≠ 0 := by
+  intro hzero
+  have hself := sign_mul_self (R := R) n
+  rw [hzero] at hself
+  grind
 
 /-- Deleting either member of an equal adjacent column pair gives the same
 minor. -/

--- a/HexResultant/ExactDiv.lean
+++ b/HexResultant/ExactDiv.lean
@@ -57,6 +57,26 @@ end ExactDivLaws
 
 variable {R : Type u}
 
+/-- A nonzero element witnesses that a lightweight ring is nontrivial. -/
+theorem one_ne_zero_of_nonzero {S : Type u} [Lean.Grind.CommRing S]
+    {a : S} (ha : a ≠ 0) : (1 : S) ≠ 0 := by
+  intro hone
+  apply ha
+  calc
+    a = a * 1 := (Lean.Grind.Semiring.mul_one _).symm
+    _ = a * 0 := by rw [hone]
+    _ = 0 := Lean.Grind.Semiring.mul_zero _
+
+/-- The additive inverse of one is nonzero in a nontrivial lightweight ring. -/
+theorem negOne_ne_zero_of_one {S : Type u} [Lean.Grind.CommRing S]
+    (h1 : (1 : S) ≠ 0) : (0 - 1 : S) ≠ 0 := by
+  intro hzero
+  apply h1
+  calc
+    1 = 0 - (0 - (1 : S)) := by grind
+    _ = 0 - 0 := by rw [hzero]
+    _ = 0 := by grind
+
 /-- Total exact quotient wrapper. The zero denominator is a documented junk
 input and returns zero. -/
 @[expose]
@@ -96,8 +116,20 @@ def powNat [One R] [Mul R] (x : R) (n : Nat) : R :=
 termination_by n
 decreasing_by omega
 
+/-- Powers distribute over multiplication in a lightweight commutative ring. -/
+theorem mul_pow {S : Type u} [Lean.Grind.CommRing S]
+    (a b : S) : ∀ n : Nat, (a * b) ^ n = a ^ n * b ^ n
+  | 0 => by
+      rw [Lean.Grind.Semiring.pow_zero, Lean.Grind.Semiring.pow_zero,
+        Lean.Grind.Semiring.pow_zero]
+      exact (Lean.Grind.Semiring.mul_one 1).symm
+  | n + 1 => by
+      rw [Lean.Grind.Semiring.pow_succ, Lean.Grind.Semiring.pow_succ,
+        Lean.Grind.Semiring.pow_succ, mul_pow a b n]
+      grind
+
 /-- Raising a power to another power multiplies the two exponents. -/
-private theorem pow_mul {S : Type u} [Lean.Grind.Semiring S]
+theorem pow_mul {S : Type u} [Lean.Grind.Semiring S]
     (x : S) (m n : Nat) : x ^ (m * n) = (x ^ m) ^ n := by
   symm
   induction n with
@@ -106,6 +138,17 @@ private theorem pow_mul {S : Type u} [Lean.Grind.Semiring S]
       rw [Lean.Grind.Semiring.pow_succ, ih,
         ← Lean.Grind.Semiring.pow_add]
       congr 1
+
+/-- Natural powers of a nonzero element stay nonzero in every nontrivial
+exact-division ring. -/
+theorem pow_ne_zero {S : Type u} [Lean.Grind.CommRing S] [Div S]
+    [ExactDivLaws S] (h1 : (1 : S) ≠ 0) {a : S} (ha : a ≠ 0) :
+    ∀ n : Nat, a ^ n ≠ 0
+  | 0 => by
+      simpa only [Lean.Grind.Semiring.pow_zero] using h1
+  | n + 1 => by
+      rw [Lean.Grind.Semiring.pow_succ]
+      exact ExactDivLaws.mul_ne_zero (pow_ne_zero h1 ha n) ha
 
 /-- The executable binary power agrees with the lightweight semiring power. -/
 theorem powNat_eq_pow {S : Type u} [Lean.Grind.Semiring S]
@@ -130,6 +173,13 @@ theorem powNat_eq_pow {S : Type u} [Lean.Grind.Semiring S]
           congr 1
           have hmod := Nat.mod_lt n (by decide : 0 < 2)
           omega
+
+/-- The executable natural power of a nonzero element stays nonzero. -/
+theorem powNat_ne_zero {S : Type u} [Lean.Grind.CommRing S] [Div S]
+    [ExactDivLaws S] (h1 : (1 : S) ≠ 0) {a : S} (ha : a ≠ 0) (n : Nat) :
+    powNat a n ≠ 0 := by
+  rw [powNat_eq_pow]
+  exact pow_ne_zero h1 ha n
 
 /-- Brown's scalar update `x^n / y^(n-1)`, with the same total zero behavior
 as `exactDiv`. -/
@@ -158,6 +208,15 @@ theorem size_scale [Lean.Grind.CommRing R] [DecidableEq R] [Div R]
   apply Nat.le_of_not_gt
   intro hlt
   exact hcoeff (coeff_eq_zero_of_size_le (scale a p) (by omega))
+
+/-- Scaling a nonzero polynomial by a nonzero coefficient remains nonzero. -/
+theorem scale_ne_zero [Lean.Grind.CommRing R] [DecidableEq R] [Div R]
+    [ExactDivLaws R] {a : R} (ha : a ≠ 0) {p : DensePoly R} (hp : p ≠ 0) :
+    scale a p ≠ 0 := by
+  intro hzero
+  have hsize := congrArg DensePoly.size hzero
+  rw [size_scale ha, size_zero] at hsize
+  exact hp ((size_eq_zero_iff p).mp hsize)
 
 /-- The leading coefficient scales with a nonzero coefficient scalar. -/
 theorem leadingCoeff_scale [Lean.Grind.CommRing R] [DecidableEq R] [Div R]
@@ -250,6 +309,13 @@ theorem divScalar_scale [Lean.Grind.CommRing R] [DecidableEq R] [Div R]
   rw [coeff_divScalar _ hb, coeff_scale_semiring,
     Lean.Grind.CommSemiring.mul_comm]
   exact ExactDivLaws.mul_div_cancel_right (p.coeff n) b hb
+
+/-- Scaling by a nonzero coefficient is cancellable. -/
+theorem scale_cancel [Lean.Grind.CommRing R] [DecidableEq R] [Div R]
+    [ExactDivLaws R] {b : R} (hb : b ≠ 0) {p q : DensePoly R}
+    (h : scale b p = scale b q) : p = q := by
+  have hdiv := congrArg (fun r : DensePoly R => divScalar r b) h
+  simpa only [divScalar_scale _ hb] using hdiv
 
 end DensePoly
 

--- a/HexResultant/PseudoDivMod.lean
+++ b/HexResultant/PseudoDivMod.lean
@@ -27,18 +27,6 @@ variable {S : Type u} [Lean.Grind.CommRing S] [DecidableEq S]
 
 variable [Div S] [ExactDivLaws S]
 
-/-- Powers distribute over multiplication in the lightweight commutative ring. -/
-private theorem mul_pow {T : Type u} [Lean.Grind.CommRing T]
-    (a b : T) : ∀ n : Nat, (a * b) ^ n = a ^ n * b ^ n
-  | 0 => by
-      rw [Lean.Grind.Semiring.pow_zero, Lean.Grind.Semiring.pow_zero,
-        Lean.Grind.Semiring.pow_zero]
-      exact (Lean.Grind.Semiring.mul_one 1).symm
-  | n + 1 => by
-      rw [Lean.Grind.Semiring.pow_succ, Lean.Grind.Semiring.pow_succ,
-        Lean.Grind.Semiring.pow_succ, mul_pow a b n]
-      grind
-
 /-- Below a positive-degree divisor, a strict dense-size bound gives the
 corresponding default-degree bound. -/
 private theorem degree_lt_of_size_lt {T : Type u} [Lean.Grind.CommRing T]

--- a/HexResultant/SPEC/hex-resultant.md
+++ b/HexResultant/SPEC/hex-resultant.md
@@ -188,14 +188,14 @@ separate Brown--Traub subresultant theorem recorded by `BrownLaw`.
 In particular, reversing `divScalar` by scaling requires the coefficientwise
 exactness certified by that law; the homogeneity API does not assume it.
 
-## Fraction-field proof bridge
+## Integral Brown--Traub proof bridge
 
-The Brown--Traub integrality proof works first in a Mathlib-free fraction
-field constructed locally from cross-multiplication classes. This is proof
-infrastructure only: the executable recurrence never constructs a fraction,
-and `hex-resultant` still has no matrix or Mathlib dependency. A nonzero Brown
-input supplies the local `1 ≠ 0` witness needed by the coefficient embedding;
-`ExactDivLaws` supplies cancellation and rules out zero products.
+The Brown--Traub correctness proof stays in the coefficient ring. Its state
+invariant keeps every accumulated leading-coefficient and Brown-scale factor
+cross-multiplied, so no fraction representative and no divisibility hypothesis
+beyond `ExactDivLaws` is needed. A nonzero Brown input supplies `1 ≠ 0`;
+`ExactDivLaws` supplies cancellation, rules out zero products, and reverses an
+exact scalar multiple after its factorization has been proved.
 
 The generalized Sylvester constructions in this proof are local,
 coefficient-indexed proof objects with their finite-sum identities developed
@@ -260,23 +260,26 @@ factorization gives the scalar and polynomial forms of Brown--Traub Lemma 1:
 `lc(G)^(deg F - deg H)`, and
 `lc(H)^(deg G - deg H - 1)`. In a lawful exact-division domain,
 `divScalar_brownTraub` immediately turns this factorization into an exact
-coefficientwise quotient. The remaining Brown correctness step specializes
-these identities to pseudo-remainders, composes their nonunit multiple of `F`
-with `poly_scale_left`, treats the defective range
-`deg(H) < J < deg(G)`, aligns accumulated scalar factors across recursive
-states, and discharges `subresultantOrdered_brownLaw`.
+coefficientwise quotient.
 
-The injective coefficient map extends to dense polynomials and preserves
-normalized size, leading coefficients, constants, addition, subtraction,
-scaling, multiplication, and ordered pseudo-division. Generalized Sylvester
-subresultants can therefore establish the Brown scale identities in the
-fraction field. Once a scalar or coefficientwise quotient is shown to lie in
-the embedding image, `Fraction.divExp_exact` and
-`DensePoly.Fraction.divScalar_exact` prove exactly the two reconstruction
-equalities recorded by `BrownLaw`; the corresponding pullback lemmas identify
-the quotient returned by the original coefficient ring. Thus the
-fraction-field argument proves integrality instead of changing the executable
-algorithm's coefficient type.
+The executable specialization is split into two further polynomial identities.
+`poly_prem` identifies `S_(deg G - 1)(F,G)` with the signed
+pseudo-remainder, including defective degree drops. `poly_descent` transports
+the entire lower subresultant family across any nonzero scaled
+pseudo-remainder while leaving all factors cross-multiplied. In
+`Subresultant.lean`, the private `BrownInv` states that every generalized
+subresultant of the current adjacent pair is an explicit scalar multiple of
+the corresponding original-pair subresultant. Its initialization, scale,
+factor, and step lemmas identify each `hCurr`, prove both exact Brown
+divisions, cancel the alternating signs, and preserve the family through the
+recursive call. Fuel induction then proves `subresultantOrdered_brownLaw`, so
+the valid run cannot take either executable junk exit.
+
+The Mathlib-free fraction field and its dense-polynomial embedding remain
+available as general proof infrastructure. Their map and pullback theorems
+preserve normalized size, leading coefficients, ring operations,
+pseudo-division, and generalized subresultants, but the Brown recurrence proof
+does not depend on that detour.
 
 ## Ordered Brown run
 
@@ -324,9 +327,11 @@ The executable recurrence calls the proved runtime twins `scaleImpl` and
 list-facing specifications above. Its two fuel/junk exits are deterministic:
 fuel exhaustion returns the current `(chain, hPrev)`, while an unexpectedly
 zero `next` returns `(chain, hCurr)` without storing that zero. Neither branch
-is reachable from a valid ordered nonzero state over an exact-division domain;
-`subresultantOrdered_brownLaw` is the proof boundary for that algebraic claim.
-The structural guarantees below do not depend on it.
+is compatible with the exactness and nonzero obligations recorded by
+`BrownLaw`; `subresultantOrdered_brownLaw` establishes that law for the initial
+ordered state. The reference `divScalar` in the law is identified with the
+worker's `divScalarImpl` by its correspondence theorem. The structural
+guarantees below remain independently useful and do not depend on `BrownLaw`.
 
 The public chain stores exactly Brown's nonzero `G₁, …, Gₖ`. It does not
 store the generated terminal zero, gap zeros from defective subresultants, the
@@ -423,8 +428,9 @@ quotient is exact over every stated exact-division domain.
   resulting `G, H` coefficient matrix, formal-degree collapse,
   leading-coefficient and endpoint factorizations, and the exact
   coefficientwise Brown--Traub quotient.
-- `HexResultant/Subresultant.lean`: the Brown worker,
-  `subresultantChain`, `resultant`, chain termination, and degree bounds.
+- `HexResultant/Subresultant.lean`: the integral recursive subresultant
+  invariant, `BrownLaw`, the Brown worker, `subresultantChain`, `resultant`,
+  chain termination, and degree bounds.
 - `HexResultant/Discriminant.lean`: `disc` and the algebraic
   identities we need downstream (for example
   `disc (f * g) = disc f · disc g · (resultant f g)²`).

--- a/HexResultant/Subresultant.lean
+++ b/HexResultant/Subresultant.lean
@@ -6,8 +6,7 @@ Authors: Kim Morrison
 
 module
 
-public import HexResultant.ExactDiv
-public import HexResultant.PseudoDivMod
+public import HexResultant.BrownTraub
 public meta import HexResultant.ExactDiv
 public meta import HexPoly.Dense
 public meta import HexPoly.Euclid.DivGcd
@@ -49,6 +48,19 @@ variable {R : Type u} [Zero R] [DecidableEq R]
 def negOnePow [One R] [Sub R] (n : Nat) : R :=
   if n % 2 = 0 then 1 else 0 - 1
 
+omit [Zero R] [DecidableEq R] in
+/-- The executable Brown sign is the local determinant's alternating sign. -/
+theorem negOnePow_eq_sign {S : Type u} [Zero S] [One S] [Sub S] (n : Nat) :
+    negOnePow (R := S) n = SubresultantMinor.sign (R := S) n := by
+  rfl
+
+omit [Zero R] [DecidableEq R] in
+/-- Brown signs are nonzero in every nontrivial commutative ring. -/
+theorem negOnePow_ne_zero {S : Type u} [Lean.Grind.CommRing S]
+    (h1 : (1 : S) ≠ 0) (n : Nat) : negOnePow (R := S) n ≠ 0 := by
+  rw [negOnePow_eq_sign]
+  exact SubresultantMinor.sign_ne_zero h1 n
+
 /-- The exactness and nonzero obligations for every reachable Brown worker
 state. A valid state must terminate naturally before its fuel reaches zero;
 the adjacent polynomials have strictly decreasing size, the current and
@@ -74,6 +86,518 @@ def BrownLaw [One R] [Add R] [Sub R] [Mul R] [Div R]
           let next := divScalar p divisor
           divisor ≠ 0 ∧ p = scale divisor next ∧ next ≠ 0 ∧
             BrownLaw curr next hCurr fuel
+
+/-- Integral subresultant-family invariant for one recursive Brown state. It
+keeps all accumulated factors cross-multiplied in the coefficient ring. -/
+private def BrownInv [Lean.Grind.CommRing R] [DecidableEq R]
+    (f g prev curr : DensePoly R) (hPrev : R) : Prop :=
+  prev ≠ 0 ∧ curr ≠ 0 ∧ curr.size < prev.size ∧ hPrev ≠ 0 ∧
+    ∀ J, J < curr.size →
+      Subresultant.poly J prev curr =
+        scale
+          (prev.leadingCoeff ^ (curr.size - 1 - J) *
+            hPrev ^ (prev.size - 2 - J))
+          (Subresultant.poly J f g)
+
+/-- The block-swap sign cancels the repeated signed-pseudo-remainder factor
+at every index below the divisor degree. -/
+private theorem sign_prem_cancel {S : Type u} [Lean.Grind.CommRing S]
+    (m n J : Nat) (hnm : n ≤ m) (hJ : J < n) :
+    SubresultantMinor.sign (R := S) ((m - 1 - J) * (n - 1 - J)) *
+        SubresultantMinor.sign (R := S) (m - n + 1) ^ (n - 1 - J) = 1 := by
+  let t := n - 1 - J
+  let delta := m - n
+  have hmJ : m - 1 - J = t + delta := by
+    dsimp only [t, delta]
+    omega
+  rw [hmJ]
+  rw [← SubresultantMinor.sign_mul (R := S) (delta + 1) t,
+    ← SubresultantMinor.sign_add]
+  have hexp :
+      (t + delta) * t + (delta + 1) * t =
+        (t + delta + (delta + 1)) * t := by
+    simp only [Nat.add_mul]
+  rw [hexp]
+  have hmod : ((t + delta + (delta + 1)) * t) % 2 = 0 := by
+    by_cases ht : t % 2 = 0
+    · rw [Nat.mul_mod, ht]
+      omega
+    · have ht1 : t % 2 = 1 := by
+        have := Nat.mod_lt t (by decide : 0 < 2)
+        omega
+      have hu : (t + delta + (delta + 1)) % 2 = 0 := by
+        omega
+      rw [Nat.mul_mod, hu]
+      omega
+  unfold SubresultantMinor.sign
+  rw [if_pos hmod]
+
+/-- The invariant identifies the next Brown scale with the leading principal
+coefficient of the original-pair subresultant and proves its exact quotient
+law inside the base ring. -/
+private theorem BrownInv.nextScale {S : Type u}
+    [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [ExactDivLaws S]
+    (f g prev curr : DensePoly S) (hPrev : S)
+    (hinv : BrownInv f g prev curr hPrev) :
+    let delta := prev.size - curr.size
+    let hCurr := divExp curr.leadingCoeff hPrev delta
+    hCurr = (Subresultant.poly (curr.size - 1) f g).coeff (curr.size - 1) ∧
+      hCurr ≠ 0 ∧
+      powNat curr.leadingCoeff delta =
+        powNat hPrev (delta - 1) * hCurr := by
+  rcases hinv with ⟨hprev, hcurr, hlt, hhPrev, hfamily⟩
+  let delta := prev.size - curr.size
+  let J := curr.size - 1
+  let root := Subresultant.poly J f g
+  let w := root.coeff J
+  have hprevPos : 0 < prev.size := Nat.pos_of_ne_zero fun hzero =>
+    hprev ((size_eq_zero_iff prev).mp hzero)
+  have hcurrPos : 0 < curr.size := Nat.pos_of_ne_zero fun hzero =>
+    hcurr ((size_eq_zero_iff curr).mp hzero)
+  have hdelta : 0 < delta := by
+    dsimp only [delta]
+    omega
+  have hJ : J < curr.size := by
+    dsimp only [J]
+    omega
+  have hInvJ : Subresultant.poly J prev curr =
+      scale (hPrev ^ (delta - 1)) root := by
+    have h := hfamily J hJ
+    have hexp₁ : curr.size - 1 - J = 0 := by
+      dsimp only [J]
+      omega
+    have hexp₂ : prev.size - 2 - J = delta - 1 := by
+      dsimp only [J, delta]
+      omega
+    rw [hexp₁, hexp₂, Lean.Grind.Semiring.pow_zero,
+      Lean.Grind.Semiring.one_mul] at h
+    exact h
+  have hEdge : Subresultant.poly J prev curr =
+      scale (curr.leadingCoeff ^ (delta - 1)) curr := by
+    have h := Subresultant.poly_rightDegree (prev.size - 1)
+      (curr.size - 1) prev curr (by omega) (by omega) (by omega)
+    have hexp : (prev.size - 1) - (curr.size - 1) - 1 = delta - 1 := by
+      dsimp only [delta]
+      omega
+    simpa only [J, hexp] using h
+  have hcoeff := congrArg (fun p : DensePoly S => p.coeff J)
+    (hEdge.symm.trans hInvJ)
+  rw [coeff_scale_semiring, coeff_scale_semiring] at hcoeff
+  have hcurrCoeff : curr.coeff J = curr.leadingCoeff := by
+    exact (leadingCoeff_eq_coeff_last curr hcurrPos).symm
+  have hnum : curr.leadingCoeff ^ delta = hPrev ^ (delta - 1) * w := by
+    rw [hcurrCoeff] at hcoeff
+    change curr.leadingCoeff ^ (delta - 1) * curr.leadingCoeff =
+      hPrev ^ (delta - 1) * w at hcoeff
+    rw [← Lean.Grind.Semiring.pow_succ] at hcoeff
+    simpa only [show delta - 1 + 1 = delta by omega] using hcoeff
+  have hcurrLc : curr.leadingCoeff ≠ 0 :=
+    leadingCoeff_ne_zero_of_pos_size curr hcurrPos
+  have h1 : (1 : S) ≠ 0 := one_ne_zero_of_nonzero hcurrLc
+  have hden : hPrev ^ (delta - 1) ≠ 0 :=
+    pow_ne_zero h1 hhPrev (delta - 1)
+  have hnumNe : curr.leadingCoeff ^ delta ≠ 0 :=
+    pow_ne_zero h1 hcurrLc delta
+  have hw : w ≠ 0 := by
+    intro hwzero
+    apply hnumNe
+    rw [hnum, hwzero, Lean.Grind.Semiring.mul_zero]
+  have hdiv : divExp curr.leadingCoeff hPrev delta = w := by
+    unfold divExp
+    rw [powNat_eq_pow, powNat_eq_pow, hnum]
+    rw [show hPrev ^ (delta - 1) * w = w * hPrev ^ (delta - 1) by grind]
+    exact exactDiv_mul_right w hden
+  dsimp only
+  refine ⟨?_, hdiv ▸ hw, ?_⟩
+  · simpa only [J, root, w] using hdiv
+  · rw [hdiv, powNat_eq_pow, powNat_eq_pow]
+    exact hnum
+
+/-- The signed first pseudo-remainder establishes the integral invariant for
+the first recursive Brown state. -/
+private theorem brownInv_init {S : Type u}
+    [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [ExactDivLaws S]
+    (f g : DensePoly S) (hg : g ≠ 0) (hgf : g.size ≤ f.size)
+    (hp : (pseudoDivMod f g).2 ≠ 0) :
+    let delta := f.size - g.size
+    let h₂ := powNat g.leadingCoeff delta
+    let g₃ := scale (negOnePow (R := S) (delta + 1)) (pseudoDivMod f g).2
+    BrownInv f g g g₃ h₂ := by
+  let delta := f.size - g.size
+  let p := (pseudoDivMod f g).2
+  let s := negOnePow (R := S) (delta + 1)
+  let h₂ := powNat g.leadingCoeff delta
+  let g₃ := scale s p
+  have hgpos : 0 < g.size := Nat.pos_of_ne_zero fun hzero =>
+    hg ((size_eq_zero_iff g).mp hzero)
+  have hglc : g.leadingCoeff ≠ 0 :=
+    leadingCoeff_ne_zero_of_pos_size g hgpos
+  have h1 : (1 : S) ≠ 0 := one_ne_zero_of_nonzero hglc
+  have hs : s ≠ 0 := negOnePow_ne_zero h1 (delta + 1)
+  have hg₃ : g₃ ≠ 0 := scale_ne_zero hs hp
+  have hg₃size : g₃.size = p.size := size_scale hs p
+  have hg₃lt : g₃.size < g.size := by
+    rw [hg₃size]
+    simpa only [p] using pseudoDivMod_remainder_lt f g hg
+  have hh₂ : h₂ ≠ 0 := powNat_ne_zero h1 hglc delta
+  have hsquare : s * s = 1 := by
+    simpa only [s, negOnePow_eq_sign] using
+      (SubresultantMinor.sign_mul_self (R := S) (delta + 1))
+  have hpback : p = scale s g₃ := by
+    apply ext_coeff
+    intro i
+    simp only [g₃, coeff_scale_semiring]
+    change p.coeff i = s * (s * p.coeff i)
+    grind
+  refine ⟨hg, hg₃, hg₃lt, hh₂, ?_⟩
+  intro J hJ
+  have hdes := Subresultant.poly_descent f g g₃ hs hg hg₃ hgf
+    (by simpa only [p] using hpback) J hJ
+  have hJg : J < g.size := Nat.lt_trans hJ hg₃lt
+  have hsign := sign_prem_cancel (S := S) f.size g.size J hgf hJg
+  have hscalar :
+      SubresultantMinor.sign (R := S)
+          ((f.size - 1 - J) * (g.size - 1 - J)) *
+        g.leadingCoeff ^ (f.size - g₃.size) *
+        s ^ (g.size - 1 - J) =
+      g.leadingCoeff ^ (f.size - g₃.size) := by
+    rw [show s = SubresultantMinor.sign (R := S) (f.size - g.size + 1) by
+      simp only [s, delta, negOnePow_eq_sign]]
+    grind
+  rw [hscalar] at hdes
+  let common := f.size - g₃.size
+  let targetExp := (g₃.size - 1 - J) + delta * (g.size - 2 - J)
+  let leftExp := (delta + 1) * (g.size - 1 - J)
+  have hexp : leftExp = common + targetExp := by
+    have hJle₃ : J + 1 ≤ g₃.size := Nat.succ_le_of_lt hJ
+    have hJstrong : J + 1 < g.size :=
+      Nat.lt_of_le_of_lt hJle₃ hg₃lt
+    have hJleg : J + 1 ≤ g.size := Nat.le_of_lt hJstrong
+    have hg₃f : g₃.size ≤ f.size :=
+      Nat.le_trans (Nat.le_of_lt hg₃lt) hgf
+    have hn : g.size - 1 - J = (g.size - 2 - J) + 1 := by omega
+    have hleft :
+        (f.size - g₃.size) + (g₃.size - 1 - J) =
+          f.size - (J + 1) := by
+      rw [show g₃.size - 1 - J = g₃.size - (J + 1) by omega]
+      exact Nat.sub_add_sub_cancel hg₃f hJle₃
+    have hright :
+        (f.size - g.size) + (g.size - 1 - J) =
+          f.size - (J + 1) := by
+      rw [show g.size - 1 - J = g.size - (J + 1) by omega]
+      exact Nat.sub_add_sub_cancel hgf hJleg
+    have hlin :
+        (f.size - g₃.size) + (g₃.size - 1 - J) =
+          (f.size - g.size) + (g.size - 1 - J) := by
+      exact hleft.trans hright.symm
+    dsimp only [leftExp, common, targetExp, delta]
+    calc
+      (f.size - g.size + 1) * (g.size - 1 - J) =
+          (f.size - g.size) * (g.size - 1 - J) +
+            (g.size - 1 - J) := by
+        rw [Nat.add_mul, Nat.one_mul]
+      _ = (f.size - g.size) * ((g.size - 2 - J) + 1) +
+            (g.size - 1 - J) := by rw [hn]
+      _ = (f.size - g.size) * (g.size - 2 - J) +
+            (f.size - g.size) + (g.size - 1 - J) := by
+        rw [Nat.mul_add, Nat.mul_one]
+      _ = ((f.size - g₃.size) + (g₃.size - 1 - J)) +
+            (f.size - g.size) * (g.size - 2 - J) := by
+        rw [hlin]
+        omega
+      _ = (f.size - g₃.size) +
+            ((g₃.size - 1 - J) +
+              (f.size - g.size) * (g.size - 2 - J)) := by omega
+  have htarget :
+      g.leadingCoeff ^ (g₃.size - 1 - J) * h₂ ^ (g.size - 2 - J) =
+        g.leadingCoeff ^ targetExp := by
+    rw [show h₂ = g.leadingCoeff ^ delta by
+      simp only [h₂, powNat_eq_pow], ← pow_mul,
+      ← Lean.Grind.Semiring.pow_add]
+  apply scale_cancel (pow_ne_zero h1 hglc common)
+  rw [scale_scale]
+  rw [htarget]
+  rw [← Lean.Grind.Semiring.pow_add, ← hexp]
+  simpa only [common, leftExp, delta, s, g₃, p] using hdes.symm
+
+/-- At a nonterminal invariant state, the pseudo-remainder has the exact Brown
+factor and its quotient is the adjacent original-pair subresultant. -/
+private theorem BrownInv.factor {S : Type u}
+    [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [ExactDivLaws S]
+    (f g prev curr : DensePoly S) (hPrev : S)
+    (hinv : BrownInv f g prev curr hPrev)
+    (hp : (pseudoDivMod prev curr).2 ≠ 0) :
+    let delta := prev.size - curr.size
+    let p := (pseudoDivMod prev curr).2
+    let divisor :=
+      negOnePow (R := S) (delta + 1) * prev.leadingCoeff * powNat hPrev delta
+    let next := divScalar p divisor
+    divisor ≠ 0 ∧ p = scale divisor next ∧ next ≠ 0 ∧
+      next = Subresultant.poly (curr.size - 2) f g := by
+  rcases hinv with ⟨hprev, hcurr, hlt, hhPrev, hfamily⟩
+  let delta := prev.size - curr.size
+  let p := (pseudoDivMod prev curr).2
+  let s := negOnePow (R := S) (delta + 1)
+  let divisor := s * prev.leadingCoeff * powNat hPrev delta
+  let next := divScalar p divisor
+  let J := curr.size - 2
+  let root := Subresultant.poly J f g
+  have hprevPos : 0 < prev.size := Nat.pos_of_ne_zero fun hzero =>
+    hprev ((size_eq_zero_iff prev).mp hzero)
+  have hcurrPos : 0 < curr.size := Nat.pos_of_ne_zero fun hzero =>
+    hcurr ((size_eq_zero_iff curr).mp hzero)
+  have hprevLc : prev.leadingCoeff ≠ 0 :=
+    leadingCoeff_ne_zero_of_pos_size prev hprevPos
+  have h1 : (1 : S) ≠ 0 := one_ne_zero_of_nonzero hprevLc
+  have hs : s ≠ 0 := negOnePow_ne_zero h1 (delta + 1)
+  have hpow : powNat hPrev delta ≠ 0 :=
+    powNat_ne_zero h1 hhPrev delta
+  have hdivisor : divisor ≠ 0 :=
+    ExactDivLaws.mul_ne_zero
+      (ExactDivLaws.mul_ne_zero hs hprevLc) hpow
+  have hcurrBig : 2 ≤ curr.size := by
+    by_cases hbig : 2 ≤ curr.size
+    · exact hbig
+    · have hpsize : p.size < curr.size := by
+        simpa only [p] using pseudoDivMod_remainder_lt prev curr hcurr
+      have hpzero : p = 0 := (size_eq_zero_iff p).mp (by omega)
+      exact (hp hpzero).elim
+  have hJ : J < curr.size := by
+    dsimp only [J]
+    omega
+  have hInvJ : Subresultant.poly J prev curr =
+      scale (prev.leadingCoeff * hPrev ^ delta) root := by
+    have h := hfamily J hJ
+    have hexp₁ : curr.size - 1 - J = 1 := by
+      dsimp only [J]
+      omega
+    have hexp₂ : prev.size - 2 - J = delta := by
+      dsimp only [J, delta]
+      omega
+    rw [hexp₁, hexp₂, Lean.Grind.Semiring.pow_one] at h
+    exact h
+  have hPrem : Subresultant.poly J prev curr = scale s p := by
+    have h := Subresultant.poly_prem prev curr hcurrBig (Nat.le_of_lt hlt)
+    simpa only [J, s, delta, p, negOnePow_eq_sign] using h
+  have hsquare : s * s = 1 := by
+    simpa only [s, negOnePow_eq_sign] using
+      (SubresultantMinor.sign_mul_self (R := S) (delta + 1))
+  have hfactor : p = scale divisor root := by
+    apply scale_cancel hs
+    rw [scale_scale]
+    have heq : scale s p = scale (prev.leadingCoeff * hPrev ^ delta) root :=
+      hPrem.symm.trans hInvJ
+    have hscalar :
+        s * divisor = prev.leadingCoeff * hPrev ^ delta := by
+      dsimp only [divisor]
+      rw [powNat_eq_pow]
+      grind
+    rw [hscalar]
+    exact heq
+  have hnext : next = root := by
+    dsimp only [next]
+    rw [hfactor]
+    exact divScalar_scale root hdivisor
+  have hroot : root ≠ 0 := by
+    intro hzero
+    apply hp
+    change p = 0
+    rw [hfactor, hzero]
+    apply ext_coeff
+    intro i
+    rw [coeff_scale_semiring, coeff_zero]
+    grind
+  have hscaled : p = scale divisor next := by
+    rw [hnext]
+    exact hfactor
+  have hnextNonzero : next ≠ 0 := by
+    rw [hnext]
+    exact hroot
+  exact ⟨hdivisor, hscaled, hnextNonzero, hnext⟩
+
+/-- One nonterminal Brown step preserves the integral original-pair
+subresultant invariant. -/
+private theorem BrownInv.step {S : Type u}
+    [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [ExactDivLaws S]
+    (f g prev curr : DensePoly S) (hPrev : S)
+    (hinv : BrownInv f g prev curr hPrev)
+    (hp : (pseudoDivMod prev curr).2 ≠ 0) :
+    let delta := prev.size - curr.size
+    let hCurr := divExp curr.leadingCoeff hPrev delta
+    let p := (pseudoDivMod prev curr).2
+    let divisor :=
+      negOnePow (R := S) (delta + 1) * prev.leadingCoeff * powNat hPrev delta
+    let next := divScalar p divisor
+    BrownInv f g curr next hCurr := by
+  rcases hinv with ⟨hprev, hcurr, hlt, hhPrev, hfamily⟩
+  let delta := prev.size - curr.size
+  let hCurr := divExp curr.leadingCoeff hPrev delta
+  let p := (pseudoDivMod prev curr).2
+  let s := negOnePow (R := S) (delta + 1)
+  let divisor := s * prev.leadingCoeff * powNat hPrev delta
+  let next := divScalar p divisor
+  have hinv : BrownInv f g prev curr hPrev :=
+    ⟨hprev, hcurr, hlt, hhPrev, hfamily⟩
+  have hscale := BrownInv.nextScale f g prev curr hPrev hinv
+  rcases hscale with ⟨_, hhCurrRaw, hscaleExactRaw⟩
+  have hhCurr : hCurr ≠ 0 := by
+    simpa only [hCurr, delta] using hhCurrRaw
+  have hscaleExact :
+      powNat curr.leadingCoeff delta =
+        powNat hPrev (delta - 1) * hCurr := by
+    simpa only [hCurr, delta] using hscaleExactRaw
+  have hfactor := BrownInv.factor f g prev curr hPrev hinv hp
+  rcases hfactor with
+    ⟨hdivisorRaw, hscaledRaw, hnextRaw, hnextEqRaw⟩
+  have hdivisor : divisor ≠ 0 := by
+    simpa only [divisor, s, delta] using hdivisorRaw
+  have hscaled : p = scale divisor next := by
+    simpa only [p, divisor, next, s, delta] using hscaledRaw
+  have hnext : next ≠ 0 := by
+    simpa only [p, divisor, next, s, delta] using hnextRaw
+  have hnextEq :
+      next = Subresultant.poly (curr.size - 2) f g := by
+    simpa only [p, divisor, next, s, delta] using hnextEqRaw
+  have hprevPos : 0 < prev.size := Nat.pos_of_ne_zero fun hzero =>
+    hprev ((size_eq_zero_iff prev).mp hzero)
+  have hcurrPos : 0 < curr.size := Nat.pos_of_ne_zero fun hzero =>
+    hcurr ((size_eq_zero_iff curr).mp hzero)
+  have hprevLc : prev.leadingCoeff ≠ 0 :=
+    leadingCoeff_ne_zero_of_pos_size prev hprevPos
+  have hcurrLc : curr.leadingCoeff ≠ 0 :=
+    leadingCoeff_ne_zero_of_pos_size curr hcurrPos
+  have h1 : (1 : S) ≠ 0 := one_ne_zero_of_nonzero hcurrLc
+  have hcurrBig : 2 ≤ curr.size := by
+    by_cases hbig : 2 ≤ curr.size
+    · exact hbig
+    · have hpsize : p.size < curr.size := by
+        simpa only [p] using pseudoDivMod_remainder_lt prev curr hcurr
+      have hpzero : p = 0 := (size_eq_zero_iff p).mp (by omega)
+      exact (hp hpzero).elim
+  have hnextSize : next.size ≤ curr.size - 1 := by
+    rw [hnextEq]
+    exact Nat.le_trans
+      (Subresultant.poly_size_le (curr.size - 2) f g) (by omega)
+  have hnextLt : next.size < curr.size := by omega
+  refine ⟨hcurr, hnext, hnextLt, hhCurr, ?_⟩
+  intro J hJ
+  have hJnext : J < next.size := by
+    simpa only [next, p, divisor, s, delta] using hJ
+  have hJcurr : J < curr.size := Nat.lt_trans hJnext hnextLt
+  have hdes := Subresultant.poly_descent prev curr next hdivisor
+    hcurr hnext (Nat.le_of_lt hlt) hscaled J hJnext
+  have hfamilyJ := hfamily J hJcurr
+  let t := curr.size - 1 - J
+  let b := curr.size - 2 - J
+  let a := next.size - 1 - J
+  let common :=
+    curr.leadingCoeff ^ (prev.size - next.size) *
+      prev.leadingCoeff ^ t * hPrev ^ (delta * t)
+  let target := curr.leadingCoeff ^ a * hCurr ^ b
+  have ht : t = b + 1 := by
+    dsimp only [t, b]
+    omega
+  have hdelta : 0 < delta := by
+    dsimp only [delta]
+    omega
+  have hrecPow :
+      curr.leadingCoeff ^ delta = hPrev ^ (delta - 1) * hCurr := by
+    simpa only [powNat_eq_pow] using hscaleExact
+  have hrecPowB :
+      curr.leadingCoeff ^ (delta * b) =
+        hPrev ^ ((delta - 1) * b) * hCurr ^ b := by
+    rw [pow_mul, hrecPow, mul_pow, ← pow_mul]
+  have hlcExp :
+      (delta + 1) * t =
+        ((prev.size - next.size) + a) + delta * b := by
+    have hgap : (prev.size - next.size) + a = delta + t := by
+      dsimp only [delta, t, a]
+      omega
+    rw [hgap, ht, Nat.add_mul, Nat.one_mul, Nat.mul_add, Nat.mul_one]
+    omega
+  have hprevExp :
+      prev.size - 2 - J = delta + b := by
+    dsimp only [delta, b]
+    omega
+  have hhExp :
+      (delta - 1) * b + (prev.size - 2 - J) = delta * t := by
+    rw [hprevExp, ht]
+    have hd : delta = (delta - 1) + 1 := by omega
+    calc
+      (delta - 1) * b + (delta + b) =
+          ((delta - 1) * b + b) + delta := by omega
+      _ = ((delta - 1) + 1) * b + delta := by
+        rw [Nat.add_mul, Nat.one_mul]
+      _ = delta * b + delta := by rw [← hd]
+      _ = delta * (b + 1) := by rw [Nat.mul_add, Nat.mul_one]
+  have hhCombine :
+      hPrev ^ ((delta - 1) * b) * hPrev ^ (prev.size - 2 - J) =
+        hPrev ^ (delta * t) := by
+    rw [← Lean.Grind.Semiring.pow_add, hhExp]
+  have hleftScalar :
+      curr.leadingCoeff ^ ((delta + 1) * t) *
+          (prev.leadingCoeff ^ t * hPrev ^ (prev.size - 2 - J)) =
+        common * target := by
+    rw [hlcExp, Lean.Grind.Semiring.pow_add,
+      Lean.Grind.Semiring.pow_add, hrecPowB]
+    dsimp only [common, target]
+    calc
+      curr.leadingCoeff ^ (prev.size - next.size) *
+            curr.leadingCoeff ^ a *
+            (hPrev ^ ((delta - 1) * b) * hCurr ^ b) *
+            (prev.leadingCoeff ^ t * hPrev ^ (prev.size - 2 - J)) =
+          curr.leadingCoeff ^ (prev.size - next.size) *
+            prev.leadingCoeff ^ t *
+            (hPrev ^ ((delta - 1) * b) *
+              hPrev ^ (prev.size - 2 - J)) *
+            (curr.leadingCoeff ^ a * hCurr ^ b) := by grind
+      _ = curr.leadingCoeff ^ (prev.size - next.size) *
+            prev.leadingCoeff ^ t * hPrev ^ (delta * t) *
+            (curr.leadingCoeff ^ a * hCurr ^ b) := by rw [hhCombine]
+  have hsign := sign_prem_cancel (S := S) prev.size curr.size J
+    (Nat.le_of_lt hlt) hJcurr
+  have hrightScalar :
+      SubresultantMinor.sign (R := S)
+          ((prev.size - 1 - J) * (curr.size - 1 - J)) *
+          curr.leadingCoeff ^ (prev.size - next.size) *
+          divisor ^ (curr.size - 1 - J) = common := by
+    have hsEq : s =
+        SubresultantMinor.sign (R := S) (prev.size - curr.size + 1) := by
+      simp only [s, delta, negOnePow_eq_sign]
+    dsimp only [divisor]
+    rw [mul_pow, mul_pow, powNat_eq_pow, ← pow_mul, hsEq]
+    dsimp only [common, t, delta]
+    grind
+  rw [hfamilyJ, scale_scale] at hdes
+  change
+    scale
+        (curr.leadingCoeff ^ ((delta + 1) * t) *
+          (prev.leadingCoeff ^ t * hPrev ^ (prev.size - 2 - J)))
+        (Subresultant.poly J f g) = _ at hdes
+  rw [hleftScalar] at hdes
+  change
+    scale (common * target) (Subresultant.poly J f g) =
+      scale
+        (SubresultantMinor.sign (R := S)
+            ((prev.size - 1 - J) * (curr.size - 1 - J)) *
+          curr.leadingCoeff ^ (prev.size - next.size) *
+          divisor ^ (curr.size - 1 - J))
+        (Subresultant.poly J curr next) at hdes
+  rw [hrightScalar] at hdes
+  have hcommon : common ≠ 0 := by
+    dsimp only [common]
+    exact ExactDivLaws.mul_ne_zero
+      (ExactDivLaws.mul_ne_zero
+        (pow_ne_zero h1 hcurrLc (prev.size - next.size))
+        (pow_ne_zero h1 hprevLc t))
+      (pow_ne_zero h1 hhPrev (delta * t))
+  have heq :
+      scale common (scale target (Subresultant.poly J f g)) =
+        scale common (Subresultant.poly J curr next) := by
+    rw [scale_scale]
+    exact hdes
+  have hcancel := scale_cancel hcommon heq
+  simpa only [target, a, b] using hcancel.symm
 
 /-- Fuel-bounded Brown recurrence after the initial pseudo-division.
 
@@ -174,6 +698,76 @@ coefficient. -/
 private theorem size_pos_of_ne_zero (p : DensePoly R) (hp : p ≠ 0) :
     0 < p.size :=
   (isZero_eq_false_iff p).1 (isZero_false_of_ne_zero p hp)
+
+/-- The integral subresultant invariant supplies every obligation in the
+fuel-bounded executable Brown law. -/
+private theorem brownLaw_of_inv {S : Type u}
+    [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [ExactDivLaws S]
+    (f g : DensePoly S) (fuel : Nat) (prev curr : DensePoly S) (hPrev : S)
+    (hinv : BrownInv f g prev curr hPrev) (hfuel : curr.size ≤ fuel) :
+    BrownLaw prev curr hPrev fuel := by
+  induction fuel generalizing prev curr hPrev with
+  | zero =>
+      rcases hinv with ⟨_, hcurr, _, _, _⟩
+      have hpos := size_pos_of_ne_zero curr hcurr
+      omega
+  | succ fuel ih =>
+      rcases hinv with ⟨hprev, hcurr, hlt, hhPrev, hfamily⟩
+      let delta := prev.size - curr.size
+      let hCurr := divExp curr.leadingCoeff hPrev delta
+      let p := (pseudoDivMod prev curr).2
+      have hinv : BrownInv f g prev curr hPrev :=
+        ⟨hprev, hcurr, hlt, hhPrev, hfamily⟩
+      have hscale := BrownInv.nextScale f g prev curr hPrev hinv
+      rcases hscale with ⟨_, hhCurrRaw, hscaleExactRaw⟩
+      have hhCurr : hCurr ≠ 0 := by
+        simpa only [hCurr, delta] using hhCurrRaw
+      have hscaleExact :
+          powNat curr.leadingCoeff delta =
+            powNat hPrev (delta - 1) * hCurr := by
+        simpa only [hCurr, delta] using hscaleExactRaw
+      have hresult :
+          prev ≠ 0 ∧ curr ≠ 0 ∧ curr.size < prev.size ∧
+            hPrev ≠ 0 ∧ hCurr ≠ 0 ∧
+            powNat curr.leadingCoeff delta =
+              powNat hPrev (delta - 1) * hCurr ∧
+            if p.isZero then
+              True
+            else
+              let divisor :=
+                negOnePow (R := S) (delta + 1) * prev.leadingCoeff *
+                  powNat hPrev delta
+              let next := divScalar p divisor
+              divisor ≠ 0 ∧ p = scale divisor next ∧ next ≠ 0 ∧
+                BrownLaw curr next hCurr fuel := by
+        refine ⟨hprev, hcurr, hlt, hhPrev, hhCurr, hscaleExact, ?_⟩
+        cases hpzero : p.isZero with
+        | true => simp only [↓reduceIte]
+        | false =>
+            have hp : p ≠ 0 := ne_zero_of_isZero_false p hpzero
+            let divisor :=
+              negOnePow (R := S) (delta + 1) * prev.leadingCoeff *
+                powNat hPrev delta
+            let next := divScalar p divisor
+            have hpRaw : (pseudoDivMod prev curr).2 ≠ 0 := by
+              simpa only [p] using hp
+            have hfactor := BrownInv.factor f g prev curr hPrev hinv hpRaw
+            rcases hfactor with
+              ⟨hdivisorRaw, hscaledRaw, hnextRaw, _⟩
+            have hdivisor : divisor ≠ 0 := by
+              simpa only [divisor, delta] using hdivisorRaw
+            have hscaled : p = scale divisor next := by
+              simpa only [p, divisor, next, delta] using hscaledRaw
+            have hnext : next ≠ 0 := by
+              simpa only [p, divisor, next, delta] using hnextRaw
+            have hstepRaw := BrownInv.step f g prev curr hPrev hinv hpRaw
+            have hstep : BrownInv f g curr next hCurr := by
+              simpa only [p, divisor, next, hCurr, delta] using hstepRaw
+            have hnextLt : next.size < curr.size := hstep.2.2.1
+            have hrec := ih curr next hCurr hstep (by omega)
+            simp only [Bool.false_eq_true, ↓reduceIte]
+            exact ⟨hdivisor, hscaled, hnext, hrec⟩
+      simpa only [BrownLaw, delta, hCurr, p] using hresult
 
 /-- Once the worker has more fuel than the current polynomial has stored
 coefficients, its result is independent of the exact fuel value. Every
@@ -549,7 +1143,7 @@ obligation recorded by `BrownLaw`, including the unreachability of the junk
 zero-quotient branch. -/
 theorem subresultantOrdered_brownLaw {S : Type u}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [ExactDivLaws S]
-    (f g : DensePoly S) (hf : f ≠ 0) (hg : g ≠ 0) (hgf : g.size ≤ f.size) :
+    (f g : DensePoly S) (hg : g ≠ 0) (hgf : g.size ≤ f.size) :
     let delta := f.size - g.size
     let h₂ := powNat g.leadingCoeff delta
     let p := (pseudoDivMod f g).2
@@ -558,7 +1152,48 @@ theorem subresultantOrdered_brownLaw {S : Type u}
     else
       let g₃ := scaleImpl (negOnePow (delta + 1)) p
       g₃ ≠ 0 ∧ BrownLaw g g₃ h₂ (g.size + 1) := by
-  sorry
+  let delta := f.size - g.size
+  let h₂ := powNat g.leadingCoeff delta
+  let p := (pseudoDivMod f g).2
+  have hgpos := size_pos_of_ne_zero g hg
+  have hglc : g.leadingCoeff ≠ 0 :=
+    leadingCoeff_ne_zero_of_pos_size g hgpos
+  have h1 : (1 : S) ≠ 0 := one_ne_zero_of_nonzero hglc
+  have hh₂ : h₂ ≠ 0 := powNat_ne_zero h1 hglc delta
+  change
+    if p.isZero then
+      h₂ ≠ 0
+    else
+      let g₃ := scaleImpl (negOnePow (R := S) (delta + 1)) p
+      g₃ ≠ 0 ∧ BrownLaw g g₃ h₂ (g.size + 1)
+  cases hpzero : p.isZero with
+  | true =>
+      simp only [↓reduceIte]
+      exact hh₂
+  | false =>
+      let s := negOnePow (R := S) (delta + 1)
+      let g₃ := scaleImpl s p
+      have hp : p ≠ 0 := ne_zero_of_isZero_false p hpzero
+      have hs : s ≠ 0 := negOnePow_ne_zero h1 (delta + 1)
+      have hg₃Eq : g₃ = scale s p := by
+        dsimp only [g₃]
+        exact (scale_eq_scaleImpl s p).symm
+      have hg₃ : g₃ ≠ 0 := by
+        rw [hg₃Eq]
+        exact scale_ne_zero hs hp
+      have hpRaw : (pseudoDivMod f g).2 ≠ 0 := by
+        simpa only [p] using hp
+      have hinvRaw := brownInv_init f g hg hgf hpRaw
+      have hinvScale : BrownInv f g g (scale s p) h₂ := by
+        simpa only [delta, h₂, p, s] using hinvRaw
+      have hinv : BrownInv f g g g₃ h₂ := by
+        rw [hg₃Eq]
+        exact hinvScale
+      have hg₃lt : g₃.size < g.size := hinv.2.2.1
+      have hlaw := brownLaw_of_inv f g (g.size + 1) g g₃ h₂ hinv
+        (by omega)
+      simp only [Bool.false_eq_true, ↓reduceIte]
+      simpa only [g₃, s] using ⟨hg₃, hlaw⟩
 
 /-- Adding fuel beyond the public ordered-run budget leaves the result
 unchanged. This is a structural consequence of strict remainder-size descent

--- a/conformance/HexResultant/Conformance.lean
+++ b/conformance/HexResultant/Conformance.lean
@@ -32,10 +32,10 @@ Covered properties:
   updates, consecutive-block rotation, Brown multiplier updates, and the
   generalized polynomials obey left/right homogeneity, the input-swap sign law,
   the Brown--Traub column identity, formal-degree collapse, endpoint
-  factorization, and exact scalar quotient;
+  factorization, pseudo-remainder descent, and exact scalar quotient;
 - Brown chains omit zero terms, order unequal-degree inputs, strictly decrease
-  after their first two entries, obey the sharp length bound, and are stable
-  under extra fuel;
+  after their first two entries, obey the sharp length bound, are stable under
+  extra fuel, and satisfy the recursive exactness law on ordered nonzero inputs;
 - resultants obey linear evaluation, the degree-product swap sign, common-root
   vanishing, recursive bivariate elimination, and the corrected defective-drop
   scale;
@@ -366,6 +366,28 @@ example (f g b h : DensePoly Int) (hb : b.size ≤ 2)
   DensePoly.Subresultant.coeffMinorAt_addMul 2 1 1 0 0 f g b h
     (by omega) rfl hb hh
 
+example (f g : DensePoly Int) (hgsize : 2 ≤ g.size)
+    (hgf : g.size ≤ f.size) :
+    DensePoly.Subresultant.poly (g.size - 2) f g =
+      scale
+        (SubresultantMinor.sign (R := Int) (f.size - g.size + 1))
+        (pseudoDivMod f g).2 :=
+  DensePoly.Subresultant.poly_prem f g hgsize hgf
+
+example (f g h : DensePoly Int) {c : Int} (hc : c ≠ 0)
+    (hg : g ≠ 0) (hh : h ≠ 0) (hgf : g.size ≤ f.size)
+    (hp : (pseudoDivMod f g).2 = scale c h) (J : Nat) (hJ : J < h.size) :
+    scale
+        (g.leadingCoeff ^ ((f.size - g.size + 1) * (g.size - 1 - J)))
+        (DensePoly.Subresultant.poly J f g) =
+      scale
+        (SubresultantMinor.sign (R := Int)
+            ((f.size - 1 - J) * (g.size - 1 - J)) *
+          g.leadingCoeff ^ (f.size - h.size) *
+          c ^ (g.size - 1 - J))
+        (DensePoly.Subresultant.poly J g h) :=
+  DensePoly.Subresultant.poly_descent f g h hc hg hh hgf hp J hJ
+
 -- Equal input degrees, odd swap parity, `J > 0`, and a remainder whose degree
 -- drops below `G` pin the nontrivial Brown column-update regime entrywise.
 #guard
@@ -434,6 +456,17 @@ example (f g : DensePoly Int) (hg : g ≠ 0) (extra : Nat) :
     subresultantOrderedFuel f g (g.size + 1 + extra) =
       subresultantOrdered f g :=
   subresultantOrderedFuel_eq f g hg extra
+
+example (f g : DensePoly Int) (hg : g ≠ 0) (hgf : g.size ≤ f.size) :
+    let delta := f.size - g.size
+    let h₂ := powNat g.leadingCoeff delta
+    let p := (pseudoDivMod f g).2
+    if p.isZero then
+      h₂ ≠ 0
+    else
+      let g₃ := scaleImpl (negOnePow (delta + 1)) p
+      g₃ ≠ 0 ∧ BrownLaw g g₃ h₂ (g.size + 1) :=
+  subresultantOrdered_brownLaw f g hg hgf
 
 #guard
   let f := poly [1, 0, 1]

--- a/progress/20260729T020758Z_resultant-recursive-brown-law.md
+++ b/progress/20260729T020758Z_resultant-recursive-brown-law.md
@@ -1,0 +1,30 @@
+# Resultant recursive Brown law
+
+## Accomplished
+
+- Proved the signed pseudo-remainder endpoint and the cross-multiplied
+  subresultant-family descent law, including defective degree drops.
+- Built the integral `BrownInv` initialization, scale, factor, and preservation
+  proofs and used fuel induction to discharge `subresultantOrdered_brownLaw`
+  without `sorry`.
+- Added shared power, nonzero, scalar-cancellation, and alternating-sign lemmas;
+  removed duplicate local proofs and the umbrella-only sign bridge.
+- Added theorem-level conformance examples and updated the Resultant SPEC and
+  manual to describe the base-ring proof.
+- Completed a fresh independent mathematical review and ran the full 9,573-job
+  `lake build` successfully.
+
+## Current frontier
+
+The computational Resultant library now proves the recursive Brown exactness
+and nonzero obligations for every ordered nonzero input pair. The next
+Resultant obligations are in the Mathlib correspondence layer.
+
+## Next step
+
+Open one ready PR for this milestone, keep it as the only active Resultant PR,
+and merge it before starting the Resultant Mathlib work.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## What changed

- prove the signed pseudo-remainder endpoint and cross-multiplied subresultant-family descent law, including defective degree drops
- introduce the integral recursive invariant used to prove Brown scale updates, exact scalar factors, nonzero quotients, invariant preservation, and fuel-bounded `BrownLaw`
- discharge `subresultantOrdered_brownLaw` without `sorry`
- add reusable power, cancellation, and alternating-sign lemmas and remove duplicate local proofs
- add theorem-level conformance examples and update the Resultant SPEC and manual to describe the base-ring proof

## Why

The ordered Brown worker already computed the intended recurrence, but its recursive exact-division and nonzero obligations were not proved. The completed invariant keeps every accumulated factor cross-multiplied in the coefficient ring, so the proof covers regular and defective degree drops without making a fraction-field detour.

## Impact

Ordered nonzero inputs over a lawful exact-division ring now establish the complete recursive `BrownLaw`, including nonzero denominators, exact reconstruction, strict descent, and unreachability of the quotient junk branch.

## Validation

- `lake build HexResultant.Conformance`
- `lake build HexManual.Chapters.HexResultant`
- full `lake build` (9,573 jobs)