### PR TITLE
feat(number-field): prove lazy arithmetic totality

### DIFF
--- a/HexManual/Chapters/HexNumberField.lean
+++ b/HexManual/Chapters/HexNumberField.lean
@@ -108,17 +108,37 @@ tag := "hex-number-field-lazy"
 
 Every certificate-producing operation has an `Option` form. The total form is
 the primary algebraic API; its loud fallback is paired with a companion
-completeness contract.
+completeness contract. In particular, the Mathlib companion proves that the
+bounded searches for addition, multiplication, inversion, and division always
+return a certificate. Their total wrappers therefore compute the corresponding
+complex operations, including the convention `0⁻¹ = 0`. Subtraction composes
+addition with certificate-free polynomial reflection.
 
 {docstring Hex.AlgebraicRoot.add?}
+
+{docstring Hex.AlgebraicRoot.sub?}
 
 {docstring Hex.AlgebraicRoot.mul?}
 
 {docstring Hex.AlgebraicRoot.inv?}
 
+{docstring Hex.AlgebraicRoot.div?}
+
 {docstring Hex.AlgebraicRoot.exact?}
 
 {docstring Hex.AlgebraicRoot.exact}
+
+{docstring Hex.AlgebraicRoot.add?_isSome}
+
+{docstring Hex.AlgebraicRoot.mul?_isSome}
+
+{docstring Hex.AlgebraicRoot.inv?_isSome}
+
+{docstring Hex.AlgebraicRoot.div?_isSome}
+
+{docstring Hex.AlgebraicRoot.mul_toComplex}
+
+{docstring Hex.AlgebraicRoot.inv_toComplex}
 
 Canonical algebraic numbers reuse these lazy operations and exactify the
 answer. Their Boolean equality compares represented values rather than record

--- a/HexNumberField/Lazy.lean
+++ b/HexNumberField/Lazy.lean
@@ -31,6 +31,27 @@ coefficients are constant polynomials in a second variable `t`. -/
 def liftOuter (p : ZPoly) : DensePoly ZPoly :=
   DensePoly.ofCoeffs (p.toArray.map DensePoly.C)
 
+/-- Coefficients of the outer lift are the corresponding constant
+polynomials. -/
+@[simp] theorem coeff_liftOuter (p : ZPoly) (n : Nat) :
+    p.liftOuter.coeff n = DensePoly.C (p.coeff n) := by
+  unfold liftOuter
+  rw [DensePoly.coeff_ofCoeffs, Array.getD_eq_getD_getElem?,
+    Array.getElem?_map]
+  by_cases hn : n < p.size
+  · have hnArray : n < p.toArray.size := by simpa using hn
+    rw [Array.getElem?_eq_getElem hnArray]
+    simp only [Option.map_some, Option.getD_some]
+    congr 1
+    rw [Array.getElem_eq_getD (Zero.zero : Int), DensePoly.toArray_getD]
+  · have hnArray : p.toArray.size ≤ n := by simpa using Nat.le_of_not_gt hn
+    rw [Array.getElem?_eq_none hnArray]
+    simp only [Option.map_none, Option.getD_none]
+    have hpcoeff : p.coeff n = 0 :=
+      DensePoly.coeff_eq_zero_of_size_le p (Nat.le_of_not_gt hn)
+    rw [hpcoeff]
+    rfl
+
 /-- The eliminant whose roots are pairwise sums of roots of `p` and `q`. -/
 @[expose]
 def addEliminant (p q : ZPoly) : ZPoly :=

--- a/HexNumberField/SPEC/hex-number-field.md
+++ b/HexNumberField/SPEC/hex-number-field.md
@@ -270,6 +270,16 @@ HexRoots separation theorem makes distinct candidates disjoint, so exactly one
 candidate isolation meets the operation ball. This path does not need a second
 eliminant or the Stage 2 resultant value theorem.
 
+Candidate isolations use `resultIsolationPrec(e)` itself. The operand balls use
+an additional, input-computable guard: four bits for addition,
+`8 + rootBits(a) + rootBits(b)` for multiplication, and
+`2 * ceilLog2(1 + coeffAbsMax(a.p)) + 16` for inversion. The multiplication
+guard pays for operand-magnitude amplification. The reciprocal guard combines
+the reciprocal Cauchy lower bound with the quadratic distortion of inversion
+and dyadic rounding. The selected operation ball is two bits smaller than the
+candidate separation precision for addition and four bits smaller for
+multiplication and inversion.
+
 Canonical `AlgebraicNumber` arithmetic converts inputs with `toRoot`, performs
 the lazy operation, then calls `exact`. A many-input common-field routine is used
 internally only for polynomials with canonical algebraic coefficients.

--- a/HexNumberFieldMathlib/Approx.lean
+++ b/HexNumberFieldMathlib/Approx.lean
@@ -175,7 +175,8 @@ private theorem invCenter_eq (a : DyadicComplexBall) :
   exact HexRootsMathlib.GaussDyadic.toComplex_add
     (a.re, a.im) (b.re, b.im)
 
-@[simp] private theorem realRadius_add (a b : DyadicComplexBall) :
+/-- Ball addition adds the represented radii. -/
+@[simp] theorem realRadius_add (a b : DyadicComplexBall) :
     (a.add b).realRadius = a.realRadius + b.realRadius := by
   exact HexRootsMathlib.Dyadic.toReal_add a.radius b.radius
 
@@ -335,7 +336,9 @@ private theorem realRadius_toBall_nonneg (s : DyadicSquare) :
     0 ≤ s.toBall.realRadius := by
   simpa [DyadicSquare.toBall, realRadius] using (radiusHi_pos s).le
 
-private theorem realRadius_toBall_le {s : DyadicSquare} {prec : Int}
+/-- A square refined to `prec` has a dyadic-ball radius bounded by two ulps at
+that precision. -/
+theorem realRadius_toBall_le {s : DyadicSquare} {prec : Int}
     (hprec : prec ≤ s.prec) :
     s.toBall.realRadius ≤ 2 * (2 : ℝ) ^ (-prec) := by
   have hpow : (2 : ℝ) ^ (-s.prec) ≤ (2 : ℝ) ^ (-prec) :=
@@ -794,6 +797,34 @@ theorem add_mem {a b : DyadicComplexBall} {z w : ℂ}
     _ ≤ ‖z - a.center‖ + ‖w - b.center‖ := norm_add_le _ _
     _ = dist z a.center + dist w b.center := by rw [dist_eq_norm, dist_eq_norm]
     _ ≤ a.realRadius + b.realRadius := add_le_add hz hw
+
+/-- Two certified balls containing the same point meet. -/
+theorem meets_of_mem {a b : DyadicComplexBall} {z : ℂ}
+    (ha : z ∈ a.set) (hb : z ∈ b.set) : a.meets b = true := by
+  have ha' : dist a.center z ≤ a.realRadius := by
+    rw [dist_comm]
+    exact Metric.mem_closedBall.mp ha
+  have hb' : dist z b.center ≤ b.realRadius :=
+    Metric.mem_closedBall.mp hb
+  have hra : 0 ≤ a.realRadius := dist_nonneg.trans ha'
+  have hrb : 0 ≤ b.realRadius := dist_nonneg.trans hb'
+  have hdist : dist a.center b.center ≤ a.realRadius + b.realRadius :=
+    (dist_triangle a.center z b.center).trans (add_le_add ha' hb')
+  have hsq : dist a.center b.center ^ 2 ≤
+      (a.realRadius + b.realRadius) ^ 2 :=
+    (sq_le_sq₀ dist_nonneg (add_nonneg hra hrb)).mpr hdist
+  have hreal :
+      HexRootsMathlib.Dyadic.toReal
+          (GaussDyadic.distSq (a.re, a.im) (b.re, b.im)) ≤
+        HexRootsMathlib.Dyadic.toReal
+          ((a.radius + b.radius) * (a.radius + b.radius)) := by
+    simpa only [HexRootsMathlib.Dyadic.toReal_mul,
+      HexRootsMathlib.Dyadic.toReal_add,
+      HexRootsMathlib.DyadicSquare.toReal_distSq,
+      DyadicComplexBall.center, DyadicComplexBall.realRadius,
+      pow_two] using hsq
+  have hdy := HexRootsMathlib.Dyadic.toReal_le_toReal_iff.mp hreal
+  simpa [DyadicComplexBall.meets] using decide_eq_true hdy
 
 /-- A rational coefficient lies in its executable rounded enclosure. -/
 theorem ofRat_mem (q : Rat) (prec : Int) :

--- a/HexNumberFieldMathlib/Approx.lean
+++ b/HexNumberFieldMathlib/Approx.lean
@@ -113,6 +113,18 @@ private theorem abs_sub_round_lt (q : Rat) (prec : Int) :
   rw [abs_of_nonneg (sub_nonneg.mpr (round_le q prec))]
   linarith [lt_round_add q prec]
 
+private theorem invGuard_ulp_eq (prec : Int) (bits : Nat) :
+    (2 : ℝ) ^ (-(prec + ((2 * bits + 16 : Nat) : Int))) =
+      (2 : ℝ) ^ (-prec) /
+        (65536 * ((2 : ℝ) ^ bits) ^ 2) := by
+  rw [show -(prec + ((2 * bits + 16 : Nat) : Int)) =
+      -prec - ((2 * bits + 16 : Nat) : Int) by omega,
+    zpow_sub₀ (by norm_num : (2 : ℝ) ≠ 0), zpow_natCast]
+  rw [show 2 * bits + 16 = (bits + bits) + 16 by omega,
+    pow_add, pow_add]
+  norm_num
+  ring
+
 private theorem round_eq_of_pow2 (q : Rat) (prec : Int) (hprec : 0 ≤ prec)
     (hpow : q.den = 2 ^ q.den.log2) (hle : q.den.log2 ≤ prec.toNat) :
     HexRootsMathlib.Dyadic.toReal (q.toDyadic prec) = (q : ℝ) := by
@@ -1234,6 +1246,332 @@ theorem inv_mem {a b : DyadicComplexBall} {z : ℂ} {prec : Int}
   · contradiction
 
 end DyadicComplexBall
+
+namespace RefinedIsolation
+
+/-- Refining two root isolations by the multiplication guard makes the product
+ball four bits smaller than the requested operation precision. The literal
+guard formula mirrors `AlgebraicRoot.mulGuardBits`, which is defined in the
+downstream lazy-arithmetic module. This margin is stronger than singleton
+selection currently requires. -/
+theorem mulRadius_le {p q : ZPoly}
+    (a : RefinedIsolation p) (b : RefinedIsolation q)
+    (prec : Int) (strategy : AtomStrategy)
+    {ar : {r : RefinedIsolation p //
+      SimpleRoot.mk r = SimpleRoot.mk a}}
+    {br : {r : RefinedIsolation q //
+      SimpleRoot.mk r = SimpleRoot.mk b}}
+    (har : a.refineTo?
+      (prec + ((8 + QAdjoin.rootBits a.1.square +
+        QAdjoin.rootBits b.1.square : Nat) : Int)) strategy = some ar)
+    (hbr : b.refineTo?
+      (prec + ((8 + QAdjoin.rootBits a.1.square +
+        QAdjoin.rootBits b.1.square : Nat) : Int)) strategy = some br) :
+    (ar.1.1.square.toBall.mul br.1.1.square.toBall).realRadius ≤
+      (2 : ℝ) ^ (-(prec + 4)) := by
+  let A := QAdjoin.rootBits a.1.square
+  let B := QAdjoin.rootBits b.1.square
+  let G := 8 + A + B
+  let H := 4 + A + B
+  let δ : ℝ := (2 : ℝ) ^ (-(prec + (G : Int)))
+  have harPrec : prec + (G : Int) ≤ ar.1.1.square.prec := by
+    exact refineTo?_precision a (prec + (G : Int)) strategy
+      (by simpa [G, A, B] using har)
+  have hbrPrec : prec + (G : Int) ≤ br.1.1.square.prec := by
+    exact refineTo?_precision b (prec + (G : Int)) strategy
+      (by simpa [G, A, B] using hbr)
+  have harRadius : ar.1.1.square.toBall.realRadius ≤ 2 * δ := by
+    simpa only [δ] using
+      DyadicComplexBall.realRadius_toBall_le harPrec
+  have hbrRadius : br.1.1.square.toBall.realRadius ≤ 2 * δ := by
+    simpa only [δ] using
+      DyadicComplexBall.realRadius_toBall_le hbrPrec
+  have har0 : 0 ≤ ar.1.1.square.toBall.realRadius :=
+    DyadicComplexBall.realRadius_toBall_nonneg _
+  have hbr0 : 0 ≤ br.1.1.square.toBall.realRadius :=
+    DyadicComplexBall.realRadius_toBall_nonneg _
+  have harExtent :
+      DyadicComplexBall.extent ar.1.1.square.toBall ≤
+        4 * (2 : ℝ) ^ A := by
+    calc
+      DyadicComplexBall.extent ar.1.1.square.toBall ≤
+          4 * DyadicComplexBall.extent a.1.square.toBall :=
+        DyadicComplexBall.refined_extent_le a
+          (prec + (G : Int)) strategy (by simpa [G, A, B] using har)
+      _ ≤ 4 * (2 : ℝ) ^ A :=
+        mul_le_mul_of_nonneg_left
+          (DyadicComplexBall.extent_toBall_le a.1.square) (by norm_num)
+  have hbrExtent :
+      DyadicComplexBall.extent br.1.1.square.toBall ≤
+        4 * (2 : ℝ) ^ B := by
+    calc
+      DyadicComplexBall.extent br.1.1.square.toBall ≤
+          4 * DyadicComplexBall.extent b.1.square.toBall :=
+        DyadicComplexBall.refined_extent_le b
+          (prec + (G : Int)) strategy (by simpa [G, A, B] using hbr)
+      _ ≤ 4 * (2 : ℝ) ^ B :=
+        mul_le_mul_of_nonneg_left
+          (DyadicComplexBall.extent_toBall_le b.1.square) (by norm_num)
+  have hA1 : 1 ≤ (2 : ℝ) ^ A := one_le_pow₀ (by norm_num)
+  have hB1 : 1 ≤ (2 : ℝ) ^ B := one_le_pow₀ (by norm_num)
+  have hsum :
+      (2 : ℝ) ^ A + (2 : ℝ) ^ B ≤
+        2 * (2 : ℝ) ^ (A + B) := by
+    calc
+      (2 : ℝ) ^ A + (2 : ℝ) ^ B ≤
+          (2 : ℝ) ^ A * (2 : ℝ) ^ B +
+            (2 : ℝ) ^ A * (2 : ℝ) ^ B :=
+        add_le_add
+          (by
+            calc
+              (2 : ℝ) ^ A = (2 : ℝ) ^ A * 1 := by ring
+              _ ≤ (2 : ℝ) ^ A * (2 : ℝ) ^ B :=
+                mul_le_mul_of_nonneg_left hB1 (by positivity))
+          (by
+            calc
+              (2 : ℝ) ^ B = 1 * (2 : ℝ) ^ B := by ring
+              _ ≤ (2 : ℝ) ^ A * (2 : ℝ) ^ B :=
+                mul_le_mul_of_nonneg_right hA1 (by positivity))
+      _ = 2 * (2 : ℝ) ^ (A + B) := by
+        rw [pow_add]
+        ring
+  have hamp :
+      8 * ((2 : ℝ) ^ A + (2 : ℝ) ^ B) ≤
+        (2 : ℝ) ^ H := by
+    calc
+      8 * ((2 : ℝ) ^ A + (2 : ℝ) ^ B) ≤
+          8 * (2 * (2 : ℝ) ^ (A + B)) :=
+        mul_le_mul_of_nonneg_left hsum (by norm_num)
+      _ = (2 : ℝ) ^ H := by
+        dsimp [H]
+        rw [show 4 + A + B = 4 + (A + B) by omega, pow_add]
+        ring
+  have hδ0 : 0 ≤ δ := by positivity
+  calc
+    (ar.1.1.square.toBall.mul br.1.1.square.toBall).realRadius ≤
+        DyadicComplexBall.extent ar.1.1.square.toBall *
+            br.1.1.square.toBall.realRadius +
+          DyadicComplexBall.extent br.1.1.square.toBall *
+            ar.1.1.square.toBall.realRadius :=
+      DyadicComplexBall.realRadius_mul_le _ _ har0 hbr0
+    _ ≤ (4 * (2 : ℝ) ^ A) * (2 * δ) +
+          (4 * (2 : ℝ) ^ B) * (2 * δ) :=
+      add_le_add
+        (mul_le_mul harExtent hbrRadius hbr0 (by positivity))
+        (mul_le_mul hbrExtent harRadius har0 (by positivity))
+    _ = 8 * ((2 : ℝ) ^ A + (2 : ℝ) ^ B) * δ := by ring
+    _ ≤ (2 : ℝ) ^ H * δ :=
+      mul_le_mul_of_nonneg_right hamp hδ0
+    _ = (2 : ℝ) ^ ((H : Int) + (-(prec + (G : Int)))) := by
+      dsimp [δ]
+      rw [← zpow_natCast, ← zpow_add₀ (by norm_num : (2 : ℝ) ≠ 0)]
+    _ = (2 : ℝ) ^ (-(prec + 4)) := by
+      congr 1
+      dsimp [H, G]
+      omega
+
+/-- The reciprocal guard separates a refined nonzero root ball from zero and
+leaves four bits of radius slack after reciprocal distortion and rounding. The
+literal guard formula mirrors `AlgebraicRoot.invGuardBits`, which is defined in
+the downstream lazy-arithmetic module. This margin is stronger than singleton
+selection currently requires. -/
+theorem invBall_exists {p : ZPoly} (a : RefinedIsolation p)
+    (prec : Int) (hprec : 0 ≤ prec) (strategy : AtomStrategy)
+    (hlower : (((p.coeffAbsMax + 1 : Nat) : ℝ))⁻¹ <
+      ‖HexRootsMathlib.RefinedIsolation.root a‖)
+    {ar : {r : RefinedIsolation p //
+      SimpleRoot.mk r = SimpleRoot.mk a}}
+    (har : a.refineTo?
+      (prec + ((2 * Hex.ceilLog2 (p.coeffAbsMax + 1) + 16 : Nat) : Int))
+      strategy = some ar) :
+    ∃ ball : DyadicComplexBall,
+      ar.1.1.square.toBall.inv?
+          (prec + ((2 * Hex.ceilLog2 (p.coeffAbsMax + 1) + 16 : Nat) : Int)) =
+        some ball ∧
+      ball.realRadius ≤ (2 : ℝ) ^ (-(prec + 4)) := by
+  let D := p.coeffAbsMax + 1
+  let C := Hex.ceilLog2 D
+  let G := 2 * C + 16
+  let target : Int := prec + (G : Int)
+  let z := HexRootsMathlib.RefinedIsolation.root a
+  let input := ar.1.1.square.toBall
+  let r := input.realRadius
+  let lower := HexRootsMathlib.Dyadic.toReal
+    (GaussDyadic.lo (input.re, input.im))
+  let U : ℝ := (2 : ℝ) ^ C
+  let e : ℝ := (2 : ℝ) ^ (-prec)
+  let δ : ℝ := (2 : ℝ) ^ (-target)
+  have hDpos : 0 < (D : ℝ) := by
+    dsimp [D]
+    positivity
+  have hDU : (D : ℝ) ≤ U := by
+    dsimp [U]
+    exact_mod_cast HexRootsMathlib.le_two_pow_ceilLog2 D
+  have hUpos : 0 < U := by positivity
+  have hD1 : (1 : ℝ) ≤ D := by
+    dsimp [D]
+    norm_num
+  have hU1 : 1 ≤ U := hD1.trans hDU
+  have he0 : 0 ≤ e := by positivity
+  have he1 : e ≤ 1 := by
+    exact zpow_le_one_of_nonpos₀ (by norm_num) (by omega)
+  have hδeq : δ = e / (65536 * U ^ 2) := by
+    simpa only [δ, target, G, C, e, U] using
+      DyadicComplexBall.invGuard_ulp_eq prec C
+  have hδ0 : 0 ≤ δ := by positivity
+  have hreach : target ≤ ar.1.1.square.prec := by
+    exact refineTo?_precision a target strategy
+      (by simpa only [target, G, C, D] using har)
+  have hrBound : r ≤ 2 * δ := by
+    simpa only [r, input, δ, target] using
+      DyadicComplexBall.realRadius_toBall_le hreach
+  have hr0 : 0 ≤ r := by
+    exact DyadicComplexBall.realRadius_toBall_nonneg _
+  have hrSmall : r ≤ U⁻¹ / 8 := by
+    calc
+      r ≤ 2 * δ := hrBound
+      _ = e / (32768 * U ^ 2) := by
+        rw [hδeq]
+        field_simp
+        ring
+      _ ≤ U⁻¹ / 8 := by
+        rw [div_le_div_iff₀ (by positivity : (0 : ℝ) < 32768 * U ^ 2)
+          (by positivity : (0 : ℝ) < 8)]
+        rw [inv_eq_one_div]
+        field_simp
+        nlinarith [sq_nonneg U]
+  have hrFine : 8 * U ^ 2 * r ≤ e / 4096 := by
+    calc
+      8 * U ^ 2 * r ≤ 8 * U ^ 2 * (2 * δ) := by
+        gcongr
+      _ = e / 4096 := by
+        rw [hδeq]
+        field_simp
+        ring
+  have hrootEq :
+      HexRootsMathlib.RefinedIsolation.root ar.1 = z := by
+    exact HexRootsMathlib.RefinedIsolation.refineTo_root
+      a target strategy (by simpa only [target, G, C, D] using har)
+  have hzBall : z ∈ input.set := by
+    rw [← hrootEq]
+    exact DyadicComplexBall.mem_toBall
+      (HexRootsMathlib.RefinedIsolation.root_mem_closedDisc ar.1)
+  have hzDist : dist z input.center ≤ r := by
+    simpa only [DyadicComplexBall.set, Metric.mem_closedBall, input, r]
+      using hzBall
+  have hzNorm : ‖z‖ ≤ r + ‖input.center‖ := by
+    calc
+      ‖z‖ = ‖(z - input.center) + input.center‖ := by
+        congr 1
+        ring
+      _ ≤ ‖z - input.center‖ + ‖input.center‖ := norm_add_le _ _
+      _ ≤ r + ‖input.center‖ := by
+        gcongr
+        simpa [dist_eq_norm] using hzDist
+  have hlower0 : 0 ≤ lower := by
+    dsimp [lower]
+    rw [HexRootsMathlib.GaussDyadic.toReal_lo]
+    positivity
+  have hsqrt : √(2 : ℝ) ≤ 3 / 2 := by
+    have hs0 : 0 ≤ √(2 : ℝ) := Real.sqrt_nonneg _
+    have hsq : √(2 : ℝ) ^ 2 = 2 := Real.sq_sqrt (by norm_num)
+    nlinarith
+  have hcenter : ‖input.center‖ ≤ (3 / 2 : ℝ) * lower := by
+    calc
+      ‖input.center‖ ≤ √(2 : ℝ) * lower := by
+        simpa only [DyadicComplexBall.center, lower] using
+          HexRootsMathlib.GaussDyadic.norm_le_sqrt_two_mul_lo
+            (input.re, input.im)
+      _ ≤ (3 / 2 : ℝ) * lower :=
+        mul_le_mul_of_nonneg_right hsqrt hlower0
+  have hInvUD : U⁻¹ ≤ (D : ℝ)⁻¹ :=
+    (inv_le_inv₀ hUpos hDpos).mpr hDU
+  have hrootU : U⁻¹ < ‖z‖ := by
+    exact hInvUD.trans_lt (by simpa only [z, D] using hlower)
+  have hrootUpper : ‖z‖ ≤ r + (3 / 2 : ℝ) * lower :=
+    hzNorm.trans (add_le_add_right hcenter r)
+  have hUinvPos : 0 < U⁻¹ := inv_pos.mpr hUpos
+  have hlowerHalf : U⁻¹ / 2 < lower := by
+    nlinarith
+  have hgap : (3 / 8 : ℝ) * U⁻¹ < lower - r := by
+    nlinarith
+  have hsepReal : r < lower := by
+    nlinarith
+  have hdenom : U⁻¹ ^ 2 / 8 < (lower - r) * lower := by
+    calc
+      U⁻¹ ^ 2 / 8 ≤
+          ((3 / 8 : ℝ) * U⁻¹) * (U⁻¹ / 2) := by
+        nlinarith [sq_nonneg U⁻¹]
+      _ < (lower - r) * (U⁻¹ / 2) :=
+        mul_lt_mul_of_pos_right hgap (by positivity)
+      _ < (lower - r) * lower :=
+        mul_lt_mul_of_pos_left hlowerHalf (by nlinarith)
+  have hsep : input.radius < GaussDyadic.lo (input.re, input.im) := by
+    exact HexRootsMathlib.Dyadic.toReal_lt_toReal_iff.mp
+      (by simpa only [r, DyadicComplexBall.realRadius, lower] using hsepReal)
+  let norm := GaussDyadic.normSq (input.re, input.im)
+  let denom := (GaussDyadic.lo (input.re, input.im) - input.radius) *
+    GaussDyadic.lo (input.re, input.im)
+  let qdist : Rat := input.radius.toRat / denom.toRat
+  let out : DyadicComplexBall :=
+    { re := (input.re.toRat / norm.toRat).toDyadic target
+      im := ((-input.im.toRat) / norm.toRat).toDyadic target
+      radius := qdist.toDyadic target + Dyadic.ofIntWithPrec 1 target +
+        Dyadic.ofIntWithPrec 1 target + Dyadic.ofIntWithPrec 1 target }
+  have hout : input.inv? target = some out := by
+    unfold DyadicComplexBall.inv?
+    dsimp only
+    rw [if_pos hsep]
+  refine ⟨out, by simpa only [input, target, G, C, D] using hout, ?_⟩
+  have hqdistReal : (qdist : ℝ) =
+      r / ((lower - r) * lower) := by
+    simp only [qdist, denom, Rat.cast_div, _root_.Dyadic.toRat_mul,
+      _root_.Dyadic.toRat_sub, Rat.cast_mul, Rat.cast_sub]
+    rfl
+  have hqdist0 : 0 ≤ (qdist : ℝ) := by
+    rw [hqdistReal]
+    positivity
+  have hqdist : (qdist : ℝ) ≤ e / 4096 := by
+    rw [hqdistReal]
+    calc
+      r / ((lower - r) * lower) ≤ r / (U⁻¹ ^ 2 / 8) :=
+        div_le_div_of_nonneg_left hr0 (by positivity) hdenom.le
+      _ = 8 * U ^ 2 * r := by
+        field_simp
+      _ ≤ e / 4096 := hrFine
+  have hδSmall : δ ≤ e / 65536 := by
+    rw [hδeq]
+    apply div_le_div_of_nonneg_left he0 (by positivity)
+    nlinarith [sq_nonneg U]
+  have houtRadius : out.realRadius ≤ (qdist : ℝ) + 3 * δ := by
+    change HexRootsMathlib.Dyadic.toReal
+        (qdist.toDyadic target + Dyadic.ofIntWithPrec 1 target +
+          Dyadic.ofIntWithPrec 1 target + Dyadic.ofIntWithPrec 1 target) ≤
+      (qdist : ℝ) + 3 * δ
+    simp only [HexRootsMathlib.Dyadic.toReal_add,
+      HexRootsMathlib.Dyadic.toReal_ofIntWithPrec]
+    have hround := DyadicComplexBall.round_le qdist target
+    norm_num
+    have hpow : ((2 : ℝ) ^ target)⁻¹ = δ := by
+      dsimp [δ]
+      rw [zpow_neg]
+    rw [hpow]
+    linarith
+  have hfinal : out.realRadius ≤ e / 16 := by
+    calc
+      out.realRadius ≤ (qdist : ℝ) + 3 * δ := houtRadius
+      _ ≤ e / 4096 + 3 * (e / 65536) :=
+        add_le_add hqdist (mul_le_mul_of_nonneg_left hδSmall (by norm_num))
+      _ ≤ e / 16 := by nlinarith
+  calc
+    out.realRadius ≤ e / 16 := hfinal
+    _ = (2 : ℝ) ^ (-(prec + 4)) := by
+      dsimp [e]
+      rw [show -(prec + 4) = -prec - 4 by omega,
+        zpow_sub₀ (by norm_num : (2 : ℝ) ≠ 0)]
+      norm_num
+
+end RefinedIsolation
 
 namespace QAdjoin
 

--- a/HexNumberFieldMathlib/Exact.lean
+++ b/HexNumberFieldMathlib/Exact.lean
@@ -1065,7 +1065,9 @@ private theorem toBall_radius_lt_rootDist {q : ZPoly} (hq : q ≠ 0)
     _ < ‖z - w‖ / 4 :=
       HexRootsMathlib.mahlerPrec_separates q hq z w hz hw hne
 
-private theorem root_eq_of_meetsBall {q : ZPoly} (hq : q ≠ 0)
+/-- A sufficiently small certified ball can meet a refined isolation only at
+the root it contains. -/
+theorem root_eq_of_meetsBall {q : ZPoly} (hq : q ≠ 0)
     (r : RefinedIsolation q) {z : ℂ}
     (hz : (HexRootsMathlib.toPolyℂ q).IsRoot z)
     {b : DyadicComplexBall} (hzmem : z ∈ b.set)

--- a/HexNumberFieldMathlib/Lazy.lean
+++ b/HexNumberFieldMathlib/Lazy.lean
@@ -23,6 +23,8 @@ namespace Hex
 
 noncomputable section
 
+section
+
 @[implicit_reducible] local instance : CommRing ZPoly :=
   let s := (inferInstance : Lean.Grind.CommRing ZPoly)
   { s with
@@ -62,6 +64,35 @@ private theorem ZPoly.map_liftOuter (p : ZPoly) (t : ℂ) :
     (p.coeff n : ℂ)
   rw [HexPolyMathlib.toPolynomial_C, Polynomial.eval₂_C]
   rfl
+
+private theorem ZPoly.natDegree_liftOuter (p : ZPoly) :
+    (HexPolyMathlib.toPolynomial p.liftOuter).natDegree =
+      p.degree?.getD 0 := by
+  rw [HexPolyMathlib.natDegree_toPolynomial]
+  by_cases hp : p.size = 0
+  · have hlift : p.liftOuter.size = 0 := by
+      apply Nat.eq_zero_of_le_zero
+      unfold ZPoly.liftOuter
+      exact (DensePoly.size_ofCoeffs_le _).trans (by simp [hp])
+    rw [(DensePoly.degree?_eq_none_iff p.liftOuter).2 hlift,
+      (DensePoly.degree?_eq_none_iff p).2 hp]
+  · have hppos : 0 < p.size := Nat.pos_of_ne_zero hp
+    have hliftLe : p.liftOuter.size ≤ p.size := by
+      unfold ZPoly.liftOuter
+      exact (DensePoly.size_ofCoeffs_le _).trans (by simp)
+    have hcoeff : p.liftOuter.coeff (p.size - 1) ≠ 0 := by
+      rw [ZPoly.coeff_liftOuter]
+      intro hzero
+      have hconst := congrArg (fun q : ZPoly => q.coeff 0) hzero
+      simp at hconst
+      exact DensePoly.coeff_last_ne_zero_of_pos_size p hppos hconst
+    have hliftGe : p.size ≤ p.liftOuter.size := by
+      by_contra h
+      exact hcoeff (DensePoly.coeff_eq_zero_of_size_le _ (by omega))
+    have hsize : p.liftOuter.size = p.size := Nat.le_antisymm hliftLe hliftGe
+    rw [DensePoly.degree?_eq_some_of_pos_size p hppos,
+      DensePoly.degree?_eq_some_of_pos_size p.liftOuter (by omega),
+      Option.getD_some, Option.getD_some, hsize]
 
 private theorem evalZPoly_X (t : ℂ) : evalZPoly t ZPoly.X = t := by
   simp [evalZPoly, ZPoly.X, HexPolyMathlib.equiv_apply,
@@ -139,6 +170,102 @@ private theorem resultant_eval_eq_zero_of_common_root
   rw [hcorrespondence]
   exact hresultant
 
+private theorem ZPoly.addEliminant_ne_zero (a b : AlgebraicRoot) :
+    ZPoly.addEliminant a.p b.p ≠ 0 := by
+  let P := HexRootsMathlib.toPolyℂ a.p
+  let Q := HexRootsMathlib.toPolyℂ b.p
+  have haPoly : a.p ≠ 0 :=
+    HexRootsMathlib.RefinedIsolation.poly_ne_zero a.rep
+  have hbPoly : b.p ≠ 0 :=
+    HexRootsMathlib.RefinedIsolation.poly_ne_zero b.rep
+  have hPne : P ≠ 0 := by
+    exact HexRootsMathlib.toPolyℂ_ne_zero a.p fun hsize =>
+      haPoly ((DensePoly.size_eq_zero_iff a.p).mp hsize)
+  have hQne : Q ≠ 0 := by
+    exact HexRootsMathlib.toPolyℂ_ne_zero b.p fun hsize =>
+      hbPoly ((DensePoly.size_eq_zero_iff b.p).mp hsize)
+  let sums : Set ℂ :=
+    (fun xy : ℂ × ℂ => xy.1 + xy.2) ''
+      (P.rootSet ℂ ×ˢ Q.rootSet ℂ)
+  have hsums : sums.Finite := by
+    exact ((Polynomial.rootSet_finite P ℂ).prod
+      (Polynomial.rootSet_finite Q ℂ)).image _
+  obtain ⟨t, ht⟩ := hsums.exists_notMem
+  let G := Q.comp (Polynomial.C t - Polynomial.X)
+  have hcoprime : IsCoprime P G := by
+    apply (Polynomial.isCoprime_iff_aeval_ne_zero_of_isAlgClosed
+      (k := ℂ) ℂ P G).2
+    intro y
+    by_contra hboth
+    push Not at hboth
+    apply ht
+    refine ⟨(y, t - y), ⟨?_, ?_⟩, by simp⟩
+    · exact (Polynomial.mem_rootSet_of_ne hPne).2 (by
+        simpa [Polynomial.aeval_def] using hboth.1)
+    · apply (Polynomial.mem_rootSet_of_ne hQne).2
+      simpa [G, Polynomial.aeval_def, Polynomial.eval_comp] using hboth.2
+  have hresultant : Polynomial.resultant P G ≠ 0 :=
+    Polynomial.resultant_ne_zero P G hcoprime
+  let y : DensePoly ZPoly := DensePoly.monomial 1 1
+  let x : DensePoly ZPoly := DensePoly.C ZPoly.X
+  let f : DensePoly ZPoly := a.p.liftOuter
+  let g : DensePoly ZPoly := DensePoly.compose b.p.liftOuter (x - y)
+  have hfmap :
+      (HexPolyMathlib.toPolynomial f).map (evalZPoly t) = P := by
+    simpa [f, P] using ZPoly.map_liftOuter a.p t
+  have hgmap :
+      (HexPolyMathlib.toPolynomial g).map (evalZPoly t) = G := by
+    dsimp only [g, G, x, y]
+    rw [HexPolyMathlib.toPolynomial_compose, Polynomial.map_comp,
+      ZPoly.map_liftOuter]
+    simp [Q, HexPolyMathlib.toPolynomial_monomial,
+      Polynomial.monomial_one_one_eq_X, evalZPoly_X]
+  have hfnat :
+      (HexPolyMathlib.toPolynomial f).natDegree = P.natDegree := by
+    calc
+      (HexPolyMathlib.toPolynomial f).natDegree =
+          a.p.degree?.getD 0 := by
+        simpa [f] using ZPoly.natDegree_liftOuter a.p
+      _ = P.natDegree := by
+        simp [P]
+  have hinnerNat :
+      (HexPolyMathlib.toPolynomial (x - y)).natDegree = 1 := by
+    dsimp only [x, y]
+    rw [HexPolyMathlib.toPolynomial_sub,
+      HexPolyMathlib.toPolynomial_C,
+      HexPolyMathlib.toPolynomial_monomial,
+      Polynomial.monomial_one_one_eq_X,
+      show Polynomial.C ZPoly.X - Polynomial.X =
+          -(Polynomial.X - Polynomial.C ZPoly.X) by ring,
+      Polynomial.natDegree_neg, Polynomial.natDegree_X_sub_C]
+  have hcomplexInnerNat :
+      (Polynomial.C t - Polynomial.X).natDegree = 1 := by
+    rw [show Polynomial.C t - Polynomial.X =
+        -(Polynomial.X - Polynomial.C t) by ring,
+      Polynomial.natDegree_neg, Polynomial.natDegree_X_sub_C]
+  have hgnat :
+      (HexPolyMathlib.toPolynomial g).natDegree = G.natDegree := by
+    rw [show HexPolyMathlib.toPolynomial g =
+        (HexPolyMathlib.toPolynomial b.p.liftOuter).comp
+          (HexPolyMathlib.toPolynomial (x - y)) by
+        simp [g]]
+    rw [Polynomial.natDegree_comp, hinnerNat, mul_one,
+      ZPoly.natDegree_liftOuter]
+    rw [show G.natDegree = Q.natDegree *
+        (Polynomial.C t - Polynomial.X).natDegree by
+      exact Polynomial.natDegree_comp]
+    rw [hcomplexInnerNat, mul_one]
+    simp [Q]
+  intro hzero
+  have hcorrespondence := congrArg (evalZPoly t)
+    (DensePoly.toPolynomial_resultant f g)
+  rw [← Polynomial.resultant_map_map] at hcorrespondence
+  have hraw : DensePoly.resultant f g = 0 := by
+    simpa [ZPoly.addEliminant, f, g, x, y] using hzero
+  rw [hraw, map_zero, hfmap, hgmap] at hcorrespondence
+  apply hresultant
+  simpa [← hfnat, ← hgnat] using hcorrespondence.symm
+
 private theorem ZPoly.addEliminant_isRoot (a b : AlgebraicRoot) :
     (HexRootsMathlib.toPolyℂ (ZPoly.addEliminant a.p b.p)).IsRoot
       (a.toComplex + b.toComplex) := by
@@ -182,6 +309,255 @@ private theorem ZPoly.addEliminant_isRoot (a b : AlgebraicRoot) :
     simp [HexPolyMathlib.toPolynomial_monomial,
       Polynomial.monomial_one_one_eq_X, evalZPoly_X,
       Polynomial.eval_comp, AlgebraicRoot.toComplex_isRoot]
+
+end
+
+
+/-- A successful eliminant search selects the supplied semantic root whenever
+the operation ball contains it. -/
+private theorem AlgebraicRoot.ofEliminant?_sound
+    (raw : ZPoly) (ballAt : Int → Option DyadicComplexBall)
+    {c : AlgebraicRoot} {z : ℂ}
+    (h : AlgebraicRoot.ofEliminant? raw ballAt = some c)
+    (hroot : (HexRootsMathlib.toPolyℂ raw).IsRoot z)
+    (hball : ∀ (ball : DyadicComplexBall),
+      ballAt (separationDepth (ZPoly.squareFreeCore raw)) = some ball →
+        z ∈ ball.set) :
+    c.toComplex = z := by
+  unfold AlgebraicRoot.ofEliminant? at h
+  dsimp only at h
+  split at h
+  · rename_i hprim
+    split at h
+    · rename_i hpos
+      split at h
+      · rename_i hdegree
+        split at h
+        · rename_i hsimple
+          obtain ⟨ball, hballAt, h⟩ := Option.bind_eq_some_iff.mp h
+          obtain ⟨isolations, hisolate, h⟩ :=
+            Option.bind_eq_some_iff.mp h
+          obtain ⟨refined, hrefined, h⟩ :=
+            Option.bind_eq_some_iff.mp h
+          cases hselected : refined.toList.filter fun r =>
+              r.1.square.meetsBall ball with
+          | nil => simp [hselected] at h
+          | cons matching rest =>
+              cases rest with
+              | cons second rest => simp [hselected] at h
+              | nil =>
+                  rw [hselected] at h
+                  have hc := Option.some.inj h
+                  subst c
+                  let p := ZPoly.squareFreeCore raw
+                  have hpne : p ≠ 0 := by
+                    intro hp
+                    have hdegree' := hdegree
+                    change ZPoly.squareFreeCore raw = 0 at hp
+                    rw [hp] at hdegree'
+                    simp at hdegree'
+                  have hrawne : raw ≠ 0 := by
+                    intro hraw
+                    apply hpne
+                    subst raw
+                    rfl
+                  have hpRoot : (HexRootsMathlib.toPolyℂ p).IsRoot z := by
+                    simpa [p] using
+                      HexPolyZMathlib.isRoot_squareFreeCore hrawne hroot
+                  obtain ⟨iso, hiso, hisoRoot⟩ :=
+                    HexRootsMathlib.isolate_root_mem_of_pos p hsimple
+                      (separationDepth p : Int) .nkThenPellet hdegree
+                      hisolate hpRoot
+                  obtain ⟨i, hiList, hidx⟩ := List.getElem_of_mem hiso
+                  have hi : i < isolations.size := by simpa using hiList
+                  obtain ⟨hmapSize, hmapGet⟩ :=
+                    HexRootsMathlib.array_mapM_some_get hrefined
+                  have hj : i < refined.size := by
+                    simpa [← hmapSize] using hi
+                  have hto := hmapGet i hi hj
+                  have hrawIso : refined[i].1 = isolations[i] := by
+                    rw [DyadicRootIsolation.toRefined?] at hto
+                    split at hto
+                    · exact (congrArg Subtype.val (Option.some.inj hto)).symm
+                    · simp at hto
+                  have harrIso : isolations[i] = iso := by
+                    rw [← hidx]
+                    exact (Array.getElem_toList hi).symm
+                  have hrefinedRoot :
+                      HexRootsMathlib.RefinedIsolation.root refined[i] = z := by
+                    change HexRootsMathlib.DyadicRootIsolation.root refined[i].1 = z
+                    rw [hrawIso, harrIso]
+                    exact hisoRoot
+                  have hzCandidate :
+                      z ∈ refined[i].1.square.toBall.set := by
+                    rw [← hrefinedRoot]
+                    exact DyadicComplexBall.mem_toBall
+                      (HexRootsMathlib.RefinedIsolation.root_mem_closedDisc
+                        refined[i])
+                  have hzBall : z ∈ ball.set := by
+                    exact hball ball (by simpa [p] using hballAt)
+                  have hmeet :
+                      refined[i].1.square.meetsBall ball = true := by
+                    simpa [DyadicSquare.meetsBall] using
+                      DyadicComplexBall.meets_of_mem hzCandidate hzBall
+                  have hmem : refined[i] ∈
+                      refined.toList.filter fun r =>
+                        r.1.square.meetsBall ball := by
+                    simp [hmeet]
+                  rw [hselected] at hmem
+                  have heq : refined[i] = matching := by simpa using hmem
+                  change matching.root = z
+                  rw [← heq]
+                  exact hrefinedRoot
+        · simp at h
+      · simp at h
+    · simp at h
+  · simp at h
+
+/-- A nonzero eliminant root enclosed by a sufficiently small operation ball
+survives normalization, isolation, and the singleton selection filter. -/
+private theorem AlgebraicRoot.ofEliminant?_isSome
+    (raw : ZPoly) (ballAt : Int → Option DyadicComplexBall)
+    {z : ℂ} (hraw : raw ≠ 0)
+    (hroot : (HexRootsMathlib.toPolyℂ raw).IsRoot z)
+    (ball : DyadicComplexBall)
+    (hballAt : ballAt (separationDepth (ZPoly.squareFreeCore raw)) =
+      some ball)
+    (hzball : z ∈ ball.set)
+    (hballRadius : ball.realRadius ≤
+      (2 : ℝ) ^ (-(mahlerPrec (ZPoly.squareFreeCore raw) : ℤ))) :
+    (AlgebraicRoot.ofEliminant? raw ballAt).isSome := by
+  have hpne : ZPoly.squareFreeCore raw ≠ 0 :=
+    ZPoly.squareFreeCore_ne_zero raw hraw
+  have hpRoot :
+      (HexRootsMathlib.toPolyℂ (ZPoly.squareFreeCore raw)).IsRoot z := by
+    exact HexPolyZMathlib.isRoot_squareFreeCore hraw hroot
+  have hprim : ZPoly.content (ZPoly.squareFreeCore raw) = 1 := by
+    simpa [ZPoly.Primitive] using ZPoly.squareFreeCore_primitive raw hraw
+  have hpos : 0 < (ZPoly.squareFreeCore raw).leadingCoeff :=
+    ZPoly.leadingCoeff_squareFreeCore_pos raw hraw
+  have hsimple : HasOnlySimpleRoots (ZPoly.squareFreeCore raw) := by
+    simpa [HasOnlySimpleRoots] using
+      ZPoly.squareFreeRat_squareFreeCore raw hraw
+  have hdegree : 0 < (ZPoly.squareFreeCore raw).degree?.getD 0 := by
+    by_contra hn
+    have hsize : (ZPoly.squareFreeCore raw).size ≠ 0 := by
+      intro hsize
+      exact hpne ((DensePoly.size_eq_zero_iff _).mp hsize)
+    exact HexRootsMathlib.not_isRoot_of_degree_not_pos
+      (ZPoly.squareFreeCore raw) hsize hn z hpRoot
+  unfold AlgebraicRoot.ofEliminant?
+  dsimp only
+  rw [dif_pos hprim, dif_pos hpos, dif_pos hdegree, dif_pos hsimple]
+  rw [hballAt]
+  have hisolateSome := HexRootsMathlib.isolate_isSome
+    (ZPoly.squareFreeCore raw) hsimple hpne
+    (separationDepth (ZPoly.squareFreeCore raw) : Int) .nkThenPellet
+  cases hisolate : isolate (ZPoly.squareFreeCore raw) hsimple
+      (separationDepth (ZPoly.squareFreeCore raw) : Int) with
+  | none => simp [hisolate] at hisolateSome
+  | some isolations =>
+      simp only [Option.bind_eq_bind, Option.bind_some]
+      have hmapSome := HexRootsMathlib.array_mapM_isSome
+        (xs := isolations) (f := DyadicRootIsolation.toRefined?)
+        (fun iso hiso => by
+          simp [DyadicRootIsolation.toRefined?,
+            HexRootsMathlib.isolate_refined (ZPoly.squareFreeCore raw) hsimple
+              (separationDepth (ZPoly.squareFreeCore raw) : Int)
+              .nkThenPellet hisolate iso hiso])
+      cases hrefined : isolations.mapM DyadicRootIsolation.toRefined? with
+      | none => simp [hrefined] at hmapSome
+      | some refined =>
+          simp only [Option.bind_some]
+          obtain ⟨hmapSize, hmapGet⟩ :=
+            HexRootsMathlib.array_mapM_some_get hrefined
+          have hrefinedPairwise : refined.toList.Pairwise fun r s =>
+              HexRootsMathlib.RefinedIsolation.root r ≠
+                HexRootsMathlib.RefinedIsolation.root s := by
+            rw [List.pairwise_iff_getElem]
+            intro i j hi hj hij
+            have hi' : i < isolations.size := by
+              simpa [hmapSize] using hi
+            have hj' : j < isolations.size := by
+              simpa [hmapSize] using hj
+            have htoI := hmapGet i hi' hi
+            have htoJ := hmapGet j hj' hj
+            have hrawI : refined[i].1 = isolations[i] := by
+              rw [DyadicRootIsolation.toRefined?] at htoI
+              split at htoI
+              · exact (congrArg Subtype.val (Option.some.inj htoI)).symm
+              · simp at htoI
+            have hrawJ : refined[j].1 = isolations[j] := by
+              rw [DyadicRootIsolation.toRefined?] at htoJ
+              split at htoJ
+              · exact (congrArg Subtype.val (Option.some.inj htoJ)).symm
+              · simp at htoJ
+            intro hroots
+            apply HexRootsMathlib.isolate_roots_ne
+              (ZPoly.squareFreeCore raw) hsimple
+              (separationDepth (ZPoly.squareFreeCore raw) : Int)
+              .nkThenPellet hisolate
+              hi' hj' (Nat.ne_of_lt hij)
+            change HexRootsMathlib.DyadicRootIsolation.root refined[i].1 =
+              HexRootsMathlib.DyadicRootIsolation.root refined[j].1 at hroots
+            simpa [hrawI, hrawJ] using hroots
+          obtain ⟨iso, hiso, hisoRoot⟩ :=
+            HexRootsMathlib.isolate_root_mem_of_pos
+              (ZPoly.squareFreeCore raw) hsimple
+              (separationDepth (ZPoly.squareFreeCore raw) : Int)
+              .nkThenPellet hdegree hisolate hpRoot
+          obtain ⟨i, hiList, hidx⟩ := List.getElem_of_mem hiso
+          have hi : i < isolations.size := by simpa using hiList
+          have hj : i < refined.size := by simpa [← hmapSize] using hi
+          have hto := hmapGet i hi hj
+          have hrawIso : refined[i].1 = isolations[i] := by
+            rw [DyadicRootIsolation.toRefined?] at hto
+            split at hto
+            · exact (congrArg Subtype.val (Option.some.inj hto)).symm
+            · simp at hto
+          have harrIso : isolations[i] = iso := by
+            rw [← hidx]
+            exact (Array.getElem_toList hi).symm
+          have hrefinedRoot :
+              HexRootsMathlib.RefinedIsolation.root refined[i] = z := by
+            change HexRootsMathlib.DyadicRootIsolation.root refined[i].1 = z
+            rw [hrawIso, harrIso]
+            exact hisoRoot
+          have hzCandidate : z ∈ refined[i].1.square.toBall.set := by
+            rw [← hrefinedRoot]
+            exact DyadicComplexBall.mem_toBall
+              (HexRootsMathlib.RefinedIsolation.root_mem_closedDisc refined[i])
+          have hmeet : refined[i].1.square.meetsBall ball = true := by
+            simpa [DyadicSquare.meetsBall] using
+              DyadicComplexBall.meets_of_mem hzCandidate hzball
+          have hmem : refined[i] ∈ refined.toList.filter fun r =>
+              r.1.square.meetsBall ball := by
+            simp [hmeet]
+          cases hselected : refined.toList.filter fun r =>
+              r.1.square.meetsBall ball with
+          | nil => simp [hselected] at hmem
+          | cons matching rest =>
+              cases rest with
+              | nil => simp
+              | cons second tail =>
+                  have hfilteredPairwise := hrefinedPairwise.filter fun r =>
+                    r.1.square.meetsBall ball
+                  rw [hselected] at hfilteredPairwise
+                  have hneRoots : matching.root ≠ second.root :=
+                    List.rel_of_pairwise_cons hfilteredPairwise (by simp)
+                  have hmatching := List.mem_filter.mp (show matching ∈
+                      refined.toList.filter fun r =>
+                        r.1.square.meetsBall ball by simp [hselected])
+                  have hsecond := List.mem_filter.mp (show second ∈
+                      refined.toList.filter fun r =>
+                        r.1.square.meetsBall ball by simp [hselected])
+                  have hmatchingRoot : matching.root = z :=
+                    QAdjoin.root_eq_of_meetsBall hpne matching hpRoot
+                      hzball hballRadius hmatching.2
+                  have hsecondRoot : second.root = z :=
+                    QAdjoin.root_eq_of_meetsBall hpne second hpRoot
+                      hzball hballRadius hsecond.2
+                  exact (hneRoots (hmatchingRoot.trans hsecondRoot.symm)).elim
 
 private theorem ZPoly.negRoots_isRoot_of_isRoot {p : ZPoly} {z : ℂ}
     (hp : p ≠ 0) (hz : (HexRootsMathlib.toPolyℂ p).IsRoot z) :
@@ -282,12 +658,141 @@ theorem neg_toComplex (a : AlgebraicRoot) :
 theorem add?_sound (a b : AlgebraicRoot) {c : AlgebraicRoot}
     (h : a.add? b = some c) :
     c.toComplex = a.toComplex + b.toComplex := by
-  sorry
+  unfold AlgebraicRoot.add? at h
+  apply AlgebraicRoot.ofEliminant?_sound
+    (raw := ZPoly.addEliminant a.p b.p)
+    (ballAt := fun prec => do
+      let target := prec + 4
+      let ar ← a.rep.refineTo? target
+      let br ← b.rep.refineTo? target
+      some (ar.1.1.square.toBall.add br.1.1.square.toBall))
+    h (ZPoly.addEliminant_isRoot a b)
+  intro ball hball
+  dsimp only at hball
+  obtain ⟨ar, har, hball⟩ := Option.bind_eq_some_iff.mp hball
+  obtain ⟨br, hbr, hball⟩ := Option.bind_eq_some_iff.mp hball
+  have hballEq := Option.some.inj hball
+  subst ball
+  apply DyadicComplexBall.add_mem
+  · have harRoot :
+        HexRootsMathlib.RefinedIsolation.root ar.1 = a.toComplex := by
+      exact (HexRootsMathlib.RefinedIsolation.refineTo_root
+        a.rep _ .nkThenPellet har).trans rfl
+    rw [← harRoot]
+    exact DyadicComplexBall.mem_toBall
+      (HexRootsMathlib.RefinedIsolation.root_mem_closedDisc ar.1)
+  · have hbrRoot :
+        HexRootsMathlib.RefinedIsolation.root br.1 = b.toComplex := by
+      exact (HexRootsMathlib.RefinedIsolation.refineTo_root
+        b.rep _ .nkThenPellet hbr).trans rfl
+    rw [← hbrRoot]
+    exact DyadicComplexBall.mem_toBall
+      (HexRootsMathlib.RefinedIsolation.root_mem_closedDisc br.1)
 
 /-- The bounded lazy addition search always finds its certificate. -/
 theorem add?_isSome (a b : AlgebraicRoot) :
     (a.add? b).isSome := by
-  sorry
+  unfold AlgebraicRoot.add?
+  have harSome := RefinedIsolation.refineTo?_isSome a.rep
+    ((separationDepth (ZPoly.squareFreeCore
+      (ZPoly.addEliminant a.p b.p)) : Int) + 4)
+  cases har : a.rep.refineTo?
+      ((separationDepth (ZPoly.squareFreeCore
+        (ZPoly.addEliminant a.p b.p)) : Int) + 4) .nkThenPellet with
+  | none => simp [har] at harSome
+  | some ar =>
+      have hbrSome := RefinedIsolation.refineTo?_isSome b.rep
+        ((separationDepth (ZPoly.squareFreeCore
+          (ZPoly.addEliminant a.p b.p)) : Int) + 4)
+      cases hbr : b.rep.refineTo?
+          ((separationDepth (ZPoly.squareFreeCore
+            (ZPoly.addEliminant a.p b.p)) : Int) + 4) .nkThenPellet with
+      | none => simp [hbr] at hbrSome
+      | some br =>
+          apply AlgebraicRoot.ofEliminant?_isSome
+            (raw := ZPoly.addEliminant a.p b.p)
+            (ballAt := fun prec => do
+              let target := prec + 4
+              let ar ← a.rep.refineTo? target
+              let br ← b.rep.refineTo? target
+              some (ar.1.1.square.toBall.add br.1.1.square.toBall))
+            (z := a.toComplex + b.toComplex)
+            (ZPoly.addEliminant_ne_zero a b)
+            (ZPoly.addEliminant_isRoot a b)
+            (ar.1.1.square.toBall.add br.1.1.square.toBall)
+          · dsimp only
+            rw [har, hbr]
+            rfl
+          · apply DyadicComplexBall.add_mem
+            · have harRoot :
+                  HexRootsMathlib.RefinedIsolation.root ar.1 = a.toComplex := by
+                exact (HexRootsMathlib.RefinedIsolation.refineTo_root
+                  a.rep _ .nkThenPellet har).trans rfl
+              rw [← harRoot]
+              exact DyadicComplexBall.mem_toBall
+                (HexRootsMathlib.RefinedIsolation.root_mem_closedDisc ar.1)
+            · have hbrRoot :
+                  HexRootsMathlib.RefinedIsolation.root br.1 = b.toComplex := by
+                exact (HexRootsMathlib.RefinedIsolation.refineTo_root
+                  b.rep _ .nkThenPellet hbr).trans rfl
+              rw [← hbrRoot]
+              exact DyadicComplexBall.mem_toBall
+                (HexRootsMathlib.RefinedIsolation.root_mem_closedDisc br.1)
+          · rw [DyadicComplexBall.realRadius_add]
+            have harPrec := RefinedIsolation.refineTo?_precision a.rep
+              ((separationDepth (ZPoly.squareFreeCore
+                (ZPoly.addEliminant a.p b.p)) : Int) + 4)
+              .nkThenPellet har
+            have hbrPrec := RefinedIsolation.refineTo?_precision b.rep
+              ((separationDepth (ZPoly.squareFreeCore
+                (ZPoly.addEliminant a.p b.p)) : Int) + 4)
+              .nkThenPellet hbr
+            have hsepNat :
+                mahlerPrec (ZPoly.squareFreeCore (ZPoly.addEliminant a.p b.p)) ≤
+                  separationDepth
+                    (ZPoly.squareFreeCore (ZPoly.addEliminant a.p b.p)) := by
+              rw [separationDepth]
+              omega
+            have hsepInt :
+                (mahlerPrec
+                    (ZPoly.squareFreeCore (ZPoly.addEliminant a.p b.p)) : Int) ≤
+                  (separationDepth
+                    (ZPoly.squareFreeCore (ZPoly.addEliminant a.p b.p)) : Int) := by
+              exact_mod_cast hsepNat
+            have hpow :
+                (2 : ℝ) ^ (-(separationDepth
+                    (ZPoly.squareFreeCore (ZPoly.addEliminant a.p b.p)) : Int)) ≤
+                  (2 : ℝ) ^ (-(mahlerPrec
+                    (ZPoly.squareFreeCore (ZPoly.addEliminant a.p b.p)) : Int)) :=
+              zpow_le_zpow_right₀ (by norm_num) (by omega)
+            calc
+              ar.1.1.square.toBall.realRadius +
+                    br.1.1.square.toBall.realRadius ≤
+                  2 * (2 : ℝ) ^ (-((separationDepth
+                      (ZPoly.squareFreeCore (ZPoly.addEliminant a.p b.p)) : Int) + 4)) +
+                    2 * (2 : ℝ) ^ (-((separationDepth
+                      (ZPoly.squareFreeCore (ZPoly.addEliminant a.p b.p)) : Int) + 4)) :=
+                add_le_add
+                  (DyadicComplexBall.realRadius_toBall_le harPrec)
+                  (DyadicComplexBall.realRadius_toBall_le hbrPrec)
+              _ = (1 / 4 : ℝ) * (2 : ℝ) ^ (-(separationDepth
+                    (ZPoly.squareFreeCore (ZPoly.addEliminant a.p b.p)) : Int)) := by
+                rw [show -((separationDepth
+                    (ZPoly.squareFreeCore (ZPoly.addEliminant a.p b.p)) : Int) + 4) =
+                    -(separationDepth
+                      (ZPoly.squareFreeCore (ZPoly.addEliminant a.p b.p)) : Int) - 4 by
+                  omega]
+                rw [zpow_sub₀ (by norm_num : (2 : ℝ) ≠ 0)]
+                norm_num
+                ring
+              _ ≤ (2 : ℝ) ^ (-(separationDepth
+                    (ZPoly.squareFreeCore (ZPoly.addEliminant a.p b.p)) : Int)) := by
+                have hnonneg : 0 ≤ (2 : ℝ) ^ (-(separationDepth
+                    (ZPoly.squareFreeCore (ZPoly.addEliminant a.p b.p)) : Int)) := by
+                  positivity
+                nlinarith
+              _ ≤ (2 : ℝ) ^ (-(mahlerPrec
+                    (ZPoly.squareFreeCore (ZPoly.addEliminant a.p b.p)) : Int)) := hpow
 
 /-- Total lazy addition computes complex addition. -/
 theorem add_toComplex (a b : AlgebraicRoot) :

--- a/HexNumberFieldMathlib/Lazy.lean
+++ b/HexNumberFieldMathlib/Lazy.lean
@@ -21,12 +21,262 @@ numbers.
 
 namespace Hex
 
+noncomputable section
+
+@[implicit_reducible] local instance : CommRing ZPoly :=
+  let s := (inferInstance : Lean.Grind.CommRing ZPoly)
+  { s with
+    zero_add := Lean.Grind.AddCommMonoid.zero_add
+    right_distrib := Lean.Grind.Semiring.right_distrib
+    mul_zero := Lean.Grind.Semiring.mul_zero
+    one_mul := Lean.Grind.Semiring.one_mul
+    nsmul := nsmulRec
+    zsmul := zsmulRec
+    npow := npowRec
+    natCast := Nat.cast
+    natCast_zero := Lean.Grind.Semiring.natCast_zero
+    natCast_succ n := Lean.Grind.Semiring.natCast_succ n
+    intCast := Int.cast
+    intCast_ofNat := Lean.Grind.Ring.intCast_natCast
+    intCast_negSucc n := by
+      rw [Int.negSucc_eq, Lean.Grind.Ring.intCast_neg,
+        Lean.Grind.Ring.intCast_natCast_add_one,
+        Lean.Grind.Semiring.natCast_succ] }
+
+local instance : IsDomain ZPoly :=
+  MulEquiv.isDomain (Polynomial Int)
+    (HexPolyMathlib.equiv (R := Int)).toMulEquiv
+
+private noncomputable def evalZPoly (t : ℂ) : ZPoly →+* ℂ :=
+  (Polynomial.eval₂RingHom (Int.castRingHom ℂ) t).comp
+    (HexPolyMathlib.equiv (R := Int)).toRingHom
+
+private theorem ZPoly.map_liftOuter (p : ZPoly) (t : ℂ) :
+    (HexPolyMathlib.toPolynomial p.liftOuter).map (evalZPoly t) =
+      HexRootsMathlib.toPolyℂ p := by
+  ext n
+  rw [Polynomial.coeff_map, HexPolyMathlib.coeff_toPolynomial,
+    ZPoly.coeff_liftOuter, HexRootsMathlib.coeff_toPolyℂ]
+  change Polynomial.eval₂ (Int.castRingHom ℂ) t
+      (HexPolyMathlib.toPolynomial (DensePoly.C (p.coeff n))) =
+    (p.coeff n : ℂ)
+  rw [HexPolyMathlib.toPolynomial_C, Polynomial.eval₂_C]
+  rfl
+
+private theorem evalZPoly_X (t : ℂ) : evalZPoly t ZPoly.X = t := by
+  simp [evalZPoly, ZPoly.X, HexPolyMathlib.equiv_apply,
+    HexPolyMathlib.toPolynomial_monomial,
+    Polynomial.monomial_one_one_eq_X]
+
+private theorem resultant_eval_eq_zero_of_common_root
+    (f g : DensePoly ZPoly) (t y : ℂ)
+    (hpos : 1 < f.size ∨ 1 < g.size)
+    (hf : ((HexPolyMathlib.toPolynomial f).map
+      ((Polynomial.eval₂RingHom (Int.castRingHom ℂ) t).comp
+        (HexPolyMathlib.equiv (R := Int)).toRingHom)).eval y = 0)
+    (hg : ((HexPolyMathlib.toPolynomial g).map
+      ((Polynomial.eval₂RingHom (Int.castRingHom ℂ) t).comp
+        (HexPolyMathlib.equiv (R := Int)).toRingHom)).eval y = 0) :
+    (HexRootsMathlib.toPolyℂ (DensePoly.resultant f g)).eval t = 0 := by
+  let ε : ZPoly →+* ℂ :=
+    (Polynomial.eval₂RingHom (Int.castRingHom ℂ) t).comp
+      (HexPolyMathlib.equiv (R := Int)).toRingHom
+  let F : Polynomial ℂ := (HexPolyMathlib.toPolynomial f).map ε
+  let G : Polynomial ℂ := (HexPolyMathlib.toPolynomial g).map ε
+  let m := f.degree?.getD 0
+  let n := g.degree?.getD 0
+  have hm : F.natDegree ≤ m := by
+    calc
+      F.natDegree ≤ (HexPolyMathlib.toPolynomial f).natDegree :=
+        Polynomial.natDegree_map_le
+      _ = m := by
+        simp [m]
+  have hn : G.natDegree ≤ n := by
+    calc
+      G.natDegree ≤ (HexPolyMathlib.toPolynomial g).natDegree :=
+        Polynomial.natDegree_map_le
+      _ = n := by
+        simp [n]
+  have hmn : 0 < m ∨ 0 < n := by
+    rcases hpos with hfpos | hgpos
+    · left
+      dsimp only [m]
+      rw [DensePoly.degree?_eq_some_of_pos_size f (by omega), Option.getD_some]
+      omega
+    · right
+      dsimp only [n]
+      rw [DensePoly.degree?_eq_some_of_pos_size g (by omega), Option.getD_some]
+      omega
+  have hresultant : Polynomial.resultant F G m n = 0 := by
+    by_cases hboth : F = 0 ∧ G = 0
+    · rcases hboth with ⟨hFzero, hGzero⟩
+      rw [hFzero, hGzero, Polynomial.resultant_zero_zero]
+      exact zero_pow (by omega)
+    · have hne : F ≠ 0 ∨ G ≠ 0 := by
+        by_cases hFzero : F = 0
+        · right
+          intro hGzero
+          exact hboth ⟨hFzero, hGzero⟩
+        · exact Or.inl hFzero
+      have hdefault : Polynomial.resultant F G = 0 :=
+        DensePoly.resultant_eq_zero_of_common_eval F G y
+          (by simpa [F, ε] using hf) (by simpa [G, ε] using hg) hne
+      have hmEq : m = F.natDegree + (m - F.natDegree) := by omega
+      have hnEq : n = G.natDegree + (n - G.natDegree) := by omega
+      rw [hmEq, Polynomial.resultant_add_left_deg F G F.natDegree n
+        (m - F.natDegree) le_rfl]
+      rw [hnEq, Polynomial.resultant_add_right_deg F G F.natDegree
+        G.natDegree (n - G.natDegree) le_rfl]
+      rw [hdefault]
+      ring
+  have hcorrespondence := congrArg ε
+    (DensePoly.toPolynomial_resultant f g)
+  rw [← Polynomial.resultant_map_map] at hcorrespondence
+  have heval (q : ZPoly) :
+      ε q = (HexRootsMathlib.toPolyℂ q).eval t := by
+    simp [ε, HexRootsMathlib.toPolyℂ, Polynomial.eval_map]
+  rw [← heval]
+  rw [hcorrespondence]
+  exact hresultant
+
+private theorem ZPoly.addEliminant_isRoot (a b : AlgebraicRoot) :
+    (HexRootsMathlib.toPolyℂ (ZPoly.addEliminant a.p b.p)).IsRoot
+      (a.toComplex + b.toComplex) := by
+  unfold ZPoly.addEliminant
+  apply resultant_eval_eq_zero_of_common_root
+      (y := a.toComplex)
+  · left
+    have hsize : 1 < a.p.size := by
+      have hpos : 0 < a.p.size := by
+        by_contra h
+        have hzero : a.p = 0 :=
+          (DensePoly.size_eq_zero_iff a.p).mp (by omega)
+        have hdegree := a.pos_degree
+        rw [hzero] at hdegree
+        simp at hdegree
+      have hdegree := a.pos_degree
+      rw [DensePoly.degree?_eq_some_of_pos_size a.p hpos,
+        Option.getD_some] at hdegree
+      omega
+    have hcoeff :
+        a.p.liftOuter.coeff (a.p.size - 1) ≠ 0 := by
+      rw [ZPoly.coeff_liftOuter]
+      intro hzero
+      have hconst := congrArg (fun p : ZPoly => p.coeff 0) hzero
+      simp at hconst
+      exact DensePoly.coeff_last_ne_zero_of_pos_size a.p (by omega) hconst
+    have hlt : a.p.size - 1 < a.p.liftOuter.size := by
+      by_contra h
+      exact hcoeff (DensePoly.coeff_eq_zero_of_size_le _ (by omega))
+    omega
+  · change ((HexPolyMathlib.toPolynomial a.p.liftOuter).map
+      (evalZPoly (a.toComplex + b.toComplex))).eval a.toComplex = 0
+    rw [ZPoly.map_liftOuter]
+    exact AlgebraicRoot.toComplex_isRoot a
+  · change (((HexPolyMathlib.toPolynomial
+      (DensePoly.compose b.p.liftOuter
+        (DensePoly.C ZPoly.X - DensePoly.monomial 1 1))).map
+          (evalZPoly (a.toComplex + b.toComplex))).eval a.toComplex) = 0
+    rw [HexPolyMathlib.toPolynomial_compose, Polynomial.map_comp,
+      ZPoly.map_liftOuter]
+    simp [HexPolyMathlib.toPolynomial_monomial,
+      Polynomial.monomial_one_one_eq_X, evalZPoly_X,
+      Polynomial.eval_comp, AlgebraicRoot.toComplex_isRoot]
+
+private theorem ZPoly.negRoots_isRoot_of_isRoot {p : ZPoly} {z : ℂ}
+    (hp : p ≠ 0) (hz : (HexRootsMathlib.toPolyℂ p).IsRoot z) :
+    (HexRootsMathlib.toPolyℂ p.negRoots).IsRoot (-z) := by
+  let reflected : ZPoly := DensePoly.compose p (-ZPoly.X)
+  have hreflected :
+      HexRootsMathlib.toPolyℂ reflected =
+        (HexRootsMathlib.toPolyℂ p).comp (-Polynomial.X) := by
+    change
+      (HexPolyMathlib.toPolynomial reflected).map (Int.castRingHom ℂ) =
+        ((HexPolyMathlib.toPolynomial p).map (Int.castRingHom ℂ)).comp
+          (-Polynomial.X)
+    dsimp only [reflected]
+    rw [HexPolyMathlib.toPolynomial_compose, Polynomial.map_comp]
+    simp [ZPoly.X, HexPolyMathlib.toPolynomial_monomial,
+      Polynomial.monomial_one_one_eq_X]
+  have hreflectedRoot :
+      (HexRootsMathlib.toPolyℂ reflected).eval (-z) = 0 := by
+    rw [hreflected, Polynomial.eval_comp]
+    simpa [Polynomial.IsRoot] using hz
+  have hpSize : p.size ≠ 0 := by
+    intro hsize
+    exact hp ((DensePoly.size_eq_zero_iff p).mp hsize)
+  have hpComplex : HexRootsMathlib.toPolyℂ p ≠ 0 :=
+    HexRootsMathlib.toPolyℂ_ne_zero p hpSize
+  have hreflectedComplex : HexRootsMathlib.toPolyℂ reflected ≠ 0 := by
+    rw [hreflected]
+    intro hzero
+    have hdegree := congrArg Polynomial.degree hzero
+    rw [Polynomial.degree_comp_neg_X, Polynomial.degree_zero] at hdegree
+    exact hpComplex (Polynomial.degree_eq_bot.mp hdegree)
+  have hreflectedNe : reflected ≠ 0 := by
+    intro hzero
+    apply hreflectedComplex
+    rw [hzero]
+    simp [HexRootsMathlib.toPolyℂ]
+  have hcontent : ZPoly.content reflected ≠ 0 :=
+    HexPolyZMathlib.content_ne_zero reflected hreflectedNe
+  have hdecomp :
+      HexRootsMathlib.toPolyℂ reflected =
+        Polynomial.C (ZPoly.content reflected : ℂ) *
+          HexRootsMathlib.toPolyℂ (ZPoly.primitivePart reflected) := by
+    simpa [HexRootsMathlib.toPolyℂ] using congrArg
+      (fun q : Polynomial ℤ => q.map (Int.castRingHom ℂ))
+      (HexPolyZMathlib.toPolynomial_eq_C_content_mul_primitivePart reflected)
+  have hprimitiveRoot :
+      (HexRootsMathlib.toPolyℂ (ZPoly.primitivePart reflected)).eval (-z) = 0 := by
+    have hproduct :
+        (ZPoly.content reflected : ℂ) *
+          (HexRootsMathlib.toPolyℂ (ZPoly.primitivePart reflected)).eval (-z) = 0 := by
+      rw [← Polynomial.eval_C_mul, ← hdecomp]
+      exact hreflectedRoot
+    exact (mul_eq_zero.mp hproduct).resolve_left (by exact_mod_cast hcontent)
+  unfold ZPoly.negRoots ZPoly.normalizePrimitiveSign
+  change (HexRootsMathlib.toPolyℂ
+    (if (ZPoly.primitivePart reflected).leadingCoeff < 0 then
+      DensePoly.scale (-1) (ZPoly.primitivePart reflected)
+    else ZPoly.primitivePart reflected)).IsRoot (-z)
+  split
+  · simpa [Polynomial.IsRoot, HexRootsMathlib.toPolyℂ,
+      HexPolyMathlib.toPolynomial_scale] using hprimitiveRoot
+  · exact hprimitiveRoot
+
+private theorem DyadicSquare.neg_mem_closedDisc {s : DyadicSquare} {z : ℂ}
+    (hz : z ∈ HexRootsMathlib.DyadicSquare.closedDisc s) :
+    -z ∈ HexRootsMathlib.DyadicSquare.closedDisc s.neg := by
+  have hcenter : HexRootsMathlib.DyadicSquare.center s.neg =
+      -HexRootsMathlib.DyadicSquare.center s := by
+    apply Complex.ext <;>
+      simp [DyadicSquare.neg, HexRootsMathlib.DyadicSquare.center,
+        Hex.DyadicSquare.center, HexRootsMathlib.GaussDyadic.toComplex]
+  have hradius : HexRootsMathlib.DyadicSquare.radius s.neg =
+      HexRootsMathlib.DyadicSquare.radius s := by
+    simp [HexRootsMathlib.DyadicSquare.radius_eq, DyadicSquare.neg]
+  rw [HexRootsMathlib.DyadicSquare.closedDisc, Metric.mem_closedBall] at hz ⊢
+  rw [hcenter, hradius]
+  simpa only [dist_neg_neg] using hz
+
 namespace AlgebraicRoot
 
 /-- Reflection computes complex negation. -/
 theorem neg_toComplex (a : AlgebraicRoot) :
     a.neg.toComplex = -a.toComplex := by
-  sorry
+  have hroot :
+      (HexRootsMathlib.toPolyℂ a.p.negRoots).IsRoot (-a.toComplex) :=
+    ZPoly.negRoots_isRoot_of_isRoot
+      (HexRootsMathlib.RefinedIsolation.poly_ne_zero a.rep)
+      (AlgebraicRoot.toComplex_isRoot a)
+  have hmem :
+      -a.toComplex ∈
+        HexRootsMathlib.DyadicSquare.closedDisc a.neg.rep.1.square := by
+    exact DyadicSquare.neg_mem_closedDisc
+      (HexRootsMathlib.RefinedIsolation.root_mem_closedDisc a.rep)
+  exact (HexRootsMathlib.RefinedIsolation.eq_root_of_mem_closedDisc
+    a.neg.rep hroot hmem).symm
 
 /-- A certified lazy sum denotes the sum of its inputs. -/
 theorem add?_sound (a b : AlgebraicRoot) {c : AlgebraicRoot}
@@ -195,5 +445,7 @@ theorem div_toComplex (a b : AlgebraicNumber) :
     AlgebraicNumber.toRoot_toComplex, AlgebraicNumber.toRoot_toComplex]
 
 end AlgebraicNumber
+
+end
 
 end Hex

--- a/HexNumberFieldMathlib/Lazy.lean
+++ b/HexNumberFieldMathlib/Lazy.lean
@@ -94,10 +94,362 @@ private theorem ZPoly.natDegree_liftOuter (p : ZPoly) :
       DensePoly.degree?_eq_some_of_pos_size p.liftOuter (by omega),
       Option.getD_some, Option.getD_some, hsize]
 
+private theorem ZPoly.coeff_mulSubstitute (q : ZPoly) (j : Nat) :
+    q.mulSubstitute.coeff j =
+      if j ≤ q.degree?.getD 0 then
+        DensePoly.monomial (q.degree?.getD 0 - j)
+          (q.coeff (q.degree?.getD 0 - j))
+      else 0 := by
+  unfold ZPoly.mulSubstitute
+  change (DensePoly.ofList ((List.range (q.degree?.getD 0 + 1)).map fun j =>
+      DensePoly.monomial (q.degree?.getD 0 - j)
+        (q.coeff (q.degree?.getD 0 - j)))).coeff j = _
+  rw [DensePoly.coeff_ofList,
+    HexPolyMathlib.list_getD_map_range_zero]
+  split <;> rename_i h
+  · rw [if_pos (by omega)]
+  · rw [if_neg (by omega)]
+    rfl
+
 private theorem evalZPoly_X (t : ℂ) : evalZPoly t ZPoly.X = t := by
   simp [evalZPoly, ZPoly.X, HexPolyMathlib.equiv_apply,
     HexPolyMathlib.toPolynomial_monomial,
     Polynomial.monomial_one_one_eq_X]
+
+private theorem evalZPoly_monomial (t : ℂ) (n : Nat) (c : Int) :
+    evalZPoly t (DensePoly.monomial n c) = (c : ℂ) * t ^ n := by
+  simp [evalZPoly, HexPolyMathlib.equiv_apply,
+    HexPolyMathlib.toPolynomial_monomial]
+
+private theorem ZPoly.map_mulSubstitute (q : ZPoly) (t : ℂ) :
+    (HexPolyMathlib.toPolynomial q.mulSubstitute).map (evalZPoly t) =
+      ∑ j ∈ Finset.range (q.degree?.getD 0 + 1),
+        Polynomial.monomial j
+          ((q.coeff (q.degree?.getD 0 - j) : ℂ) *
+            t ^ (q.degree?.getD 0 - j)) := by
+  ext j
+  rw [Polynomial.coeff_map, HexPolyMathlib.coeff_toPolynomial,
+    ZPoly.coeff_mulSubstitute]
+  rw [← Polynomial.lcoeff_apply, map_sum]
+  simp only [Polynomial.lcoeff_apply]
+  by_cases hj : j ≤ q.degree?.getD 0
+  · rw [if_pos hj, evalZPoly_monomial]
+    rw [Finset.sum_eq_single j]
+    · simp
+    · intro b hb hbj
+      exact Polynomial.coeff_monomial_of_ne
+        ((q.coeff (q.degree?.getD 0 - b) : ℂ) *
+          t ^ (q.degree?.getD 0 - b)) hbj.symm
+    · simp [hj]
+  · rw [if_neg hj, map_zero]
+    symm
+    exact Finset.sum_eq_zero
+      (s := Finset.range (q.degree?.getD 0 + 1)) fun b hb =>
+      Polynomial.coeff_monomial_of_ne
+        ((q.coeff (q.degree?.getD 0 - b) : ℂ) *
+          t ^ (q.degree?.getD 0 - b)) (by
+        have hbLe : b ≤ q.degree?.getD 0 := by simpa using hb
+        omega)
+
+private theorem ZPoly.eval_map_mulSubstitute (q : ZPoly) (t y : ℂ)
+    (hy : y ≠ 0) :
+    ((HexPolyMathlib.toPolynomial q.mulSubstitute).map
+      (evalZPoly t)).eval y =
+      y ^ q.degree?.getD 0 *
+        (HexRootsMathlib.toPolyℂ q).eval (t / y) := by
+  rw [ZPoly.map_mulSubstitute, Polynomial.eval_finsetSum]
+  simp_rw [Polynomial.eval_monomial]
+  rw [Polynomial.eval_eq_sum_range,
+    HexRootsMathlib.natDegree_toPolyℂ, Finset.mul_sum]
+  conv_rhs => rw [← Finset.sum_range_reflect]
+  apply Finset.sum_congr rfl
+  intro j hj
+  have hjle : j ≤ q.degree?.getD 0 := by simpa using hj
+  rw [HexRootsMathlib.coeff_toPolyℂ, div_pow]
+  field_simp
+  have hidx : q.degree?.getD 0 + 1 - 1 - j =
+      q.degree?.getD 0 - j := by omega
+  rw [hidx]
+  have hpow : y ^ j * y ^ (q.degree?.getD 0 - j) =
+      y ^ q.degree?.getD 0 := by
+    rw [← pow_add]
+    congr 1
+    omega
+  rw [mul_assoc, hpow]
+  ring
+
+private theorem ZPoly.natDegree_map_mulSubstitute (q : ZPoly) (hq : q ≠ 0)
+    (t : ℂ) (ht : t ≠ 0) :
+    ((HexPolyMathlib.toPolynomial q.mulSubstitute).map
+      (evalZPoly t)).natDegree =
+      (HexPolyMathlib.toPolynomial q.mulSubstitute).natDegree := by
+  let g := q.mulSubstitute
+  have hqpos : 0 < q.size := by
+    by_contra h
+    exact hq ((DensePoly.size_eq_zero_iff q).mp (by omega))
+  have hn : q.degree?.getD 0 = q.size - 1 := by
+    rw [DensePoly.degree?_eq_some_of_pos_size q hqpos, Option.getD_some]
+  have hqtop : q.coeff (q.degree?.getD 0) ≠ (Zero.zero : Int) := by
+    simpa [hn] using DensePoly.coeff_last_ne_zero_of_pos_size q hqpos
+  have hgcoeff0 : g.coeff 0 =
+      DensePoly.monomial (q.degree?.getD 0)
+        (q.coeff (q.degree?.getD 0)) := by
+    dsimp only [g]
+    rw [ZPoly.coeff_mulSubstitute, if_pos (Nat.zero_le _), Nat.sub_zero]
+  have hgcoeff0ne : g.coeff 0 ≠ 0 := by
+    rw [hgcoeff0]
+    exact DensePoly.monomial_ne_zero_of_ne_zero hqtop
+  have hgpos : 0 < g.size := by
+    by_contra h
+    exact hgcoeff0ne (DensePoly.coeff_eq_zero_of_size_le g (by omega))
+  have hgsize : g.size ≤ q.degree?.getD 0 + 1 := by
+    dsimp only [g]
+    unfold ZPoly.mulSubstitute
+    exact (DensePoly.size_ofCoeffs_le _).trans (by simp)
+  have hdle : g.size - 1 ≤ q.degree?.getD 0 := by omega
+  have hgLast : g.coeff (g.size - 1) ≠ 0 :=
+    DensePoly.coeff_last_ne_zero_of_pos_size g hgpos
+  have hcoeff : q.coeff (q.degree?.getD 0 - (g.size - 1)) ≠ 0 := by
+    intro hzero
+    apply hgLast
+    dsimp only [g]
+    rw [ZPoly.coeff_mulSubstitute, if_pos hdle, hzero]
+    simp
+  apply Polynomial.natDegree_map_of_leadingCoeff_ne_zero
+  rw [HexPolyMathlib.leadingCoeff_toPolynomial,
+    DensePoly.leadingCoeff_eq_coeff_last g hgpos]
+  dsimp only [g]
+  rw [ZPoly.coeff_mulSubstitute, if_pos hdle, evalZPoly_monomial]
+  have htPow :
+      t ^ (q.degree?.getD 0 - (g.size - 1)) ≠ 0 :=
+    _root_.pow_ne_zero _ ht
+  exact mul_ne_zero (by exact_mod_cast hcoeff) htPow
+
+private theorem ZPoly.removeX_eq_ofList_dropWhile (p : ZPoly) :
+    p.removeX = DensePoly.ofList (p.toList.dropWhile (· == 0)) := by
+  unfold ZPoly.removeX DensePoly.toList DensePoly.ofList
+  apply congrArg DensePoly.ofCoeffs
+  have h := congrArg Array.reverse
+    (List.popWhile_toArray (fun x : Int => x == 0)
+      p.toArray.toList.reverse)
+  have hreverse : p.toArray.toList.reverse.toArray = p.toArray.reverse := by
+    rw [← List.reverse_toArray, Array.toArray_toList]
+  rw [hreverse] at h
+  simpa only [List.reverse_toArray, List.reverse_reverse,
+    Array.toArray_toList, Array.reverse_reverse] using h
+
+private theorem toPolynomial_ofList_zero_cons (l : List Int) :
+    HexPolyMathlib.toPolynomial (DensePoly.ofList (0 :: l)) =
+      Polynomial.X * HexPolyMathlib.toPolynomial (DensePoly.ofList l) := by
+  ext n
+  cases n with
+  | zero =>
+      simp [HexPolyMathlib.coeff_toPolynomial]
+  | succ n =>
+      simp [HexPolyMathlib.coeff_toPolynomial, Polynomial.coeff_X_mul]
+
+private theorem toPolynomial_ofList_eq_X_pow_dropWhile (l : List Int) :
+    ∃ k : Nat,
+      HexPolyMathlib.toPolynomial (DensePoly.ofList l) =
+        Polynomial.X ^ k * HexPolyMathlib.toPolynomial
+          (DensePoly.ofList (l.dropWhile (· == 0))) := by
+  induction l with
+  | nil =>
+      exact ⟨0, by simp⟩
+  | cons a l ih =>
+      by_cases ha : a = 0
+      · subst a
+        obtain ⟨k, hk⟩ := ih
+        refine ⟨k + 1, ?_⟩
+        rw [toPolynomial_ofList_zero_cons, hk]
+        simp only [List.dropWhile_cons, beq_self_eq_true, if_true]
+        rw [pow_succ]
+        ring
+      · refine ⟨0, ?_⟩
+        simp [ha]
+
+private theorem ZPoly.toPolynomial_eq_X_pow_mul_removeX (p : ZPoly) :
+    ∃ k : Nat,
+      HexPolyMathlib.toPolynomial p = Polynomial.X ^ k *
+        HexPolyMathlib.toPolynomial p.removeX := by
+  obtain ⟨k, hk⟩ := toPolynomial_ofList_eq_X_pow_dropWhile p.toList
+  refine ⟨k, ?_⟩
+  simpa [ZPoly.removeX_eq_ofList_dropWhile] using hk
+
+private theorem ZPoly.removeX_ne_zero {p : ZPoly} (hp : p ≠ 0) :
+    p.removeX ≠ 0 := by
+  intro hremove
+  obtain ⟨k, hk⟩ := ZPoly.toPolynomial_eq_X_pow_mul_removeX p
+  rw [hremove, HexPolyMathlib.toPolynomial_zero, mul_zero] at hk
+  apply hp
+  exact HexPolyMathlib.equiv.injective (by simpa using hk)
+
+private theorem ZPoly.removeX_isRoot {p : ZPoly} {z : ℂ}
+    (hz : z ≠ 0) (hroot : (HexRootsMathlib.toPolyℂ p).IsRoot z) :
+    (HexRootsMathlib.toPolyℂ p.removeX).IsRoot z := by
+  obtain ⟨k, hk⟩ := ZPoly.toPolynomial_eq_X_pow_mul_removeX p
+  have hmap := congrArg
+    (Polynomial.map (Int.castRingHom ℂ)) hk
+  have hfactor :
+      HexRootsMathlib.toPolyℂ p = Polynomial.X ^ k *
+        HexRootsMathlib.toPolyℂ p.removeX := by
+    simpa using hmap
+  change (HexRootsMathlib.toPolyℂ p.removeX).eval z = 0
+  change (HexRootsMathlib.toPolyℂ p).eval z = 0 at hroot
+  rw [hfactor, Polynomial.eval_mul, Polynomial.eval_pow,
+    Polynomial.eval_X] at hroot
+  exact (mul_eq_zero.mp hroot).resolve_left
+    (_root_.pow_ne_zero _ hz)
+
+private theorem ZPoly.coeff_reciprocal (p : ZPoly) (j : Nat) :
+    p.reciprocal.coeff j =
+      if j < p.size then p.coeff (p.size - 1 - j) else 0 := by
+  unfold ZPoly.reciprocal
+  rw [DensePoly.coeff_ofCoeffs, Array.getD_eq_getD_getElem?]
+  by_cases hj : j < p.size
+  · rw [if_pos hj, Array.getElem?_reverse (by simpa using hj)]
+    rw [← Array.getD_eq_getD_getElem?, DensePoly.toArray_getD]
+    rw [DensePoly.toArray_size]
+  · rw [if_neg hj, Array.getElem?_eq_none (by simpa using
+      (Nat.le_of_not_gt hj))]
+    rfl
+
+private theorem ZPoly.toPolynomial_reciprocal (p : ZPoly) (hp : p ≠ 0) :
+    HexPolyMathlib.toPolynomial p.reciprocal =
+      (HexPolyMathlib.toPolynomial p).reverse := by
+  have hpos : 0 < p.size := by
+    by_contra h
+    exact hp ((DensePoly.size_eq_zero_iff p).mp (by omega))
+  have hdegree : (HexPolyMathlib.toPolynomial p).natDegree = p.size - 1 := by
+    rw [HexPolyMathlib.natDegree_toPolynomial,
+      DensePoly.degree?_eq_some_of_pos_size p hpos, Option.getD_some]
+  ext j
+  rw [HexPolyMathlib.coeff_toPolynomial, ZPoly.coeff_reciprocal,
+    Polynomial.coeff_reverse, hdegree, HexPolyMathlib.coeff_toPolynomial]
+  by_cases hj : j < p.size
+  · rw [if_pos hj, Polynomial.revAt_le (by omega)]
+  · rw [if_neg hj, Polynomial.revAt_eq_self_of_lt (by omega)]
+    exact (DensePoly.coeff_eq_zero_of_size_le p
+      (Nat.le_of_not_gt hj)).symm
+
+private theorem ZPoly.toPolyℂ_reciprocal (p : ZPoly) (hp : p ≠ 0) :
+    HexRootsMathlib.toPolyℂ p.reciprocal =
+      (HexRootsMathlib.toPolyℂ p).reverse := by
+  have hdegree :
+      ((HexPolyMathlib.toPolynomial p).map
+        (Int.castRingHom ℂ)).natDegree =
+        (HexPolyMathlib.toPolynomial p).natDegree :=
+    Polynomial.natDegree_map_eq_of_injective
+      (RingHom.injective_int (Int.castRingHom ℂ))
+      (HexPolyMathlib.toPolynomial p)
+  change (HexPolyMathlib.toPolynomial p.reciprocal).map
+      (Int.castRingHom ℂ) =
+    ((HexPolyMathlib.toPolynomial p).map
+      (Int.castRingHom ℂ)).reverse
+  rw [ZPoly.toPolynomial_reciprocal p hp]
+  ext j
+  rw [Polynomial.coeff_map, Polynomial.coeff_reverse,
+    Polynomial.coeff_reverse, hdegree, Polynomial.coeff_map]
+
+private theorem ZPoly.reciprocal_ne_zero {p : ZPoly} (hp : p ≠ 0) :
+    p.reciprocal ≠ 0 := by
+  have hpos : 0 < p.size := by
+    by_contra h
+    exact hp ((DensePoly.size_eq_zero_iff p).mp (by omega))
+  have hlast := DensePoly.coeff_last_ne_zero_of_pos_size p hpos
+  intro hzero
+  have hcoeff := congrArg (fun q : ZPoly => q.coeff 0) hzero
+  rw [ZPoly.coeff_reciprocal, if_pos hpos, Nat.sub_zero] at hcoeff
+  simp at hcoeff
+  exact hlast hcoeff
+
+private theorem ZPoly.reciprocal_isRoot {p : ZPoly} {z : ℂ}
+    (hp : p ≠ 0) (hz : z ≠ 0)
+    (hroot : (HexRootsMathlib.toPolyℂ p).IsRoot z) :
+    (HexRootsMathlib.toPolyℂ p.reciprocal).IsRoot z⁻¹ := by
+  rw [ZPoly.toPolyℂ_reciprocal p hp]
+  letI : Invertible z := invertibleOfNonzero hz
+  change ((HexRootsMathlib.toPolyℂ p).reverse).eval z⁻¹ = 0
+  change (HexRootsMathlib.toPolyℂ p).eval z = 0 at hroot
+  have hreverse :=
+    (Polynomial.eval₂_reverse_eq_zero_iff (RingHom.id ℂ) z
+      (HexRootsMathlib.toPolyℂ p)).mpr (by simpa using hroot)
+  simpa [invOf_eq_inv] using hreverse
+
+private theorem AlgebraicRoot.inv_norm_lower (a : AlgebraicRoot)
+    (ha : a.toComplex ≠ 0) :
+    (((a.p.coeffAbsMax + 1 : Nat) : ℝ))⁻¹ < ‖a.toComplex‖ := by
+  let P := HexRootsMathlib.toPolyℂ a.p
+  let R := P.reverse
+  have hp : a.p ≠ 0 :=
+    HexRootsMathlib.RefinedIsolation.poly_ne_zero a.rep
+  have hPne : P ≠ 0 := by
+    exact HexRootsMathlib.toPolyℂ_ne_zero a.p fun hsize =>
+      hp ((DensePoly.size_eq_zero_iff a.p).mp hsize)
+  have hRne : R ≠ 0 := by
+    simpa [R] using hPne
+  have hRroot : R.IsRoot a.toComplex⁻¹ := by
+    simpa [R, ZPoly.toPolyℂ_reciprocal a.p hp] using
+      ZPoly.reciprocal_isRoot hp ha
+        (AlgebraicRoot.toComplex_isRoot a)
+  have hsup :
+      (Finset.range R.natDegree).sup (fun i => ‖R.coeff i‖₊) ≤
+        (a.p.coeffAbsMax : NNReal) := by
+    apply Finset.sup_le
+    intro i hi
+    rw [show R.coeff i = P.coeff (Polynomial.revAt P.natDegree i) by
+      simp [R, Polynomial.coeff_reverse]]
+    rw [show P.coeff (Polynomial.revAt P.natDegree i) =
+        (a.p.coeff (Polynomial.revAt P.natDegree i) : ℂ) by
+      simp [P]]
+    rw [Complex.nnnorm_intCast, ← NNReal.natCast_natAbs]
+    exact_mod_cast HexRootsMathlib.coeff_natAbs_le_coeffAbsMax a.p
+      (Polynomial.revAt P.natDegree i)
+  have htrail : P.trailingCoeff ≠ 0 :=
+    Polynomial.trailingCoeff_nonzero_iff_nonzero.mpr hPne
+  have htrailCoeff : a.p.coeff P.natTrailingDegree ≠ 0 := by
+    intro hzero
+    apply htrail
+    rw [Polynomial.trailingCoeff, show P.coeff P.natTrailingDegree =
+        (a.p.coeff P.natTrailingDegree : ℂ) by simp [P], hzero]
+    simp
+  have hlead : (1 : NNReal) ≤ ‖R.leadingCoeff‖₊ := by
+    rw [show R.leadingCoeff = P.trailingCoeff by
+      simp [R, Polynomial.reverse_leadingCoeff],
+      Polynomial.trailingCoeff,
+      show P.coeff P.natTrailingDegree =
+        (a.p.coeff P.natTrailingDegree : ℂ) by simp [P],
+      Complex.nnnorm_intCast, ← NNReal.natCast_natAbs]
+    exact_mod_cast (show 1 ≤ (a.p.coeff P.natTrailingDegree).natAbs by
+      have := Int.natAbs_pos.mpr htrailCoeff
+      omega)
+  have hcauchyNN :
+      Polynomial.cauchyBound R ≤ (a.p.coeffAbsMax : NNReal) + 1 := by
+    rw [Polynomial.cauchyBound]
+    calc
+      (Finset.range R.natDegree).sup (fun i => ‖R.coeff i‖₊) /
+              ‖R.leadingCoeff‖₊ + 1 ≤
+          (a.p.coeffAbsMax : NNReal) / 1 + 1 := by
+        gcongr
+      _ = (a.p.coeffAbsMax : NNReal) + 1 := by simp
+  have hinvNN := hRroot.norm_lt_cauchyBound hRne
+  have hinv : ‖a.toComplex⁻¹‖ <
+      ((a.p.coeffAbsMax + 1 : Nat) : ℝ) := by
+    calc
+      ‖a.toComplex⁻¹‖ < (Polynomial.cauchyBound R : ℝ) := by
+        exact_mod_cast hinvNN
+      _ ≤ ((a.p.coeffAbsMax : NNReal) + 1 : NNReal) := by
+        exact_mod_cast hcauchyNN
+      _ = ((a.p.coeffAbsMax + 1 : Nat) : ℝ) := by norm_num
+  rw [norm_inv] at hinv
+  have hnorm : 0 < ‖a.toComplex‖ := norm_pos_iff.mpr ha
+  have hdenom : 0 < ((a.p.coeffAbsMax + 1 : Nat) : ℝ) := by positivity
+  have hprod :
+      1 < ((a.p.coeffAbsMax + 1 : Nat) : ℝ) * ‖a.toComplex‖ := by
+    exact (mul_inv_lt_iff₀ hnorm).mp (by simpa using hinv)
+  have hfinal := (mul_inv_lt_iff₀ hdenom).mpr (by
+    simpa [mul_comm] using hprod)
+  simpa only [one_mul] using hfinal
 
 private theorem resultant_eval_eq_zero_of_common_root
     (f g : DensePoly ZPoly) (t y : ℂ)
@@ -266,6 +618,111 @@ private theorem ZPoly.addEliminant_ne_zero (a b : AlgebraicRoot) :
   apply hresultant
   simpa [← hfnat, ← hgnat] using hcorrespondence.symm
 
+private theorem ZPoly.mulEliminant_ne_zero (a b : AlgebraicRoot) :
+    ZPoly.mulEliminant a.p b.p ≠ 0 := by
+  let P := HexRootsMathlib.toPolyℂ a.p
+  let Q := HexRootsMathlib.toPolyℂ b.p
+  have haPoly : a.p ≠ 0 :=
+    HexRootsMathlib.RefinedIsolation.poly_ne_zero a.rep
+  have hbPoly : b.p ≠ 0 :=
+    HexRootsMathlib.RefinedIsolation.poly_ne_zero b.rep
+  have hPne : P ≠ 0 := by
+    exact HexRootsMathlib.toPolyℂ_ne_zero a.p fun hsize =>
+      haPoly ((DensePoly.size_eq_zero_iff a.p).mp hsize)
+  have hQne : Q ≠ 0 := by
+    exact HexRootsMathlib.toPolyℂ_ne_zero b.p fun hsize =>
+      hbPoly ((DensePoly.size_eq_zero_iff b.p).mp hsize)
+  let products : Set ℂ :=
+    (fun xy : ℂ × ℂ => xy.1 * xy.2) ''
+      (P.rootSet ℂ ×ˢ Q.rootSet ℂ)
+  have hproducts : products.Finite := by
+    exact ((Polynomial.rootSet_finite P ℂ).prod
+      (Polynomial.rootSet_finite Q ℂ)).image _
+  have hforbidden : ({0} ∪ products : Set ℂ).Finite :=
+    Set.Finite.union (Set.finite_singleton 0) hproducts
+  obtain ⟨t, ht⟩ := hforbidden.exists_notMem
+  have ht0 : t ≠ 0 := by
+    intro hzero
+    apply ht
+    subst t
+    exact Set.mem_union_left products (Set.mem_singleton 0)
+  have htProducts : t ∉ products := by
+    intro hmem
+    exact ht (Set.mem_union_right {0} hmem)
+  let G := (HexPolyMathlib.toPolynomial b.p.mulSubstitute).map
+    (evalZPoly t)
+  have hcoprime : IsCoprime P G := by
+    apply (Polynomial.isCoprime_iff_aeval_ne_zero_of_isAlgClosed
+      (k := ℂ) ℂ P G).2
+    intro y
+    by_contra hboth
+    push Not at hboth
+    have hPy : P.eval y = 0 := by
+      simpa [Polynomial.aeval_def] using hboth.1
+    have hGy : G.eval y = 0 := by
+      simpa [Polynomial.aeval_def] using hboth.2
+    by_cases hy : y = 0
+    · subst y
+      have hcoeff :
+          (b.p.coeff (b.p.degree?.getD 0) : ℂ) *
+              t ^ b.p.degree?.getD 0 = 0 := by
+        rw [← Polynomial.coeff_zero_eq_eval_zero] at hGy
+        simpa [G, Polynomial.coeff_map,
+          HexPolyMathlib.coeff_toPolynomial,
+          ZPoly.coeff_mulSubstitute, evalZPoly_monomial] using hGy
+      have hbpos : 0 < b.p.size := by
+        by_contra h
+        exact hbPoly ((DensePoly.size_eq_zero_iff b.p).mp (by omega))
+      have hbtop : b.p.coeff (b.p.degree?.getD 0) ≠ 0 := by
+        rw [DensePoly.degree?_eq_some_of_pos_size b.p hbpos,
+          Option.getD_some]
+        exact DensePoly.coeff_last_ne_zero_of_pos_size b.p hbpos
+      exact (mul_ne_zero (by exact_mod_cast hbtop)
+        (_root_.pow_ne_zero _ ht0)) hcoeff
+    · have hQeval : Q.eval (t / y) = 0 := by
+        have hproduct :
+            y ^ b.p.degree?.getD 0 * Q.eval (t / y) = 0 := by
+          rw [← ZPoly.eval_map_mulSubstitute b.p t y hy]
+          simpa [G] using hGy
+        exact (mul_eq_zero.mp hproduct).resolve_left
+          (_root_.pow_ne_zero _ hy)
+      apply htProducts
+      refine ⟨(y, t / y), ⟨?_, ?_⟩, ?_⟩
+      · exact (Polynomial.mem_rootSet_of_ne hPne).2 hPy
+      · exact (Polynomial.mem_rootSet_of_ne hQne).2 hQeval
+      · field_simp
+  have hresultant : Polynomial.resultant P G ≠ 0 :=
+    Polynomial.resultant_ne_zero P G hcoprime
+  let f : DensePoly ZPoly := a.p.liftOuter
+  let g : DensePoly ZPoly := b.p.mulSubstitute
+  have hfmap :
+      (HexPolyMathlib.toPolynomial f).map (evalZPoly t) = P := by
+    simpa [f, P] using ZPoly.map_liftOuter a.p t
+  have hgmap :
+      (HexPolyMathlib.toPolynomial g).map (evalZPoly t) = G := by
+    rfl
+  have hfnat :
+      (HexPolyMathlib.toPolynomial f).natDegree = P.natDegree := by
+    calc
+      (HexPolyMathlib.toPolynomial f).natDegree =
+          a.p.degree?.getD 0 := by
+        simpa [f] using ZPoly.natDegree_liftOuter a.p
+      _ = P.natDegree := by
+        simp [P]
+  have hgnat :
+      (HexPolyMathlib.toPolynomial g).natDegree = G.natDegree := by
+    simpa [g, G] using
+      (ZPoly.natDegree_map_mulSubstitute b.p hbPoly t ht0).symm
+  intro hzero
+  have hcorrespondence := congrArg (evalZPoly t)
+    (DensePoly.toPolynomial_resultant f g)
+  rw [← Polynomial.resultant_map_map] at hcorrespondence
+  have hraw : DensePoly.resultant f g = 0 := by
+    simpa [ZPoly.mulEliminant, f, g] using hzero
+  rw [hraw, map_zero, hfmap, hgmap] at hcorrespondence
+  apply hresultant
+  simpa [← hfnat, ← hgnat] using hcorrespondence.symm
+
 private theorem ZPoly.addEliminant_isRoot (a b : AlgebraicRoot) :
     (HexRootsMathlib.toPolyℂ (ZPoly.addEliminant a.p b.p)).IsRoot
       (a.toComplex + b.toComplex) := by
@@ -309,6 +766,49 @@ private theorem ZPoly.addEliminant_isRoot (a b : AlgebraicRoot) :
     simp [HexPolyMathlib.toPolynomial_monomial,
       Polynomial.monomial_one_one_eq_X, evalZPoly_X,
       Polynomial.eval_comp, AlgebraicRoot.toComplex_isRoot]
+
+private theorem ZPoly.mulEliminant_isRoot (a b : AlgebraicRoot)
+    (ha : a.toComplex ≠ 0) :
+    (HexRootsMathlib.toPolyℂ (ZPoly.mulEliminant a.p b.p)).IsRoot
+      (a.toComplex * b.toComplex) := by
+  unfold ZPoly.mulEliminant
+  apply resultant_eval_eq_zero_of_common_root
+      (y := a.toComplex)
+  · left
+    have hsize : 1 < a.p.size := by
+      have hpos : 0 < a.p.size := by
+        by_contra h
+        have hzero : a.p = 0 :=
+          (DensePoly.size_eq_zero_iff a.p).mp (by omega)
+        have hdegree := a.pos_degree
+        rw [hzero] at hdegree
+        simp at hdegree
+      have hdegree := a.pos_degree
+      rw [DensePoly.degree?_eq_some_of_pos_size a.p hpos,
+        Option.getD_some] at hdegree
+      omega
+    have hcoeff :
+        a.p.liftOuter.coeff (a.p.size - 1) ≠ 0 := by
+      rw [ZPoly.coeff_liftOuter]
+      intro hzero
+      have hconst := congrArg (fun p : ZPoly => p.coeff 0) hzero
+      simp at hconst
+      exact DensePoly.coeff_last_ne_zero_of_pos_size a.p (by omega) hconst
+    have hlt : a.p.size - 1 < a.p.liftOuter.size := by
+      by_contra h
+      exact hcoeff (DensePoly.coeff_eq_zero_of_size_le _ (by omega))
+    omega
+  · change ((HexPolyMathlib.toPolynomial a.p.liftOuter).map
+      (evalZPoly (a.toComplex * b.toComplex))).eval a.toComplex = 0
+    rw [ZPoly.map_liftOuter]
+    exact AlgebraicRoot.toComplex_isRoot a
+  · change ((HexPolyMathlib.toPolynomial b.p.mulSubstitute).map
+      (evalZPoly (a.toComplex * b.toComplex))).eval a.toComplex = 0
+    rw [ZPoly.eval_map_mulSubstitute b.p _ _ ha]
+    have hdiv : a.toComplex * b.toComplex / a.toComplex = b.toComplex := by
+      field_simp
+    rw [hdiv, AlgebraicRoot.toComplex_isRoot]
+    simp
 
 end
 
@@ -461,10 +961,12 @@ private theorem AlgebraicRoot.ofEliminant?_isSome
       have hmapSome := HexRootsMathlib.array_mapM_isSome
         (xs := isolations) (f := DyadicRootIsolation.toRefined?)
         (fun iso hiso => by
-          simp [DyadicRootIsolation.toRefined?,
-            HexRootsMathlib.isolate_refined (ZPoly.squareFreeCore raw) hsimple
-              (separationDepth (ZPoly.squareFreeCore raw) : Int)
-              .nkThenPellet hisolate iso hiso])
+          unfold DyadicRootIsolation.toRefined?
+          rw [dif_pos (HexRootsMathlib.isolate_refined
+            (ZPoly.squareFreeCore raw) hsimple
+            (separationDepth (ZPoly.squareFreeCore raw) : Int)
+            .nkThenPellet hisolate iso hiso)]
+          rfl)
       cases hrefined : isolations.mapM DyadicRootIsolation.toRefined? with
       | none => simp [hrefined] at hmapSome
       | some refined =>
@@ -538,7 +1040,7 @@ private theorem AlgebraicRoot.ofEliminant?_isSome
           | nil => simp [hselected] at hmem
           | cons matching rest =>
               cases rest with
-              | nil => simp
+              | nil => rfl
               | cons second tail =>
                   have hfilteredPairwise := hrefinedPairwise.filter fun r =>
                     r.1.square.meetsBall ball
@@ -832,12 +1334,167 @@ theorem sub_toComplex (a b : AlgebraicRoot) :
 theorem mul?_sound (a b : AlgebraicRoot) {c : AlgebraicRoot}
     (h : a.mul? b = some c) :
     c.toComplex = a.toComplex * b.toComplex := by
-  sorry
+  unfold AlgebraicRoot.mul? at h
+  split at h
+  · rename_i hzero
+    have hc := Option.some.inj h
+    subst c
+    change (0 : AlgebraicNumber).toComplex =
+      a.toComplex * b.toComplex
+    rw [AlgebraicNumber.zero_toComplex]
+    rw [Bool.or_eq_true] at hzero
+    rcases hzero with ha | hb
+    · rw [(AlgebraicRoot.isZero_iff a).mp ha]
+      simp
+    · rw [(AlgebraicRoot.isZero_iff b).mp hb]
+      simp
+  · rename_i hnonzero
+    have ha : a.toComplex ≠ 0 := by
+      intro ha
+      have hazero : a.isZero = true :=
+        (AlgebraicRoot.isZero_iff a).mpr ha
+      simp [hazero] at hnonzero
+    have hb : b.toComplex ≠ 0 := by
+      intro hb
+      have hbzero : b.isZero = true :=
+        (AlgebraicRoot.isZero_iff b).mpr hb
+      simp [hbzero] at hnonzero
+    let raw := (ZPoly.mulEliminant a.p b.p).removeX
+    have hroot : (HexRootsMathlib.toPolyℂ raw).IsRoot
+        (a.toComplex * b.toComplex) := by
+      exact ZPoly.removeX_isRoot (mul_ne_zero ha hb)
+        (ZPoly.mulEliminant_isRoot a b ha)
+    apply AlgebraicRoot.ofEliminant?_sound
+      (raw := raw)
+      (ballAt := fun prec => do
+        let target := prec + (AlgebraicRoot.mulGuardBits a b : Int)
+        let ar ← a.rep.refineTo? target
+        let br ← b.rep.refineTo? target
+        some (ar.1.1.square.toBall.mul br.1.1.square.toBall))
+      h hroot
+    intro ball hball
+    dsimp only at hball
+    obtain ⟨ar, har, hball⟩ := Option.bind_eq_some_iff.mp hball
+    obtain ⟨br, hbr, hball⟩ := Option.bind_eq_some_iff.mp hball
+    have hballEq := Option.some.inj hball
+    subst ball
+    apply DyadicComplexBall.mul_mem
+    · have harRoot :
+          HexRootsMathlib.RefinedIsolation.root ar.1 = a.toComplex := by
+        exact (HexRootsMathlib.RefinedIsolation.refineTo_root
+          a.rep _ .nkThenPellet har).trans rfl
+      rw [← harRoot]
+      exact DyadicComplexBall.mem_toBall
+        (HexRootsMathlib.RefinedIsolation.root_mem_closedDisc ar.1)
+    · have hbrRoot :
+          HexRootsMathlib.RefinedIsolation.root br.1 = b.toComplex := by
+        exact (HexRootsMathlib.RefinedIsolation.refineTo_root
+          b.rep _ .nkThenPellet hbr).trans rfl
+      rw [← hbrRoot]
+      exact DyadicComplexBall.mem_toBall
+        (HexRootsMathlib.RefinedIsolation.root_mem_closedDisc br.1)
 
 /-- The bounded lazy multiplication search always finds its certificate. -/
 theorem mul?_isSome (a b : AlgebraicRoot) :
     (a.mul? b).isSome := by
-  sorry
+  unfold AlgebraicRoot.mul?
+  split
+  · simp
+  · rename_i hnonzero
+    have ha : a.toComplex ≠ 0 := by
+      intro ha
+      have hazero : a.isZero = true :=
+        (AlgebraicRoot.isZero_iff a).mpr ha
+      simp [hazero] at hnonzero
+    have hb : b.toComplex ≠ 0 := by
+      intro hb
+      have hbzero : b.isZero = true :=
+        (AlgebraicRoot.isZero_iff b).mpr hb
+      simp [hbzero] at hnonzero
+    let raw := (ZPoly.mulEliminant a.p b.p).removeX
+    have hraw : raw ≠ 0 := by
+      exact ZPoly.removeX_ne_zero (ZPoly.mulEliminant_ne_zero a b)
+    have hroot : (HexRootsMathlib.toPolyℂ raw).IsRoot
+        (a.toComplex * b.toComplex) := by
+      exact ZPoly.removeX_isRoot (mul_ne_zero ha hb)
+        (ZPoly.mulEliminant_isRoot a b ha)
+    have harSome := RefinedIsolation.refineTo?_isSome a.rep
+      ((separationDepth (ZPoly.squareFreeCore raw) : Int) +
+        (AlgebraicRoot.mulGuardBits a b : Int))
+    cases har : a.rep.refineTo?
+        ((separationDepth (ZPoly.squareFreeCore raw) : Int) +
+          (AlgebraicRoot.mulGuardBits a b : Int)) .nkThenPellet with
+    | none => simp [har] at harSome
+    | some ar =>
+      have hbrSome := RefinedIsolation.refineTo?_isSome b.rep
+        ((separationDepth (ZPoly.squareFreeCore raw) : Int) +
+          (AlgebraicRoot.mulGuardBits a b : Int))
+      cases hbr : b.rep.refineTo?
+          ((separationDepth (ZPoly.squareFreeCore raw) : Int) +
+            (AlgebraicRoot.mulGuardBits a b : Int)) .nkThenPellet with
+      | none => simp [hbr] at hbrSome
+      | some br =>
+        apply AlgebraicRoot.ofEliminant?_isSome
+          (raw := raw)
+          (ballAt := fun prec => do
+            let target := prec + (AlgebraicRoot.mulGuardBits a b : Int)
+            let ar ← a.rep.refineTo? target
+            let br ← b.rep.refineTo? target
+            some (ar.1.1.square.toBall.mul br.1.1.square.toBall))
+          (z := a.toComplex * b.toComplex)
+          hraw hroot
+          (ar.1.1.square.toBall.mul br.1.1.square.toBall)
+        · dsimp only
+          rw [har, hbr]
+          rfl
+        · apply DyadicComplexBall.mul_mem
+          · have harRoot :
+                HexRootsMathlib.RefinedIsolation.root ar.1 =
+                  a.toComplex := by
+              exact (HexRootsMathlib.RefinedIsolation.refineTo_root
+                a.rep _ .nkThenPellet har).trans rfl
+            rw [← harRoot]
+            exact DyadicComplexBall.mem_toBall
+              (HexRootsMathlib.RefinedIsolation.root_mem_closedDisc ar.1)
+          · have hbrRoot :
+                HexRootsMathlib.RefinedIsolation.root br.1 =
+                  b.toComplex := by
+              exact (HexRootsMathlib.RefinedIsolation.refineTo_root
+                b.rep _ .nkThenPellet hbr).trans rfl
+            rw [← hbrRoot]
+            exact DyadicComplexBall.mem_toBall
+              (HexRootsMathlib.RefinedIsolation.root_mem_closedDisc br.1)
+        · have hguardRadius :
+              (ar.1.1.square.toBall.mul br.1.1.square.toBall).realRadius ≤
+                (2 : ℝ) ^ (-((separationDepth
+                  (ZPoly.squareFreeCore raw) : Int) + 4)) := by
+            exact RefinedIsolation.mulRadius_le a.rep b.rep
+              (separationDepth (ZPoly.squareFreeCore raw) : Int)
+              .nkThenPellet
+              (by simpa [AlgebraicRoot.mulGuardBits] using har)
+              (by simpa [AlgebraicRoot.mulGuardBits] using hbr)
+          have hsepNat :
+              mahlerPrec (ZPoly.squareFreeCore raw) ≤
+                separationDepth (ZPoly.squareFreeCore raw) := by
+            rw [separationDepth]
+            omega
+          have hsepInt :
+              (mahlerPrec (ZPoly.squareFreeCore raw) : Int) ≤
+                (separationDepth (ZPoly.squareFreeCore raw) : Int) := by
+            exact_mod_cast hsepNat
+          have hshift :
+              (2 : ℝ) ^ (-((separationDepth
+                  (ZPoly.squareFreeCore raw) : Int) + 4)) ≤
+                (2 : ℝ) ^ (-(separationDepth
+                  (ZPoly.squareFreeCore raw) : Int)) :=
+            zpow_le_zpow_right₀ (by norm_num) (by omega)
+          have hpow :
+              (2 : ℝ) ^ (-(separationDepth
+                  (ZPoly.squareFreeCore raw) : Int)) ≤
+                (2 : ℝ) ^ (-(mahlerPrec
+                  (ZPoly.squareFreeCore raw) : Int)) :=
+            zpow_le_zpow_right₀ (by norm_num) (by omega)
+          exact hguardRadius.trans (hshift.trans hpow)
 
 /-- Total lazy multiplication computes complex multiplication. -/
 theorem mul_toComplex (a b : AlgebraicRoot) :
@@ -854,12 +1511,115 @@ the executable convention `0⁻¹ = 0`. -/
 theorem inv?_sound (a : AlgebraicRoot) {b : AlgebraicRoot}
     (h : a.inv? = some b) :
     b.toComplex = a.toComplex⁻¹ := by
-  sorry
+  unfold AlgebraicRoot.inv? at h
+  split at h
+  · rename_i hzero
+    have hb := Option.some.inj h
+    subst b
+    change (0 : AlgebraicNumber).toComplex = a.toComplex⁻¹
+    rw [AlgebraicNumber.zero_toComplex,
+      (AlgebraicRoot.isZero_iff a).mp hzero]
+    simp
+  · rename_i hnonzero
+    have ha : a.toComplex ≠ 0 := by
+      intro ha
+      exact hnonzero ((AlgebraicRoot.isZero_iff a).mpr ha)
+    have hp : a.p ≠ 0 :=
+      HexRootsMathlib.RefinedIsolation.poly_ne_zero a.rep
+    have hroot : (HexRootsMathlib.toPolyℂ a.p.reciprocal).IsRoot
+        a.toComplex⁻¹ :=
+      ZPoly.reciprocal_isRoot hp ha (AlgebraicRoot.toComplex_isRoot a)
+    apply AlgebraicRoot.ofEliminant?_sound
+      (raw := a.p.reciprocal)
+      (ballAt := fun prec => do
+        let target := prec + (AlgebraicRoot.invGuardBits a : Int)
+        let ar ← a.rep.refineTo? target
+        ar.1.1.square.toBall.inv? target)
+      h hroot
+    intro ball hball
+    dsimp only at hball
+    obtain ⟨ar, har, hball⟩ := Option.bind_eq_some_iff.mp hball
+    apply DyadicComplexBall.inv_mem (h := hball)
+    have harRoot :
+        HexRootsMathlib.RefinedIsolation.root ar.1 = a.toComplex := by
+      exact (HexRootsMathlib.RefinedIsolation.refineTo_root
+        a.rep _ .nkThenPellet har).trans rfl
+    rw [← harRoot]
+    exact DyadicComplexBall.mem_toBall
+      (HexRootsMathlib.RefinedIsolation.root_mem_closedDisc ar.1)
 
 /-- The bounded lazy inverse search always finds its certificate. -/
 theorem inv?_isSome (a : AlgebraicRoot) :
     a.inv?.isSome := by
-  sorry
+  unfold AlgebraicRoot.inv?
+  split
+  · simp
+  · rename_i hnonzero
+    have ha : a.toComplex ≠ 0 := by
+      intro ha
+      exact hnonzero ((AlgebraicRoot.isZero_iff a).mpr ha)
+    have hp : a.p ≠ 0 :=
+      HexRootsMathlib.RefinedIsolation.poly_ne_zero a.rep
+    let raw := a.p.reciprocal
+    have hraw : raw ≠ 0 := ZPoly.reciprocal_ne_zero hp
+    have hroot : (HexRootsMathlib.toPolyℂ raw).IsRoot a.toComplex⁻¹ := by
+      exact ZPoly.reciprocal_isRoot hp ha
+        (AlgebraicRoot.toComplex_isRoot a)
+    have harSome := RefinedIsolation.refineTo?_isSome a.rep
+      ((separationDepth (ZPoly.squareFreeCore raw) : Int) +
+        (AlgebraicRoot.invGuardBits a : Int))
+    cases har : a.rep.refineTo?
+        ((separationDepth (ZPoly.squareFreeCore raw) : Int) +
+          (AlgebraicRoot.invGuardBits a : Int)) .nkThenPellet with
+    | none => simp [har] at harSome
+    | some ar =>
+        obtain ⟨ball, hinv, hguardRadius⟩ :=
+          RefinedIsolation.invBall_exists a.rep
+            (separationDepth (ZPoly.squareFreeCore raw) : Int)
+            (by positivity) .nkThenPellet
+            (AlgebraicRoot.inv_norm_lower a ha)
+            (by simpa only [AlgebraicRoot.invGuardBits] using har)
+        apply AlgebraicRoot.ofEliminant?_isSome
+          (raw := raw)
+          (ballAt := fun prec => do
+            let target := prec + (AlgebraicRoot.invGuardBits a : Int)
+            let ar ← a.rep.refineTo? target
+            ar.1.1.square.toBall.inv? target)
+          (z := a.toComplex⁻¹) hraw hroot ball
+        · dsimp only
+          rw [har]
+          simp only [Option.bind_eq_bind, Option.bind_some]
+          simpa only [AlgebraicRoot.invGuardBits] using hinv
+        · apply DyadicComplexBall.inv_mem (h := hinv)
+          have harRoot :
+              HexRootsMathlib.RefinedIsolation.root ar.1 = a.toComplex := by
+            exact (HexRootsMathlib.RefinedIsolation.refineTo_root
+              a.rep _ .nkThenPellet har).trans rfl
+          rw [← harRoot]
+          exact DyadicComplexBall.mem_toBall
+            (HexRootsMathlib.RefinedIsolation.root_mem_closedDisc ar.1)
+        · have hshift :
+              (2 : ℝ) ^ (-((separationDepth
+                  (ZPoly.squareFreeCore raw) : Int) + 4)) ≤
+                (2 : ℝ) ^ (-(separationDepth
+                  (ZPoly.squareFreeCore raw) : Int)) :=
+            zpow_le_zpow_right₀ (by norm_num) (by omega)
+          have hsepNat :
+              mahlerPrec (ZPoly.squareFreeCore raw) ≤
+                separationDepth (ZPoly.squareFreeCore raw) := by
+            rw [separationDepth]
+            omega
+          have hsepInt :
+              (mahlerPrec (ZPoly.squareFreeCore raw) : Int) ≤
+                (separationDepth (ZPoly.squareFreeCore raw) : Int) := by
+            exact_mod_cast hsepNat
+          have hpow :
+              (2 : ℝ) ^ (-(separationDepth
+                  (ZPoly.squareFreeCore raw) : Int)) ≤
+                (2 : ℝ) ^ (-(mahlerPrec
+                  (ZPoly.squareFreeCore raw) : Int)) :=
+            zpow_le_zpow_right₀ (by norm_num) (by omega)
+          exact hguardRadius.trans (hshift.trans hpow)
 
 /-- Total lazy inversion computes complex inversion. -/
 theorem inv_toComplex (a : AlgebraicRoot) :
@@ -910,46 +1670,90 @@ namespace AlgebraicNumber
 /-- Canonical addition computes complex addition. -/
 theorem add_toComplex (a b : AlgebraicNumber) :
     (a + b).toComplex = a.toComplex + b.toComplex := by
-  change (a.toRoot.add b.toRoot).exact.toComplex = _
+  change (AlgebraicNumber.add a b).toComplex = _
+  rw [AlgebraicNumber.add]
   rw [AlgebraicRoot.exact_toComplex, AlgebraicRoot.add_toComplex,
     AlgebraicNumber.toRoot_toComplex, AlgebraicNumber.toRoot_toComplex]
 
 /-- Canonical subtraction computes complex subtraction. -/
 theorem sub_toComplex (a b : AlgebraicNumber) :
     (a - b).toComplex = a.toComplex - b.toComplex := by
-  change (a.toRoot.sub b.toRoot).exact.toComplex = _
+  change (AlgebraicNumber.sub a b).toComplex = _
+  rw [AlgebraicNumber.sub]
   rw [AlgebraicRoot.exact_toComplex, AlgebraicRoot.sub_toComplex,
     AlgebraicNumber.toRoot_toComplex, AlgebraicNumber.toRoot_toComplex]
 
 /-- Canonical multiplication computes complex multiplication. -/
 theorem mul_toComplex (a b : AlgebraicNumber) :
     (a * b).toComplex = a.toComplex * b.toComplex := by
-  change (a.toRoot.mul b.toRoot).exact.toComplex = _
+  change (AlgebraicNumber.mul a b).toComplex = _
+  rw [AlgebraicNumber.mul]
   rw [AlgebraicRoot.exact_toComplex, AlgebraicRoot.mul_toComplex,
     AlgebraicNumber.toRoot_toComplex, AlgebraicNumber.toRoot_toComplex]
 
 /-- Canonical negation computes complex negation. -/
 theorem neg_toComplex (a : AlgebraicNumber) :
     (-a).toComplex = -a.toComplex := by
-  change a.toRoot.neg.exact.toComplex = _
+  change (AlgebraicNumber.neg a).toComplex = _
+  rw [AlgebraicNumber.neg]
   rw [AlgebraicRoot.exact_toComplex, AlgebraicRoot.neg_toComplex,
     AlgebraicNumber.toRoot_toComplex]
 
 /-- Canonical inversion computes complex inversion. -/
 theorem inv_toComplex (a : AlgebraicNumber) :
     a⁻¹.toComplex = a.toComplex⁻¹ := by
-  change a.toRoot.inv.exact.toComplex = _
+  change (AlgebraicNumber.inv a).toComplex = _
+  rw [AlgebraicNumber.inv]
   rw [AlgebraicRoot.exact_toComplex, AlgebraicRoot.inv_toComplex,
     AlgebraicNumber.toRoot_toComplex]
 
 /-- Canonical division computes complex division. -/
 theorem div_toComplex (a b : AlgebraicNumber) :
     (a / b).toComplex = a.toComplex / b.toComplex := by
-  change (a.toRoot.div b.toRoot).exact.toComplex = _
+  change (AlgebraicNumber.div a b).toComplex = _
+  rw [AlgebraicNumber.div]
   rw [AlgebraicRoot.exact_toComplex, AlgebraicRoot.div_toComplex,
     AlgebraicNumber.toRoot_toComplex, AlgebraicNumber.toRoot_toComplex]
 
 end AlgebraicNumber
+
+/-! The lazy arithmetic totality headlines must not inherit unfinished proofs. -/
+
+/--
+info: 'Hex.AlgebraicRoot.add?_isSome' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms AlgebraicRoot.add?_isSome
+
+/--
+info: 'Hex.AlgebraicRoot.mul?_isSome' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms AlgebraicRoot.mul?_isSome
+
+/--
+info: 'Hex.AlgebraicRoot.inv?_isSome' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms AlgebraicRoot.inv?_isSome
+
+/--
+info: 'Hex.AlgebraicRoot.div?_isSome' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms AlgebraicRoot.div?_isSome
+
+/--
+info: 'Hex.AlgebraicNumber.add_toComplex' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms AlgebraicNumber.add_toComplex
+
+/--
+info: 'Hex.AlgebraicNumber.div_toComplex' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms AlgebraicNumber.div_toComplex
 
 end
 

--- a/HexNumberFieldMathlib/SPEC/hex-number-field-mathlib.md
+++ b/HexNumberFieldMathlib/SPEC/hex-number-field-mathlib.md
@@ -161,6 +161,14 @@ Operation soundness uses the Stage 1 specialization-vanishing theorem from
 `hex-resultant-mathlib`. `_isSome` uses squarefree normalization,
 root-isolation completeness, and HexRoots separation at
 `resultIsolationPrec`; it does not require the Stage 2 resultant value theorem.
+Addition's fixed four-bit refinement bound follows directly from ball addition.
+Multiplication uses root-size bounds for both operands, while inversion uses the
+reciprocal Cauchy lower bound for a nonzero root and a doubled coefficient-height
+guard for reciprocal distortion. The resulting ball is two bits smaller than
+`resultIsolationPrec` for addition and four bits smaller for multiplication and
+inversion; each bound is sufficient for singleton selection. The checked
+multiplication and inversion zero branches are handled before eliminant
+construction and agree with `0⁻¹ = 0`.
 Canonical `AlgebraicNumber` arithmetic follows by `toRoot`, the lazy headline,
 and `exact_toComplex`.
 

--- a/HexPolyZ/Decomposition.lean
+++ b/HexPolyZ/Decomposition.lean
@@ -693,9 +693,40 @@ theorem squareFreeCore_ne_zero (f : ZPoly) (hf : f ≠ 0) :
     show (primitiveSquareFreeDecomposition f).squareFreeCore = 0 from hcore,
     DensePoly.zero_mul, DensePoly.scale_zero_right]
 
-/-- The square-free part of a nonzero polynomial is square-free over `Rat[x]`:
-combine the executable square-freeness result with nonzeroness of the
-square-free part. -/
+/-- The square-free core of a nonzero polynomial is primitive. -/
+theorem squareFreeCore_primitive (f : ZPoly) (hf : f ≠ 0) :
+    Primitive (squareFreeCore f) := by
+  let d := primitiveSquareFreeDecomposition f
+  have hproduct : Primitive (d.squareFreeCore * d.repeatedPart) := by
+    simpa [d] using
+      primitiveSquareFreeDecomposition_squareFreeCore_repeatedPart_primitive f hf
+  have hmul : content d.squareFreeCore * content d.repeatedPart = 1 := by
+    rw [← content_mul]
+    exact hproduct
+  have hmulNat :
+      DensePoly.contentNat d.squareFreeCore *
+          DensePoly.contentNat d.repeatedPart = 1 := by
+    simp only [content, DensePoly.content] at hmul
+    have habs := congrArg Int.natAbs hmul
+    simpa only [Int.natAbs_mul, Int.natAbs_ofNat', Int.natAbs_one]
+      using habs
+  have hcoreNat : DensePoly.contentNat d.squareFreeCore = 1 := by
+    exact Nat.dvd_one.mp ⟨DensePoly.contentNat d.repeatedPart, hmulNat.symm⟩
+  simp [Primitive, squareFreeCore_eq, d, content,
+    DensePoly.content, hcoreNat]
+
+/-- The square-free core of a nonzero polynomial has positive leading
+coefficient. -/
+theorem leadingCoeff_squareFreeCore_pos (f : ZPoly) (hf : f ≠ 0) :
+    0 < (squareFreeCore f).leadingCoeff := by
+  have hnonneg : 0 ≤ (squareFreeCore f).leadingCoeff := by
+    simpa [squareFreeCore_eq] using leadingCoeff_squareFreeCore_nonneg f
+  have hne : (squareFreeCore f).leadingCoeff ≠ 0 :=
+    leadingCoeff_ne_zero_of_ne_zero _ (squareFreeCore_ne_zero f hf)
+  omega
+
+/-- The square-free core of a nonzero polynomial is square-free over `Rat[x]`:
+combine the executable core square-freeness with core nonzeroness. -/
 theorem squareFreeRat_squareFreeCore (f : ZPoly) (hf : f ≠ 0) :
     SquareFreeRat (squareFreeCore f) :=
   primitiveSquareFreeDecomposition_squareFreeCore f (squareFreeCore_ne_zero f hf)

--- a/HexPolyZMathlib/Squarefree.lean
+++ b/HexPolyZMathlib/Squarefree.lean
@@ -102,6 +102,92 @@ theorem squareFreeRat_iff (f : Hex.ZPoly) (hf : f ≠ 0) :
   rw [key, hG, EuclideanDomain.gcd_isUnit_iff, ← Polynomial.separable_def,
     PerfectField.separable_iff_squarefree]
 
+private theorem repeatedPart_dvd_derivative_complex (f : Hex.ZPoly) :
+    ((toPolynomial (Hex.ZPoly.primitiveSquareFreeDecomposition f).repeatedPart).map
+        (Int.castRingHom ℂ)) ∣
+      derivative ((toPolynomial (Hex.ZPoly.primitivePart f)).map
+        (Int.castRingHom ℂ)) := by
+  rcases Hex.ZPoly.toRatPoly_repeatedPart_dvd_derivative f with ⟨q, hq⟩
+  refine ⟨(HexPolyMathlib.toPolynomial q).map (algebraMap ℚ ℂ), ?_⟩
+  have hqPolynomial := congrArg HexPolyMathlib.toPolynomial hq
+  rw [HexPolyMathlib.toPolynomial_mul,
+    HexPolyMathlib.toPolynomial_derivative,
+    toPolynomial_toRatPoly, toPolynomial_toRatPoly] at hqPolynomial
+  have hmapped := congrArg
+    (fun p : Polynomial ℚ => p.map (algebraMap ℚ ℂ)) hqPolynomial
+  have hcomp :
+      (algebraMap ℚ ℂ).comp (Int.castRingHom ℚ) =
+        Int.castRingHom ℂ := RingHom.ext_int _ _
+  simpa [Polynomial.map_mul, Polynomial.map_map, hcomp] using hmapped
+
+/-- Passing to the executable square-free core preserves every complex root
+of a nonzero integer polynomial. -/
+theorem isRoot_squareFreeCore {f : Hex.ZPoly} (hf : f ≠ 0) {z : ℂ}
+    (hz : ((toPolynomial f).map (Int.castRingHom ℂ)).IsRoot z) :
+    ((toPolynomial (Hex.ZPoly.squareFreeCore f)).map
+      (Int.castRingHom ℂ)).IsRoot z := by
+  let d := Hex.ZPoly.primitiveSquareFreeDecomposition f
+  let P : Polynomial ℂ :=
+    (toPolynomial (Hex.ZPoly.primitivePart f)).map (Int.castRingHom ℂ)
+  let C : Polynomial ℂ :=
+    (toPolynomial d.squareFreeCore).map (Int.castRingHom ℂ)
+  let R : Polynomial ℂ :=
+    (toPolynomial d.repeatedPart).map (Int.castRingHom ℂ)
+  have hcontent : Hex.ZPoly.content f ≠ 0 := content_ne_zero f hf
+  have hdecomp := congrArg
+    (fun p : Polynomial ℤ => p.map (Int.castRingHom ℂ))
+    (toPolynomial_eq_C_content_mul_primitivePart f)
+  rw [Polynomial.map_mul, Polynomial.map_C] at hdecomp
+  have hPRoot : P.IsRoot z := by
+    have hproduct : (Hex.ZPoly.content f : ℂ) * P.eval z = 0 := by
+      rw [hdecomp] at hz
+      change (Polynomial.C (Hex.ZPoly.content f : ℂ) * P).eval z = 0 at hz
+      rw [Polynomial.eval_mul, Polynomial.eval_C] at hz
+      exact hz
+    exact (mul_eq_zero.mp hproduct).resolve_left (by exact_mod_cast hcontent)
+  have hprimitive : Hex.ZPoly.primitivePart f ≠ 0 :=
+    Hex.ZPoly.ne_zero_of_primitive _
+      (Hex.ZPoly.primitivePart_primitive f hcontent)
+  have hPne : P ≠ 0 := by
+    intro hzero
+    apply hprimitive
+    have hpolynomial : toPolynomial (Hex.ZPoly.primitivePart f) = 0 :=
+      (Polynomial.map_eq_zero_iff
+        (RingHom.injective_int (Int.castRingHom ℂ))).mp (by
+          simpa [P] using hzero)
+    apply (HexPolyMathlib.equiv (R := Int)).injective
+    simpa [HexPolyMathlib.equiv_apply] using hpolynomial
+  have hrepDvd : R ∣ derivative P := by
+    simpa [d, P, R] using repeatedPart_dvd_derivative_complex f
+  rcases hrepDvd with ⟨Q, hQ⟩
+  rcases Hex.ZPoly.primitiveSquareFreeDecomposition_reassembly_signed f hf with
+    ⟨ε, hε, hreassembly⟩
+  have hreassemblyComplex := congrArg
+    (fun p : Hex.ZPoly => (toPolynomial p).map (Int.castRingHom ℂ))
+    hreassembly
+  have hPdvd : P ∣ derivative P * C := by
+    rcases hε with rfl | rfl
+    · refine ⟨Q, ?_⟩
+      simp only [HexPolyMathlib.toPolynomial_scale,
+        HexPolyMathlib.toPolynomial_mul, Polynomial.map_mul,
+        Polynomial.C_1, one_mul] at hreassemblyComplex
+      change C * R = P at hreassemblyComplex
+      rw [hQ]
+      change R * Q * C = P * Q
+      rw [← hreassemblyComplex]
+      ring
+    · refine ⟨-Q, ?_⟩
+      simp [HexPolyMathlib.toPolynomial_scale,
+        HexPolyMathlib.toPolynomial_mul] at hreassemblyComplex
+      change -(C * R) = P at hreassemblyComplex
+      rw [hQ]
+      change R * Q * C = P * -Q
+      rw [← hreassemblyComplex]
+      ring
+  have hCRoot : C.IsRoot z :=
+    Polynomial.isRoot_of_isRoot_of_dvd_derivative_mul hPne hPdvd hPRoot
+  simpa [d, C, Hex.ZPoly.squareFreeCore_eq] using hCRoot
+
 end
 
 end HexPolyZMathlib

--- a/HexResultantMathlib/Specialize.lean
+++ b/HexResultantMathlib/Specialize.lean
@@ -254,7 +254,7 @@ private theorem natDegree_specialize_le [CommRing R] [DecidableEq R]
 /-- Over a domain, a common root makes the default-degree resultant vanish as
 soon as at least one polynomial is nonzero. The proof maps injectively to the
 fraction field and uses Mathlib's field criterion. -/
-private theorem resultant_default_eq_zero_of_common_eval
+theorem resultant_eq_zero_of_common_eval
     [CommRing R] [IsDomain R]
     (F G : Polynomial R) (b : R)
     (hF : F.eval b = 0) (hG : G.eval b = 0)
@@ -349,7 +349,7 @@ theorem eval_resultant_eq_zero_of_common_root
         exact hboth ⟨hFzero, hGzero⟩
       · exact Or.inl hFzero
     have hdefault :=
-      resultant_default_eq_zero_of_common_eval F G b hFroot hGroot hne
+      resultant_eq_zero_of_common_eval F G b hFroot hGroot hne
     have hmEq : m = F.natDegree + (m - F.natDegree) := by omega
     have hnEq : n = G.natDegree + (n - G.natDegree) := by omega
     rw [hmEq, Polynomial.resultant_add_left_deg F G F.natDegree n

--- a/progress/20260729T111243Z_number-field-lazy-arithmetic.md
+++ b/progress/20260729T111243Z_number-field-lazy-arithmetic.md
@@ -1,0 +1,41 @@
+# Number-field lazy arithmetic semantics
+
+## Accomplished
+
+- Began the next cohesive NumberField milestone locally while PR #9091 remained
+  in CI; no additional PR was opened.
+- Proved `AlgebraicRoot.neg_toComplex` from polynomial reflection and certified
+  root isolation.
+- Exposed the existing domain-level common-root resultant criterion under the
+  shorter name `DensePoly.resultant_eq_zero_of_common_eval`.
+- Added the executable coefficient contract `ZPoly.coeff_liftOuter` beside
+  `liftOuter`, avoiding reliance on opaque `Array.map` reduction downstream.
+- Proved the coefficient-specialized bivariate resultant vanishes at a common
+  root, and used it to prove that `ZPoly.addEliminant a.p b.p` vanishes at
+  `a.toComplex + b.toComplex`.
+- Proved `HexPolyZMathlib.isRoot_squareFreeCore`: every complex root of a
+  nonzero integer polynomial remains a root of its executable square-free
+  core. The proof uses the signed primitive decomposition, the repeated-part
+  derivative divisor, and Mathlib's characteristic-zero root-transfer lemma.
+- Verified `lake build HexNumberField.Lazy`,
+  `lake build HexResultantMathlib.Specialize`, and
+  `lake build HexNumberFieldMathlib.Lazy`.
+
+## Current frontier
+
+The raw addition eliminant now has the required semantic root, and that root
+survives `ZPoly.squareFreeCore`. Checked-addition soundness now reduces to
+showing the refined operand balls contain their selected roots and the output
+filter selected the unique matching isolation.
+
+## Next step
+
+Factor the successful `AlgebraicRoot.ofEliminant?` branch into a reusable
+soundness lemma for addition, multiplication, and inversion, reusing the
+existing root-selection geometry from exactification and the operation-ball
+membership/radius bounds from `HexNumberFieldMathlib.Approx`.
+
+## Blockers
+
+None. PR #9091 passed its full CI suite and merged as `09668c54` while this
+local stage was in progress.

--- a/progress/20260729T120202Z_number-field-addition-totality.md
+++ b/progress/20260729T120202Z_number-field-addition-totality.md
@@ -1,0 +1,34 @@
+# Number-field lazy addition totality
+
+## Accomplished
+
+- Confirmed PR #9091 completed its full CI suite and merged before continuing
+  this stage; no new PR was opened.
+- Proved that the addition eliminant is nonzero and has
+  `a.toComplex + b.toComplex` as a root, using specialization of the bivariate
+  resultant and a coprimality witness away from the finite set of root sums.
+- Added the square-free-core primitivity and positive-leading-coefficient
+  contracts needed by the generic eliminant pipeline.
+- Factored the successful eliminant path into reusable soundness and totality
+  lemmas. The totality proof connects isolation completeness, refined-root
+  separation, and sufficiently small operation balls.
+- Proved checked addition soundness and totality. Consequently the total
+  addition and the checked and total subtraction semantic theorems are now
+  complete without new `sorry`s.
+- Verified `lake build HexNumberFieldMathlib.Lazy`.
+
+## Current frontier
+
+Lazy negation, addition, and subtraction now have complete Mathlib semantics.
+The remaining arithmetic obligations are multiplication and inversion; division
+then follows by composition.
+
+## Next step
+
+Prove the multiplication eliminant's nonzeroness and common-root statement,
+show that removing its `X` factor preserves the selected nonzero product root,
+and reuse the generic eliminant lemmas with the multiplication-ball guard bound.
+
+## Blockers
+
+None.

--- a/progress/20260802T091221Z_number-field-lazy-arithmetic-totality.md
+++ b/progress/20260802T091221Z_number-field-lazy-arithmetic-totality.md
@@ -1,0 +1,41 @@
+# Number-field lazy arithmetic totality
+
+## Accomplished
+
+- Proved multiplication-eliminant nonzeroness and root transport, including
+  removal of the spurious maximal `X` factor for nonzero products.
+- Proved reciprocal coefficient reversal, nonzeroness, root transport, and the
+  reciprocal Cauchy lower bound for nonzero selected roots.
+- Proved explicit multiplication- and inversion-ball guard bounds, including
+  successful separation of reciprocal balls from zero.
+- Completed checked soundness, bounded-search totality, and total complex
+  semantics for multiplication, inversion, and division. Added axiom guards for
+  the completed addition, multiplication, inversion, and division headlines.
+- Updated the NumberField specs and manual with the implemented guard bounds
+  and totality contracts. Confirmed the superseded
+  `SPEC/hex-number-field-expansion-plan.md` had already been deleted on the
+  current branch ancestry.
+- Verified `HexNumberFieldMathlib`, `HexManual`, `HexConformance`, the
+  NumberField fixture emitter, and all nine NumberField benchmark checks.
+- Completed an independent pre-merge review and corrected its one concrete
+  documentation finding: addition has two bits of operation-ball slack, while
+  multiplication and inversion have four.
+- Rebased onto current `main`, updated proof scripts for the new DensePoly and
+  elaborator behavior, and passed the full 9,907-target build. Recorded the
+  exact proof-only `HexPolyZ/Decomposition.lean` blob transition so its two new
+  theorems do not falsely invalidate factorization runtime measurements.
+
+## Current frontier
+
+The factorization-lazy addition, multiplication, inversion, and division
+pipelines now have `sorry`-free Mathlib soundness and totality proofs. The
+cohesive arithmetic milestone is in PR #9135 with auto-merge armed.
+
+## Next step
+
+Pass PR #9135 CI and merge it, then audit the Resultant, NumberField, and
+NumberFieldTower specs for the next remaining proof stage.
+
+## Blockers
+
+None.

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -4,5 +4,11 @@
     "baseline_blob": "893e5013cacbf1f00dc5a3f88c99f43ee97d5958",
     "current_blob": "6a967b30b4778ae1f5d9fed74e62452d35bac004",
     "reason": "Adds local classical decidability to a theorem proof; compiled factorization code is unchanged."
+  },
+  {
+    "path": "HexPolyZ/Decomposition.lean",
+    "baseline_blob": "9137a73618359488c9c2f8de6a0674f7918c7bd7",
+    "current_blob": "275022ccb5ce74a3bac17daa81a2ede16fe7e963",
+    "reason": "Adds square-free-core theorem proofs and docstring changes only; executable factorization definitions are unchanged."
   }
 ]


### PR DESCRIPTION
## Summary

- prove eliminant semantics and bounded certificate totality for lazy addition, multiplication, inversion, and division
- prove the multiplication and reciprocal ball-radius bounds used by the executable guards
- expose canonical complex semantics, add axiom guards, and align the NumberField SPEC and manual with the proved bounds

## Verification

- `lake build HexNumberFieldMathlib HexManual HexConformance hexnumberfield_emit_fixtures hexnumberfield_bench`
- `BENCH_VERIFY_HARD_CAP_SECONDS=120 bash scripts/ci/check_bench_verify_budget.sh hexnumberfield_bench` (9/9 passed, 1s total)
- independent proof review found no substantive blockers; the documented addition margin was corrected from four bits to the proved two-bit bound
