### PR TITLE
feat(resultant): prove Mathlib correspondence

### DIFF
--- a/HexResultant/BrownTraub.lean
+++ b/HexResultant/BrownTraub.lean
@@ -985,6 +985,92 @@ theorem divScalar_brownTraub {R : Type u}
     hhsize hh]
   exact divScalar_scale h hc
 
+/-- A positive-size all-zero right block makes the zeroth coefficient minor
+vanish. -/
+private theorem coeffMinorAt_zero_right {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R]
+    (d : Nat) (hd : 0 < d) (g : DensePoly R) :
+    coeffMinorAt d 0 0 0 g 0 = 0 := by
+  unfold coeffMinorAt
+  let M := coeffMatrixAt d 0 0 0 g (0 : DensePoly R)
+  change SubresultantMinor.det M = 0
+  let dst : Fin d := ⟨0, hd⟩
+  have hcol (i : Fin d) : M i dst = 0 := by
+    simp [M, dst, coeffMatrixAt, coeffInt]
+  have hset :
+      SubresultantMinor.setCol M dst (fun _ => 0) = M := by
+    funext i j
+    by_cases hj : j = dst
+    · subst j
+      simp [SubresultantMinor.setCol, hcol]
+    · simp [SubresultantMinor.setCol, hj]
+  rw [← hset]
+  exact SubresultantMinor.det_setCol_zero M dst
+
+/-- If an ordered pseudo-division terminates at a nonconstant divisor, the
+zeroth generalized subresultant vanishes. -/
+theorem coeffMinor_zero_of_prem_zero {R : Type u}
+    [Lean.Grind.CommRing R] [DecidableEq R] [Div R] [ExactDivLaws R]
+    (f g : DensePoly R) (hg : g ≠ 0) (hgf : g.size ≤ f.size)
+    (hgBig : 2 ≤ g.size) (hp : (pseudoDivMod f g).2 = 0) :
+    coeffMinor 0 0 f g = 0 := by
+  let df := f.size - 1
+  let dg := g.size - 1
+  let db := f.size - g.size
+  let a := g.leadingCoeff ^ (db + 1)
+  let q := (pseudoDivMod f g).1
+  let b := scale (0 - 1) q
+  have hgpos : 0 < g.size := by omega
+  have hglc : g.leadingCoeff ≠ 0 :=
+    leadingCoeff_ne_zero_of_pos_size g hgpos
+  have h1 : (1 : R) ≠ 0 := one_ne_zero_of_nonzero hglc
+  have ha : a ≠ 0 := pow_ne_zero h1 hglc (db + 1)
+  have hbsize : b.size ≤ db + 1 := by
+    have hneg : (0 - 1 : R) ≠ 0 := negOne_ne_zero_of_one h1
+    rw [size_scale hneg]
+    simpa only [q, db] using pseudoDivMod_quotient_size_le f g
+  have hbneg : b = -q := by
+    apply ext_coeff
+    intro i
+    simp only [b, coeff_scale_semiring, coeff_neg_ring]
+    grind
+  have hzero : (0 : DensePoly R) = scale a f + b * g := by
+    rw [hbneg]
+    have hrec := pseudoDivMod_reconstruct f g hg hgf
+    rw [hp] at hrec
+    simpa only [a, db, q] using (show
+      (0 : DensePoly R) =
+        scale (g.leadingCoeff ^ (f.size - g.size + 1)) f +
+          -(pseudoDivMod f g).1 * g by grind)
+  have hdf : df = db + dg := by
+    dsimp only [df, db, dg]
+    omega
+  have hfg : g.size = dg + 1 := by
+    dsimp only [dg]
+    omega
+  have hdg : 0 < dg := by
+    dsimp only [dg]
+    omega
+  have hbt := coeffMinorAt_brownTraub df dg db 0 0 0
+    (scale a f) g b (0 : DensePoly R) (Nat.le_refl 0) hdg hdf hfg
+    hbsize (by simp) hzero
+  have hright : coeffMinorAt dg 0 0 0 g 0 = 0 :=
+    coeffMinorAt_zero_right dg hdg g
+  rw [hright, Lean.Grind.Semiring.mul_zero, Lean.Grind.Semiring.mul_zero] at hbt
+  have hscale := coeffMinorAt_scale_left df dg 0 0 a f g
+  rw [hbt] at hscale
+  have hapow : a ^ (dg - 0) ≠ 0 := pow_ne_zero h1 ha (dg - 0)
+  have hminor : coeffMinorAt df dg 0 0 f g = 0 := by
+    apply ExactDivLaws.mul_right_cancel hapow
+    grind
+  unfold coeffMinor
+  have hff : formalDegree f = df := by
+    simp [formalDegree, df]
+  have hgg : formalDegree g = dg := by
+    simp [formalDegree, dg]
+  rw [hff, hgg]
+  exact hminor
+
 end Subresultant
 end DensePoly
 end Hex

--- a/HexResultant/SPEC/hex-resultant.md
+++ b/HexResultant/SPEC/hex-resultant.md
@@ -92,6 +92,14 @@ def coeffMinor [Zero R] [DecidableEq R] [One R] [Add R] [Sub R] [Mul R]
 def poly [Zero R] [DecidableEq R] [One R] [Add R] [Sub R] [Mul R]
     (J : Nat) (f g : DensePoly R) : DensePoly R := ...
 
+/-- A terminating zero pseudo-remainder at a nonconstant ordered divisor makes
+    the zeroth coefficient minor vanish. -/
+theorem coeffMinor_zero_of_prem_zero
+    [Lean.Grind.CommRing R] [DecidableEq R] [Div R] [ExactDivLaws R]
+    (f g : DensePoly R) (hg : g ≠ 0) (hgf : g.size ≤ f.size)
+    (hgBig : 2 ≤ g.size) (hp : (pseudoDivMod f g).2 = 0) :
+    coeffMinor 0 0 f g = 0
+
 end Subresultant
 
 /-- Polynomial pseudo-division: for `f, g : DensePoly R` with `g ≠ 0`
@@ -120,6 +128,14 @@ def subresultantChain [Zero R] [DecidableEq R] [One R] [Add R] [Sub R]
     otherwise. Reversed inputs receive the standard degree-product sign. -/
 def resultant [Zero R] [DecidableEq R] [One R] [Add R] [Sub R] [Mul R]
     [Div R] (f g : DensePoly R) : R := ...
+
+/-- Brown's corrected ordered terminal value is the zeroth generalized
+    coefficient minor. -/
+theorem resultantOrdered_eq_coeffMinor
+    [Lean.Grind.CommRing R] [DecidableEq R] [Div R] [ExactDivLaws R]
+    (f g : DensePoly R) (hf : f ≠ 0) (hg : g ≠ 0)
+    (hgf : g.size ≤ f.size) :
+    resultantOrdered f g = Subresultant.coeffMinor 0 0 f g
 
 /-- Standard discriminant. It is `1` for zero and constant polynomials. For
     positive degree `n`, let `d = f.derivative` and
@@ -361,8 +377,11 @@ next exact divisor and the final resultant.
 
 For an ordered nonzero run ending in `(#[G₁, …, Gₖ], hₖ)`, the resultant
 is `hₖ` if `Gₖ` has degree zero and `0` otherwise. In particular, a final
-constant `Gₖ` need not itself equal the resultant. For reversed nonzero
-inputs,
+constant `Gₖ` need not itself equal the resultant. The theorem
+`resultantOrdered_eq_coeffMinor` identifies this corrected terminal value
+with `Subresultant.coeffMinor 0 0 f g`; a terminal zero pseudo-remainder at a
+nonconstant divisor is handled by `coeffMinor_zero_of_prem_zero`. For reversed
+nonzero inputs,
 
 ```text
 resultant f g = (-1)^(deg f * deg g) * resultantOrdered g f.

--- a/HexResultant/Subresultant.lean
+++ b/HexResultant/Subresultant.lean
@@ -921,6 +921,105 @@ private theorem getD_push_last {A : Type u} (xs : Array A) (x fallback : A) :
     omega
   rw [← Array.getElem_eq_getD fallback (h := hi), Array.getElem_push_eq]
 
+/-- Extract the corrected terminal scalar when the final stored polynomial is
+a constant. -/
+private def terminalValue {S : Type u} [Zero S] [DecidableEq S]
+    (run : PRSResult S) : S :=
+  let last := run.chain.getD (run.chain.size - 1) 0
+  if last.size = 1 then run.scale else 0
+
+/-- A worker launched from an integral Brown invariant returns the zeroth
+subresultant coefficient of the original pair. -/
+private theorem subresultantAux_terminal {S : Type u}
+    [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [ExactDivLaws S]
+    (f g prev curr : DensePoly S) (hPrev : S)
+    (chain : Array (DensePoly S)) (fuel : Nat)
+    (hinv : BrownInv f g prev curr hPrev) (hfuel : curr.size ≤ fuel)
+    (hlast : chain.getD (chain.size - 1) 0 = curr) :
+    terminalValue (subresultantAux prev curr hPrev chain fuel) =
+      Subresultant.coeffMinor 0 0 f g := by
+  induction fuel generalizing prev curr hPrev chain with
+  | zero =>
+      have hcurr : curr ≠ 0 := hinv.2.1
+      have hpos := size_pos_of_ne_zero curr hcurr
+      omega
+  | succ fuel ih =>
+      rcases hinv with ⟨hprev, hcurr, hlt, hhPrev, hfamily⟩
+      let delta := prev.size - curr.size
+      let hCurr := divExp curr.leadingCoeff hPrev delta
+      let p := (pseudoDivMod prev curr).2
+      have hinv : BrownInv f g prev curr hPrev :=
+        ⟨hprev, hcurr, hlt, hhPrev, hfamily⟩
+      have hscaleRaw := BrownInv.nextScale f g prev curr hPrev hinv
+      have hscale :
+          hCurr =
+            (Subresultant.poly (curr.size - 1) f g).coeff (curr.size - 1) := by
+        simpa only [hCurr, delta] using hscaleRaw.1
+      cases hpzero : p.isZero with
+      | true =>
+          have hp : (pseudoDivMod prev curr).2 = 0 := by
+            have : p = 0 := eq_zero_of_isZero_true p hpzero
+            simpa only [p] using this
+          unfold terminalValue
+          simp only [subresultantAux, p, hpzero, ↓reduceIte]
+          rw [hlast]
+          by_cases hconst : curr.size = 1
+          · rw [if_pos hconst]
+            have hscale0 :
+                hCurr = Subresultant.coeffMinor 0 0 f g := by
+              simpa [hconst, Subresultant.coeff_poly] using hscale
+            simpa only [hCurr, delta, hconst] using hscale0
+          · rw [if_neg hconst]
+            have hcurrPos := size_pos_of_ne_zero curr hcurr
+            have hcurrBig : 2 ≤ curr.size := by omega
+            have hlocal := Subresultant.coeffMinor_zero_of_prem_zero
+              prev curr hcurr (Nat.le_of_lt hlt) hcurrBig hp
+            have hinv0 := hfamily 0 hcurrPos
+            have hcoeff := congrArg (fun q : DensePoly S => q.coeff 0) hinv0
+            simp only [Subresultant.coeff_poly, coeff_scale_semiring] at hcoeff
+            rw [hlocal] at hcoeff
+            have hprevPos := size_pos_of_ne_zero prev hprev
+            have hprevLc := leadingCoeff_ne_zero_of_pos_size prev hprevPos
+            have h1 : (1 : S) ≠ 0 := one_ne_zero_of_nonzero hprevLc
+            have hscalar :
+                prev.leadingCoeff ^ (curr.size - 1) *
+                    hPrev ^ (prev.size - 2) ≠ 0 :=
+              ExactDivLaws.mul_ne_zero
+                (pow_ne_zero h1 hprevLc (curr.size - 1))
+                (pow_ne_zero h1 hhPrev (prev.size - 2))
+            have horig : Subresultant.coeffMinor 0 0 f g = 0 := by
+              apply ExactDivLaws.mul_right_cancel hscalar
+              grind
+            exact horig.symm
+      | false =>
+          have hp : p ≠ 0 := ne_zero_of_isZero_false p hpzero
+          let divisor :=
+            negOnePow (R := S) (delta + 1) * prev.leadingCoeff *
+              powNat hPrev delta
+          let next := divScalar p divisor
+          let nextImpl := divScalarImpl p divisor
+          have hnextEq : next = nextImpl := divScalar_eq_divScalarImpl p divisor
+          have hpRaw : (pseudoDivMod prev curr).2 ≠ 0 := by
+            simpa only [p] using hp
+          have hstepRaw := BrownInv.step f g prev curr hPrev hinv hpRaw
+          have hstep : BrownInv f g curr next hCurr := by
+            simpa only [p, divisor, next, hCurr, delta] using hstepRaw
+          have hnext : next ≠ 0 := hstep.2.1
+          have hnextImpl : nextImpl ≠ 0 := by
+            rw [← hnextEq]
+            exact hnext
+          have hnextZero : nextImpl.isZero = false :=
+            isZero_false_of_ne_zero nextImpl hnextImpl
+          have hlast' :
+              (chain.push next).getD ((chain.push next).size - 1) 0 = next := by
+            rw [Array.size_push, show chain.size + 1 - 1 = chain.size by omega,
+              getD_push_last]
+          have hrec := ih curr next hCurr (chain.push next) hstep
+            (by have := hstep.2.2.1; omega) hlast'
+          simpa only [subresultantAux, delta, hCurr, p, hpzero,
+            Bool.false_eq_true, ↓reduceIte, divisor, nextImpl, hnextZero,
+            hnextEq] using hrec
+
 /-- Appending a smaller successor preserves strict tail descent. -/
 private theorem ChainStrict.push
     (chain : Array (DensePoly R)) (curr next : DensePoly R)
@@ -1237,6 +1336,94 @@ def resultantOrdered [One R] [Add R] [Sub R] [Mul R] [Div R]
   let run := subresultantOrdered f g
   let last := run.chain.getD (run.chain.size - 1) 0
   if last.size = 1 then run.scale else 0
+
+/-- For ordered nonzero inputs, Brown's corrected terminal value is the
+zeroth generalized subresultant coefficient. -/
+theorem resultantOrdered_eq_coeffMinor {S : Type u}
+    [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [ExactDivLaws S]
+    (f g : DensePoly S) (hf : f ≠ 0) (hg : g ≠ 0)
+    (hgf : g.size ≤ f.size) :
+    resultantOrdered f g = Subresultant.coeffMinor 0 0 f g := by
+  let delta := f.size - g.size
+  let h₂ := powNat g.leadingCoeff delta
+  let p := (pseudoDivMod f g).2
+  have hfpos := size_pos_of_ne_zero f hf
+  have hgpos := size_pos_of_ne_zero g hg
+  have hglc := leadingCoeff_ne_zero_of_pos_size g hgpos
+  have h1 : (1 : S) ≠ 0 := one_ne_zero_of_nonzero hglc
+  cases hpzero : p.isZero with
+  | true =>
+      have hp : (pseudoDivMod f g).2 = 0 := by
+        have : p = 0 := eq_zero_of_isZero_true p hpzero
+        simpa only [p] using this
+      have hlast :
+          (#[f, g] : Array (DensePoly S)).getD
+              ((#[f, g] : Array (DensePoly S)).size - 1) 0 = g := by
+        rfl
+      unfold resultantOrdered subresultantOrdered
+        subresultantOrderedFuel
+      simp only [p, hpzero, ↓reduceIte]
+      rw [hlast]
+      by_cases hconst : g.size = 1
+      · rw [if_pos hconst]
+        by_cases hfconst : f.size = 1
+        · rw [show powNat g.leadingCoeff (f.size - g.size) = 1 by
+            simp [hfconst, hconst, powNat]]
+          unfold Subresultant.coeffMinor
+          rw [show Subresultant.formalDegree f = 0 by
+            simp [Subresultant.formalDegree, hfconst]]
+          rw [show Subresultant.formalDegree g = 0 by
+            simp [Subresultant.formalDegree, hconst]]
+          rfl
+        · have hminor := Subresultant.coeffMinorAt_rightDegree
+            (f.size - 1) 0 0 f g (by omega) hconst
+          have hff : Subresultant.formalDegree f = f.size - 1 := by
+            simp [Subresultant.formalDegree]
+          have hgg : Subresultant.formalDegree g = 0 := by
+            simp [Subresultant.formalDegree, hconst]
+          have hgc : g.coeff 0 = g.leadingCoeff := by
+            simpa [hconst] using (leadingCoeff_eq_coeff_last g hgpos).symm
+          unfold Subresultant.coeffMinor
+          rw [hff, hgg, hminor, hgc]
+          rw [powNat_eq_pow]
+          rw [← Lean.Grind.Semiring.pow_succ]
+          congr 1
+          omega
+      · rw [if_neg hconst]
+        have hgBig : 2 ≤ g.size := by omega
+        have hzero := Subresultant.coeffMinor_zero_of_prem_zero
+          f g hg hgf hgBig hp
+        exact hzero.symm
+  | false =>
+      have hp : p ≠ 0 := ne_zero_of_isZero_false p hpzero
+      let s := negOnePow (R := S) (delta + 1)
+      let g₃ := scaleImpl s p
+      have hs : s ≠ 0 := negOnePow_ne_zero h1 (delta + 1)
+      have hg₃Eq : g₃ = scale s p := by
+        rw [scale_eq_scaleImpl]
+      have hg₃ : g₃ ≠ 0 := by
+        rw [hg₃Eq]
+        exact scale_ne_zero hs hp
+      have hg₃Zero : g₃.isZero = false := isZero_false_of_ne_zero g₃ hg₃
+      have hpRaw : (pseudoDivMod f g).2 ≠ 0 := by
+        simpa only [p] using hp
+      have hinvRaw := brownInv_init f g hg hgf hpRaw
+      have hinv : BrownInv f g g g₃ h₂ := by
+        rw [hg₃Eq]
+        simpa only [delta, h₂, p, s] using hinvRaw
+      have hlast :
+          (#[f, g, g₃] : Array (DensePoly S)).getD
+              ((#[f, g, g₃] : Array (DensePoly S)).size - 1) 0 = g₃ := by
+        rfl
+      have hterminal := subresultantAux_terminal f g g g₃ h₂
+        #[f, g, g₃] (g.size + 1) hinv (by
+          have := hinv.2.2.1
+          omega) hlast
+      unfold terminalValue at hterminal
+      unfold resultantOrdered subresultantOrdered subresultantOrderedFuel
+      simp only [delta, p, hpzero, Bool.false_eq_true, ↓reduceIte,
+        s, g₃, hg₃Zero]
+      exact hterminal
 
 /-- Executable polynomial resultant with default formal-degree conventions.
 

--- a/HexResultantMathlib/Basic.lean
+++ b/HexResultantMathlib/Basic.lean
@@ -28,6 +28,52 @@ universe u
 
 variable {R : Type u}
 
+private theorem evalCoeffList_eq_sum_fin [CommSemiring R]
+    (xs : List R) (x : R) :
+    evalCoeffList xs x =
+      ∑ i : Fin xs.length, xs.get i * x ^ i.val := by
+  induction xs with
+  | nil =>
+      change (Zero.zero : R) = (0 : R)
+      exact ((Lean.Grind.Semiring.ofNat_eq_natCast (α := R) 0).trans
+        Lean.Grind.Semiring.natCast_zero).symm
+  | cons c cs ih =>
+      change evalCoeffList (c :: cs) x =
+        ∑ i : Fin (cs.length + 1), (c :: cs).get i * x ^ i.val
+      rw [Fin.sum_univ_succ]
+      simp only [evalCoeffList, List.get_cons_zero, List.get_cons_succ',
+        Fin.val_zero, pow_zero, mul_one, Fin.val_succ]
+      rw [ih]
+      simp_rw [pow_succ]
+      calc
+        (∑ i : Fin cs.length, cs.get i * x ^ i.val) * x + c =
+            c + (∑ i : Fin cs.length, cs.get i * x ^ i.val) * x := by ring
+        _ = c + ∑ i : Fin cs.length, (cs.get i * x ^ i.val) * x := by
+          rw [Finset.sum_mul]
+        _ = c + ∑ i : Fin cs.length, cs.get i * (x ^ i.val * x) := by
+          apply congrArg (fun z => c + z)
+          apply Finset.sum_congr rfl
+          intro i _
+          ring
+
+/-- Horner evaluation of a dense polynomial agrees with evaluation after
+conversion to Mathlib's polynomial representation. -/
+theorem eval_toPolynomial [CommSemiring R] [DecidableEq R]
+    (p : DensePoly R) (x : R) :
+    eval p x = (HexPolyMathlib.toPolynomial p).eval x := by
+  unfold eval
+  rw [evalCoeffList_eq_sum_fin]
+  rw [Polynomial.eval, HexPolyMathlib.eval₂_toPolynomial]
+  rw [Finset.sum_fin_eq_sum_range]
+  apply Finset.sum_congr rfl
+  intro i hi
+  have hil : i < p.size := Finset.mem_range.mp hi
+  rw [← length_toList p] at hil
+  rw [dif_pos hil, List.get_eq_getElem,
+    List.getElem_eq_getD (l := p.toList) (i := i) (h := hil) (Zero.zero : R),
+    toList_getD_eq_coeff]
+  rfl
+
 /-- Specialize the coefficient variable of a dense bivariate polynomial while
 retaining its outer polynomial variable. -/
 @[expose]
@@ -35,6 +81,35 @@ noncomputable def specialize [CommRing R] [DecidableEq R]
     (f : DensePoly (DensePoly R)) (a : R) : Polynomial R :=
   Finset.sum (Finset.range f.size) fun i =>
     Polynomial.monomial i (eval (f.coeff i) a)
+
+/-- Specialization evaluates each stored coefficient, with the dense zero
+extension supplying the coefficients outside the stored range. -/
+@[simp]
+theorem coeff_specialize [CommRing R] [DecidableEq R]
+    (f : DensePoly (DensePoly R)) (a : R) (n : Nat) :
+    (specialize f a).coeff n = eval (f.coeff n) a := by
+  unfold specialize
+  rw [Polynomial.finsetSum_coeff]
+  by_cases hn : n < f.size
+  · simp [Polynomial.coeff_monomial, hn]
+  · rw [Finset.sum_eq_zero]
+    · rw [coeff_eq_zero_of_size_le f (Nat.le_of_not_gt hn)]
+      have heval : eval (Zero.zero : DensePoly R) a = (Zero.zero : R) := rfl
+      rw [heval]
+      exact (Lean.Grind.Semiring.ofNat_eq_natCast (α := R) 0).trans
+        Lean.Grind.Semiring.natCast_zero
+    · intro i hi
+      have hin : i < f.size := Finset.mem_range.mp hi
+      have hne : i ≠ n := by omega
+      simp [Polynomial.coeff_monomial, hne]
+
+/-- The zero dense polynomial specializes to the zero Mathlib polynomial. -/
+@[simp]
+theorem specialize_zero [CommRing R] [DecidableEq R] (a : R) :
+    specialize (0 : DensePoly (DensePoly R)) a = 0 := by
+  unfold specialize
+  rw [size_zero]
+  simp
 
 /-- Evaluate a dense bivariate polynomial at `(a, b)`. -/
 @[expose]

--- a/HexResultantMathlib/Chain.lean
+++ b/HexResultantMathlib/Chain.lean
@@ -6,23 +6,88 @@ Authors: Kim Morrison
 
 module
 
-public import HexResultantMathlib.Basic
+public import HexResultantMathlib.Roots
+public import Mathlib.Analysis.Complex.Polynomial.Basic
 
 public section
 
 /-!
-Common-root consequences of the executable subresultant chain.
+Common-root consequences of the executable resultant correspondence.
 -/
 namespace Hex.DensePoly
 
-/-- Two nonzero integer dense polynomials have zero executable resultant
-exactly when they share a complex root. -/
+/-- If the first integer dense polynomial is nonzero, the executable
+resultant vanishes exactly when the two polynomials share a complex root. -/
 theorem resultant_eq_zero_iff_common_root
-    (f g : DensePoly Int) (hf : f ≠ 0) (hg : g ≠ 0) :
+    (f g : DensePoly Int) (hf : f ≠ 0) :
     resultant f g = 0 ↔
       ∃ z : ℂ,
         Polynomial.aeval z (HexPolyMathlib.toPolynomial f) = 0 ∧
         Polynomial.aeval z (HexPolyMathlib.toPolynomial g) = 0 := by
-  sorry
+  let F := HexPolyMathlib.toPolynomial f
+  let G := HexPolyMathlib.toPolynomial g
+  let φ : Int →+* ℂ := Int.castRingHom ℂ
+  let FC := F.map φ
+  let GC := G.map φ
+  have hφ : Function.Injective φ := Int.cast_injective
+  have hF : F ≠ 0 := by
+    intro hzero
+    apply hf
+    apply (HexPolyMathlib.equiv (R := Int)).injective
+    simpa only [HexPolyMathlib.equiv_apply, HexPolyMathlib.toPolynomial_zero]
+      using hzero
+  have hFC : FC ≠ 0 := (Polynomial.map_ne_zero_iff hφ).2 hF
+  have hdf : f.degree?.getD 0 = F.natDegree := by
+    simpa only [F] using (HexPolyMathlib.natDegree_toPolynomial f).symm
+  have hdg : g.degree?.getD 0 = G.natDegree := by
+    simpa only [G] using (HexPolyMathlib.natDegree_toPolynomial g).symm
+  have hFCdeg : FC.natDegree = F.natDegree :=
+    Polynomial.natDegree_map_eq_of_injective hφ F
+  have hGCdeg : GC.natDegree = G.natDegree :=
+    Polynomial.natDegree_map_eq_of_injective hφ G
+  rw [toPolynomial_resultant]
+  constructor
+  · intro hres
+    rw [hdf, hdg] at hres
+    have hres' : Polynomial.resultant F G F.natDegree G.natDegree = 0 := by
+      simpa only [F, G] using hres
+    have hresC : Polynomial.resultant FC GC = 0 := by
+      rw [show Polynomial.resultant FC GC =
+          φ (Polynomial.resultant F G F.natDegree G.natDegree) by
+        simp [FC, GC, hFCdeg, hGCdeg]]
+      simp [hres']
+    rw [resultant_eq_leadingCoeff_mul_prod_roots FC GC] at hresC
+    have hprod : (FC.roots.map GC.eval).prod = 0 := by
+      rcases mul_eq_zero.mp hresC with hlc | hprod
+      · exact (pow_ne_zero one_ne_zero
+          (Polynomial.leadingCoeff_ne_zero.mpr hFC) _ hlc).elim
+      · exact hprod
+    obtain ⟨z, hzroot, hzG⟩ := Multiset.mem_map.mp
+      (Multiset.prod_eq_zero_iff.mp hprod)
+    have hzF : FC.eval z = 0 :=
+      Polynomial.IsRoot.def.mp ((Polynomial.mem_roots hFC).mp hzroot)
+    refine ⟨z, ?_, ?_⟩
+    · simpa [F, FC, φ, Polynomial.aeval_def,
+        Polynomial.eval₂_eq_eval_map] using hzF
+    · simpa [G, GC, φ, Polynomial.aeval_def,
+        Polynomial.eval₂_eq_eval_map] using hzG
+  · rintro ⟨z, hzF, hzG⟩
+    have hzFC : FC.eval z = 0 := by
+      simpa [F, FC, φ, Polynomial.aeval_def,
+        Polynomial.eval₂_eq_eval_map] using hzF
+    have hzGC : GC.eval z = 0 := by
+      simpa [G, GC, φ, Polynomial.aeval_def,
+        Polynomial.eval₂_eq_eval_map] using hzG
+    have hzroot : z ∈ FC.roots :=
+      (Polynomial.mem_roots hFC).2 (Polynomial.IsRoot.def.mpr hzFC)
+    have hzeroMem : 0 ∈ FC.roots.map GC.eval :=
+      Multiset.mem_map.mpr ⟨z, hzroot, hzGC⟩
+    have hresC : Polynomial.resultant FC GC = 0 := by
+      rw [resultant_eq_leadingCoeff_mul_prod_roots FC GC]
+      rw [Multiset.prod_eq_zero hzeroMem, mul_zero]
+    have hcast : φ (Polynomial.resultant F G F.natDegree G.natDegree) = 0 := by
+      simpa [FC, GC, hFCdeg, hGCdeg] using hresC
+    rw [hdf, hdg]
+    exact Int.cast_eq_zero.mp hcast
 
 end Hex.DensePoly

--- a/HexResultantMathlib/Discriminant.lean
+++ b/HexResultantMathlib/Discriminant.lean
@@ -24,6 +24,106 @@ correspondence. -/
 theorem toPolynomial_disc [CommRing R] [IsDomain R] [DecidableEq R]
     [Div R] [Hex.ExactDivLaws R] (f : DensePoly R) :
     disc f = Polynomial.discr (HexPolyMathlib.toPolynomial f) := by
-  sorry
+  let F := HexPolyMathlib.toPolynomial f
+  by_cases hsmall : f.size ≤ 1
+  · unfold disc
+    rw [if_pos hsmall]
+    have hdeg : F.natDegree = 0 := by
+      rw [show F.natDegree = f.degree?.getD 0 by
+        simpa only [F] using HexPolyMathlib.natDegree_toPolynomial f]
+      by_cases hf : f = 0
+      · subst f
+        simp
+      · have hfpos : 0 < f.size := by
+          by_contra h
+          apply hf
+          exact (size_eq_zero_iff f).mp (by omega)
+        rw [degree?_eq_some_of_pos_size f hfpos, Option.getD_some]
+        omega
+    change 1 = Polynomial.discr F
+    rw [Polynomial.eq_C_of_natDegree_eq_zero hdeg]
+    exact (Polynomial.discr_C _).symm
+  · let n := f.size - 1
+    let d := f.derivative
+    let D := HexPolyMathlib.toPolynomial d
+    let k := d.degree?.getD 0
+    let gap := n - 1 - k
+    have hfpos : 0 < f.size := by omega
+    have hn : 0 < n := by
+      dsimp only [n]
+      omega
+    have hFn : F.natDegree = n := by
+      rw [show F.natDegree = f.degree?.getD 0 by
+        simpa only [F] using HexPolyMathlib.natDegree_toPolynomial f]
+      rw [degree?_eq_some_of_pos_size f hfpos, Option.getD_some]
+    have hD : D = F.derivative := by
+      simpa only [D, d, F] using HexPolyMathlib.toPolynomial_derivative f
+    have hDk : D.natDegree = k := by
+      simpa only [D, k] using HexPolyMathlib.natDegree_toPolynomial d
+    have hk : k ≤ n - 1 := by
+      rw [← hDk, hD, ← hFn]
+      exact Polynomial.natDegree_derivative_le F
+    have hkgap : k + gap = n - 1 := by
+      dsimp only [gap]
+      omega
+    have hlc : F.leadingCoeff = f.leadingCoeff := by
+      simpa only [F] using HexPolyMathlib.leadingCoeff_toPolynomial f
+    have hactual :
+        resultant f d = Polynomial.resultant F D n k := by
+      rw [toPolynomial_resultant]
+      rw [show f.degree?.getD 0 = n by
+        rw [degree?_eq_some_of_pos_size f hfpos, Option.getD_some]]
+    have hpromote :
+        powNat f.leadingCoeff gap * resultant f d =
+          Polynomial.resultant F F.derivative n (n - 1) := by
+      have hadd := Polynomial.resultant_add_right_deg F D n k gap
+        (by rw [hDk])
+      rw [hkgap, hD] at hadd
+      have hcoeff : F.coeff n = F.leadingCoeff := by
+        rw [← hFn]
+        exact Polynomial.coeff_natDegree
+      rw [powNat_eq_pow, hactual, ← hlc, hD, ← hcoeff]
+      exact hadd.symm
+    have hdegree : 0 < F.degree := by
+      rw [← Polynomial.natDegree_pos_iff_degree_pos, hFn]
+      exact hn
+    have hformal := Polynomial.resultant_deriv (f := F) hdegree
+    rw [hFn] at hformal
+    rw [hlc] at hformal
+    unfold disc
+    rw [if_neg hsmall]
+    change
+      negOnePow (R := R) (n * (n - 1) / 2) *
+          exactDiv (powNat f.leadingCoeff gap * resultant f d)
+            f.leadingCoeff =
+        Polynomial.discr F
+    rw [show powNat f.leadingCoeff (n - 1 - k) * resultant f d =
+        Polynomial.resultant F F.derivative n (n - 1) by
+      simpa only [gap] using hpromote]
+    rw [hformal]
+    rw [negOnePow_eq_sign,
+      Hex.SubresultantMinor.sign_eq_pow]
+    have hflc : f.leadingCoeff ≠ 0 :=
+      leadingCoeff_ne_zero_of_pos_size f hfpos
+    have hdiv :
+        exactDiv
+            ((-1 : R) ^ (n * (n - 1) / 2) * f.leadingCoeff *
+              Polynomial.discr F)
+            f.leadingCoeff =
+          (-1 : R) ^ (n * (n - 1) / 2) * Polynomial.discr F := by
+      rw [show
+          (-1 : R) ^ (n * (n - 1) / 2) * f.leadingCoeff *
+              Polynomial.discr F =
+            ((-1 : R) ^ (n * (n - 1) / 2) * Polynomial.discr F) *
+              f.leadingCoeff by ring]
+      exact Hex.exactDiv_mul_right _ hflc
+    rw [hdiv]
+    have hsign :
+        (-1 : R) ^ (n * (n - 1) / 2) *
+            (-1 : R) ^ (n * (n - 1) / 2) = 1 := by
+      simpa only [← Hex.SubresultantMinor.sign_eq_pow] using
+        (Hex.SubresultantMinor.sign_mul_self (R := R)
+          (n * (n - 1) / 2))
+    rw [← mul_assoc, hsign, one_mul]
 
 end Hex.DensePoly

--- a/HexResultantMathlib/SPEC/hex-resultant-mathlib.md
+++ b/HexResultantMathlib/SPEC/hex-resultant-mathlib.md
@@ -17,11 +17,28 @@ commutative integral domain with decidable equality, a quotient operation, and
 more general and need only `[CommRing R] [DecidableEq R]`.
 
 ```lean
-namespace Hex.DensePoly
-
 universe u
 
 variable {R : Type u}
+
+namespace Hex.SubresultantMinor
+
+/-- The local alternating sign is the usual power of `-1`. -/
+theorem sign_eq_pow [CommRing R] (j : Nat) :
+    sign (R := R) j = (-1 : R) ^ j
+
+/-- The dependency-free Laplace determinant agrees with Mathlib's determinant. -/
+theorem det_eq_matrixDet [CommRing R] {n : Nat} (M : Square R n) :
+    det M = Matrix.det (Matrix.of M)
+
+end Hex.SubresultantMinor
+
+namespace Hex.DensePoly
+
+/-- Horner evaluation agrees with evaluation after conversion to Mathlib. -/
+theorem eval_toPolynomial [CommSemiring R] [DecidableEq R]
+    (p : DensePoly R) (x : R) :
+    eval p x = (HexPolyMathlib.toPolynomial p).eval x
 
 /-- Specialize the coefficient variable of a dense bivariate polynomial while
     retaining the outer polynomial variable. -/
@@ -30,10 +47,40 @@ noncomputable def specialize [CommRing R] [DecidableEq R]
   Finset.sum (Finset.range f.size) fun i =>
     Polynomial.monomial i (eval (f.coeff i) a)
 
+@[simp]
+theorem coeff_specialize [CommRing R] [DecidableEq R]
+    (f : DensePoly (DensePoly R)) (a : R) (n : Nat) :
+    (specialize f a).coeff n = eval (f.coeff n) a
+
+@[simp]
+theorem specialize_zero [CommRing R] [DecidableEq R] (a : R) :
+    specialize (0 : DensePoly (DensePoly R)) a = 0
+
 /-- Evaluate a dense bivariate polynomial at `(a, b)`. -/
 noncomputable def evalBivariate [CommRing R] [DecidableEq R]
     (f : DensePoly (DensePoly R)) (a b : R) : R :=
   (specialize f a).eval b
+
+namespace Subresultant
+
+/-- The zeroth generalized coefficient minor at explicit degree bounds is
+    Mathlib's Sylvester determinant at those bounds. -/
+theorem coeffMinorAt_zero_eq_resultant [CommRing R] [DecidableEq R]
+    (df dg : Nat) (f g : DensePoly R)
+    (hf : f.size ≤ df + 1) (hg : g.size ≤ dg + 1) :
+    coeffMinorAt df dg 0 0 f g =
+      Polynomial.resultant (HexPolyMathlib.toPolynomial f)
+        (HexPolyMathlib.toPolynomial g) (m := df) (n := dg)
+
+/-- The default-formal-degree zeroth minor is the corresponding resultant. -/
+theorem coeffMinor_zero_eq_resultant [CommRing R] [DecidableEq R]
+    (f g : DensePoly R) :
+    coeffMinor 0 0 f g =
+      Polynomial.resultant (HexPolyMathlib.toPolynomial f)
+        (HexPolyMathlib.toPolynomial g)
+        (m := formalDegree f) (n := formalDegree g)
+
+end Subresultant
 
 namespace PseudoDivMod
 
@@ -107,7 +154,7 @@ theorem toPolynomial_resultant [CommRing R] [IsDomain R] [DecidableEq R]
 
 /-- Vanishing criterion over an algebraically closed extension. -/
 theorem resultant_eq_zero_iff_common_root
-    (f g : DensePoly Int) (hf : f ≠ 0) (hg : g ≠ 0) :
+    (f g : DensePoly Int) (hf : f ≠ 0) :
     resultant f g = 0 ↔
       ∃ z : ℂ,
         Polynomial.aeval z (HexPolyMathlib.toPolynomial f) = 0 ∧
@@ -162,82 +209,66 @@ equivalence without installing that global instance.
 
 Consequently the bivariate specialization theorems are **not** obtained by
 instantiating `toPolynomial_resultant` with coefficient type `DensePoly R`.
-Their proofs transfer the Brown recurrence directly through coefficient
-evaluation: prove that `specialize` preserves each executable coefficientwise
-operation and exact quotient used by the chain, then identify the specialized
-recurrence with the Mathlib resultant at the original formal degrees. This
-direct map argument keeps the deliberate no-global-`CommRing (DensePoly R)`
-boundary intact.
+Instead, the proof gives `DensePoly R` a proof-local Mathlib ring structure,
+identifies coefficient evaluation with a ring hom through
+`HexPolyMathlib.toPolynomial`, and maps the explicit-degree zeroth coefficient
+minor through that hom. `coeffMinorAt_zero_eq_resultant` then identifies the
+mapped determinant with the resultant of the specialized inputs. The local
+instance never escapes the proof, and the executable correspondence theorem is
+not recursively instantiated over `DensePoly R`.
 
 The formal degrees on `eval_resultant` are essential: specialization can erase
 a leading coefficient. For example, specializing `t` to zero in `t*y + 1` and
 `t*y - 1` drops both degrees; the default-degree resultant of the specialized
 constants is not the specialization of the original resultant. Also provide a
 default-degree corollary under hypotheses that both leading coefficients remain
-nonzero. The Stage 1 one-way vanishing theorem only needs to exclude the case
+nonzero. The one-way vanishing theorem only needs to exclude the case
 where both outer formal degrees are zero: under the project convention the
 formal-degree `(0, 0)` resultant is `1`, even when both specialized constants
-vanish.
+vanish. The vanishing proof maps the default-degree common-root criterion
+injectively to the fraction field, promotes the resulting zero back to the
+original formal degrees, and uses the positive-formal-degree hypothesis in the
+case where both specialized polynomials are zero.
 
 The displayed root-product formula fixes intent rather than Mathlib's final
 multiset notation. The implementation uses the pinned revision's existing
 `roots` and splitting-field APIs and states the theorem with their actual
 multiplicity representation.
 
-## Proof staging
+## Proof architecture
 
-### Stage 1: chain and vanishing
-
-Stage 1 is sufficient for `AlgebraicRoot` operation soundness and can land before
-the determinant correspondence.
-
-1. Transport the executable pseudo-division reconstruction and degree bounds to
-   Mathlib polynomials. `PseudoDivMod.resultant_step` and
-   `resultant_step_degree` already
-   package the resulting Sylvester row operation, scalar power, swap sign, and
-   formal-degree promotion.
-2. Transfer the executable pseudo-remainder sequence through `toPolynomial`.
-3. Prove forward and backward preservation of common roots along the chain.
-4. Relate a positive-degree final gcd to executable resultant zero.
-5. Prove `resultant_eq_zero_iff_common_root` and the one-way bivariate
-   specialization-vanishing theorem.
-
-This stage justifies claims such as: if `p(α) = 0` and `q(β) = 0`, then the
-addition or product eliminant vanishes at the proposed result.
-
-### Stage 2: full value correspondence
-
-Stage 2 is required before `hex-number-field-tower-mathlib` can prove
-factorization, splitting, or flattening.
-
-1. Relate every subresultant recurrence term to the corresponding Sylvester
-   minor, including the exact scale factors and degree-drop signs.
-2. Identify the corrected final constant with the Sylvester determinant.
-3. Compose with Mathlib's determinant definition of `Polynomial.resultant` to
-   prove `toPolynomial_resultant` generically.
-4. Prove `eval_resultant` by the direct coefficient-evaluation transfer above;
-   do not instantiate the generic theorem at `DensePoly R`.
-5. Specialize Mathlib's existing `Polynomial.resultant_eq_prod_eval` for the
-   root-product formula, then derive norm identities and discriminant
-   agreement.
-
-The prior scope estimate of about 600 lines covered only Stage 1. Stage 2 is a
-substantial computer-algebra development and must be estimated from the actual
-Sylvester-minor proof rather than retaining that obsolete total.
+1. `PseudoDivMod` transports pseudo-division reconstruction, degree bounds, and
+   the one-step resultant identity to Mathlib polynomials.
+2. The generalized coefficient matrix is identified with Mathlib's Sylvester
+   matrix after reversing both axes; the local Laplace determinant is identified
+   with `Matrix.det`.
+3. The recursive Brown invariant identifies the worker's corrected terminal
+   value with the zeroth generalized coefficient minor, including defective
+   drops and terminal zero pseudo-remainders.
+4. These facts compose to prove `toPolynomial_resultant` for all inputs,
+   including zero polynomials, constants, and caller-order swaps.
+5. The integer common-root criterion is a corollary of full value
+   correspondence and the complex root-product formula.
+6. Bivariate specialization maps the explicit-degree coefficient minor through
+   coefficient evaluation. This preserves formal degrees even when leading
+   coefficients specialize to zero; the default-degree and common-zero results
+   follow as corollaries.
+7. Mathlib's root-product and discriminant identities then transfer to the
+   executable API.
 
 ## Downstream contracts
 
-- `hex-number-field-mathlib` lazy arithmetic `_sound` theorems use Stage 1
+- `hex-number-field-mathlib` lazy arithmetic `_sound` theorems use
   specialization-vanishing.
-- Exactification and root completeness use Stage 1 plus the factorization and
-  isolation companions.
+- Exactification and root completeness use common-root correspondence plus the
+  factorization and isolation companions.
 - `resultIsolationPrec` for lazy binary arithmetic uses only HexRoots separation
   between roots of one squarefree eliminant.
-- `evalDisambiguationPrec` uses the Stage 2 root-product formula to certify a
+- `evalDisambiguationPrec` uses the root-product formula to certify a
   nonzero lower bound for wrong root/factor evaluations.
-- Tower norms and Trager factor recovery use Stage 2 full agreement and
+- Tower norms and Trager factor recovery use full agreement and
   specialization.
-- Discriminant and squarefree corollaries use Stage 2 discriminant agreement.
+- Discriminant and squarefree corollaries use discriminant agreement.
 
 ## File organisation
 
@@ -245,7 +276,7 @@ Sylvester-minor proof rather than retaining that obsolete total.
 HexResultantMathlib/
   Basic.lean           : public theorem statements
   PseudoDivMod.lean    : reconstruction and one-step resultant transport
-  Chain.lean           : pseudo-division transfer and Stage 1
+  Chain.lean           : common-root consequences of full agreement
   Sylvester.lean       : subresultant minors and full agreement
   Specialize.lean      : bivariate specialization and norm corollaries
   Roots.lean           : root-product formula

--- a/HexResultantMathlib/Specialize.lean
+++ b/HexResultantMathlib/Specialize.lean
@@ -20,6 +20,74 @@ universe u
 
 variable {R : Type u}
 
+section DenseCommRing
+
+attribute [local instance] Lean.Grind.Semiring.natCast Lean.Grind.Ring.intCast
+
+/-- The Mathlib ring structure induced by the executable dense-polynomial
+operations. It remains proof-local: the public API deliberately does not
+install a global `CommRing (DensePoly R)` instance. -/
+@[implicit_reducible]
+private noncomputable def denseCommRing [CommRing R] [DecidableEq R] :
+    CommRing (DensePoly R) :=
+  let s := (inferInstance : Lean.Grind.CommRing (DensePoly R))
+  { s with
+    zero_add := Lean.Grind.AddCommMonoid.zero_add
+    right_distrib := Lean.Grind.Semiring.right_distrib
+    mul_zero := Lean.Grind.Semiring.mul_zero
+    one_mul := Lean.Grind.Semiring.one_mul
+    nsmul := nsmulRec
+    zsmul := zsmulRec
+    npow := npowRec
+    natCast := Nat.cast
+    natCast_zero := Lean.Grind.Semiring.natCast_zero
+    natCast_succ n := Lean.Grind.Semiring.natCast_succ n
+    intCast := Int.cast
+    intCast_ofNat := Lean.Grind.Ring.intCast_natCast
+    intCast_negSucc n := by
+      rw [Int.negSucc_eq, Lean.Grind.Ring.intCast_neg,
+        Lean.Grind.Ring.intCast_natCast_add_one,
+        Lean.Grind.Semiring.natCast_succ] }
+
+end DenseCommRing
+
+/-- Evaluation carries an explicit-degree coefficient minor to the resultant
+of the specialized inputs. This is the direct coefficient-map transfer; it
+does not instantiate the executable resultant correspondence over
+`DensePoly R`. -/
+private theorem eval_coeffMinorAt_zero [CommRing R] [DecidableEq R]
+    (df dg : Nat) (f g : DensePoly (DensePoly R)) (a : R)
+    (hf : f.size ≤ df + 1) (hg : g.size ≤ dg + 1) :
+    eval (Subresultant.coeffMinorAt df dg 0 0 f g) a =
+      Polynomial.resultant (specialize f a) (specialize g a)
+        (m := df) (n := dg) := by
+  letI : CommRing (DensePoly R) := denseCommRing
+  let ε : DensePoly R →+* R :=
+    (Polynomial.evalRingHom a).comp
+      (HexPolyMathlib.equiv (R := R)).toRingHom
+  have hε (p : DensePoly R) : ε p = eval p a := by
+    change (HexPolyMathlib.toPolynomial p).eval a = eval p a
+    exact (eval_toPolynomial p a).symm
+  have hfMap :
+      (HexPolyMathlib.toPolynomial f).map ε = specialize f a := by
+    ext i
+    rw [Polynomial.coeff_map, HexPolyMathlib.coeff_toPolynomial,
+      coeff_specialize, hε]
+  have hgMap :
+      (HexPolyMathlib.toPolynomial g).map ε = specialize g a := by
+    ext i
+    rw [Polynomial.coeff_map, HexPolyMathlib.coeff_toPolynomial,
+      coeff_specialize, hε]
+  rw [← hε]
+  have hminor :=
+    Subresultant.coeffMinorAt_zero_eq_resultant df dg f g hf hg
+  calc
+    ε (Subresultant.coeffMinorAt df dg 0 0 f g) =
+        ε (Polynomial.resultant (HexPolyMathlib.toPolynomial f)
+          (HexPolyMathlib.toPolynomial g) df dg) := congrArg ε hminor
+    _ = Polynomial.resultant (specialize f a) (specialize g a) df dg := by
+      rw [← Polynomial.resultant_map_map, hfMap, hgMap]
+
 /-- Specializing the coefficient variable after elimination agrees with the
 formal-degree Mathlib resultant of the specialized inputs. -/
 theorem eval_resultant [CommRing R] [IsDomain R] [DecidableEq R]
@@ -28,7 +96,200 @@ theorem eval_resultant [CommRing R] [IsDomain R] [DecidableEq R]
     eval (resultant f g) a =
       Polynomial.resultant (specialize f a) (specialize g a)
         (m := f.degree?.getD 0) (n := g.degree?.getD 0) := by
-  sorry
+  by_cases hf : f = 0
+  · subst f
+    have hz : (0 : DensePoly (DensePoly R)).isZero = true :=
+      (isZero_eq_true_iff (0 : DensePoly (DensePoly R))).2 rfl
+    have hzdeg : (0 : DensePoly (DensePoly R)).degree?.getD 0 = 0 := by
+      simp
+    by_cases hgsmall : g.size ≤ 1
+    · have hgdeg : g.degree?.getD 0 = 0 := by
+        by_cases hg : g = 0
+        · subst g
+          simp
+        · have hgpos : 0 < g.size := by
+            by_contra h
+            apply hg
+            exact (size_eq_zero_iff g).mp (by omega)
+          rw [degree?_eq_some_of_pos_size g hgpos, Option.getD_some]
+          omega
+      unfold resultant
+      rw [hz]
+      simp only [↓reduceIte]
+      rw [if_pos hgsmall, specialize_zero, hzdeg, hgdeg,
+        eval_toPolynomial, HexPolyMathlib.toPolynomial_one]
+      simp [Polynomial.resultant]
+    · have hgdeg : 0 < g.degree?.getD 0 := by
+        have hgpos : 0 < g.size := by omega
+        rw [degree?_eq_some_of_pos_size g hgpos, Option.getD_some]
+        omega
+      unfold resultant
+      rw [hz]
+      simp only [↓reduceIte]
+      rw [if_neg hgsmall, specialize_zero, hzdeg,
+        eval_toPolynomial, HexPolyMathlib.toPolynomial_zero,
+        Polynomial.eval_zero, Polynomial.resultant_zero_left]
+      simp [hgdeg.ne']
+  · by_cases hg : g = 0
+    · subst g
+      have hz : (0 : DensePoly (DensePoly R)).isZero = true :=
+        (isZero_eq_true_iff (0 : DensePoly (DensePoly R))).2 rfl
+      have hzdeg : (0 : DensePoly (DensePoly R)).degree?.getD 0 = 0 := by
+        simp
+      have hfpos : 0 < f.size := by
+        by_contra h
+        apply hf
+        exact (size_eq_zero_iff f).mp (by omega)
+      have hfz : f.isZero = false := (isZero_eq_false_iff f).2 hfpos
+      by_cases hfsmall : f.size ≤ 1
+      · have hfdeg : f.degree?.getD 0 = 0 := by
+          rw [degree?_eq_some_of_pos_size f hfpos, Option.getD_some]
+          omega
+        unfold resultant
+        rw [hfz, hz]
+        simp only [Bool.false_eq_true, ↓reduceIte]
+        rw [if_pos hfsmall, specialize_zero, hzdeg, hfdeg,
+          eval_toPolynomial, HexPolyMathlib.toPolynomial_one]
+        simp [Polynomial.resultant]
+      · have hfdeg : 0 < f.degree?.getD 0 := by
+          rw [degree?_eq_some_of_pos_size f hfpos, Option.getD_some]
+          omega
+        unfold resultant
+        rw [hfz, hz]
+        simp only [Bool.false_eq_true, ↓reduceIte]
+        rw [if_neg hfsmall, specialize_zero, hzdeg,
+          eval_toPolynomial, HexPolyMathlib.toPolynomial_zero,
+          Polynomial.eval_zero, Polynomial.resultant_zero_right]
+        simp [hfdeg.ne']
+    · have hfpos : 0 < f.size := by
+        by_contra h
+        apply hf
+        exact (size_eq_zero_iff f).mp (by omega)
+      have hgpos : 0 < g.size := by
+        by_contra h
+        apply hg
+        exact (size_eq_zero_iff g).mp (by omega)
+      have hfz : f.isZero = false := (isZero_eq_false_iff f).2 hfpos
+      have hgz : g.isZero = false := (isZero_eq_false_iff g).2 hgpos
+      have hdf : f.degree?.getD 0 = Subresultant.formalDegree f := by
+        rw [degree?_eq_some_of_pos_size f hfpos, Option.getD_some]
+        rfl
+      have hdg : g.degree?.getD 0 = Subresultant.formalDegree g := by
+        rw [degree?_eq_some_of_pos_size g hgpos, Option.getD_some]
+        rfl
+      have hfBound : f.size ≤ Subresultant.formalDegree f + 1 := by
+        unfold Subresultant.formalDegree
+        omega
+      have hgBound : g.size ≤ Subresultant.formalDegree g + 1 := by
+        unfold Subresultant.formalDegree
+        omega
+      rw [hdf, hdg]
+      unfold resultant
+      simp only [hfz, hgz, Bool.false_eq_true, ↓reduceIte]
+      by_cases hfg : f.size < g.size
+      · rw [if_pos hfg]
+        rw [resultantOrdered_eq_coeffMinor g f hg hf (by omega),
+          negOnePow_eq_sign]
+        have hswap := Subresultant.coeffMinor_swap 0 0 f g
+        simp only [Nat.sub_zero, Subresultant.formalDegree] at hswap
+        rw [← hswap]
+        unfold Subresultant.coeffMinor
+        exact eval_coeffMinorAt_zero _ _ f g a hfBound hgBound
+      · rw [if_neg hfg]
+        rw [resultantOrdered_eq_coeffMinor f g hf hg (by omega)]
+        unfold Subresultant.coeffMinor
+        exact eval_coeffMinorAt_zero _ _ f g a hfBound hgBound
+
+/-- A nonvanishing specialized leading coefficient preserves the outer
+degree under specialization. -/
+private theorem natDegree_specialize [CommRing R] [DecidableEq R]
+    (f : DensePoly (DensePoly R)) (a : R)
+    (hf : eval f.leadingCoeff a ≠ 0) :
+    (specialize f a).natDegree = f.degree?.getD 0 := by
+  have hfpos : 0 < f.size := by
+    by_contra h
+    have hfzero : f = 0 := (size_eq_zero_iff f).mp (by omega)
+    subst f
+    rw [leadingCoeff_zero, eval_toPolynomial,
+      HexPolyMathlib.toPolynomial_zero, Polynomial.eval_zero] at hf
+    exact hf rfl
+  rw [degree?_eq_some_of_pos_size f hfpos, Option.getD_some]
+  apply le_antisymm
+  · apply Polynomial.natDegree_le_iff_coeff_eq_zero.mpr
+    intro n hn
+    rw [coeff_specialize]
+    have hsize : f.size ≤ n := by omega
+    rw [coeff_eq_zero_of_size_le f hsize]
+    have heval : eval (Zero.zero : DensePoly R) a = (Zero.zero : R) := rfl
+    rw [heval]
+    exact ((Lean.Grind.Semiring.ofNat_eq_natCast (α := R) 0).trans
+      Lean.Grind.Semiring.natCast_zero).symm
+  · apply Polynomial.le_natDegree_of_ne_zero
+    rw [coeff_specialize]
+    have hcoeff : f.coeff (f.size - 1) = f.leadingCoeff :=
+      (leadingCoeff_eq_coeff_last f hfpos).symm
+    rw [hcoeff]
+    exact hf
+
+/-- Specialization cannot increase the outer degree. -/
+private theorem natDegree_specialize_le [CommRing R] [DecidableEq R]
+    (f : DensePoly (DensePoly R)) (a : R) :
+    (specialize f a).natDegree ≤ f.degree?.getD 0 := by
+  by_cases hfsize : f.size = 0
+  · have hf : f = 0 := (size_eq_zero_iff f).mp hfsize
+    subst f
+    simp
+  · have hfpos : 0 < f.size := Nat.pos_of_ne_zero hfsize
+    rw [degree?_eq_some_of_pos_size f hfpos, Option.getD_some]
+    apply Polynomial.natDegree_le_iff_coeff_eq_zero.mpr
+    intro n hn
+    rw [coeff_specialize]
+    have hsize : f.size ≤ n := by omega
+    rw [coeff_eq_zero_of_size_le f hsize]
+    have heval : eval (Zero.zero : DensePoly R) a = (Zero.zero : R) := rfl
+    rw [heval]
+    exact ((Lean.Grind.Semiring.ofNat_eq_natCast (α := R) 0).trans
+      Lean.Grind.Semiring.natCast_zero).symm
+
+/-- Over a domain, a common root makes the default-degree resultant vanish as
+soon as at least one polynomial is nonzero. The proof maps injectively to the
+fraction field and uses Mathlib's field criterion. -/
+private theorem resultant_default_eq_zero_of_common_eval
+    [CommRing R] [IsDomain R]
+    (F G : Polynomial R) (b : R)
+    (hF : F.eval b = 0) (hG : G.eval b = 0)
+    (hne : F ≠ 0 ∨ G ≠ 0) :
+    Polynomial.resultant F G = 0 := by
+  let K := FractionRing R
+  let φ : R →+* K := algebraMap R K
+  let FK := F.map φ
+  let GK := G.map φ
+  have hφ : Function.Injective φ :=
+    FaithfulSMul.algebraMap_injective R K
+  have hFKeval : FK.eval (φ b) = 0 := by
+    simpa [FK, φ] using congrArg φ hF
+  have hGKeval : GK.eval (φ b) = 0 := by
+    simpa [GK, φ] using congrArg φ hG
+  have hneMap : FK ≠ 0 ∨ GK ≠ 0 := by
+    rcases hne with hFne | hGne
+    · exact Or.inl ((Polynomial.map_ne_zero_iff hφ).2 hFne)
+    · exact Or.inr ((Polynomial.map_ne_zero_iff hφ).2 hGne)
+  have hnot : ¬IsCoprime FK GK := by
+    intro hcop
+    rcases Polynomial.aeval_ne_zero_of_isCoprime hcop (φ b) with h | h
+    · exact h (by simpa [Polynomial.aeval_def] using hFKeval)
+    · exact h (by simpa [Polynomial.aeval_def] using hGKeval)
+  have hmapres : Polynomial.resultant FK GK = 0 :=
+    Polynomial.resultant_eq_zero_iff.mpr ⟨hneMap, hnot⟩
+  have hFKdeg : FK.natDegree = F.natDegree :=
+    Polynomial.natDegree_map_eq_of_injective hφ F
+  have hGKdeg : GK.natDegree = G.natDegree :=
+    Polynomial.natDegree_map_eq_of_injective hφ G
+  have hres : φ (Polynomial.resultant F G) = 0 := by
+    rw [← Polynomial.resultant_map_map]
+    simpa [FK, GK, hFKdeg, hGKdeg] using hmapres
+  apply hφ
+  simpa using hres
 
 /-- The specialization law at default Mathlib degrees when neither outer
 leading coefficient vanishes. -/
@@ -39,7 +300,8 @@ theorem eval_resultant_default
     (hf : eval f.leadingCoeff a ≠ 0) (hg : eval g.leadingCoeff a ≠ 0) :
     eval (resultant f g) a =
       Polynomial.resultant (specialize f a) (specialize g a) := by
-  sorry
+  rw [eval_resultant]
+  rw [← natDegree_specialize f a hf, ← natDegree_specialize g a hg]
 
 /-- A common bivariate zero forces the specialized eliminant to vanish when at
 least one input genuinely has positive degree in the eliminated variable. The
@@ -51,6 +313,50 @@ theorem eval_resultant_eq_zero_of_common_root
     (hpos : 1 < f.size ∨ 1 < g.size)
     (hfb : evalBivariate f a b = 0) (hgb : evalBivariate g a b = 0) :
     eval (resultant f g) a = 0 := by
-  sorry
+  rw [eval_resultant]
+  let F := specialize f a
+  let G := specialize g a
+  let m := f.degree?.getD 0
+  let n := g.degree?.getD 0
+  change Polynomial.resultant F G m n = 0
+  have hFroot : F.eval b = 0 := by
+    simpa only [F, evalBivariate] using hfb
+  have hGroot : G.eval b = 0 := by
+    simpa only [G, evalBivariate] using hgb
+  have hm : F.natDegree ≤ m := by
+    simpa only [F, m] using natDegree_specialize_le f a
+  have hn : G.natDegree ≤ n := by
+    simpa only [G, n] using natDegree_specialize_le g a
+  have hmn : 0 < m ∨ 0 < n := by
+    rcases hpos with hfpos | hgpos
+    · left
+      dsimp only [m]
+      rw [degree?_eq_some_of_pos_size f (by omega), Option.getD_some]
+      omega
+    · right
+      dsimp only [n]
+      rw [degree?_eq_some_of_pos_size g (by omega), Option.getD_some]
+      omega
+  by_cases hboth : F = 0 ∧ G = 0
+  · rcases hboth with ⟨hFzero, hGzero⟩
+    rw [hFzero, hGzero, Polynomial.resultant_zero_zero]
+    have hsum : m + n ≠ 0 := by omega
+    exact zero_pow hsum
+  · have hne : F ≠ 0 ∨ G ≠ 0 := by
+      by_cases hFzero : F = 0
+      · right
+        intro hGzero
+        exact hboth ⟨hFzero, hGzero⟩
+      · exact Or.inl hFzero
+    have hdefault :=
+      resultant_default_eq_zero_of_common_eval F G b hFroot hGroot hne
+    have hmEq : m = F.natDegree + (m - F.natDegree) := by omega
+    have hnEq : n = G.natDegree + (n - G.natDegree) := by omega
+    rw [hmEq, Polynomial.resultant_add_left_deg F G F.natDegree n
+      (m - F.natDegree) le_rfl]
+    rw [hnEq, Polynomial.resultant_add_right_deg F G F.natDegree
+      G.natDegree (n - G.natDegree) le_rfl]
+    rw [hdefault]
+    ring
 
 end Hex.DensePoly

--- a/HexResultantMathlib/Sylvester.lean
+++ b/HexResultantMathlib/Sylvester.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexResultantMathlib.Basic
+public import Mathlib.Data.Fin.Rev
 
 public section
 
@@ -14,11 +15,231 @@ public section
 Full-value correspondence between Brown's executable recurrence and Mathlib's
 Sylvester-determinant resultant.
 -/
-namespace Hex.DensePoly
+namespace Hex
 
 universe u
 
 variable {R : Type u}
+
+namespace SubresultantMinor
+
+/-- The parity sign used by the proof-only Laplace recursion is the usual
+power of `-1`. -/
+theorem sign_eq_pow [CommRing R] (j : Nat) :
+    Hex.SubresultantMinor.sign (R := R) j = (-1 : R) ^ j := by
+  induction j with
+  | zero => simp [Hex.SubresultantMinor.sign]
+  | succ j ih =>
+      rw [Hex.SubresultantMinor.sign_succ, ih, pow_succ]
+      ring
+
+/-- The dependency-free Laplace determinant used by `hex-resultant` agrees
+with Mathlib's determinant on the same finite square matrix. -/
+theorem det_eq_matrixDet [CommRing R] {n : Nat}
+    (M : Hex.SubresultantMinor.Square R n) :
+    Hex.SubresultantMinor.det M = Matrix.det (Matrix.of M) := by
+  induction n with
+  | zero => simp [Hex.SubresultantMinor.det]
+  | succ n ih =>
+      let term := fun j : Fin (n + 1) =>
+        Hex.SubresultantMinor.sign (R := R) j.val * M 0 j *
+          Hex.SubresultantMinor.det (Hex.SubresultantMinor.deleteFirst M j)
+      have hfold (xs : List (Fin (n + 1))) (acc : R) :
+          xs.foldl (fun a j => a + term j) acc = acc + (xs.map term).sum := by
+        induction xs generalizing acc with
+        | nil => simp
+        | cons j js hjs =>
+            simp only [List.foldl_cons, List.map_cons, List.sum_cons, hjs]
+            ring
+      have hfold0 :
+          (List.finRange (n + 1)).foldl (fun a j => a + term j) 0 =
+            ∑ j, term j := by
+        rw [hfold]
+        calc
+          0 + (List.map term (List.finRange (n + 1))).sum =
+              (List.map term (List.finRange (n + 1))).sum := by ring
+          _ = ∑ j, term j := by
+            rw [← List.sum_toFinset term (List.nodup_finRange _),
+              List.toFinset_finRange]
+      rw [Hex.SubresultantMinor.det]
+      change (List.finRange (n + 1)).foldl (fun a j => a + term j) 0 = _
+      rw [hfold0]
+      rw [Matrix.det_succ_row_zero]
+      apply Finset.sum_congr rfl
+      intro j _
+      simp only [term, Matrix.of_apply]
+      rw [sign_eq_pow, ih]
+      congr 3
+
+end SubresultantMinor
+
+namespace DensePoly
+namespace Subresultant
+
+/-- A value-indexed presentation of Mathlib's Sylvester matrix. -/
+private def sylvesterByVal [CommRing R] (f g : Polynomial R) (df dg : Nat) :
+    Matrix (Fin (df + dg)) (Fin (df + dg)) R :=
+  Matrix.of fun i j =>
+    if _ : j.val < df then
+      if j.val ≤ i.val ∧ i.val ≤ j.val + dg then
+        g.coeff (i.val - j.val)
+      else 0
+    else
+      let jj := j.val - df
+      if jj ≤ i.val ∧ i.val ≤ jj + df then
+        f.coeff (i.val - jj)
+      else 0
+
+private theorem sylvester_eq_byVal [CommRing R] (f g : Polynomial R)
+    (df dg : Nat) :
+    Polynomial.sylvester f g df dg = sylvesterByVal f g df dg := by
+  ext i j
+  induction j using Fin.addCases with
+  | left j =>
+      have hle : Fin.castAdd dg j ≤ i ↔ j.val ≤ i.val := by
+        change (Fin.castAdd dg j).val ≤ i.val ↔ j.val ≤ i.val
+        rw [Fin.val_castAdd]
+      simp [Polynomial.sylvester, sylvesterByVal, Set.mem_Icc]
+      simp only [hle]
+  | right j =>
+      simp [Polynomial.sylvester, sylvesterByVal, Set.mem_Icc]
+      split <;> simp_all <;> omega
+
+/-- Integer coefficient lookup is the bounded coefficient selected by one
+reversed Sylvester block. -/
+private theorem coeffInt_eq_ite [CommRing R] [DecidableEq R]
+    (p : DensePoly R) (d i j : Nat) (hp : p.size ≤ d + 1) :
+    coeffInt p ((d : Int) - (i : Int) + (j : Int)) =
+      if j ≤ i ∧ i ≤ d + j then p.coeff (d + j - i) else 0 := by
+  unfold coeffInt
+  by_cases hnonneg : 0 ≤ (d : Int) - (i : Int) + (j : Int)
+  · rw [if_neg (by omega)]
+    have hnat : ((d : Int) - (i : Int) + (j : Int)).toNat = d + j - i := by
+      omega
+    rw [hnat]
+    by_cases hji : j ≤ i
+    · have hidj : i ≤ d + j := by omega
+      rw [if_pos ⟨hji, hidj⟩]
+    · rw [if_neg (by omega)]
+      exact coeff_eq_zero_of_size_le p (by omega)
+  · rw [if_pos (by omega), if_neg (by omega)]
+
+/-- At index zero, the generalized coefficient matrix is Mathlib's
+Sylvester matrix with both axes reversed. -/
+private theorem coeffMatrixAt_zero_eq_sylvester [CommRing R] [DecidableEq R]
+    (df dg : Nat) (f g : DensePoly R) (hf : f.size ≤ df + 1)
+    (hg : g.size ≤ dg + 1) :
+    Matrix.of (coeffMatrixAt df dg 0 0 f g) =
+      (Polynomial.sylvester (HexPolyMathlib.toPolynomial f)
+        (HexPolyMathlib.toPolynomial g) df dg).submatrix
+          Fin.revPerm Fin.revPerm := by
+  rw [sylvester_eq_byVal]
+  ext i j
+  simp only [Matrix.of_apply, Matrix.submatrix_apply, Fin.revPerm_apply]
+  unfold coeffMatrixAt sylvesterByVal
+  simp only [Nat.sub_zero, Matrix.of_apply, HexPolyMathlib.coeff_toPolynomial,
+    Int.ofNat_eq_natCast, Int.natCast_zero]
+  by_cases hj : j.val < dg
+  · rw [if_pos hj]
+    have hiBound : i.val < df + dg := by simp
+    have hrow :
+        (if i.val = df + dg - 1 then
+            coeffInt f ((0 : Int) - (dg - 1 : Nat) + j.val)
+          else coeffInt f ((df : Int) - i.val + j.val)) =
+          coeffInt f ((df : Int) - i.val + j.val) := by
+      by_cases hi : i.val = df + dg - 1
+      · rw [if_pos hi]
+        congr 1
+        omega
+      · rw [if_neg hi]
+    rw [hrow, coeffInt_eq_ite f df i.val j.val hf]
+    have hjrev : ¬(Fin.rev j).val < df := by
+      simp [Fin.rev]
+      omega
+    rw [dif_neg hjrev]
+    by_cases hji : j.val ≤ i.val ∧ i.val ≤ df + j.val
+    · rw [if_pos hji]
+      have hraw :
+          (Fin.rev j).val - df ≤ (Fin.rev i).val ∧
+            (Fin.rev i).val ≤ (Fin.rev j).val - df + df := by
+        simp [Fin.rev]
+        omega
+      rw [if_pos hraw]
+      congr 1
+      simp [Fin.rev]
+      omega
+    · rw [if_neg hji]
+      rw [if_neg]
+      simp [Fin.rev] at hji ⊢
+      omega
+  · rw [if_neg hj]
+    have hiBound : i.val < df + dg := by simp
+    have hrow :
+        (if i.val = df + dg - 1 then
+            coeffInt g
+              ((0 : Int) - (df - 1 : Nat) + ((j.val - dg : Nat) : Int))
+          else coeffInt g
+            ((dg : Int) - i.val + ((j.val - dg : Nat) : Int))) =
+          coeffInt g
+            ((dg : Int) - i.val + ((j.val - dg : Nat) : Int)) := by
+      by_cases hi : i.val = df + dg - 1
+      · rw [if_pos hi]
+        congr 1
+        omega
+      · rw [if_neg hi]
+    rw [hrow, coeffInt_eq_ite g dg i.val (j.val - dg) hg]
+    have hjrev : (Fin.rev j).val < df := by
+      simp [Fin.rev]
+      omega
+    rw [dif_pos hjrev]
+    by_cases hji : j.val - dg ≤ i.val ∧ i.val ≤ dg + (j.val - dg)
+    · rw [if_pos hji]
+      have hraw :
+          (Fin.rev j).val ≤ (Fin.rev i).val ∧
+            (Fin.rev i).val ≤ (Fin.rev j).val + dg := by
+        simp [Fin.rev]
+        omega
+      rw [if_pos hraw]
+      congr 1
+      simp [Fin.rev]
+      omega
+    · rw [if_neg hji]
+      rw [if_neg]
+      simp [Fin.rev] at hji ⊢
+      omega
+
+/-- The zeroth generalized coefficient minor at explicit degree bounds is
+Mathlib's Sylvester determinant at those same bounds. -/
+theorem coeffMinorAt_zero_eq_resultant [CommRing R] [DecidableEq R]
+    (df dg : Nat) (f g : DensePoly R)
+    (hf : f.size ≤ df + 1) (hg : g.size ≤ dg + 1) :
+    coeffMinorAt df dg 0 0 f g =
+      Polynomial.resultant (HexPolyMathlib.toPolynomial f)
+        (HexPolyMathlib.toPolynomial g)
+        (m := df) (n := dg) := by
+  unfold coeffMinorAt Polynomial.resultant
+  rw [Hex.SubresultantMinor.det_eq_matrixDet]
+  rw [coeffMatrixAt_zero_eq_sylvester _ _ f g hf hg]
+  exact Matrix.det_submatrix_equiv_self Fin.revPerm _
+
+/-- The zeroth generalized coefficient minor is Mathlib's Sylvester
+determinant at the same formal degrees. -/
+theorem coeffMinor_zero_eq_resultant [CommRing R] [DecidableEq R]
+    (f g : DensePoly R) :
+    coeffMinor 0 0 f g =
+      Polynomial.resultant (HexPolyMathlib.toPolynomial f)
+        (HexPolyMathlib.toPolynomial g)
+        (m := formalDegree f) (n := formalDegree g) := by
+  have hf : f.size ≤ formalDegree f + 1 := by
+    unfold formalDegree
+    omega
+  have hg : g.size ≤ formalDegree g + 1 := by
+    unfold formalDegree
+    omega
+  unfold coeffMinor
+  exact coeffMinorAt_zero_eq_resultant _ _ f g hf hg
+
+end Subresultant
 
 /-- The executable and Mathlib resultants agree under dense-polynomial
 correspondence, with the executable default formal degrees made explicit. -/
@@ -28,6 +249,96 @@ theorem toPolynomial_resultant [CommRing R] [IsDomain R] [DecidableEq R]
       Polynomial.resultant (HexPolyMathlib.toPolynomial f)
         (HexPolyMathlib.toPolynomial g)
         (m := f.degree?.getD 0) (n := g.degree?.getD 0) := by
-  sorry
+  by_cases hf : f = 0
+  · subst f
+    have hz : (0 : DensePoly R).isZero = true :=
+      (isZero_eq_true_iff (0 : DensePoly R)).2 rfl
+    have hzdeg : (0 : DensePoly R).degree?.getD 0 = 0 := by simp
+    by_cases hgsmall : g.size ≤ 1
+    · have hgdeg : g.degree?.getD 0 = 0 := by
+        by_cases hg : g = 0
+        · subst g
+          simp
+        · have hgpos : 0 < g.size := by
+            by_contra h
+            apply hg
+            exact (size_eq_zero_iff g).mp (by omega)
+          rw [degree?_eq_some_of_pos_size g hgpos, Option.getD_some]
+          omega
+      unfold resultant
+      rw [hz]
+      simp only [↓reduceIte]
+      rw [if_pos hgsmall, HexPolyMathlib.toPolynomial_zero, hzdeg, hgdeg]
+      simp [Polynomial.resultant]
+    · have hgdeg : 0 < g.degree?.getD 0 := by
+        have hgpos : 0 < g.size := by omega
+        rw [degree?_eq_some_of_pos_size g hgpos, Option.getD_some]
+        omega
+      unfold resultant
+      rw [hz]
+      simp only [↓reduceIte]
+      rw [if_neg hgsmall, HexPolyMathlib.toPolynomial_zero, hzdeg,
+        Polynomial.resultant_zero_left]
+      simp [hgdeg.ne']
+  · by_cases hg : g = 0
+    · subst g
+      have hz : (0 : DensePoly R).isZero = true :=
+        (isZero_eq_true_iff (0 : DensePoly R)).2 rfl
+      have hzdeg : (0 : DensePoly R).degree?.getD 0 = 0 := by simp
+      have hfpos : 0 < f.size := by
+        by_contra h
+        apply hf
+        exact (size_eq_zero_iff f).mp (by omega)
+      have hfz : f.isZero = false := (isZero_eq_false_iff f).2 hfpos
+      by_cases hfsmall : f.size ≤ 1
+      · have hfdeg : f.degree?.getD 0 = 0 := by
+          rw [degree?_eq_some_of_pos_size f hfpos, Option.getD_some]
+          omega
+        unfold resultant
+        rw [hfz, hz]
+        simp only [Bool.false_eq_true, ↓reduceIte]
+        rw [if_pos hfsmall, HexPolyMathlib.toPolynomial_zero, hzdeg, hfdeg]
+        simp [Polynomial.resultant]
+      · have hfdeg : 0 < f.degree?.getD 0 := by
+          rw [degree?_eq_some_of_pos_size f hfpos, Option.getD_some]
+          omega
+        unfold resultant
+        rw [hfz, hz]
+        simp only [Bool.false_eq_true, ↓reduceIte]
+        rw [if_neg hfsmall, HexPolyMathlib.toPolynomial_zero, hzdeg,
+          Polynomial.resultant_zero_right]
+        simp [hfdeg.ne']
+    · have hfpos : 0 < f.size := by
+        by_contra h
+        apply hf
+        exact (size_eq_zero_iff f).mp (by omega)
+      have hgpos : 0 < g.size := by
+        by_contra h
+        apply hg
+        exact (size_eq_zero_iff g).mp (by omega)
+      have hfz : f.isZero = false := (isZero_eq_false_iff f).2 hfpos
+      have hgz : g.isZero = false := (isZero_eq_false_iff g).2 hgpos
+      have hdf : f.degree?.getD 0 = Subresultant.formalDegree f := by
+        rw [degree?_eq_some_of_pos_size f hfpos, Option.getD_some]
+        rfl
+      have hdg : g.degree?.getD 0 = Subresultant.formalDegree g := by
+        rw [degree?_eq_some_of_pos_size g hgpos, Option.getD_some]
+        rfl
+      unfold resultant
+      simp only [hfz, hgz, Bool.false_eq_true, ↓reduceIte]
+      by_cases hfg : f.size < g.size
+      · rw [if_pos hfg]
+        rw [resultantOrdered_eq_coeffMinor g f hg hf (by omega)]
+        rw [Subresultant.coeffMinor_zero_eq_resultant]
+        rw [hdf, hdg]
+        rw [negOnePow_eq_sign,
+          Hex.SubresultantMinor.sign_eq_pow]
+        exact (Polynomial.resultant_comm
+          (HexPolyMathlib.toPolynomial f) (HexPolyMathlib.toPolynomial g)
+          (Subresultant.formalDegree f) (Subresultant.formalDegree g)).symm
+      · rw [if_neg hfg]
+        rw [resultantOrdered_eq_coeffMinor f g hf hg (by omega)]
+        rw [Subresultant.coeffMinor_zero_eq_resultant, hdf, hdg]
 
-end Hex.DensePoly
+end DensePoly
+end Hex

--- a/progress/20260729T034233Z_resultant-mathlib-correspondence.md
+++ b/progress/20260729T034233Z_resultant-mathlib-correspondence.md
@@ -1,0 +1,22 @@
+# Resultant–Mathlib correspondence
+
+## Accomplished
+
+- Proved that the terminal value of the ordered Brown–Traub recurrence is the generalized Sylvester coefficient minor.
+- Proved the full executable/Mathlib resultant correspondence, including zero, constant, degree-order, and swap cases.
+- Derived common-root, root-product, and discriminant correspondence theorems.
+- Proved bivariate specialization, including formal-degree drops after evaluation and the default-degree corollary.
+- Updated the Resultant and Resultant–Mathlib specifications to describe the completed public API and proof architecture.
+- Verified the complete repository with `lake build` (9,573 jobs) and confirmed the Resultant libraries contain no `sorry` or `axiom` declarations.
+
+## Current frontier
+
+The Resultant–Mathlib correspondence milestone is complete and ready to land as one cohesive pull request. There were no open Resultant or NumberField pull requests before this milestone.
+
+## Next step
+
+Open the single Resultant–Mathlib correspondence pull request, monitor its individual GitHub Actions jobs, and merge it before resuming NumberField or tower work.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Summary

- identify the ordered Brown–Traub terminal value with the generalized Sylvester coefficient minor
- prove full executable/Mathlib resultant correspondence and derive common-root, root-product, and discriminant results
- prove bivariate specialization, including formal-degree drops, and update both Resultant specifications

This closes the Resultant–Mathlib correspondence milestone as one cohesive change before NumberField work resumes.

## Validation

- `lake build` (9,573 jobs)
- `git diff --check`
- no `sorry` or `axiom` declarations in `HexResultant` or `HexResultantMathlib`