### PR TITLE
feat(mvpoly): add reusable tree merge and prove convolution

### DIFF
--- a/HexBasic.lean
+++ b/HexBasic.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexBasic.ArrayDecEq
+public import HexBasic.ExtTreeMap
 public import HexBasic.Fold
 public import HexBasic.ModuleBoundaryTests
 public import HexBasic.OfFn
@@ -18,7 +19,8 @@ public section
 /-!
 `HexBasic` is the lowest Mathlib-free `hex` library: a home for small,
 general-purpose helpers that clearly belong in the standard library and are
-reproduced here so the library remains Mathlib-free. It provides the shared
+reproduced here so the library remains Mathlib-free. It provides reusable
+`ExtTreeMap` merge/traversal operations, the shared
 `List.foldl` algebra (`HexBasic.Fold`), the `Batteries` list lemmas reproduced
 in `HexBasic.ListShim`, the `Vector.modify` update helper, and
 kernel-reducible `Array`/`Vector` equality (`HexBasic.ArrayDecEq`) and

--- a/HexBasic/ExtTreeMap.lean
+++ b/HexBasic/ExtTreeMap.lean
@@ -1,0 +1,145 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import Std.Data.ExtTreeMap.Lemmas
+
+@[expose] public section
+
+/-!
+Reusable operations missing from `Std.ExtTreeMap`.
+
+The declarations stay in the `Std.ExtTreeMap` namespace and use only standard
+library types so they can be proposed upstream independently of Hex.
+
+`mergeWith?` is the deletion-capable analogue of `mergeWith`. It folds the
+smaller tree into the larger one, preserving the argument order seen by the
+collision function. `foldl₂` performs one ordered traversal of both maps and
+reports left-only, shared, and right-only keys without repeated lookup.
+-/
+
+namespace Std.ExtTreeMap
+
+universe u v w x
+
+variable {α : Type u} {β : Type v} {γ : Type w} {δ : Type x}
+  {cmp : α → α → Ordering}
+
+/-- Fold two sorted entry streams together.
+
+At a shared key the left key is passed to `f`; `LawfulEqCmp` ensures that the
+right key is propositionally equal to it. -/
+def mergeFold [LawfulEqCmp cmp]
+    (f : δ → α → Option β → Option γ → δ) :
+    δ → List (α × β) → List (α × γ) → δ
+  | acc, [], right =>
+      right.foldl (fun acc entry => f acc entry.1 none (some entry.2)) acc
+  | acc, left, [] =>
+      left.foldl (fun acc entry => f acc entry.1 (some entry.2) none) acc
+  | acc, leftEntry :: left, rightEntry :: right =>
+      match cmp leftEntry.1 rightEntry.1 with
+      | .lt =>
+          mergeFold f
+            (f acc leftEntry.1 (some leftEntry.2) none)
+            left (rightEntry :: right)
+      | .eq =>
+          mergeFold f
+            (f acc leftEntry.1 (some leftEntry.2) (some rightEntry.2))
+            left right
+      | .gt =>
+          mergeFold f
+            (f acc rightEntry.1 none (some rightEntry.2))
+            (leftEntry :: left) right
+termination_by _ left right => left.length + right.length
+decreasing_by all_goals simp_wf <;> omega
+
+/-- Joint ordered fold over two maps.
+
+The callback sees `some` on the sides that contain the current key. The
+implementation is linear in the combined entry count after materializing the
+two ordered streams. -/
+def foldl₂ [TransCmp cmp] [LawfulEqCmp cmp]
+    (f : δ → α → Option β → Option γ → δ) (init : δ)
+    (left : ExtTreeMap α β cmp) (right : ExtTreeMap α γ cmp) : δ :=
+  mergeFold (cmp := cmp) f init left.toList right.toList
+
+/-- Merge two maps, allowing a collision to delete its key.
+
+Left-only and right-only entries are retained unchanged. The smaller map is
+folded into the larger map, so the operation performs
+`O(min(m,n) * log(max(m,n)))` tree work. The collision callback always receives
+the left value before the right value, independent of which map is smaller. -/
+def mergeWith? [TransCmp cmp] [LawfulEqCmp cmp]
+    (f : α → β → β → Option β)
+    (left right : ExtTreeMap α β cmp) : ExtTreeMap α β cmp :=
+  if left.size < right.size then
+    left.foldl
+      (fun out key leftValue =>
+        out.alter key fun
+          | none => some leftValue
+          | some rightValue => f key leftValue rightValue)
+      right
+  else
+    right.foldl
+      (fun out key rightValue =>
+        out.alter key fun
+          | none => some rightValue
+          | some leftValue => f key leftValue rightValue)
+      left
+
+@[simp] theorem foldl₂_empty_left [TransCmp cmp] [LawfulEqCmp cmp]
+    (f : δ → α → Option β → Option γ → δ) (init : δ)
+    (right : ExtTreeMap α γ cmp) :
+    foldl₂ f init (∅ : ExtTreeMap α β cmp) right =
+      right.foldl (fun acc key value => f acc key none (some value)) init := by
+  unfold foldl₂
+  have hempty : (∅ : ExtTreeMap α β cmp).toList = [] :=
+    toList_eq_nil_iff.mpr rfl
+  rw [hempty, mergeFold, foldl_eq_foldl_toList]
+
+@[simp] theorem foldl₂_empty_right [TransCmp cmp] [LawfulEqCmp cmp]
+    (f : δ → α → Option β → Option γ → δ) (init : δ)
+    (left : ExtTreeMap α β cmp) :
+    foldl₂ f init left (∅ : ExtTreeMap α γ cmp) =
+      left.foldl (fun acc key value => f acc key (some value) none) init := by
+  unfold foldl₂
+  have hempty : (∅ : ExtTreeMap α γ cmp).toList = [] :=
+    toList_eq_nil_iff.mpr rfl
+  rw [hempty, foldl_eq_foldl_toList]
+  cases hleft : left.toList <;> simp [mergeFold]
+
+@[simp] theorem mergeWith?_empty_left [TransCmp cmp] [LawfulEqCmp cmp]
+    (f : α → β → β → Option β) (right : ExtTreeMap α β cmp) :
+    mergeWith? f ∅ right = right := by
+  unfold mergeWith?
+  rw [size_empty]
+  split
+  · rw [foldl_eq_foldl_toList]
+    have hempty : (∅ : ExtTreeMap α β cmp).toList = [] :=
+      toList_eq_nil_iff.mpr rfl
+    rw [hempty]
+    rfl
+  · rename_i hsize
+    have hright : right = ∅ := eq_empty_iff_size_eq_zero.mpr (by omega)
+    subst right
+    rw [foldl_eq_foldl_toList]
+    have hempty : (∅ : ExtTreeMap α β cmp).toList = [] :=
+      toList_eq_nil_iff.mpr rfl
+    rw [hempty]
+    rfl
+
+@[simp] theorem mergeWith?_empty_right [TransCmp cmp] [LawfulEqCmp cmp]
+    (f : α → β → β → Option β) (left : ExtTreeMap α β cmp) :
+    mergeWith? f left ∅ = left := by
+  simp only [mergeWith?, size_empty, Nat.not_lt_zero, ↓reduceIte]
+  rw [foldl_eq_foldl_toList]
+  have hempty : (∅ : ExtTreeMap α β cmp).toList = [] :=
+    toList_eq_nil_iff.mpr rfl
+  rw [hempty]
+  rfl
+
+end Std.ExtTreeMap

--- a/HexBasic/ExtTreeMap.lean
+++ b/HexBasic/ExtTreeMap.lean
@@ -67,6 +67,13 @@ def foldl₂ [TransCmp cmp] [LawfulEqCmp cmp]
     (left : ExtTreeMap α β cmp) (right : ExtTreeMap α γ cmp) : δ :=
   mergeFold (cmp := cmp) f init left.toList right.toList
 
+/-- Result for one key in a deletion-capable merge. -/
+def mergeValue? (f : α → β → β → Option β) (key : α) :
+    Option β → Option β → Option β
+  | none, right => right
+  | left, none => left
+  | some left, some right => f key left right
+
 /-- Merge two maps, allowing a collision to delete its key.
 
 Left-only and right-only entries are retained unchanged. The smaller map is
@@ -79,17 +86,90 @@ def mergeWith? [TransCmp cmp] [LawfulEqCmp cmp]
   if left.size < right.size then
     left.foldl
       (fun out key leftValue =>
-        out.alter key fun
-          | none => some leftValue
-          | some rightValue => f key leftValue rightValue)
+        out.alter key (mergeValue? f key (some leftValue)))
       right
   else
     right.foldl
       (fun out key rightValue =>
-        out.alter key fun
-          | none => some rightValue
-          | some leftValue => f key leftValue rightValue)
+        out.alter key fun leftValue =>
+          mergeValue? f key leftValue (some rightValue))
       left
+
+private theorem getElem?_foldl_alter_of_forall [TransCmp cmp]
+    (entries : List (α × γ)) (out : ExtTreeMap α β cmp)
+    (update : α → γ → Option β → Option β) (key : α)
+    (h : ∀ entry ∈ entries, cmp entry.1 key ≠ .eq) :
+    (entries.foldl
+      (fun out entry => out.alter entry.1 (update entry.1 entry.2))
+      out)[key]? = out[key]? := by
+  induction entries generalizing out with
+  | nil => rfl
+  | cons entry entries ih =>
+      rw [List.foldl_cons, ih]
+      · rw [getElem?_alter, if_neg (h entry (by simp))]
+      · intro later hlater
+        exact h later (by simp [hlater])
+
+private theorem getElem?_foldl_alter_of_mem
+    [TransCmp cmp] [LawfulEqCmp cmp]
+    (entries : List (α × γ)) (out : ExtTreeMap α β cmp)
+    (update : α → γ → Option β → Option β) (key : α) (value : γ)
+    (hpair : entries.Pairwise (fun a b => cmp a.1 b.1 ≠ .eq))
+    (hmem : (key, value) ∈ entries) :
+    (entries.foldl
+      (fun out entry => out.alter entry.1 (update entry.1 entry.2))
+      out)[key]? = update key value out[key]? := by
+  induction entries generalizing out with
+  | nil => simp at hmem
+  | cons entry entries ih =>
+      simp only [List.pairwise_cons] at hpair
+      rcases List.mem_cons.mp hmem with heq | hmem
+      · subst entry
+        rw [List.foldl_cons,
+          getElem?_foldl_alter_of_forall entries
+            (out.alter key (update key value)) update key]
+        · rw [getElem?_alter_self]
+        · intro later hlater heq
+          have hkey : later.1 = key := LawfulEqCmp.eq_of_compare heq
+          apply hpair.1 later hlater
+          simp [hkey]
+      · rw [List.foldl_cons, ih (out := out.alter entry.1 (update entry.1 entry.2))
+          hpair.2 hmem, getElem?_alter, if_neg (hpair.1 (key, value) hmem)]
+
+private theorem getElem?_foldl_alter [TransCmp cmp] [LawfulEqCmp cmp]
+    (source : ExtTreeMap α γ cmp) (out : ExtTreeMap α β cmp)
+    (update : α → γ → Option β → Option β) (key : α) :
+    (source.foldl (fun out key value => out.alter key (update key value)) out)[key]? =
+      match source[key]? with
+      | none => out[key]?
+      | some value => update key value out[key]? := by
+  rw [foldl_eq_foldl_toList]
+  cases hsource : source[key]? with
+  | none =>
+      rw [getElem?_foldl_alter_of_forall]
+      intro entry hentry heq
+      have hkey : entry.1 = key := LawfulEqCmp.eq_of_compare heq
+      have hentryGet : source[entry.1]? = some entry.2 :=
+        mem_toList_iff_getElem?_eq_some.mp hentry
+      rw [hkey, hsource] at hentryGet
+      contradiction
+  | some value =>
+      rw [getElem?_foldl_alter_of_mem source.toList out update key value
+        source.distinct_keys_toList
+        (mem_toList_iff_getElem?_eq_some.mpr hsource)]
+
+/-- Lookup specification for a deletion-capable merge. -/
+@[simp] theorem getElem?_mergeWith? [TransCmp cmp] [LawfulEqCmp cmp]
+    (f : α → β → β → Option β)
+    (left right : ExtTreeMap α β cmp) (key : α) :
+    (mergeWith? f left right)[key]? =
+      mergeValue? f key left[key]? right[key]? := by
+  unfold mergeWith?
+  split
+  · rw [getElem?_foldl_alter]
+    cases left[key]? <;> cases right[key]? <;> rfl
+  · rw [getElem?_foldl_alter]
+    cases left[key]? <;> cases right[key]? <;> rfl
 
 @[simp] theorem foldl₂_empty_left [TransCmp cmp] [LawfulEqCmp cmp]
     (f : δ → α → Option β → Option γ → δ) (init : δ)

--- a/HexBasic/ExtTreeMap.lean
+++ b/HexBasic/ExtTreeMap.lean
@@ -15,6 +15,9 @@ Reusable operations missing from `Std.ExtTreeMap`.
 
 The declarations stay in the `Std.ExtTreeMap` namespace and use only standard
 library types so they can be proposed upstream independently of Hex.
+When one lands upstream, delete the copy here in the same commit that updates
+the toolchain: unlike theorem shims, duplicate definitions cannot coexist
+across imported modules even when their signatures agree.
 
 `mergeWith?` is the deletion-capable analogue of `mergeWith`. It folds the
 smaller tree into the larger one, preserving the argument order seen by the
@@ -29,43 +32,45 @@ universe u v w x
 variable {α : Type u} {β : Type v} {γ : Type w} {δ : Type x}
   {cmp : α → α → Ordering}
 
-/-- Fold two sorted entry streams together.
+/-- Joint ordered fold over two maps in increasing comparator order.
 
-At a shared key the left key is passed to `f`; `LawfulEqCmp` ensures that the
-right key is propositionally equal to it. -/
-def mergeFold [LawfulEqCmp cmp]
-    (f : δ → α → Option β → Option γ → δ) :
-    δ → List (α × β) → List (α × γ) → δ
-  | acc, [], right =>
-      right.foldl (fun acc entry => f acc entry.1 none (some entry.2)) acc
-  | acc, left, [] =>
-      left.foldl (fun acc entry => f acc entry.1 (some entry.2) none) acc
-  | acc, leftEntry :: left, rightEntry :: right =>
-      match cmp leftEntry.1 rightEntry.1 with
-      | .lt =>
-          mergeFold f
-            (f acc leftEntry.1 (some leftEntry.2) none)
-            left (rightEntry :: right)
-      | .eq =>
-          mergeFold f
-            (f acc leftEntry.1 (some leftEntry.2) (some rightEntry.2))
-            left right
-      | .gt =>
-          mergeFold f
-            (f acc rightEntry.1 none (some rightEntry.2))
-            (leftEntry :: left) right
-termination_by _ left right => left.length + right.length
-decreasing_by all_goals simp_wf <;> omega
-
-/-- Joint ordered fold over two maps.
-
-The callback sees `some` on the sides that contain the current key. The
-implementation is linear in the combined entry count after materializing the
-two ordered streams. -/
-def foldl₂ [TransCmp cmp] [LawfulEqCmp cmp]
+The callback sees `some` exactly on the sides that contain a
+comparator-equivalent key; at a shared entry it receives the left map's key
+representative. The implementation performs linear merge work after
+materializing the two ordered streams. -/
+def foldl₂ [TransCmp cmp]
     (f : δ → α → Option β → Option γ → δ) (init : δ)
     (left : ExtTreeMap α β cmp) (right : ExtTreeMap α γ cmp) : δ :=
   mergeFold (cmp := cmp) f init left.toList right.toList
+where
+  /-- Joint-fold worker. Nesting keeps it out of the top-level
+  `Std.ExtTreeMap` namespace, but exposure makes it a public constant. Callers
+  must supply sorted, comparator-distinct streams, as `ExtTreeMap.toList`
+  produces; behavior on other lists is unspecified. -/
+  mergeFold {α : Type u} {β : Type v} {γ : Type w} {δ : Type x}
+      {cmp : α → α → Ordering}
+      (f : δ → α → Option β → Option γ → δ) :
+      δ → List (α × β) → List (α × γ) → δ
+    | acc, [], right =>
+        right.foldl (fun acc entry => f acc entry.1 none (some entry.2)) acc
+    | acc, left, [] =>
+        left.foldl (fun acc entry => f acc entry.1 (some entry.2) none) acc
+    | acc, leftEntry :: left, rightEntry :: right =>
+        match cmp leftEntry.1 rightEntry.1 with
+        | .lt =>
+            mergeFold (cmp := cmp) f
+              (f acc leftEntry.1 (some leftEntry.2) none)
+              left (rightEntry :: right)
+        | .eq =>
+            mergeFold (cmp := cmp) f
+              (f acc leftEntry.1 (some leftEntry.2) (some rightEntry.2))
+              left right
+        | .gt =>
+            mergeFold (cmp := cmp) f
+              (f acc rightEntry.1 none (some rightEntry.2))
+              (leftEntry :: left) right
+  termination_by _ left right => left.length + right.length
+  decreasing_by all_goals simp_wf <;> omega
 
 /-- Result for one key in a deletion-capable merge. -/
 def mergeValue? (f : α → β → β → Option β) (key : α) :
@@ -79,7 +84,9 @@ def mergeValue? (f : α → β → β → Option β) (key : α) :
 Left-only and right-only entries are retained unchanged. The smaller map is
 folded into the larger map, so the operation performs
 `O(min(m,n) * log(max(m,n)))` tree work. The collision callback always receives
-the left value before the right value, independent of which map is smaller. -/
+the left value before the right value, independent of which map is smaller.
+`LawfulEqCmp` makes comparator-equivalent keys propositionally equal, so the
+choice of the larger map cannot observably change the stored collision key. -/
 def mergeWith? [TransCmp cmp] [LawfulEqCmp cmp]
     (f : α → β → β → Option β)
     (left right : ExtTreeMap α β cmp) : ExtTreeMap α β cmp :=
@@ -171,7 +178,7 @@ private theorem getElem?_foldl_alter [TransCmp cmp] [LawfulEqCmp cmp]
   · rw [getElem?_foldl_alter]
     cases left[key]? <;> cases right[key]? <;> rfl
 
-@[simp] theorem foldl₂_empty_left [TransCmp cmp] [LawfulEqCmp cmp]
+@[simp] theorem foldl₂_empty_left [TransCmp cmp]
     (f : δ → α → Option β → Option γ → δ) (init : δ)
     (right : ExtTreeMap α γ cmp) :
     foldl₂ f init (∅ : ExtTreeMap α β cmp) right =
@@ -179,9 +186,9 @@ private theorem getElem?_foldl_alter [TransCmp cmp] [LawfulEqCmp cmp]
   unfold foldl₂
   have hempty : (∅ : ExtTreeMap α β cmp).toList = [] :=
     toList_eq_nil_iff.mpr rfl
-  rw [hempty, mergeFold, foldl_eq_foldl_toList]
+  rw [hempty, foldl₂.mergeFold, foldl_eq_foldl_toList]
 
-@[simp] theorem foldl₂_empty_right [TransCmp cmp] [LawfulEqCmp cmp]
+@[simp] theorem foldl₂_empty_right [TransCmp cmp]
     (f : δ → α → Option β → Option γ → δ) (init : δ)
     (left : ExtTreeMap α β cmp) :
     foldl₂ f init left (∅ : ExtTreeMap α γ cmp) =
@@ -190,7 +197,7 @@ private theorem getElem?_foldl_alter [TransCmp cmp] [LawfulEqCmp cmp]
   have hempty : (∅ : ExtTreeMap α γ cmp).toList = [] :=
     toList_eq_nil_iff.mpr rfl
   rw [hempty, foldl_eq_foldl_toList]
-  cases hleft : left.toList <;> simp [mergeFold]
+  cases hleft : left.toList <;> simp [foldl₂.mergeFold]
 
 @[simp] theorem mergeWith?_empty_left [TransCmp cmp] [LawfulEqCmp cmp]
     (f : α → β → β → Option β) (right : ExtTreeMap α β cmp) :

--- a/HexBasic/Fold.lean
+++ b/HexBasic/Fold.lean
@@ -40,13 +40,14 @@ universe u v w
 variable {α : Type v} {β : Type w} {R : Type u}
 
 /-!
-The `Std.Associative` / `Std.LawfulIdentity` instances that {name}`List.foldl_assoc`
-and friends need are kept **file-local**: they are used only to prove the
-lemmas below, which state their conclusions over `Lean.Grind.Ring` / `CommRing`
-without exposing the instances. Keeping them local avoids adding a second
-global `Std.Associative` resolution path for every `Grind.Semiring` (e.g.
-`Nat`/`Int` in the Mathlib bridge layers, where Mathlib already supplies its
-own). Promote / upstream them separately if a consumer ever needs them.
+The `Std.Associative` / `Std.LawfulIdentity` instances that
+{name}`List.foldl_assoc` and friends need are kept **file-local**: they are used
+only to prove the lemmas below, whose conclusions use `Lean.Grind.Semiring`,
+with `Ring` or `CommRing` required only where negation or commutative
+multiplication is genuinely involved. Keeping them local avoids adding a
+second global `Std.Associative` resolution path for every `Grind.Semiring`
+(e.g. `Nat`/`Int` in the Mathlib bridge layers, where Mathlib already supplies
+its own). Promote / upstream them separately if a consumer ever needs them.
 -/
 
 /-- Addition in a `Grind.Semiring` is an associative operation. -/
@@ -134,7 +135,7 @@ theorem foldl_add_perm [Lean.Grind.Semiring R] (f : α → R) {xs ys : List α}
   | trans _ _ ih₁ ih₂ => exact (ih₁ z).trans (ih₂ z)
 
 /-- A multiplicative fold-product is invariant under permuting the list. -/
-theorem foldl_mul_perm [Lean.Grind.CommRing R] (f : α → R) {xs ys : List α}
+theorem foldl_mul_perm [Lean.Grind.CommSemiring R] (f : α → R) {xs ys : List α}
     (h : xs.Perm ys) (z : R) :
     xs.foldl (fun acc x => acc * f x) z = ys.foldl (fun acc x => acc * f x) z := by
   induction h generalizing z with
@@ -353,21 +354,18 @@ theorem foldl_add_comm {γ : Type w} (xs : List α) (ys : List γ) (f : α → �
 
 end Semiring
 
-section CommRing
+section Semiring
 
-variable [Lean.Grind.CommRing R]
+variable [Lean.Grind.Semiring R]
 
 /-- Factor a right scalar out of an additive fold-sum started from `0`. -/
 theorem foldl_add_mul_right_zero (xs : List α) (f : α → R) (c : R) :
     xs.foldl (fun acc x => acc + f x * c) 0 =
       xs.foldl (fun acc x => acc + f x) 0 * c := by
-  calc xs.foldl (fun acc x => acc + f x * c) 0
-      = xs.foldl (fun acc x => acc + c * f x) 0 := by
-        apply foldl_add_congr; intro x _; grind
-    _ = c * xs.foldl (fun acc x => acc + f x) 0 := foldl_add_mul_left_zero xs c f
-    _ = xs.foldl (fun acc x => acc + f x) 0 * c := by grind
+  simpa [Lean.Grind.Semiring.zero_mul] using
+    (foldl_add_mul_right xs f c 0).symm
 
-end CommRing
+end Semiring
 
 /-! # flatMap -/
 

--- a/HexBasic/Fold.lean
+++ b/HexBasic/Fold.lean
@@ -124,7 +124,7 @@ theorem foldl_const_step (xs : List α) (z : β) :
 /-! # Permutation invariance -/
 
 /-- An additive fold-sum is invariant under permuting the list. -/
-theorem foldl_add_perm [Lean.Grind.Ring R] (f : α → R) {xs ys : List α}
+theorem foldl_add_perm [Lean.Grind.Semiring R] (f : α → R) {xs ys : List α}
     (h : xs.Perm ys) (z : R) :
     xs.foldl (fun acc x => acc + f x) z = ys.foldl (fun acc x => acc + f x) z := by
   induction h generalizing z with
@@ -143,9 +143,9 @@ theorem foldl_mul_perm [Lean.Grind.CommRing R] (f : α → R) {xs ys : List α}
   | swap x y xs => simp only [List.foldl_cons]; congr 1; grind
   | trans _ _ ih₁ ih₂ => exact (ih₁ z).trans (ih₂ z)
 
-section Ring
+section Semiring
 
-variable [Lean.Grind.Ring R]
+variable [Lean.Grind.Semiring R]
 
 /-! # Accumulator extraction -/
 
@@ -210,7 +210,13 @@ theorem foldl_add_mul_right (xs : List α) (f : α → R) (c z : R) :
     simp only [List.foldl_cons]
     rw [ih (z := z + f x), show (z + f x) * c = z * c + f x * c by grind]
 
-/-! # Negation and subtraction -/
+end Semiring
+
+section Ring
+
+variable [Lean.Grind.Ring R]
+
+/-! # Negation -/
 
 /-- Negation distributes through an additive fold-sum. -/
 theorem foldl_add_neg (xs : List α) (f : α → R) (z : R) :
@@ -222,6 +228,12 @@ theorem foldl_add_neg (xs : List α) (f : α → R) (z : R) :
     simp only [List.foldl_cons]
     rw [show -z + -f x = -(z + f x) by grind]
     exact ih (z + f x)
+
+end Ring
+
+section Semiring
+
+variable [Lean.Grind.Semiring R]
 
 /-! # Additivity -/
 
@@ -259,6 +271,14 @@ theorem foldl_add_add (xs : List α) (f g : α → R) :
     _ = xs.foldl (fun acc x => acc + f x) 0 + xs.foldl (fun acc x => acc + g x) 0 :=
         foldl_add_add_start xs f g 0 0
 
+end Semiring
+
+section Ring
+
+variable [Lean.Grind.Ring R]
+
+/-! # Subtraction -/
+
 /-- An additive fold-sum of a pointwise difference splits into the difference
 of the two fold-sums, distributing the starting accumulator. -/
 theorem foldl_add_sub (xs : List α) (f g : α → R) (a b : R) :
@@ -279,6 +299,12 @@ theorem foldl_add_sub_zero (xs : List α) (f g : α → R) :
       xs.foldl (fun acc x => acc + f x) 0 - xs.foldl (fun acc x => acc + g x) 0 := by
   have h := foldl_add_sub xs f g 0 0
   rwa [show (0 : R) - 0 = 0 by grind] at h
+
+end Ring
+
+section Semiring
+
+variable [Lean.Grind.Semiring R]
 
 /-! # Fubini -/
 
@@ -325,7 +351,7 @@ theorem foldl_add_comm {γ : Type w} (xs : List α) (ys : List γ) (f : α → �
         (fun y => xs.foldl (fun acc' x' => acc' + f x' y) 0)
     rw [hLHS, hRHS, ih]
 
-end Ring
+end Semiring
 
 section CommRing
 
@@ -361,7 +387,7 @@ theorem foldl_add_flatMap [Add R] {γ : Type w}
 
 /-- An additive fold-sum over a `Nodup` list whose summand is supported at a
 single matching element collects exactly that summand. -/
-theorem foldl_add_single [Lean.Grind.CommRing R] [DecidableEq α]
+theorem foldl_add_single [Lean.Grind.Semiring R] [DecidableEq α]
     (xs : List α) (z : R) (q : α) (f : α → R)
     (hmem : q ∈ xs) (hnodup : xs.Nodup) :
     xs.foldl (fun acc x => acc + (if x = q then f x else 0)) z = z + f q := by

--- a/HexBasic/ModuleBoundaryTests.lean
+++ b/HexBasic/ModuleBoundaryTests.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexBasic.ArrayDecEq
+public import HexBasic.ExtTreeMap
 public import HexBasic.OfFn
 
 open scoped Hex   -- kernel-reducible Array/Vector equality; see HexBasic.ArrayDecEq
@@ -23,6 +24,10 @@ a same-module test passes whether or not the workaround is present and proves
 nothing. Without the workarounds, the examples fail against core's
 {name}`Array.instDecidableEq`, {name}`Vector`'s derived instance, or
 {name}`Array.ofFn`.
+
+The final section also checks that the exposed `ExtTreeMap` merge/traversal
+closure remains kernel-reducible after crossing a module boundary; retain it
+when the array/vector workarounds are eventually removed.
 -/
 
 namespace Hex.ModuleBoundaryTests
@@ -59,6 +64,43 @@ An exponent vector built with `ofFn'` and compared for equality. -/
 example :
     (Vector.ofFn' (n := 3) (fun j => if j = 1 then 1 else 0) : Vector Nat 3)
       ≠ Vector.ofFn' (fun j => if j = 2 then 1 else 0) := by
+  decide +kernel
+
+/-! # `ExtTreeMap` joint traversal and size-biased merge -/
+
+example :
+    Std.ExtTreeMap.foldl₂
+        (fun acc key left right => acc ++ [(key, left, right)])
+        []
+        (Std.ExtTreeMap.ofList [(0, 10), (2, 12)] compare)
+        (Std.ExtTreeMap.ofList [(1, 21), (2, 22), (3, 23)] compare) =
+      [(0, some 10, none), (1, none, some 21), (2, some 12, some 22),
+        (3, none, some 23)] := by
+  decide +kernel
+
+/-- Joint traversal also drains a nonempty left tail after the right side is
+exhausted. -/
+example :
+    Std.ExtTreeMap.foldl₂
+        (fun acc key left right => acc ++ [(key, left, right)])
+        []
+        (Std.ExtTreeMap.ofList [(0, 10), (5, 15)] compare)
+        (Std.ExtTreeMap.ofList [(1, 21)] compare) =
+      [(0, some 10, none), (1, none, some 21), (5, some 15, none)] := by
+  decide +kernel
+
+/-- The left value stays first when the left map is smaller. -/
+example :
+    (Std.ExtTreeMap.mergeWith? (fun _ left _ => some left)
+      (Std.ExtTreeMap.ofList [(1, 10)] compare)
+      (Std.ExtTreeMap.ofList [(1, 20), (2, 20)] compare))[1]? = some 10 := by
+  decide +kernel
+
+/-- The left value stays first when the right map is smaller. -/
+example :
+    (Std.ExtTreeMap.mergeWith? (fun _ left _ => some left)
+      (Std.ExtTreeMap.ofList [(0, 10), (1, 10)] compare)
+      (Std.ExtTreeMap.ofList [(1, 20)] compare))[1]? = some 10 := by
   decide +kernel
 
 end Hex.ModuleBoundaryTests

--- a/HexMvPoly/Basic.lean
+++ b/HexMvPoly/Basic.lean
@@ -6,7 +6,7 @@ Authors: Kim Morrison
 
 module
 
-public import Batteries.Data.List.Perm
+public import HexBasic.ListShim
 public import HexMvPoly.Mono
 
 @[expose] public section

--- a/HexMvPoly/Basic.lean
+++ b/HexMvPoly/Basic.lean
@@ -78,11 +78,30 @@ theorem monomials_nodup (p : MvPoly n R cmp) : p.monomials.Nodup := by
   rw [Std.ExtTreeMap.map_fst_toList_eq_keys]
   exact p.termsInternal.nodup_keys
 
-@[simp] theorem mem_monomials_iff (m : Mono n) (p : MvPoly n R cmp) :
+theorem mem_monomials_iff_isSome (m : Mono n) (p : MvPoly n R cmp) :
     m ∈ p.monomials ↔ (p.coeff? m).isSome := by
   unfold monomials termsList coeff?
   rw [Std.ExtTreeMap.map_fst_toList_eq_keys, Std.ExtTreeMap.mem_keys,
     Std.ExtTreeMap.mem_iff_isSome_getElem?]
+
+@[simp] theorem mem_monomials_iff (m : Mono n) (p : MvPoly n R cmp) :
+    m ∈ p.monomials ↔ coeff m p ≠ 0 := by
+  rw [mem_monomials_iff_isSome]
+  unfold coeff
+  cases hcoeff : coeff? m p with
+  | none => simp
+  | some c =>
+      have hc : c ≠ 0 := by
+        intro hzero
+        apply p.nonzeroInternal m
+        unfold coeff? at hcoeff
+        simpa [hzero] using hcoeff
+      simp [hc]
+
+@[simp] theorem mem_support_iff (m : Mono n) (p : MvPoly n R cmp) :
+    m ∈ p.support ↔ coeff m p ≠ 0 := by
+  unfold support
+  exact mem_monomials_iff m p
 
 /-- A monomial outside the canonical support has coefficient zero. -/
 theorem coeff_eq_zero_of_not_mem (m : Mono n) (p : MvPoly n R cmp)
@@ -93,7 +112,7 @@ theorem coeff_eq_zero_of_not_mem (m : Mono n) (p : MvPoly n R cmp)
   | none => rfl
   | some c =>
       exfalso
-      exact h ((mem_monomials_iff m p).mpr (by simp [hcoeff]))
+      exact h ((mem_monomials_iff_isSome m p).mpr (by simp [hcoeff]))
 
 /-- A stored term carries exactly the coefficient returned by lookup. -/
 theorem coeff_eq_of_mem_terms (p : MvPoly n R cmp) {m : Mono n} {c : R}

--- a/HexMvPoly/Basic.lean
+++ b/HexMvPoly/Basic.lean
@@ -72,6 +72,39 @@ def monomials (p : MvPoly n R cmp) : List (Mono n) :=
 def support (p : MvPoly n R cmp) : List (Mono n) :=
   monomials p
 
+/-- The canonical support enumeration contains no duplicate monomials. -/
+theorem monomials_nodup (p : MvPoly n R cmp) : p.monomials.Nodup := by
+  unfold monomials termsList
+  rw [Std.ExtTreeMap.map_fst_toList_eq_keys]
+  exact p.termsInternal.nodup_keys
+
+@[simp] theorem mem_monomials_iff (m : Mono n) (p : MvPoly n R cmp) :
+    m ∈ p.monomials ↔ (p.coeff? m).isSome := by
+  unfold monomials termsList coeff?
+  rw [Std.ExtTreeMap.map_fst_toList_eq_keys, Std.ExtTreeMap.mem_keys,
+    Std.ExtTreeMap.mem_iff_isSome_getElem?]
+
+/-- A monomial outside the canonical support has coefficient zero. -/
+theorem coeff_eq_zero_of_not_mem (m : Mono n) (p : MvPoly n R cmp)
+    (h : m ∉ p.monomials) :
+    coeff m p = 0 := by
+  unfold coeff
+  cases hcoeff : coeff? m p with
+  | none => rfl
+  | some c =>
+      exfalso
+      exact h ((mem_monomials_iff m p).mpr (by simp [hcoeff]))
+
+/-- A stored term carries exactly the coefficient returned by lookup. -/
+theorem coeff_eq_of_mem_terms (p : MvPoly n R cmp) {m : Mono n} {c : R}
+    (h : (m, c) ∈ p.termsList) :
+    coeff m p = c := by
+  unfold termsList at h
+  have hcoeff := Std.ExtTreeMap.mem_toList_iff_getElem?_eq_some.mp h
+  unfold coeff coeff?
+  rw [hcoeff]
+  rfl
+
 /-- Number of nonzero terms. -/
 @[inline] def termCount (p : MvPoly n R cmp) : Nat :=
   p.termsInternal.size

--- a/HexMvPoly/Mono.lean
+++ b/HexMvPoly/Mono.lean
@@ -7,8 +7,8 @@ Authors: Kim Morrison
 module
 
 public import HexBasic.ArrayDecEq
+public import HexBasic.ExtTreeMap
 public import HexBasic.OfFn
-public import Std.Data.ExtTreeMap.Lemmas
 
 @[expose] public section
 

--- a/HexMvPoly/Mono.lean
+++ b/HexMvPoly/Mono.lean
@@ -264,6 +264,14 @@ instance (priority := 100) instGrevlexOrder : IsMonomialOrder (@grevlex n) := by
     (prepend e m)[i.succ] = m[i] := by
   simp [prepend]
 
+@[simp] theorem dropHead_prepend (e : Nat) (m : Mono n) :
+    dropHead (prepend e m) = m := by
+  apply Vector.ext
+  intro i hi
+  let j : Fin n := ⟨i, hi⟩
+  change (dropHead (prepend e m))[j] = m[j]
+  rw [getElem_dropHead, getElem_prepend_succ]
+
 theorem prepend_head_dropHead (m : Mono (n + 1)) :
     prepend m.head (dropHead m) = m := by
   apply Vector.ext
@@ -533,6 +541,40 @@ theorem splits_mem_iff (m a b : Mono n) :
           (prepend a.head (dropHead a),
             prepend (m.head - a.head) (dropHead b)) = (a, b)
         rw [hb, prepend_head_dropHead, prepend_head_dropHead]
+
+/-- Every monomial decomposition occurs exactly once in `splits`. -/
+theorem splits_nodup (m : Mono n) : (splits m).Nodup := by
+  induction n with
+  | zero =>
+      simp [splits]
+  | succ n ih =>
+      unfold splits
+      unfold List.Nodup
+      rw [List.pairwise_flatMap]
+      constructor
+      · intro k hk
+        apply (ih (dropHead m)).map
+          (fun ab =>
+            (prepend k ab.1, prepend (m.head - k) ab.2))
+        intro x y hxy h
+        apply hxy
+        apply Prod.ext
+        · have hleft :=
+            congrArg (fun z : Mono (n + 1) × Mono (n + 1) => dropHead z.1) h
+          simpa using hleft
+        · have hright :=
+            congrArg (fun z : Mono (n + 1) × Mono (n + 1) => dropHead z.2) h
+          simpa using hright
+      · apply List.nodup_range.imp
+        intro k l hkl x hx y hy hxy
+        rcases List.mem_map.mp hx with ⟨⟨a, b⟩, hab, rfl⟩
+        rcases List.mem_map.mp hy with ⟨⟨c, d⟩, hcd, rfl⟩
+        apply hkl
+        have hhead :=
+          congrArg
+            (fun z : Mono (n + 1) × Mono (n + 1) => z.1[0])
+            hxy
+        simpa using hhead
 
 theorem dvd_lcm_left (a b : Mono n) : dvd a (lcm a b) = true := by
   simp only [dvd, decide_eq_true_eq]

--- a/HexMvPoly/Operations.lean
+++ b/HexMvPoly/Operations.lean
@@ -26,11 +26,29 @@ variable {n : Nat} {R : Type u} {cmp : Mono n → Mono n → Ordering}
 
 /-- Polynomial addition, combining equal monomials and deleting cancellations. -/
 def add [Lean.Grind.Semiring R] [DecidableEq R]
-    (p q : MvPoly n R cmp) : MvPoly n R cmp :=
-  if p.termCount < q.termCount then
-    p.foldTerms (fun acc m c => acc.addMonomial m c) q
-  else
-    q.foldTerms (fun acc m c => acc.addMonomial m c) p
+    (p q : MvPoly n R cmp) : MvPoly n R cmp where
+  termsInternal :=
+    p.termsInternal.mergeWith?
+      (fun _ a b =>
+        let c := a + b
+        if c = 0 then none else some c)
+      q.termsInternal
+  nonzeroInternal := by
+    intro m
+    rw [Std.ExtTreeMap.getElem?_mergeWith?]
+    cases hp : p.termsInternal[m]? with
+    | none =>
+        cases hq : q.termsInternal[m]? with
+        | none => simp [Std.ExtTreeMap.mergeValue?]
+        | some b =>
+            simpa [Std.ExtTreeMap.mergeValue?, hq] using q.nonzeroInternal m
+    | some a =>
+        cases hq : q.termsInternal[m]? with
+        | none =>
+            simpa [Std.ExtTreeMap.mergeValue?, hp] using p.nonzeroInternal m
+        | some b =>
+            simp only [Std.ExtTreeMap.mergeValue?]
+            split <;> simp_all
 
 instance [Lean.Grind.Semiring R] [DecidableEq R] :
     Add (MvPoly n R cmp) where
@@ -106,53 +124,14 @@ instance [Lean.Grind.Semiring R] [DecidableEq R] :
 theorem coeff_add [Lean.Grind.Semiring R] [DecidableEq R]
     (m : Mono n) (p q : MvPoly n R cmp) :
     coeff m (p + q) = coeff m p + coeff m q := by
-  have aux : ∀ (ts : List (Mono n × R)) (init : MvPoly n R cmp),
-      coeff m (ts.foldl (fun acc t => acc.addMonomial t.1 t.2) init) =
-        (ts.filter (fun t => t.1 = m)).foldl
-          (fun acc t => acc + t.2) (coeff m init) := by
-    intro ts
-    induction ts with
-    | nil =>
-      intro init
-      rfl
-    | cons t ts ih =>
-      intro init
-      rw [List.foldl_cons, ih]
-      by_cases ht : t.1 = m
-      · simp [ht, coeff_addMonomial]
-      · have hmt : m ≠ t.1 := fun h => ht h.symm
-        simp [ht, hmt, coeff_addMonomial]
-  have fold_start : ∀ (ts : List (Mono n × R)) (a : R),
-      ts.foldl (fun acc t => acc + t.2) a =
-        a + ts.foldl (fun acc t => acc + t.2) 0 := by
-    intro ts
-    induction ts with
-    | nil =>
-      intro a
-      exact (Lean.Grind.AddCommMonoid.add_zero a).symm
-    | cons t ts ih =>
-      intro a
-      rw [List.foldl_cons, ih (a + t.2), List.foldl_cons,
-        ih (0 + t.2)]
-      rw [Lean.Grind.AddCommMonoid.zero_add,
-        Lean.Grind.AddCommMonoid.add_assoc]
-  have hfold (source init : MvPoly n R cmp) :
-      coeff m
-          (source.termsInternal.foldl
-            (fun acc key value => acc.addMonomial key value) init) =
-        coeff m init + coeff m source := by
-    rw [Std.ExtTreeMap.foldl_eq_foldl_toList, aux, fold_start]
-    have hs :
-      (source.termsInternal.toList.filter (fun t => t.1 = m)).foldl
-          (fun acc t => acc + t.2) 0 =
-        coeff m source := by
-      simpa [termsList] using coeff_terms m source
-    rw [hs]
-  change coeff m (add p q) = coeff m p + coeff m q
-  unfold add foldTerms
-  split
-  · rw [hfold, Lean.Grind.AddCommMonoid.add_comm]
-  · rw [hfold]
+  change ((add p q).termsInternal[m]?).getD 0 =
+    p.termsInternal[m]?.getD 0 + q.termsInternal[m]?.getD 0
+  unfold add
+  rw [Std.ExtTreeMap.getElem?_mergeWith?]
+  cases p.termsInternal[m]? <;> cases q.termsInternal[m]? <;>
+    simp [Std.ExtTreeMap.mergeValue?, Lean.Grind.AddCommMonoid.zero_add,
+      Lean.Grind.AddCommMonoid.add_zero] <;>
+    split <;> simp_all
 
 theorem coeff_neg [Lean.Grind.Ring R] (m : Mono n) (p : MvPoly n R cmp) :
     coeff m (-p) = -coeff m p := by

--- a/HexMvPoly/Operations.lean
+++ b/HexMvPoly/Operations.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+public import HexBasic.Fold
 public import HexMvPoly.Basic
 
 @[expose] public section
@@ -153,7 +154,137 @@ theorem coeff_mul [Lean.Grind.Semiring R] [DecidableEq R]
     coeff m (p * q) =
       (Mono.splits m).foldl
         (fun acc ab => acc + coeff ab.1 p * coeff ab.2 q) 0 := by
-  sorry
+  let pairs : List ((Mono n × R) × (Mono n × R)) :=
+    p.termsList.flatMap fun pt => q.termsList.map fun qt => (pt, qt)
+  have hmul :
+      mul p q =
+        ofTerms (pairs.map fun t =>
+          (Mono.mul t.1.1 t.2.1, t.1.2 * t.2.2)) := by
+    unfold mul ofTerms foldTerms pairs termsList
+    simp only [Std.ExtTreeMap.foldl_eq_foldl_toList, List.foldl_map,
+      List.foldl_flatMap]
+  have hpairsCoeff :
+      coeff m (mul p q) =
+        pairs.foldl
+          (fun acc t =>
+            acc + if Mono.mul t.1.1 t.2.1 = m then t.1.2 * t.2.2 else 0)
+          0 := by
+    rw [hmul, coeff_ofTerms, List.foldl_filter, List.foldl_map]
+    apply List.foldl_congr
+    intro acc t ht
+    by_cases hterm : Mono.mul t.1.1 t.2.1 = m <;>
+      simp [hterm, Lean.Grind.AddCommMonoid.add_zero]
+  let keyPairs : List (Mono n × Mono n) :=
+    pairs.map fun t => (t.1.1, t.2.1)
+  have hpairsKeys :
+      pairs.foldl
+          (fun acc t =>
+            acc + if Mono.mul t.1.1 t.2.1 = m then t.1.2 * t.2.2 else 0)
+          0 =
+        keyPairs.foldl
+          (fun acc ab =>
+            acc + if Mono.mul ab.1 ab.2 = m then
+              coeff ab.1 p * coeff ab.2 q
+            else 0)
+          0 := by
+    unfold keyPairs
+    rw [List.foldl_map]
+    apply List.foldl_congr
+    intro acc t ht
+    rcases List.mem_flatMap.mp ht with ⟨pt, hpt, ht⟩
+    rcases List.mem_map.mp ht with ⟨qt, hqt, rfl⟩
+    rw [coeff_eq_of_mem_terms p hpt, coeff_eq_of_mem_terms q hqt]
+  have hkeyPairs :
+      keyPairs =
+        p.monomials.flatMap fun a => q.monomials.map fun b => (a, b) := by
+    have cross (xs ys : List (Mono n × R)) :
+        (xs.flatMap fun x => ys.map fun y => (x, y)).map
+            (fun t => (t.1.1, t.2.1)) =
+          (xs.map Prod.fst).flatMap fun x =>
+            (ys.map Prod.fst).map fun y => (x, y) := by
+      induction xs with
+      | nil => rfl
+      | cons x xs ih =>
+          simp only [List.flatMap_cons, List.map_append, List.map_cons, ih,
+            List.map_map]
+          rfl
+    unfold keyPairs pairs monomials
+    exact cross p.termsList q.termsList
+  have hkeyPairsNodup : keyPairs.Nodup := by
+    rw [hkeyPairs]
+    unfold List.Nodup
+    rw [List.pairwise_flatMap]
+    constructor
+    · intro a ha
+      apply q.monomials_nodup.map (fun b => (a, b))
+      intro b c hbc hpair
+      exact hbc (congrArg Prod.snd hpair)
+    · apply p.monomials_nodup.imp
+      intro a c hac x hx y hy hpair
+      rcases List.mem_map.mp hx with ⟨b, hb, rfl⟩
+      rcases List.mem_map.mp hy with ⟨d, hd, rfl⟩
+      exact hac (congrArg Prod.fst hpair)
+  have mem_keyPairs (a b : Mono n) :
+      (a, b) ∈ keyPairs ↔ a ∈ p.monomials ∧ b ∈ q.monomials := by
+    rw [hkeyPairs]
+    simp
+  let active :=
+    keyPairs.filter fun ab => Mono.mul ab.1 ab.2 = m
+  let splitActive :=
+    (Mono.splits m).filter fun ab =>
+      ab.1 ∈ p.monomials ∧ ab.2 ∈ q.monomials
+  have hactivePerm : active.Perm splitActive := by
+    rw [List.perm_ext_iff_of_nodup
+      (hkeyPairsNodup.filter _)
+      ((Mono.splits_nodup m).filter _)]
+    intro ab
+    simp only [List.mem_filter, decide_eq_true_eq]
+    rw [mem_keyPairs, Mono.splits_mem_iff]
+    constructor
+    · rintro ⟨⟨ha, hb⟩, hmul⟩
+      exact ⟨hmul, ha, hb⟩
+    · rintro ⟨hmul, ha, hb⟩
+      exact ⟨⟨ha, hb⟩, hmul⟩
+  let value (ab : Mono n × Mono n) :=
+    coeff ab.1 p * coeff ab.2 q
+  have hkeyFilter :
+      keyPairs.foldl
+          (fun acc ab =>
+            acc + if Mono.mul ab.1 ab.2 = m then value ab else 0)
+          0 =
+        active.foldl (fun acc ab => acc + value ab) 0 := by
+    unfold active
+    rw [List.foldl_filter]
+    apply List.foldl_congr
+    intro acc ab hab
+    by_cases hmul : Mono.mul ab.1 ab.2 = m <;>
+      simp [hmul, Lean.Grind.AddCommMonoid.add_zero]
+  have hsplitFilter :
+      splitActive.foldl (fun acc ab => acc + value ab) 0 =
+        (Mono.splits m).foldl (fun acc ab => acc + value ab) 0 := by
+    unfold splitActive
+    rw [List.foldl_filter]
+    apply List.foldl_congr
+    intro acc ab hab
+    unfold value
+    by_cases ha : ab.1 ∈ p.monomials
+    · by_cases hb : ab.2 ∈ q.monomials
+      · simp [ha, hb]
+      · rw [coeff_eq_zero_of_not_mem ab.2 q hb,
+          Lean.Grind.Semiring.mul_zero, Lean.Grind.AddCommMonoid.add_zero]
+        simp [ha, hb]
+    · rw [coeff_eq_zero_of_not_mem ab.1 p ha,
+        Lean.Grind.Semiring.zero_mul, Lean.Grind.AddCommMonoid.add_zero]
+      simp [ha]
+  change coeff m (mul p q) = _
+  rw [hpairsCoeff, hpairsKeys]
+  change
+    keyPairs.foldl
+        (fun acc ab =>
+          acc + if Mono.mul ab.1 ab.2 = m then value ab else 0)
+        0 =
+      (Mono.splits m).foldl (fun acc ab => acc + value ab) 0
+  rw [hkeyFilter, List.foldl_add_perm value hactivePerm 0, hsplitFilter]
 
 theorem coeff_pow_succ [Lean.Grind.Semiring R] [DecidableEq R]
     (m : Mono n) (p : MvPoly n R cmp) (k : Nat) :

--- a/HexMvPoly/Operations.lean
+++ b/HexMvPoly/Operations.lean
@@ -6,7 +6,7 @@ Authors: Kim Morrison
 
 module
 
-public import HexBasic.Fold
+import HexBasic.Fold
 public import HexMvPoly.Basic
 
 @[expose] public section

--- a/SPEC/Libraries/hex-mv-poly.md
+++ b/SPEC/Libraries/hex-mv-poly.md
@@ -198,7 +198,7 @@ refers to, so the class and this API have to agree on it. State
 `IsMonomialOrder` in terms of `Mono.mul` rather than a bare `+`. The
 laws worth naming are that `dvd` agrees with the existence of an exact
 quotient, that `div` is a left inverse of `mul` on the divisible case,
-`degree_mul`, `rename_mul`, `splits_mem_iff`, and the `lcm`/`gcd`
+`degree_mul`, `rename_mul`, `splits_mem_iff`, `splits_nodup`, and the `lcm`/`gcd`
 lattice laws, all of which the S-polynomial construction uses.
 
 ## Kernel reduction

--- a/progress/20260729T075513Z_hex-mv-poly-ext-tree-map.md
+++ b/progress/20260729T075513Z_hex-mv-poly-ext-tree-map.md
@@ -1,0 +1,32 @@
+# Hex multivariate polynomial reusable tree-map API
+
+## Accomplished
+
+- Added `HexBasic.ExtTreeMap` as the designated home for reusable,
+  upstream-shaped `Std.ExtTreeMap` operations.
+- Implemented a joint ordered traversal of two maps and a deletion-capable,
+  size-biased merge that preserves callback argument order.
+- Added executable empty-map laws for both APIs.
+- Repointed the monomial layer at the reusable module and removed
+  `HexMvPoly.Basic`'s direct Batteries dependency in favor of
+  `HexBasic.ListShim`.
+
+## Current frontier
+
+- The reusable module and `HexMvPoly.Basic` build cleanly.
+- The initial core API PR is still running its final CI stages with auto-merge
+  enabled.
+- The merge API has its boundary laws; a general per-key lookup theorem remains
+  useful before `MvPoly.add` can consume it without weakening the canonical
+  nonzero invariant or its size-biased complexity.
+
+## Next step
+
+- Prove the lookup semantics of the generic deletion-capable merge, then
+  refactor polynomial addition onto it.
+- Continue discharging the remaining coefficient and recursive laws after the
+  core PR merges.
+
+## Blockers
+
+- None.

--- a/progress/20260729T080106Z_hex-mv-poly-tree-merge-law.md
+++ b/progress/20260729T080106Z_hex-mv-poly-tree-merge-law.md
@@ -1,0 +1,32 @@
+# Hex multivariate polynomial tree-merge integration
+
+## Accomplished
+
+- Proved the per-key lookup semantics of the generic
+  `Std.ExtTreeMap.mergeWith?` operation.
+- Factored the proof through reusable distinct-source `foldl`/`alter` lemmas,
+  keeping the public specification independent of polynomial details.
+- Refactored `MvPoly.add` to use the size-biased, deletion-capable tree-map
+  merge directly.
+- Reproved `coeff_add` from the generic lookup theorem, substantially
+  simplifying the former list-fold proof.
+- Rebuilt the kernel tests and reran the DAG and published trust-surface
+  checks successfully.
+
+## Current frontier
+
+- Addition now has the intended tree-level implementation and retains the
+  canonical no-explicit-zero invariant without a cleanup traversal.
+- The core API PR has passed all build stages and is running its final
+  conformance/oracle gate.
+- Eleven pre-existing proof obligations remain in the core implementation.
+
+## Next step
+
+- Land the follow-up tree-map/addition commit after the core PR auto-merges and
+  obtain the required independent review before merging its PR.
+- Continue with `coeff_mul` and the monomial split uniqueness infrastructure.
+
+## Blockers
+
+- None.

--- a/progress/20260729T080638Z_hex-mv-poly-splits-nodup.md
+++ b/progress/20260729T080638Z_hex-mv-poly-splits-nodup.md
@@ -1,0 +1,28 @@
+# Hex multivariate polynomial split uniqueness
+
+## Accomplished
+
+- Proved `Mono.dropHead_prepend`, the inverse needed to reason about the
+  recursive split encoding.
+- Proved `Mono.splits_nodup` by showing each recursive block is injective and
+  different head-exponent blocks are disjoint.
+- Confirmed the initial core API PR passed its full CI pipeline and
+  auto-merged.
+
+## Current frontier
+
+- `Mono.splits` now characterizes every factorization and enumerates each one
+  exactly once.
+- The follow-up tree-map work is ready to rebase onto the squash-merged core.
+- The remaining multiplication coefficient proof can now use permutation and
+  single-indicator fold arguments soundly.
+
+## Next step
+
+- Rebase the follow-up branch onto current `main`.
+- Finish `coeff_mul`, using the new split uniqueness theorem and reusable
+  additive fold algebra.
+
+## Blockers
+
+- None.

--- a/progress/20260729T081738Z_hex-mv-poly-coeff-mul.md
+++ b/progress/20260729T081738Z_hex-mv-poly-coeff-mul.md
@@ -1,0 +1,32 @@
+# Hex multivariate polynomial multiplication coefficient law
+
+## Accomplished
+
+- Proved `coeff_mul` for arbitrary `Lean.Grind.Semiring` coefficients.
+- Connected the executable Gustavson traversal to its flattened list of
+  stored term pairs, then to the canonical support-pair enumeration.
+- Proved the active support pairs are a permutation of the supported entries
+  in `Mono.splits`, using split uniqueness and support-list uniqueness.
+- Added reusable support/lookup lemmas to `MvPoly.Basic`.
+- Generalized additive-only `HexBasic.Fold` lemmas from ring hypotheses to
+  semiring hypotheses, matching the algebra they actually use.
+- Rebuilt kernel tests and passed DAG, release-manifest, trust-surface, and
+  Phase 4 checks.
+
+## Current frontier
+
+- The core implementation now has ten remaining proof obligations; the
+  multiplication convolution is no longer one of them.
+- The follow-up branch contains the reusable tree-map API, addition
+  integration, split uniqueness, and multiplication coefficient proof, all
+  rebased onto current `main`.
+
+## Next step
+
+- Obtain an independent review of this follow-up and open its intermediate PR.
+- While that PR runs, continue with the power recurrence or another independent
+  correctness obligation on a branch based on the follow-up head.
+
+## Blockers
+
+- None.

--- a/progress/20260729T084634Z_hex-mv-poly-followup-review.md
+++ b/progress/20260729T084634Z_hex-mv-poly-followup-review.md
@@ -1,0 +1,35 @@
+# Hex multivariate polynomial follow-up review
+
+## Accomplished
+
+- Obtained two independent reviews of the reusable tree-map/addition and
+  multiplication-coefficient follow-up.
+- Verified the proof content was accepted as sound for noncommutative
+  semirings and addressed all concrete pre-merge findings.
+- Nested and documented the joint-traversal worker's sorted-stream contract,
+  documented the actual upstream deletion requirement for duplicate
+  definitions, and explained why size bias needs `LawfulEqCmp`.
+- Added module-boundary kernel tests for joint interleaving, both exhausted-tail
+  cases, and callback argument order in both size branches.
+- Normalized support membership lemmas to `coeff m p ≠ 0`, retained the
+  internal `isSome` bridge, and added the `support` companion.
+- Generalized the remaining additive/multiplicative fold lemmas to their honest
+  `Semiring`/`CommSemiring` hypotheses.
+- Audited the new main proofs with `#print axioms`; each uses only `propext`,
+  `Classical.choice`, and `Quot.sound`, with no `sorryAx`.
+
+## Current frontier
+
+- The reviewed follow-up is green under `HexMvPolyTests` and all static release
+  checks and is ready for an intermediate PR.
+- Ten implementation proof obligations remain after `coeff_mul`.
+
+## Next step
+
+- Open the reviewed follow-up PR with auto-merge after CI.
+- Continue proving the power recurrence and remaining semantic/recursive laws
+  from the reviewed follow-up head while CI runs.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
## Summary

- add an upstream-shaped `HexBasic.ExtTreeMap` module with joint ordered traversal and a deletion-capable, size-biased merge
- prove the generic merge lookup law and use it for canonical `MvPoly.add`
- prove `Mono.splits_nodup` and the noncommutative-semiring `coeff_mul` convolution law
- broaden reusable additive fold lemmas to their honest semiring bounds
- add module-boundary kernel tests for joint traversal and both merge size branches

## Verification

- `lake build HexBasic.Fold HexBasic.ModuleBoundaryTests HexMvPolyTests`
- `python3 scripts/check_dag.py`
- `python3 scripts/release/check_released_manifest.py`
- `python3 scripts/release/check_trust_surface.py`
- `python3 scripts/check_phase4.py`
- `#print axioms` on `coeff_mul`, `coeff_add`, `splits_nodup`, and `getElem?_mergeWith?`: only `propext`, `Classical.choice`, and `Quot.sound`
- two independent pre-merge reviews, including a focused re-review after fixes
