### PR TITLE
feat(mvpoly): prove recursive view round trips

### DIFF
--- a/HexMvPoly/KernelTests.lean
+++ b/HexMvPoly/KernelTests.lean
@@ -113,9 +113,38 @@ example :
     evalHorner (fun i => if i = 0 then 2 else 3) outerGap = 68 := by
   decide +kernel
 
-example :
+theorem splitFirst_roundtrip :
     ofUnivariate (cmp := Mono.grevlex) 0 Mono.lex
       (toUnivariate 0 Mono.lex q) = q := by
+  decide +kernel
+
+theorem splitLast_roundtrip :
+    ofUnivariate (cmp := Mono.grevlex) 1 Mono.lex
+      (toUnivariate 1 Mono.lex q) = q := by
+  decide +kernel
+
+@[expose] def gapCoeffs : DensePoly (MvPoly 1 Rat Mono.lex) :=
+  DensePoly.ofList [C 2 + X 0, 0, C 3]
+
+theorem gapCoeffs_roundtrip :
+    toUnivariate 1 Mono.lex
+        (ofUnivariate (cmp := Mono.grevlex) 1 Mono.lex gapCoeffs) =
+      gapCoeffs := by
+  decide +kernel
+
+abbrev P3 := MvPoly 3 Int Mono.lex
+
+@[expose] def middleSplit : P3 :=
+  ofTerms [(#v[2, 3, 4], 5), (#v[0, 1, 2], -7), (Mono.zero, 11)]
+
+theorem middleSplit_roundtrip :
+    ofUnivariate (cmp := Mono.lex) 1 Mono.grevlex
+      (toUnivariate 1 Mono.grevlex middleSplit) = middleSplit := by
+  decide +kernel
+
+theorem zero_roundtrip :
+    ofUnivariate (cmp := Mono.grevlex) 1 Mono.lex
+      (toUnivariate 1 Mono.lex (0 : QP)) = 0 := by
   decide +kernel
 
 abbrev P0 := MvPoly 0 Int Mono.lex
@@ -128,8 +157,40 @@ example : evalHorner (fun i => nomatch i) (C 7 : P0) = 7 := by
 
 abbrev P1 := MvPoly 1 Int Mono.lex
 
+theorem oneVar_roundtrip :
+    ofUnivariate (cmp := Mono.lex) 0 Mono.lex
+      (toUnivariate 0 Mono.lex ((X 0 : P1) * X 0 + C 7)) =
+        (X 0 : P1) * X 0 + C 7 := by
+  decide +kernel
+
 example : (X 0 : P1) * X 0 = monomial
     (Mono.succAt 0 (Mono.unit 0)) 1 := by
   decide +kernel
+
+/-! # Axiom hygiene -/
+
+/-- info: 'Hex.MvPoly.KernelTests.splitFirst_roundtrip' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms splitFirst_roundtrip
+
+/-- info: 'Hex.MvPoly.KernelTests.splitLast_roundtrip' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms splitLast_roundtrip
+
+/-- info: 'Hex.MvPoly.KernelTests.gapCoeffs_roundtrip' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms gapCoeffs_roundtrip
+
+/-- info: 'Hex.MvPoly.KernelTests.middleSplit_roundtrip' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms middleSplit_roundtrip
+
+/-- info: 'Hex.MvPoly.KernelTests.zero_roundtrip' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms zero_roundtrip
+
+/-- info: 'Hex.MvPoly.KernelTests.oneVar_roundtrip' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms oneVar_roundtrip
 
 end Hex.MvPoly.KernelTests

--- a/HexMvPoly/Recursive.lean
+++ b/HexMvPoly/Recursive.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+import HexBasic.Fold
 public import HexMvPoly.Structural
 public import HexPoly
 
@@ -42,27 +43,161 @@ def insertVar (i : Fin (n + 1)) (e : Nat) (m : Mono n) : Mono (n + 1) :=
     else
       m[(⟨j.val - 1, by omega⟩ : Fin n)]
 
+@[simp] theorem degreeOf_insertVar
+    (i : Fin (n + 1)) (e : Nat) (m : Mono n) :
+    Mono.degreeOf i (insertVar i e m) = e := by
+  simp [Mono.degreeOf, insertVar]
+
+@[simp] theorem removeVar_insertVar
+    (i : Fin (n + 1)) (e : Nat) (m : Mono n) :
+    removeVar i (insertVar i e m) = m := by
+  apply Vector.ext
+  intro j
+  intro hj
+  by_cases hlt : j < i.val
+  · have hne : j ≠ i.val := Nat.ne_of_lt hlt
+    simp [removeVar, insertVar, hlt, hne]
+  · have hne : j + 1 ≠ i.val := by omega
+    have hnlt : ¬ j + 1 < i.val := by omega
+    simp [removeVar, insertVar, hlt, hne, hnlt]
+
+@[simp] theorem insertVar_removeVar
+    (i : Fin (n + 1)) (m : Mono (n + 1)) :
+    insertVar i (Mono.degreeOf i m) (removeVar i m) = m := by
+  apply Vector.ext
+  intro j
+  intro hj
+  by_cases heq : j = i.val
+  · simp [insertVar, Mono.degreeOf, heq]
+  · by_cases hlt : j < i.val
+    · simp [insertVar, removeVar, heq, hlt]
+    · have hnlt : ¬ j - 1 < i.val := by omega
+      have hsucc : j - 1 + 1 = j := by omega
+      simp [insertVar, removeVar, heq, hlt, hnlt, hsucc]
+
+theorem insertVar_inj (i : Fin (n + 1)) (e d : Nat) (m k : Mono n) :
+    insertVar i e m = insertVar i d k ↔ e = d ∧ m = k := by
+  constructor
+  · intro h
+    constructor
+    · simpa only [degreeOf_insertVar] using congrArg (Mono.degreeOf i) h
+    · simpa only [removeVar_insertVar] using congrArg (removeVar i) h
+  · rintro ⟨rfl, rfl⟩
+    rfl
+
+/-- Array length needed to accumulate every exponent bucket. -/
+def toUnivariateSize (i : Fin (n + 1))
+    (terms : List (Mono (n + 1) × R)) : Nat :=
+  terms.foldl
+    (fun bound term => max bound (Mono.degreeOf i term.1 + 1)) 0
+
+/-- Accumulate one source term into its dense univariate coefficient bucket.
+The caller must ensure that the term's selected degree is below `coeffs.size`;
+otherwise `Array.set!` leaves the array unchanged. -/
+def toUnivariateStep [Lean.Grind.Semiring R] [DecidableEq R]
+    [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp']
+    (i : Fin (n + 1)) (coeffs : Array (MvPoly n R cmp'))
+    (term : Mono (n + 1) × R) : Array (MvPoly n R cmp') :=
+  let e := Mono.degreeOf i term.1
+  let c := (coeffs.getD e 0).addMonomial (removeVar i term.1) term.2
+  coeffs.set! e c
+
+/-- Dense coefficient array obtained by two linear passes over sparse terms:
+one to determine the array size and one to populate its buckets. -/
+def toUnivariateCoeffs [Lean.Grind.Semiring R] [DecidableEq R]
+    [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp']
+    (i : Fin (n + 1)) (terms : List (Mono (n + 1) × R)) :
+    Array (MvPoly n R cmp') :=
+  terms.foldl
+    (fun coeffs term => toUnivariateStep (cmp' := cmp') i coeffs term)
+    (Array.replicate (toUnivariateSize i terms) 0)
+
+private theorem degreeOf_lt_size (i : Fin (n + 1))
+    (terms : List (Mono (n + 1) × R)) {term : Mono (n + 1) × R}
+    (hterm : term ∈ terms) :
+    Mono.degreeOf i term.1 < toUnivariateSize i terms := by
+  have hbound :=
+    List.le_foldl_max_of_mem terms
+      (fun term => Mono.degreeOf i term.1 + 1) (init := 0) hterm
+  unfold toUnivariateSize
+  omega
+
+@[simp] private theorem size_toUnivariateStep
+    [Lean.Grind.Semiring R] [DecidableEq R]
+    [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp']
+    (i : Fin (n + 1)) (coeffs : Array (MvPoly n R cmp'))
+    (term : Mono (n + 1) × R) :
+    (toUnivariateStep (cmp' := cmp') i coeffs term).size = coeffs.size := by
+  simp [toUnivariateStep]
+
+private theorem getD_toUnivariateStep
+    [Lean.Grind.Semiring R] [DecidableEq R]
+    [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp']
+    (i : Fin (n + 1)) (coeffs : Array (MvPoly n R cmp'))
+    (term : Mono (n + 1) × R) (e : Nat)
+    (hbound : Mono.degreeOf i term.1 < coeffs.size) :
+    (toUnivariateStep (cmp' := cmp') i coeffs term).getD e 0 =
+      if Mono.degreeOf i term.1 = e then
+        (coeffs.getD e 0).addMonomial (removeVar i term.1) term.2
+      else
+        coeffs.getD e 0 := by
+  by_cases heq : Mono.degreeOf i term.1 = e
+  · subst e
+    simp [toUnivariateStep, Array.getD, hbound]
+  · by_cases he : e < coeffs.size
+    · unfold Array.getD
+      simp [toUnivariateStep, Array.set!_eq_setIfInBounds, hbound, he, heq]
+    · unfold Array.getD
+      simp [toUnivariateStep, Array.set!_eq_setIfInBounds, hbound, he, heq]
+
+private theorem coeff_foldSteps
+    [Lean.Grind.Semiring R] [DecidableEq R]
+    [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp']
+    (i : Fin (n + 1)) (allTerms terms : List (Mono (n + 1) × R))
+    (hterms : terms ⊆ allTerms) (coeffs : Array (MvPoly n R cmp'))
+    (hsize : coeffs.size = toUnivariateSize i allTerms)
+    (e : Nat) (m : Mono n) :
+    coeff m
+        ((terms.foldl
+          (fun coeffs term =>
+            toUnivariateStep (cmp' := cmp') i coeffs term)
+          coeffs).getD e 0) =
+      terms.foldl
+        (fun acc term =>
+          if Mono.degreeOf i term.1 = e then
+            if m = removeVar i term.1 then acc + term.2 else acc
+          else acc)
+        (coeff m (coeffs.getD e 0)) := by
+  induction terms generalizing coeffs with
+  | nil => rfl
+  | cons term terms ih =>
+      simp only [List.foldl_cons]
+      have hmem : term ∈ allTerms :=
+        hterms (List.mem_cons_self ..)
+      have htail : terms ⊆ allTerms :=
+        fun _ h => hterms (List.mem_cons_of_mem term h)
+      have hbound : Mono.degreeOf i term.1 < coeffs.size := by
+        rw [hsize]
+        exact degreeOf_lt_size i allTerms hmem
+      rw [ih htail _ (size_toUnivariateStep i coeffs term |>.trans hsize)]
+      rw [getD_toUnivariateStep i coeffs term e hbound]
+      by_cases heq : Mono.degreeOf i term.1 = e
+      · rw [if_pos heq, if_pos heq, coeff_addMonomial]
+      · rw [if_neg heq, if_neg heq]
+
 /-- Coefficients of `p` as a dense univariate polynomial in variable `i`.
 Each coefficient is a polynomial in the remaining `n` variables. -/
 def toUnivariate [Lean.Grind.Semiring R] [DecidableEq R]
     (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
-    [IsMonomialOrder cmp']
+    [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp']
     (p : MvPoly (n + 1) R cmp) : DensePoly (MvPoly n R cmp') :=
   let terms := p.termsList
-  let size := terms.foldl
-    (fun bound term => max bound (Mono.degreeOf i term.1 + 1)) 0
-  DensePoly.ofCoeffs <| Id.run do
-    let mut coeffs : Array (MvPoly n R cmp') := Array.replicate size 0
-    for term in terms do
-      let e := Mono.degreeOf i term.1
-      let c := monomial (removeVar i term.1) term.2
-      coeffs := coeffs.set! e (coeffs[e]! + c)
-    return coeffs
+  DensePoly.ofCoeffs (toUnivariateCoeffs i terms)
 
 /-- Inverse of `toUnivariate`, reinserting variable `i`. -/
 def ofUnivariate [Lean.Grind.Semiring R] [DecidableEq R]
     (i : Fin (n + 1)) (cmp' : Mono n → Mono n → Ordering)
-    [IsMonomialOrder cmp']
+    [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp']
     (q : DensePoly (MvPoly n R cmp')) : MvPoly (n + 1) R cmp :=
   (List.range q.size).foldl
     (fun acc e =>
@@ -72,29 +207,208 @@ def ofUnivariate [Lean.Grind.Semiring R] [DecidableEq R]
     0
 
 theorem toUnivariate_coeff [Lean.Grind.Semiring R] [DecidableEq R]
-    (i : Fin (n + 1)) [IsMonomialOrder cmp']
+    (i : Fin (n + 1)) [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp']
     (p : MvPoly (n + 1) R cmp) (e : Nat) (m : Mono n) :
     coeff m ((toUnivariate i cmp' p).coeff e) =
       coeff (insertVar i e m) p := by
-  sorry
+  unfold toUnivariate
+  rw [DensePoly.coeff_ofCoeffs]
+  unfold toUnivariateCoeffs
+  change
+    coeff m
+        ((p.termsList.foldl
+          (fun coeffs term =>
+            toUnivariateStep (cmp' := cmp') i coeffs term)
+          (Array.replicate (toUnivariateSize i p.termsList) 0)).getD
+            e (0 : MvPoly n R cmp')) =
+      coeff (insertVar i e m) p
+  rw [coeff_foldSteps i p.termsList p.termsList (fun _ h => h)
+    (Array.replicate (toUnivariateSize i p.termsList) 0) (by simp) e m]
+  have hinit :
+      coeff m
+          ((Array.replicate (toUnivariateSize i p.termsList)
+            (0 : MvPoly n R cmp')).getD e 0) = 0 := by
+    simp [Array.getD]
+  rw [hinit]
+  rw [← coeff_terms (insertVar i e m) p, List.foldl_filter]
+  apply List.foldl_congr
+  intro acc term _
+  simp only [decide_eq_true_eq]
+  by_cases hkey : term.1 = insertVar i e m
+  · have hdegree : Mono.degreeOf i term.1 = e := by
+      rw [hkey, degreeOf_insertVar]
+    have hremove : m = removeVar i term.1 := by
+      rw [hkey, removeVar_insertVar]
+    rw [if_pos hdegree, if_pos hremove, if_pos hkey]
+  · by_cases hdegree : Mono.degreeOf i term.1 = e
+    · by_cases hremove : m = removeVar i term.1
+      · have hkey' : term.1 = insertVar i e m := by
+          calc
+            term.1 =
+                insertVar i (Mono.degreeOf i term.1)
+                  (removeVar i term.1) :=
+              (insertVar_removeVar i term.1).symm
+            _ = insertVar i e m := by rw [hdegree, ← hremove]
+        exact (hkey hkey').elim
+      · rw [if_pos hdegree, if_neg hremove, if_neg hkey]
+    · rw [if_neg hdegree, if_neg hkey]
+
+private theorem coeff_foldInsert [Lean.Grind.Semiring R] [DecidableEq R]
+    (i : Fin (n + 1)) [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp']
+    (p : MvPoly n R cmp') (d e : Nat) (m : Mono n)
+    (init : MvPoly (n + 1) R cmp) :
+    coeff (insertVar i e m)
+        (p.foldTerms
+          (fun acc k c => acc.addMonomial (insertVar i d k) c)
+          init) =
+      coeff (insertVar i e m) init +
+        if d = e then coeff m p else 0 := by
+  have aux : ∀ (terms : List (Mono n × R))
+      (init : MvPoly (n + 1) R cmp),
+      coeff (insertVar i e m)
+          (terms.foldl
+            (fun acc term =>
+              acc.addMonomial (insertVar i d term.1) term.2)
+            init) =
+        terms.foldl
+          (fun acc term =>
+            if insertVar i e m = insertVar i d term.1 then
+              acc + term.2
+            else acc)
+          (coeff (insertVar i e m) init) := by
+    intro terms
+    induction terms with
+    | nil =>
+        intro init
+        rfl
+    | cons term terms ih =>
+        intro init
+        simp only [List.foldl_cons]
+        rw [ih, coeff_addMonomial]
+  unfold foldTerms
+  rw [Std.ExtTreeMap.foldl_eq_foldl_toList, aux]
+  change
+    p.termsList.foldl
+        (fun acc term =>
+          if insertVar i e m = insertVar i d term.1 then acc + term.2
+          else acc)
+        (coeff (insertVar i e m) init) =
+      coeff (insertVar i e m) init + if d = e then coeff m p else 0
+  by_cases hde : d = e
+  · subst d
+    rw [if_pos rfl]
+    calc
+      p.termsList.foldl
+          (fun acc term =>
+            if insertVar i e m = insertVar i e term.1 then acc + term.2
+            else acc)
+          (coeff (insertVar i e m) init) =
+          p.termsList.foldl
+            (fun acc term => acc + if term.1 = m then term.2 else 0)
+            (coeff (insertVar i e m) init) := by
+              apply List.foldl_congr
+              intro acc term _
+              by_cases hkey : term.1 = m
+              · have hinsert : insertVar i e m = insertVar i e term.1 := by
+                  rw [hkey]
+                rw [if_pos hinsert, if_pos hkey]
+              · have hinsert : insertVar i e m ≠ insertVar i e term.1 := by
+                  intro h
+                  exact hkey ((insertVar_inj i e e m term.1).mp h).2.symm
+                rw [if_neg hinsert, if_neg hkey,
+                  Lean.Grind.Semiring.add_zero]
+      _ = coeff (insertVar i e m) init +
+          p.termsList.foldl
+            (fun acc term => acc + if term.1 = m then term.2 else 0)
+            0 :=
+        List.foldl_add_eq_add_foldl _ _ _
+      _ = coeff (insertVar i e m) init + coeff m p := by
+        congr 1
+        rw [← coeff_terms m p, List.foldl_filter]
+        apply List.foldl_congr
+        intro acc term _
+        simp only [decide_eq_true_eq]
+        by_cases hkey : term.1 = m
+        · rw [if_pos hkey, if_pos hkey]
+        · rw [if_neg hkey, if_neg hkey,
+            Lean.Grind.Semiring.add_zero]
+  · rw [if_neg hde, Lean.Grind.Semiring.add_zero]
+    calc
+      p.termsList.foldl
+          (fun acc term =>
+            if insertVar i e m = insertVar i d term.1 then acc + term.2
+            else acc)
+          (coeff (insertVar i e m) init) =
+          p.termsList.foldl (fun acc _ => acc)
+            (coeff (insertVar i e m) init) := by
+              apply List.foldl_congr
+              intro acc term _
+              have hinsert : insertVar i e m ≠ insertVar i d term.1 := by
+                intro h
+                exact hde ((insertVar_inj i e d m term.1).mp h).1.symm
+              rw [if_neg hinsert]
+      _ = coeff (insertVar i e m) init :=
+        List.foldl_const_step _ _
 
 theorem ofUnivariate_coeff [Lean.Grind.Semiring R] [DecidableEq R]
-    (i : Fin (n + 1)) [IsMonomialOrder cmp']
+    (i : Fin (n + 1)) [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp']
     (q : DensePoly (MvPoly n R cmp')) (e : Nat) (m : Mono n) :
     coeff (insertVar i e m) (ofUnivariate (cmp := cmp) i cmp' q) =
       coeff m (q.coeff e) := by
-  sorry
+  have coeff_foldIndices : ∀ (indices : List Nat)
+      (init : MvPoly (n + 1) R cmp),
+      coeff (insertVar i e m)
+          (indices.foldl
+            (fun acc d =>
+              (q.coeff d).foldTerms
+                (fun acc k c => acc.addMonomial (insertVar i d k) c)
+                acc)
+            init) =
+        indices.foldl
+          (fun acc d =>
+            acc + if d = e then coeff m (q.coeff d) else 0)
+          (coeff (insertVar i e m) init) := by
+    intro indices
+    induction indices with
+    | nil =>
+        intro init
+        rfl
+    | cons d indices ih =>
+        intro init
+        simp only [List.foldl_cons]
+        rw [ih, coeff_foldInsert]
+  unfold ofUnivariate
+  rw [coeff_foldIndices, coeff_zero]
+  by_cases he : e < q.size
+  · have hsingle := List.foldl_add_single
+        (List.range q.size) (0 : R) e (fun d => coeff m (q.coeff d))
+        (List.mem_range.mpr he) List.nodup_range
+    exact hsingle.trans (by grind)
+  · have hzero : q.coeff e = 0 :=
+      DensePoly.coeff_eq_zero_of_size_le q (Nat.le_of_not_gt he)
+    rw [List.foldl_add_eq_self, hzero, coeff_zero]
+    intro d hd
+    have hdlt : d < q.size := List.mem_range.mp hd
+    have hde : d ≠ e := by omega
+    rw [if_neg hde]
 
 theorem ofUnivariate_toUnivariate [Lean.Grind.Semiring R] [DecidableEq R]
-    (i : Fin (n + 1)) [IsMonomialOrder cmp']
+    (i : Fin (n + 1)) [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp']
     (p : MvPoly (n + 1) R cmp) :
     ofUnivariate (cmp := cmp) i cmp' (toUnivariate i cmp' p) = p := by
-  sorry
+  apply MvPoly.ext
+  intro m
+  rw [← insertVar_removeVar i m, ofUnivariate_coeff,
+    toUnivariate_coeff, insertVar_removeVar]
 
 theorem toUnivariate_ofUnivariate [Lean.Grind.Semiring R] [DecidableEq R]
-    (i : Fin (n + 1)) [IsMonomialOrder cmp']
+    (i : Fin (n + 1)) [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp']
     (q : DensePoly (MvPoly n R cmp')) :
     toUnivariate i cmp' (ofUnivariate (cmp := cmp) i cmp' q) = q := by
-  sorry
+  apply DensePoly.ext_coeff
+  intro e
+  apply MvPoly.ext
+  intro m
+  rw [toUnivariate_coeff, ofUnivariate_coeff]
 
 end Hex.MvPoly

--- a/SPEC/Libraries/hex-mv-poly.md
+++ b/SPEC/Libraries/hex-mv-poly.md
@@ -427,12 +427,14 @@ The recursive view is a separate face on the same data:
 /-- Coefficients of `p` as a univariate polynomial in variable `i`,
 with coefficients in the remaining `n` variables. -/
 def toUnivariate (i : Fin (n+1)) (cmp' : Mono n → Mono n → Ordering)
-    [IsMonomialOrder cmp'] (p : MvPoly (n+1) R cmp) :
+    [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp']
+    (p : MvPoly (n+1) R cmp) :
     DensePoly (MvPoly n R cmp')
 
 /-- Inverse of `toUnivariate`, reinserting variable `i`. -/
 def ofUnivariate (i : Fin (n+1)) (cmp' : Mono n → Mono n → Ordering)
-    [IsMonomialOrder cmp'] (q : DensePoly (MvPoly n R cmp')) :
+    [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp']
+    (q : DensePoly (MvPoly n R cmp')) :
     MvPoly (n+1) R cmp
 ```
 
@@ -442,7 +444,9 @@ excludes the last one and makes the one-variable case `n = 0` have no
 admissible index at all. The reindexing between the remaining `n`
 variables and the original `n+1` is `Fin.succAbove i` and its partial
 inverse, and the comparator on the remaining variables is an explicit
-argument since nothing determines it from `cmp`.
+argument since nothing determines it from `cmp`. These conversions only
+store and traverse terms, so they require the map comparator laws rather
+than the stronger `IsMonomialOrder` laws used by leading-term algorithms.
 
 Required theorems: coefficient characterisations in both directions,
 both round trips (`ofUnivariate i cmp' (toUnivariate i cmp' p) = p` and
@@ -528,7 +532,7 @@ def isEmptyRingEquiv [CommSemiring R] [DecidableEq R] :
 /-- The recursive view as a ring equivalence, at the first variable. -/
 def finSuccEquiv [CommSemiring R] [DecidableEq R]
     (cmp' : Mono n → Mono n → Ordering)
-    [IsMonomialOrder cmp'] :
+    [Std.TransCmp cmp'] [Std.LawfulEqCmp cmp'] :
     MvPoly (n+1) R cmp ≃+* DensePoly (MvPoly n R cmp')
 
 def oneVarEquiv [CommSemiring R] [DecidableEq R] :

--- a/progress/20260729T100537Z_hex-mv-poly-recursive-view.md
+++ b/progress/20260729T100537Z_hex-mv-poly-recursive-view.md
@@ -1,0 +1,41 @@
+# Hex multivariate polynomial recursive view
+
+## Accomplished
+
+- Proved the coordinate insertion/removal laws and injectivity of
+  `insertVar`.
+- Refactored `toUnivariate` into named, proof-friendly two-pass array
+  helpers while preserving its sparse executable behavior.
+- Switched bucket updates from singleton-polynomial allocation plus merge to
+  the direct `addMonomial` tree update.
+- Proved both coefficient characterizations and both
+  `toUnivariate`/`ofUnivariate` round trips.
+- Removed the unused `IsMonomialOrder` requirement from the recursive view,
+  retaining only the comparator laws actually needed by storage, and updated
+  the SPEC accordingly.
+- Added kernel round-trip coverage for first, last, and middle variables,
+  sparse dense coefficients with an interior zero, the zero polynomial, and
+  the one-variable boundary.
+- Ran focused builds and the full 9,631-target `lake build`. Axiom audits of
+  the four generic theorems and six concrete kernel tests contain no
+  `sorryAx`; `#guard_msgs` makes the concrete test audit CI-enforced.
+- Obtained two independent Claude review passes, addressed their pre-merge
+  issues and several concrete performance, documentation, naming, and
+  coverage suggestions.
+
+## Current frontier
+
+Five `HexMvPoly` sorries remain: the three `IsMonomialOrder` instances in
+`Mono.lean`, `coeff_pow_succ` in `Operations.lean`, and
+`partialEval_eq_subst` in `Structural.lean`.
+
+## Next step
+
+Land the recursive-view checkpoint after the Horner PR merges, then prove the
+operation and structural laws before tackling the three well-founded
+monomial-order instances.
+
+## Blockers
+
+No implementation blocker. The preceding Horner PR is still running CI, so
+this checkpoint has not yet been opened as a second concurrent PR.


### PR DESCRIPTION
## Summary
- prove insertVar/removeVar inverse laws and both recursive coefficient characterizations
- prove both toUnivariate/ofUnivariate round trips
- keep conversion sparse and efficient with two-pass array sizing plus direct addMonomial bucket updates
- weaken the inner comparator requirement to the storage laws actually used and synchronize the SPEC
- add kernel coverage for first/last/middle variables, dense gaps, zero, and the one-variable boundary
- enforce concrete axiom hygiene with guard messages

## Validation
- lake build HexMvPoly.Recursive HexMvPoly.KernelTests
- full lake build (9,631 jobs)
- axiom audits: only propext, Classical.choice, and Quot.sound; no sorryAx
- two independent Claude Opus review passes; all pre-merge findings addressed