### PR TITLE
prove(number-field): establish root semantics foundations

### DIFF
--- a/HexNumberFieldMathlib/Roots.lean
+++ b/HexNumberFieldMathlib/Roots.lean
@@ -72,24 +72,210 @@ end RootSet
 
 namespace QAdjoin.Roots
 
+private theorem transported_root {p q : ZPoly} (h : p = q)
+    (rep : RefinedIsolation p) :
+    (h ▸ rep).root = rep.root := by
+  cases h
+  rfl
+
 /-- A successful lazy-root comparison decides equality of represented complex
 values. -/
 theorem sameValue?_sound (a b : AlgebraicRoot) {same : Bool}
     (h : sameValue? a b = some same) :
     same ↔ a.toComplex = b.toComplex := by
-  sorry
+  rw [sameValue?] at h
+  split at h
+  next hp =>
+    have hsame : (hp ▸ a.rep).sameRoot b.rep = same := by
+      simpa using Option.some.inj h
+    rw [← hsame,
+      HexRootsMathlib.RefinedIsolation.sameRoot_eq_true_iff,
+      HexRootsMathlib.RefinedIsolation.intersects_iff_root_eq]
+    change (hp ▸ a.rep).root = b.rep.root ↔
+      a.rep.root = b.rep.root
+    rw [transported_root hp a.rep]
+  next hp =>
+    obtain ⟨a', ha'⟩ := Option.isSome_iff_exists.mp
+      (AlgebraicRoot.exact?_isSome a)
+    obtain ⟨b', hb'⟩ := Option.isSome_iff_exists.mp
+      (AlgebraicRoot.exact?_isSome b)
+    simp only [ha', hb'] at h
+    have hsame : (a' == b') = same := Option.some.inj h
+    rw [← hsame, AlgebraicNumber.beq_iff,
+      AlgebraicRoot.exact?_sound a ha',
+      AlgebraicRoot.exact?_sound b hb']
 
 /-- Lazy-root comparison always succeeds, exactifying only when the enclosing
 polynomials differ. -/
 theorem sameValue?_isSome (a b : AlgebraicRoot) :
     (sameValue? a b).isSome := by
-  sorry
+  rw [sameValue?]
+  split
+  · simp
+  · obtain ⟨a', ha'⟩ := Option.isSome_iff_exists.mp
+      (AlgebraicRoot.exact?_isSome a)
+    obtain ⟨b', hb'⟩ := Option.isSome_iff_exists.mp
+      (AlgebraicRoot.exact?_isSome b)
+    simp [ha', hb']
+
+variable {p : ZPoly} {x : SimpleRoot p}
+
+/-- Converting a fixed-field coefficient to a lazy root cannot fail. -/
+theorem coeffRoot?_isSome [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) :
+    (coeffRoot? a rep h).isSome := by
+  rw [coeffRoot?]
+  split
+  · simp
+  · obtain ⟨exact, hexact⟩ := Option.isSome_iff_exists.mp
+      (QAdjoin.toAlgebraicNumber?_isSome a rep h)
+    simp [hexact]
+
+/-- Converting a fixed-field coefficient preserves its selected complex
+value. -/
+theorem coeffRoot?_sound [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) {root : AlgebraicRoot}
+    (hrun : coeffRoot? a rep h = some root) :
+    root.toComplex = QAdjoin.toComplex a rep h := by
+  rw [coeffRoot?] at hrun
+  split at hrun
+  next hzero =>
+    have hroot : AlgebraicNumber.zero.toRoot = root := Option.some.inj hrun
+    rw [← hroot, AlgebraicNumber.toRoot_toComplex,
+      show AlgebraicNumber.zero = (0 : AlgebraicNumber) by rfl,
+      AlgebraicNumber.zero_toComplex]
+    have ha : a = 0 := (QAdjoin.isZero_iff a).mp hzero
+    subst a
+    exact (QAdjoin.map_zero rep h).symm
+  next hnonzero =>
+    obtain ⟨canonical, hcanonical, hroot⟩ :=
+      Option.bind_eq_some_iff.mp hrun
+    have hroot' : canonical.toRoot = root := Option.some.inj hroot
+    rw [← hroot', AlgebraicNumber.toRoot_toComplex,
+      QAdjoin.toAlgebraicNumber?_sound a rep h hcanonical]
+
+private theorem evalRootFold_isSome [ZPoly.CheckedIrreducible p]
+    (coefficients : List (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) (candidate acc : AlgebraicRoot) :
+    (coefficients.foldlM
+      (fun (acc : AlgebraicRoot) (coeff : QAdjoin p x) => do
+        let product ← acc.mul? candidate
+        let coefficient ← coeffRoot? coeff rep h
+        product.add? coefficient)
+      acc).isSome := by
+  induction coefficients generalizing acc with
+  | nil => simp
+  | cons coefficient coefficients ih =>
+      obtain ⟨product, hproduct⟩ := Option.isSome_iff_exists.mp
+        (AlgebraicRoot.mul?_isSome acc candidate)
+      obtain ⟨coefficientRoot, hcoefficient⟩ := Option.isSome_iff_exists.mp
+        (coeffRoot?_isSome coefficient rep h)
+      obtain ⟨next, hnext⟩ := Option.isSome_iff_exists.mp
+        (AlgebraicRoot.add?_isSome product coefficientRoot)
+      simpa [List.foldlM_cons, hproduct, hcoefficient, hnext] using ih next
+
+private theorem evalRootFold_sound [ZPoly.CheckedIrreducible p]
+    (coefficients : List (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) (candidate acc : AlgebraicRoot)
+    {out : AlgebraicRoot}
+    (hrun : coefficients.foldlM
+      (fun (acc : AlgebraicRoot) (coeff : QAdjoin p x) => do
+        let product ← acc.mul? candidate
+        let coefficient ← coeffRoot? coeff rep h
+        product.add? coefficient)
+      acc = some out) :
+    out.toComplex =
+      (coefficients.map fun coefficient => QAdjoin.toComplex coefficient rep h).foldl
+        (fun value coefficient => value * candidate.toComplex + coefficient)
+        acc.toComplex := by
+  induction coefficients generalizing acc out with
+  | nil =>
+      have hout : acc = out := by simpa using hrun
+      subst out
+      rfl
+  | cons coefficient coefficients ih =>
+      cases hproduct : acc.mul? candidate with
+      | none => simp [List.foldlM_cons, hproduct] at hrun
+      | some product =>
+          cases hcoefficient : coeffRoot? coefficient rep h with
+          | none => simp [List.foldlM_cons, hproduct, hcoefficient] at hrun
+          | some coefficientRoot =>
+              cases hnext : product.add? coefficientRoot with
+              | none =>
+                  simp [List.foldlM_cons, hproduct, hcoefficient, hnext] at hrun
+              | some next =>
+                  have htail : coefficients.foldlM
+                      (fun (acc : AlgebraicRoot) (coeff : QAdjoin p x) => do
+                        let product ← acc.mul? candidate
+                        let coefficient ← coeffRoot? coeff rep h
+                        product.add? coefficient)
+                      next = some out := by
+                    simpa [List.foldlM_cons, hproduct, hcoefficient, hnext]
+                      using hrun
+                  rw [ih next htail]
+                  simp only [List.map_cons, List.foldl_cons]
+                  rw [AlgebraicRoot.add?_sound product coefficientRoot hnext,
+                    AlgebraicRoot.mul?_sound acc candidate hproduct,
+                    coeffRoot?_sound coefficient rep h hcoefficient]
+
+private theorem reverse_foldl_horner (coefficients : List ℂ) (z : ℂ) :
+    coefficients.reverse.foldl
+        (fun value coefficient => value * z + coefficient) 0 =
+      coefficients.foldr
+        (fun coefficient value => value * z + coefficient) 0 := by
+  induction coefficients with
+  | nil => rfl
+  | cons coefficient coefficients ih =>
+      rw [List.reverse_cons, List.foldl_append, ih]
+      rfl
+
+/-- Exact lazy Horner evaluation always succeeds. -/
+theorem evalRoot?_isSome [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) (candidate : AlgebraicRoot) :
+    (evalRoot? f rep h candidate).isSome := by
+  exact evalRootFold_isSome f.toArray.reverse.toList rep h candidate
+    AlgebraicNumber.zero.toRoot
+
+/-- Certified ball Horner evaluation always reaches its requested precision. -/
+theorem evalBall?_isSome [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) (candidate : AlgebraicRoot) (prec : Nat) :
+    (evalBall? f rep h candidate prec).isSome := by
+  obtain ⟨candidate', hrefine⟩ := Option.isSome_iff_exists.mp
+    (RefinedIsolation.refineTo?_isSome candidate.rep ((prec : Int) + 1))
+  rw [evalBall?, hrefine]
+  simp only
+  cases f.toArray.back? <;> simp
+
+private theorem mergeRootAux_isSome (candidate : RootCount) (index fuel : Nat)
+    (roots : Array RootCount) :
+    (mergeRootAux candidate index fuel roots).isSome := by
+  induction fuel generalizing index roots with
+  | zero => simp [mergeRootAux]
+  | succ fuel ih =>
+      rw [mergeRootAux]
+      split
+      · rename_i hi
+        obtain ⟨same, hsame⟩ := Option.isSome_iff_exists.mp
+          (sameValue?_isSome roots[index].root candidate.root)
+        cases same <;> simp [hsame, ih]
+      · simp
+
+/-- Merging a root through a complete semantic scan cannot fail. -/
+theorem mergeRoot_isSome (roots : Array RootCount) (candidate : RootCount) :
+    (mergeRoot roots candidate).isSome := by
+  exact mergeRootAux_isSome candidate 0 (roots.size + 1) roots
 
 end QAdjoin.Roots
 
 namespace QAdjoin
 
 variable {p : ZPoly} {x : SimpleRoot p}
+
+open scoped QAdjoinField
 
 /-- Interpret a fixed-field dense polynomial at the selected embedding. -/
 @[expose]
@@ -99,12 +285,42 @@ noncomputable def toPolynomialAt (f : DensePoly (QAdjoin p x))
     (fun a value => Polynomial.C (toComplex a rep h) +
       Polynomial.X * value) 0
 
+private theorem coeff_hornerAt (coeffs : List (QAdjoin p x))
+    (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) (n : Nat) :
+    (coeffs.foldr
+        (fun (a : QAdjoin p x) (value : Polynomial ℂ) =>
+          Polynomial.C (toComplex a rep h) + Polynomial.X * value) 0).coeff n =
+      toComplex (coeffs.getD n 0) rep h := by
+  induction coeffs generalizing n with
+  | nil => simp [QAdjoin.map_zero]
+  | cons a coeffs ih =>
+      cases n with
+      | zero => simp
+      | succ n => simpa using ih n
+
+private theorem array_toList_getDAt (coeffs : Array (QAdjoin p x)) (n : Nat) :
+    coeffs.toList.getD n 0 = coeffs.getD n 0 := by
+  rw [List.getD_eq_getElem?_getD, Array.getD_eq_getD_getElem?,
+    Array.getElem?_toList]
+
 /-- Semantic coefficients agree with fixed-coordinate evaluation. -/
 theorem coeff_toPolynomialAt (f : DensePoly (QAdjoin p x))
     (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) (n : Nat) :
     (QAdjoin.toPolynomialAt f rep h).coeff n =
       toComplex (f.coeff n) rep h := by
-  sorry
+  rw [toPolynomialAt, ← Array.foldr_toList,
+    coeff_hornerAt, array_toList_getDAt]
+  rfl
+
+private theorem toPolynomialAt_eq_map [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) :
+    QAdjoin.toPolynomialAt f rep h =
+      (HexPolyMathlib.toPolynomial f).map (QAdjoin.embedding rep h) := by
+  ext n
+  rw [coeff_toPolynomialAt, Polynomial.coeff_map,
+    HexPolyMathlib.coeff_toPolynomial]
+  rfl
 
 /-- Fixed-field executable zero detection agrees with semantic polynomial
 zero. -/
@@ -112,15 +328,224 @@ theorem poly_isZero_iff [ZPoly.CheckedIrreducible p]
     (f : DensePoly (QAdjoin p x))
     (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) :
     f.isZero ↔ QAdjoin.toPolynomialAt f rep h = 0 := by
-  sorry
+  constructor
+  · intro hf
+    have hsize : f.size = 0 := (DensePoly.isZero_eq_true_iff f).mp hf
+    have hfzero : f = 0 := by
+      apply DensePoly.ext_coeff
+      intro n
+      exact DensePoly.coeff_eq_zero_of_size_le f (by omega)
+    rw [toPolynomialAt_eq_map, hfzero,
+      HexPolyMathlib.toPolynomial_zero, Polynomial.map_zero]
+  · intro hpoly
+    have hfzero : f = 0 := by
+      apply DensePoly.ext_coeff
+      intro n
+      apply QAdjoin.toComplex_injective rep h
+      change toComplex (f.coeff n) rep h =
+        toComplex ((0 : DensePoly (QAdjoin p x)).coeff n) rep h
+      rw [DensePoly.coeff_zero, QAdjoin.map_zero,
+        ← coeff_toPolynomialAt, hpoly]
+      simp
+    subst f
+    exact (DensePoly.isZero_eq_true_iff
+      (0 : DensePoly (QAdjoin p x))).mpr DensePoly.size_zero
 
 /-- A nonzero fixed-field polynomial has the expected semantic degree. -/
 theorem natDegree_toPolynomialAt [ZPoly.CheckedIrreducible p]
     (f : DensePoly (QAdjoin p x))
     (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x)
-    (hf : !f.isZero) :
+    (_hf : !f.isZero) :
     (QAdjoin.toPolynomialAt f rep h).natDegree = f.degree?.getD 0 := by
-  sorry
+  rw [toPolynomialAt_eq_map,
+    Polynomial.natDegree_map_eq_of_injective
+      (QAdjoin.embedding_injective rep h),
+    HexPolyMathlib.natDegree_toPolynomial]
+
+namespace Roots
+
+private theorem eval_hornerAt (coefficients : List (QAdjoin p x))
+    (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) (z : ℂ) :
+    Polynomial.eval z
+        (coefficients.foldr
+          (fun coefficient value =>
+            Polynomial.C (QAdjoin.toComplex coefficient rep h) +
+              Polynomial.X * value)
+          0) =
+      (coefficients.map fun coefficient => QAdjoin.toComplex coefficient rep h).foldr
+        (fun coefficient value => value * z + coefficient) 0 := by
+  induction coefficients with
+  | nil => simp
+  | cons coefficient coefficients ih =>
+      simp only [List.foldr_cons, List.map_cons, Polynomial.eval_add,
+        Polynomial.eval_C, Polynomial.eval_mul, Polynomial.eval_X]
+      rw [ih]
+      ring
+
+/-- Exact lazy Horner evaluation denotes polynomial evaluation at the selected
+fixed-field embedding and absolute candidate. -/
+theorem evalRoot?_sound [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) (candidate : AlgebraicRoot)
+    {out : AlgebraicRoot} (hrun : evalRoot? f rep h candidate = some out) :
+    out.toComplex =
+      Polynomial.eval candidate.toComplex (QAdjoin.toPolynomialAt f rep h) := by
+  have hfold := evalRootFold_sound f.toArray.reverse.toList rep h candidate
+    AlgebraicNumber.zero.toRoot hrun
+  have harray : f.toArray.toList.reverse.toArray = f.toArray.reverse := by
+    rw [← List.reverse_toArray, Array.toArray_toList]
+  have hreverse : f.toArray.reverse.toList = f.toArray.toList.reverse := by
+    symm
+    exact congrArg Array.toList harray
+  have hzero : AlgebraicNumber.zero.toRoot.toComplex = 0 := by
+    rw [AlgebraicNumber.toRoot_toComplex,
+      show AlgebraicNumber.zero = (0 : AlgebraicNumber) by rfl,
+      AlgebraicNumber.zero_toComplex]
+  have hpoly :
+      f.toArray.toList.foldr
+          (fun coefficient value =>
+            Polynomial.C (QAdjoin.toComplex coefficient rep h) +
+              Polynomial.X * value)
+          0 = QAdjoin.toPolynomialAt f rep h := by
+    rw [QAdjoin.toPolynomialAt, ← Array.foldr_toList]
+  calc
+    out.toComplex =
+        (f.toArray.reverse.toList.map fun coefficient =>
+          QAdjoin.toComplex coefficient rep h).foldl
+          (fun value coefficient => value * candidate.toComplex + coefficient)
+          AlgebraicNumber.zero.toRoot.toComplex := hfold
+    _ = (f.toArray.toList.map fun coefficient =>
+          QAdjoin.toComplex coefficient rep h).foldr
+          (fun coefficient value => value * candidate.toComplex + coefficient) 0 := by
+      rw [hreverse, List.map_reverse, hzero, reverse_foldl_horner]
+    _ = Polynomial.eval candidate.toComplex
+        (QAdjoin.toPolynomialAt f rep h) := by
+      rw [← hpoly]
+      exact (eval_hornerAt f.toArray.toList rep h candidate.toComplex).symm
+
+private theorem hornerBall_mem [ZPoly.CheckedIrreducible p]
+    (coefficients : List (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) (z : ℂ) (zBall initBall : DyadicComplexBall)
+    (prec : Int) (init : ℂ) (hz : z ∈ zBall.set)
+    (hinit : init ∈ initBall.set) :
+    coefficients.foldr
+        (fun coefficient value => value * z + QAdjoin.toComplex coefficient rep h)
+        init ∈
+      (coefficients.foldr
+        (fun coefficient value =>
+          (coefficient.approx rep h prec).2.add (zBall.mul value))
+        initBall).set := by
+  induction coefficients with
+  | nil => exact hinit
+  | cons coefficient coefficients ih =>
+      simpa only [List.foldr_cons, add_comm, mul_comm] using
+        DyadicComplexBall.add_mem (QAdjoin.approx_sound coefficient rep h prec)
+          (DyadicComplexBall.mul_mem hz ih)
+
+private theorem foldr_map_horner (coefficients : List (QAdjoin p x))
+    (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) (z init : ℂ) :
+    (coefficients.map fun coefficient => QAdjoin.toComplex coefficient rep h).foldr
+        (fun coefficient value => value * z + coefficient) init =
+      coefficients.foldr
+        (fun coefficient value =>
+          value * z + QAdjoin.toComplex coefficient rep h) init := by
+  induction coefficients with
+  | nil => rfl
+  | cons coefficient coefficients ih =>
+      simp only [List.map_cons, List.foldr_cons]
+      rw [ih]
+
+/-- Certified ball Horner evaluation encloses exact evaluation at the selected
+embedding and candidate root. -/
+theorem evalBall?_sound [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) (candidate : AlgebraicRoot) (prec : Nat)
+    {ball : DyadicComplexBall} (hrun : evalBall? f rep h candidate prec = some ball) :
+    Polynomial.eval candidate.toComplex (QAdjoin.toPolynomialAt f rep h) ∈
+      ball.set := by
+  rw [evalBall?] at hrun
+  obtain ⟨candidate', hrefine, hrun⟩ := Option.bind_eq_some_iff.mp hrun
+  have hroot : candidate'.1.root = candidate.toComplex := by
+    calc
+      candidate'.1.root = candidate.rep.root :=
+        HexRootsMathlib.RefinedIsolation.refineTo_root candidate.rep
+          ((prec : Int) + 1) .nkThenPellet hrefine
+      _ = candidate.toComplex := by
+        unfold AlgebraicRoot.toComplex
+        rfl
+  have hz : candidate.toComplex ∈ candidate'.1.1.square.toBall.set := by
+    rw [← hroot]
+    exact DyadicComplexBall.mem_toBall
+      (HexRootsMathlib.RefinedIsolation.root_mem_closedDisc candidate'.1)
+  cases hback : f.toArray.back? with
+  | none =>
+      have hball : DyadicComplexBall.zero = ball := by
+        apply Option.some.inj
+        simpa [hback] using hrun
+      subst ball
+      have hempty : f.toArray = #[] := Array.back?_eq_none_iff.mp hback
+      rw [QAdjoin.toPolynomialAt, hempty]
+      simp [DyadicComplexBall.zero, DyadicComplexBall.set,
+        DyadicComplexBall.center, DyadicComplexBall.realRadius]
+  | some top =>
+      have hball : f.toArray.foldr
+          (fun coefficient value =>
+            (coefficient.approx rep h (prec : Int)).2.add
+              (candidate'.1.1.square.toBall.mul value))
+          (top.approx rep h (prec : Int)).2
+          (start := f.toArray.size - 1) = ball := by
+        apply Option.some.inj
+        simpa [hback] using hrun
+      subst ball
+      obtain ⟨pre, hprefix⟩ := Array.back?_eq_some_iff.mp hback
+      have hlist : f.toArray.toList = pre.toList ++ [top] := by
+        rw [hprefix, Array.toList_push]
+      have hsize : f.toArray.size - 1 = pre.size := by
+        rw [hprefix]
+        simp
+      have hfold :
+          f.toArray.foldr
+              (fun coefficient value =>
+                (coefficient.approx rep h (prec : Int)).2.add
+                  (candidate'.1.1.square.toBall.mul value))
+              (top.approx rep h (prec : Int)).2
+              (start := f.toArray.size - 1) =
+            pre.toList.foldr
+              (fun coefficient value =>
+                (coefficient.approx rep h (prec : Int)).2.add
+                  (candidate'.1.1.square.toBall.mul value))
+              (top.approx rep h (prec : Int)).2 := by
+        rw [hsize, Array.foldr_eq_foldr_extract]
+        rw [hprefix, Array.extract_push_of_le (le_refl pre.size)]
+        simp
+      rw [hfold]
+      have hvalue :
+          Polynomial.eval candidate.toComplex
+              (QAdjoin.toPolynomialAt f rep h) =
+            pre.toList.foldr
+              (fun coefficient value =>
+                value * candidate.toComplex + QAdjoin.toComplex coefficient rep h)
+              (QAdjoin.toComplex top rep h) := by
+        have hpoly :
+            f.toArray.toList.foldr
+                (fun coefficient value =>
+                  Polynomial.C (QAdjoin.toComplex coefficient rep h) +
+                    Polynomial.X * value)
+                0 = QAdjoin.toPolynomialAt f rep h := by
+          rw [QAdjoin.toPolynomialAt, ← Array.foldr_toList]
+        rw [← hpoly, eval_hornerAt, hlist, List.map_append,
+          List.foldr_append]
+        simp only [List.map_singleton, List.foldr_cons, List.foldr_nil]
+        rw [zero_mul, zero_add]
+        exact foldr_map_horner pre.toList rep h candidate.toComplex
+          (QAdjoin.toComplex top rep h)
+      rw [hvalue]
+      exact hornerBall_mem pre.toList rep h candidate.toComplex
+        candidate'.1.1.square.toBall (top.approx rep h (prec : Int)).2
+        prec (QAdjoin.toComplex top rep h) hz
+        (QAdjoin.approx_sound top rep h prec)
+
+end Roots
 
 /-- The fixed-field root driver always produces a checked root set. -/
 theorem roots?_isSome [ZPoly.CheckedIrreducible p]
@@ -159,7 +584,11 @@ theorem roots_positive [ZPoly.CheckedIrreducible p]
     (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
     (h : SimpleRoot.mk rep = x) :
     RootSet.Positive (QAdjoin.roots f rep h) := by
-  sorry
+  cases hroots : QAdjoin.roots f rep h with
+  | all => trivial
+  | finite roots =>
+      intro entry _hentry
+      exact entry.multiplicity_pos
 
 /-- The fixed-field driver merges all semantic duplicates. -/
 theorem roots_noDuplicates [ZPoly.CheckedIrreducible p]
@@ -216,7 +645,11 @@ theorem multiplicity_roots (f : AlgebraicPoly) (z : ℂ) :
 /-- The algebraic-coefficient driver produces positive multiplicities. -/
 theorem roots_positive (f : AlgebraicPoly) :
     RootSet.Positive f.roots := by
-  sorry
+  cases hroots : f.roots with
+  | all => trivial
+  | finite roots =>
+      intro entry _hentry
+      exact entry.multiplicity_pos
 
 /-- The algebraic-coefficient driver merges all semantic duplicates. -/
 theorem roots_noDuplicates (f : AlgebraicPoly) :
@@ -236,5 +669,31 @@ theorem totalMultiplicity_roots (f : AlgebraicPoly)
   sorry
 
 end AlgebraicPoly
+
+/-! The completed root-semantics foundations must not inherit unfinished proofs. -/
+
+/--
+info: 'Hex.QAdjoin.Roots.sameValue?_sound' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms QAdjoin.Roots.sameValue?_sound
+
+/--
+info: 'Hex.QAdjoin.Roots.sameValue?_isSome' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms QAdjoin.Roots.sameValue?_isSome
+
+/--
+info: 'Hex.QAdjoin.Roots.evalRoot?_sound' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms QAdjoin.Roots.evalRoot?_sound
+
+/--
+info: 'Hex.QAdjoin.Roots.evalBall?_sound' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms QAdjoin.Roots.evalBall?_sound
 
 end Hex

--- a/progress/20260802T103708Z_number-field-root-semantics-foundation.md
+++ b/progress/20260802T103708Z_number-field-root-semantics-foundation.md
@@ -1,0 +1,23 @@
+# Number-field root-semantics foundation
+
+## Accomplished
+
+- Read the Resultant, NumberField, and NumberFieldTower specifications and their Mathlib companions to identify the next dependency-ordered stage.
+- Proved lazy algebraic-root comparison sound and total.
+- Proved fixed-field coefficient conversion, exact Horner evaluation, certified ball Horner evaluation, and duplicate merging are sound or total as appropriate.
+- Connected fixed-field dense-polynomial coefficients, zero detection, and degree to the selected complex embedding.
+- Proved the fixed-field and algebraic root drivers return positive multiplicities.
+- Reduced `HexNumberFieldMathlib/Roots.lean` from 21 to 14 public `sorry` obligations without adding axioms or new sorries.
+- Verified the focused target, the NumberField Mathlib/manual/conformance/fixture/bench targets, and the full repository build.
+
+## Current frontier
+
+The semantic plumbing beneath the root drivers is complete. The remaining fixed-field obligations are the substantive Yun decomposition, norm-root isolation, candidate disambiguation, duplicate/order, and multiplicity-completeness proofs. The algebraic-coefficient driver remains downstream of those fixed-field results.
+
+## Next step
+
+Merge this cohesive foundation PR, then prove fixed-field root-driver totality and correctness as the next larger stage before lifting the result to algebraic coefficients. Begin NumberFieldTower root work only after the fixed-field and algebraic layers are complete.
+
+## Blockers
+
+None. The remaining fixed-field completeness block is substantial but its required evaluation, conversion, and merging lemmas are now available.

--- a/progress/20260802T103708Z_number-field-root-semantics-foundation.md
+++ b/progress/20260802T103708Z_number-field-root-semantics-foundation.md
@@ -9,6 +9,7 @@
 - Proved the fixed-field and algebraic root drivers return positive multiplicities.
 - Reduced `HexNumberFieldMathlib/Roots.lean` from 21 to 14 public `sorry` obligations without adding axioms or new sorries.
 - Verified the focused target, the NumberField Mathlib/manual/conformance/fixture/bench targets, and the full repository build.
+- Repaired the factor-sweep freshness gate so source-identical measurements survive the repository's required squash-merge workflow; this unblocks the already-failing `main` CI introduced by PR #9134.
 
 ## Current frontier
 
@@ -20,4 +21,4 @@ Merge this cohesive foundation PR, then prove fixed-field root-driver totality a
 
 ## Blockers
 
-None. The remaining fixed-field completeness block is substantial but its required evaluation, conversion, and merging lemmas are now available.
+PR CI initially exposed a pre-existing mainline failure: the factor-sweep checker required the pre-squash measurement commit to remain an ancestor. The branch now repairs that incompatible ancestry check while preserving exact relevant-source comparison. The remaining fixed-field completeness block is substantial but its required evaluation, conversion, and merging lemmas are available.

--- a/scripts/bench/check_factor_sweep_freshness.py
+++ b/scripts/bench/check_factor_sweep_freshness.py
@@ -2,10 +2,11 @@
 """Fail when factorization measurements no longer cover their source code.
 
 The newest committed observation for every published curve must use the current
-corpus, come from a clean ancestor commit, and contain one result for every
-corpus instance.  A measurement becomes stale when its system adapter, the
-shared sweep protocol, the corpus, or (for Hex) executable factorization code
-has changed since that commit.
+corpus, come from a clean recorded commit, and contain one result for every
+corpus instance. A measurement remains valid across a squash merge when the
+relevant source tree is unchanged. It becomes stale when its system adapter,
+the shared sweep protocol, the corpus, or (for Hex) executable factorization
+code differs from that recorded commit.
 """
 
 from __future__ import annotations
@@ -161,11 +162,11 @@ def main() -> int:
         if not commit:
             errors.append(f"{system}: {path.name} has no source commit")
             continue
-        ancestor = subprocess.run(
-            ["git", "merge-base", "--is-ancestor", commit, "HEAD"],
+        commit_exists = subprocess.run(
+            ["git", "cat-file", "-e", f"{commit}^{{commit}}"],
             cwd=ROOT, capture_output=True).returncode == 0
-        if not ancestor:
-            errors.append(f"{system}: measured commit {commit[:12]} is not an ancestor")
+        if not commit_exists:
+            errors.append(f"{system}: measured commit {commit[:12]} is unavailable")
             continue
         rows = [row for row in report.get("results", []) if row.get("system") == system]
         current_rows[system] = rows
@@ -194,7 +195,7 @@ def main() -> int:
                     name, commit, proof_only_exemptions)))
         if stale:
             errors.append(
-                f"{system}: source changed after {commit[:12]}: " + ", ".join(stale))
+                f"{system}: source differs from {commit[:12]}: " + ", ".join(stale))
 
     # Newest-per-system plots may combine records made at different times.
     # Recheck those selected answers together rather than relying only on each


### PR DESCRIPTION
## Summary

- prove lazy algebraic-root comparison sound and total
- connect fixed-field dense polynomials to their selected complex embedding, including coefficient, zero, and degree semantics
- prove coefficient conversion, exact and ball Horner evaluation, and duplicate merging sound or total
- discharge positive-multiplicity contracts for both root drivers
- reduce the public placeholders in `HexNumberFieldMathlib/Roots.lean` from 21 to 14, without new sorries or axioms

This is the cohesive semantic foundation for the next Yun/norm/disambiguation completeness stage.

## Mainline CI repair

The first run exposed an existing failure on `main`: PR #9134 recorded its factorization measurement on a source-identical PR-head commit, then squash-merged it so that commit was no longer an ancestor. The freshness checker now validates availability plus exact relevant-source differences, preserving the intended stale-data gate while making it compatible with squash merges.

## Verification

- `lake build HexNumberFieldMathlib.Roots`
- `lake build HexNumberFieldMathlib HexManual HexConformance hexnumberfield_emit_fixtures hexnumberfield_bench`
- `lake build`
- `python3 scripts/bench/check_factor_sweep_freshness.py`
- `git diff --check`
- guarded `#print axioms` checks for root equality and exact/ball evaluation