### PR TITLE
test: bound real-root conformance cost

### DIFF
--- a/conformance/HexRealRootsMathlib/Conformance.lean
+++ b/conformance/HexRealRootsMathlib/Conformance.lean
@@ -220,10 +220,13 @@ concrete polynomial, so the "one certified interval, `simp`" path stays green:
 * the Sturm squarefree certificate `squareFreeRat_of_hasSquarefreeSturmChain`,
   discharged by `by decide` on the executable chain (no rational gcd);
 * the coefficient-sum `eval_toPolyℝ` bridge, turning `IsRoot` into `x⁴ − 2 = 0`;
-* the `toReal_ofInt_shiftRight` simp lemma for the `k / 2²⁰` dyadic endpoints;
+* the conversion of integral dyadic endpoints to real numbers;
 * the `Hex`-namespace dot-notation alias `RealRootIsolation.exists_unique_root`.
 
-The tight interval `(1246974/2²⁰, 1246975/2²⁰]` isolates `+2^{1/4}`. -/
+The interval `(1, 2]` isolates `+2^{1/4}`.  High-precision refinement belongs
+to the executable real-roots benchmarks; this theorem checks the
+mathematician-facing correspondence without making compilation depend on the
+size of dyadic numerators. -/
 
 /-- `x⁴ − 2`; two real roots `±2^{1/4}`. -/
 private def quartic : Hex.ZPoly := Hex.DensePoly.ofCoeffs #[(-2 : Int), 0, 0, 0, 1]
@@ -231,10 +234,9 @@ private def quartic : Hex.ZPoly := Hex.DensePoly.ofCoeffs #[(-2 : Int), 0, 0, 0,
 private theorem quartic_squarefree : Hex.ZPoly.SquareFreeRat quartic :=
   squareFreeRat_of_hasSquarefreeSturmChain _ (by decide)
 
-/-- The refined, width-`2⁻²⁰` isolating interval for the positive root. -/
-private def quarticIsoTight : Hex.RealRootIsolation quartic :=
-  ⟨⟨Dyadic.ofInt 1246974 >>> (20 : Int), Dyadic.ofInt 1246975 >>> (20 : Int), by decide⟩,
-    by decide⟩
+/-- The isolating interval `(1, 2]` for the positive root. -/
+private def quarticIso : Hex.RealRootIsolation quartic :=
+  ⟨⟨Dyadic.ofInt 1, Dyadic.ofInt 2, by decide⟩, by decide⟩
 
 private theorem quartic_isRoot_iff (x : ℝ) : (toPolyℝ quartic).IsRoot x ↔ x ^ 4 - 2 = 0 := by
   rw [Polynomial.IsRoot, eval_toPolyℝ, show quartic.size = 5 from by decide]
@@ -243,10 +245,10 @@ private theorem quartic_isRoot_iff (x : ℝ) : (toPolyℝ quartic).IsRoot x ↔ 
   norm_num
   constructor <;> intro h <;> linarith
 
-private theorem quartic_root_pos_tight :
-    ∃! x : ℝ, x ^ 4 - 2 = 0 ∧ (1246974 : ℝ) / 2 ^ 20 < x ∧ x ≤ 1246975 / 2 ^ 20 := by
-  have h := quarticIsoTight.exists_unique_root quartic_squarefree
-  simp only [quarticIsoTight, toReal_ofInt_shiftRight, quartic_isRoot_iff] at h
+private theorem quartic_root_pos :
+    ∃! x : ℝ, x ^ 4 - 2 = 0 ∧ 1 < x ∧ x ≤ 2 := by
+  have h := quarticIso.exists_unique_root quartic_squarefree
+  simp only [quarticIso, toReal_ofInt, quartic_isRoot_iff] at h
   convert h using 3
   all_goals norm_num
 

--- a/progress/20260731T173125Z.md
+++ b/progress/20260731T173125Z.md
@@ -1,0 +1,30 @@
+# Accomplished
+
+- Merged release-readiness PRs #9116 and #9117 after full builds, benchmark
+  verification, external oracles, BZ gates, and an independent review.
+- Published the complete 36-repository graph from `hex-dev@b708fe43eb84`,
+  repaired the Hensel standalone workflow's missing `python-flint` dependency,
+  and propagated every resulting exact pin without overriding the
+  uncoordinated-commit guard.
+- Verified the corrected standalone FLINT paths, Hensel module precompilation,
+  fpLLL bootstrap, Linux/macOS native loading, and BZ downstream builds.
+- Replaced the RealRootsMathlib conformance example's 20-bit dyadic interval
+  with the sufficient interval `(1, 2]`.  The example still proves the unique
+  positive root of `x⁴ - 2` through the public correspondence theorem, while
+  its clean module build falls from more than 90 minutes to 3.9 seconds.
+
+# Current frontier
+
+- All exact-head standalone workflows except the superseded
+  RealRootsMathlib conformance run are green.
+- The conformance-runtime change builds locally as
+  `HexRealRootsMathlib.Conformance` across 8,868 targets with no diagnostics.
+
+# Next step
+
+- Merge the conformance-runtime follow-up, publish the two affected mirrors,
+  and repeat the 36-head / 37-workflow exact-revision audit.
+
+# Blockers
+
+- None.


### PR DESCRIPTION
The fresh released HexRealRootsMathlib workflow exposed a 90+ minute private conformance declaration: its 20-bit dyadic endpoints force large Sturm arithmetic during by-decide elaboration.

This keeps the same end-to-end mathematical regression for the unique positive root of x^4 - 2, but uses the sufficient isolating interval (1, 2]. High-precision refinement remains covered by the executable real-roots benchmarks.

Evidence:
- lake build HexRealRootsMathlib.Conformance: 8,868/8,868 targets, module 3.9s, 7.6s end-to-end
- published trust surface: 408 files, no axiom, sorry, or native_decide
- no change to released library code or performance evidence