### PR TITLE
Prove NumberField exactification totality

### DIFF
--- a/HexBerlekampZassenhausMathlib/PublicSurface.lean
+++ b/HexBerlekampZassenhausMathlib/PublicSurface.lean
@@ -493,6 +493,95 @@ private theorem mem_factorizationFlattenedFactors_iff
   · rintro ⟨entry, hentry, hne_mul, rfl⟩
     exact ⟨entry, hentry, hne_mul, rfl⟩
 
+/-- Every recorded factor divides the transported input polynomial. -/
+theorem factorize_entry_dvd (f : Hex.ZPoly) {entry : Hex.ZPoly × Nat}
+    (hentry : entry ∈ (Hex.ZPoly.factorize f).factors) :
+    HexPolyZMathlib.toPolynomial entry.1 ∣
+      HexPolyZMathlib.toPolynomial f := by
+  let φ := Hex.ZPoly.factorize f
+  have hmult : entry.2 ≠ 0 := by
+    have hpos := Hex.factorize_entry_multiplicity_pos f entry
+      (Array.mem_toList_iff.mpr hentry)
+    omega
+  have hflat : entry.1 ∈ factorizationFlattenedFactors φ :=
+    mem_factorizationFlattenedFactors_iff.mpr
+      ⟨entry, Array.mem_toList_iff.mpr hentry, hmult, rfl⟩
+  have hmapped : HexPolyZMathlib.toPolynomial entry.1 ∈
+      (factorizationFlattenedFactors φ).map
+        HexPolyZMathlib.toPolynomial :=
+    List.mem_map.mpr ⟨entry.1, hflat, rfl⟩
+  obtain ⟨r, hr⟩ := List.dvd_prod hmapped
+  have hdvd : HexPolyZMathlib.toPolynomial entry.1 ∣
+      Polynomial.C φ.scalar *
+        ((factorizationFlattenedFactors φ).map
+          HexPolyZMathlib.toPolynomial).prod := by
+    refine ⟨Polynomial.C φ.scalar * r, ?_⟩
+    rw [hr]
+    ring
+  have hproduct := congrArg HexPolyZMathlib.toPolynomial
+    (factorize_product f)
+  rw [factorizationProduct_toPolynomial] at hproduct
+  exact hproduct ▸ hdvd
+
+private theorem exists_isRoot_prod {z : ℂ}
+    {polys : List (Polynomial ℂ)} (h : polys.prod.IsRoot z) :
+    ∃ p ∈ polys, p.IsRoot z := by
+  induction polys with
+  | nil => simp [Polynomial.IsRoot] at h
+  | cons p polys ih =>
+      rw [List.prod_cons, Polynomial.IsRoot, Polynomial.eval_mul] at h
+      rcases mul_eq_zero.mp h with hp | htail
+      · exact ⟨p, List.mem_cons_self, hp⟩
+      · obtain ⟨q, hq, hz⟩ := ih htail
+        exact ⟨q, List.mem_cons_of_mem p hq, hz⟩
+
+private theorem map_list_prod (polys : List (Polynomial ℤ)) :
+    polys.prod.map (Int.castRingHom ℂ) =
+      (polys.map fun p => p.map (Int.castRingHom ℂ)).prod := by
+  induction polys with
+  | nil => simp
+  | cons p polys ih => simp [ih]
+
+/-- Every complex root of a nonzero input is a root of one of the recorded
+irreducible factors. -/
+theorem factorize_exists_root (f : Hex.ZPoly) (hf : f ≠ 0) {z : ℂ}
+    (hz : ((HexPolyZMathlib.toPolynomial f).map
+      (Int.castRingHom ℂ)).IsRoot z) :
+    ∃ entry ∈ (Hex.ZPoly.factorize f).factors,
+      ((HexPolyZMathlib.toPolynomial entry.1).map
+        (Int.castRingHom ℂ)).IsRoot z := by
+  let φ := Hex.ZPoly.factorize f
+  have hproduct := congrArg HexPolyZMathlib.toPolynomial
+    (factorize_product f)
+  rw [factorizationProduct_toPolynomial] at hproduct
+  have hscalar : φ.scalar ≠ 0 := by
+    intro hs
+    have hzero : HexPolyZMathlib.toPolynomial f = 0 := by
+      simpa [φ, hs] using hproduct.symm
+    apply hf
+    apply HexPolyZMathlib.equiv.injective
+    simpa [HexPolyZMathlib.equiv_apply] using hzero
+  have hproductℂ := congrArg (Polynomial.map (Int.castRingHom ℂ)) hproduct
+  have hroot :
+      (((factorizationFlattenedFactors φ).map
+        ((fun p : Polynomial ℤ => p.map (Int.castRingHom ℂ)) ∘
+          HexPolyZMathlib.toPolynomial)).prod).IsRoot z := by
+    rw [← hproductℂ] at hz
+    have heval :
+        (φ.scalar : ℂ) *
+        (((factorizationFlattenedFactors φ).map
+          ((fun p : Polynomial ℤ => p.map (Int.castRingHom ℂ)) ∘
+            HexPolyZMathlib.toPolynomial)).prod).eval z = 0 := by
+      simpa [Polynomial.IsRoot, φ, map_list_prod, List.map_map,
+        Function.comp_apply] using hz
+    exact (mul_eq_zero.mp heval).resolve_left (by exact_mod_cast hscalar)
+  obtain ⟨qℂ, hqℂ, hqroot⟩ := exists_isRoot_prod hroot
+  obtain ⟨q, hq, rfl⟩ := List.mem_map.mp hqℂ
+  obtain ⟨entry, hentry, _hmult, rfl⟩ :=
+    mem_factorizationFlattenedFactors_iff.mp hq
+  exact ⟨entry, Array.mem_toList_iff.mp hentry,
+    by simpa [Function.comp_apply] using hqroot⟩
+
 /--
 The transport coercion of `factorizationFlattenedFactors` to a multiset
 equals the multiplicity sum over the original entry list. -/

--- a/HexNumberField/Basic.lean
+++ b/HexNumberField/Basic.lean
@@ -159,6 +159,35 @@ def ofNormalized?
     some (.mk p prim pos_lc pos_degree checked squarefree (SimpleRoot.mk canonical)
       canonical rfl)
 
+/-- The success bit of canonicalization is exactly the success bit of its
+isolation, refinement, and representative-selection pipeline. This exposes
+the checked boundary needed by the Mathlib totality proof without exposing the
+sealed `AlgebraicNumber` constructor. -/
+theorem ofNormalized?_isSome_eq
+    (p : ZPoly) (prim : ZPoly.Primitive p) (pos_lc : 0 < p.leadingCoeff)
+    (pos_degree : 0 < p.degree?.getD 0)
+    (checked : ZPoly.CheckedIrreducible p) (squarefree : HasOnlySimpleRoots p)
+    (rep : RefinedIsolation p) :
+    (ofNormalized? p prim pos_lc pos_degree checked squarefree rep).isSome =
+      if _hzero : p = ZPoly.X then true else
+        (do
+          let isolations ← isolate p squarefree (separationDepth p : Int)
+          let refined ← isolations.mapM DyadicRootIsolation.toRefined?
+          refined.toList.find? fun (r : RefinedIsolation p) =>
+            r.sameRoot rep).isSome := by
+  unfold ofNormalized?
+  split
+  · simp
+  · cases hisolate : isolate p squarefree (separationDepth p : Int) with
+    | none => simp
+    | some isolations =>
+        cases hrefine : isolations.mapM DyadicRootIsolation.toRefined? with
+        | none => simp [hrefine]
+        | some refined =>
+            cases hfind : refined.find? fun r => r.sameRoot rep with
+            | none => simp [hrefine, hfind]
+            | some canonical => simp [hrefine, hfind]
+
 /-- Successful canonicalization retains the supplied normalized polynomial. -/
 theorem ofNormalized?_p
     (p : ZPoly) (prim : ZPoly.Primitive p) (pos_lc : 0 < p.leadingCoeff)

--- a/HexNumberField/Convert.lean
+++ b/HexNumberField/Convert.lean
@@ -50,32 +50,25 @@ end AlgebraicNumber
 
 namespace AlgebraicRoot
 
-/-- Factor a lazy root's enclosing polynomial and select the normalized
-irreducible factor containing its chosen root. -/
+/-- Try one normalized factor of a lazy root's enclosing polynomial. Candidate
+isolations are refined to the enclosing polynomial's separation precision
+before their discs are compared. -/
 @[expose]
-def exact? (a : AlgebraicRoot) : Option AlgebraicNumber :=
-  let tryFactor := fun q =>
-    if hprim : ZPoly.content q = 1 then
-      if hpos : 0 < q.leadingCoeff then
-        if hdegree : 0 < q.degree?.getD 0 then
-          if hirred : ZPoly.isIrreducible q = true then
-            if hsquarefree : HasOnlySimpleRoots q then do
-              let isolations ← isolate q hsquarefree (separationDepth q : Int)
-              let refined ← isolations.mapM DyadicRootIsolation.toRefined?
-              -- `a.rep` has the separation precision for `a.p`. A factor can
-              -- have a weaker intrinsic bound, so refine its roots to the
-              -- enclosing polynomial's precision before comparing discs.
-              let comparable ← refined.mapM fun r => do
-                let r' ← r.refineTo? (mahlerPrec a.p : Int)
-                some r'.1
-              -- Separation for `a.p` makes a match unique across all of its
-              -- factors, so selecting the first matching isolation is sound.
-              let matching ← comparable.toList.find? fun r =>
+def exactFactor? (a : AlgebraicRoot) (q : ZPoly) : Option AlgebraicNumber :=
+  if hprim : ZPoly.content q = 1 then
+    if hpos : 0 < q.leadingCoeff then
+      if hdegree : 0 < q.degree?.getD 0 then
+        if hirred : ZPoly.isIrreducible q = true then
+          if hsquarefree : HasOnlySimpleRoots q then do
+            let isolations ← isolate q hsquarefree (separationDepth q : Int)
+            let refined ← isolations.mapM DyadicRootIsolation.toRefined?
+            let comparable ← refined.mapM fun r =>
+              (r.refineTo? (mahlerPrec a.p : Int)).unattach
+            let matching ← comparable.toList.find? fun r =>
+              decide ((mahlerPrec a.p : Int) ≤ r.1.square.prec) &&
                 r.1.square.discsMeet a.rep.1.square
-              AlgebraicNumber.ofNormalized? q hprim hpos hdegree
-                ⟨hirred, hdegree⟩ hsquarefree matching
-            else
-              none
+            AlgebraicNumber.ofNormalized? q hprim hpos hdegree
+              ⟨hirred, hdegree⟩ hsquarefree matching
           else
             none
         else
@@ -84,11 +77,18 @@ def exact? (a : AlgebraicRoot) : Option AlgebraicNumber :=
         none
     else
       none
+  else
+    none
+
+/-- Factor a lazy root's enclosing polynomial and select the normalized
+irreducible factor containing its chosen root. -/
+@[expose]
+def exact? (a : AlgebraicRoot) : Option AlgebraicNumber :=
   (ZPoly.factorize a.p).factors.foldl
     (fun found entry =>
       match found with
       | some b => some b
-      | none => tryFactor entry.1)
+      | none => exactFactor? a entry.1)
     none
 
 /-- Canonicalize a lazy root. Failure is a checked implementation branch whose
@@ -203,24 +203,53 @@ def mulMatrix (a : QAdjoin p x) :
   Matrix.ofFn fun i j =>
     products[j].coeffs.coeff i.val
 
+/-- The first `n + 1` Krylov powers, built with one multiplication per step. -/
+@[expose]
+def krylovPowers (a : QAdjoin p x) :
+    (n : Nat) → Vector (QAdjoin p x) (n + 1)
+  | 0 => #v[1]
+  | n + 1 =>
+      let previous := krylovPowers a n
+      previous.push (previous.get (Fin.last n) * a)
+
+/-- Krylov orbit `1, a, a², ...` through the defining-field dimension. -/
+@[expose]
+def krylovOrbit [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) :
+    Vector (QAdjoin p x) (p.degree?.getD 0 + 1) :=
+  krylovPowers a (p.degree?.getD 0)
+
+/-- The monic polynomial encoded by a Krylov dependence vector. -/
+@[expose]
+def relationPoly {k : Nat} (coeffs : Vector Rat k) : DensePoly Rat :=
+  DensePoly.ofCoeffs ((coeffs.toArray.map fun c => -c).push 1)
+
+/-- The monic relation at one Krylov-orbit index, when the new power is in
+the span of its predecessors. -/
+@[expose]
+def relationAt? [ZPoly.CheckedIrreducible p]
+    (_a : QAdjoin p x)
+    (orbit : Vector (QAdjoin p x) (p.degree?.getD 0 + 1))
+    (k : Nat) : Option ZPoly :=
+  let n := p.degree?.getD 0
+  if hk : k ≤ n then
+    let previous : Matrix Rat k n := Matrix.ofFn fun i j =>
+      (orbit.get ⟨i.val, by omega⟩).coeffs.coeff j
+    let target : Vector Rat n := Vector.ofFn fun j =>
+      (orbit.get ⟨k, Nat.lt_succ_of_le hk⟩).coeffs.coeff j
+    (Matrix.spanCoeffs previous target).map fun coeffs =>
+      ZPoly.ratPolyPrimitivePart (relationPoly coeffs)
+  else
+    none
+
 /-- First monic relation in the Krylov orbit of the multiplication operator,
 normalized as a primitive positive-leading integer polynomial. -/
 @[expose]
 def minpoly? [ZPoly.CheckedIrreducible p]
     (a : QAdjoin p x) : Option ZPoly :=
   let n := p.degree?.getD 0
-  let M := a.mulMatrix
-  let one : Vector Rat n := Vector.unit Rat ⟨0, ZPoly.CheckedIrreducible.pos_degree⟩
-  let orbit := (List.range n).foldl
-    (fun vs _ => vs.push (M * vs[vs.size - 1]!)) #[one]
-  let relation := fun (k : Nat) => do
-    let previous : Matrix Rat k n := Matrix.ofFn fun i j =>
-      orbit[i.val]![j]
-    let target : Vector Rat n := orbit[k]!
-    let coeffs ← Matrix.spanCoeffs previous target
-    let rational := DensePoly.ofCoeffs ((coeffs.toArray.map fun c => -c).push 1)
-    some (ZPoly.ratPolyPrimitivePart rational)
-  (List.range n).findSome? fun i => relation (i + 1)
+  let orbit := a.krylovOrbit
+  (List.range n).findSome? fun i => a.relationAt? orbit (i + 1)
 
 /-- Convert a fixed-presentation value to its canonical irreducible
 representation. Every stored certificate and every precision-sensitive step

--- a/HexNumberField/SPEC/hex-number-field.md
+++ b/HexNumberField/SPEC/hex-number-field.md
@@ -207,9 +207,10 @@ def AlgebraicRoot.exact (a : AlgebraicRoot) : AlgebraicNumber :=
   a.exact?.getD (panicWith 0 "AlgebraicRoot.exact: certification failed")
 ```
 
-`QAdjoin.toAlgebraicNumber?` computes the minimal polynomial of the
-multiplication operator by row reduction, clears denominators, normalizes the
-primitive part, and identifies the matching isolated root.
+`QAdjoin.toAlgebraicNumber?` materializes `1, a, a², ...` once with one
+fixed-field multiplication per new power, finds the first Krylov dependence by
+row reduction, clears denominators, normalizes the primitive part, and
+identifies the matching isolated root.
 
 `AlgebraicRoot.exact?` factors `a.p`, selects the unique irreducible factor whose
 isolated root agrees with `a.rep`, and returns that factor in canonical form.

--- a/HexNumberFieldMathlib/AdjoinRoot.lean
+++ b/HexNumberFieldMathlib/AdjoinRoot.lean
@@ -522,6 +522,20 @@ executable code should use the unscoped operations instead. -/
 noncomputable scoped instance (p : ZPoly) (x : SimpleRoot p)
     [ZPoly.CheckedIrreducible p] : Field (QAdjoin p x) := field p x
 
+/-- A checked rational presentation has characteristic zero. -/
+noncomputable scoped instance (p : ZPoly) (x : SimpleRoot p)
+    [ZPoly.CheckedIrreducible p] : CharZero (QAdjoin p x) := by
+  letI : Field (QAdjoin p x) := field p x
+  let rep : RefinedIsolation p := Quot.out x
+  have hrep : SimpleRoot.mk rep = x := Quot.out_eq x
+  constructor
+  intro m n hmn
+  have hvalue := congrArg (fun a : QAdjoin p x => toComplex a rep hrep) hmn
+  change toComplex ((m : Rat) • (1 : QAdjoin p x)) rep hrep =
+    toComplex ((n : Rat) • (1 : QAdjoin p x)) rep hrep at hvalue
+  simp only [map_smul, map_one, mul_one] at hvalue
+  exact_mod_cast hvalue
+
 end QAdjoinField
 
 open scoped QAdjoinField
@@ -595,6 +609,22 @@ theorem toAdjoinRoot_mul [ZPoly.CheckedIrreducible p]
   rw [rootHom_toAdjoinRoot, (rootHom rep).map_mul,
     rootHom_toAdjoinRoot, rootHom_toAdjoinRoot]
   exact map_mul a b rep hrep
+
+/-- The quotient comparison preserves executable rational scalar
+multiplication. -/
+theorem toAdjoinRoot_smul [ZPoly.CheckedIrreducible p]
+    (q : Rat) (a : QAdjoin p x) :
+    toAdjoinRoot (q • a) = q • toAdjoinRoot a := by
+  let rep : RefinedIsolation p := Quot.out x
+  have hrep : SimpleRoot.mk rep = x := Quot.out_eq x
+  letI : Fact (_root_.Irreducible (definingPolynomial p)) :=
+    ⟨definingPolynomial_irreducible p⟩
+  apply (rootHom rep).injective
+  rw [rootHom_toAdjoinRoot]
+  conv_rhs => rw [Algebra.smul_def]
+  rw [(rootHom rep).map_mul, RingHom.map_rat_algebraMap,
+    rootHom_toAdjoinRoot]
+  exact map_smul q a rep hrep
 
 /-- The reduced-coordinate comparison as a ring homomorphism. -/
 @[expose]

--- a/HexNumberFieldMathlib/Approx.lean
+++ b/HexNumberFieldMathlib/Approx.lean
@@ -30,34 +30,7 @@ strategy. -/
 theorem refineTo?_isSome {p : ZPoly} (rep : RefinedIsolation p)
     (target : Int) :
     (rep.refineTo? target .nkThenPellet).isSome := by
-  rw [RefinedIsolation.refineTo?]
-  let rawTarget := max target (mahlerPrec p : Int)
-  have hsome :=
-    HexRootsMathlib.DyadicRootIsolation.refineTo?_isSome_mixed rep rawTarget
-  cases hraw : rep.1.refineTo? rawTarget .nkThenPellet with
-  | none => simp [hraw] at hsome
-  | some iso' =>
-      have hready : rawTarget ≤ iso'.square.prec := by
-        exact HexRootsMathlib.DyadicRootIsolation.refineTo_ready hraw
-      have hprec : (mahlerPrec p : Int) ≤ iso'.square.prec :=
-        (le_max_right target (mahlerPrec p : Int)).trans hready
-      let out : RefinedIsolation p := ⟨iso', hprec⟩
-      have hroot : HexRootsMathlib.RefinedIsolation.root out =
-          HexRootsMathlib.RefinedIsolation.root rep := by
-        calc
-          HexRootsMathlib.RefinedIsolation.root out =
-              HexRootsMathlib.DyadicRootIsolation.root iso' :=
-            (HexRootsMathlib.DyadicRootIsolation.root_refined iso' hprec).symm
-          _ = HexRootsMathlib.DyadicRootIsolation.root rep.1 :=
-            HexRootsMathlib.DyadicRootIsolation.refineTo_root rep.1 rawTarget
-              .nkThenPellet hraw
-          _ = HexRootsMathlib.RefinedIsolation.root rep :=
-            HexRootsMathlib.DyadicRootIsolation.root_refined rep.1 rep.property
-      have hI : Intersects out rep :=
-        (HexRootsMathlib.RefinedIsolation.intersects_iff_root_eq out rep).2 hroot
-      simp only [Option.bind_eq_bind, Option.bind_some]
-      rw [dif_pos hprec, dif_pos hI]
-      simp
+  exact HexRootsMathlib.RefinedIsolation.refineTo?_isSome_mixed rep target
 
 /-- Every successful refined result reaches the requested precision. -/
 theorem refineTo?_precision {p : ZPoly} (rep : RefinedIsolation p)

--- a/HexNumberFieldMathlib/Exact.lean
+++ b/HexNumberFieldMathlib/Exact.lean
@@ -7,6 +7,8 @@ Authors: Kim Morrison
 module
 
 public import HexNumberFieldMathlib.Approx
+import HexMatrixMathlib.Vector
+import Mathlib.FieldTheory.Minpoly.Finite
 
 public section
 
@@ -27,20 +29,382 @@ theorem toRoot_toComplex (a : AlgebraicNumber) :
     a.toRoot.toComplex = a.toComplex := by
   rfl
 
+/-- Canonicalization of an already normalized polynomial is total. -/
+theorem ofNormalized?_isSome
+    (p : ZPoly) (prim : ZPoly.Primitive p) (pos_lc : 0 < p.leadingCoeff)
+    (pos_degree : 0 < p.degree?.getD 0)
+    (checked : ZPoly.CheckedIrreducible p) (squarefree : HasOnlySimpleRoots p)
+    (rep : RefinedIsolation p) :
+    (AlgebraicNumber.ofNormalized? p prim pos_lc pos_degree checked
+      squarefree rep).isSome := by
+  rw [AlgebraicNumber.ofNormalized?_isSome_eq]
+  split
+  · simp
+  · have hpne : p ≠ 0 := by
+      intro hp
+      rw [hp] at pos_degree
+      simp at pos_degree
+    have hisolate := HexRootsMathlib.isolate_isSome p squarefree hpne
+      (separationDepth p : Int) .nkThenPellet
+    cases hrun : isolate p squarefree (separationDepth p : Int) with
+    | none => simp [hrun] at hisolate
+    | some isolations =>
+        have hmapSome := HexRootsMathlib.array_mapM_isSome
+          (xs := isolations) (f := DyadicRootIsolation.toRefined?)
+          (fun iso hiso => by
+            simp [DyadicRootIsolation.toRefined?,
+              HexRootsMathlib.isolate_refined p squarefree
+                (separationDepth p : Int) .nkThenPellet hrun iso hiso])
+        cases hmap : isolations.mapM DyadicRootIsolation.toRefined? with
+        | none => simp [hmap] at hmapSome
+        | some refined =>
+            obtain ⟨iso, hiso, hisoRoot⟩ :=
+              HexRootsMathlib.isolate_root_mem_of_pos p squarefree
+                (separationDepth p : Int) .nkThenPellet pos_degree hrun
+                (HexRootsMathlib.RefinedIsolation.isRoot rep)
+            obtain ⟨i, hiList, hidx⟩ := List.getElem_of_mem hiso
+            have hi : i < isolations.size := by simpa using hiList
+            obtain ⟨hsize, hget⟩ :=
+              HexRootsMathlib.array_mapM_some_get hmap
+            have hj : i < refined.size := by simpa [← hsize] using hi
+            have hto := hget i hi hj
+            have hraw : refined[i].1 = isolations[i] := by
+              rw [DyadicRootIsolation.toRefined?] at hto
+              split at hto
+              · exact (congrArg Subtype.val (Option.some.inj hto)).symm
+              · simp at hto
+            have harrIso : isolations[i] = iso := by
+              rw [← hidx]
+              exact (Array.getElem_toList hi).symm
+            have hroot :
+                HexRootsMathlib.RefinedIsolation.root refined[i] = rep.root := by
+              change HexRootsMathlib.DyadicRootIsolation.root refined[i].1 =
+                HexRootsMathlib.RefinedIsolation.root rep
+              rw [hraw, harrIso]
+              exact hisoRoot
+            have hsame : refined[i].sameRoot rep = true :=
+              HexRootsMathlib.RefinedIsolation.sameRoot_eq_true_iff
+                refined[i] rep |>.mpr <|
+                (HexRootsMathlib.RefinedIsolation.intersects_iff_root_eq
+                  refined[i] rep).mpr hroot
+            simp [hmap]
+            exact ⟨refined[i], by simp,
+              hsame⟩
+
 end AlgebraicNumber
 
 namespace AlgebraicRoot
+
+/-- Trying a factor is semantically sound whenever every root of that factor
+is a root of the enclosing polynomial. -/
+theorem exactFactor?_sound (a : AlgebraicRoot) (q : ZPoly)
+    (hq : ∀ z : ℂ, (HexRootsMathlib.toPolyℂ q).IsRoot z →
+      (HexRootsMathlib.toPolyℂ a.p).IsRoot z)
+    {b : AlgebraicNumber} (h : a.exactFactor? q = some b) :
+    b.toComplex = a.toComplex := by
+  unfold AlgebraicRoot.exactFactor? at h
+  split at h
+  · rename_i hprim
+    split at h
+    · rename_i hpos
+      split at h
+      · rename_i hdegree
+        split at h
+        · rename_i hirred
+          split at h
+          · rename_i hsimple
+            obtain ⟨isolations, _hisolate, h⟩ :=
+              Option.bind_eq_some_iff.mp h
+            obtain ⟨refined, _hrefined, h⟩ :=
+              Option.bind_eq_some_iff.mp h
+            obtain ⟨comparable, _hcomparable, h⟩ :=
+              Option.bind_eq_some_iff.mp h
+            obtain ⟨matching, hmatching, hnormalized⟩ :=
+              Option.bind_eq_some_iff.mp h
+            have hmatch := List.find?_some
+              (p := fun r : RefinedIsolation q =>
+                decide ((mahlerPrec a.p : Int) ≤ r.1.square.prec) &&
+                  r.1.square.discsMeet a.rep.1.square)
+              hmatching
+            simp only [Bool.and_eq_true, decide_eq_true_eq] at hmatch
+            have hmatchingRoot :
+                (HexRootsMathlib.toPolyℂ a.p).IsRoot matching.root :=
+              hq matching.root
+                (HexRootsMathlib.RefinedIsolation.isRoot matching)
+            have hroot : matching.root = a.rep.root :=
+              HexRootsMathlib.DyadicSquare.root_eq_of_discsMeet
+                (HexRootsMathlib.RefinedIsolation.poly_ne_zero a.rep)
+                hmatch.1 a.rep.property hmatchingRoot
+                (HexRootsMathlib.RefinedIsolation.isRoot a.rep)
+                (HexRootsMathlib.RefinedIsolation.root_mem_closedDisc matching)
+                (HexRootsMathlib.RefinedIsolation.root_mem_closedDisc a.rep)
+                hmatch.2
+            have hout := AlgebraicNumber.ofNormalized?_toComplex
+              q hprim hpos hdegree ⟨hirred, hdegree⟩ hsimple matching
+              hnormalized
+            change b.toComplex = a.rep.root
+            exact hout.trans hroot
+          · simp at h
+        · simp at h
+      · simp at h
+    · simp at h
+  · simp at h
+
+/-- A normalized irreducible factor containing the selected root always
+survives isolation, refinement, and canonicalization. -/
+theorem exactFactor?_isSome (a : AlgebraicRoot) (q : ZPoly)
+    (hprim : ZPoly.content q = 1) (hpos : 0 < q.leadingCoeff)
+    (hdegree : 0 < q.degree?.getD 0)
+    (hirred : ZPoly.isIrreducible q = true)
+    (hsimple : HasOnlySimpleRoots q)
+    (hroot : (HexRootsMathlib.toPolyℂ q).IsRoot a.toComplex) :
+    (a.exactFactor? q).isSome := by
+  unfold AlgebraicRoot.exactFactor?
+  rw [dif_pos hprim, dif_pos hpos, dif_pos hdegree, dif_pos hirred,
+    dif_pos hsimple]
+  have hqne : q ≠ 0 := by
+    intro hq
+    rw [hq] at hdegree
+    simp at hdegree
+  have hisolate := HexRootsMathlib.isolate_isSome q hsimple hqne
+    (separationDepth q : Int) .nkThenPellet
+  cases hrun : isolate q hsimple (separationDepth q : Int) with
+  | none => simp [hrun] at hisolate
+  | some isolations =>
+      have hmapSome := HexRootsMathlib.array_mapM_isSome
+        (xs := isolations) (f := DyadicRootIsolation.toRefined?)
+        (fun iso hiso => by
+          simp [DyadicRootIsolation.toRefined?,
+            HexRootsMathlib.isolate_refined q hsimple
+              (separationDepth q : Int) .nkThenPellet hrun iso hiso])
+      cases hmap : isolations.mapM DyadicRootIsolation.toRefined? with
+      | none => simp [hmap] at hmapSome
+      | some refined =>
+          have hrefineSome := HexRootsMathlib.array_mapM_isSome
+            (xs := refined)
+            (f := fun r : RefinedIsolation q =>
+              (r.refineTo? (mahlerPrec a.p : Int)).unattach)
+            (fun r _hr => by
+              have hsome :=
+                HexRootsMathlib.RefinedIsolation.refineTo?_isSome_mixed
+                  r (mahlerPrec a.p : Int)
+              cases hrun' : r.refineTo? (mahlerPrec a.p : Int)
+                  .nkThenPellet with
+              | none => simp [hrun'] at hsome
+              | some out => simp)
+          cases hrefine : refined.mapM (fun r : RefinedIsolation q =>
+              (r.refineTo? (mahlerPrec a.p : Int)).unattach) with
+          | none => simp [hrefine] at hrefineSome
+          | some comparable =>
+              obtain ⟨iso, hiso, hisoRoot⟩ :=
+                HexRootsMathlib.isolate_root_mem_of_pos q hsimple
+                  (separationDepth q : Int) .nkThenPellet hdegree hrun hroot
+              obtain ⟨i, hiList, hidx⟩ := List.getElem_of_mem hiso
+              have hi : i < isolations.size := by simpa using hiList
+              obtain ⟨hmapSize, hmapGet⟩ :=
+                HexRootsMathlib.array_mapM_some_get hmap
+              have hj : i < refined.size := by
+                simpa [← hmapSize] using hi
+              have hto := hmapGet i hi hj
+              have hraw : refined[i].1 = isolations[i] := by
+                rw [DyadicRootIsolation.toRefined?] at hto
+                split at hto
+                · exact (congrArg Subtype.val (Option.some.inj hto)).symm
+                · simp at hto
+              have harrIso : isolations[i] = iso := by
+                rw [← hidx]
+                exact (Array.getElem_toList hi).symm
+              have hrefinedRoot :
+                  HexRootsMathlib.RefinedIsolation.root refined[i] =
+                    a.rep.root := by
+                change HexRootsMathlib.DyadicRootIsolation.root refined[i].1 =
+                  HexRootsMathlib.RefinedIsolation.root a.rep
+                rw [hraw, harrIso]
+                exact hisoRoot
+              obtain ⟨hrefineSize, hrefineGet⟩ :=
+                HexRootsMathlib.array_mapM_some_get hrefine
+              have hk : i < comparable.size := by
+                simpa [← hrefineSize] using hj
+              have hget := hrefineGet i hj hk
+              cases hrun' : refined[i].refineTo? (mahlerPrec a.p : Int)
+                  .nkThenPellet with
+              | none => simp [hrun'] at hget
+              | some out =>
+                  simp only [hrun', Option.unattach_some] at hget
+                  have hout : out.1 = comparable[i] := Option.some.inj hget
+                  have hprec := Hex.RefinedIsolation.refineTo?_precision
+                    refined[i] (mahlerPrec a.p : Int)
+                      (strategy := .nkThenPellet) hrun'
+                  rw [hout] at hprec
+                  have hcomparableRoot :
+                      HexRootsMathlib.RefinedIsolation.root comparable[i] =
+                        a.rep.root := by
+                    rw [← hout]
+                    exact
+                      (HexRootsMathlib.RefinedIsolation.refineTo_root
+                        refined[i] (mahlerPrec a.p : Int) .nkThenPellet
+                          hrun').trans hrefinedRoot
+                  have hmeet : comparable[i].1.square.discsMeet
+                      a.rep.1.square = true := by
+                    by_contra hnot
+                    have hfalse := Bool.eq_false_of_not_eq_true hnot
+                    have hdisj :=
+                      HexRootsMathlib.DyadicSquare.closedDisc_disjoint_of_discsMeet_eq_false
+                        comparable[i].1.square a.rep.1.square hfalse
+                    have hmem : HexRootsMathlib.RefinedIsolation.root comparable[i] ∈
+                        HexRootsMathlib.DyadicSquare.closedDisc a.rep.1.square := by
+                      rw [hcomparableRoot]
+                      exact HexRootsMathlib.RefinedIsolation.root_mem_closedDisc a.rep
+                    exact (Set.disjoint_left.mp hdisj)
+                      (HexRootsMathlib.RefinedIsolation.root_mem_closedDisc
+                        comparable[i]) hmem
+                  have hmatching :
+                      (comparable.find? fun r =>
+                        decide ((mahlerPrec a.p : Int) ≤ r.1.square.prec) &&
+                          r.1.square.discsMeet a.rep.1.square).isSome := by
+                    simp
+                    exact ⟨comparable[i], by
+                      simp, hprec, hmeet⟩
+                  cases hfind : comparable.find? fun r =>
+                      decide ((mahlerPrec a.p : Int) ≤ r.1.square.prec) &&
+                        r.1.square.discsMeet a.rep.1.square with
+                  | none => simp [hfind] at hmatching
+                  | some matching =>
+                      have hnormalized := AlgebraicNumber.ofNormalized?_isSome
+                        q hprim hpos hdegree ⟨hirred, hdegree⟩ hsimple matching
+                      simpa [hmap, hrefine, hfind] using hnormalized
+
+private theorem exactFold_some (a : AlgebraicRoot)
+    (entries : List (ZPoly × Nat)) (b : AlgebraicNumber) :
+    entries.foldl
+        (fun found entry =>
+          match found with
+          | some b => some b
+          | none => a.exactFactor? entry.1)
+        (some b) = some b := by
+  induction entries with
+  | nil => rfl
+  | cons entry entries ih =>
+      rw [List.foldl_cons]
+      exact ih
+
+private theorem exactFold_witness (a : AlgebraicRoot)
+    (entries : List (ZPoly × Nat)) {b : AlgebraicNumber}
+    (h : entries.foldl
+        (fun found entry =>
+          match found with
+          | some b => some b
+          | none => a.exactFactor? entry.1)
+        none = some b) :
+    ∃ entry ∈ entries, a.exactFactor? entry.1 = some b := by
+  induction entries with
+  | nil => simp at h
+  | cons entry entries ih =>
+      rw [List.foldl_cons] at h
+      cases hfactor : a.exactFactor? entry.1 with
+      | none =>
+          simp only [hfactor] at h
+          obtain ⟨witness, hmem, hwitness⟩ := ih h
+          exact ⟨witness, List.mem_cons_of_mem entry hmem, hwitness⟩
+      | some c =>
+          simp only [hfactor, exactFold_some] at h
+          cases h
+          exact ⟨entry, List.mem_cons_self, hfactor⟩
+
+private theorem exactFold_isSome_of_mem (a : AlgebraicRoot)
+    (entries : List (ZPoly × Nat)) {entry : ZPoly × Nat}
+    (hentry : entry ∈ entries) (hfactor : (a.exactFactor? entry.1).isSome) :
+    (entries.foldl
+      (fun found entry =>
+        match found with
+        | some b => some b
+        | none => a.exactFactor? entry.1)
+      none).isSome := by
+  cases hrun : a.exactFactor? entry.1 with
+  | none => simp [hrun] at hfactor
+  | some b =>
+      induction entries with
+      | nil => simp at hentry
+      | cons head tail ih =>
+          rw [List.foldl_cons]
+          by_cases heq : head = entry
+          · subst head
+            rw [hrun, exactFold_some]
+            simp
+          · have htail : entry ∈ tail :=
+              (List.mem_cons.mp hentry).resolve_left (Ne.symm heq)
+            cases hhead : a.exactFactor? head.1 with
+            | none => simpa [hhead] using ih htail
+            | some c =>
+                change (tail.foldl
+                  (fun found entry =>
+                    match found with
+                    | some b => some b
+                    | none => a.exactFactor? entry.1)
+                  (some c)).isSome
+                rw [exactFold_some]
+                simp
 
 /-- Every successful exactification denotes the original selected root. -/
 theorem exact?_sound (a : AlgebraicRoot) {b : AlgebraicNumber}
     (h : a.exact? = some b) :
     b.toComplex = a.toComplex := by
-  sorry
+  rw [AlgebraicRoot.exact?] at h
+  rw [← Array.foldl_toList] at h
+  obtain ⟨entry, hentry, hfactor⟩ := exactFold_witness a _ h
+  have hdvdℤ := HexBerlekampZassenhausMathlib.factorize_entry_dvd a.p
+    (Array.mem_toList_iff.mp hentry)
+  have hdvdℂ : HexRootsMathlib.toPolyℂ entry.1 ∣
+      HexRootsMathlib.toPolyℂ a.p := by
+    obtain ⟨r, hr⟩ := hdvdℤ
+    refine ⟨r.map (Int.castRingHom ℂ), ?_⟩
+    have hm := congrArg (Polynomial.map (Int.castRingHom ℂ)) hr
+    simpa [HexRootsMathlib.toPolyℂ, Polynomial.map_mul] using hm
+  exact exactFactor?_sound a entry.1
+    (fun z hz => hz.dvd hdvdℂ) hfactor
 
 /-- Factor selection and isolation always find the canonical representative. -/
 theorem exact?_isSome (a : AlgebraicRoot) :
     a.exact?.isSome := by
-  sorry
+  have hpne : a.p ≠ 0 := by
+    intro hp
+    have hdegree := a.pos_degree
+    rw [hp] at hdegree
+    simp at hdegree
+  obtain ⟨entry, hentry, hentryRoot⟩ :=
+    HexBerlekampZassenhausMathlib.factorize_exists_root a.p hpne
+      (by simpa [HexRootsMathlib.toPolyℂ] using
+        AlgebraicRoot.toComplex_isRoot a)
+  have hprim :=
+    HexBerlekampZassenhausMathlib.factorize_entries_primitive_of_chosen_raw_primitive
+      a.p hpne entry hentry
+  have hpos :=
+    HexBerlekampZassenhausMathlib.factorize_entries_leadingCoeff_pos
+      a.p entry hentry
+  have hdegree :=
+    HexBerlekampZassenhausMathlib.factorize_entries_degree_pos
+      a.p hpne entry hentry
+  have hirredProp :=
+    HexBerlekampZassenhausMathlib.factorize_irreducible_of_nonUnit
+      a.p entry hentry
+  have hirred : ZPoly.isIrreducible entry.1 = true :=
+    (HexBerlekampZassenhausMathlib.Hex.ZPoly.isIrreducible_iff
+      entry.1).mpr hirredProp
+  let checked : ZPoly.CheckedIrreducible entry.1 := ⟨hirred, hdegree⟩
+  letI : ZPoly.CheckedIrreducible entry.1 := checked
+  have hentryNe : entry.1 ≠ 0 := by
+    intro hq
+    rw [hq] at hdegree
+    simp at hdegree
+  have hsimple : HasOnlySimpleRoots entry.1 :=
+    (HexRootsMathlib.hasOnlySimpleRoots_iff_separable entry.1
+      hentryNe).mpr (ZPoly.CheckedIrreducible.separable entry.1)
+  have hfactor := exactFactor?_isSome a entry.1 hprim hpos hdegree
+    hirred hsimple (by
+      simpa [HexRootsMathlib.toPolyℂ] using hentryRoot)
+  rw [AlgebraicRoot.exact?, ← Array.foldl_toList]
+  exact exactFold_isSome_of_mem a _
+    (Array.mem_toList_iff.mpr hentry) hfactor
 
 /-- The total canonicalization wrapper preserves the represented value. -/
 theorem exact_toComplex (a : AlgebraicRoot) :
@@ -58,6 +422,707 @@ namespace QAdjoin
 
 variable {p : ZPoly} {x : SimpleRoot p}
 
+open scoped QAdjoinField
+
+private theorem range_findSome?_eq_some {α : Type*} {n : Nat}
+    {f : Nat → Option α} {a : α}
+    (h : (List.range n).findSome? f = some a) :
+    ∃ i, i < n ∧ f i = some a ∧ (∀ j < i, f j = none) := by
+  rw [List.findSome?_eq_some_iff] at h
+  obtain ⟨before, found, after, hrange, hfound, hbefore⟩ := h
+  rw [List.range_eq_range'] at hrange
+  obtain ⟨k, hkn, hbeforeRange, hafterRange⟩ :=
+    List.range'_eq_append_iff.mp hrange
+  have hcons := hafterRange.symm
+  rw [List.range'_eq_cons_iff] at hcons
+  have hkfound : k = found := by omega
+  subst found
+  have hklt : k < n := by omega
+  have hprior : ∀ j < k, f j = none := by
+    intro j hj
+    apply hbefore j
+    rw [hbeforeRange]
+    simp [List.mem_range']
+    omega
+  exact ⟨k, hklt, hfound, hprior⟩
+
+private theorem relationPoly_coeff {k : Nat} (coeffs : Vector Rat k)
+    (i : Fin k) :
+    (relationPoly coeffs).coeff i.val = -coeffs[i] := by
+  rw [relationPoly, DensePoly.coeff_ofCoeffs]
+  simp [Array.getD, Array.getElem_push]
+
+private theorem relationPoly_coeff_top {k : Nat} (coeffs : Vector Rat k) :
+    (relationPoly coeffs).coeff k = 1 := by
+  rw [relationPoly, DensePoly.coeff_ofCoeffs]
+  have hsize : (coeffs.toArray.map fun c => -c).size = k := by simp
+  simp [Array.getD, Array.getElem_push, hsize]
+
+private theorem relationPoly_size {k : Nat} (coeffs : Vector Rat k) :
+    (relationPoly coeffs).size = k + 1 := by
+  apply Nat.le_antisymm
+  · exact (DensePoly.size_ofCoeffs_le _).trans (by simp)
+  · by_contra h
+    have hle : (relationPoly coeffs).size ≤ k := by omega
+    have hzero := DensePoly.coeff_eq_zero_of_size_le
+      (relationPoly coeffs) hle
+    rw [relationPoly_coeff_top coeffs] at hzero
+    norm_num at hzero
+
+private theorem relationPoly_natDegree {k : Nat} (coeffs : Vector Rat k) :
+    (HexPolyMathlib.toPolynomial (relationPoly coeffs)).natDegree = k := by
+  rw [HexPolyMathlib.natDegree_toPolynomial]
+  simp [DensePoly.degree?, relationPoly_size coeffs]
+
+private theorem relationPoly_monic {k : Nat} (coeffs : Vector Rat k) :
+    (HexPolyMathlib.toPolynomial (relationPoly coeffs)).Monic := by
+  rw [Polynomial.Monic.def]
+  rw [HexPolyMathlib.leadingCoeff_toPolynomial]
+  have hsize := relationPoly_size coeffs
+  have hpos : 0 < (relationPoly coeffs).size := by omega
+  rw [DensePoly.leadingCoeff_eq_coeff_last _ hpos, hsize]
+  simpa using relationPoly_coeff_top coeffs
+
+private theorem adjoinRoot_repr [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) (i : Fin (definingPolynomial p).natDegree) :
+    (AdjoinRoot.powerBasisAux' (definingPolynomial_monic p)).repr
+        (toAdjoinRoot a) i = a.coeffs.coeff i.val := by
+  rw [AdjoinRoot.powerBasisAux'_repr_apply_to_fun, toAdjoinRoot,
+    AdjoinRoot.modByMonicHom_mk]
+  rw [(Polynomial.modByMonic_eq_self_iff
+    (definingPolynomial_monic p)).mpr]
+  · rw [HexPolyMathlib.coeff_toPolynomial]
+  · apply Polynomial.degree_lt_degree
+    rw [HexPolyMathlib.natDegree_toPolynomial,
+      natDegree_definingPolynomial]
+    exact a.degree_lt
+
+private noncomputable def adjoinRootAlgEquiv [ZPoly.CheckedIrreducible p] :
+    QAdjoin p x ≃ₐ[Rat] AdjoinRoot (definingPolynomial p) :=
+  AlgEquiv.ofRingEquiv
+      (f := adjoinRootEquiv (p := p) (x := x)) fun r => by
+    rw [Algebra.algebraMap_eq_smul_one, Algebra.algebraMap_eq_smul_one]
+    change toAdjoinRoot (r • (1 : QAdjoin p x)) =
+      r • (1 : AdjoinRoot (definingPolynomial p))
+    rw [toAdjoinRoot_smul, toAdjoinRoot_one]
+
+private theorem krylovPowers_get (a : QAdjoin p x) (n : Nat)
+    (i : Fin (n + 1)) :
+    (krylovPowers a n).get i = a ^ i.val := by
+  induction n with
+  | zero =>
+      have hi : i = 0 := Fin.eq_zero i
+      subst i
+      rfl
+  | succ n ih =>
+      by_cases hi : i = Fin.last (n + 1)
+      · subst i
+        simp [krylovPowers, ih]
+        rfl
+      · let j : Fin (n + 1) := ⟨i.val, by
+          have hilast : i.val ≠ n + 1 := by
+            intro hval
+            apply hi
+            exact Fin.ext hval
+          omega⟩
+        have hij : i = Fin.castSucc j := Fin.ext rfl
+        rw [hij]
+        simp [krylovPowers, ih]
+
+private theorem krylovOrbit_get [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) (i : Fin (p.degree?.getD 0 + 1)) :
+    a.krylovOrbit.get i = a ^ i.val := by
+  exact krylovPowers_get a _ i
+
+private theorem vecMul_of_linear [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) (k : Nat) (coeffs : Vector Rat k)
+    (hlinear : ∑ i : Fin k, coeffs[i] • a ^ i.val = a ^ k) :
+    Matrix.vecMul coeffs
+        (Matrix.ofFn fun i : Fin k => fun j : Fin (p.degree?.getD 0) =>
+          (a ^ i.val).coeffs.coeff j) =
+      Vector.ofFn fun j : Fin (p.degree?.getD 0) =>
+        (a ^ k).coeffs.coeff j := by
+  have himage := congrArg (adjoinRootEquiv (p := p) (x := x)) hlinear
+  simp only [map_sum, adjoinRootEquiv_apply, toAdjoinRoot_smul] at himage
+  let B := AdjoinRoot.powerBasisAux' (definingPolynomial_monic p)
+  have hrepr := congrArg B.repr himage
+  apply Vector.ext
+  intro j _hj
+  have hjlt : j < (definingPolynomial p).natDegree := by
+    rw [natDegree_definingPolynomial]
+    exact _hj
+  let j' : Fin (definingPolynomial p).natDegree := ⟨j, hjlt⟩
+  have hj := congrArg (fun v => v j') hrepr
+  simp only [map_sum, map_smulₛₗ, RingHom.id_apply,
+    Finset.sum_apply', Finsupp.coe_smul, Pi.smul_apply, smul_eq_mul] at hj
+  have hrepr' (b : QAdjoin p x) :
+      (B.repr (toAdjoinRoot b)) j' = b.coeffs.coeff j := by
+    simpa [B, j'] using adjoinRoot_repr b j'
+  rw [hrepr' (a ^ k)] at hj
+  have hsum :
+      (∑ i : Fin k, coeffs[i] *
+        (B.repr (toAdjoinRoot (a ^ i.val))) j') =
+        ∑ i : Fin k, coeffs[i] * (a ^ i.val).coeffs.coeff j := by
+    apply Finset.sum_congr rfl
+    intro i _hi
+    rw [hrepr' (a ^ i.val)]
+  rw [hsum] at hj
+  let jf : Fin (p.degree?.getD 0) := ⟨j, _hj⟩
+  change (coeffs * (Matrix.ofFn fun i : Fin k =>
+    fun j : Fin (p.degree?.getD 0) => (a ^ i.val).coeffs.coeff j))[jf] =
+      (Vector.ofFn fun j : Fin (p.degree?.getD 0) =>
+        (a ^ k).coeffs.coeff j)[jf]
+  rw [Matrix.getElem_vecMul, HexMatrixMathlib.dotProduct_eq]
+  have hentry (i : Fin k) :
+      (Matrix.getRow (Matrix.ofFn fun i : Fin k =>
+        fun j : Fin (p.degree?.getD 0) =>
+          (a ^ i.val).coeffs.coeff j) i)[jf] =
+        (a ^ i.val).coeffs.coeff jf.val := by
+    rw [← Matrix.getElem_eq_getRow, Matrix.getElem_ofFn]
+  simpa [dotProduct, Matrix.col, hentry, jf, mul_comm] using hj
+
+private theorem relationAt?_isSome_of_linear [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) (k : Nat) (coeffs : Vector Rat k)
+    (hk : k ≤ p.degree?.getD 0)
+    (hlinear : ∑ i : Fin k, coeffs[i] • a ^ i.val = a ^ k) :
+    (a.relationAt? a.krylovOrbit k).isSome := by
+  let previous : Matrix Rat k (p.degree?.getD 0) :=
+    Matrix.ofFn fun i j =>
+      (a.krylovOrbit.get ⟨i.val, by omega⟩).coeffs.coeff j
+  let target : Vector Rat (p.degree?.getD 0) :=
+    Vector.ofFn fun j =>
+      (a.krylovOrbit.get ⟨k, Nat.lt_succ_of_le hk⟩).coeffs.coeff j
+  have hcoords : Matrix.vecMul coeffs previous = target := by
+    simpa [previous, target, krylovOrbit_get] using
+      vecMul_of_linear a k coeffs hlinear
+  have hnotnone : Matrix.spanCoeffs previous target ≠ none := by
+    intro hnone
+    exact (Matrix.spanCoeffs_eq_none_iff previous target).mp hnone
+      ⟨coeffs, hcoords⟩
+  unfold relationAt?
+  dsimp only
+  rw [dif_pos hk]
+  cases hspan : Matrix.spanCoeffs previous target with
+  | none => exact (hnotnone hspan).elim
+  | some found => simp
+
+private theorem minpoly_relation [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) :
+    let b : AdjoinRoot (definingPolynomial p) := toAdjoinRoot a
+    let d := (minpoly Rat b).natDegree
+    0 < d ∧ d ≤ p.degree?.getD 0 ∧
+      (a.relationAt? a.krylovOrbit d).isSome := by
+  let b : AdjoinRoot (definingPolynomial p) := toAdjoinRoot a
+  letI : Module.Free Rat (AdjoinRoot (definingPolynomial p)) :=
+    (definingPolynomial_monic p).free_adjoinRoot
+  letI : Module.Finite Rat (AdjoinRoot (definingPolynomial p)) :=
+    (definingPolynomial_monic p).finite_adjoinRoot
+  have hbint : IsIntegral Rat b := IsIntegral.of_finite Rat b
+  let m : Polynomial Rat := minpoly Rat b
+  let d : Nat := m.natDegree
+  have hmonic : m.Monic := minpoly.monic hbint
+  have hdpos : 0 < d := minpoly.natDegree_pos hbint
+  have hdle : d ≤ p.degree?.getD 0 := by
+    have hbound := minpoly.natDegree_le (A := Rat) b
+    have hfinrank : Module.finrank Rat
+        (AdjoinRoot (definingPolynomial p)) =
+        (definingPolynomial p).natDegree :=
+      (AdjoinRoot.powerBasis' (definingPolynomial_monic p)).finrank
+    rw [hfinrank] at hbound
+    simpa [d, m, natDegree_definingPolynomial] using hbound
+  let coeffs : Vector Rat d := Vector.ofFn fun i => -m.coeff i.val
+  have hbzero := minpoly.aeval Rat b
+  have hblinear : ∑ i : Fin d, coeffs[i] • b ^ i.val = b ^ d := by
+    rw [Polynomial.aeval_eq_sum_range, Finset.sum_range_succ,
+      hmonic.coeff_natDegree] at hbzero
+    have hcoeff (i : Fin d) : coeffs[i] = -m.coeff i.val := by
+      simp [coeffs]
+    simp_rw [hcoeff]
+    simp only [neg_smul, Finset.sum_neg_distrib]
+    rw [neg_eq_iff_add_eq_zero]
+    rw [← Fin.sum_univ_eq_sum_range] at hbzero
+    simpa [d, m] using hbzero
+  have halinear : ∑ i : Fin d, coeffs[i] • a ^ i.val = a ^ d := by
+    apply (adjoinRootEquiv (p := p) (x := x)).injective
+    simp only [map_sum, adjoinRootEquiv_apply, toAdjoinRoot_smul]
+    have hpow (i : Nat) : toAdjoinRoot (a ^ i) = toAdjoinRoot a ^ i := by
+      change adjoinRootEquiv (a ^ i) = adjoinRootEquiv a ^ i
+      rw [map_pow]
+    simp_rw [hpow]
+    simpa [b] using hblinear
+  have hrelation := relationAt?_isSome_of_linear a d coeffs hdle halinear
+  exact ⟨hdpos, hdle, hrelation⟩
+
+private theorem minpoly?_isSome [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) : a.minpoly?.isSome := by
+  let b : AdjoinRoot (definingPolynomial p) := toAdjoinRoot a
+  let d := (minpoly Rat b).natDegree
+  obtain ⟨hdpos, hdle, hrelation⟩ :
+      0 < d ∧ d ≤ p.degree?.getD 0 ∧
+        (a.relationAt? a.krylovOrbit d).isSome := by
+    simpa [b, d] using minpoly_relation a
+  unfold minpoly?
+  rw [List.findSome?_isSome_iff]
+  refine ⟨d - 1, ?_, ?_⟩
+  · simp
+    omega
+  · rw [Nat.sub_add_cancel (n := d) (m := 1) hdpos]
+    exact hrelation
+
+private theorem span_relation [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) (k : Nat) (coeffs : Vector Rat k)
+    (hspan : Matrix.spanCoeffs
+        (Matrix.ofFn fun i : Fin k => fun j : Fin (p.degree?.getD 0) =>
+          (a ^ i.val).coeffs.coeff j)
+        (Vector.ofFn fun j : Fin (p.degree?.getD 0) =>
+          (a ^ k).coeffs.coeff j) = some coeffs) :
+    Polynomial.aeval a
+      (HexPolyMathlib.toPolynomial (relationPoly coeffs)) = 0 := by
+  have hcoords := Matrix.spanCoeffs_sound _ _ _ hspan
+  have hlinear : ∑ i : Fin k, coeffs[i] • a ^ i.val = a ^ k := by
+    apply (adjoinRootEquiv (p := p) (x := x)).injective
+    simp only [map_sum, adjoinRootEquiv_apply, toAdjoinRoot_smul]
+    let B := AdjoinRoot.powerBasisAux' (definingPolynomial_monic p)
+    apply B.repr.injective
+    ext j
+    simp only [map_sum, map_smulₛₗ, RingHom.id_apply,
+      Finset.sum_apply', Finsupp.coe_smul, Pi.smul_apply, smul_eq_mul]
+    have hrepr (b : QAdjoin p x) :
+        (B.repr (toAdjoinRoot b)) j = b.coeffs.coeff j.val := by
+      simpa [B] using adjoinRoot_repr b j
+    rw [hrepr (a ^ k)]
+    have hsum :
+        (∑ i : Fin k, coeffs[i] *
+          (B.repr (toAdjoinRoot (a ^ i.val))) j) =
+        ∑ i : Fin k, coeffs[i] * (a ^ i.val).coeffs.coeff j.val := by
+      apply Finset.sum_congr rfl
+      intro i _hi
+      rw [hrepr (a ^ i.val)]
+    rw [hsum]
+    have hjlt : j.val < p.degree?.getD 0 := by
+      rw [← natDegree_definingPolynomial p]
+      exact j.isLt
+    let j' : Fin (p.degree?.getD 0) := ⟨j.val, hjlt⟩
+    have hj := congrArg
+      (fun v : Vector Rat (p.degree?.getD 0) => v[j']) hcoords
+    change (coeffs * (Matrix.ofFn fun i : Fin k =>
+      fun j : Fin (p.degree?.getD 0) => (a ^ i.val).coeffs.coeff j))[j'] =
+        (Vector.ofFn fun j : Fin (p.degree?.getD 0) =>
+          (a ^ k).coeffs.coeff j)[j'] at hj
+    rw [Matrix.getElem_vecMul, HexMatrixMathlib.dotProduct_eq] at hj
+    have hentry (i : Fin k) :
+        (Matrix.getRow (Matrix.ofFn fun i : Fin k =>
+          fun j : Fin (p.degree?.getD 0) =>
+            (a ^ i.val).coeffs.coeff j) i)[j'] =
+          (a ^ i.val).coeffs.coeff j'.val := by
+      rw [← Matrix.getElem_eq_getRow, Matrix.getElem_ofFn]
+    have hj' :
+        (∑ i : Fin k, (a ^ i.val).coeffs.coeff j.val * coeffs[i]) =
+          (a ^ k).coeffs.coeff j.val := by
+      simpa [dotProduct, Matrix.col, hentry, j',
+        natDegree_definingPolynomial] using hj
+    calc
+      _ = ∑ i : Fin k, (a ^ i.val).coeffs.coeff j.val * coeffs[i] := by
+        apply Finset.sum_congr rfl
+        intro i _hi
+        exact mul_comm _ _
+      _ = _ := hj'
+  rw [Polynomial.aeval_def, HexPolyMathlib.eval₂_toPolynomial]
+  rw [relationPoly_size, Finset.sum_range_succ, relationPoly_coeff_top]
+  have hlow :
+      (∑ i ∈ Finset.range k,
+        (algebraMap Rat (QAdjoin p x)) ((relationPoly coeffs).coeff i) * a ^ i) =
+        -∑ i : Fin k, coeffs[i] • a ^ i.val := by
+    rw [← Finset.sum_neg_distrib, Finset.sum_fin_eq_sum_range]
+    apply Finset.sum_congr rfl
+    intro i hi
+    have hik : i < k := Finset.mem_range.mp hi
+    rw [relationPoly_coeff coeffs ⟨i, hik⟩,
+      (algebraMap Rat (QAdjoin p x)).map_neg]
+    simp [hik, Algebra.smul_def]
+  rw [hlow, hlinear]
+  simp
+
+private theorem relationAt?_sound [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) (k : Nat) {q : ZPoly}
+    (hq : a.relationAt? a.krylovOrbit k = some q) :
+    Polynomial.aeval a (HexPolyZMathlib.toPolyℚ q) = 0 := by
+  unfold relationAt? at hq
+  dsimp only at hq
+  split at hq
+  · obtain ⟨coeffs, hspan, rfl⟩ := Option.map_eq_some_iff.mp hq
+    have hspan' : Matrix.spanCoeffs
+        (Matrix.ofFn fun i : Fin k =>
+          fun j : Fin (p.degree?.getD 0) =>
+            (a ^ i.val).coeffs.coeff j)
+        (Vector.ofFn fun j : Fin (p.degree?.getD 0) =>
+          (a ^ k).coeffs.coeff j) = some coeffs := by
+      simpa only [krylovOrbit_get] using hspan
+    have hrel := span_relation a k coeffs hspan'
+    rcases ZPoly.ratPolyPrimitivePart_rational_associate
+        (relationPoly coeffs) with ⟨u, hu⟩
+    have hrelation_ne : relationPoly coeffs ≠ 0 := by
+      intro hzero
+      have htop := relationPoly_coeff_top coeffs
+      rw [hzero] at htop
+      simp at htop
+    have hu_ne : u ≠ 0 := by
+      intro hzero
+      rw [hzero] at hu
+      simp at hu
+      exact hrelation_ne hu
+    have hpoly := congrArg HexPolyMathlib.toPolynomial hu
+    rw [HexPolyMathlib.toPolynomial_scale,
+      HexPolyZMathlib.toPolynomial_toRatPoly] at hpoly
+    have hscaled :
+        (algebraMap Rat (QAdjoin p x)) u *
+          Polynomial.aeval a
+            (HexPolyZMathlib.toPolyℚ
+              (ZPoly.ratPolyPrimitivePart (relationPoly coeffs))) = 0 := by
+      simpa [hpoly] using hrel
+    exact (mul_eq_zero.mp hscaled).resolve_left
+      (by simpa using (algebraMap Rat (QAdjoin p x)).injective.ne hu_ne)
+  · simp at hq
+
+private theorem relationAt?_natDegree [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) (k : Nat) {q : ZPoly}
+    (hq : a.relationAt? a.krylovOrbit k = some q) :
+    (HexPolyZMathlib.toPolyℚ q).natDegree = k := by
+  unfold relationAt? at hq
+  dsimp only at hq
+  split at hq
+  · obtain ⟨coeffs, _hspan, rfl⟩ := Option.map_eq_some_iff.mp hq
+    rcases ZPoly.ratPolyPrimitivePart_rational_associate
+        (relationPoly coeffs) with ⟨u, hu⟩
+    have hrelation_ne : relationPoly coeffs ≠ 0 := by
+      intro hzero
+      have htop := relationPoly_coeff_top coeffs
+      rw [hzero] at htop
+      simp at htop
+    have hu_ne : u ≠ 0 := by
+      intro hzero
+      rw [hzero] at hu
+      simp at hu
+      exact hrelation_ne hu
+    have hpoly := congrArg HexPolyMathlib.toPolynomial hu
+    rw [HexPolyMathlib.toPolynomial_scale,
+      HexPolyZMathlib.toPolynomial_toRatPoly] at hpoly
+    have hdegree := congrArg Polynomial.natDegree hpoly
+    rw [relationPoly_natDegree, Polynomial.natDegree_C_mul hu_ne] at hdegree
+    exact hdegree.symm
+  · simp at hq
+
+private theorem relationAt?_degree [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) (k : Nat) {q : ZPoly}
+    (hq : a.relationAt? a.krylovOrbit k = some q) :
+    q.degree?.getD 0 = k := by
+  have hdegree := relationAt?_natDegree a k hq
+  rw [HexPolyZMathlib.toPolyℚ,
+    Polynomial.natDegree_map_eq_of_injective
+      (RingHom.injective_int (Int.castRingHom Rat)),
+    HexPolyMathlib.natDegree_toPolynomial] at hdegree
+  exact hdegree
+
+private theorem minpoly?_sound [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) {q : ZPoly} (hq : a.minpoly? = some q) :
+    Polynomial.aeval a (HexPolyZMathlib.toPolyℚ q) = 0 := by
+  unfold minpoly? at hq
+  obtain ⟨k, _hk, hrelation⟩ := List.exists_of_findSome?_eq_some hq
+  exact relationAt?_sound a (k + 1) hrelation
+
+private theorem minpoly?_natDegree [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) {q : ZPoly} (hq : a.minpoly? = some q) :
+    let b : AdjoinRoot (definingPolynomial p) := toAdjoinRoot a
+    (HexPolyZMathlib.toPolyℚ q).natDegree = (minpoly Rat b).natDegree := by
+  let b : AdjoinRoot (definingPolynomial p) := toAdjoinRoot a
+  let d := (minpoly Rat b).natDegree
+  letI : Module.Free Rat (AdjoinRoot (definingPolynomial p)) :=
+    (definingPolynomial_monic p).free_adjoinRoot
+  letI : Module.Finite Rat (AdjoinRoot (definingPolynomial p)) :=
+    (definingPolynomial_monic p).finite_adjoinRoot
+  have hbint : IsIntegral Rat b := IsIntegral.of_finite Rat b
+  unfold minpoly? at hq
+  dsimp only at hq
+  obtain ⟨i, hi, hrelation, hprior⟩ := range_findSome?_eq_some hq
+  have hqdegree := relationAt?_natDegree a (i + 1) hrelation
+  have hqrootA := relationAt?_sound a (i + 1) hrelation
+  let E := adjoinRootAlgEquiv (p := p) (x := x)
+  have hqrootB : Polynomial.aeval b (HexPolyZMathlib.toPolyℚ q) = 0 := by
+    change Polynomial.aeval (E a) (HexPolyZMathlib.toPolyℚ q) = 0
+    rw [Polynomial.aeval_algEquiv]
+    simp [hqrootA]
+  have hqne : HexPolyZMathlib.toPolyℚ q ≠ 0 := by
+    intro hzero
+    rw [hzero, Polynomial.natDegree_zero] at hqdegree
+    omega
+  have hdvd : minpoly Rat b ∣ HexPolyZMathlib.toPolyℚ q :=
+    minpoly.dvd Rat b hqrootB
+  have hdle : d ≤ i + 1 := by
+    have := Polynomial.natDegree_le_of_dvd hdvd hqne
+    have hbase : d ≤ (HexPolyZMathlib.toPolyℚ q).natDegree := by
+      simpa [d] using this
+    exact hbase.trans_eq hqdegree
+  obtain ⟨hdpos, _hdbound, hdrelation⟩ :
+      0 < d ∧ d ≤ p.degree?.getD 0 ∧
+        (a.relationAt? a.krylovOrbit d).isSome := by
+    simpa [b, d] using minpoly_relation a
+  have hile : i + 1 ≤ d := by
+    by_contra hnot
+    have hdlt : d < i + 1 := Nat.lt_of_not_ge hnot
+    have hnone := hprior (d - 1) (by omega)
+    have hnone' : a.relationAt? a.krylovOrbit d = none := by
+      simpa [Nat.sub_add_cancel (n := d) (m := 1) hdpos] using hnone
+    rw [hnone'] at hdrelation
+    simp at hdrelation
+  have hid : i + 1 = d := Nat.le_antisymm hile hdle
+  exact hqdegree.trans hid
+
+private theorem minpoly?_certificates [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) {q : ZPoly} (hq : a.minpoly? = some q) :
+    ZPoly.content q = 1 ∧ 0 < q.leadingCoeff ∧
+      0 < q.degree?.getD 0 ∧ ZPoly.isIrreducible q = true ∧
+      HasOnlySimpleRoots q := by
+  have hdegreeMin := minpoly?_natDegree a hq
+  have hrootA := minpoly?_sound a hq
+  have hfind := hq
+  unfold minpoly? at hfind
+  dsimp only at hfind
+  obtain ⟨i, hi, hrelation, _hprior⟩ :=
+    range_findSome?_eq_some hfind
+  have hrelation' := hrelation
+  unfold relationAt? at hrelation
+  dsimp only at hrelation
+  rw [dif_pos (by omega : i + 1 ≤ p.degree?.getD 0)] at hrelation
+  obtain ⟨coeffs, _hspan, rfl⟩ := Option.map_eq_some_iff.mp hrelation
+  have hrelationNe : relationPoly coeffs ≠ 0 := by
+    intro hzero
+    have htop := relationPoly_coeff_top coeffs
+    rw [hzero] at htop
+    simp at htop
+  have hpos : 0 < (ZPoly.ratPolyPrimitivePart
+      (relationPoly coeffs)).leadingCoeff :=
+    ZPoly.leadingCoeff_ratPolyPrimitivePart_pos_of_ne_zero
+      (relationPoly coeffs) hrelationNe
+  have hdegreeEq := relationAt?_degree a (i + 1) hrelation'
+  have hdegree : 0 < (ZPoly.ratPolyPrimitivePart
+      (relationPoly coeffs)).degree?.getD 0 := by omega
+  have hqne : ZPoly.ratPolyPrimitivePart (relationPoly coeffs) ≠ 0 := by
+    intro hzero
+    rw [hzero] at hdegree
+    simp at hdegree
+  have hcontentNe : ZPoly.content
+      (ZPoly.ratPolyPrimitivePart (relationPoly coeffs)) ≠ 0 := by
+    intro hcontent
+    have hreconstruct := ZPoly.content_mul_primitivePart
+      (ZPoly.ratPolyPrimitivePart (relationPoly coeffs))
+    rw [hcontent] at hreconstruct
+    apply hqne
+    simpa using hreconstruct.symm
+  have hprim : ZPoly.Primitive
+      (ZPoly.ratPolyPrimitivePart (relationPoly coeffs)) :=
+    ZPoly.ratPolyPrimitivePart_primitive (relationPoly coeffs) hcontentNe
+  let q := ZPoly.ratPolyPrimitivePart (relationPoly coeffs)
+  let b : AdjoinRoot (definingPolynomial p) := toAdjoinRoot a
+  letI : Module.Free Rat (AdjoinRoot (definingPolynomial p)) :=
+    (definingPolynomial_monic p).free_adjoinRoot
+  letI : Module.Finite Rat (AdjoinRoot (definingPolynomial p)) :=
+    (definingPolynomial_monic p).finite_adjoinRoot
+  have hbint : IsIntegral Rat b := IsIntegral.of_finite Rat b
+  let E := adjoinRootAlgEquiv (p := p) (x := x)
+  have hrootB : Polynomial.aeval b (HexPolyZMathlib.toPolyℚ q) = 0 := by
+    change Polynomial.aeval (E a) (HexPolyZMathlib.toPolyℚ q) = 0
+    rw [Polynomial.aeval_algEquiv]
+    simpa [q] using congrArg E hrootA
+  have hqRatNe : HexPolyZMathlib.toPolyℚ q ≠ 0 := by
+    intro hzero
+    have hdegzero := congrArg Polynomial.natDegree hzero
+    rw [Polynomial.natDegree_zero] at hdegzero
+    have hratDegree : (HexPolyZMathlib.toPolyℚ q).natDegree =
+        q.degree?.getD 0 := by
+      rw [HexPolyZMathlib.toPolyℚ,
+        Polynomial.natDegree_map_eq_of_injective
+          (RingHom.injective_int (Int.castRingHom Rat)),
+        HexPolyMathlib.natDegree_toPolynomial]
+    rw [hratDegree] at hdegzero
+    exact (Nat.ne_of_gt (by simpa [q] using hdegree)) hdegzero
+  have hdvd : minpoly Rat b ∣ HexPolyZMathlib.toPolyℚ q :=
+    minpoly.dvd Rat b hrootB
+  have hdegreeMin' : (HexPolyZMathlib.toPolyℚ q).natDegree =
+      (minpoly Rat b).natDegree := by
+    simpa [q, b] using hdegreeMin
+  have hassoc : Associated (minpoly Rat b) (HexPolyZMathlib.toPolyℚ q) :=
+    Polynomial.associated_of_dvd_of_natDegree_le hdvd hqRatNe
+      hdegreeMin'.le
+  have hirredRat : Irreducible (HexPolyZMathlib.toPolyℚ q) :=
+    hassoc.irreducible (minpoly.irreducible hbint)
+  have hprimPoly : (HexPolyZMathlib.toPolynomial q).IsPrimitive :=
+    HexPolyZMathlib.isPrimitive_toPolynomial_of_primitive q (by
+      simpa [q] using hprim)
+  have hirredPoly : Irreducible (HexPolyZMathlib.toPolynomial q) :=
+    (Polynomial.IsPrimitive.Int.irreducible_iff_irreducible_map_cast
+      hprimPoly).mpr (by simpa [HexPolyZMathlib.toPolyℚ] using hirredRat)
+  have hirredProp : ZPoly.Irreducible q :=
+    (HexBerlekampZassenhausMathlib.Hex.ZPoly.Irreducible_iff_polynomialIrreducible
+      q).mpr hirredPoly
+  have hirred : ZPoly.isIrreducible q = true :=
+    (HexBerlekampZassenhausMathlib.Hex.ZPoly.isIrreducible_iff q).mpr
+      hirredProp
+  let checked : ZPoly.CheckedIrreducible q := ⟨hirred, by
+    simpa [q] using hdegree⟩
+  letI : ZPoly.CheckedIrreducible q := checked
+  have hsimple : HasOnlySimpleRoots q :=
+    (HexRootsMathlib.hasOnlySimpleRoots_iff_separable q (by simpa [q] using hqne)).mpr
+      (ZPoly.CheckedIrreducible.separable q)
+  exact ⟨by simpa [q, ZPoly.Primitive] using hprim,
+    by simpa [q] using hpos, by simpa [q] using hdegree,
+    hirred, hsimple⟩
+
+private theorem minpoly?_complexRoot [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) {q : ZPoly} (hq : a.minpoly? = some q) :
+    (HexPolyZMathlib.toPolyℚ q).eval₂ (algebraMap Rat ℂ)
+      (toComplex a rep h) = 0 := by
+  have hroot := minpoly?_sound a hq
+  have hcomp :
+      (algebraMap Rat ℂ).comp (RingHom.id Rat) =
+        (embedding rep h).comp (algebraMap Rat (QAdjoin p x)) := by
+    ext r
+    simp only [RingHom.comp_apply, RingHom.id_apply]
+    exact ((embedding rep h).map_rat_algebraMap r).symm
+  have hmapped := Polynomial.map_aeval_eq_aeval_map hcomp
+    (HexPolyZMathlib.toPolyℚ q) a
+  rw [hroot, (embedding rep h).map_zero] at hmapped
+  simpa [Polynomial.aeval_def] using hmapped.symm
+
+private theorem dist_center_le_of_meets
+    {b c : DyadicComplexBall} (hb : 0 ≤ b.realRadius)
+    (hc : 0 ≤ c.realRadius) (h : b.meets c = true) :
+    dist b.center c.center ≤ b.realRadius + c.realRadius := by
+  have hdy :
+      GaussDyadic.distSq (b.re, b.im) (c.re, c.im) ≤
+        (b.radius + c.radius) * (b.radius + c.radius) := by
+    simpa [DyadicComplexBall.meets] using of_decide_eq_true h
+  have hreal := HexRootsMathlib.Dyadic.toReal_le_toReal_iff.mpr hdy
+  apply (sq_le_sq₀ dist_nonneg (add_nonneg hb hc)).mp
+  simpa only [HexRootsMathlib.Dyadic.toReal_mul,
+    HexRootsMathlib.Dyadic.toReal_add,
+    HexRootsMathlib.DyadicSquare.toReal_distSq,
+    DyadicComplexBall.center, DyadicComplexBall.realRadius,
+    pow_two] using hreal
+
+private theorem meets_of_mem {b c : DyadicComplexBall} {z : ℂ}
+    (hb : z ∈ b.set) (hc : z ∈ c.set) : b.meets c = true := by
+  have hb' : dist b.center z ≤ b.realRadius := by
+    rw [dist_comm]
+    exact Metric.mem_closedBall.mp hb
+  have hc' : dist z c.center ≤ c.realRadius :=
+    Metric.mem_closedBall.mp hc
+  have hrb : 0 ≤ b.realRadius := dist_nonneg.trans hb'
+  have hrc : 0 ≤ c.realRadius := dist_nonneg.trans hc'
+  have hdist : dist b.center c.center ≤
+      b.realRadius + c.realRadius := by
+    exact (dist_triangle b.center z c.center).trans
+      (add_le_add hb' hc')
+  have hsq : dist b.center c.center ^ 2 ≤
+      (b.realRadius + c.realRadius) ^ 2 :=
+    (sq_le_sq₀ dist_nonneg (add_nonneg hrb hrc)).mpr hdist
+  have hreal :
+      HexRootsMathlib.Dyadic.toReal
+          (GaussDyadic.distSq (b.re, b.im) (c.re, c.im)) ≤
+        HexRootsMathlib.Dyadic.toReal
+          ((b.radius + c.radius) * (b.radius + c.radius)) := by
+    simpa only [HexRootsMathlib.Dyadic.toReal_mul,
+      HexRootsMathlib.Dyadic.toReal_add,
+      HexRootsMathlib.DyadicSquare.toReal_distSq,
+      DyadicComplexBall.center, DyadicComplexBall.realRadius,
+      pow_two] using hsq
+  have hdy := HexRootsMathlib.Dyadic.toReal_le_toReal_iff.mp hreal
+  simpa [DyadicComplexBall.meets] using decide_eq_true hdy
+
+private theorem toBall_radius_lt_rootDist {q : ZPoly} (hq : q ≠ 0)
+    {s : DyadicSquare} (hprec : (mahlerPrec q : Int) ≤ s.prec)
+    {z w : ℂ} (hz : (HexRootsMathlib.toPolyℂ q).IsRoot z)
+    (hw : (HexRootsMathlib.toPolyℂ q).IsRoot w) (hne : z ≠ w) :
+    s.toBall.realRadius < ‖z - w‖ / 4 := by
+  have hpow : (2 : ℝ) ^ (-s.prec) ≤
+      (2 : ℝ) ^ (-(mahlerPrec q : ℤ)) := by
+    apply zpow_le_zpow_right₀ (by norm_num : (1 : ℝ) ≤ 2)
+    omega
+  rw [DyadicSquare.toBall, DyadicComplexBall.realRadius,
+    HexRootsMathlib.DyadicSquare.radiusHi_eq,
+    HexRootsMathlib.DyadicSquare.halfWidth_eq]
+  calc
+    (2 : ℝ) ^ (-s.prec) *
+        HexRootsMathlib.Dyadic.toReal sqrt2Hi =
+        (2 : ℝ) ^ (-s.prec) * (1449 / 1024 : ℝ) := by
+      congr 1
+      norm_num [sqrt2Hi, HexRootsMathlib.Dyadic.toReal_ofIntWithPrec]
+    _ ≤ (2 : ℝ) ^ (-(mahlerPrec q : ℤ)) *
+        (1449 / 1024 : ℝ) :=
+      mul_le_mul_of_nonneg_right hpow (by norm_num)
+    _ < ‖z - w‖ / 4 :=
+      HexRootsMathlib.mahlerPrec_separates q hq z w hz hw hne
+
+private theorem root_eq_of_meetsBall {q : ZPoly} (hq : q ≠ 0)
+    (r : RefinedIsolation q) {z : ℂ}
+    (hz : (HexRootsMathlib.toPolyℂ q).IsRoot z)
+    {b : DyadicComplexBall} (hzmem : z ∈ b.set)
+    (hbradius : b.realRadius ≤ (2 : ℝ) ^ (-(mahlerPrec q : ℤ)))
+    (hmeet : r.1.square.meetsBall b = true) :
+    r.root = z := by
+  have hrmem : r.root ∈ r.1.square.toBall.set := by
+    rw [DyadicComplexBall.set, Metric.mem_closedBall]
+    change dist r.root (HexRootsMathlib.DyadicSquare.center r.1.square) ≤
+      HexRootsMathlib.Dyadic.toReal r.1.square.radiusHi
+    exact (Metric.mem_closedBall.mp
+      (HexRootsMathlib.RefinedIsolation.root_mem_closedDisc r)).trans
+        (HexRootsMathlib.DyadicSquare.radius_lt_radiusHi r.1.square).le
+  have hrnonneg : 0 ≤ r.1.square.toBall.realRadius :=
+    dist_nonneg.trans (Metric.mem_closedBall.mp hrmem)
+  have hbnonneg : 0 ≤ b.realRadius :=
+    dist_nonneg.trans (Metric.mem_closedBall.mp hzmem)
+  have hcenters := dist_center_le_of_meets hrnonneg hbnonneg (by
+    simpa [DyadicSquare.meetsBall] using hmeet)
+  by_contra hne
+  have hrradius : r.1.square.toBall.realRadius < ‖r.root - z‖ / 4 :=
+    toBall_radius_lt_rootDist hq r.property
+      (HexRootsMathlib.RefinedIsolation.isRoot r) hz hne
+  have hbasepos : 0 < (2 : ℝ) ^ (-(mahlerPrec q : ℤ)) := by
+    positivity
+  have hbase_lt :
+      (2 : ℝ) ^ (-(mahlerPrec q : ℤ)) <
+        (2 : ℝ) ^ (-(mahlerPrec q : ℤ)) * (1449 / 1024 : ℝ) := by
+    nlinarith
+  have hbradius' : b.realRadius < ‖r.root - z‖ / 4 :=
+    hbradius.trans_lt <| hbase_lt.trans <|
+      HexRootsMathlib.mahlerPrec_separates q hq r.root z
+        (HexRootsMathlib.RefinedIsolation.isRoot r) hz hne
+  have hrcenter : dist r.root r.1.square.toBall.center ≤
+      r.1.square.toBall.realRadius :=
+    Metric.mem_closedBall.mp hrmem
+  have hbcenter : dist b.center z ≤ b.realRadius := by
+    rw [dist_comm]
+    exact Metric.mem_closedBall.mp hzmem
+  have hdist : dist r.root z ≤
+      2 * (r.1.square.toBall.realRadius + b.realRadius) := by
+    calc
+      dist r.root z ≤
+          dist r.root r.1.square.toBall.center +
+            dist r.1.square.toBall.center z := dist_triangle _ _ _
+      _ ≤ dist r.root r.1.square.toBall.center +
+          (dist r.1.square.toBall.center b.center + dist b.center z) := by
+        simpa only [add_assoc] using add_le_add_right
+          (dist_triangle r.1.square.toBall.center b.center z)
+          (dist r.root r.1.square.toBall.center)
+      _ ≤ r.1.square.toBall.realRadius +
+          ((r.1.square.toBall.realRadius + b.realRadius) + b.realRadius) :=
+        add_le_add hrcenter (add_le_add hcenters hbcenter)
+      _ = 2 * (r.1.square.toBall.realRadius + b.realRadius) := by ring
+  rw [Complex.dist_eq] at hdist
+  have : ‖r.root - z‖ < ‖r.root - z‖ := by
+    nlinarith [hrradius, hbradius']
+  exact (lt_irrefl _ this)
+
 /-- Successful conversion out of fixed coordinates preserves their value at
 the selected embedding. -/
 theorem toAlgebraicNumber?_sound [ZPoly.CheckedIrreducible p]
@@ -65,7 +1130,75 @@ theorem toAlgebraicNumber?_sound [ZPoly.CheckedIrreducible p]
     (h : SimpleRoot.mk rep = x) {b : AlgebraicNumber}
     (hb : a.toAlgebraicNumber? rep h = some b) :
     b.toComplex = toComplex a rep h := by
-  sorry
+  unfold QAdjoin.toAlgebraicNumber? at hb
+  obtain ⟨q, hq, hb⟩ := Option.bind_eq_some_iff.mp hb
+  split at hb
+  · rename_i hprim
+    split at hb
+    · rename_i hpos
+      split at hb
+      · rename_i hdegree
+        split at hb
+        · rename_i hirred
+          split at hb
+          · rename_i hsimple
+            obtain ⟨isolations, hisolate, hb⟩ :=
+              Option.bind_eq_some_iff.mp hb
+            obtain ⟨refined, hrefined, hb⟩ :=
+              Option.bind_eq_some_iff.mp hb
+            obtain ⟨threaded, hthreaded, hb⟩ :=
+              Option.bind_eq_some_iff.mp hb
+            obtain ⟨matching, hmatching, hnormalized⟩ :=
+              Option.bind_eq_some_iff.mp hb
+            let requested : Int := mahlerPrec q
+            let target : Int := requested +
+              (approxGuardBits rep.1.square a.coeffs : Int)
+            let valueBall := evalRatBall a.coeffs threaded.1.1.square target
+            have hmeet : matching.1.square.meetsBall valueBall = true := by
+              simpa [valueBall, target, requested] using
+                List.find?_some hmatching
+            have hvalueMem : toComplex a rep h ∈ valueBall.set := by
+              have hsound := QAdjoin.approx_sound a rep h requested
+              unfold QAdjoin.approx at hsound
+              dsimp only at hsound
+              rw [hthreaded] at hsound
+              simpa [valueBall, target, requested] using hsound
+            have hvalueRadius : valueBall.realRadius ≤
+                (2 : ℝ) ^ (-(mahlerPrec q : ℤ)) := by
+              have hradius := QAdjoin.approx_radius a rep h requested
+              unfold QAdjoin.approx at hradius
+              dsimp only at hradius
+              rw [hthreaded] at hradius
+              simpa [valueBall, target, requested] using hradius
+            have hrootRat := minpoly?_complexRoot a rep h hq
+            have hcomp :
+                (algebraMap Rat ℂ).comp (Int.castRingHom Rat) =
+                  Int.castRingHom ℂ := RingHom.ext_int _ _
+            have hmap :
+                (HexPolyZMathlib.toPolyℚ q).map (algebraMap Rat ℂ) =
+                  HexRootsMathlib.toPolyℂ q := by
+              dsimp [HexPolyZMathlib.toPolyℚ, HexRootsMathlib.toPolyℂ]
+              rw [Polynomial.map_map, hcomp]
+            have hroot :
+                (HexRootsMathlib.toPolyℂ q).IsRoot (toComplex a rep h) := by
+              rw [Polynomial.IsRoot.def, ← hmap, Polynomial.eval_map]
+              exact hrootRat
+            have hqne : q ≠ 0 := by
+              intro hzero
+              rw [hzero] at hdegree
+              simp at hdegree
+            have hrootEq : matching.root = toComplex a rep h :=
+              root_eq_of_meetsBall hqne matching hroot hvalueMem
+                hvalueRadius hmeet
+            have hout := AlgebraicNumber.ofNormalized?_toComplex
+              q hprim hpos hdegree ⟨hirred, hdegree⟩ hsimple matching
+              hnormalized
+            exact hout.trans hrootEq
+          · simp at hb
+        · simp at hb
+      · simp at hb
+    · simp at hb
+  · simp at hb
 
 /-- The minimal-polynomial and isolation search for fixed coordinates always
 finds a canonical representative. -/
@@ -73,7 +1206,116 @@ theorem toAlgebraicNumber?_isSome [ZPoly.CheckedIrreducible p]
     (a : QAdjoin p x) (rep : RefinedIsolation p)
     (h : SimpleRoot.mk rep = x) :
     (a.toAlgebraicNumber? rep h).isSome := by
-  sorry
+  have hmin := minpoly?_isSome a
+  cases hq : a.minpoly? with
+  | none => simp [hq] at hmin
+  | some q =>
+      obtain ⟨hprim, hpos, hdegree, hirred, hsimple⟩ :=
+        minpoly?_certificates a hq
+      unfold QAdjoin.toAlgebraicNumber?
+      simp only [hq, Option.bind_eq_bind, Option.bind_some]
+      rw [dif_pos hprim, dif_pos hpos, dif_pos hdegree,
+        dif_pos hirred, dif_pos hsimple]
+      have hqne : q ≠ 0 := by
+        intro hzero
+        rw [hzero] at hdegree
+        simp at hdegree
+      have hisolate := HexRootsMathlib.isolate_isSome q hsimple hqne
+        (separationDepth q : Int) .nkThenPellet
+      cases hrun : isolate q hsimple (separationDepth q : Int) with
+      | none => simp [hrun] at hisolate
+      | some isolations =>
+          have hmapSome := HexRootsMathlib.array_mapM_isSome
+            (xs := isolations) (f := DyadicRootIsolation.toRefined?)
+            (fun iso hiso => by
+              simp [DyadicRootIsolation.toRefined?,
+                HexRootsMathlib.isolate_refined q hsimple
+                  (separationDepth q : Int) .nkThenPellet hrun iso hiso])
+          cases hmap : isolations.mapM DyadicRootIsolation.toRefined? with
+          | none => simp [hmap] at hmapSome
+          | some refined =>
+              have hrootRat := minpoly?_complexRoot a rep h hq
+              have hcomp :
+                  (algebraMap Rat ℂ).comp (Int.castRingHom Rat) =
+                    Int.castRingHom ℂ := RingHom.ext_int _ _
+              have hpolyMap :
+                  (HexPolyZMathlib.toPolyℚ q).map (algebraMap Rat ℂ) =
+                    HexRootsMathlib.toPolyℂ q := by
+                dsimp [HexPolyZMathlib.toPolyℚ, HexRootsMathlib.toPolyℂ]
+                rw [Polynomial.map_map, hcomp]
+              have hroot :
+                  (HexRootsMathlib.toPolyℂ q).IsRoot
+                    (toComplex a rep h) := by
+                rw [Polynomial.IsRoot.def, ← hpolyMap,
+                  Polynomial.eval_map]
+                exact hrootRat
+              obtain ⟨iso, hiso, hisoRoot⟩ :=
+                HexRootsMathlib.isolate_root_mem_of_pos q hsimple
+                  (separationDepth q : Int) .nkThenPellet hdegree hrun hroot
+              obtain ⟨i, hiList, hidx⟩ := List.getElem_of_mem hiso
+              have hi : i < isolations.size := by simpa using hiList
+              obtain ⟨hmapSize, hmapGet⟩ :=
+                HexRootsMathlib.array_mapM_some_get hmap
+              have hj : i < refined.size := by
+                simpa [← hmapSize] using hi
+              have hto := hmapGet i hi hj
+              have hraw : refined[i].1 = isolations[i] := by
+                rw [DyadicRootIsolation.toRefined?] at hto
+                split at hto
+                · exact (congrArg Subtype.val (Option.some.inj hto)).symm
+                · simp at hto
+              have harrIso : isolations[i] = iso := by
+                rw [← hidx]
+                exact (Array.getElem_toList hi).symm
+              have hrefinedRoot :
+                  HexRootsMathlib.RefinedIsolation.root refined[i] =
+                    toComplex a rep h := by
+                change HexRootsMathlib.DyadicRootIsolation.root refined[i].1 =
+                  toComplex a rep h
+                rw [hraw, harrIso]
+                exact hisoRoot
+              let requested : Int := mahlerPrec q
+              let target : Int := requested +
+                (approxGuardBits rep.1.square a.coeffs : Int)
+              have hthreadSome :=
+                Hex.RefinedIsolation.refineTo?_isSome rep target
+              cases hthreaded : rep.refineTo? target .nkThenPellet with
+              | none => simp [hthreaded] at hthreadSome
+              | some threaded =>
+                  let valueBall :=
+                    evalRatBall a.coeffs threaded.1.1.square target
+                  have hvalueMem :
+                      toComplex a rep h ∈ valueBall.set := by
+                    have hsound := QAdjoin.approx_sound a rep h requested
+                    unfold QAdjoin.approx at hsound
+                    dsimp only at hsound
+                    rw [hthreaded] at hsound
+                    simpa [valueBall, target, requested] using hsound
+                  have hcandMem :
+                      toComplex a rep h ∈
+                        refined[i].1.square.toBall.set := by
+                    rw [← hrefinedRoot]
+                    exact DyadicComplexBall.mem_toBall
+                      (HexRootsMathlib.RefinedIsolation.root_mem_closedDisc
+                        refined[i])
+                  have hmeet : refined[i].1.square.meetsBall valueBall = true := by
+                    simpa [DyadicSquare.meetsBall] using
+                      meets_of_mem hcandMem hvalueMem
+                  have hmatching :
+                      (refined.find? fun r =>
+                        r.1.square.meetsBall valueBall).isSome := by
+                    simp
+                    exact ⟨refined[i], by
+                      simp, hmeet⟩
+                  cases hfind : refined.find? fun r =>
+                      r.1.square.meetsBall valueBall with
+                  | none => simp [hfind] at hmatching
+                  | some matching =>
+                      have hnormalized :=
+                        AlgebraicNumber.ofNormalized?_isSome q hprim hpos
+                          hdegree ⟨hirred, hdegree⟩ hsimple matching
+                      simpa [hmap, hthreaded, hfind, valueBall, target,
+                        requested] using hnormalized
 
 /-- The total fixed-presentation conversion preserves the selected complex
 value. -/
@@ -90,5 +1332,31 @@ theorem toAlgebraicNumber_toComplex [ZPoly.CheckedIrreducible p]
         toAlgebraicNumber?_sound a rep h hb
 
 end QAdjoin
+
+/-! The total exactification headlines must not inherit an unfinished proof. -/
+
+/--
+info: 'Hex.AlgebraicRoot.exact?_isSome' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms AlgebraicRoot.exact?_isSome
+
+/--
+info: 'Hex.AlgebraicRoot.exact_toComplex' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms AlgebraicRoot.exact_toComplex
+
+/--
+info: 'Hex.QAdjoin.toAlgebraicNumber?_isSome' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms QAdjoin.toAlgebraicNumber?_isSome
+
+/--
+info: 'Hex.QAdjoin.toAlgebraicNumber_toComplex' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms QAdjoin.toAlgebraicNumber_toComplex
 
 end Hex

--- a/HexNumberFieldMathlib/SPEC/hex-number-field-mathlib.md
+++ b/HexNumberFieldMathlib/SPEC/hex-number-field-mathlib.md
@@ -111,12 +111,30 @@ theorem AlgebraicRoot.exact_toComplex (a : AlgebraicRoot) :
 theorem QAdjoin.toAlgebraicNumber?_sound
     [ZPoly.CheckedIrreducible p] (...) {b} (h : ... = some b) :
     b.toComplex = QAdjoin.toComplex a rep hrep
+
+theorem QAdjoin.toAlgebraicNumber?_isSome
+    [ZPoly.CheckedIrreducible p] (...) :
+    (a.toAlgebraicNumber? rep hrep).isSome
+
+theorem QAdjoin.toAlgebraicNumber_toComplex
+    [ZPoly.CheckedIrreducible p] (...) :
+    (a.toAlgebraicNumber rep hrep).toComplex =
+      QAdjoin.toComplex a rep hrep
 ```
 
 Exactification completeness follows because the squarefree enclosing polynomial
 factors into distinct irreducibles and exactly one factor contains the selected
 root. Factor soundness supplies the product identity; resultant common-root facts
 and disjoint refined isolations supply uniqueness.
+
+Fixed-presentation completeness instead uses the first Krylov dependence of the
+represented element. Finite dimensionality supplies a dependence at the Mathlib
+minimal-polynomial degree, first-success minimality proves that the executable
+relation has exactly that degree, and Gauss normalization supplies its primitive,
+positive-leading, irreducible, and simple-root certificates. Isolation completeness
+finds its represented complex root; the guarded approximation ball and the
+candidate disc share that root, so the executable intersection test succeeds and
+canonical normalization is total.
 
 ## Lazy arithmetic
 

--- a/HexRoots/SimpleRoot.lean
+++ b/HexRoots/SimpleRoot.lean
@@ -132,6 +132,7 @@ theorem SimpleRoot.posDegree {p : ZPoly} (x : SimpleRoot p) :
     precision, deciding the subtype bound. `isolate`'s output always
     qualifies (its target has a `separationDepth ≥ mahlerPrec` floor); this
     is the constructor consumers use to record that fact. -/
+@[expose]
 def DyadicRootIsolation.toRefined? {p : ZPoly} (iso : DyadicRootIsolation p) :
     Option (RefinedIsolation p) :=
   if h : (mahlerPrec p : Int) ≤ iso.square.prec then some ⟨iso, h⟩ else none

--- a/HexRootsMathlib/Completeness/RefinementCompleteness.lean
+++ b/HexRootsMathlib/Completeness/RefinementCompleteness.lean
@@ -709,6 +709,37 @@ theorem refineTo?_isSome_mixed {p : Hex.ZPoly}
 
 end DyadicRootIsolation
 
+namespace RefinedIsolation
+
+/-- Refined-level refinement is total for the default mixed strategy. -/
+theorem refineTo?_isSome_mixed {p : Hex.ZPoly}
+    (rep : Hex.RefinedIsolation p) (target : Int) :
+    (rep.refineTo? target .nkThenPellet).isSome := by
+  have hsome := DyadicRootIsolation.refineTo?_isSome_mixed rep
+    (max target (Hex.mahlerPrec p : Int))
+  cases hraw : rep.1.refineTo? (max target (Hex.mahlerPrec p : Int))
+      .nkThenPellet with
+  | none => simp [hraw] at hsome
+  | some iso =>
+      have hready := DyadicRootIsolation.refineTo_ready hraw
+      have hprec : (Hex.mahlerPrec p : Int) ≤ iso.square.prec :=
+        (le_max_right target (Hex.mahlerPrec p : Int)).trans hready
+      let out : Hex.RefinedIsolation p := ⟨iso, hprec⟩
+      have hroot : RefinedIsolation.root out = RefinedIsolation.root rep := by
+        exact DyadicRootIsolation.refineTo_root rep.1
+          (max target (Hex.mahlerPrec p : Int)) .nkThenPellet hraw
+      have hinter : Hex.Intersects out rep :=
+        (RefinedIsolation.intersects_iff_root_eq out rep).mpr hroot
+      rw [Hex.RefinedIsolation.refineTo?]
+      simp only [hraw, Option.bind_eq_bind, Option.bind_some]
+      split
+      · rename_i hprec'
+        simp
+      · rename_i hnot
+        exact (hnot hprec).elim
+
+end RefinedIsolation
+
 end
 
 end HexRootsMathlib

--- a/HexRootsMathlib/Isolate.lean
+++ b/HexRootsMathlib/Isolate.lean
@@ -93,7 +93,7 @@ private theorem list_mapM_some_get {α β : Type*} {f : α → Option β}
 
 /-- An option-valued array map that succeeds preserves size and corresponding
 entries. -/
-private theorem array_mapM_some_get {α β : Type*} {f : α → Option β}
+theorem array_mapM_some_get {α β : Type*} {f : α → Option β}
     {xs : Array α} {ys : Array β} (hmap : xs.mapM f = some ys) :
     xs.size = ys.size ∧
       ∀ (i : Nat) (hi : i < xs.size) (hj : i < ys.size),
@@ -108,6 +108,37 @@ private theorem array_mapM_some_get {α β : Type*} {f : α → Option β}
   intro i hi hj
   simpa only [← Array.getElem_toList] using hget i (by simpa using hi)
     (by simpa using hj)
+
+private theorem list_mapM_isSome {α β : Type*} {f : α → Option β}
+    {xs : List α} (h : ∀ x ∈ xs, (f x).isSome) :
+    (xs.mapM f).isSome := by
+  rw [Option.isSome_iff_exists]
+  induction xs with
+  | nil => exact ⟨[], rfl⟩
+  | cons x xs ih =>
+      have hx := h x (List.mem_cons_self)
+      have hxs : ∀ y ∈ xs, (f y).isSome := fun y hy =>
+        h y (List.mem_cons_of_mem x hy)
+      rw [Option.isSome_iff_exists] at hx
+      obtain ⟨y, hy⟩ := hx
+      obtain ⟨ys, hys⟩ := ih hxs
+      exact ⟨y :: ys, by simp [hy, hys]⟩
+
+/-- An option-valued array map succeeds when its function succeeds on every
+input entry. -/
+theorem array_mapM_isSome {α β : Type*} {f : α → Option β}
+    {xs : Array α} (h : ∀ x ∈ xs.toList, (f x).isSome) :
+    (xs.mapM f).isSome := by
+  have hlist := list_mapM_isSome h
+  cases hmap : xs.mapM f with
+  | none =>
+      have hnone : xs.toList.mapM f = none := by
+        calc
+          xs.toList.mapM f = Array.toList <$> xs.mapM f := Array.toList_mapM.symm
+          _ = none := by rw [hmap]; rfl
+      rw [hnone] at hlist
+      simp at hlist
+  | some ys => simp
 
 /-- In the positive-degree branch, successful isolation is a successful
 Cauchy-started general driver run whose results correspond indexwise to the

--- a/HexRootsMathlib/MahlerPrec.lean
+++ b/HexRootsMathlib/MahlerPrec.lean
@@ -8,6 +8,7 @@ module
 
 public import Mathlib
 public import HexRootsMathlib.Basic
+public import HexRootsMathlib.Geometry
 public import HexPolyZMathlib.MahlerSeparation
 
 public section
@@ -267,6 +268,69 @@ theorem mahlerPrec_separates (p : Hex.ZPoly) (hp : p ≠ 0) :
       div_lt_div_of_pos_right (mul_lt_mul_of_pos_left hconst hinv0) (by norm_num)
     _ = ((2 : ℝ) ^ E)⁻¹ / 4 := by ring
     _ ≤ ‖z₁ - z₂‖ / 4 := by linarith
+
+namespace DyadicSquare
+
+/-- A square at the ambient polynomial's Mahler precision has radius less
+than one quarter of the distance between any two distinct ambient roots. -/
+theorem radius_lt_rootDist {p : Hex.ZPoly} (hp : p ≠ 0)
+    {s : Hex.DyadicSquare} (hprec : (Hex.mahlerPrec p : Int) ≤ s.prec)
+    {z w : ℂ} (hz : (toPolyℂ p).IsRoot z) (hw : (toPolyℂ p).IsRoot w)
+    (hne : z ≠ w) :
+    radius s < ‖z - w‖ / 4 := by
+  have hpow : (2 : ℝ) ^ (-s.prec) ≤
+      (2 : ℝ) ^ (-(Hex.mahlerPrec p : ℤ)) := by
+    apply zpow_le_zpow_right₀ (by norm_num : (1 : ℝ) ≤ 2)
+    omega
+  have hsqrt : √2 < (1449 / 1024 : ℝ) := by
+    convert sqrt_two_lt_sqrt2Hi using 1
+    norm_num [Hex.sqrt2Hi, HexRootsMathlib.Dyadic.toReal_ofIntWithPrec]
+  calc
+    radius s = (2 : ℝ) ^ (-s.prec) * √2 := radius_eq _
+    _ < (2 : ℝ) ^ (-s.prec) * (1449 / 1024 : ℝ) :=
+      mul_lt_mul_of_pos_left hsqrt (zpow_pos (by norm_num) _)
+    _ ≤ (2 : ℝ) ^ (-(Hex.mahlerPrec p : ℤ)) * (1449 / 1024 : ℝ) :=
+      mul_le_mul_of_nonneg_right hpow (by norm_num)
+    _ < ‖z - w‖ / 4 := mahlerPrec_separates p hp z w hz hw hne
+
+/-- Intersecting sufficiently refined discs around roots of one ambient
+polynomial represent the same root. The two isolations may come from different
+factors of that polynomial. -/
+theorem root_eq_of_discsMeet {p : Hex.ZPoly} (hp : p ≠ 0)
+    {s t : Hex.DyadicSquare}
+    (hs : (Hex.mahlerPrec p : Int) ≤ s.prec)
+    (ht : (Hex.mahlerPrec p : Int) ≤ t.prec)
+    {z w : ℂ} (hz : (toPolyℂ p).IsRoot z) (hw : (toPolyℂ p).IsRoot w)
+    (hzmem : z ∈ closedDisc s) (hwmem : w ∈ closedDisc t)
+    (hmeet : s.discsMeet t = true) : z = w := by
+  by_contra hne
+  have hrs := radius_lt_rootDist hp hs hz hw hne
+  have hrt := radius_lt_rootDist hp ht hw hz (Ne.symm hne)
+  rw [norm_sub_rev] at hrt
+  have hc : dist (center s) (center t) ≤ radius s + radius t :=
+    dist_center_le_of_discsMeet hmeet
+  have hmz : dist z (center s) ≤ radius s := by
+    simpa only [closedDisc, Metric.mem_closedBall] using hzmem
+  have hmw : dist (center t) w ≤ radius t := by
+    rw [dist_comm]
+    simpa only [closedDisc, Metric.mem_closedBall] using hwmem
+  have hdist : dist z w ≤ 2 * (radius s + radius t) := by
+    calc
+      dist z w ≤ dist z (center s) + dist (center s) w :=
+        dist_triangle _ _ _
+      _ ≤ dist z (center s) + (dist (center s) (center t) +
+          dist (center t) w) := by
+        simpa only [add_assoc] using
+          add_le_add_right (dist_triangle (center s) (center t) w)
+            (dist z (center s))
+      _ ≤ radius s + ((radius s + radius t) + radius t) :=
+        add_le_add hmz (add_le_add hc hmw)
+      _ = 2 * (radius s + radius t) := by ring
+  rw [Complex.dist_eq] at hdist
+  have : ‖z - w‖ < ‖z - w‖ := by nlinarith [hrs, hrt]
+  exact (lt_irrefl _ this)
+
+end DyadicSquare
 
 end
 

--- a/bench/HexNumberField/Bench.lean
+++ b/bench/HexNumberField/Bench.lean
@@ -12,7 +12,7 @@ Benchmark registrations for `HexNumberField`.
 
 The fixed cases separate the costs requested by the library SPEC:
 
-* degree-10 fixed-presentation multiplication and inversion;
+* degree-10 fixed-presentation multiplication, inversion, and minimal relation;
 * lazy addition eliminant construction;
 * isolation and operation-ball disambiguation for a precomputed eliminant;
 * the complete lazy addition driver;
@@ -97,6 +97,16 @@ def runFixedInv : Unit → IO UInt64 :=
   else
     fun _ => throw <| IO.userError "fixed/inv: irreducibility check failed"
 
+def runFixedMinpoly : Unit → IO UInt64 :=
+  if hirred : ZPoly.isIrreducible degreeTenPoly = true then
+    letI : ZPoly.CheckedIrreducible degreeTenPoly :=
+      ⟨hirred, by decide⟩
+    fun _ => do
+      let a ← requireSome "fixed/minpoly" (← fixedFieldRef.get)
+      return polyChecksum (← requireSome "fixed/minpoly" a.minpoly?)
+  else
+    fun _ => throw <| IO.userError "fixed/minpoly: irreducibility check failed"
+
 /- Degree-`n` dense multiplication followed by reduction modulo a degree-`n`
 relation performs `O(n²)` rational coefficient operations. This canonical
 `n = 10` case is fixed because the SPEC supplies an absolute 100 ms budget,
@@ -112,6 +122,14 @@ required degree-10 budget is tested as a fixed regression. -/
 setup_fixed_benchmark runFixedInv where {
   repeats := 5, maxSecondsPerCall := 0.1,
   expectedHash := some 0x1525969728101d06
+}
+
+/- One iterative Krylov orbit is shared across the degree-10 first-dependence
+search. This fixed registration catches accidental recomputation of powers in
+each span matrix entry before that cost reaches exactification callers. -/
+setup_fixed_benchmark runFixedMinpoly where {
+  repeats := 3, maxSecondsPerCall := 5.0,
+  expectedHash := some 0xb1ed00ebc8d039e9
 }
 
 /-! # Lazy arithmetic fixtures -/

--- a/progress/20260729T100121Z_number-field-exactification-totality.md
+++ b/progress/20260729T100121Z_number-field-exactification-totality.md
@@ -1,0 +1,29 @@
+# Number-field exactification totality
+
+## Accomplished
+
+- Proved totality and soundness of normalized algebraic-number construction and irreducible-factor exactification.
+- Reworked fixed-presentation relation discovery around direct Krylov powers and proved span-solver soundness and completeness.
+- Proved the first relation returned by `QAdjoin.minpoly?` has minimal-polynomial degree and yields the required primitive, positive-leading, irreducible, and simple-root certificates.
+- Proved fixed-presentation exactification survives isolation, refinement, guarded approximation, candidate matching, and canonical normalization, with the total wrapper preserving its selected complex value.
+- Added the public factorization, refinement, geometry, coordinate, and algebra-equivalence bridges needed by those proofs.
+- Recorded the fixed-presentation totality and semantic headline in the permanent Mathlib SPEC.
+- Reworked the executable relation search to share one linear-multiplication Krylov orbit, added its coordinate proof, and registered a degree-10 minimal-relation benchmark after review caught repeated power recomputation.
+- Added axiom guards for all four exactification totality/headline theorems and deduplicated refined-level totality through the lower HexRootsMathlib theorem.
+- Built `HexNumberFieldMathlib.Exact` successfully with no new `sorry` declarations.
+- Monitored and repaired the preceding approximation-radius PR through CI; PR #9080 is merged.
+
+## Current frontier
+
+The fixed-presentation exactification milestone is rebased onto merged PR #9080,
+reviewed, and locally complete. The review's performance blocker is fixed, and
+the final whole-project, conformance, and benchmark checks pass.
+
+## Next step
+
+Publish this milestone as the sole NumberField PR, monitor its CI, and begin the
+next NumberField stage locally without opening another PR before this one merges.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Summary

- prove totality and semantic soundness for `AlgebraicRoot.exact?` and fixed-presentation `QAdjoin.toAlgebraicNumber?`
- prove the Krylov/row-reduction relation search returns the minimal-polynomial degree and all canonical certificates
- add the factorization, refinement, isolation-geometry, coordinate, and algebra-equivalence bridges needed by those proofs
- construct and share one iterative Krylov orbit, with a degree-10 benchmark guarding against repeated power recomputation
- add axiom guards for the four exactification headline theorems and record the contract in the permanent NumberField specs

## Why

The executable exactification paths were present, but their Mathlib totality and value-preservation obligations were unfinished. A first implementation also recomputed powers inside every relation-matrix entry; this version materializes the orbit once, so only one fixed-field multiplication is needed per new power.

## Validation

- `lake build` (9,632 jobs)
- `lake build HexNumberField.Conformance`
- `lake exe hexnumberfield_bench verify` (all 9 benchmarks)
- no new `sorry`, `axiom`, or `native_decide` in changed sources
- explicit `#print axioms` guards confirm only `propext`, `Classical.choice`, and `Quot.sound`
