### PR TITLE
Fix staged release dependency pins

### DIFF
--- a/progress/20260801T145409Z.md
+++ b/progress/20260801T145409Z.md
@@ -1,0 +1,26 @@
+# Accomplished
+
+- Diagnosed a staged-release failure in which `sync_released.py --only` began
+  with an empty dependency map and therefore left a downstream mirror's Lake
+  pins at stale upstream revisions.
+- Seeded staged publication pins from the live release baseline and added a
+  regression test covering an isolated downstream sync.
+- Ran all release-sync unit tests and the released-manifest validator.
+
+# Current frontier
+
+- The fix is ready for review and publication.
+- The required HexBasic and HexPoly mirrors are already published at their
+  Lean 4.33 revisions; HexMvPoly must be republished once this fix lands so it
+  records those exact transitive pins.
+
+# Next step
+
+- Merge the release-driver fix, dry-run and republish only `hex-mv-poly`, then
+  update and validate the Mathlib-free SOS staging branch against that head.
+
+# Blockers
+
+- The release token lacks write access to unrelated `leanprover/hex-arith`, so
+  the full 36-repository update cannot presently finish. This does not block
+  the HexBasic → HexPoly → HexMvPoly chain needed by SOS.

--- a/scripts/release/sync_released.py
+++ b/scripts/release/sync_released.py
@@ -672,7 +672,11 @@ def main() -> int:
     dep_owner = {e["repo"].split("/")[-1]: e["repo"].split("/")[0]
                  for e in manifest["repos"]}
     pins = external_pins()
-    synced: dict[str, str] = {}
+    # A staged `--only` publication still has to pin all of its already-published
+    # upstreams. Seed the pin map from the live baseline; otherwise an isolated
+    # downstream sync silently retains stale pins because skipped entries never
+    # populate `synced`.
+    synced: dict[str, str] = dict(baseline) if args.only else {}
     failed_repo: str | None = None
     current_repo = "<manifest>"
     try:

--- a/scripts/release/test_sync_released.py
+++ b/scripts/release/test_sync_released.py
@@ -205,6 +205,50 @@ class SyncReleasedTests(unittest.TestCase):
         self.assertEqual(advanced["first"], "new-first")
         self.assertEqual(advanced["second"], "old-second")
 
+    def test_only_sync_seeds_dependency_pins_from_baseline(self) -> None:
+        manifest = self.repo / "released.yml"
+        manifest.write_text(
+            "repos:\n"
+            "  - repo: leanprover/upstream\n"
+            "  - repo: leanprover/downstream\n",
+            encoding="utf-8",
+        )
+        baseline = self.repo / "baseline.json"
+        baseline.write_text(
+            json.dumps({"upstream": "new-upstream", "downstream": "old-downstream"}),
+            encoding="utf-8",
+        )
+
+        def publish(entry, _source_sha, _token, _dry_run, synced,
+                    _baseline, _force, _dep_owner, _pins):
+            self.assertEqual(entry["repo"], "leanprover/downstream")
+            self.assertEqual(synced["upstream"], "new-upstream")
+            self.assertEqual(synced["downstream"], "old-downstream")
+            synced["downstream"] = "new-downstream"
+            return True
+
+        argv = [
+            "sync_released.py",
+            "--token",
+            "secret-token",
+            "--baseline",
+            str(baseline),
+            "--only",
+            "downstream",
+        ]
+        with (
+            patch.object(sync_released, "MANIFEST", manifest),
+            patch.object(sync_released, "external_pins", return_value={}),
+            patch.object(sync_released, "run", return_value="source-sha"),
+            patch.object(sync_released, "sync_repo", side_effect=publish),
+            patch("sys.argv", argv),
+        ):
+            self.assertEqual(sync_released.main(), 0)
+
+        advanced = json.loads(baseline.read_text(encoding="utf-8"))
+        self.assertEqual(advanced["upstream"], "new-upstream")
+        self.assertEqual(advanced["downstream"], "new-downstream")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A real staged publication exposed that `sync_released.py --only` initialized its `synced` map empty. Skipped upstream entries therefore never contributed their live-baseline SHAs, so an isolated downstream release silently retained stale Lake pins.

This seeds staged runs from the live baseline and adds a regression test proving a downstream-only publication sees both upstream and its own recorded heads. Full runs retain their existing topological behavior.

Validation:
- `python3 -m unittest scripts/release/test_sync_released.py`
- `python3 scripts/release/check_released_manifest.py`
- `git diff --check`

After merge I will dry-run and republish only `hex-mv-poly`; no force overwrite is needed.