### PR TITLE
release: harden standalone package checks

### DIFF
--- a/Hex/BenchOracle/Flint.lean
+++ b/Hex/BenchOracle/Flint.lean
@@ -50,10 +50,10 @@ result schema. For example:
 
 ## Configuration
 
-* `HEX_FLINT_BENCH_DRIVER` — absolute path to the driver script,
-  overriding the default `scripts/oracle/flint_bench_driver.py`
-  (relative to the bench process's cwd, which is the repo root
-  under `lake exe`).
+* `HEX_FLINT_BENCH_DRIVER` — path to the driver script, overriding automatic
+  discovery.  By default the helper checks `scripts/oracle/flint_bench_driver.py`
+  and then `../scripts/oracle/flint_bench_driver.py`, covering both the
+  development repository root and a released repository's `bench/` side project.
 * `HEX_FLINT_BENCH_PYTHON` — interpreter command (default
   `python3`). Useful in CI when only `python` is on `PATH`.
 -/
@@ -115,8 +115,13 @@ private def envOr (name : String) (default : String) : IO String := do
   | some v => return v
   | none => return default
 
-private def driverPath : IO String :=
-  envOr "HEX_FLINT_BENCH_DRIVER" "scripts/oracle/flint_bench_driver.py"
+private def driverPath : IO String := do
+  if let some path ← IO.getEnv "HEX_FLINT_BENCH_DRIVER" then
+    return path
+  let rootPath : System.FilePath := "scripts/oracle/flint_bench_driver.py"
+  if ← rootPath.pathExists then
+    return rootPath.toString
+  return "../scripts/oracle/flint_bench_driver.py"
 
 private def pythonCommand : IO String :=
   envOr "HEX_FLINT_BENCH_PYTHON" "python3"

--- a/progress/20260731T144701Z.md
+++ b/progress/20260731T144701Z.md
@@ -17,6 +17,8 @@
 - Pinned the fpLLL FFI source and made its clean-cache build use Hex's exact
   stable Lean toolchain rather than the external repository's stale release
   candidate.  A fresh native build and explicit loader probe pass.
+- Corrected the bootstrap baseline note to describe the current self-advancing
+  release branch and partial-publication recovery behavior.
 
 # Current frontier
 

--- a/progress/20260731T144701Z.md
+++ b/progress/20260731T144701Z.md
@@ -14,6 +14,9 @@
   benchmark cases.
 - Added publisher validation and a regression test so a released library that
   declares module precompilation cannot silently lose it from its Lake skeleton.
+- Pinned the fpLLL FFI source and made its clean-cache build use Hex's exact
+  stable Lean toolchain rather than the external repository's stale release
+  candidate.  A fresh native build and explicit loader probe pass.
 
 # Current frontier
 
@@ -22,6 +25,8 @@
 - The shared FLINT driver discovery and publisher guard are ready on
   `release-packaging-followup`; targeted Lean builds, publisher tests, manifest
   validation, the release DAG check, and the 47-case Berlekamp verification pass.
+- The standalone LLL bootstrap failure is fixed locally and included in the
+  follow-up after reproducing it from an empty oracle cache.
 
 # Next step
 

--- a/progress/20260731T144701Z.md
+++ b/progress/20260731T144701Z.md
@@ -1,0 +1,34 @@
+# Accomplished
+
+- Merged the polynomial-factorization release preparation as PR #9116 after the
+  full monorepo CI, external oracles, benchmark gate, and BZ trace gate passed.
+- Published all 35 split repositories and the aggregate from
+  `hex-dev@f72c2b8d21f3`, then verified all 36 live heads against the advanced
+  release baseline.
+- Repaired the released `hex-lll` native-loader check to pass its probe library
+  explicitly; the replacement Linux and macOS workflow is running.
+- Diagnosed two fresh-clone packaging failures.  A fresh 365-target downstream
+  build confirms that precompiling the released `HexHensel` modules restores
+  interpreter-time BZ guards.  A released-directory Berlekamp verification
+  confirms that root-or-side-project FLINT driver discovery passes all 47
+  benchmark cases.
+- Added publisher validation and a regression test so a released library that
+  declares module precompilation cannot silently lose it from its Lake skeleton.
+
+# Current frontier
+
+- The Hensel skeleton fix is live at `6abb80de6326` and recorded in the release
+  baseline.
+- The shared FLINT driver discovery and publisher guard are ready on
+  `release-packaging-followup`; targeted Lean builds, publisher tests, manifest
+  validation, the release DAG check, and the 47-case Berlekamp verification pass.
+
+# Next step
+
+- Open and merge the follow-up PR, republish from its merged commit so downstream
+  pins name the corrected Hex test kit and Hensel heads, and require every
+  exact-head standalone workflow to pass.
+
+# Blockers
+
+- None.

--- a/scripts/oracle/setup_fplll_ffi.sh
+++ b/scripts/oracle/setup_fplll_ffi.sh
@@ -14,14 +14,14 @@
 #   HEX_FPLLL_FFI_REPO   — repo URL (default: https://github.com/leanprover/fplll).
 #   HEX_ORACLE_CACHE     — cache root (default: <repo>/.cache/oracles).
 #
-# The build uses the toolchain pinned by `fplll-ffi/lean-toolchain` via `elan`,
-# vendors fplll-5.5.0 as a submodule, and dynamically links libfplll/GMP/MPFR.
-# On Linux the runtime path to Lean's `libLake_shared.so` is supplied by the
-# caller via `LD_LIBRARY_PATH`; on macOS via `DYLD_LIBRARY_PATH`.
+# The build uses Hex's pinned Lean toolchain via `elan`, vendors fplll-5.5.0 as
+# a submodule, and dynamically links libfplll/GMP/MPFR.
+# The final shim carries runtime paths for both libfplll and Lean's shared
+# runtime, so callers need not modify their dynamic-loader search path.
 set -euo pipefail
 
 # Pinned fplll-ffi commit. Bump in lockstep with the SPEC / report updates.
-default_ref="main"
+default_ref="c9a56a93108f0c1181c2d4e36dbfa135b810c3fc"
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cache_root="${HEX_ORACLE_CACHE:-${repo_root}/.cache/oracles}/fplll-ffi"
@@ -86,11 +86,18 @@ clone_or_update() {
 
 clone_or_update
 
-# Install the toolchain pinned by fplll-ffi (matches hex's toolchain in
-# practice, so this is a no-op when the two pin the same version). `lake`
-# inside `src_dir` reads the local `lean-toolchain` file via elan, so no
-# `+toolchain` prefix is needed once the toolchain is installed.
-toolchain="$(tr -d '\r\n' < "${src_dir}/lean-toolchain")"
+# The external repository's Lake file and toolchain pin can move independently.
+# Compile the pinned source with Hex's exact stable toolchain, and invalidate the
+# external build cache when either input changes.
+toolchain="$(tr -d '\r\n' < "${repo_root}/lean-toolchain")"
+source_head="$(git -C "${src_dir}" rev-parse HEAD)"
+build_context="${source_head} ${toolchain}"
+build_context_stamp="${cache_root}/build-context"
+if [[ ! -f "${build_context_stamp}" ]] ||
+   [[ "$(tr -d '\r\n' < "${build_context_stamp}")" != "${build_context}" ]]; then
+  rm -rf "${src_dir}/.lake/build"
+  printf '%s\n' "${build_context}" > "${build_context_stamp}"
+fi
 if ! elan toolchain list | grep -Fq "${toolchain}"; then
   elan toolchain install "${toolchain}" >&2
 fi
@@ -98,7 +105,7 @@ fi
 static_path="${src_dir}/.lake/build/lib/libfplllffi.a"
 
 if [[ ! -f "${static_path}" ]]; then
-  (cd "${src_dir}" && lake build FPLLL >&2)
+  (cd "${src_dir}" && elan run "${toolchain}" lake build FPLLL >&2)
 fi
 
 if [[ ! -f "${static_path}" ]]; then
@@ -116,7 +123,8 @@ fi
 # system fplll/MPFR/GMP, and bake the toolchain lib dir into the rpath so
 # `Hex.lll.loadExternalReducer`'s dlopen of this library does not depend on the
 # caller's `LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH`.
-lean_lib_dir="$(cd "$(dirname "$(elan which lean)")/../lib/lean" && pwd)"
+lean_prefix="$(elan run "${toolchain}" lean --print-prefix)"
+lean_lib_dir="${lean_prefix}/lib/lean"
 fplll_install_lib="${src_dir}/.lake/build/fplll-install/lib"
 out_dir="${cache_root}/shim"
 mkdir -p "${out_dir}"

--- a/scripts/release/check_released_manifest.py
+++ b/scripts/release/check_released_manifest.py
@@ -109,6 +109,8 @@ def main() -> int:
             if lib in library_names:
                 fail(f"duplicate released library {lib}")
             library_names.add(lib)
+            if not isinstance(entry.get("precompile_modules", False), bool):
+                fail(f"{repo}: precompile_modules must be a Boolean")
             test_modules = entry.get("test_modules", [])
             if (
                 not isinstance(test_modules, list)

--- a/scripts/release/released.yml
+++ b/scripts/release/released.yml
@@ -178,6 +178,7 @@ repos:
 
   - repo: leanprover/hex-hensel
     lib: HexHensel
+    precompile_modules: true
     umbrella: true
     spec: hex-hensel
     bench: true

--- a/scripts/release/sync_released.py
+++ b/scripts/release/sync_released.py
@@ -223,6 +223,16 @@ def validate_skeleton(entry: dict, clone: Path) -> None:
             f"{clone}"
         )
     text = lakefile.read_text(encoding="utf-8")
+    if entry.get("precompile_modules"):
+        assignment = (
+            r"(?m)^\s*precompileModules\s*=\s*true\s*$"
+            if entry["lakefile"] == "toml"
+            else r"(?m)^\s*precompileModules\s*:=\s*true\s*$"
+        )
+        if re.search(assignment, text) is None:
+            raise RuntimeError(
+                f"released Lake file {lakefile} must precompile modules"
+            )
     for module in entry.get("test_modules", []):
         if module not in text:
             raise RuntimeError(

--- a/scripts/release/synced.json
+++ b/scripts/release/synced.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Per-repo `main` HEAD that this monorepo's content corresponds to. The publish sync (sync_released.py) refuses to overwrite a released repo whose main has moved off this baseline (an uncoordinated commit). After a real sync the workflow uploads the advanced baseline as an artifact; commit it via a normal PR (main is a protected branch).",
+  "_comment": "Bootstrap per-repo `main` HEADs used only until the dedicated `release-sync-baseline` branch exists. The publish sync refuses to overwrite a released repo whose main has moved off the live baseline, and every real workflow run advances that branch even when a later mirror fails.",
   "hex-test-kit": "610207eec0ca214928eec42a6dd2084d859bf94d",
   "hex-matrix": "42c865718206dc1c2e63e3fc0ebb94db8174bd12",
   "hex-matrix-mathlib": "a0ae2639613d29f73a5fe5abccd7749af8f9a67c",

--- a/scripts/release/test_sync_released.py
+++ b/scripts/release/test_sync_released.py
@@ -126,6 +126,21 @@ class SyncReleasedTests(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "lakefile.toml"):
             sync_released.validate_skeleton({"lakefile": "toml"}, self.repo)
 
+    def test_release_skeleton_checks_module_precompilation(self) -> None:
+        lakefile = self.repo / "lakefile.toml"
+        lakefile.write_text(
+            '[[lean_lib]]\nname = "Consumer"\n',
+            encoding="utf-8",
+        )
+        entry = {"lakefile": "toml", "precompile_modules": True}
+        with self.assertRaisesRegex(RuntimeError, "must precompile modules"):
+            sync_released.validate_skeleton(entry, self.repo)
+        lakefile.write_text(
+            '[[lean_lib]]\nname = "Consumer"\nprecompileModules = true\n',
+            encoding="utf-8",
+        )
+        sync_released.validate_skeleton(entry, self.repo)
+
     def test_manifest_uses_exact_external_commit(self) -> None:
         manifest = {
             "version": "1.1.0",


### PR DESCRIPTION
Follow-up to #9116 after exercising every published mirror from a fresh push.

- discover the shared FLINT driver from both the monorepo root and a released bench side project
- declare that hex-hensel requires precompiled modules for downstream interpreter-time guards
- make the publisher reject a skeleton that loses that setting
- add the corresponding publisher regression test
- pin the fpLLL FFI source and build it with the exact Hex Lean toolchain, invalidating its cache when either input changes
- make the bootstrap baseline note describe the current self-advancing release branch

Evidence:
- fresh 365-target BZ build passes with the corrected Hensel skeleton
- released-directory Berlekamp verification passes all 47 cases
- clean-cache fpLLL native build reaches the pinned stable-toolchain modules and the resulting shim passes the explicit loader probe
- publisher tests: 10/10
- release manifest, DAG, trust-surface checks: pass
- lake build Hex.BenchOracle.Flint: pass