### PR TITLE
bench(mvpoly): register native workload families

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Define the hex-dev cache + build target sets
         run: |
           echo "HEX_LIB_TARGETS=HexBasic HexArith HexPoly HexMvPoly HexMvPolyTests HexModArith HexGF2 HexPolyZ HexRoots HexResultant HexInterval HexIntervalExperiment HexIntervalMathlibExperiment HexIntervalReplayProbe HexIntervalMathlibReplayProbe HexRealRootsMathlibReplayProbe HexRCFProofProbe HexPolyFp HexGFqRing HexGFqField HexBerlekamp HexHensel HexConway HexGFq HexBerlekampZassenhaus HexRealRoots HexMatrix HexRowReduce HexDeterminant HexBareiss HexGramSchmidt HexLLL HexMatrixMathlib HexGramSchmidtMathlib HexLLLMathlib HexBerlekampZassenhausMathlib HexRealRootsMathlib HexRCF HexRCFTests HexRootsMathlib HexResultantMathlib HexNumberField HexNumberFieldMathlib HexNumberFieldTower HexNumberFieldTowerMathlib HexReleaseTests HexReleaseExamples" >> "$GITHUB_ENV"
-          echo "HEX_EXE_TARGETS=hexarith_bench hexpoly_bench hexpolyz_bench hexpolyfp_bench hexmodarith_bench hexgf2_bench hexgfqring_bench hexgfqfield_bench hexgfq_bench hexhensel_bench hexberlekamp_bench hexbz_bench hexconway_bench hexmatrix_bench hexstrassen_compare hexdeterminant_bench hexbareiss_bench hexgramschmidt_bench hexrealroots_bench hexrcf_bench hexroots_bench hexresultant_bench hexnumberfield_bench hexnumberfieldtower_bench hexroots_demo hex_interval_representation_spike hex_interval_center_spike hex_interval_scale_spike hex_interval_scheduler_spike hex_interval_policy_frontier_spike hex_classical_spike hex_lattice_spike hex_arith_floor hex_recursive_relift_spike hex_prime_policy_spike hexlll_bench hexlll_gram_bench hexlll_provider_probe" >> "$GITHUB_ENV"
+          echo "HEX_EXE_TARGETS=hexarith_bench hexpoly_bench hexmvpoly_bench hexpolyz_bench hexpolyfp_bench hexmodarith_bench hexgf2_bench hexgfqring_bench hexgfqfield_bench hexgfq_bench hexhensel_bench hexberlekamp_bench hexbz_bench hexconway_bench hexmatrix_bench hexstrassen_compare hexdeterminant_bench hexbareiss_bench hexgramschmidt_bench hexrealroots_bench hexrcf_bench hexroots_bench hexresultant_bench hexnumberfield_bench hexnumberfieldtower_bench hexroots_demo hex_interval_representation_spike hex_interval_center_spike hex_interval_scale_spike hex_interval_scheduler_spike hex_interval_policy_frontier_spike hex_classical_spike hex_lattice_spike hex_arith_floor hex_recursive_relift_spike hex_prime_policy_spike hexlll_bench hexlll_gram_bench hexlll_provider_probe" >> "$GITHUB_ENV"
       # Shared build. The libraries, bench exes, conformance #guard drivers, and
       # emit-fixture exes are all elaborated here so the two verification tails
       # below only *run* things, never rebuild them -- which is what lets the
@@ -217,7 +217,7 @@ jobs:
           BENCH_VERIFY_HARD_CAP_SECONDS: "360"
         run: |
           bash scripts/ci/check_bench_verify_budget.sh \
-            hexarith_bench hexpoly_bench hexpolyz_bench \
+            hexarith_bench hexpoly_bench hexmvpoly_bench hexpolyz_bench \
             hexpolyfp_bench hexmodarith_bench \
             hexgf2_bench hexgfqring_bench hexgfqfield_bench hexgfq_bench \
             hexhensel_bench hexberlekamp_bench hexbz_bench \

--- a/bench/HexMvPoly/Bench.lean
+++ b/bench/HexMvPoly/Bench.lean
@@ -1,0 +1,334 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexMvPolyBench.Corpus
+import LeanBench
+
+/-!
+Native benchmark registrations for `hex-mv-poly`.
+
+The registrations cover the five SPEC input families. Separable operations are
+registered independently so a timing change is attributable to one algorithm:
+
+* sparse addition under lex, grlex, and grevlex, `O(n log n)`;
+* low- and high-collision sparse products, `O(n² log n)`;
+* cancellation-heavy `Int` and genuine-fraction `Rat` identities,
+  `O(n² log n)`;
+* rename, partial evaluation, and substitution collisions, respectively
+  `O(n)`, `O(n)`, and `O(n log n)`;
+* sums of three genuinely multivariate squares, `O(n² log n)`.
+
+Input construction is hoisted through `prep`. Timed targets return structural
+hashes of the canonical outputs, so result traversal stays within the declared
+operation cost and gives LeanBench a conformance signal.
+
+`HexMvPolyBench.Corpus` owns the representation-independent deterministic term
+generators. Phase 4's informational CompPoly and Mathlib `MvSparsePoly`
+adapters consume those generators externally; neither comparator is imported
+here, keeping the native executable Mathlib-free.
+
+Each child batch autotunes to about 200 ms. The default 10x executable-spawn
+floor would disqualify every row on this host, so
+`signalFloorMultiplier := 1.0` keeps the autotuned in-process measurements.
+-/
+
+namespace Hex.MvPolyBench
+
+open Hex
+open Hex.MvPoly
+open Corpus
+
+abbrev LexP4 (R : Type) [Zero R] := MvPoly 4 R Mono.lex
+abbrev GrlexP4 (R : Type) [Zero R] := MvPoly 4 R Mono.grlex
+abbrev GrlexP8 (R : Type) [Zero R] := MvPoly 8 R Mono.grlex
+abbrev GrevlexP4 (R : Type) [Zero R] := MvPoly 4 R Mono.grevlex
+abbrev GrevlexP2 (R : Type) [Zero R] := MvPoly 2 R Mono.grevlex
+
+/-- Stable structural hash of a canonical sparse polynomial. -/
+def checksum [Zero R] [Hashable R] {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    (p : MvPoly n R cmp) : UInt64 :=
+  p.termsList.foldl
+    (fun acc term => mixHash (mixHash acc (hash term.1.toList)) (hash term.2))
+    0
+
+instance [Zero R] [Hashable R] {cmp : Mono n → Mono n → Ordering}
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp] :
+    Hashable (MvPoly n R cmp) where
+  hash := checksum
+
+def sparseInt {arity : Nat} (cmp : Mono arity → Mono arity → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    (size salt : Nat) (key : Nat → Mono arity) : MvPoly arity Int cmp :=
+  ofTerms (intTerms size salt key)
+
+def sparseFrac {arity : Nat} (cmp : Mono arity → Mono arity → Ordering)
+    [Std.TransCmp cmp] [Std.LawfulEqCmp cmp]
+    (size salt : Nat) (key : Nat → Mono arity) : MvPoly arity Rat cmp :=
+  ofTerms (fracTerms size salt key)
+
+structure AdditionInput where
+  lexLeft : LexP4 Int
+  lexRight : LexP4 Int
+  grlexLeft : GrlexP4 Int
+  grlexRight : GrlexP4 Int
+  grevlexLeft : GrevlexP4 Int
+  grevlexRight : GrevlexP4 Int
+  deriving Hashable
+
+def prepSparseAddition (n : Nat) : AdditionInput :=
+  { lexLeft := sparseInt Mono.lex n 3 (fun i => axisMono 0 i)
+    lexRight := sparseInt Mono.lex n 5 (fun i => axisMono 0 (n + i))
+    grlexLeft := sparseInt Mono.grlex n 7 (fun i => axisMono 0 (2 * i))
+    grlexRight := sparseInt Mono.grlex n 11 (fun i => axisMono 0 (2 * i + 1))
+    grevlexLeft := sparseInt Mono.grevlex n 13 (patternedMono n · 1)
+    grevlexRight := sparseInt Mono.grevlex n 17 (patternedMono n · 5) }
+
+def runSparseAdditionLex (input : AdditionInput) : UInt64 :=
+  checksum (input.lexLeft + input.lexRight)
+
+def runSparseAdditionGrlex (input : AdditionInput) : UInt64 :=
+  checksum (input.grlexLeft + input.grlexRight)
+
+def runSparseAdditionGrevlex (input : AdditionInput) : UInt64 :=
+  checksum (input.grevlexLeft + input.grevlexRight)
+
+structure MultiplicationInput where
+  lowLeft : GrlexP8 Int
+  lowRight : GrlexP8 Int
+  highLeft : GrevlexP2 Rat
+  highRight : GrevlexP2 Rat
+  deriving Hashable
+
+def prepSparseMultiplication (n : Nat) : MultiplicationInput :=
+  { lowLeft := sparseInt Mono.grlex n 19 (axisMono 6)
+    lowRight := sparseInt Mono.grlex n 23 (axisMono 7)
+    highLeft := sparseFrac Mono.grevlex n 29 (axisMono 1)
+    highRight := sparseFrac Mono.grevlex n 31 (axisMono 1) }
+
+def runSparseMultiplicationLow (input : MultiplicationInput) : UInt64 :=
+  checksum (input.lowLeft * input.lowRight)
+
+def runSparseMultiplicationHigh (input : MultiplicationInput) : UInt64 :=
+  checksum (input.highLeft * input.highRight)
+
+structure CancellationInput where
+  intLeft : LexP4 Int
+  intRight : LexP4 Int
+  ratLeft : GrevlexP4 Rat
+  ratRight : GrevlexP4 Rat
+  deriving Hashable
+
+def prepCancellationArithmetic (n : Nat) : CancellationInput :=
+  { intLeft := sparseInt Mono.lex n 37 (fun i => axisMono 0 (i + 1))
+    intRight := sparseInt Mono.lex n 41 (fun i => axisMono 1 (i + 1))
+    ratLeft := sparseFrac Mono.grevlex n 43 (fun i => axisMono 0 (i + 1))
+    ratRight := sparseFrac Mono.grevlex n 47 (fun i => axisMono 1 (i + 1)) }
+
+def runCancellationInt (input : CancellationInput) : UInt64 :=
+  checksum <|
+    (input.intLeft + input.intRight) * (input.intLeft + input.intRight) -
+      (input.intLeft * input.intLeft + input.intRight * input.intRight)
+
+def runCancellationRat (input : CancellationInput) : UInt64 :=
+  checksum <|
+    (input.ratLeft + input.ratRight) * (input.ratLeft + input.ratRight) -
+      (input.ratLeft * input.ratLeft + input.ratRight * input.ratRight)
+
+structure StructuralInput where
+  collisionPoly : GrlexP4 Int
+  partialPoly : GrlexP4 Int
+  deriving Hashable
+
+def prepStructuralCollisions (n : Nat) : StructuralInput :=
+  { collisionPoly := sparseInt Mono.grlex n 53 (collisionMono n)
+    partialPoly := sparseInt Mono.grlex n 71 partialEvalMono }
+
+def runRenameCollisions (input : StructuralInput) : UInt64 :=
+  let renamed : GrevlexP2 Int :=
+    rename Mono.grevlex
+      (fun i => if i.val % 2 = 0 then 0 else 1)
+      input.collisionPoly
+  checksum renamed
+
+def runPartialEvalCollisions (input : StructuralInput) : UInt64 :=
+  let partiallyEvaluated :=
+    partialEval
+      (fun i =>
+        if i.val = 0 then some (2 : Int)
+        else if i.val = 2 then some (-3)
+        else none)
+      input.partialPoly
+  checksum partiallyEvaluated
+
+def runSubstCollisions (input : StructuralInput) : UInt64 :=
+  let substituted : GrevlexP2 Int :=
+    subst (targetCmp := Mono.grevlex)
+      (fun i => if i.val % 2 = 0 then X 0 else C 3 * X 1)
+      input.collisionPoly
+  checksum substituted
+
+structure SumOfSquaresInput where
+  first : GrevlexP4 Int
+  second : GrevlexP4 Int
+  third : GrevlexP4 Int
+  deriving Hashable
+
+def prepSumOfSquares (n : Nat) : SumOfSquaresInput :=
+  { first := sparseInt Mono.grevlex n 59 (patternedMono n · 3)
+    second := sparseInt Mono.grevlex n 61 (patternedMono n · 7)
+    third := sparseInt Mono.grevlex n 67 (patternedMono n · 11) }
+
+def runSumOfSquaresArithmetic (input : SumOfSquaresInput) : UInt64 :=
+  checksum <|
+    input.first * input.first +
+      input.second * input.second +
+      input.third * input.third
+
+#guard
+  let input := prepSumOfSquares 32
+  termCount
+      (input.first * input.first +
+        input.second * input.second +
+        input.third * input.third) =
+    3 * 32 * 33 / 2
+
+/- `mergeWith?` folds the smaller `n`-term lex tree into the larger one; each
+`alter` is logarithmic. Structural hashing is linear in the output support. -/
+setup_benchmark runSparseAdditionLex n => n * Nat.log2 (n + 1)
+  with prep := prepSparseAddition
+  where {
+    paramSchedule := .custom #[128, 256, 512, 1024, 2048, 4096]
+    maxSecondsPerCall := 3.0
+    targetInnerNanos := 200000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- The same disjoint/interleaved addition under graded lexicographic order. -/
+setup_benchmark runSparseAdditionGrlex n => n * Nat.log2 (n + 1)
+  with prep := prepSparseAddition
+  where {
+    paramSchedule := .custom #[128, 256, 512, 1024, 2048, 4096]
+    maxSecondsPerCall := 3.0
+    targetInnerNanos := 200000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- Cost model: graded reverse lexicographic addition performs the same `n`
+logarithmic tree updates as the other orders, now on genuinely multivariate
+monomials. -/
+setup_benchmark runSparseAdditionGrevlex n => n * Nat.log2 (n + 1)
+  with prep := prepSparseAddition
+  where {
+    paramSchedule := .custom #[128, 256, 512, 1024, 2048, 4096]
+    maxSecondsPerCall := 3.0
+    targetInnerNanos := 200000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- The low-collision output has `n²` terms and every Gustavson accumulator
+update performs a logarithmic tree operation. -/
+setup_benchmark runSparseMultiplicationLow n => n * n * Nat.log2 (n * n + 1)
+  with prep := prepSparseMultiplication
+  where {
+    paramSchedule := .custom #[8, 12, 16, 24, 32, 48, 64, 96, 128]
+    maxSecondsPerCall := 4.0
+    targetInnerNanos := 200000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- Cost model: the high-collision rational product visits `n²` source pairs but
+accumulates into `2n-1` keys, so each accumulator update is logarithmic in `n`.
+Bounded non-unit denominators exercise Rat normalization without changing the
+sparse structural parameter. -/
+setup_benchmark runSparseMultiplicationHigh n => n * n * Nat.log2 (n + 1)
+  with prep := prepSparseMultiplication
+  where {
+    paramSchedule := .custom #[8, 16, 32, 64, 128, 192, 256, 384, 512]
+    maxSecondsPerCall := 4.0
+    targetInnerNanos := 200000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- Expanding the integer identity `(a + b)² - (a² + b²)` performs three
+sparse products and cancels both square components while retaining the `n²`
+nonzero cross terms. Each accumulator update is logarithmic in an output of at
+most `O(n²)` terms. -/
+setup_benchmark runCancellationInt n => n * n * Nat.log2 (n * n + 1)
+  with prep := prepCancellationArithmetic
+  where {
+    paramSchedule := .custom #[8, 16, 32, 64, 96, 128, 192, 256]
+    maxSecondsPerCall := 4.0
+    targetInnerNanos := 200000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- Cost model: the same cancellation identity over bounded genuine fractions
+performs quadratically many sparse updates. Rat addition and multiplication
+take nontrivial normalization paths; the finite denominator set keeps
+coefficient bit-size subordinate to the `n²` sparse updates. -/
+setup_benchmark runCancellationRat n => n * n * Nat.log2 (n * n + 1)
+  with prep := prepCancellationArithmetic
+  where {
+    paramSchedule := .custom #[8, 16, 32, 64, 96, 128, 192, 256]
+    maxSecondsPerCall := 4.0
+    targetInnerNanos := 200000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- Cost model: rename maps `n` fixed-arity source monomials into eight
+destination keys. Both monomial mapping and bounded-size tree updates are
+constant per term, giving linear work. -/
+setup_benchmark runRenameCollisions n => n
+  with prep := prepStructuralCollisions
+  where {
+    paramSchedule := .custom #[64, 128, 256, 512, 768, 1024]
+    maxSecondsPerCall := 4.0
+    targetInnerNanos := 200000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- Cost model: partial evaluation also combines `n` source terms into eight
+keys. The evaluated exponents are bounded below 32, so non-unit coefficient
+powers and destination-tree updates take constant work per source term, giving
+linear work. -/
+setup_benchmark runPartialEvalCollisions n => n
+  with prep := prepStructuralCollisions
+  where {
+    paramSchedule := .custom #[64, 128, 256, 512, 768, 1024]
+    maxSecondsPerCall := 4.0
+    targetInnerNanos := 200000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- Substitution maps every source variable to a single target monomial and
+combines `n` terms into eight keys. Source exponents reach `O(n)`, so monomial
+images are powered by repeated squaring in `O(log n)` steps per term. -/
+setup_benchmark runSubstCollisions n => n * Nat.log2 (n + 1)
+  with prep := prepStructuralCollisions
+  where {
+    paramSchedule := .custom #[64, 128, 256, 512, 768, 1024]
+    maxSecondsPerCall := 4.0
+    targetInnerNanos := 200000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- The target sums three squares of genuinely multivariate `n`-term
+polynomials. It visits `3n²` source pairs and performs logarithmic updates into
+the canonical output tree. -/
+setup_benchmark runSumOfSquaresArithmetic n => n * n * Nat.log2 (n * n + 1)
+  with prep := prepSumOfSquares
+  where {
+    paramSchedule := .custom #[8, 16, 32, 64, 128, 192, 256, 384, 512]
+    maxSecondsPerCall := 4.0
+    targetInnerNanos := 200000000
+    signalFloorMultiplier := 1.0
+  }
+
+end Hex.MvPolyBench
+
+def main (args : List String) : IO UInt32 :=
+  LeanBench.Cli.dispatch args

--- a/bench/HexMvPolyBench/Corpus.lean
+++ b/bench/HexMvPolyBench/Corpus.lean
@@ -1,0 +1,108 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMvPoly
+
+@[expose] public section
+
+/-!
+Deterministic input generators shared by the native `HexMvPoly` benchmark and
+the external CompPoly and Mathlib `MvSparsePoly` comparator adapters.
+
+This file deliberately does not import LeanBench or Mathlib. Comparator drivers
+translate the returned term lists into their own representations, so every
+implementation receives the same monomials and coefficients.
+-/
+
+namespace Hex.MvPolyBench.Corpus
+
+open Hex
+open Hex.MvPoly
+
+/-- Deterministic nonzero signed benchmark coefficient. -/
+def coeffValue (size i salt : Nat) : Int :=
+  let magnitude : Int :=
+    Int.ofNat (((i + 3) * (salt + 11) + size * 17 + i * i * 5) % 251 + 1)
+  if (i + salt) % 2 = 0 then magnitude else -magnitude
+
+/-- Monomial supported on one coordinate. -/
+def axisMono {arity : Nat} (axis : Fin arity) (exponent : Nat) : Mono arity :=
+  Hex.Vector.ofFn' fun i => if i.val = axis then exponent else 0
+
+/-- A genuinely multivariate monomial whose first coordinate keeps sources
+duplicate-free. In a square, the first two coordinate sums `(i+j, i²+j²)`
+uniquely determine the unordered source pair, so the output support is
+quadratic rather than a modular-collision artifact. The third coordinate keeps
+the different salted SOS inputs disjoint. -/
+def patternedMono (_size i salt : Nat) : Mono 4 :=
+  Hex.Vector.ofFn' fun j =>
+    if j.val = 0 then i
+    else if j.val = 1 then i * i + salt
+    else if j.val = 2 then (i + 1) * (salt + 2)
+    else (i * i + i + 1) * (salt + 3)
+
+/-- A duplicate-free source monomial designed to collide after even variables
+are erased or the four variables are paired into two targets. -/
+def collisionMono (size i : Nat) : Mono 4 :=
+  Hex.Vector.ofFn' fun j =>
+    if j.val = 0 then i
+    else if j.val = 1 then i % 8
+    else if j.val = 2 then size - i
+    else i % 8
+
+/-- A duplicate-free source monomial for partial evaluation. The two evaluated
+coordinates encode `i < 1024` in base 32, so their exponents stay bounded while
+the two surviving coordinates deliberately collapse to eight destination
+keys. -/
+def partialEvalMono (i : Nat) : Mono 4 :=
+  Hex.Vector.ofFn' fun j =>
+    if j.val = 0 then i % 32
+    else if j.val = 1 then i % 8
+    else if j.val = 2 then (i / 32) % 32
+    else i % 8
+
+/-- Integer terms for a deterministic sparse support. -/
+def intTerms {arity : Nat} (size salt : Nat) (key : Nat → Mono arity) :
+    List (Mono arity × Int) :=
+  (List.range size).map fun i => (key i, coeffValue size i salt)
+
+/-- Integral-valued rational terms matching `intTerms` coefficient-for-
+coefficient, retained as a controlled representation-overhead input for
+external comparator adapters. -/
+def ratTerms {arity : Nat} (size salt : Nat) (key : Nat → Mono arity) :
+    List (Mono arity × Rat) :=
+  (List.range size).map fun i => (key i, Rat.ofInt (coeffValue size i salt))
+
+/-- Rational terms with genuine but bounded non-unit denominators. Cycling
+through small primes exercises normalization without making coefficient
+bit-size, rather than sparse structure, the benchmark parameter. -/
+def fracTerms {arity : Nat} (size salt : Nat) (key : Nat → Mono arity) :
+    List (Mono arity × Rat) :=
+  (List.range size).map fun i =>
+    let den : Int :=
+      match (i + salt) % 5 with
+      | 0 => 2
+      | 1 => 3
+      | 2 => 5
+      | 3 => 7
+      | _ => 11
+    let numerator := coeffValue size i salt
+    let coprimeNumerator :=
+      if numerator % den = 0 then numerator + 1 else numerator
+    (key i, Rat.divInt coprimeNumerator den)
+
+/- The comparator adapters rely on duplicate-free sources. Keep representative
+largest-rung checks beside the generators so a corpus edit cannot silently
+change `ofTerms` from insertion into coefficient summation. -/
+#guard ((intTerms 256 3 (axisMono (0 : Fin 4))).map Prod.fst).Nodup
+#guard ((intTerms 4096 13 (patternedMono 4096 · 1)).map Prod.fst).Nodup
+#guard ((intTerms 1024 53 (collisionMono 1024)).map Prod.fst).Nodup
+#guard ((intTerms 1024 71 partialEvalMono).map Prod.fst).Nodup
+#guard (fracTerms 64 29 (axisMono (0 : Fin 4))).all (·.2.den != 1)
+
+end Hex.MvPolyBench.Corpus

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -227,6 +227,10 @@ lean_lib HexGF2BenchSupport where
   srcDir := "bench"
   globs := #[`HexGF2.Bench]
 
+lean_lib HexMvPolyBenchSupport where
+  srcDir := "bench"
+  globs := #[`HexMvPolyBench.Corpus]
+
 lean_lib HexIntervalExperiment where
   globs := #[`HexInterval.Experiment.Representation,
     `HexInterval.Experiment.Rational, `HexInterval.Experiment.Center,
@@ -499,6 +503,10 @@ lean_exe hexarith_bench where
 lean_exe hexpoly_bench where
   srcDir := "bench"
   root := `HexPoly.Bench
+
+lean_exe hexmvpoly_bench where
+  srcDir := "bench"
+  root := `HexMvPoly.Bench
 
 lean_exe hexpoly_emit_fixtures where
   srcDir := "conformance"

--- a/progress/20260729T121420Z_hex-mv-poly-native-bench.md
+++ b/progress/20260729T121420Z_hex-mv-poly-native-bench.md
@@ -1,0 +1,46 @@
+# HexMvPoly native benchmark slice
+
+## Accomplished
+
+- Added the Mathlib-free `hexmvpoly_bench` executable and registered it in the
+  existing single-job CI build and sequential bench verification gate.
+- Added deterministic LeanBench families for sparse addition, low- and
+  high-collision multiplication, cancellation-heavy `Int`/`Rat` arithmetic,
+  collision-heavy structural maps, and sum-of-squares-shaped arithmetic.
+- Registered each separable phase independently: three addition orders, two
+  multiplication collision regimes, two coefficient domains, and the three
+  structural operations are distinct timed targets.
+- Hoisted input construction out of timed regions and made every target return a
+  structural checksum of the canonical result.
+- Added bounded genuine-fraction coefficients, typed axis indices, and
+  duplicate-free corpus guards so comparator inputs exercise rational
+  normalization without silently collapsing their supports.
+- Made the SOS monomial mixer preserve a genuinely quadratic output support;
+  a content guard fixes the three-square result at `3n(n+1)/2` terms.
+- Verified all eleven registrations, the Mathlib-free import boundary, the
+  repository source lints, and the CI smoke wall-clock budget.
+- Ran the scientific ladders. All eleven targets are consistent with their
+  declared models; the multiplication-high and sum-of-squares ladders extend
+  through 512 so their logarithmic tree factor is visible above narrow-range
+  noise. Focused reruns measured an executable-spawn floor near 22 ms, below
+  the approximately 200 ms autotuned in-process batches.
+- Extracted `HexMvPolyBench.Corpus`, a LeanBench-free shared term generator for
+  the later CompPoly and Mathlib `MvSparsePoly` adapters.
+
+## Current frontier
+
+The native ExtTreeMap workload families are implemented and locally green. All
+eleven attribution-isolated scientific ladders are consistent with their
+declared textbook models.
+
+## Next step
+
+Publish this slice after the conformance slice. Build the CompPoly and Mathlib
+`MvSparsePoly` comparator drivers once the Mathlib companion is available so
+all three implementations can consume the same deterministic corpus.
+
+## Blockers
+
+The comparator report, plots, and profiles depend on the not-yet-implemented
+Mathlib companion and comparator adapters. They are later Phase 4 work, not part
+of this native registration slice.

--- a/scripts/check_dag.py
+++ b/scripts/check_dag.py
@@ -27,6 +27,7 @@ QUALIFIED_IMPORT_RE = re.compile(r"^\s*(?:public\s+|private\s+)?import\s+([A-Za-
 UMBRELLA_BUILD_TARGETS = {
     "HexLLLBenchSupport",
     "HexGF2BenchSupport",
+    "HexMvPolyBenchSupport",
     "HexIntervalExperiment",
     "HexIntervalMathlibExperiment",
     "HexIntervalReplayProbe",

--- a/scripts/libgraph.py
+++ b/scripts/libgraph.py
@@ -15,6 +15,7 @@ KNOWN_EXCEPTIONS = {"Hex", "HexManual"}
 BUILD_ONLY_LIBS = {
     "HexLLLBenchSupport",
     "HexGF2BenchSupport",
+    "HexMvPolyBenchSupport",
     "HexIntervalExperiment",
     "HexIntervalMathlibExperiment",
     "HexIntervalReplayProbe",


### PR DESCRIPTION
## Summary

- add the Mathlib-free `hexmvpoly_bench` executable and shared `HexMvPolyBench.Corpus`
- cover the five SPEC families with 11 attribution-isolated timed targets
- exercise lex/grlex/grevlex, low/high collisions, `Int` and genuine-fraction `Rat`, rename/partial-eval/subst, and SOS-shaped arithmetic
- extend the existing single CI job and classify the build-only corpus library

## Validation

- `lake build hexmvpoly_bench`
- `lake exe hexmvpoly_bench verify` (11/11)
- scientific `run` ladders: 11/11 consistent with declared complexity
- `python3 scripts/check_phase4.py --base origin/main` (11 registrations)
- `python3 scripts/check_dag.py`
- `python3 scripts/ci/check_benches_mathlib_free.py`
- `BENCH_VERIFY_HARD_CAP_SECONDS=30 scripts/ci/check_bench_verify_budget.sh hexmvpoly_bench` (3s)
- copyright, line-count, and diff checks