### PR TITLE
prove(number-field): make fixed root driver total

### DIFF
--- a/HexNumberFieldMathlib/Approx.lean
+++ b/HexNumberFieldMathlib/Approx.lean
@@ -197,7 +197,9 @@ private theorem invCenter_eq (a : DyadicComplexBall) :
   exact HexRootsMathlib.GaussDyadic.toComplex_mul
     (a.re, a.im) (b.re, b.im)
 
-@[simp] private theorem realRadius_mul (a b : DyadicComplexBall) :
+/-- Ball multiplication propagates centre and radius errors by the standard
+bilinear enclosure formula. -/
+@[simp] theorem realRadius_mul (a b : DyadicComplexBall) :
     (a.mul b).realRadius =
       HexRootsMathlib.Dyadic.toReal (GaussDyadic.hi (a.re, a.im)) * b.realRadius +
         HexRootsMathlib.Dyadic.toReal (GaussDyadic.hi (b.re, b.im)) * a.realRadius +
@@ -367,6 +369,36 @@ theorem realRadius_toBall_le {s : DyadicSquare} {prec : Int}
     _ ≤ (2 : ℝ) ^ (-prec) * 2 :=
       mul_le_mul_of_nonneg_right hpow (by norm_num)
     _ = 2 * (2 : ℝ) ^ (-prec) := by ring
+
+/-- Refinement one bit beyond `prec` gives the sharper three-quarter-ulp
+radius used by the bounded Horner disambiguation majorant. -/
+theorem realRadius_toBall_le_three_quarters {s : DyadicSquare} {prec : Int}
+    (hprec : prec + 1 ≤ s.prec) :
+    s.toBall.realRadius ≤ (3 / 4 : ℝ) * (2 : ℝ) ^ (-prec) := by
+  have hpow : (2 : ℝ) ^ (-s.prec) ≤ (2 : ℝ) ^ (-(prec + 1)) :=
+    zpow_le_zpow_right₀ (by norm_num) (by omega)
+  have hsqrt : HexRootsMathlib.Dyadic.toReal sqrt2Hi ≤ (3 / 2 : ℝ) := by
+    norm_num [Hex.sqrt2Hi, HexRootsMathlib.Dyadic.toReal_ofIntWithPrec]
+  rw [DyadicSquare.toBall, realRadius,
+    HexRootsMathlib.DyadicSquare.radiusHi_eq,
+    HexRootsMathlib.DyadicSquare.halfWidth_eq]
+  calc
+    (2 : ℝ) ^ (-s.prec) * HexRootsMathlib.Dyadic.toReal sqrt2Hi ≤
+        (2 : ℝ) ^ (-(prec + 1)) * (3 / 2 : ℝ) := by
+      calc
+        (2 : ℝ) ^ (-s.prec) * HexRootsMathlib.Dyadic.toReal sqrt2Hi ≤
+            (2 : ℝ) ^ (-(prec + 1)) *
+              HexRootsMathlib.Dyadic.toReal sqrt2Hi :=
+          mul_le_mul_of_nonneg_right hpow (by
+            norm_num [Hex.sqrt2Hi,
+              HexRootsMathlib.Dyadic.toReal_ofIntWithPrec])
+        _ ≤ (2 : ℝ) ^ (-(prec + 1)) * (3 / 2 : ℝ) :=
+          mul_le_mul_of_nonneg_left hsqrt (by positivity)
+    _ = (3 / 4 : ℝ) * (2 : ℝ) ^ (-prec) := by
+      rw [show -(prec + 1) = -prec + (-1 : Int) by ring,
+        zpow_add₀ (by norm_num : (2 : ℝ) ≠ 0)]
+      norm_num
+      ring
 
 private theorem refined_extent_le {p : ZPoly} (rep : RefinedIsolation p)
     (target : Int) (strategy : AtomStrategy)

--- a/HexNumberFieldMathlib/Lazy.lean
+++ b/HexNumberFieldMathlib/Lazy.lean
@@ -65,7 +65,28 @@ private theorem ZPoly.map_liftOuter (p : ZPoly) (t : ℂ) :
   rw [HexPolyMathlib.toPolynomial_C, Polynomial.eval₂_C]
   rfl
 
-private theorem ZPoly.natDegree_liftOuter (p : ZPoly) :
+/-- Specialization of the coefficient variable commutes with the constant
+bivariate lift. -/
+theorem ZPoly.map_liftOuterAt (p : ZPoly) (t : ℂ) :
+    (HexPolyMathlib.toPolynomial p.liftOuter).map
+      ((Polynomial.eval₂RingHom (Int.castRingHom ℂ) t).comp
+        (HexPolyMathlib.equiv (R := Int)).toRingHom) =
+      HexRootsMathlib.toPolyℂ p :=
+  map_liftOuter p t
+
+/-- Specializing the coefficient variable of the constant bivariate lift
+recovers the original complex polynomial. -/
+theorem ZPoly.eval_liftOuter (p : ZPoly) (t y : ℂ) :
+    ((HexPolyMathlib.toPolynomial p.liftOuter).map
+      ((Polynomial.eval₂RingHom (Int.castRingHom ℂ) t).comp
+        (HexPolyMathlib.equiv (R := Int)).toRingHom)).eval y =
+      (HexRootsMathlib.toPolyℂ p).eval y := by
+  have hmap := map_liftOuterAt p t
+  exact congrArg (fun q : Polynomial ℂ => q.eval y) hmap
+
+/-- The constant bivariate lift preserves the degree of the source integer
+polynomial. -/
+theorem ZPoly.natDegree_liftOuter (p : ZPoly) :
     (HexPolyMathlib.toPolynomial p.liftOuter).natDegree =
       p.degree?.getD 0 := by
   rw [HexPolyMathlib.natDegree_toPolynomial]
@@ -276,7 +297,8 @@ private theorem ZPoly.toPolynomial_eq_X_pow_mul_removeX (p : ZPoly) :
   refine ⟨k, ?_⟩
   simpa [ZPoly.removeX_eq_ofList_dropWhile] using hk
 
-private theorem ZPoly.removeX_ne_zero {p : ZPoly} (hp : p ≠ 0) :
+/-- Removing the maximal power of `X` preserves nonzeroness. -/
+theorem ZPoly.removeX_ne_zero {p : ZPoly} (hp : p ≠ 0) :
     p.removeX ≠ 0 := by
   intro hremove
   obtain ⟨k, hk⟩ := ZPoly.toPolynomial_eq_X_pow_mul_removeX p
@@ -284,7 +306,8 @@ private theorem ZPoly.removeX_ne_zero {p : ZPoly} (hp : p ≠ 0) :
   apply hp
   exact HexPolyMathlib.equiv.injective (by simpa using hk)
 
-private theorem ZPoly.removeX_isRoot {p : ZPoly} {z : ℂ}
+/-- Removing the maximal power of `X` preserves every nonzero complex root. -/
+theorem ZPoly.removeX_isRoot {p : ZPoly} {z : ℂ}
     (hz : z ≠ 0) (hroot : (HexRootsMathlib.toPolyℂ p).IsRoot z) :
     (HexRootsMathlib.toPolyℂ p.removeX).IsRoot z := by
   obtain ⟨k, hk⟩ := ZPoly.toPolynomial_eq_X_pow_mul_removeX p
@@ -376,82 +399,91 @@ private theorem ZPoly.reciprocal_isRoot {p : ZPoly} {z : ℂ}
       (HexRootsMathlib.toPolyℂ p)).mpr (by simpa using hroot)
   simpa [invOf_eq_inv] using hreverse
 
-private theorem AlgebraicRoot.inv_norm_lower (a : AlgebraicRoot)
-    (ha : a.toComplex ≠ 0) :
-    (((a.p.coeffAbsMax + 1 : Nat) : ℝ))⁻¹ < ‖a.toComplex‖ := by
-  let P := HexRootsMathlib.toPolyℂ a.p
+/-- A nonzero complex root of a nonzero integer polynomial is bounded away
+from zero by the reciprocal Cauchy bound of its coefficient height. -/
+theorem ZPoly.root_norm_lower {p : ZPoly} {z : ℂ}
+    (hp : p ≠ 0) (hz : z ≠ 0)
+    (hroot : (HexRootsMathlib.toPolyℂ p).IsRoot z) :
+    (((p.coeffAbsMax + 1 : Nat) : ℝ))⁻¹ < ‖z‖ := by
+  let P := HexRootsMathlib.toPolyℂ p
   let R := P.reverse
-  have hp : a.p ≠ 0 :=
-    HexRootsMathlib.RefinedIsolation.poly_ne_zero a.rep
   have hPne : P ≠ 0 := by
-    exact HexRootsMathlib.toPolyℂ_ne_zero a.p fun hsize =>
-      hp ((DensePoly.size_eq_zero_iff a.p).mp hsize)
+    exact HexRootsMathlib.toPolyℂ_ne_zero p fun hsize =>
+      hp ((DensePoly.size_eq_zero_iff p).mp hsize)
   have hRne : R ≠ 0 := by
     simpa [R] using hPne
-  have hRroot : R.IsRoot a.toComplex⁻¹ := by
-    simpa [R, ZPoly.toPolyℂ_reciprocal a.p hp] using
-      ZPoly.reciprocal_isRoot hp ha
-        (AlgebraicRoot.toComplex_isRoot a)
+  have hRroot : R.IsRoot z⁻¹ := by
+    simpa [R, ZPoly.toPolyℂ_reciprocal p hp] using
+      ZPoly.reciprocal_isRoot hp hz hroot
   have hsup :
       (Finset.range R.natDegree).sup (fun i => ‖R.coeff i‖₊) ≤
-        (a.p.coeffAbsMax : NNReal) := by
+        (p.coeffAbsMax : NNReal) := by
     apply Finset.sup_le
     intro i hi
     rw [show R.coeff i = P.coeff (Polynomial.revAt P.natDegree i) by
       simp [R, Polynomial.coeff_reverse]]
     rw [show P.coeff (Polynomial.revAt P.natDegree i) =
-        (a.p.coeff (Polynomial.revAt P.natDegree i) : ℂ) by
+        (p.coeff (Polynomial.revAt P.natDegree i) : ℂ) by
       simp [P]]
     rw [Complex.nnnorm_intCast, ← NNReal.natCast_natAbs]
-    exact_mod_cast HexRootsMathlib.coeff_natAbs_le_coeffAbsMax a.p
+    exact_mod_cast HexRootsMathlib.coeff_natAbs_le_coeffAbsMax p
       (Polynomial.revAt P.natDegree i)
   have htrail : P.trailingCoeff ≠ 0 :=
     Polynomial.trailingCoeff_nonzero_iff_nonzero.mpr hPne
-  have htrailCoeff : a.p.coeff P.natTrailingDegree ≠ 0 := by
+  have htrailCoeff : p.coeff P.natTrailingDegree ≠ 0 := by
     intro hzero
     apply htrail
     rw [Polynomial.trailingCoeff, show P.coeff P.natTrailingDegree =
-        (a.p.coeff P.natTrailingDegree : ℂ) by simp [P], hzero]
+        (p.coeff P.natTrailingDegree : ℂ) by simp [P], hzero]
     simp
   have hlead : (1 : NNReal) ≤ ‖R.leadingCoeff‖₊ := by
     rw [show R.leadingCoeff = P.trailingCoeff by
       simp [R, Polynomial.reverse_leadingCoeff],
       Polynomial.trailingCoeff,
       show P.coeff P.natTrailingDegree =
-        (a.p.coeff P.natTrailingDegree : ℂ) by simp [P],
+        (p.coeff P.natTrailingDegree : ℂ) by simp [P],
       Complex.nnnorm_intCast, ← NNReal.natCast_natAbs]
-    exact_mod_cast (show 1 ≤ (a.p.coeff P.natTrailingDegree).natAbs by
+    exact_mod_cast (show 1 ≤ (p.coeff P.natTrailingDegree).natAbs by
       have := Int.natAbs_pos.mpr htrailCoeff
       omega)
   have hcauchyNN :
-      Polynomial.cauchyBound R ≤ (a.p.coeffAbsMax : NNReal) + 1 := by
+      Polynomial.cauchyBound R ≤ (p.coeffAbsMax : NNReal) + 1 := by
     rw [Polynomial.cauchyBound]
     calc
       (Finset.range R.natDegree).sup (fun i => ‖R.coeff i‖₊) /
               ‖R.leadingCoeff‖₊ + 1 ≤
-          (a.p.coeffAbsMax : NNReal) / 1 + 1 := by
+          (p.coeffAbsMax : NNReal) / 1 + 1 := by
         gcongr
-      _ = (a.p.coeffAbsMax : NNReal) + 1 := by simp
+      _ = (p.coeffAbsMax : NNReal) + 1 := by simp
   have hinvNN := hRroot.norm_lt_cauchyBound hRne
-  have hinv : ‖a.toComplex⁻¹‖ <
-      ((a.p.coeffAbsMax + 1 : Nat) : ℝ) := by
+  have hinv : ‖z⁻¹‖ <
+      ((p.coeffAbsMax + 1 : Nat) : ℝ) := by
     calc
-      ‖a.toComplex⁻¹‖ < (Polynomial.cauchyBound R : ℝ) := by
+      ‖z⁻¹‖ < (Polynomial.cauchyBound R : ℝ) := by
         exact_mod_cast hinvNN
-      _ ≤ ((a.p.coeffAbsMax : NNReal) + 1 : NNReal) := by
+      _ ≤ ((p.coeffAbsMax : NNReal) + 1 : NNReal) := by
         exact_mod_cast hcauchyNN
-      _ = ((a.p.coeffAbsMax + 1 : Nat) : ℝ) := by norm_num
+      _ = ((p.coeffAbsMax + 1 : Nat) : ℝ) := by norm_num
   rw [norm_inv] at hinv
-  have hnorm : 0 < ‖a.toComplex‖ := norm_pos_iff.mpr ha
-  have hdenom : 0 < ((a.p.coeffAbsMax + 1 : Nat) : ℝ) := by positivity
+  have hnorm : 0 < ‖z‖ := norm_pos_iff.mpr hz
+  have hdenom : 0 < ((p.coeffAbsMax + 1 : Nat) : ℝ) := by positivity
   have hprod :
-      1 < ((a.p.coeffAbsMax + 1 : Nat) : ℝ) * ‖a.toComplex‖ := by
+      1 < ((p.coeffAbsMax + 1 : Nat) : ℝ) * ‖z‖ := by
     exact (mul_inv_lt_iff₀ hnorm).mp (by simpa using hinv)
   have hfinal := (mul_inv_lt_iff₀ hdenom).mpr (by
     simpa [mul_comm] using hprod)
   simpa only [one_mul] using hfinal
 
-private theorem resultant_eval_eq_zero_of_common_root
+private theorem AlgebraicRoot.inv_norm_lower (a : AlgebraicRoot)
+    (ha : a.toComplex ≠ 0) :
+    (((a.p.coeffAbsMax + 1 : Nat) : ℝ))⁻¹ < ‖a.toComplex‖ :=
+  ZPoly.root_norm_lower
+    (HexRootsMathlib.RefinedIsolation.poly_ne_zero a.rep) ha
+    (AlgebraicRoot.toComplex_isRoot a)
+
+/-- A common complex root after specializing the coefficient variable is a
+root of the executable bivariate resultant. -/
+theorem resultant_isRoot
     (f g : DensePoly ZPoly) (t y : ℂ)
     (hpos : 1 < f.size ∨ 1 < g.size)
     (hf : ((HexPolyMathlib.toPolynomial f).map
@@ -727,7 +759,7 @@ private theorem ZPoly.addEliminant_isRoot (a b : AlgebraicRoot) :
     (HexRootsMathlib.toPolyℂ (ZPoly.addEliminant a.p b.p)).IsRoot
       (a.toComplex + b.toComplex) := by
   unfold ZPoly.addEliminant
-  apply resultant_eval_eq_zero_of_common_root
+  apply resultant_isRoot
       (y := a.toComplex)
   · left
     have hsize : 1 < a.p.size := by
@@ -772,7 +804,7 @@ private theorem ZPoly.mulEliminant_isRoot (a b : AlgebraicRoot)
     (HexRootsMathlib.toPolyℂ (ZPoly.mulEliminant a.p b.p)).IsRoot
       (a.toComplex * b.toComplex) := by
   unfold ZPoly.mulEliminant
-  apply resultant_eval_eq_zero_of_common_root
+  apply resultant_isRoot
       (y := a.toComplex)
   · left
     have hsize : 1 < a.p.size := by

--- a/HexNumberFieldMathlib/RootDisambiguation.lean
+++ b/HexNumberFieldMathlib/RootDisambiguation.lean
@@ -1,0 +1,883 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexNumberField.Roots
+public import HexNumberFieldMathlib.Lazy
+
+public section
+
+/-!
+# Correctness of root-candidate disambiguation
+
+This module supplies the polynomial lower bound and complex-ball facts used by
+the bounded zero test in the fixed-field and tower root drivers.
+-/
+
+namespace Hex
+
+namespace QAdjoin
+
+private theorem le_mul_ceilDiv (n d : Nat) (hd : 0 < d) :
+    n ≤ ((n + d - 1) / d) * d := by
+  by_cases hn : n = 0
+  · simp [hn]
+  · have hrewrite : n + d - 1 = (n - 1) + d := by omega
+    rw [hrewrite, Nat.add_div_right _ hd]
+    have hmod := Nat.mod_lt (n - 1) hd
+    have hdecomp := Nat.div_add_mod (n - 1) d
+    have hpred : n - 1 + 1 = n := Nat.sub_add_cancel (by omega)
+    calc
+      n = n - 1 + 1 := hpred.symm
+      _ = d * ((n - 1) / d) + (n - 1) % d + 1 := by rw [hdecomp]
+      _ ≤ d * ((n - 1) / d) + d := by omega
+      _ = ((n - 1) / d + 1) * d := by ring
+
+private theorem le_mul_ratAbsCeil (q : Rat) :
+    q.num.natAbs ≤ ratAbsCeil q * q.den := by
+  unfold ratAbsCeil
+  exact le_mul_ceilDiv q.num.natAbs q.den q.den_pos
+
+/-- The executable rational ceiling majorizes the complex norm of the
+rational coefficient. -/
+theorem norm_rat_le_ratAbsCeil (q : Rat) :
+    ‖(q : ℂ)‖ ≤ ratAbsCeil q := by
+  rw [show (q : ℂ) = ((q : ℝ) : ℂ) by norm_num,
+    Complex.norm_real, Real.norm_eq_abs, Rat.cast_def, abs_div]
+  have hdenReal : 0 < (q.den : ℝ) := by positivity
+  rw [abs_of_pos hdenReal]
+  apply (div_le_iff₀ hdenReal).mpr
+  rw [← Int.cast_abs, ← Nat.cast_natAbs]
+  exact_mod_cast le_mul_ratAbsCeil q
+
+private theorem evalRat_horner (coefficients : List Rat) (z : ℂ) :
+    (coefficients.foldr
+      (fun coefficient value =>
+        Polynomial.C coefficient + Polynomial.X * value) 0).eval₂
+        (algebraMap Rat ℂ) z =
+      coefficients.foldr
+        (fun coefficient value => (coefficient : ℂ) + z * value) 0 := by
+  induction coefficients with
+  | nil => simp
+  | cons coefficient coefficients ih =>
+      simp only [List.foldr_cons, Polynomial.eval₂_add, Polynomial.eval₂_C,
+        Polynomial.eval₂_mul, Polynomial.eval₂_X]
+      change (algebraMap Rat ℂ) coefficient + z *
+          (coefficients.foldr
+            (fun coefficient value =>
+              Polynomial.C coefficient + Polynomial.X * value) 0).eval₂
+              (algebraMap Rat ℂ) z =
+        (coefficient : ℂ) + z * coefficients.foldr
+          (fun coefficient value => (coefficient : ℂ) + z * value) 0
+      rw [ih]
+      rfl
+
+private theorem coeff_rat_horner (coefficients : List Rat) (n : Nat) :
+    (coefficients.foldr
+      (fun coefficient value =>
+        Polynomial.C coefficient + Polynomial.X * value) 0).coeff n =
+      coefficients.getD n 0 := by
+  induction coefficients generalizing n with
+  | nil =>
+      simp
+  | cons coefficient coefficients ih =>
+      cases n with
+      | zero => simp
+      | succ n => simpa using ih n
+
+private theorem toPolynomial_eq_horner (f : DensePoly Rat) :
+    HexPolyMathlib.toPolynomial f =
+      f.toList.foldr
+        (fun coefficient value =>
+          Polynomial.C coefficient + Polynomial.X * value) 0 := by
+  ext n
+  rw [HexPolyMathlib.coeff_toPolynomial, coeff_rat_horner]
+  rw [List.getD_eq_getElem?_getD, Array.getElem?_toList,
+    ← Array.getD_eq_getD_getElem?]
+  exact (DensePoly.toArray_getD f n).symm
+
+private theorem norm_horner_le (coefficients : List Rat) (z : ℂ) (B : Nat)
+    (hz : ‖z‖ ≤ B) :
+    ‖coefficients.foldr
+        (fun coefficient value => (coefficient : ℂ) + z * value) 0‖ ≤
+      (coefficients.foldr
+        (fun coefficient value => value * B + ratAbsCeil coefficient) 0 : Nat) := by
+  induction coefficients with
+  | nil => simp
+  | cons coefficient coefficients ih =>
+      simp only [List.foldr_cons]
+      have hproduct :
+          ‖z‖ * ‖coefficients.foldr
+              (fun coefficient value => (coefficient : ℂ) + z * value) 0‖ ≤
+            (B : ℝ) *
+              (coefficients.foldr
+                (fun coefficient value =>
+                  value * B + ratAbsCeil coefficient) 0 : Nat) := by
+        exact mul_le_mul hz ih (norm_nonneg _) (by positivity)
+      calc
+        ‖(coefficient : ℂ) + z * coefficients.foldr
+            (fun coefficient value => (coefficient : ℂ) + z * value) 0‖ ≤
+            ‖(coefficient : ℂ)‖ +
+              ‖z * coefficients.foldr
+                (fun coefficient value => (coefficient : ℂ) + z * value) 0‖ :=
+          norm_add_le _ _
+        _ = ‖(coefficient : ℂ)‖ + ‖z‖ *
+              ‖coefficients.foldr
+                (fun coefficient value => (coefficient : ℂ) + z * value) 0‖ := by
+          rw [norm_mul]
+        _ ≤ (ratAbsCeil coefficient : ℝ) + (B : ℝ) *
+              (coefficients.foldr
+                (fun coefficient value =>
+                  value * B + ratAbsCeil coefficient) 0 : Nat) :=
+          add_le_add (norm_rat_le_ratAbsCeil coefficient) hproduct
+        _ = ((coefficients.foldr
+              (fun coefficient value =>
+                value * B + ratAbsCeil coefficient) 0) * B +
+              ratAbsCeil coefficient : Nat) := by
+          norm_num
+          ring
+
+/-- The coordinate majorant bounds the complex norm at the selected field
+embedding. -/
+theorem norm_toComplex_le_valueMajorant {p : ZPoly} {x : SimpleRoot p}
+    (a : QAdjoin p x) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) :
+    ‖toComplex a rep h‖ ≤ valueMajorant a := by
+  let B := 2 ^ cauchyExp p + 1
+  have hp : HexRootsMathlib.toPolyℂ p ≠ 0 := by
+    have hpRaw : p ≠ 0 :=
+      HexRootsMathlib.RefinedIsolation.poly_ne_zero rep
+    exact HexRootsMathlib.toPolyℂ_ne_zero p fun hsize =>
+      hpRaw ((DensePoly.size_eq_zero_iff p).mp hsize)
+  have hroot : (HexRootsMathlib.toPolyℂ p).IsRoot rep.root :=
+    HexRootsMathlib.RefinedIsolation.isRoot rep
+  have hdegree : 0 < p.degree?.getD 0 := by
+    rw [← HexRootsMathlib.natDegree_toPolyℂ p,
+      Polynomial.natDegree_pos_iff_degree_pos]
+    exact Polynomial.degree_pos_of_root hp hroot
+  have hz : ‖rep.root‖ ≤ B := by
+    calc
+      ‖rep.root‖ ≤ (Polynomial.cauchyBound
+          (HexRootsMathlib.toPolyℂ p) : ℝ) := by
+        exact_mod_cast (hroot.norm_lt_cauchyBound hp).le
+      _ ≤ (2 : ℝ) ^ cauchyExp p :=
+        HexRootsMathlib.cauchyBound_le_two_pow p hdegree
+      _ ≤ (B : ℝ) := by
+        dsimp [B]
+        norm_num
+  rw [toComplex, toPolynomial_eq_horner, evalRat_horner]
+  unfold valueMajorant
+  rw [← Array.foldr_toList]
+  exact norm_horner_le a.coeffs.toList rep.root B hz
+
+end QAdjoin
+
+namespace AlgebraicRoot
+
+/-- The executable Cauchy root bound majorizes the represented complex norm. -/
+theorem norm_lt_rootBound (a : AlgebraicRoot) :
+    ‖a.toComplex‖ < (2 ^ cauchyExp a.p + 1 : Nat) := by
+  have hp : HexRootsMathlib.toPolyℂ a.p ≠ 0 := by
+    have hpRaw : a.p ≠ 0 :=
+      HexRootsMathlib.RefinedIsolation.poly_ne_zero a.rep
+    exact HexRootsMathlib.toPolyℂ_ne_zero a.p fun hsize =>
+      hpRaw ((DensePoly.size_eq_zero_iff a.p).mp hsize)
+  have hroot : (HexRootsMathlib.toPolyℂ a.p).IsRoot a.toComplex :=
+    AlgebraicRoot.toComplex_isRoot a
+  calc
+    ‖a.toComplex‖ <
+        (Polynomial.cauchyBound (HexRootsMathlib.toPolyℂ a.p) : ℝ) := by
+      exact_mod_cast hroot.norm_lt_cauchyBound hp
+    _ ≤ (2 : ℝ) ^ cauchyExp a.p :=
+      HexRootsMathlib.cauchyBound_le_two_pow a.p a.pos_degree
+    _ < (2 ^ cauchyExp a.p + 1 : Nat) := by norm_num
+
+end AlgebraicRoot
+
+namespace ZPoly
+
+/-- Normalizing an evaluation eliminant preserves nonzeroness. -/
+theorem normalizeEval_ne_zero {q : ZPoly} (hq : q ≠ 0) :
+    q.normalizeEval ≠ 0 := by
+  unfold normalizeEval
+  have hremove : q.removeX ≠ 0 := removeX_ne_zero hq
+  exact ne_zero_of_primitive _
+    (primitivePart_primitive _ (HexPolyZMathlib.content_ne_zero _ hremove))
+
+/-- Normalizing an evaluation eliminant preserves every nonzero complex root. -/
+theorem normalizeEval_isRoot {q : ZPoly} {z : ℂ}
+    (hq : q ≠ 0) (hz : z ≠ 0)
+    (hroot : (HexRootsMathlib.toPolyℂ q).IsRoot z) :
+    (HexRootsMathlib.toPolyℂ q.normalizeEval).IsRoot z := by
+  have hremove : q.removeX ≠ 0 := removeX_ne_zero hq
+  have hremoveRoot : (HexRootsMathlib.toPolyℂ q.removeX).IsRoot z :=
+    removeX_isRoot hz hroot
+  have hdecomp :
+      HexRootsMathlib.toPolyℂ q.removeX =
+        Polynomial.C (q.removeX.content : ℂ) *
+          HexRootsMathlib.toPolyℂ q.removeX.primitivePart := by
+    change (HexPolyZMathlib.toPolynomial q.removeX).map
+        (Int.castRingHom ℂ) =
+      Polynomial.C ((Int.castRingHom ℂ) q.removeX.content) *
+        (HexPolyZMathlib.toPolynomial q.removeX.primitivePart).map
+          (Int.castRingHom ℂ)
+    have h := congrArg (Polynomial.map (Int.castRingHom ℂ))
+      (HexPolyZMathlib.toPolynomial_eq_C_content_mul_primitivePart q.removeX)
+    simpa only [Polynomial.map_mul, Polynomial.map_C] using h
+  have hcontent : (q.removeX.content : ℂ) ≠ 0 := by
+    exact_mod_cast HexPolyZMathlib.content_ne_zero q.removeX hremove
+  change (HexRootsMathlib.toPolyℂ q.removeX.primitivePart).eval z = 0
+  change (HexRootsMathlib.toPolyℂ q.removeX).eval z = 0 at hremoveRoot
+  rw [hdecomp, Polynomial.eval_mul, Polynomial.eval_C] at hremoveRoot
+  exact (mul_eq_zero.mp hremoveRoot).resolve_left hcontent
+
+/-- The normalized evaluation eliminant gives the lower bound used by the
+bounded zero test. -/
+theorem normalizeEval_root_norm_lower {q : ZPoly} {z : ℂ}
+    (hq : q ≠ 0) (hz : z ≠ 0)
+    (hroot : (HexRootsMathlib.toPolyℂ q).IsRoot z) :
+    (((q.evalLowerDenom : Nat) : ℝ))⁻¹ < ‖z‖ := by
+  have hlower := root_norm_lower (normalizeEval_ne_zero hq) hz
+    (normalizeEval_isRoot hq hz hroot)
+  simpa only [evalLowerDenom, Nat.cast_add, Nat.cast_one, add_comm] using hlower
+
+end ZPoly
+
+namespace DyadicComplexBall
+
+private theorem center_max_nonneg (b : DyadicComplexBall) :
+    0 ≤ max |b.center.re| |b.center.im| := by positivity
+
+private theorem center_max_eq (b : DyadicComplexBall) :
+    max |b.center.re| |b.center.im| =
+      HexRootsMathlib.Dyadic.toReal
+        (Hex.Dyadic.max (Hex.Dyadic.abs b.re) (Hex.Dyadic.abs b.im)) := by
+  simp [center, HexRootsMathlib.GaussDyadic.toComplex]
+
+private theorem radius_nonneg_of_mem {b : DyadicComplexBall} {z : ℂ}
+    (hz : z ∈ b.set) :
+    0 ≤ b.realRadius := by
+  rw [set, Metric.mem_closedBall] at hz
+  exact dist_nonneg.trans hz
+
+private theorem hi_le_two_norm_add_three_halves_radius
+    {b : DyadicComplexBall} {z : ℂ} (hz : z ∈ b.set) :
+    HexRootsMathlib.Dyadic.toReal (GaussDyadic.hi (b.re, b.im)) ≤
+      2 * ‖z‖ + (3 / 2 : ℝ) * b.realRadius := by
+  have hradius : 0 ≤ b.realRadius := radius_nonneg_of_mem hz
+  have hmem : dist z b.center ≤ b.realRadius := by
+    simpa only [set, Metric.mem_closedBall] using hz
+  have hcenter : ‖b.center‖ ≤ ‖z‖ + b.realRadius := by
+    calc
+      ‖b.center‖ = ‖(b.center - z) + z‖ := by
+        congr 1
+        ring
+      _ ≤ ‖b.center - z‖ + ‖z‖ := norm_add_le _ _
+      _ = dist z b.center + ‖z‖ := by rw [dist_comm, dist_eq_norm]
+      _ ≤ b.realRadius + ‖z‖ := add_le_add hmem le_rfl
+      _ = ‖z‖ + b.realRadius := add_comm _ _
+  have hsqrt : Real.sqrt 2 ≤ (3 / 2 : ℝ) := by
+    have hsqrt0 : 0 ≤ Real.sqrt 2 := Real.sqrt_nonneg _
+    have hsqrtSq : (Real.sqrt 2) ^ 2 = 2 := Real.sq_sqrt (by norm_num)
+    nlinarith
+  calc
+    HexRootsMathlib.Dyadic.toReal (GaussDyadic.hi (b.re, b.im)) ≤
+        Real.sqrt 2 * ‖b.center‖ := by
+      simpa only [center] using
+        HexRootsMathlib.GaussDyadic.hi_le_sqrt_two_mul_norm (b.re, b.im)
+    _ ≤ (3 / 2 : ℝ) * ‖b.center‖ :=
+      mul_le_mul_of_nonneg_right hsqrt (norm_nonneg _)
+    _ ≤ (3 / 2 : ℝ) * (‖z‖ + b.realRadius) :=
+      mul_le_mul_of_nonneg_left hcenter (by norm_num)
+    _ ≤ 2 * ‖z‖ + (3 / 2 : ℝ) * b.realRadius := by
+      nlinarith [norm_nonneg z]
+
+private theorem realRadius_horner_le
+    {z value coefficient : ℂ}
+    (zBall valueBall coefficientBall : DyadicComplexBall)
+    (B V E δ : ℝ)
+    (hz : z ∈ zBall.set) (hvalue : value ∈ valueBall.set)
+    (hcoefficient : coefficient ∈ coefficientBall.set)
+    (hzNorm : ‖z‖ ≤ B) (hvalueNorm : ‖value‖ ≤ V)
+    (hzRadius : zBall.realRadius ≤ (3 / 4 : ℝ) * δ)
+    (hvalueRadius : valueBall.realRadius ≤ E * δ)
+    (hcoefficientRadius : coefficientBall.realRadius ≤ δ)
+    (hB : 0 ≤ B) (hV : 0 ≤ V) (hE : 0 ≤ E)
+    (hδ : 0 ≤ δ) (hδ1 : δ ≤ 1) :
+    (coefficientBall.add (zBall.mul valueBall)).realRadius ≤
+      (2 * V + 2 * B * E + 3 * E + 1) * δ := by
+  have hzRadius0 : 0 ≤ zBall.realRadius := radius_nonneg_of_mem hz
+  have hvalueRadius0 : 0 ≤ valueBall.realRadius :=
+    radius_nonneg_of_mem hvalue
+  have hcoefficientRadius0 : 0 ≤ coefficientBall.realRadius :=
+    radius_nonneg_of_mem hcoefficient
+  have hzHi := hi_le_two_norm_add_three_halves_radius hz
+  have hvalueHi := hi_le_two_norm_add_three_halves_radius hvalue
+  have hzHi' :
+      HexRootsMathlib.Dyadic.toReal (GaussDyadic.hi (zBall.re, zBall.im)) ≤
+        2 * B + (3 / 2 : ℝ) * zBall.realRadius := by
+    exact hzHi.trans (add_le_add
+      (mul_le_mul_of_nonneg_left hzNorm (by norm_num)) le_rfl)
+  have hvalueHi' :
+      HexRootsMathlib.Dyadic.toReal
+          (GaussDyadic.hi (valueBall.re, valueBall.im)) ≤
+        2 * V + (3 / 2 : ℝ) * valueBall.realRadius := by
+    exact hvalueHi.trans (add_le_add
+      (mul_le_mul_of_nonneg_left hvalueNorm (by norm_num)) le_rfl)
+  have hmul :
+      (zBall.mul valueBall).realRadius ≤
+        2 * B * valueBall.realRadius +
+          2 * V * zBall.realRadius +
+            4 * zBall.realRadius * valueBall.realRadius := by
+    rw [realRadius_mul]
+    calc
+      HexRootsMathlib.Dyadic.toReal (GaussDyadic.hi (zBall.re, zBall.im)) *
+            valueBall.realRadius +
+          HexRootsMathlib.Dyadic.toReal
+              (GaussDyadic.hi (valueBall.re, valueBall.im)) *
+            zBall.realRadius +
+          zBall.realRadius * valueBall.realRadius ≤
+          (2 * B + (3 / 2 : ℝ) * zBall.realRadius) *
+              valueBall.realRadius +
+            (2 * V + (3 / 2 : ℝ) * valueBall.realRadius) *
+              zBall.realRadius +
+            zBall.realRadius * valueBall.realRadius := by
+        exact add_le_add
+          (add_le_add
+            (mul_le_mul_of_nonneg_right hzHi' hvalueRadius0)
+            (mul_le_mul_of_nonneg_right hvalueHi' hzRadius0))
+          le_rfl
+      _ = 2 * B * valueBall.realRadius +
+          2 * V * zBall.realRadius +
+            4 * zBall.realRadius * valueBall.realRadius := by ring
+  have hzRadius' : zBall.realRadius ≤ δ := by nlinarith
+  have hfirst :
+      2 * B * valueBall.realRadius ≤ 2 * B * E * δ := by
+    calc
+      2 * B * valueBall.realRadius ≤ 2 * B * (E * δ) :=
+        mul_le_mul_of_nonneg_left hvalueRadius (by positivity)
+      _ = 2 * B * E * δ := by ring
+  have hsecond : 2 * V * zBall.realRadius ≤ 2 * V * δ :=
+    mul_le_mul_of_nonneg_left hzRadius' (by positivity)
+  have hcross0 :
+      zBall.realRadius * valueBall.realRadius ≤
+        ((3 / 4 : ℝ) * δ) * (E * δ) := by
+    exact mul_le_mul hzRadius hvalueRadius hvalueRadius0 (by positivity)
+  have hδsq : δ * δ ≤ δ := by
+    nlinarith [mul_nonneg hδ (sub_nonneg.mpr hδ1)]
+  have hcross :
+      4 * zBall.realRadius * valueBall.realRadius ≤ 3 * E * δ := by
+    calc
+      4 * zBall.realRadius * valueBall.realRadius =
+          4 * (zBall.realRadius * valueBall.realRadius) := by ring
+      _ ≤ 4 * (((3 / 4 : ℝ) * δ) * (E * δ)) :=
+        mul_le_mul_of_nonneg_left hcross0 (by norm_num)
+      _ = 3 * E * (δ * δ) := by ring
+      _ ≤ 3 * E * δ :=
+        mul_le_mul_of_nonneg_left hδsq (by positivity)
+  rw [realRadius_add]
+  calc
+    coefficientBall.realRadius + (zBall.mul valueBall).realRadius ≤
+        δ + (2 * B * valueBall.realRadius +
+          2 * V * zBall.realRadius +
+            4 * zBall.realRadius * valueBall.realRadius) :=
+      add_le_add hcoefficientRadius hmul
+    _ ≤ δ + (2 * B * E * δ + 2 * V * δ + 3 * E * δ) :=
+      add_le_add le_rfl (add_le_add (add_le_add hfirst hsecond) hcross)
+    _ = (2 * V + 2 * B * E + 3 * E + 1) * δ := by ring
+
+/-- A ball that passes the executable zero-exclusion test cannot contain zero. -/
+theorem excludesZero_sound {b : DyadicComplexBall} {z : ℂ}
+    (hz : z ∈ b.set) (hexcludes : b.excludesZero) :
+    z ≠ 0 := by
+  intro hzero
+  subst z
+  have hmem : dist 0 b.center ≤ b.realRadius := by
+    simpa [set] using hz
+  have hnorm : ‖b.center‖ ≤ b.realRadius := by
+    simpa [dist_eq_norm, norm_neg] using hmem
+  have hmax : max |b.center.re| |b.center.im| ≤ ‖b.center‖ :=
+    max_le (Complex.abs_re_le_norm _) (Complex.abs_im_le_norm _)
+  have hexcludes' :
+      HexRootsMathlib.Dyadic.toReal b.radius <
+        HexRootsMathlib.Dyadic.toReal
+          (Hex.Dyadic.max (Hex.Dyadic.abs b.re) (Hex.Dyadic.abs b.im)) := by
+    rw [HexRootsMathlib.Dyadic.toReal_lt_toReal_iff]
+    exact of_decide_eq_true hexcludes
+  rw [← center_max_eq, ← realRadius] at hexcludes'
+  linarith
+
+/-- A sufficiently small ball containing a value above a reciprocal lower
+bound passes the executable zero-exclusion test. -/
+theorem excludesZero_of_mem_of_lower {b : DyadicComplexBall} {z : ℂ} {D : Nat}
+    (hD : 0 < D) (hz : z ∈ b.set)
+    (hlower : (((D : Nat) : ℝ))⁻¹ < ‖z‖)
+    (hsmall : 3 * (D : ℝ) * b.realRadius < 1) :
+    b.excludesZero := by
+  apply decide_eq_true
+  rw [← HexRootsMathlib.Dyadic.toReal_lt_toReal_iff,
+    ← center_max_eq, ← realRadius]
+  by_contra hnot
+  have hcenterMax : max |b.center.re| |b.center.im| ≤ b.realRadius :=
+    le_of_not_gt hnot
+  have hmax0 := center_max_nonneg b
+  have hradius0 : 0 ≤ b.realRadius := hmax0.trans hcenterMax
+  have hsqrt0 : 0 ≤ Real.sqrt 2 := Real.sqrt_nonneg _
+  have hsqrtSq : (Real.sqrt 2) ^ 2 = 2 := Real.sq_sqrt (by norm_num)
+  have hsqrtLe : Real.sqrt 2 ≤ 2 := by nlinarith
+  have hcenter : ‖b.center‖ ≤ 2 * b.realRadius := by
+    calc
+      ‖b.center‖ ≤ Real.sqrt 2 * max |b.center.re| |b.center.im| :=
+        Complex.norm_le_sqrt_two_mul_max _
+      _ ≤ Real.sqrt 2 * b.realRadius :=
+        mul_le_mul_of_nonneg_left hcenterMax hsqrt0
+      _ ≤ 2 * b.realRadius :=
+        mul_le_mul_of_nonneg_right hsqrtLe hradius0
+  have hmem : dist z b.center ≤ b.realRadius := by
+    simpa [set] using hz
+  have hnorm : ‖z‖ ≤ 3 * b.realRadius := by
+    calc
+      ‖z‖ = ‖(z - b.center) + b.center‖ := by ring_nf
+      _ ≤ ‖z - b.center‖ + ‖b.center‖ := norm_add_le _ _
+      _ = dist z b.center + ‖b.center‖ := by rw [dist_eq_norm]
+      _ ≤ b.realRadius + 2 * b.realRadius := add_le_add hmem hcenter
+      _ = 3 * b.realRadius := by ring
+  have hDreal : 0 < (D : ℝ) := by positivity
+  have hsmall' : 3 * b.realRadius < ((D : ℝ))⁻¹ := by
+    rw [inv_eq_one_div]
+    exact (lt_div_iff₀ hDreal).mpr (by nlinarith)
+  linarith
+
+end DyadicComplexBall
+
+namespace QAdjoin.Roots
+
+variable {p : ZPoly} {x : SimpleRoot p}
+
+private theorem hornerBall_bounds [ZPoly.CheckedIrreducible p]
+    (coefficients : List (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) (z : ℂ) (zBall : DyadicComplexBall)
+    (prec : Nat) (rootBound : Nat) (init : ℂ)
+    (initBall : DyadicComplexBall) (initState : Nat × Nat)
+    (hz : z ∈ zBall.set) (hzNorm : ‖z‖ ≤ rootBound)
+    (hzRadius : zBall.realRadius ≤
+      (3 / 4 : ℝ) * (2 : ℝ) ^ (-(prec : Int)))
+    (hinit : init ∈ initBall.set)
+    (hinitNorm : ‖init‖ ≤ initState.1)
+    (hinitRadius : initBall.realRadius ≤
+      (initState.2 : ℝ) * (2 : ℝ) ^ (-(prec : Int))) :
+    let state := coefficients.foldr
+      (fun coeff state =>
+        (state.1 * rootBound + valueMajorant coeff,
+          2 * state.1 + 2 * rootBound * state.2 + 3 * state.2 + 1))
+      initState
+    let value := coefficients.foldr
+      (fun coeff value => toComplex coeff rep h + z * value) init
+    let ball := coefficients.foldr
+      (fun coeff value =>
+        (coeff.approx rep h (prec : Int)).2.add (zBall.mul value))
+      initBall
+    value ∈ ball.set ∧ ‖value‖ ≤ state.1 ∧
+      ball.realRadius ≤
+        (state.2 : ℝ) * (2 : ℝ) ^ (-(prec : Int)) := by
+  induction coefficients with
+  | nil =>
+      exact ⟨hinit, hinitNorm, hinitRadius⟩
+  | cons coefficient coefficients ih =>
+      simp only [List.foldr_cons]
+      obtain ⟨hvalue, hvalueNorm, hvalueRadius⟩ := ih
+      let state := coefficients.foldr
+        (fun coeff state =>
+          (state.1 * rootBound + valueMajorant coeff,
+            2 * state.1 + 2 * rootBound * state.2 + 3 * state.2 + 1))
+        initState
+      let value := coefficients.foldr
+        (fun coeff value => toComplex coeff rep h + z * value) init
+      let ball := coefficients.foldr
+        (fun coeff value =>
+          (coeff.approx rep h (prec : Int)).2.add (zBall.mul value))
+        initBall
+      have hcoefficient := QAdjoin.approx_sound coefficient rep h (prec : Int)
+      have hcoefficientNorm :=
+        QAdjoin.norm_toComplex_le_valueMajorant coefficient rep h
+      have hcoefficientRadius :=
+        QAdjoin.approx_radius coefficient rep h (prec : Int)
+      have hδ : 0 ≤ (2 : ℝ) ^ (-(prec : Int)) := by positivity
+      have hδ1 : (2 : ℝ) ^ (-(prec : Int)) ≤ 1 := by
+        rw [← zpow_zero (2 : ℝ)]
+        exact zpow_le_zpow_right₀ (by norm_num) (by omega)
+      have hnorm :
+          ‖toComplex coefficient rep h + z * value‖ ≤
+            (state.1 * rootBound + valueMajorant coefficient : Nat) := by
+        have hproduct : ‖z‖ * ‖value‖ ≤
+            (rootBound : ℝ) * (state.1 : ℝ) := by
+          exact mul_le_mul hzNorm hvalueNorm (norm_nonneg _) (by positivity)
+        calc
+          ‖toComplex coefficient rep h + z * value‖ ≤
+              ‖toComplex coefficient rep h‖ + ‖z * value‖ :=
+            norm_add_le _ _
+          _ = ‖toComplex coefficient rep h‖ + ‖z‖ * ‖value‖ := by
+            rw [norm_mul]
+          _ ≤ (valueMajorant coefficient : ℝ) +
+              (rootBound : ℝ) * (state.1 : ℝ) :=
+            add_le_add hcoefficientNorm hproduct
+          _ = (state.1 * rootBound + valueMajorant coefficient : Nat) := by
+            norm_num
+            ring
+      refine ⟨?_, hnorm, ?_⟩
+      · exact DyadicComplexBall.add_mem hcoefficient
+          (DyadicComplexBall.mul_mem hz hvalue)
+      · have hradius := DyadicComplexBall.realRadius_horner_le
+          zBall ball (coefficient.approx rep h (prec : Int)).2
+          (rootBound : ℝ) (state.1 : ℝ) (state.2 : ℝ)
+          ((2 : ℝ) ^ (-(prec : Int)))
+          hz hvalue hcoefficient hzNorm hvalueNorm hzRadius hvalueRadius
+          hcoefficientRadius (by positivity) (by positivity) (by positivity)
+          hδ hδ1
+        simpa only [state, ball, Nat.cast_add, Nat.cast_mul, Nat.cast_ofNat,
+          Nat.cast_one] using hradius
+
+end QAdjoin.Roots
+
+namespace QAdjoin.Roots
+
+variable {p : ZPoly} {x : SimpleRoot p}
+
+/-- The certified fixed-field Horner evaluator has the radius promised by its
+executable error majorant. -/
+theorem evalBall?_radius [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) (candidate : AlgebraicRoot) (prec : Nat)
+    {ball : DyadicComplexBall}
+    (hrun : evalBall? f rep h candidate prec = some ball) :
+    ball.realRadius ≤ (evalMajorant f candidate.p : ℝ) *
+      (2 : ℝ) ^ (-(prec : Int)) := by
+  rw [evalBall?] at hrun
+  obtain ⟨candidate', hrefine, hrun⟩ := Option.bind_eq_some_iff.mp hrun
+  have hroot : candidate'.1.root = candidate.toComplex := by
+    calc
+      candidate'.1.root = candidate.rep.root :=
+        HexRootsMathlib.RefinedIsolation.refineTo_root candidate.rep
+          ((prec : Int) + 1) .nkThenPellet hrefine
+      _ = candidate.toComplex := by
+        unfold AlgebraicRoot.toComplex
+        rfl
+  have hz : candidate.toComplex ∈ candidate'.1.1.square.toBall.set := by
+    rw [← hroot]
+    exact DyadicComplexBall.mem_toBall
+      (HexRootsMathlib.RefinedIsolation.root_mem_closedDisc candidate'.1)
+  have hzNorm : ‖candidate.toComplex‖ ≤
+      (2 ^ cauchyExp candidate.p + 1 : Nat) :=
+    (AlgebraicRoot.norm_lt_rootBound candidate).le
+  have hzRadius : candidate'.1.1.square.toBall.realRadius ≤
+      (3 / 4 : ℝ) * (2 : ℝ) ^ (-(prec : Int)) := by
+    apply DyadicComplexBall.realRadius_toBall_le_three_quarters
+    exact RefinedIsolation.refineTo?_precision candidate.rep
+      ((prec : Int) + 1) .nkThenPellet hrefine
+  cases hback : f.toArray.back? with
+  | none =>
+      have hball : DyadicComplexBall.zero = ball := by
+        apply Option.some.inj
+        simpa [hback] using hrun
+      subst ball
+      simp [DyadicComplexBall.zero, DyadicComplexBall.realRadius]
+  | some top =>
+      have hball : f.toArray.foldr
+          (fun coefficient value =>
+            (coefficient.approx rep h (prec : Int)).2.add
+              (candidate'.1.1.square.toBall.mul value))
+          (top.approx rep h (prec : Int)).2
+          (start := f.toArray.size - 1) = ball := by
+        apply Option.some.inj
+        simpa [hback] using hrun
+      subst ball
+      obtain ⟨pre, hprefix⟩ := Array.back?_eq_some_iff.mp hback
+      have hlist : f.toArray.toList = pre.toList ++ [top] := by
+        rw [hprefix, Array.toList_push]
+      have hsize : f.toArray.size - 1 = pre.size := by
+        rw [hprefix]
+        simp
+      have hfold :
+          f.toArray.foldr
+              (fun coefficient value =>
+                (coefficient.approx rep h (prec : Int)).2.add
+                  (candidate'.1.1.square.toBall.mul value))
+              (top.approx rep h (prec : Int)).2
+              (start := f.toArray.size - 1) =
+            pre.toList.foldr
+              (fun coefficient value =>
+                (coefficient.approx rep h (prec : Int)).2.add
+                  (candidate'.1.1.square.toBall.mul value))
+              (top.approx rep h (prec : Int)).2 := by
+        rw [hsize, Array.foldr_eq_foldr_extract]
+        rw [hprefix, Array.extract_push_of_le (le_refl pre.size)]
+        simp
+      rw [hfold]
+      let rootBound := 2 ^ cauchyExp candidate.p + 1
+      let step := fun (coefficient : QAdjoin p x) (state : Nat × Nat) =>
+        (state.1 * rootBound + valueMajorant coefficient,
+          2 * state.1 + 2 * rootBound * state.2 + 3 * state.2 + 1)
+      let state := pre.toList.foldr step (valueMajorant top, 1)
+      have hbounds := hornerBall_bounds pre.toList rep h candidate.toComplex
+        candidate'.1.1.square.toBall prec rootBound
+        (toComplex top rep h) (top.approx rep h (prec : Int)).2
+        (valueMajorant top, 1) hz (by simpa only [rootBound] using hzNorm)
+        hzRadius (QAdjoin.approx_sound top rep h (prec : Int))
+        (QAdjoin.norm_toComplex_le_valueMajorant top rep h)
+        (by simpa using QAdjoin.approx_radius top rep h (prec : Int))
+      have hradius :
+          (pre.toList.foldr
+            (fun coefficient value =>
+              (coefficient.approx rep h (prec : Int)).2.add
+                (candidate'.1.1.square.toBall.mul value))
+            (top.approx rep h (prec : Int)).2).realRadius ≤
+              (state.2 : ℝ) * (2 : ℝ) ^ (-(prec : Int)) := by
+        simpa only [state, step, rootBound] using hbounds.2.2
+      have hstate : f.toArray.foldr step (0, 0) = state := by
+        rw [← Array.foldr_toList, hlist, List.foldr_append]
+        simp [state, step]
+      have hmajorant : state.2 ≤ evalMajorant f candidate.p := by
+        unfold evalMajorant Disambiguation.evalMajorant
+        dsimp only
+        rw [hstate]
+        exact Nat.le_max_right _ _
+      exact hradius.trans (mul_le_mul_of_nonneg_right
+        (by exact_mod_cast hmajorant) (by positivity))
+
+end QAdjoin.Roots
+
+/-- The executable radius predicate is its stated real inequality. -/
+theorem evalRadiusSmall_real {q : ZPoly} {radius : Dyadic}
+    (hsmall : evalRadiusSmall q radius) :
+    3 * (q.evalLowerDenom : ℝ) * HexRootsMathlib.Dyadic.toReal radius < 1 := by
+  unfold evalRadiusSmall at hsmall
+  have hdyadic :
+      (((3 * q.evalLowerDenom : Nat) : Dyadic) * radius) < 1 :=
+    of_decide_eq_true hsmall
+  have hreal := HexRootsMathlib.Dyadic.toReal_lt_toReal_iff.mpr hdyadic
+  have hcast : HexRootsMathlib.Dyadic.toReal
+      ((3 * q.evalLowerDenom : Nat) : Dyadic) =
+        ((3 * q.evalLowerDenom : Nat) : ℝ) := by
+    change HexRootsMathlib.Dyadic.toReal
+      (.ofInt (3 * q.evalLowerDenom : Nat)) = _
+    rw [HexRootsMathlib.Dyadic.toReal_ofInt]
+    norm_num
+  rw [HexRootsMathlib.Dyadic.toReal_mul, hcast,
+    HexRootsMathlib.Dyadic.toReal_one] at hreal
+  norm_num only [Nat.cast_mul, Nat.cast_ofNat] at hreal
+  exact hreal
+
+/-- The real radius inequality implies the executable radius predicate. -/
+theorem evalRadiusSmall_of_real {q : ZPoly} {radius : Dyadic}
+    (hsmall :
+      3 * (q.evalLowerDenom : ℝ) * HexRootsMathlib.Dyadic.toReal radius < 1) :
+    evalRadiusSmall q radius := by
+  unfold evalRadiusSmall
+  apply decide_eq_true
+  rw [← HexRootsMathlib.Dyadic.toReal_lt_toReal_iff]
+  rw [HexRootsMathlib.Dyadic.toReal_mul,
+    HexRootsMathlib.Dyadic.toReal_one]
+  have hcast : HexRootsMathlib.Dyadic.toReal
+      ((3 * q.evalLowerDenom : Nat) : Dyadic) =
+        ((3 * q.evalLowerDenom : Nat) : ℝ) := by
+    change HexRootsMathlib.Dyadic.toReal
+      (.ofInt (3 * q.evalLowerDenom : Nat)) = _
+    rw [HexRootsMathlib.Dyadic.toReal_ofInt]
+    norm_num
+  rw [hcast]
+  norm_num only [Nat.cast_mul, Nat.cast_ofNat]
+  exact hsmall
+
+/-- The prescribed endpoint has enough logarithmic slack: any ball whose
+radius is bounded by `max 1 majorant` ulps at that precision satisfies the
+zero-test radius predicate. -/
+theorem evalDisambiguationLimit_radius_small (q : ZPoly) (majorant : Nat)
+    (ball : DyadicComplexBall)
+    (hradius : ball.realRadius ≤
+      (Nat.max 1 majorant : ℝ) *
+        (2 : ℝ) ^ (-(evalDisambiguationLimit q majorant : Int))) :
+    evalRadiusSmall q ball.radius := by
+  let D := q.evalLowerDenom
+  let M := Nat.max 1 majorant
+  let C := Hex.ceilLog2 (2 * D * M)
+  have hD : 0 < D := by
+    dsimp [D]
+    unfold ZPoly.evalLowerDenom
+    omega
+  have hM : 0 < M := by
+    dsimp [M]
+    exact Nat.zero_lt_one.trans_le (Nat.le_max_left 1 majorant)
+  have hlimit : evalDisambiguationLimit q majorant = C + 2 := by
+    rfl
+  rw [hlimit] at hradius
+  have hceilNat : 2 * D * M ≤ 2 ^ C := by
+    exact HexRootsMathlib.le_two_pow_ceilLog2 (2 * D * M)
+  have hceil : (2 : ℝ) * D * M ≤ (2 : ℝ) ^ C := by
+    exact_mod_cast hceilNat
+  have hpowPos : 0 < (2 : ℝ) ^ C := by positivity
+  have hpowEq :
+      (2 : ℝ) ^ (-((C + 2 : Nat) : Int)) =
+        ((4 : ℝ) * (2 : ℝ) ^ C)⁻¹ := by
+    rw [zpow_neg, zpow_natCast, pow_add]
+    norm_num
+    ring
+  have hscaled :
+      3 * (D : ℝ) * (M : ℝ) *
+          (2 : ℝ) ^ (-((C + 2 : Nat) : Int)) ≤ 3 / 8 := by
+    rw [hpowEq, inv_eq_one_div]
+    have hden : 0 < (4 : ℝ) * (2 : ℝ) ^ C := by positivity
+    calc
+      3 * (D : ℝ) * (M : ℝ) * (1 / ((4 : ℝ) * (2 : ℝ) ^ C)) =
+          (3 * (D : ℝ) * (M : ℝ)) / ((4 : ℝ) * (2 : ℝ) ^ C) := by
+        rw [div_eq_mul_inv]
+        ring
+      _ ≤ 3 / 8 := by
+        apply (div_le_iff₀ hden).mpr
+        nlinarith
+  apply evalRadiusSmall_of_real
+  have hDreal : 0 ≤ (D : ℝ) := by positivity
+  calc
+    3 * (q.evalLowerDenom : ℝ) * ball.realRadius ≤
+        3 * (D : ℝ) *
+          ((M : ℝ) * (2 : ℝ) ^ (-((C + 2 : Nat) : Int))) := by
+      dsimp only [D, M] at hradius ⊢
+      exact mul_le_mul_of_nonneg_left hradius (by positivity)
+    _ = 3 * (D : ℝ) * (M : ℝ) *
+          (2 : ℝ) ^ (-((C + 2 : Nat) : Int)) := by ring
+    _ ≤ 3 / 8 := hscaled
+    _ < 1 := by norm_num
+
+/-- A successful bounded precision search exposes an available ball satisfying
+the requested radius predicate. -/
+theorem evalDisambiguationPrec_sound {q : ZPoly} {majorant prec : Nat}
+    {evalAt : Nat → Option DyadicComplexBall}
+    (hrun : evalDisambiguationPrec q majorant evalAt = some prec) :
+    ∃ ball, evalAt prec = some ball ∧ evalRadiusSmall q ball.radius := by
+  unfold evalDisambiguationPrec at hrun
+  obtain ⟨candidate, _hmem, hcandidate⟩ :=
+    List.exists_of_findSome?_eq_some hrun
+  cases hball : evalAt candidate with
+  | none => simp [hball] at hcandidate
+  | some ball =>
+      by_cases hsmall : evalRadiusSmall q ball.radius
+      · have hcand : candidate = prec := by
+          simpa [hball, hsmall] using hcandidate
+        subst prec
+        exact ⟨ball, hball, hsmall⟩
+      · simp [hball, hsmall] at hcandidate
+
+/-- The bounded search succeeds whenever its prescribed endpoint produces a
+ball satisfying the radius predicate. -/
+theorem evalDisambiguationPrec_isSome_of_endpoint (q : ZPoly) (majorant : Nat)
+    (evalAt : Nat → Option DyadicComplexBall) {ball : DyadicComplexBall}
+    (hball : evalAt (evalDisambiguationLimit q majorant) = some ball)
+    (hsmall : evalRadiusSmall q ball.radius) :
+    (evalDisambiguationPrec q majorant evalAt).isSome := by
+  unfold evalDisambiguationPrec
+  rw [List.findSome?_isSome_iff]
+  refine ⟨evalDisambiguationLimit q majorant, ?_, ?_⟩
+  · simp
+  · simp [hball, hsmall]
+
+namespace QAdjoin.Roots
+
+variable {p : ZPoly} {x : SimpleRoot p}
+
+private theorem evalBall_isSome [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) (candidate : AlgebraicRoot) (prec : Nat) :
+    (evalBall? f rep h candidate prec).isSome := by
+  obtain ⟨candidate', hrefine⟩ := Option.isSome_iff_exists.mp
+    (RefinedIsolation.refineTo?_isSome candidate.rep ((prec : Int) + 1))
+  rw [evalBall?, hrefine]
+  simp only
+  cases f.toArray.back? <;> simp
+
+/-- The prescribed bounded precision search succeeds for the fixed-field ball
+evaluator. -/
+theorem evalPrec_isSome [ZPoly.CheckedIrreducible p]
+    (q : ZPoly) (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) (candidate : AlgebraicRoot) :
+    (evalDisambiguationPrec q (evalMajorant f candidate.p)
+      (evalBall? f rep h candidate)).isSome := by
+  let limit := evalDisambiguationLimit q (evalMajorant f candidate.p)
+  obtain ⟨ball, hball⟩ := Option.isSome_iff_exists.mp
+    (evalBall_isSome f rep h candidate limit)
+  apply evalDisambiguationPrec_isSome_of_endpoint q
+    (evalMajorant f candidate.p) (evalBall? f rep h candidate) hball
+  apply evalDisambiguationLimit_radius_small q (evalMajorant f candidate.p) ball
+  have hmajorant : 1 ≤ evalMajorant f candidate.p := by
+    unfold evalMajorant Disambiguation.evalMajorant
+    exact Nat.le_max_left _ _
+  simpa only [limit, Nat.max_eq_right hmajorant] using
+    evalBall?_radius f rep h candidate limit hball
+
+/-- The bounded zero-retention test cannot fail for the fixed-field ball
+evaluator. -/
+theorem retainZero?_isSome [ZPoly.CheckedIrreducible p]
+    (q : ZPoly) (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) (candidate : AlgebraicRoot) :
+    (retainZero? q (evalMajorant f candidate.p)
+      (evalBall? f rep h candidate)).isSome := by
+  rw [retainZero?]
+  split
+  · simp
+  · obtain ⟨prec, hprec⟩ := Option.isSome_iff_exists.mp
+      (evalPrec_isSome q f rep h candidate)
+    rw [hprec]
+    obtain ⟨ball, hball⟩ := Option.isSome_iff_exists.mp
+      (evalBall_isSome f rep h candidate prec)
+    simp [hball]
+
+end QAdjoin.Roots
+
+/-- Conditional correctness of the bounded zero test. Whenever the search
+returns, it retains exactly the zero value represented by the eliminant root
+and the certified evaluation balls. -/
+theorem retainZero?_sound {q : ZPoly} {majorant : Nat}
+    {evalAt : Nat → Option DyadicComplexBall} {z : ℂ} {keep : Bool}
+    (hq : q ≠ 0) (hroot : (HexRootsMathlib.toPolyℂ q).IsRoot z)
+    (hsound : ∀ prec ball, evalAt prec = some ball → z ∈ ball.set)
+    (hrun : retainZero? q majorant evalAt = some keep) :
+    keep ↔ z = 0 := by
+  have hnormalize : q.normalizeEval ≠ 0 := ZPoly.normalizeEval_ne_zero hq
+  have hsize : 0 < q.normalizeEval.size := by
+    apply Nat.pos_of_ne_zero
+    intro hzero
+    exact hnormalize ((DensePoly.size_eq_zero_iff _).mp hzero)
+  have hisZero : q.normalizeEval.isZero = false :=
+    (DensePoly.isZero_eq_false_iff _).mpr hsize
+  rw [retainZero?, hisZero] at hrun
+  obtain ⟨prec, hprec, hrun⟩ := Option.bind_eq_some_iff.mp hrun
+  obtain ⟨ball, hball, hkeep⟩ := Option.bind_eq_some_iff.mp hrun
+  have hkeep' : (!ball.excludesZero) = keep := Option.some.inj hkeep
+  obtain ⟨searchBall, hsearchBall, hsmall⟩ :=
+    evalDisambiguationPrec_sound hprec
+  have hsbeq : searchBall = ball := by
+    rw [hball] at hsearchBall
+    exact (Option.some.inj hsearchBall).symm
+  subst searchBall
+  have hzmem : z ∈ ball.set := hsound prec ball hball
+  constructor
+  · intro hkeepTrue
+    by_contra hz
+    have hlower := ZPoly.normalizeEval_root_norm_lower hq hz hroot
+    have hsmallReal := evalRadiusSmall_real hsmall
+    have hexcludes := DyadicComplexBall.excludesZero_of_mem_of_lower
+      (show 0 < q.evalLowerDenom by unfold ZPoly.evalLowerDenom; omega)
+      hzmem hlower (by simpa [DyadicComplexBall.realRadius] using hsmallReal)
+    rw [← hkeep'] at hkeepTrue
+    simp [hexcludes] at hkeepTrue
+  · intro hz
+    subst z
+    have hnot : (!ball.excludesZero) = true := by
+      cases hexcludes : ball.excludesZero
+      · simp
+      · exact (DyadicComplexBall.excludesZero_sound hzmem hexcludes rfl).elim
+    exact hkeep'.symm.trans hnot
+
+end Hex

--- a/HexNumberFieldMathlib/Roots.lean
+++ b/HexNumberFieldMathlib/Roots.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexNumberFieldMathlib.AlgebraicPoly
+public import HexNumberFieldMathlib.RootDisambiguation
 public import Mathlib.Algebra.Polynomial.Div
 
 public section
@@ -20,6 +21,30 @@ normal-form contracts for both fixed-field and algebraic-coefficient drivers.
 -/
 
 namespace Hex
+
+@[implicit_reducible] local instance : CommRing ZPoly :=
+  let s := (inferInstance : Lean.Grind.CommRing ZPoly)
+  { s with
+    zero_add := Lean.Grind.AddCommMonoid.zero_add
+    right_distrib := Lean.Grind.Semiring.right_distrib
+    mul_zero := Lean.Grind.Semiring.mul_zero
+    one_mul := Lean.Grind.Semiring.one_mul
+    nsmul := nsmulRec
+    zsmul := zsmulRec
+    npow := npowRec
+    natCast := Nat.cast
+    natCast_zero := Lean.Grind.Semiring.natCast_zero
+    natCast_succ n := Lean.Grind.Semiring.natCast_succ n
+    intCast := Int.cast
+    intCast_ofNat := Lean.Grind.Ring.intCast_natCast
+    intCast_negSucc n := by
+      rw [Int.negSucc_eq, Lean.Grind.Ring.intCast_neg,
+        Lean.Grind.Ring.intCast_natCast_add_one,
+        Lean.Grind.Semiring.natCast_succ] }
+
+local instance : IsDomain ZPoly :=
+  MulEquiv.isDomain (Polynomial Int)
+    (HexPolyMathlib.equiv (R := Int)).toMulEquiv
 
 namespace RootSet
 
@@ -71,6 +96,26 @@ def totalMultiplicity : RootSet → Nat
 end RootSet
 
 namespace QAdjoin.Roots
+
+private theorem list_foldlM_isSome {A B : Type*} {step : B → A → Option B}
+    {items : List A} (init : B)
+    (hstep : ∀ state item, item ∈ items → (step state item).isSome) :
+    (items.foldlM step init).isSome := by
+  induction items generalizing init with
+  | nil => simp
+  | cons item items ih =>
+      obtain ⟨next, hnext⟩ := Option.isSome_iff_exists.mp
+        (hstep init item (by simp))
+      rw [List.foldlM_cons, hnext]
+      exact ih next fun state tail htail =>
+        hstep state tail (by simp [htail])
+
+private theorem array_foldlM_isSome {A B : Type*} {step : B → A → Option B}
+    {items : Array A} (init : B)
+    (hstep : ∀ state item, item ∈ items.toList → (step state item).isSome) :
+    (items.foldlM step init).isSome := by
+  rw [← Array.foldlM_toList]
+  exact list_foldlM_isSome init hstep
 
 private theorem transported_root {p q : ZPoly} (h : p = q)
     (rep : RefinedIsolation p) :
@@ -250,6 +295,106 @@ theorem evalBall?_isSome [ZPoly.CheckedIrreducible p]
   simp only
   cases f.toArray.back? <;> simp
 
+/-- Once the norm eliminant passes its normalization checks, component root
+isolation, refinement, exact evaluation, and bounded disambiguation are total. -/
+theorem componentRoots?_isSome [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (multiplicity : Nat)
+    (hMultiplicity : 0 < multiplicity) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x)
+    (hprim : ZPoly.content
+      (ZPoly.squareFreeCore (normEliminant f)) = 1)
+    (hpos : 0 <
+      (ZPoly.squareFreeCore (normEliminant f)).leadingCoeff)
+    (hdegree : 0 <
+      (ZPoly.squareFreeCore (normEliminant f)).degree?.getD 0)
+    (hsimple : HasOnlySimpleRoots
+      (ZPoly.squareFreeCore (normEliminant f))) :
+    (componentRoots? f multiplicity hMultiplicity rep h).isSome := by
+  let eliminant := ZPoly.squareFreeCore (normEliminant f)
+  change ZPoly.content eliminant = 1 at hprim
+  change 0 < eliminant.leadingCoeff at hpos
+  change 0 < eliminant.degree?.getD 0 at hdegree
+  change HasOnlySimpleRoots eliminant at hsimple
+  have heliminant : eliminant ≠ 0 := by
+    intro hzero
+    rw [hzero] at hdegree
+    simp at hdegree
+  unfold componentRoots?
+  dsimp only
+  rw [dif_pos hprim, dif_pos hpos, dif_pos hdegree, dif_pos hsimple]
+  have hisolateSome := HexRootsMathlib.isolate_isSome eliminant hsimple
+    heliminant (separationDepth eliminant : Int) .nkThenPellet
+  cases hisolate : isolate eliminant hsimple
+      (separationDepth eliminant : Int) with
+  | none => simp [hisolate] at hisolateSome
+  | some isolations =>
+      simp only [Option.bind_eq_bind, Option.bind_some]
+      have hmapSome := HexRootsMathlib.array_mapM_isSome
+        (xs := isolations) (f := DyadicRootIsolation.toRefined?)
+        (fun iso hiso => by
+          unfold DyadicRootIsolation.toRefined?
+          rw [dif_pos (HexRootsMathlib.isolate_refined eliminant hsimple
+            (separationDepth eliminant : Int) .nkThenPellet
+            hisolate iso hiso)]
+          rfl)
+      cases hmap : isolations.mapM DyadicRootIsolation.toRefined? with
+      | none => simp [hmap] at hmapSome
+      | some refined =>
+          simp only [Option.bind_some]
+          apply array_foldlM_isSome #[]
+          intro out candidateRep _hcandidateRep
+          let candidate : AlgebraicRoot :=
+            { p := eliminant
+              prim := hprim
+              pos_lc := hpos
+              pos_degree := hdegree
+              squarefree := hsimple
+              x := SimpleRoot.mk candidateRep
+              rep := candidateRep
+              rep_mk := rfl }
+          obtain ⟨evaluation, hevaluation⟩ := Option.isSome_iff_exists.mp
+            (evalRoot?_isSome f rep h candidate)
+          obtain ⟨keep, hkeep⟩ := Option.isSome_iff_exists.mp
+            (retainZero?_isSome evaluation.p f rep h candidate)
+          change (do
+            let evaluation ← evalRoot? f rep h candidate
+            let keep ← retainZero? evaluation.p
+              (evalMajorant f candidate.p) (evalBall? f rep h candidate)
+            if keep then
+              some (out.push
+                { root := candidate
+                  multiplicity
+                  multiplicity_pos := hMultiplicity })
+            else
+              some out).isSome
+          rw [hevaluation]
+          simp only [Option.bind_eq_bind, Option.bind_some]
+          rw [hkeep]
+          cases keep <;> simp
+
+/-- A nonzero norm eliminant with positive-degree square-free core supplies all
+normalization witnesses required by the component driver. -/
+theorem componentRoots?_total [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (multiplicity : Nat)
+    (hMultiplicity : 0 < multiplicity) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) (hnorm : normEliminant f ≠ 0)
+    (hdegree : 0 <
+      (ZPoly.squareFreeCore (normEliminant f)).degree?.getD 0) :
+    (componentRoots? f multiplicity hMultiplicity rep h).isSome := by
+  have hprim : ZPoly.content
+      (ZPoly.squareFreeCore (normEliminant f)) = 1 := by
+    simpa only [ZPoly.Primitive] using
+      ZPoly.squareFreeCore_primitive (normEliminant f) hnorm
+  have hpos : 0 <
+      (ZPoly.squareFreeCore (normEliminant f)).leadingCoeff :=
+    ZPoly.leadingCoeff_squareFreeCore_pos (normEliminant f) hnorm
+  have hsimple : HasOnlySimpleRoots
+      (ZPoly.squareFreeCore (normEliminant f)) := by
+    simpa only [HasOnlySimpleRoots] using
+      ZPoly.squareFreeRat_squareFreeCore (normEliminant f) hnorm
+  exact componentRoots?_isSome f multiplicity hMultiplicity rep h
+    hprim hpos hdegree hsimple
+
 private theorem mergeRootAux_isSome (candidate : RootCount) (index fuel : Nat)
     (roots : Array RootCount) :
     (mergeRootAux candidate index fuel roots).isSome := by
@@ -269,6 +414,52 @@ theorem mergeRoot_isSome (roots : Array RootCount) (candidate : RootCount) :
     (mergeRoot roots candidate).isSome := by
   exact mergeRootAux_isSome candidate 0 (roots.size + 1) roots
 
+/-- Folding semantic root merging over a finite candidate array cannot fail. -/
+theorem mergeRoots_isSome (roots candidates : Array RootCount) :
+    (candidates.foldlM mergeRoot roots).isSome := by
+  exact array_foldlM_isSome roots fun state candidate _ =>
+    mergeRoot_isSome state candidate
+
+private theorem yunAux_positive [ZPoly.CheckedIrreducible p]
+    (w repeated : DensePoly (QAdjoin p x)) (multiplicity fuel : Nat)
+    (out : Array (DensePoly (QAdjoin p x) × Nat))
+    (hMultiplicity : 0 < multiplicity)
+    (hOut : ∀ component ∈ out.toList,
+      0 < component.1.degree?.getD 0 ∧ 0 < component.2) :
+    ∀ component ∈ (yunAux w repeated multiplicity fuel out).toList,
+      0 < component.1.degree?.getD 0 ∧ 0 < component.2 := by
+  induction fuel generalizing w repeated multiplicity out with
+  | zero => simpa [yunAux] using hOut
+  | succ fuel ih =>
+      rw [yunAux]
+      split
+      · exact hOut
+      · dsimp only
+        split
+        · apply ih
+          · omega
+          · intro component hcomponent
+            rw [Array.toList_push, List.mem_append,
+              List.mem_singleton] at hcomponent
+            rcases hcomponent with hcomponent | rfl
+            · exact hOut component hcomponent
+            · exact ⟨by assumption, hMultiplicity⟩
+        · apply ih
+          · omega
+          · exact hOut
+
+/-- Every component emitted by the executable Yun loop has positive degree
+and positive multiplicity. -/
+theorem yun_positive [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (component)
+    (hcomponent : component ∈ (yun f).toList) :
+    0 < component.1.degree?.getD 0 ∧ 0 < component.2 := by
+  unfold yun at hcomponent
+  split at hcomponent
+  · simp at hcomponent
+  · exact yunAux_positive _ _ 1 (f.size + 1) #[] Nat.one_pos
+      (by simp) component hcomponent
+
 end QAdjoin.Roots
 
 namespace QAdjoin
@@ -276,6 +467,169 @@ namespace QAdjoin
 variable {p : ZPoly} {x : SimpleRoot p}
 
 open scoped QAdjoinField
+
+namespace Roots
+
+private theorem lcmFold_preserves (coefficients : List Rat) {d acc : Nat}
+    (hacc : d ∣ acc) :
+    d ∣ coefficients.foldl (fun den q => Nat.lcm den q.den) acc := by
+  induction coefficients generalizing acc with
+  | nil => exact hacc
+  | cons coefficient coefficients ih =>
+      simp only [List.foldl_cons]
+      exact ih (Nat.dvd_trans hacc
+        (Nat.dvd_lcm_left acc coefficient.den))
+
+private theorem lcmFold_dvd (coefficients : List Rat) {q : Rat} {acc : Nat}
+    (hq : q ∈ coefficients) :
+    q.den ∣ coefficients.foldl (fun den q => Nat.lcm den q.den) acc := by
+  induction coefficients generalizing acc with
+  | nil => cases hq
+  | cons coefficient coefficients ih =>
+      simp only [List.foldl_cons, List.mem_cons] at hq ⊢
+      rcases hq with rfl | hq
+      · exact lcmFold_preserves coefficients
+          (Nat.dvd_lcm_right acc q.den)
+      · exact ih hq
+
+private theorem lcmFold_pos (coefficients : List Rat) {acc : Nat}
+    (hacc : 0 < acc) :
+    0 < coefficients.foldl (fun den q => Nat.lcm den q.den) acc := by
+  induction coefficients generalizing acc with
+  | nil => exact hacc
+  | cons coefficient coefficients ih =>
+      simp only [List.foldl_cons]
+      exact ih (Nat.lcm_pos hacc coefficient.den_pos)
+
+private theorem nestedLcmFold_preserves
+    (coefficients : List (QAdjoin p x)) {d acc : Nat}
+    (hacc : d ∣ acc) :
+    d ∣ coefficients.foldl
+      (fun den a => a.coeffs.toList.foldl
+        (fun den q => Nat.lcm den q.den) den) acc := by
+  induction coefficients generalizing acc with
+  | nil => exact hacc
+  | cons coefficient coefficients ih =>
+      simp only [List.foldl_cons]
+      exact ih (lcmFold_preserves coefficient.coeffs.toList hacc)
+
+private theorem nestedLcmFold_dvd
+    (coefficients : List (QAdjoin p x)) {a : QAdjoin p x} {q : Rat}
+    {acc : Nat} (ha : a ∈ coefficients) (hq : q ∈ a.coeffs.toList) :
+    q.den ∣ coefficients.foldl
+      (fun den a => a.coeffs.toList.foldl
+        (fun den q => Nat.lcm den q.den) den) acc := by
+  induction coefficients generalizing acc with
+  | nil => cases ha
+  | cons coefficient coefficients ih =>
+      simp only [List.foldl_cons, List.mem_cons] at ha ⊢
+      rcases ha with rfl | ha
+      · exact nestedLcmFold_preserves coefficients
+          (lcmFold_dvd a.coeffs.toList hq)
+      · exact ih ha
+
+private theorem nestedLcmFold_pos
+    (coefficients : List (QAdjoin p x)) {acc : Nat}
+    (hacc : 0 < acc) :
+    0 < coefficients.foldl
+      (fun den a => a.coeffs.toList.foldl
+        (fun den q => Nat.lcm den q.den) den) acc := by
+  induction coefficients generalizing acc with
+  | nil => exact hacc
+  | cons coefficient coefficients ih =>
+      simp only [List.foldl_cons]
+      exact ih (lcmFold_pos coefficient.coeffs.toList hacc)
+
+/-- Every stored rational coordinate denominator divides the executable common
+denominator, including zero-extended coefficient reads. -/
+theorem coeffDen_dvd (f : DensePoly (QAdjoin p x)) (i j : Nat) :
+    ((f.coeff i).coeffs.coeff j).den ∣ commonDen f := by
+  by_cases hi : i < f.size
+  · have ha : f.coeff i ∈ f.toList := by
+      rw [DensePoly.toList_eq_coeff_range]
+      exact List.mem_map.mpr ⟨i, List.mem_range.mpr hi, rfl⟩
+    by_cases hj : j < (f.coeff i).coeffs.size
+    · have hq : (f.coeff i).coeffs.coeff j ∈ (f.coeff i).coeffs.toList := by
+        rw [DensePoly.toList_eq_coeff_range]
+        exact List.mem_map.mpr ⟨j, List.mem_range.mpr hj, rfl⟩
+      unfold commonDen
+      rw [← Array.foldl_toList]
+      simp only [← Array.foldl_toList]
+      exact nestedLcmFold_dvd f.toList ha hq
+    · rw [DensePoly.coeff_eq_zero_of_size_le _ (Nat.le_of_not_gt hj)]
+      change 1 ∣ commonDen f
+      exact one_dvd _
+  · rw [DensePoly.coeff_eq_zero_of_size_le f (Nat.le_of_not_gt hi)]
+    change 1 ∣ commonDen f
+    exact one_dvd _
+
+/-- The executable common denominator is positive. -/
+theorem commonDen_pos (f : DensePoly (QAdjoin p x)) :
+    0 < commonDen f := by
+  unfold commonDen
+  rw [← Array.foldl_toList]
+  simp only [← Array.foldl_toList]
+  change 0 < f.toList.foldl
+    (fun den a => a.coeffs.toList.foldl
+      (fun den q => Nat.lcm den q.den) den) 1
+  exact nestedLcmFold_pos f.toList Nat.one_pos
+
+/-- Clearing a rational coordinate against a divisible denominator has the
+expected value after embedding into `ℂ`. -/
+theorem clearRat_cast (den : Nat) (q : Rat) (hden : q.den ∣ den) :
+    (clearRat den q : ℂ) = (den : ℂ) * (q : ℂ) := by
+  have hrat : ((clearRat den q : Int) : Rat) = (den : Rat) * q := by
+    rcases hden with ⟨k, rfl⟩
+    unfold clearRat
+    rw [Nat.mul_div_right _ q.den_pos]
+    have hden_ne : ((q.den : Nat) : Rat) ≠ 0 := by
+      simp [q.den_nz]
+    have hq : ((q.num : Rat) / (q.den : Rat)) = q := by
+      simpa [Rat.divInt_eq_div, Rat.intCast_natCast] using q.num_divInt_den
+    calc
+      ((q.num * Int.ofNat k : Int) : Rat) =
+          (q.num : Rat) * (k : Rat) := by
+        rw [Rat.intCast_mul, Int.ofNat_eq_natCast, Rat.intCast_natCast]
+      _ = ((q.num : Rat) * (k : Rat) * (q.den : Rat)) /
+          (q.den : Rat) := by
+        exact (Rat.mul_div_cancel hden_ne).symm
+      _ = ((q.den * k : Nat) : Rat) *
+          ((q.num : Rat) / (q.den : Rat)) := by
+        grind [Rat.div_def, Rat.mul_assoc, Rat.mul_comm]
+      _ = ((q.den * k : Nat) : Rat) * q := by rw [hq]
+  exact_mod_cast hrat
+
+/-- The rectangular coefficient array used for the bivariate lift stores the
+cleared coordinate at the corresponding outer and polynomial indices. -/
+theorem coeff_clearedOuter (f : DensePoly (QAdjoin p x))
+    {i j : Nat} (hi : i < f.size) (hj : j < p.degree?.getD 0) :
+    ((clearedOuter f).coeff j).coeff i =
+      clearRat (commonDen f) ((f.coeff i).coeffs.coeff j) := by
+  unfold clearedOuter
+  simp [DensePoly.coeff_ofCoeffs, hi, hj]
+
+private theorem coeff_clearedOuter_eq (f : DensePoly (QAdjoin p x))
+    {j : Nat} (hj : j < p.degree?.getD 0) :
+    (clearedOuter f).coeff j = DensePoly.ofCoeffs
+      ((List.range f.size).map fun i =>
+        clearRat (commonDen f) ((f.coeff i).coeffs.coeff j)).toArray := by
+  unfold clearedOuter
+  simp [DensePoly.coeff_ofCoeffs, hj]
+
+private theorem natDegree_toPolynomial_lt {R : Type*}
+    [Semiring R] [DecidableEq R] (q : DensePoly R) {bound : Nat}
+    (hbound : q.size ≤ bound) (hpos : 0 < bound) :
+    (HexPolyMathlib.toPolynomial q).natDegree < bound := by
+  rw [HexPolyMathlib.natDegree_toPolynomial]
+  by_cases hzero : q.size = 0
+  · rw [(DensePoly.degree?_eq_none_iff q).2 hzero]
+    simp only [Option.getD_none]
+    exact hpos
+  · rw [DensePoly.degree?_eq_some_of_pos_size q (Nat.pos_of_ne_zero hzero),
+      Option.getD_some]
+    omega
+
+end Roots
 
 /-- Interpret a fixed-field dense polynomial at the selected embedding. -/
 @[expose]
@@ -362,7 +716,368 @@ theorem natDegree_toPolynomialAt [ZPoly.CheckedIrreducible p]
       (QAdjoin.embedding_injective rep h),
     HexPolyMathlib.natDegree_toPolynomial]
 
+private theorem definingPolynomial_isRoot [ZPoly.CheckedIrreducible p]
+    {y : ℂ} (hy : (HexRootsMathlib.toPolyℂ p).eval y = 0) :
+    (definingPolynomial p).eval₂ (algebraMap Rat ℂ) y = 0 := by
+  have hp : (HexPolyZMathlib.toPolyℚ p).eval₂
+      (algebraMap Rat ℂ) y = 0 := by
+    rw [Polynomial.eval₂_eq_eval_map]
+    have hcomp :
+        (algebraMap Rat ℂ).comp (Int.castRingHom Rat) =
+          Int.castRingHom ℂ := RingHom.ext_int _ _
+    rw [show (HexPolyZMathlib.toPolyℚ p).map (algebraMap Rat ℂ) =
+        HexRootsMathlib.toPolyℂ p by
+      dsimp [HexPolyZMathlib.toPolyℚ, HexRootsMathlib.toPolyℂ]
+      rw [Polynomial.map_map, hcomp]]
+    exact hy
+  rw [definingPolynomial, Polynomial.eval₂_smul, hp, mul_zero]
+
+private noncomputable def conjugateEmbedding [ZPoly.CheckedIrreducible p]
+    (y : ℂ) (hy : (HexRootsMathlib.toPolyℂ p).eval y = 0) :
+    QAdjoin p x →+* ℂ :=
+  (AdjoinRoot.lift (algebraMap Rat ℂ) y
+    (definingPolynomial_isRoot hy)).comp toAdjoinRootHom
+
+private theorem conjugateEmbedding_apply [ZPoly.CheckedIrreducible p]
+    (a : QAdjoin p x) (y : ℂ)
+    (hy : (HexRootsMathlib.toPolyℂ p).eval y = 0) :
+    conjugateEmbedding y hy a =
+      (HexPolyMathlib.toPolynomial a.coeffs).eval₂
+        (algebraMap Rat ℂ) y := by
+  unfold conjugateEmbedding
+  change AdjoinRoot.lift (algebraMap Rat ℂ) y
+      (definingPolynomial_isRoot hy) (toAdjoinRoot a) = _
+  unfold toAdjoinRoot
+  rw [AdjoinRoot.lift_mk]
+
+private theorem conjugateEmbedding_injective [ZPoly.CheckedIrreducible p]
+    (y : ℂ) (hy : (HexRootsMathlib.toPolyℂ p).eval y = 0) :
+    Function.Injective (conjugateEmbedding (x := x) y hy) := by
+  letI : Fact (_root_.Irreducible (definingPolynomial p)) :=
+    ⟨definingPolynomial_irreducible p⟩
+  exact (AdjoinRoot.lift (algebraMap Rat ℂ) y
+    (definingPolynomial_isRoot hy)).injective.comp
+      toAdjoinRoot_bijective.1
+
 namespace Roots
+
+private theorem clearedOuter_evalAt [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (y t : ℂ)
+    (hy : (HexRootsMathlib.toPolyℂ p).eval y = 0)
+    (hf : 0 < f.size) :
+    ((HexPolyMathlib.toPolynomial (clearedOuter f)).map
+      ((Polynomial.eval₂RingHom (Int.castRingHom ℂ) t).comp
+        (HexPolyMathlib.equiv (R := Int)).toRingHom)).eval y =
+      (commonDen f : ℂ) *
+        Polynomial.eval t ((HexPolyMathlib.toPolynomial f).map
+          (conjugateEmbedding y hy)) := by
+  let d := p.degree?.getD 0
+  let den := commonDen f
+  let ε : ZPoly →+* ℂ :=
+    (Polynomial.eval₂RingHom (Int.castRingHom ℂ) t).comp
+      (HexPolyMathlib.equiv (R := Int)).toRingHom
+  have hd : 0 < d := ZPoly.CheckedIrreducible.pos_degree
+  have houterSize : (clearedOuter f).size ≤ d := by
+    unfold clearedOuter
+    exact (DensePoly.size_ofCoeffs_le _).trans (by simp [d])
+  have houterDeg :
+      (HexPolyMathlib.toPolynomial (clearedOuter f)).natDegree < d :=
+    natDegree_toPolynomial_lt _ houterSize hd
+  have hinnerDeg (j : Nat) (hj : j < d) :
+      (HexPolyMathlib.toPolynomial ((clearedOuter f).coeff j)).natDegree <
+        f.size := by
+    rw [coeff_clearedOuter_eq f hj]
+    apply natDegree_toPolynomial_lt
+    · exact (DensePoly.size_ofCoeffs_le _).trans (by simp)
+    · exact hf
+  have hpolyDeg :
+      ((HexPolyMathlib.toPolynomial f).map
+        (conjugateEmbedding y hy)).natDegree < f.size := by
+    rw [Polynomial.natDegree_map_eq_of_injective
+        (conjugateEmbedding_injective y hy),
+      HexPolyMathlib.natDegree_toPolynomial,
+      DensePoly.degree?_eq_some_of_pos_size f hf, Option.getD_some]
+    omega
+  have hcoordSize (i : Nat) : (f.coeff i).coeffs.size ≤ d := by
+    by_cases hzero : (f.coeff i).coeffs.size = 0
+    · simp [hzero]
+    · have hdegree := (f.coeff i).degree_lt
+      rw [DensePoly.degree?_eq_some_of_pos_size _
+        (Nat.pos_of_ne_zero hzero), Option.getD_some] at hdegree
+      omega
+  have hcoordDeg (i : Nat) :
+      (HexPolyMathlib.toPolynomial (f.coeff i).coeffs).natDegree < d :=
+    natDegree_toPolynomial_lt _ (hcoordSize i) hd
+  have hcoefficient (j : Nat) (hj : j < d) :
+      ε ((clearedOuter f).coeff j) =
+        ∑ i ∈ Finset.range f.size,
+          (den : ℂ) * ((f.coeff i).coeffs.coeff j : ℂ) * t ^ i := by
+    change (HexPolyMathlib.toPolynomial ((clearedOuter f).coeff j)).eval₂
+        (Int.castRingHom ℂ) t = _
+    rw [Polynomial.eval₂_eq_sum_range' (Int.castRingHom ℂ)
+      (hinnerDeg j hj) t]
+    apply Finset.sum_congr rfl
+    intro i hi
+    have hi' : i < f.size := Finset.mem_range.mp hi
+    rw [HexPolyMathlib.coeff_toPolynomial,
+      coeff_clearedOuter f hi' hj]
+    change (clearRat (commonDen f) ((f.coeff i).coeffs.coeff j) : ℂ) *
+        t ^ i = (den : ℂ) * ((f.coeff i).coeffs.coeff j : ℂ) * t ^ i
+    rw [clearRat_cast (commonDen f) _ (coeffDen_dvd f i j)]
+  have hcoordinate (i : Nat) :
+      conjugateEmbedding y hy (f.coeff i) =
+        ∑ j ∈ Finset.range d,
+          ((f.coeff i).coeffs.coeff j : ℂ) * y ^ j := by
+    rw [conjugateEmbedding_apply]
+    rw [Polynomial.eval₂_eq_sum_range' (algebraMap Rat ℂ)
+      (hcoordDeg i) y]
+    apply Finset.sum_congr rfl
+    intro j hj
+    rw [HexPolyMathlib.coeff_toPolynomial]
+    rfl
+  rw [Polynomial.eval_map]
+  change (HexPolyMathlib.toPolynomial (clearedOuter f)).eval₂ ε y = _
+  rw [Polynomial.eval₂_eq_sum_range' ε houterDeg y,
+    Polynomial.eval_eq_sum_range' hpolyDeg t]
+  have hleft :
+      (∑ j ∈ Finset.range d,
+        ε ((HexPolyMathlib.toPolynomial (clearedOuter f)).coeff j) *
+          y ^ j) =
+        ∑ j ∈ Finset.range d,
+          (∑ i ∈ Finset.range f.size,
+            (den : ℂ) * ((f.coeff i).coeffs.coeff j : ℂ) * t ^ i) *
+              y ^ j := by
+    apply Finset.sum_congr rfl
+    intro j hj
+    rw [HexPolyMathlib.coeff_toPolynomial,
+      hcoefficient j (Finset.mem_range.mp hj)]
+  have hright :
+      (∑ i ∈ Finset.range f.size,
+        (((HexPolyMathlib.toPolynomial f).map
+          (conjugateEmbedding y hy)).coeff i) * t ^ i) =
+        ∑ i ∈ Finset.range f.size,
+          (∑ j ∈ Finset.range d,
+            ((f.coeff i).coeffs.coeff j : ℂ) * y ^ j) * t ^ i := by
+    apply Finset.sum_congr rfl
+    intro i hi
+    rw [Polynomial.coeff_map, HexPolyMathlib.coeff_toPolynomial, hcoordinate]
+  rw [hleft, hright]
+  simp only [Finset.sum_mul, Finset.mul_sum]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro i hi
+  apply Finset.sum_congr rfl
+  intro j hj
+  ring
+
+/-- The integer bivariate lift specializes at the selected generator to the
+fixed-field polynomial, scaled by its positive common denominator. -/
+theorem clearedOuter_eval [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) (t : ℂ) (hf : 0 < f.size) :
+    ((HexPolyMathlib.toPolynomial (clearedOuter f)).map
+      ((Polynomial.eval₂RingHom (Int.castRingHom ℂ) t).comp
+        (HexPolyMathlib.equiv (R := Int)).toRingHom)).eval rep.root =
+      (commonDen f : ℂ) *
+        Polynomial.eval t (QAdjoin.toPolynomialAt f rep h) := by
+  have hy : (HexRootsMathlib.toPolyℂ p).eval rep.root = 0 :=
+    HexRootsMathlib.RefinedIsolation.isRoot rep
+  have hemb : conjugateEmbedding (x := x) rep.root hy = embedding rep h := by
+    ext a
+    rw [conjugateEmbedding_apply, embedding_apply]
+    rfl
+  rw [clearedOuter_evalAt f rep.root t hy hf, hemb,
+    ← toPolynomialAt_eq_map]
+
+/-- Every root at the selected fixed-field embedding is a root of the integer
+norm eliminant. -/
+theorem normEliminant_isRoot [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) (t : ℂ) (hf : !f.isZero)
+    (hroot : Polynomial.eval t (QAdjoin.toPolynomialAt f rep h) = 0) :
+    (HexRootsMathlib.toPolyℂ (normEliminant f)).eval t = 0 := by
+  have hfFalse : f.isZero = false := by
+    simpa using hf
+  have hfpos : 0 < f.size :=
+    (DensePoly.isZero_eq_false_iff f).1 hfFalse
+  have hpSize : 1 < p.liftOuter.size := by
+    have hpRaw : p ≠ 0 :=
+      HexRootsMathlib.RefinedIsolation.poly_ne_zero rep
+    have hpPos : 0 < p.size := by
+      apply Nat.pos_of_ne_zero
+      intro hpZero
+      exact hpRaw ((DensePoly.size_eq_zero_iff p).mp hpZero)
+    have hpDegree : p.degree?.getD 0 = p.size - 1 := by
+      rw [DensePoly.degree?_eq_some_of_pos_size p hpPos, Option.getD_some]
+    have hpDegreePos := ZPoly.CheckedIrreducible.pos_degree (p := p)
+    have hcoeff : p.liftOuter.coeff (p.size - 1) ≠ 0 := by
+      rw [ZPoly.coeff_liftOuter]
+      intro hzero
+      have hconst := congrArg (fun q : ZPoly => q.coeff 0) hzero
+      simp at hconst
+      exact DensePoly.coeff_last_ne_zero_of_pos_size p hpPos hconst
+    have hlift : p.size - 1 < p.liftOuter.size := by
+      by_contra hnot
+      exact hcoeff (DensePoly.coeff_eq_zero_of_size_le _ (by omega))
+    omega
+  unfold normEliminant
+  apply resultant_isRoot p.liftOuter (clearedOuter f) t rep.root
+    (Or.inl hpSize)
+  · rw [ZPoly.eval_liftOuter]
+    exact HexRootsMathlib.RefinedIsolation.isRoot rep
+  · rw [clearedOuter_eval f rep h t hfpos, hroot, mul_zero]
+
+/-- The integer norm eliminant of a nonzero fixed-field polynomial is
+nonzero. -/
+theorem normEliminant_ne_zero [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (hf : !f.isZero) :
+    normEliminant f ≠ 0 := by
+  let P := HexRootsMathlib.toPolyℂ p
+  let Q := HexPolyMathlib.toPolynomial f
+  have hfFalse : f.isZero = false := by
+    simpa using hf
+  have hfpos : 0 < f.size :=
+    (DensePoly.isZero_eq_false_iff f).1 hfFalse
+  have hfne : f ≠ 0 := by
+    intro hzero
+    subst f
+    simp at hfpos
+  have hQne : Q ≠ 0 := by
+    intro hzero
+    apply hfne
+    apply (HexPolyMathlib.equiv (R := QAdjoin p x)).injective
+    simpa only [HexPolyMathlib.equiv_apply,
+      HexPolyMathlib.toPolynomial_zero] using hzero
+  have hpSize : p.size ≠ 0 := by
+    intro hzero
+    have hdegree := ZPoly.CheckedIrreducible.pos_degree (p := p)
+    rw [(DensePoly.degree?_eq_none_iff p).2 hzero] at hdegree
+    simp at hdegree
+  have hPne : P ≠ 0 := by
+    exact HexRootsMathlib.toPolyℂ_ne_zero p hpSize
+  letI : Fintype (P.rootSet ℂ) :=
+    (Polynomial.rootSet_finite P ℂ).fintype
+  let H (y : P.rootSet ℂ) : Polynomial ℂ :=
+    Q.map (conjugateEmbedding y.1 (by
+      apply (Polynomial.mem_rootSet_of_ne hPne).1
+      simp [P, y.2]))
+  have hHne (y : P.rootSet ℂ) : H y ≠ 0 := by
+    unfold H
+    apply (Polynomial.map_ne_zero_iff
+      (conjugateEmbedding_injective y.1 _)).2
+    exact hQne
+  let bad : Set ℂ := ⋃ y : P.rootSet ℂ, (H y).rootSet ℂ
+  have hbad : bad.Finite := by
+    simpa only [bad] using
+      Set.finite_iUnion fun y : P.rootSet ℂ =>
+        Polynomial.rootSet_finite (H y) ℂ
+  obtain ⟨t, ht⟩ := hbad.exists_notMem
+  have htH (y : P.rootSet ℂ) : (H y).eval t ≠ 0 := by
+    intro hroot
+    apply ht
+    apply Set.mem_iUnion_of_mem y
+    exact (Polynomial.mem_rootSet_of_ne (hHne y)).2 hroot
+  let ε : ZPoly →+* ℂ :=
+    (Polynomial.eval₂RingHom (Int.castRingHom ℂ) t).comp
+      (HexPolyMathlib.equiv (R := Int)).toRingHom
+  let G := (HexPolyMathlib.toPolynomial (clearedOuter f)).map ε
+  have hGnonroot (y : ℂ) (hy : P.eval y = 0) : G.eval y ≠ 0 := by
+    have hyMem : y ∈ P.rootSet ℂ :=
+      (Polynomial.mem_rootSet_of_ne hPne).2 hy
+    let yRoot : P.rootSet ℂ := ⟨y, hyMem⟩
+    have heval := clearedOuter_evalAt (x := x) f y t
+      (by simpa [P] using hy) hfpos
+    have hden : (commonDen f : ℂ) ≠ 0 := by
+      exact_mod_cast (Nat.ne_of_gt (commonDen_pos f))
+    intro hzero
+    have hproduct : (commonDen f : ℂ) * (H yRoot).eval t = 0 := by
+      rw [← heval]
+      simpa [G, ε, H, Q, yRoot]
+    exact (mul_ne_zero hden (htH yRoot)) hproduct
+  have hcoprime : IsCoprime P G := by
+    apply (Polynomial.isCoprime_iff_aeval_ne_zero_of_isAlgClosed
+      (k := ℂ) ℂ P G).2
+    intro y
+    by_contra hboth
+    push Not at hboth
+    exact hGnonroot y (by
+      simpa [Polynomial.aeval_def] using hboth.1) (by
+      simpa [Polynomial.aeval_def] using hboth.2)
+  have hresultant : Polynomial.resultant P G ≠ 0 :=
+    Polynomial.resultant_ne_zero P G hcoprime
+  let m := p.liftOuter.degree?.getD 0
+  let n := (clearedOuter f).degree?.getD 0
+  have hm : m = P.natDegree := by
+    calc
+      m = (HexPolyMathlib.toPolynomial p.liftOuter).natDegree := by
+        simp [m, HexPolyMathlib.natDegree_toPolynomial]
+      _ = p.degree?.getD 0 := ZPoly.natDegree_liftOuter p
+      _ = P.natDegree := by
+        simp [P]
+  have hn : G.natDegree ≤ n := by
+    dsimp only [G, n]
+    rw [← HexPolyMathlib.natDegree_toPolynomial]
+    exact Polynomial.natDegree_map_le
+  have hnEq : n = G.natDegree + (n - G.natDegree) := by omega
+  have hformal : Polynomial.resultant P G m n ≠ 0 := by
+    rw [hm, hnEq, Polynomial.resultant_add_right_deg P G
+      P.natDegree G.natDegree (n - G.natDegree) le_rfl,
+      Polynomial.coeff_natDegree]
+    exact mul_ne_zero
+      (_root_.pow_ne_zero _ (Polynomial.leadingCoeff_ne_zero.mpr hPne)) hresultant
+  intro hzero
+  have hcorrespondence := congrArg ε
+    (DensePoly.toPolynomial_resultant p.liftOuter (clearedOuter f))
+  rw [← Polynomial.resultant_map_map] at hcorrespondence
+  have hleft : ε (DensePoly.resultant p.liftOuter (clearedOuter f)) = 0 := by
+    simpa [normEliminant] using congrArg ε hzero
+  rw [hleft, ZPoly.map_liftOuterAt, show
+      (HexPolyMathlib.toPolynomial (clearedOuter f)).map ε = G by rfl]
+      at hcorrespondence
+  apply hformal
+  simpa [m, n] using hcorrespondence.symm
+
+/-- Every positive-degree fixed-field component satisfies the normalization
+conditions needed by the component root driver. -/
+theorem componentRoots?_total_of_degree [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (multiplicity : Nat)
+    (hMultiplicity : 0 < multiplicity) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) (hdegree : 0 < f.degree?.getD 0) :
+    (componentRoots? f multiplicity hMultiplicity rep h).isSome := by
+  have hfpos : 0 < f.size := by
+    by_contra hsize
+    have hzero : f.size = 0 := by omega
+    rw [(DensePoly.degree?_eq_none_iff f).2 hzero] at hdegree
+    simp at hdegree
+  have hfFalse : f.isZero = false :=
+    (DensePoly.isZero_eq_false_iff f).2 hfpos
+  have hf : !f.isZero := by simp [hfFalse]
+  have hnorm : normEliminant f ≠ 0 := normEliminant_ne_zero f hf
+  have hsemanticDegree :
+      0 < (QAdjoin.toPolynomialAt f rep h).natDegree := by
+    rw [natDegree_toPolynomialAt f rep h hf]
+    exact hdegree
+  obtain ⟨z, hz⟩ := Complex.exists_root
+    (Polynomial.natDegree_pos_iff_degree_pos.mp hsemanticDegree)
+  have hnormRoot :
+      (HexRootsMathlib.toPolyℂ (normEliminant f)).IsRoot z :=
+    normEliminant_isRoot f rep h z hf hz
+  have hcoreRoot :
+      (HexRootsMathlib.toPolyℂ
+        (ZPoly.squareFreeCore (normEliminant f))).IsRoot z :=
+    HexPolyZMathlib.isRoot_squareFreeCore hnorm hnormRoot
+  have hcoreNe : ZPoly.squareFreeCore (normEliminant f) ≠ 0 :=
+    ZPoly.squareFreeCore_ne_zero (normEliminant f) hnorm
+  have hcoreSize : (ZPoly.squareFreeCore (normEliminant f)).size ≠ 0 := by
+    intro hsize
+    exact hcoreNe ((DensePoly.size_eq_zero_iff _).mp hsize)
+  have hcoreDegree : 0 <
+      (ZPoly.squareFreeCore (normEliminant f)).degree?.getD 0 := by
+    by_contra hnot
+    exact HexRootsMathlib.not_isRoot_of_degree_not_pos
+      (ZPoly.squareFreeCore (normEliminant f)) hcoreSize hnot z hcoreRoot
+  exact componentRoots?_total f multiplicity hMultiplicity rep h
+    hnorm hcoreDegree
 
 private theorem eval_hornerAt (coefficients : List (QAdjoin p x))
     (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x) (z : ℂ) :
@@ -545,6 +1260,26 @@ theorem evalBall?_sound [ZPoly.CheckedIrreducible p]
         prec (QAdjoin.toComplex top rep h) hz
         (QAdjoin.approx_sound top rep h prec)
 
+/-- Bounded disambiguation after exact lazy evaluation retains precisely the
+candidates at which the fixed-field polynomial vanishes. -/
+theorem retainZero?_correct [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) (candidate evaluation : AlgebraicRoot)
+    {keep : Bool} (hevaluation : evalRoot? f rep h candidate = some evaluation)
+    (hkeep : retainZero? evaluation.p (evalMajorant f candidate.p)
+      (evalBall? f rep h candidate) = some keep) :
+    keep ↔ Polynomial.eval candidate.toComplex
+      (QAdjoin.toPolynomialAt f rep h) = 0 := by
+  have hevalEq := evalRoot?_sound f rep h candidate hevaluation
+  have hretain := Hex.retainZero?_sound
+    (HexRootsMathlib.RefinedIsolation.poly_ne_zero evaluation.rep)
+    (AlgebraicRoot.toComplex_isRoot evaluation)
+    (fun prec ball hball => by
+      rw [hevalEq]
+      exact evalBall?_sound f rep h candidate prec hball)
+    hkeep
+  simpa only [hevalEq] using hretain
+
 end Roots
 
 /-- The fixed-field root driver always produces a checked root set. -/
@@ -552,7 +1287,75 @@ theorem roots?_isSome [ZPoly.CheckedIrreducible p]
     (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
     (h : SimpleRoot.mk rep = x) :
     (QAdjoin.roots? f rep h).isSome := by
-  sorry
+  rw [QAdjoin.roots?]
+  split
+  · simp
+  split
+  · simp
+  · have hfold : ((Roots.yun f).foldlM
+        (fun out component =>
+          if hm : 0 < component.2 then do
+            let found ← Roots.componentRoots? component.1 component.2 hm rep h
+            found.foldlM Roots.mergeRoot out
+          else
+            none)
+        #[]).isSome := by
+      apply Roots.array_foldlM_isSome #[]
+      intro out component hcomponent
+      obtain ⟨hdegree, hMultiplicity⟩ :=
+        Roots.yun_positive f component hcomponent
+      rw [dif_pos hMultiplicity]
+      obtain ⟨found, hfound⟩ := Option.isSome_iff_exists.mp
+        (Roots.componentRoots?_total_of_degree component.1 component.2
+          hMultiplicity rep h hdegree)
+      rw [hfound]
+      exact Roots.mergeRoots_isSome out found
+    obtain ⟨roots, hroots⟩ := Option.isSome_iff_exists.mp hfold
+    apply Option.isSome_iff_exists.mpr
+    refine ⟨.finite (roots.qsort Roots.rootLe), ?_⟩
+    rw [show (Roots.yun f).foldlM
+        (fun out component =>
+          if hm : 0 < component.2 then do
+            let found ← Roots.componentRoots? component.1 component.2 hm rep h
+            found.foldlM Roots.mergeRoot out
+          else
+            none)
+        #[] = some roots by
+      convert hroots]
+    rfl
+
+/-- The total fixed-field root API is exactly the output of its now-proved
+total checked driver. -/
+theorem roots?_eq_roots [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) :
+    QAdjoin.roots? f rep h = some (QAdjoin.roots f rep h) := by
+  unfold QAdjoin.roots
+  cases hrun : QAdjoin.roots? f rep h with
+  | none =>
+      have hsome := roots?_isSome f rep h
+      simp [hrun] at hsome
+  | some roots => simp
+
+private theorem roots?_all_iff_isZero [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) :
+    QAdjoin.roots? f rep h = some .all ↔ f.isZero := by
+  rw [QAdjoin.roots?]
+  split
+  · simp_all
+  split
+  · simp_all
+  · rename_i hzero hdegree
+    simp only [hzero, Option.bind_eq_bind]
+    cases hfold : (Roots.yun f).foldlM
+        (fun out component =>
+          if hm : 0 < component.2 then do
+            let found ← Roots.componentRoots? component.1 component.2 hm rep h
+            found.foldlM Roots.mergeRoot out
+          else
+            none)
+        #[] <;> simp
 
 /-- The fixed-field driver returns `.all` exactly for the zero polynomial. -/
 theorem roots_all_iff [ZPoly.CheckedIrreducible p]
@@ -560,7 +1363,9 @@ theorem roots_all_iff [ZPoly.CheckedIrreducible p]
     (h : SimpleRoot.mk rep = x) :
     QAdjoin.roots f rep h = RootSet.all ↔
       QAdjoin.toPolynomialAt f rep h = 0 := by
-  sorry
+  rw [← QAdjoin.poly_isZero_iff f rep h,
+    ← roots?_all_iff_isZero f rep h, roots?_eq_roots]
+  simp
 
 /-- Semantic membership in the fixed-field output is exactly polynomial
 vanishing. -/

--- a/progress/20260802T124536Z_number-field-fixed-root-totality.md
+++ b/progress/20260802T124536Z_number-field-fixed-root-totality.md
@@ -1,0 +1,32 @@
+# Number-field fixed-root totality
+
+## Accomplished
+
+- Proved the coefficient-height and ball-radius bounds used by bounded root
+  disambiguation, including totality and soundness of the fixed-field evaluator.
+- Proved common-denominator clearing and conjugate-specialization identities for
+  the bivariate norm construction.
+- Proved that the norm eliminant of a nonzero fixed-field polynomial is nonzero
+  by avoiding the finitely many roots across all conjugate embeddings and using
+  the executable/Mathlib resultant correspondence.
+- Proved positive-degree component normalization, component-driver totality,
+  Yun output positivity, merge totality, and totality of `QAdjoin.roots?`.
+- Proved that `QAdjoin.roots` is exactly the successful checked output and that
+  it returns `.all` exactly for the zero semantic polynomial.
+- Verified `lake build` and `lake build HexConformance`.
+
+## Current frontier
+
+The fixed-field driver has no remaining operational failure path. The remaining
+fixed-field root theorems concern semantic membership, multiplicity transfer,
+duplicate elimination, ordering, and total multiplicity.
+
+## Next step
+
+Develop the Yun semantic invariant and component candidate completeness, then
+lift those results through merge and sorting to close the remaining fixed-field
+root contracts before reusing them for `AlgebraicPoly`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Summary

- prove the bounded ball-evaluation and disambiguation bounds used by fixed-field root filtering
- establish denominator clearing, conjugate specialization, and nonvanishing of the integer norm eliminant
- prove component/Yun/merge totality and close `QAdjoin.roots?_isSome`
- identify the total wrapper with the checked output and prove the fixed-field zero/`.all` contract

This is intentionally one cohesive PR for the fixed-root totality stage rather than a fan-out of small dependent PRs. It introduces no new `sorry`, `axiom`, or `native_decide`; the existing public `Roots.lean` sorry count drops from 14 to 12.

## Validation

- `lake build HexNumberFieldMathlib.Roots`
- `lake build`
- `lake build HexConformance`
- `git diff --check`