### PR TITLE
feat(mvpoly): prove order and algebra laws

### DIFF
--- a/HexBasic.lean
+++ b/HexBasic.lean
@@ -9,9 +9,9 @@ module
 public import HexBasic.ArrayDecEq
 public import HexBasic.ExtTreeMap
 public import HexBasic.Fold
+public import HexBasic.List
 public import HexBasic.ModuleBoundaryTests
 public import HexBasic.OfFn
-public import HexBasic.ListShim
 public import HexBasic.Vector.Modify
 
 public section
@@ -21,8 +21,9 @@ public section
 general-purpose helpers that clearly belong in the standard library and are
 reproduced here so the library remains Mathlib-free. It provides reusable
 `ExtTreeMap` merge/traversal operations, the shared
-`List.foldl` algebra (`HexBasic.Fold`), the `Batteries` list lemmas reproduced
-in `HexBasic.ListShim`, the `Vector.modify` update helper, and
+`List.foldl` algebra (`HexBasic.Fold`), reusable list lemmas (`HexBasic.List`),
+the `Batteries` list lemmas reproduced in `HexBasic.ListShim`, the
+`Vector.modify` update helper, and
 kernel-reducible `Array`/`Vector` equality (`HexBasic.ArrayDecEq`) and
 `ofFn` (`HexBasic.OfFn`).
 -/

--- a/HexBasic/List.lean
+++ b/HexBasic/List.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexBasic.ListShim
+
+public section
+
+/-!
+Reusable list lemmas that are candidates for upstreaming.
+
+Unlike `HexBasic.ListShim`, whose declarations deliberately mirror existing
+Batteries signatures, this file owns Hex-local additions to the `List` API.
+-/
+
+namespace List
+
+/-- A flat map is duplicate-free when every row is duplicate-free and rows
+coming from distinct source elements are disjoint. -/
+theorem nodup_flatMap_of_disjoint {α β} {xs : List α} {f : α → List β}
+    (hxs : xs.Nodup)
+    (hrow : ∀ x, x ∈ xs → (f x).Nodup)
+    (hdisj :
+      ∀ x, x ∈ xs → ∀ y, y ∈ xs → x ≠ y →
+        ∀ z, z ∈ f x → z ∈ f y → False) :
+    (xs.flatMap f).Nodup := by
+  induction xs with
+  | nil =>
+      simp
+  | cons x xs ih =>
+      rw [nodup_cons] at hxs
+      rw [flatMap_cons, nodup_append]
+      refine ⟨hrow x (by simp), ?_, ?_⟩
+      · exact ih hxs.2
+          (by intro y hy; exact hrow y (by simp [hy]))
+          (by
+            intro y hy z hz hyz t hty htz
+            exact hdisj y (by simp [hy]) z (by simp [hz]) hyz t hty htz)
+      · intro a ha b hb hab
+        rcases mem_flatMap.mp hb with ⟨y, hy, hby⟩
+        exact hdisj x (by simp) y (by simp [hy])
+          (fun hxy => hxs.1 (hxy ▸ hy)) a ha (hab ▸ hby)
+
+/-- Lexicographic comparison is unchanged by pointwise combining both lists
+with the same third list when the element comparison has the corresponding
+invariance. The length hypotheses ensure `zipWith` does not truncate. -/
+theorem compareLex_zipWith {α β} (cmp : α → α → Ordering) (f : α → β → α)
+    (hcmp : ∀ a b c, cmp a b = cmp (f a c) (f b c)) :
+    ∀ (as bs : List α) (cs : List β),
+      as.length = bs.length →
+      as.length = cs.length →
+      List.compareLex cmp as bs =
+        List.compareLex cmp (zipWith f as cs) (zipWith f bs cs)
+  | [], [], [], _, _ => rfl
+  | a :: as, b :: bs, c :: cs, hab, hac => by
+      simp only [length] at hab hac
+      have hab' : as.length = bs.length := by omega
+      have hac' : as.length = cs.length := by omega
+      simp only [List.zipWith]
+      rw [List.compareLex_cons_cons, List.compareLex_cons_cons,
+        ← hcmp a b c, compareLex_zipWith cmp f hcmp as bs cs hab' hac']
+
+end List

--- a/HexMvPoly/KernelTests.lean
+++ b/HexMvPoly/KernelTests.lean
@@ -72,6 +72,28 @@ example :
     Mono.gcd (Mono.unit 0 : Mono 2) (Mono.unit 1 : Mono 2) = Mono.zero := by
   decide +kernel
 
+example : Mono.lex #v[1, 5] #v[2, 0] = .lt := by
+  decide +kernel
+
+example : Mono.grlex #v[2, 0] #v[1, 2] = .lt := by
+  decide +kernel
+
+example : Mono.grevlex #v[1, 1] #v[2, 0] = .lt := by
+  decide +kernel
+
+example : Mono.grlex #v[2, 0, 1] #v[1, 2, 0] = .gt := by
+  decide +kernel
+
+example : Mono.grevlex #v[2, 0, 1] #v[1, 2, 0] = .lt := by
+  decide +kernel
+
+example :
+    Mono.grevlex #v[1, 1] #v[2, 0] =
+      Mono.grevlex
+        (Mono.mul #v[1, 1] #v[3, 4])
+        (Mono.mul #v[2, 0] #v[3, 4]) := by
+  decide +kernel
+
 abbrev GP := MvPoly 2 Int Mono.grlex
 
 @[expose] def gx : GP := X 0
@@ -104,6 +126,18 @@ example :
 example :
     evalHorner (fun i => if i = 0 then 2 else 3) sparse =
       eval (fun i => if i = 0 then 2 else 3) sparse := by
+  decide +kernel
+
+example :
+    partialEval (fun i => if i = 0 then some 2 else none) sparse =
+      ofTerms
+        [(Mono.zero, 37), (#v[0, 2], 6), (#v[0, 3], -1)] := by
+  decide +kernel
+
+example :
+    partialEval (fun i => if i = 0 then some 2 else none)
+        (ofTerms [(#v[1, 0], 1), (Mono.zero, -2)] : P) =
+      0 := by
   decide +kernel
 
 @[expose] def outerGap : P :=
@@ -192,5 +226,41 @@ example : (X 0 : P1) * X 0 = monomial
 /-- info: 'Hex.MvPoly.KernelTests.oneVar_roundtrip' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in
 #print axioms oneVar_roundtrip
+
+/-- info: 'Hex.Mono.instLexOrder' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms Hex.Mono.instLexOrder
+
+/-- info: 'Hex.Mono.instGrlexOrder' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms Hex.Mono.instGrlexOrder
+
+/-- info: 'Hex.Mono.instGrevlexOrder' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms Hex.Mono.instGrevlexOrder
+
+/-- info: 'Hex.MvPoly.coeff_pow_succ' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms Hex.MvPoly.coeff_pow_succ
+
+/-- info: 'Hex.MvPoly.pow_succ' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms Hex.MvPoly.pow_succ
+
+/-- info: 'Hex.MvPoly.mul_assoc' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms Hex.MvPoly.mul_assoc
+
+/-- info: 'Hex.MvPoly.mul_comm' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms Hex.MvPoly.mul_comm
+
+/-- info: 'Hex.MvPoly.mul_add' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms Hex.MvPoly.mul_add
+
+/-- info: 'Hex.MvPoly.partialEval_eq_subst' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in
+#print axioms Hex.MvPoly.partialEval_eq_subst
 
 end Hex.MvPoly.KernelTests

--- a/HexMvPoly/Mono.lean
+++ b/HexMvPoly/Mono.lean
@@ -6,6 +6,8 @@ Authors: Kim Morrison
 
 module
 
+import HexBasic.Fold
+import HexBasic.List
 public import HexBasic.ArrayDecEq
 public import HexBasic.ExtTreeMap
 public import HexBasic.OfFn
@@ -40,6 +42,10 @@ def unit (i : Fin n) : Mono n :=
 /-- Monomial multiplication, represented by pointwise exponent addition. -/
 def mul (a b : Mono n) : Mono n :=
   Hex.Vector.ofFn' fun i => a[i] + b[i]
+
+/-- Multiply every exponent by `k`. -/
+def scale (k : Nat) (m : Mono n) : Mono n :=
+  Hex.Vector.ofFn' fun i => k * m[i]
 
 /-- Whether `a` divides `b`, i.e. whether every exponent of `a` is at
 most the corresponding exponent of `b`. -/
@@ -248,15 +254,6 @@ class IsMonomialOrder {n : Nat} (cmp : Mono n → Mono n → Ordering) : Prop
 
 namespace Mono
 
-instance (priority := 100) instLexOrder : IsMonomialOrder (@lex n) := by
-  sorry
-
-instance (priority := 100) instGrlexOrder : IsMonomialOrder (@grlex n) := by
-  sorry
-
-instance (priority := 100) instGrevlexOrder : IsMonomialOrder (@grevlex n) := by
-  sorry
-
 @[simp] theorem getElem_zero (i : Fin n) : (zero : Mono n)[i] = 0 := by
   simp [zero]
 
@@ -267,6 +264,96 @@ instance (priority := 100) instGrevlexOrder : IsMonomialOrder (@grevlex n) := by
 @[simp] theorem getElem_mul (a b : Mono n) (i : Fin n) :
     (mul a b)[i] = a[i] + b[i] := by
   simp [mul]
+
+@[simp] theorem zero_mul (m : Mono n) : mul zero m = m := by
+  apply Vector.ext
+  intro i hi
+  simp [mul, zero]
+
+@[simp] theorem mul_zero (m : Mono n) : mul m zero = m := by
+  apply Vector.ext
+  intro i hi
+  simp [mul, zero]
+
+theorem mul_assoc (a b c : Mono n) :
+    mul (mul a b) c = mul a (mul b c) := by
+  apply Vector.ext
+  intro i hi
+  simp [mul, Nat.add_assoc]
+
+theorem mul_comm (a b : Mono n) : mul a b = mul b a := by
+  apply Vector.ext
+  intro i hi
+  simp [mul, Nat.add_comm]
+
+@[simp] theorem getElem_scale (k : Nat) (m : Mono n) (i : Fin n) :
+    (scale k m)[i] = k * m[i] := by
+  simp [scale]
+
+@[simp] theorem zero_scale (m : Mono n) : scale 0 m = zero := by
+  apply Vector.ext
+  intro i hi
+  simp [scale, zero]
+
+@[simp] theorem scale_zero (k : Nat) : scale k (zero : Mono n) = zero := by
+  apply Vector.ext
+  intro i hi
+  simp [scale, zero]
+
+@[simp] theorem one_scale (m : Mono n) : scale 1 m = m := by
+  apply Vector.ext
+  intro i hi
+  simp [scale]
+
+theorem add_scale (a b : Nat) (m : Mono n) :
+    scale (a + b) m = mul (scale a m) (scale b m) := by
+  apply Vector.ext
+  intro i hi
+  simp [scale, mul, Nat.add_mul]
+
+theorem mul_units (m : Mono n) :
+    (List.finRange n).foldl
+        (fun acc i => mul acc (scale m[i] (unit i)))
+        zero =
+      m := by
+  apply Vector.ext
+  intro j hj
+  let r : Fin n := ⟨j, hj⟩
+  have get_fold : ∀ (xs : List (Fin n)) (acc : Mono n),
+      (xs.foldl
+        (fun acc i => mul acc (scale m[i] (unit i))) acc)[r] =
+      xs.foldl
+        (fun acc i => acc + (scale m[i] (unit i))[r])
+        acc[r] := by
+    intro xs
+    induction xs with
+    | nil =>
+        intro acc
+        rfl
+    | cons i xs ih =>
+        intro acc
+        simp only [List.foldl_cons]
+        rw [ih, getElem_mul]
+  change
+    ((List.finRange n).foldl
+      (fun acc i => mul acc (scale m[i] (unit i))) zero)[r] = m[r]
+  rw [get_fold, getElem_zero]
+  calc
+    (List.finRange n).foldl
+        (fun acc i => acc + (scale m[i] (unit i))[r]) 0 =
+        (List.finRange n).foldl
+          (fun acc i => acc + if i = r then m[i] else 0) 0 := by
+            apply List.foldl_congr
+            intro acc i _
+            rw [getElem_scale, getElem_unit]
+            by_cases hir : i = r
+            · subst i
+              simp
+            · simp [hir, Ne.symm hir]
+    _ = 0 + m[r] :=
+      List.foldl_add_single _ _ _ _
+        (List.mem_finRange r) (List.nodup_finRange n)
+    _ = m[r] := by omega
 
 @[simp] theorem getElem_lcm (a b : Mono n) (i : Fin n) :
     (lcm a b)[i] = max a[i] b[i] := by
@@ -459,6 +546,342 @@ theorem degree_mul (a b : Mono n) :
   simp only [getElem_mul]
   exact fold_add (List.finRange n)
 
+@[simp] theorem toList_prepend (e : Nat) (m : Mono n) :
+    (prepend e m).toList = e :: m.toList := by
+  apply List.ext_getElem
+  · simp
+  · intro i hi hj
+    cases i with
+    | zero =>
+        simp
+    | succ i =>
+        have hi' : i < n := by simpa using hi
+        let j : Fin n := ⟨i, hi'⟩
+        change (prepend e m)[i + 1] = m[i]
+        exact getElem_prepend_succ e m j
+
+theorem toList_mul (a b : Mono n) :
+    (mul a b).toList = List.zipWith (· + ·) a.toList b.toList := by
+  apply List.ext_getElem
+  · simp
+  · intro i hi hj
+    rw [List.getElem_zipWith]
+    simp [mul]
+
+theorem lex_prepend (ea eb : Nat) (a b : Mono n) :
+    lex (prepend ea a) (prepend eb b) =
+      (compare ea eb).then (lex a b) := by
+  simp [lex, List.compareLex_cons_cons]
+
+private theorem zero_eq_prepend :
+    (zero : Mono (n + 1)) = prepend 0 (zero : Mono n) := by
+  apply Vector.ext
+  intro i hi
+  simp [zero, prepend]
+
+private theorem compare_add_right (a b c : Nat) :
+    compare a b = compare (a + c) (b + c) := by
+  cases h : compare a b with
+  | lt =>
+      rw [Nat.compare_eq_lt] at h
+      apply Eq.symm
+      rw [Nat.compare_eq_lt]
+      omega
+  | eq =>
+      rw [Nat.compare_eq_eq] at h
+      apply Eq.symm
+      rw [Nat.compare_eq_eq]
+      omega
+  | gt =>
+      rw [Nat.compare_eq_gt] at h
+      apply Eq.symm
+      rw [Nat.compare_eq_gt]
+      omega
+
+private theorem lex_zero_le : ∀ {n} (m : Mono n), lex zero m ≠ .gt
+  | 0, m => by
+      have hm : m = zero := by
+        apply Vector.ext
+        intro i hi
+        omega
+      subst m
+      intro h
+      have hself : lex (zero : Mono 0) zero = .eq :=
+        Std.ReflCmp.compare_self
+      rw [hself] at h
+      contradiction
+  | n + 1, m => by
+      rw [zero_eq_prepend, ← prepend_head_dropHead m, lex_prepend]
+      cases h : compare 0 m.head with
+      | lt => simp
+      | eq =>
+          simp only [Ordering.eq_then]
+          exact lex_zero_le (dropHead m)
+      | gt =>
+          rw [Nat.compare_eq_gt] at h
+          omega
+
+private theorem lex_mul_mono : ∀ {n} (a b c : Mono n),
+    lex a b = lex (mul a c) (mul b c)
+  | 0, a, b, c => by
+      have hz (m : Mono 0) : m = zero := by
+        apply Vector.ext
+        intro i hi
+        omega
+      simp [hz a, hz b, hz c]
+  | n + 1, a, b, c => by
+      rw [← prepend_head_dropHead a, ← prepend_head_dropHead b,
+        ← prepend_head_dropHead c, mul_prepend, mul_prepend,
+        lex_prepend, lex_prepend, ← compare_add_right,
+        lex_mul_mono (dropHead a) (dropHead b) (dropHead c)]
+
+private theorem lex_wf : ∀ n, WellFounded fun a b : Mono n => lex a b = .lt
+  | 0 => by
+      apply WellFounded.intro
+      intro a
+      apply Acc.intro
+      intro b h
+      have hz (m : Mono 0) : m = zero := by
+        apply Vector.ext
+        intro i hi
+        omega
+      have hself : lex (zero : Mono 0) zero = .eq :=
+        Std.ReflCmp.compare_self
+      rw [hz a, hz b, hself] at h
+      contradiction
+  | n + 1 => by
+      let tailOrder : WellFoundedRelation (Mono n) :=
+        ⟨fun a b => lex a b = .lt, lex_wf n⟩
+      apply Subrelation.wf
+        (r := InvImage
+          (Prod.Lex Nat.lt tailOrder.rel)
+          (fun m : Mono (n + 1) => (m.head, dropHead m)))
+      · intro a b h
+        rw [← prepend_head_dropHead a, ← prepend_head_dropHead b,
+          lex_prepend] at h
+        simp only [Ordering.then_eq_lt] at h
+        rcases h with hhead | ⟨hhead, htail⟩
+        · exact Prod.Lex.left _ _ (Nat.compare_eq_lt.mp hhead)
+        · exact Prod.lex_def.mpr
+            (Or.inr ⟨Nat.compare_eq_eq.mp hhead, htail⟩)
+      · exact InvImage.wf _
+          (Prod.lex Nat.lt_wfRel tailOrder).wf
+
+instance instLexOrder : IsMonomialOrder (@lex n) where
+  zero_le := lex_zero_le
+  mul_mono := lex_mul_mono
+  wf := lex_wf n
+
+@[simp] theorem degree_zero : degree (zero : Mono n) = 0 := by
+  unfold degree
+  apply List.foldl_add_eq_self
+  intro i _
+  exact getElem_zero i
+
+private theorem grlex_zero_le (m : Mono n) : grlex zero m ≠ .gt := by
+  unfold grlex compareLex
+  change
+    (compare (degree zero) (degree m)).then (lex zero m) ≠ .gt
+  rw [degree_zero]
+  cases h : compare 0 (degree m) with
+  | lt => simp
+  | eq =>
+      simp only [Ordering.eq_then]
+      exact lex_zero_le m
+  | gt =>
+      rw [Nat.compare_eq_gt] at h
+      omega
+
+private theorem grlex_mul_mono (a b c : Mono n) :
+    grlex a b = grlex (mul a c) (mul b c) := by
+  unfold grlex compareLex
+  change
+    (compare (degree a) (degree b)).then (lex a b) =
+      (compare (degree (mul a c)) (degree (mul b c))).then
+        (lex (mul a c) (mul b c))
+  rw [degree_mul, degree_mul, ← compare_add_right,
+    lex_mul_mono a b c]
+
+private theorem grlex_wf :
+    WellFounded fun a b : Mono n => grlex a b = .lt := by
+  let lexOrder : WellFoundedRelation (Mono n) :=
+    ⟨fun a b => lex a b = .lt, lex_wf n⟩
+  apply Subrelation.wf
+    (r := InvImage
+      (Prod.Lex Nat.lt lexOrder.rel)
+      (fun m : Mono n => (degree m, m)))
+  · intro a b h
+    unfold grlex compareLex at h
+    simp only [Ordering.then_eq_lt] at h
+    rcases h with hdegree | ⟨hdegree, hlex⟩
+    · exact Prod.Lex.left _ _ (Nat.compare_eq_lt.mp hdegree)
+    · exact Prod.lex_def.mpr
+        (Or.inr ⟨Nat.compare_eq_eq.mp hdegree, hlex⟩)
+  · exact InvImage.wf _
+      (Prod.lex Nat.lt_wfRel lexOrder).wf
+
+instance instGrlexOrder :
+    IsMonomialOrder (@grlex n) where
+  zero_le := grlex_zero_le
+  mul_mono := grlex_mul_mono
+  wf := grlex_wf
+
+private theorem revlex_mul_mono (a b c : Mono n) :
+    revlex a b = revlex (mul a c) (mul b c) := by
+  have hac : a.toList.length = c.toList.length := by simp
+  have hbc : b.toList.length = c.toList.length := by simp
+  unfold revlex
+  rw [toList_mul, toList_mul,
+    List.reverse_zipWith (f := (· + ·)) hac,
+    List.reverse_zipWith (f := (· + ·)) hbc]
+  apply List.compareLex_zipWith
+  · intro x y z
+    exact compare_add_right y x z
+  · simp
+  · simp
+
+theorem degreeOf_le_degree (i : Fin n) (m : Mono n) :
+    degreeOf i m ≤ degree m := by
+  unfold degreeOf degree
+  exact List.le_foldl_add_of_mem
+    (List.finRange n) (fun j => m[j]) (List.mem_finRange i)
+
+/-- Lexicographic key for the reverse-lexicographic tie breaker at one
+fixed total degree. Its coordinate subtractions are exact because every
+exponent is bounded by the total degree. -/
+private def revDegreeKey (m : Mono n) : Mono n :=
+  Hex.Vector.ofFn' fun i => degree m - m[i.rev]
+
+private theorem toList_revDegreeKey (m : Mono n) :
+    (revDegreeKey m).toList =
+      m.toList.reverse.map (fun e => degree m - e) := by
+  apply List.ext_getElem
+  · simp [revDegreeKey]
+  · intro i hi hj
+    simp [revDegreeKey, Fin.rev]
+    congr 2 <;> omega
+
+private theorem compare_sub (d x y : Nat) (hx : x ≤ d) (hy : y ≤ d) :
+    compare y x = compare (d - x) (d - y) := by
+  cases h : compare y x with
+  | lt =>
+      rw [Nat.compare_eq_lt] at h
+      apply Eq.symm
+      rw [Nat.compare_eq_lt]
+      omega
+  | eq =>
+      rw [Nat.compare_eq_eq] at h
+      apply Eq.symm
+      rw [Nat.compare_eq_eq]
+      omega
+  | gt =>
+      rw [Nat.compare_eq_gt] at h
+      apply Eq.symm
+      rw [Nat.compare_eq_gt]
+      omega
+
+private theorem compareLex_complement (d : Nat) :
+    ∀ (xs ys : List Nat),
+      (∀ x, x ∈ xs → x ≤ d) →
+      (∀ y, y ∈ ys → y ≤ d) →
+      List.compareLex (fun x y => compare y x) xs ys =
+        List.compareLex compare
+          (xs.map (fun x => d - x))
+          (ys.map (fun y => d - y))
+  | [], [], _, _ => rfl
+  | [], _ :: _, _, _ => rfl
+  | _ :: _, [], _, _ => rfl
+  | x :: xs, y :: ys, hxs, hys => by
+      simp only [List.map, List.compareLex_cons_cons]
+      rw [compare_sub d x y (hxs x (by simp)) (hys y (by simp)),
+        compareLex_complement d xs ys
+          (fun z hz => hxs z (by simp [hz]))
+          (fun z hz => hys z (by simp [hz]))]
+
+/-- At equal total degree, reverse lexicographic comparison is ordinary
+lexicographic comparison of the reversed degree-complement keys. -/
+private theorem revlex_eq_key_lex {a b : Mono n}
+    (hdegree : degree a = degree b) :
+    revlex a b = lex (revDegreeKey a) (revDegreeKey b) := by
+  unfold revlex lex
+  rw [toList_revDegreeKey, toList_revDegreeKey, ← hdegree]
+  apply compareLex_complement
+  · intro x hx
+    rw [List.mem_reverse] at hx
+    rcases List.mem_iff_getElem.mp hx with ⟨i, hi, rfl⟩
+    let j : Fin n := ⟨i, by simpa using hi⟩
+    exact degreeOf_le_degree j a
+  · intro x hx
+    rw [List.mem_reverse] at hx
+    rcases List.mem_iff_getElem.mp hx with ⟨i, hi, rfl⟩
+    let j : Fin n := ⟨i, by simpa using hi⟩
+    rw [hdegree]
+    exact degreeOf_le_degree j b
+
+private theorem grevlex_zero_le (m : Mono n) : grevlex zero m ≠ .gt := by
+  unfold grevlex compareLex
+  change
+    (compare (degree zero) (degree m)).then (revlex zero m) ≠ .gt
+  rw [degree_zero]
+  cases h : compare 0 (degree m) with
+  | lt => simp
+  | eq =>
+      have hdegree : degree m = 0 := Nat.compare_eq_eq.mp h |>.symm
+      have hm : m = zero := by
+        apply Vector.ext
+        intro i hi
+        let j : Fin n := ⟨i, hi⟩
+        have hj := degreeOf_le_degree j m
+        change m[j] ≤ degree m at hj
+        have : m[j] = 0 := by omega
+        change m[j] = (zero : Mono n)[j]
+        rw [getElem_zero]
+        exact this
+      subst m
+      intro hgt
+      simp [Std.ReflCmp.compare_self] at hgt
+  | gt =>
+      rw [Nat.compare_eq_gt] at h
+      omega
+
+private theorem grevlex_mul_mono (a b c : Mono n) :
+    grevlex a b = grevlex (mul a c) (mul b c) := by
+  unfold grevlex compareLex
+  change
+    (compare (degree a) (degree b)).then (revlex a b) =
+      (compare (degree (mul a c)) (degree (mul b c))).then
+        (revlex (mul a c) (mul b c))
+  rw [degree_mul, degree_mul, ← compare_add_right,
+    revlex_mul_mono a b c]
+
+private theorem grevlex_wf :
+    WellFounded fun a b : Mono n => grevlex a b = .lt := by
+  let lexOrder : WellFoundedRelation (Mono n) :=
+    ⟨fun a b => lex a b = .lt, lex_wf n⟩
+  apply Subrelation.wf
+    (r := InvImage
+      (Prod.Lex Nat.lt lexOrder.rel)
+      (fun m : Mono n => (degree m, revDegreeKey m)))
+  · intro a b h
+    unfold grevlex compareLex at h
+    simp only [Ordering.then_eq_lt] at h
+    rcases h with hdegree | ⟨hdegree, hrevlex⟩
+    · exact Prod.Lex.left _ _ (Nat.compare_eq_lt.mp hdegree)
+    · have heq := Nat.compare_eq_eq.mp hdegree
+      have hlex : lex (revDegreeKey a) (revDegreeKey b) = .lt := by
+        rw [← revlex_eq_key_lex heq]
+        exact hrevlex
+      apply Prod.lex_def.mpr
+      exact Or.inr ⟨heq, hlex⟩
+  · exact InvImage.wf _
+      (Prod.lex Nat.lt_wfRel lexOrder).wf
+
+instance instGrevlexOrder :
+    IsMonomialOrder (@grevlex n) where
+  zero_le := grevlex_zero_le
+  mul_mono := grevlex_mul_mono
+  wf := grevlex_wf
+
 theorem rename_mul {k : Nat} (f : Fin n → Fin k) (a b : Mono n) :
     rename f (mul a b) = mul (rename f a) (rename f b) := by
   have get_ofFn {r : Nat} (g : Fin r → Nat) (j : Fin r) :
@@ -612,6 +1035,14 @@ theorem dvd_lcm_right (a b : Mono n) : dvd b (lcm a b) = true := by
   rw [getElem_lcm]
   exact Nat.le_max_right _ _
 
+theorem lcm_dvd (a b c : Mono n)
+    (ha : dvd a c = true) (hb : dvd b c = true) :
+    dvd (lcm a b) c = true := by
+  rw [dvd_eq_true_iff] at ha hb ⊢
+  intro i
+  rw [getElem_lcm]
+  exact Nat.max_le.mpr ⟨ha i, hb i⟩
+
 theorem gcd_dvd_left (a b : Mono n) : dvd (gcd a b) a = true := by
   simp only [dvd, decide_eq_true_eq]
   intro i
@@ -623,6 +1054,14 @@ theorem gcd_dvd_right (a b : Mono n) : dvd (gcd a b) b = true := by
   intro i
   rw [getElem_gcd]
   exact Nat.min_le_right _ _
+
+theorem dvd_gcd (a b c : Mono n)
+    (ha : dvd c a = true) (hb : dvd c b = true) :
+    dvd c (gcd a b) = true := by
+  rw [dvd_eq_true_iff] at ha hb ⊢
+  intro i
+  rw [getElem_gcd]
+  exact Nat.le_min.mpr ⟨ha i, hb i⟩
 
 end Mono
 

--- a/HexMvPoly/Operations.lean
+++ b/HexMvPoly/Operations.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 import HexBasic.Fold
+import HexBasic.List
 public import HexMvPoly.Basic
 
 @[expose] public section
@@ -133,6 +134,41 @@ theorem coeff_add [Lean.Grind.Semiring R] [DecidableEq R]
     simp [Std.ExtTreeMap.mergeValue?, Lean.Grind.AddCommMonoid.zero_add,
       Lean.Grind.AddCommMonoid.add_zero] <;>
     split <;> simp_all
+
+theorem add_zero [Lean.Grind.Semiring R] [DecidableEq R]
+    (p : MvPoly n R cmp) : p + 0 = p := by
+  apply ext
+  intro m
+  rw [coeff_add, coeff_zero, Lean.Grind.Semiring.add_zero]
+
+theorem zero_add [Lean.Grind.Semiring R] [DecidableEq R]
+    (p : MvPoly n R cmp) : 0 + p = p := by
+  apply ext
+  intro m
+  rw [coeff_add, coeff_zero, Lean.Grind.AddCommMonoid.zero_add]
+
+theorem add_comm [Lean.Grind.Semiring R] [DecidableEq R]
+    (p q : MvPoly n R cmp) : p + q = q + p := by
+  apply ext
+  intro m
+  rw [coeff_add, coeff_add, Lean.Grind.Semiring.add_comm]
+
+theorem add_assoc [Lean.Grind.Semiring R] [DecidableEq R]
+    (p q r : MvPoly n R cmp) : (p + q) + r = p + (q + r) := by
+  apply ext
+  intro m
+  simp only [coeff_add]
+  rw [Lean.Grind.Semiring.add_assoc]
+
+theorem addMonomial_eq [Lean.Grind.Semiring R] [DecidableEq R]
+    (p : MvPoly n R cmp) (m : Mono n) (c : R) :
+    p.addMonomial m c = p + monomial m c := by
+  apply ext
+  intro k
+  rw [coeff_addMonomial, coeff_add, coeff_monomial]
+  by_cases hkm : k = m
+  · rw [if_pos hkm, if_pos hkm]
+  · rw [if_neg hkm, if_neg hkm, Lean.Grind.Semiring.add_zero]
 
 theorem coeff_neg [Lean.Grind.Ring R] (m : Mono n) (p : MvPoly n R cmp) :
     coeff m (-p) = -coeff m p := by
@@ -286,10 +322,521 @@ theorem coeff_mul [Lean.Grind.Semiring R] [DecidableEq R]
       (Mono.splits m).foldl (fun acc ab => acc + value ab) 0
   rw [hkeyFilter, List.foldl_add_perm value hactivePerm 0, hsplitFilter]
 
+theorem mul_zero [Lean.Grind.Semiring R] [DecidableEq R]
+    (p : MvPoly n R cmp) : p * 0 = 0 := by
+  apply ext
+  intro m
+  rw [coeff_mul, coeff_zero]
+  simp only [coeff_zero]
+  simp only [Lean.Grind.Semiring.mul_zero]
+  exact List.foldl_add_zero _ _
+
+theorem zero_mul [Lean.Grind.Semiring R] [DecidableEq R]
+    (p : MvPoly n R cmp) : 0 * p = 0 := by
+  apply ext
+  intro m
+  rw [coeff_mul, coeff_zero]
+  simp only [coeff_zero]
+  simp only [Lean.Grind.Semiring.zero_mul]
+  exact List.foldl_add_zero _ _
+
+theorem mul_add [Lean.Grind.Semiring R] [DecidableEq R]
+    (p q r : MvPoly n R cmp) : p * (q + r) = p * q + p * r := by
+  apply ext
+  intro m
+  simp only [coeff_mul, coeff_add]
+  calc
+    (Mono.splits m).foldl
+        (fun acc ab =>
+          acc + coeff ab.1 p * (coeff ab.2 q + coeff ab.2 r)) 0 =
+        (Mono.splits m).foldl
+          (fun acc ab =>
+            acc +
+              (coeff ab.1 p * coeff ab.2 q +
+                coeff ab.1 p * coeff ab.2 r)) 0 := by
+          apply List.foldl_congr
+          intro acc ab _
+          rw [Lean.Grind.Semiring.left_distrib]
+    _ =
+        (Mono.splits m).foldl
+            (fun acc ab => acc + coeff ab.1 p * coeff ab.2 q) 0 +
+          (Mono.splits m).foldl
+            (fun acc ab => acc + coeff ab.1 p * coeff ab.2 r) 0 :=
+      List.foldl_add_add _ _ _
+
+theorem add_mul [Lean.Grind.Semiring R] [DecidableEq R]
+    (p q r : MvPoly n R cmp) : (p + q) * r = p * r + q * r := by
+  apply ext
+  intro m
+  simp only [coeff_mul, coeff_add]
+  calc
+    (Mono.splits m).foldl
+        (fun acc ab =>
+          acc + (coeff ab.1 p + coeff ab.1 q) * coeff ab.2 r) 0 =
+        (Mono.splits m).foldl
+          (fun acc ab =>
+            acc +
+              (coeff ab.1 p * coeff ab.2 r +
+                coeff ab.1 q * coeff ab.2 r)) 0 := by
+          apply List.foldl_congr
+          intro acc ab _
+          rw [Lean.Grind.Semiring.right_distrib]
+    _ =
+        (Mono.splits m).foldl
+            (fun acc ab => acc + coeff ab.1 p * coeff ab.2 r) 0 +
+          (Mono.splits m).foldl
+            (fun acc ab => acc + coeff ab.1 q * coeff ab.2 r) 0 :=
+      List.foldl_add_add _ _ _
+
+theorem monomial_mul_monomial [Lean.Grind.Semiring R] [DecidableEq R]
+    (a b : Mono n) (ca cb : R) :
+    (monomial a ca : MvPoly n R cmp) * monomial b cb =
+      (monomial (Mono.mul a b) (ca * cb) : MvPoly n R cmp) := by
+  apply ext
+  intro m
+  rw [coeff_mul]
+  simp only [coeff_monomial]
+  by_cases hm : m = Mono.mul a b
+  · subst m
+    rw [if_pos rfl]
+    have hmem : (a, b) ∈ Mono.splits (Mono.mul a b) :=
+      (Mono.splits_mem_iff ..).mpr rfl
+    calc
+      (Mono.splits (Mono.mul a b)).foldl
+          (fun acc ab =>
+            acc + (if ab.1 = a then ca else 0) *
+              if ab.2 = b then cb else 0)
+          0 =
+          (Mono.splits (Mono.mul a b)).foldl
+            (fun acc ab =>
+              acc + if ab = (a, b) then ca * cb else 0)
+            0 := by
+              apply List.foldl_congr
+              intro acc ab _
+              rcases ab with ⟨x, y⟩
+              by_cases hx : x = a
+              · subst x
+                by_cases hy : y = b
+                · subst y
+                  simp
+                · simp [hy, Lean.Grind.Semiring.mul_zero]
+              · simp [hx, Lean.Grind.Semiring.zero_mul]
+      _ = 0 + ca * cb :=
+        List.foldl_add_single _ _ _ _ hmem (Mono.splits_nodup _)
+      _ = ca * cb := by grind
+  · rw [if_neg hm]
+    apply List.foldl_add_eq_self
+    intro ab hab
+    have hmul : Mono.mul ab.1 ab.2 = m :=
+      (Mono.splits_mem_iff ..).mp hab
+    by_cases ha : ab.1 = a
+    · by_cases hb : ab.2 = b
+      · have hmul' : Mono.mul a b = m := by
+          simpa [ha, hb] using hmul
+        exact (hm hmul'.symm).elim
+      · rw [if_pos ha, if_neg hb, Lean.Grind.Semiring.mul_zero]
+    · rw [if_neg ha, Lean.Grind.Semiring.zero_mul]
+
+theorem powBySq_monomial [Lean.Grind.Semiring R] [DecidableEq R]
+    (m : Mono n) (c : R) (k : Nat) :
+    Mono.powBySq (monomial m c : MvPoly n R cmp) k =
+      monomial (Mono.scale k m) (Mono.powBySq c k) := by
+  induction k using Nat.strongRecOn with
+  | ind k ih =>
+      cases k with
+      | zero =>
+          rw [Mono.powBySq, Mono.powBySq, Mono.zero_scale]
+          rfl
+      | succ k =>
+          have hlt : (k + 1) / 2 < k + 1 :=
+            Nat.div_lt_self (Nat.succ_pos k) (by decide : 1 < 2)
+          rw [Mono.powBySq, Mono.powBySq, ih ((k + 1) / 2) hlt,
+            monomial_mul_monomial]
+          by_cases heven : (k + 1) % 2 = 0
+          · rw [if_pos heven, if_pos heven]
+            congr 1
+            let r := (k + 1) / 2
+            change Mono.mul (Mono.scale r m) (Mono.scale r m) =
+              Mono.scale (k + 1) m
+            have hdecomp := Nat.mod_add_div (k + 1) 2
+            have hcount : k + 1 = r + r := by
+              simp only [r]
+              omega
+            apply Vector.ext
+            intro i hi
+            simp [Mono.mul, Mono.scale, hcount, Nat.add_mul]
+          · rw [if_neg heven, if_neg heven, monomial_mul_monomial]
+            congr 1
+            let r := (k + 1) / 2
+            change
+              Mono.mul (Mono.mul (Mono.scale r m) (Mono.scale r m)) m =
+                Mono.scale (k + 1) m
+            have hdecomp := Nat.mod_add_div (k + 1) 2
+            have hmod := Nat.mod_two_eq_zero_or_one (k + 1)
+            have hcount : k + 1 = (r + r) + 1 := by
+              simp only [r]
+              omega
+            apply Vector.ext
+            intro i hi
+            simp [Mono.mul, Mono.scale, hcount, Nat.add_mul,
+              Nat.succ_mul]
+
+theorem mul_one [Lean.Grind.Semiring R] [DecidableEq R]
+    (p : MvPoly n R cmp) : p * 1 = p := by
+  apply ext
+  intro m
+  rw [coeff_mul]
+  simp only [coeff_one]
+  have hmem : (m, Mono.zero) ∈ Mono.splits m :=
+    (Mono.splits_mem_iff ..).mpr (Mono.mul_zero m)
+  calc
+    (Mono.splits m).foldl
+        (fun acc ab =>
+          acc + coeff ab.1 p *
+            if ab.2 = Mono.zero then 1 else 0)
+        0 =
+        (Mono.splits m).foldl
+          (fun acc ab =>
+            acc + if ab = (m, Mono.zero) then coeff ab.1 p else 0)
+          0 := by
+            apply List.foldl_congr
+            intro acc ab hab
+            have hmul := (Mono.splits_mem_iff ..).mp hab
+            by_cases hb : ab.2 = Mono.zero
+            · have ha : ab.1 = m := by
+                rw [hb, Mono.mul_zero] at hmul
+                exact hmul
+              have hab' : ab = (m, Mono.zero) := Prod.ext ha hb
+              rw [if_pos hb, Lean.Grind.Semiring.mul_one,
+                if_pos hab', ha]
+            · have hab' : ab ≠ (m, Mono.zero) := by
+                intro h
+                exact hb (congrArg Prod.snd h)
+              rw [if_neg hb, Lean.Grind.Semiring.mul_zero, if_neg hab']
+    _ = 0 + coeff m p :=
+      List.foldl_add_single _ _ _ _ hmem (Mono.splits_nodup _)
+    _ = coeff m p := by grind
+
+theorem one_mul [Lean.Grind.Semiring R] [DecidableEq R]
+    (p : MvPoly n R cmp) : 1 * p = p := by
+  apply ext
+  intro m
+  rw [coeff_mul]
+  simp only [coeff_one]
+  have hmem : (Mono.zero, m) ∈ Mono.splits m :=
+    (Mono.splits_mem_iff ..).mpr (Mono.zero_mul m)
+  calc
+    (Mono.splits m).foldl
+        (fun acc ab =>
+          acc + (if ab.1 = Mono.zero then 1 else 0) * coeff ab.2 p)
+        0 =
+        (Mono.splits m).foldl
+          (fun acc ab =>
+            acc + if ab = (Mono.zero, m) then coeff ab.2 p else 0)
+          0 := by
+            apply List.foldl_congr
+            intro acc ab hab
+            have hmul := (Mono.splits_mem_iff ..).mp hab
+            by_cases ha : ab.1 = Mono.zero
+            · have hb : ab.2 = m := by
+                rw [ha, Mono.zero_mul] at hmul
+                exact hmul
+              have hab' : ab = (Mono.zero, m) := Prod.ext ha hb
+              simp [hab', Lean.Grind.Semiring.one_mul]
+            · have hab' : ab ≠ (Mono.zero, m) := by
+                intro h
+                exact ha (congrArg Prod.fst h)
+              rw [if_neg ha, Lean.Grind.Semiring.zero_mul, if_neg hab']
+    _ = 0 + coeff m p :=
+      List.foldl_add_single _ _ _ _ hmem (Mono.splits_nodup _)
+    _ = coeff m p := by grind
+
+private abbrev MonoTriple (n : Nat) :=
+  Mono n × (Mono n × Mono n)
+
+private def splitsLeft (m : Mono n) : List (MonoTriple n) :=
+  (Mono.splits m).flatMap fun az =>
+    (Mono.splits az.1).map fun xy => (xy.1, (xy.2, az.2))
+
+private def splitsRight (m : Mono n) : List (MonoTriple n) :=
+  (Mono.splits m).flatMap fun xb =>
+    (Mono.splits xb.2).map fun yz => (xb.1, (yz.1, yz.2))
+
+private theorem mem_splitsLeft (m : Mono n) (t : MonoTriple n) :
+    t ∈ splitsLeft m ↔
+      Mono.mul (Mono.mul t.1 t.2.1) t.2.2 = m := by
+  constructor
+  · intro ht
+    rcases List.mem_flatMap.mp ht with ⟨az, haz, ht⟩
+    rcases List.mem_map.mp ht with ⟨xy, hxy, rfl⟩
+    have houter := (Mono.splits_mem_iff ..).mp haz
+    have hinner := (Mono.splits_mem_iff ..).mp hxy
+    rw [hinner, houter]
+  · intro ht
+    let az : Mono n × Mono n :=
+      (Mono.mul t.1 t.2.1, t.2.2)
+    have haz : az ∈ Mono.splits m :=
+      (Mono.splits_mem_iff ..).mpr ht
+    apply List.mem_flatMap.mpr
+    refine ⟨az, haz, ?_⟩
+    apply List.mem_map.mpr
+    refine ⟨(t.1, t.2.1), ?_, rfl⟩
+    exact (Mono.splits_mem_iff ..).mpr rfl
+
+private theorem mem_splitsRight (m : Mono n) (t : MonoTriple n) :
+    t ∈ splitsRight m ↔
+      Mono.mul t.1 (Mono.mul t.2.1 t.2.2) = m := by
+  constructor
+  · intro ht
+    rcases List.mem_flatMap.mp ht with ⟨xb, hxb, ht⟩
+    rcases List.mem_map.mp ht with ⟨yz, hyz, rfl⟩
+    have houter := (Mono.splits_mem_iff ..).mp hxb
+    have hinner := (Mono.splits_mem_iff ..).mp hyz
+    rw [hinner, houter]
+  · intro ht
+    let xb : Mono n × Mono n :=
+      (t.1, Mono.mul t.2.1 t.2.2)
+    have hxb : xb ∈ Mono.splits m :=
+      (Mono.splits_mem_iff ..).mpr ht
+    apply List.mem_flatMap.mpr
+    refine ⟨xb, hxb, ?_⟩
+    apply List.mem_map.mpr
+    refine ⟨(t.2.1, t.2.2), ?_, rfl⟩
+    exact (Mono.splits_mem_iff ..).mpr rfl
+
+private theorem splitsLeft_nodup (m : Mono n) :
+    (splitsLeft m).Nodup := by
+  unfold splitsLeft
+  apply List.nodup_flatMap_of_disjoint (Mono.splits_nodup m)
+  · intro az _
+    apply (Mono.splits_nodup az.1).map
+    intro xy uv hxy h
+    apply hxy
+    apply Prod.ext
+    · exact congrArg (fun t : MonoTriple n => t.1) h
+    · exact congrArg (fun t : MonoTriple n => t.2.1) h
+  · intro az _ bz _ hab t hta htb
+    have recover (outer : Mono n × Mono n)
+        (ht : t ∈
+          (Mono.splits outer.1).map fun xy =>
+            (xy.1, (xy.2, outer.2))) :
+        outer = (Mono.mul t.1 t.2.1, t.2.2) := by
+      rcases List.mem_map.mp ht with ⟨xy, hxy, rfl⟩
+      apply Prod.ext
+      · exact ((Mono.splits_mem_iff ..).mp hxy).symm
+      · rfl
+    exact hab ((recover az hta).trans (recover bz htb).symm)
+
+private theorem splitsRight_nodup (m : Mono n) :
+    (splitsRight m).Nodup := by
+  unfold splitsRight
+  apply List.nodup_flatMap_of_disjoint (Mono.splits_nodup m)
+  · intro xb _
+    apply (Mono.splits_nodup xb.2).map
+    intro yz uv hyz h
+    apply hyz
+    apply Prod.ext
+    · exact congrArg (fun t : MonoTriple n => t.2.1) h
+    · exact congrArg (fun t : MonoTriple n => t.2.2) h
+  · intro xb _ yb _ hxb t htx hty
+    have recover (outer : Mono n × Mono n)
+        (ht : t ∈
+          (Mono.splits outer.2).map fun yz =>
+            (outer.1, (yz.1, yz.2))) :
+        outer = (t.1, Mono.mul t.2.1 t.2.2) := by
+      rcases List.mem_map.mp ht with ⟨yz, hyz, rfl⟩
+      apply Prod.ext
+      · rfl
+      · exact ((Mono.splits_mem_iff ..).mp hyz).symm
+    exact hxb ((recover xb htx).trans (recover yb hty).symm)
+
+theorem mul_assoc [Lean.Grind.Semiring R] [DecidableEq R]
+    (p q r : MvPoly n R cmp) :
+    (p * q) * r = p * (q * r) := by
+  apply ext
+  intro m
+  simp only [coeff_mul]
+  let leftValue (t : MonoTriple n) :=
+    (coeff t.1 p * coeff t.2.1 q) * coeff t.2.2 r
+  let rightValue (t : MonoTriple n) :=
+    coeff t.1 p * (coeff t.2.1 q * coeff t.2.2 r)
+  have hleft :
+      (Mono.splits m).foldl
+          (fun acc az =>
+            acc +
+              (Mono.splits az.1).foldl
+                  (fun acc xy =>
+                    acc + coeff xy.1 p * coeff xy.2 q)
+                  0 *
+                coeff az.2 r)
+          0 =
+        (splitsLeft m).foldl
+          (fun acc t => acc + leftValue t) 0 := by
+    unfold splitsLeft
+    rw [List.foldl_add_flatMap]
+    apply List.foldl_congr
+    intro acc az _
+    symm
+    rw [List.foldl_map, List.foldl_add_eq_add_foldl]
+    congr 1
+    unfold leftValue
+    exact List.foldl_add_mul_right_zero
+      (Mono.splits az.1)
+      (fun xy => coeff xy.1 p * coeff xy.2 q)
+      (coeff az.2 r)
+  have hright :
+      (Mono.splits m).foldl
+          (fun acc xb =>
+            acc +
+              coeff xb.1 p *
+                (Mono.splits xb.2).foldl
+                  (fun acc yz =>
+                    acc + coeff yz.1 q * coeff yz.2 r)
+                  0)
+          0 =
+        (splitsRight m).foldl
+          (fun acc t => acc + rightValue t) 0 := by
+    unfold splitsRight
+    rw [List.foldl_add_flatMap]
+    apply List.foldl_congr
+    intro acc xb _
+    symm
+    rw [List.foldl_map, List.foldl_add_eq_add_foldl]
+    congr 1
+    unfold rightValue
+    exact List.foldl_add_mul_left_zero
+      (Mono.splits xb.2) (coeff xb.1 p)
+      (fun yz => coeff yz.1 q * coeff yz.2 r)
+  have hperm : (splitsLeft m).Perm (splitsRight m) :=
+    (List.perm_ext_iff_of_nodup
+      (splitsLeft_nodup m) (splitsRight_nodup m)).mpr fun t => by
+        rw [mem_splitsLeft, mem_splitsRight, Mono.mul_assoc]
+  rw [hleft, hright]
+  calc
+    (splitsLeft m).foldl (fun acc t => acc + leftValue t) 0 =
+        (splitsLeft m).foldl (fun acc t => acc + rightValue t) 0 := by
+      apply List.foldl_add_congr
+      intro t _
+      unfold leftValue rightValue
+      exact Lean.Grind.Semiring.mul_assoc ..
+    _ = (splitsRight m).foldl (fun acc t => acc + rightValue t) 0 :=
+      List.foldl_add_perm rightValue hperm 0
+
+theorem mul_comm [Lean.Grind.CommSemiring R] [DecidableEq R]
+    (p q : MvPoly n R cmp) : p * q = q * p := by
+  apply ext
+  intro m
+  simp only [coeff_mul]
+  let swap : Mono n × Mono n → Mono n × Mono n :=
+    fun ab => (ab.2, ab.1)
+  let swapped := (Mono.splits m).map swap
+  have hinj : Function.Injective swap := by
+    intro a b h
+    apply Prod.ext
+    · exact congrArg Prod.snd h
+    · exact congrArg Prod.fst h
+  have hnodup : swapped.Nodup := by
+    unfold swapped
+    apply (Mono.splits_nodup m).map
+    intro a b hne heq
+    exact hne (hinj heq)
+  have hperm : (Mono.splits m).Perm swapped := by
+    rw [List.perm_ext_iff_of_nodup (Mono.splits_nodup m) hnodup]
+    intro ab
+    constructor
+    · intro hab
+      apply List.mem_map.mpr
+      refine ⟨swap ab, ?_, ?_⟩
+      · apply (Mono.splits_mem_iff ..).mpr
+        rw [Mono.mul_comm]
+        exact (Mono.splits_mem_iff ..).mp hab
+      · simp [swap]
+    · intro hab
+      rcases List.mem_map.mp hab with ⟨t, ht, rfl⟩
+      apply (Mono.splits_mem_iff ..).mpr
+      rw [Mono.mul_comm]
+      exact (Mono.splits_mem_iff ..).mp ht
+  let value (ab : Mono n × Mono n) :=
+    coeff ab.1 p * coeff ab.2 q
+  calc
+    (Mono.splits m).foldl
+        (fun acc ab => acc + coeff ab.1 p * coeff ab.2 q) 0 =
+        swapped.foldl (fun acc ab => acc + value ab) 0 :=
+      List.foldl_add_perm value hperm 0
+    _ = (Mono.splits m).foldl
+        (fun acc ab => acc + coeff ab.1 q * coeff ab.2 p) 0 := by
+      unfold swapped
+      rw [List.foldl_map]
+      apply List.foldl_congr
+      intro acc ab _
+      unfold value swap
+      rw [Lean.Grind.CommSemiring.mul_comm]
+
+private def linearPow [Lean.Grind.Semiring R] [DecidableEq R]
+    (p : MvPoly n R cmp) : Nat → MvPoly n R cmp
+  | 0 => 1
+  | k + 1 => linearPow p k * p
+
+private theorem linearPow_add [Lean.Grind.Semiring R] [DecidableEq R]
+    (p : MvPoly n R cmp) (a b : Nat) :
+    linearPow p (a + b) = linearPow p a * linearPow p b := by
+  induction b with
+  | zero =>
+      rw [Nat.add_zero, linearPow, mul_one]
+  | succ b ih =>
+      rw [Nat.add_succ, linearPow, ih, linearPow, mul_assoc]
+
+private theorem npowBySq_eq_linearPow
+    [Lean.Grind.Semiring R] [DecidableEq R]
+    (p : MvPoly n R cmp) (k : Nat) :
+    npowBySq p k = linearPow p k := by
+  induction k using Nat.strongRecOn with
+  | ind k ih =>
+      cases k with
+      | zero =>
+          rw [npowBySq, linearPow]
+      | succ k =>
+          let half := (k + 1) / 2
+          have hlt : half < k + 1 := by
+            simp only [half]
+            exact Nat.div_lt_self (Nat.succ_pos k) (by decide : 1 < 2)
+          rw [npowBySq, ih half hlt]
+          by_cases heven : (k + 1) % 2 = 0
+          · rw [if_pos heven]
+            have hdecomp := Nat.mod_add_div (k + 1) 2
+            have hcount : k + 1 = half + half := by
+              simp only [half]
+              omega
+            calc
+              linearPow p half * linearPow p half =
+                  linearPow p (half + half) :=
+                (linearPow_add p half half).symm
+              _ = linearPow p (k + 1) := by rw [hcount]
+          · rw [if_neg heven]
+            have hdecomp := Nat.mod_add_div (k + 1) 2
+            have hmod := Nat.mod_two_eq_zero_or_one (k + 1)
+            have hcount : k + 1 = (half + half) + 1 := by
+              simp only [half]
+              omega
+            calc
+              (linearPow p half * linearPow p half) * p =
+                  linearPow p (half + half) * p := by
+                rw [linearPow_add]
+              _ = linearPow p ((half + half) + 1) := rfl
+              _ = linearPow p (k + 1) := by rw [hcount]
+
+theorem pow_succ [Lean.Grind.Semiring R] [DecidableEq R]
+    (p : MvPoly n R cmp) (k : Nat) :
+    p ^ (k + 1) = p ^ k * p := by
+  change
+    npowBySq p (k + 1) = npowBySq p k * p
+  rw [npowBySq_eq_linearPow, npowBySq_eq_linearPow]
+  rfl
+
 theorem coeff_pow_succ [Lean.Grind.Semiring R] [DecidableEq R]
     (m : Mono n) (p : MvPoly n R cmp) (k : Nat) :
-    coeff m (p ^ (k + 1)) = coeff m (p ^ k * p) := by
-  sorry
+    coeff m (p ^ (k + 1)) = coeff m (p ^ k * p) :=
+  congrArg (coeff m) (pow_succ p k)
 
 theorem npowBySq_eq_pow [Lean.Grind.Semiring R] [DecidableEq R]
     (p : MvPoly n R cmp) (k : Nat) :

--- a/HexMvPoly/Structural.lean
+++ b/HexMvPoly/Structural.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 
 module
 
+import HexBasic.Fold
 public import HexMvPoly.Eval
 
 @[expose] public section
@@ -342,11 +343,104 @@ theorem subst_eq [Lean.Grind.Semiring R] [DecidableEq R]
   unfold termsList
   rfl
 
+private theorem prod_subst [Lean.Grind.Semiring R] [DecidableEq R]
+    (s : Fin n → Option R) (m : Mono n) :
+    Mono.prod
+        (fun i => match s i with | some x => C x | none => X i)
+        m =
+      (monomial (eraseAssigned s m)
+        (Mono.prod (fun i => (s i).getD 1) m) : MvPoly n R cmp) := by
+  let g : Fin n → MvPoly n R cmp :=
+    fun i => match s i with | some x => C x | none => X i
+  let mono : Fin n → Mono n :=
+    fun i =>
+      if (s i).isSome then Mono.zero
+      else Mono.scale m[i] (Mono.unit i)
+  let value : Fin n → R :=
+    fun i => Mono.powBySq ((s i).getD 1) m[i]
+  have factor (i : Fin n) :
+      Mono.powBySq (g i) m[i] =
+        monomial (mono i) (value i) := by
+    cases hsi : s i with
+    | none =>
+        simpa [g, mono, value, hsi, X] using
+          (powBySq_monomial (cmp := cmp) (Mono.unit i) (1 : R) m[i])
+    | some x =>
+        simpa [g, mono, value, hsi, C] using
+          (powBySq_monomial (cmp := cmp) (Mono.zero : Mono n) x m[i])
+  have fold : ∀ (xs : List (Fin n)) (a : Mono n) (c : R),
+      xs.foldl
+          (fun acc i => acc * Mono.powBySq (g i) m[i])
+          (monomial a c) =
+        monomial
+          (xs.foldl (fun acc i => Mono.mul acc (mono i)) a)
+          (xs.foldl (fun acc i => acc * value i) c) := by
+    intro xs
+    induction xs with
+    | nil =>
+        intro a c
+        rfl
+    | cons i xs ih =>
+        intro a c
+        simp only [List.foldl_cons]
+        rw [factor, monomial_mul_monomial, ih]
+  unfold Mono.prod
+  change
+    (List.finRange n).foldl
+        (fun acc i => acc * Mono.powBySq (g i) m[i])
+        (monomial Mono.zero 1) =
+      monomial (eraseAssigned s m)
+        ((List.finRange n).foldl
+          (fun acc i => acc * value i) 1)
+  rw [fold]
+  congr 1
+  calc
+    (List.finRange n).foldl
+        (fun acc i => Mono.mul acc (mono i)) Mono.zero =
+        (List.finRange n).foldl
+          (fun acc i =>
+            Mono.mul acc
+              (Mono.scale (eraseAssigned s m)[i] (Mono.unit i)))
+          Mono.zero := by
+            apply List.foldl_congr
+            intro acc i _
+            unfold mono eraseAssigned
+            cases hsi : s i <;> simp [hsi]
+    _ = eraseAssigned s m := Mono.mul_units _
+
 theorem partialEval_eq_subst [Lean.Grind.Semiring R] [DecidableEq R]
     (s : Fin n → Option R) (p : MvPoly n R cmp) :
     partialEval s p =
       subst (targetCmp := cmp)
         (fun i => match s i with | some x => C x | none => X i) p := by
-  sorry
+  unfold partialEval subst bind foldTerms
+  rw [Std.ExtTreeMap.foldl_eq_foldl_toList,
+    Std.ExtTreeMap.foldl_eq_foldl_toList]
+  apply List.foldl_congr
+  intro acc term _
+  rcases term with ⟨m, c⟩
+  simp only [id_eq]
+  let g : Fin n → MvPoly n R cmp :=
+    fun i => match s i with | some x => C x | none => X i
+  let assigned := Mono.prod (fun i => (s i).getD 1) m
+  have hprod :
+      Mono.prod g m =
+        (monomial (eraseAssigned s m) assigned : MvPoly n R cmp) := by
+    exact prod_subst (cmp := cmp) s m
+  change
+    acc.addMonomial (eraseAssigned s m) (c * assigned) =
+      acc + (monomial Mono.zero c : MvPoly n R cmp) * Mono.prod g m
+  calc
+    acc.addMonomial (eraseAssigned s m) (c * assigned) =
+        acc + monomial (eraseAssigned s m) (c * assigned) :=
+      addMonomial_eq ..
+    _ = acc + (monomial Mono.zero c : MvPoly n R cmp) *
+        monomial (eraseAssigned s m) assigned := by
+      rw [monomial_mul_monomial, Mono.zero_mul]
+    _ = acc + (monomial Mono.zero c : MvPoly n R cmp) *
+        Mono.prod g m :=
+      congrArg
+        (fun q => acc + (monomial Mono.zero c : MvPoly n R cmp) * q)
+        hprod.symm
 
 end Hex.MvPoly

--- a/SPEC/Libraries/hex-mv-poly.md
+++ b/SPEC/Libraries/hex-mv-poly.md
@@ -150,7 +150,7 @@ strictly more than a faithful total order:
 class IsMonomialOrder {n : Nat} (cmp : Mono n → Mono n → Ordering) : Prop
     extends Std.TransCmp cmp, Std.LawfulEqCmp cmp where
   zero_le  : ∀ m, cmp Mono.zero m ≠ .gt
-  add_mono : ∀ a b c,
+  mul_mono : ∀ a b c,
     cmp a b = cmp (Mono.mul a c) (Mono.mul b c)
   wf       : WellFounded (fun a b => cmp a b = .lt)
 ```
@@ -180,6 +180,7 @@ namespace Hex.Mono
 def zero : Mono n                                   -- the constant monomial
 def unit (i : Fin n) : Mono n                       -- xᵢ
 def mul (a b : Mono n) : Mono n                     -- pointwise addition
+def scale (k : Nat) (m : Mono n) : Mono n           -- pointwise scaling
 def dvd (a b : Mono n) : Bool                       -- pointwise ≤
 def div (a b : Mono n) : Option (Mono n)            -- exact quotient, none if ¬ dvd
 def lcm (a b : Mono n) : Mono n                     -- pointwise max
@@ -193,13 +194,14 @@ def splits (m : Mono n) : List (Mono n × Mono n)    -- pairs whose product is m
 def prod [One R] [Mul R] (x : Fin n → R) (m : Mono n) : R
 ```
 
-`mul` is the monoid operation the `add_mono` field of `IsMonomialOrder`
+`mul` is the monoid operation the `mul_mono` field of `IsMonomialOrder`
 refers to, so the class and this API have to agree on it. State
 `IsMonomialOrder` in terms of `Mono.mul` rather than a bare `+`. The
 laws worth naming are that `dvd` agrees with the existence of an exact
 quotient, that `div` is a left inverse of `mul` on the divisible case,
-`degree_mul`, `rename_mul`, `splits_mem_iff`, `splits_nodup`, and the `lcm`/`gcd`
-lattice laws, all of which the S-polynomial construction uses.
+`mul_assoc`, `mul_comm`, the scale/unit decomposition, `degree_mul`,
+`rename_mul`, `splits_mem_iff`, `splits_nodup`, and the `lcm`/`gcd` lattice
+laws, all of which the S-polynomial construction uses.
 
 ## Kernel reduction
 
@@ -477,6 +479,7 @@ theorem coeff_sub       : coeff m (p - q) = coeff m p - coeff m q
 theorem coeff_neg       : coeff m (-p) = -coeff m p
 theorem coeff_mul       : coeff m (p * q)
     = (m.splits.map fun ab => coeff ab.1 p * coeff ab.2 q).sum
+theorem pow_succ        : p ^ (k + 1) = p ^ k * p
 theorem coeff_pow_succ  : coeff m (p ^ (k + 1)) = coeff m (p ^ k * p)
 theorem coeff_reorder   : coeff m (reorder cmp' p) = coeff m p
 theorem coeff_rename    : coeff m (rename cmp' f p)

--- a/progress/20260729T112320Z_hex-mv-poly-laws.md
+++ b/progress/20260729T112320Z_hex-mv-poly-laws.md
@@ -1,0 +1,36 @@
+# HexMvPoly order and algebra laws
+
+## Accomplished
+
+- Proved the `lex`, `grlex`, and `grevlex` monomial-order instances, including
+  well-foundedness and compatibility with monomial multiplication.
+- Completed the remaining monomial lattice, multiplication, distributivity,
+  power, and partial-evaluation laws without adding `sorry`, `axiom`, or
+  `native_decide`.
+- Added a reusable Hex-local list API in `HexBasic/List.lean`, keeping
+  `ListShim` limited to its Batteries compatibility role.
+- Added kernel canaries that distinguish grlex from grevlex in three
+  variables, exercise partial-evaluation collisions and cancellation, and
+  guard the new proof dependencies with `#print axioms`.
+- Reconciled the HexMvPoly SPEC with the proved API, including the monomial
+  order law and the strong polynomial power recurrence.
+- Incorporated an independent Claude Opus review, including its coverage,
+  naming, theorem-orientation, API-placement, and semiring-law findings.
+- Passed formatting checks, repository lints, and the full `lake build`
+  (9634 jobs).
+
+## Current frontier
+
+The computational core's specified proof surface is implemented and the
+HexMvPoly files contain no unfinished proofs. PR #9090, which this work was
+stacked on, has merged.
+
+## Next step
+
+Rebase this law slice onto `main`, publish it as the only open HexMvPoly PR,
+then implement the SymPy-backed conformance target and fixtures while its CI
+runs.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Summary

- prove lex, grlex, and grevlex are well-founded multiplicative monomial orders
- complete monomial lattice/scaling laws and polynomial commutative-semiring laws
- prove power recurrence and partial evaluation equals substitution
- add reusable HexBasic list helpers and kernel/axiom canaries
- align the HexMvPoly SPEC with the proved API

## Independent review

A fresh Claude Opus review checked the order keys, multiplication associativity enumeration, power proof, and partial-evaluation proof. Its findings were incorporated: a three-variable grlex/grevlex discriminator, cancellation-to-zero canary, stronger power recurrence, semiring-law coverage, shorter scale names, addMonomial theorem orientation, removal of instance priority overrides, documentation of the grevlex key, and placement of reusable list helpers outside ListShim.

## Validation

- full lake build: 9634 jobs
- focused post-rebase lake build HexBasic HexMvPoly: 29 jobs
- copyright and line-count lints
- git diff --check
- no new sorry, axiom, or native_decide