### PR TITLE
prove(number-field): complete fixed root semantics

### DIFF
--- a/HexNumberField/Roots.lean
+++ b/HexNumberField/Roots.lean
@@ -211,33 +211,30 @@ def sameValue? (a b : AlgebraicRoot) : Option Bool :=
     let b' ← b.exact?
     some (a' == b')
 
-/-- Merge one root into a duplicate-free multiplicity array. -/
+/-- Merge one root into a list, retaining the first representative of an
+existing semantic value and the incoming certified multiplicity. -/
 @[expose]
-def mergeRootAux (candidate : RootCount) (index : Nat) :
-    Nat → Array RootCount → Option (Array RootCount)
-  | 0, roots => some (roots.push candidate)
-  | fuel + 1, roots =>
-      if hi : index < roots.size then do
-        let current := roots[index]
-        let same ← sameValue? current.root candidate.root
-        if same then
-          let merged : RootCount :=
-            { root := current.root
-              multiplicity := current.multiplicity + candidate.multiplicity
-              multiplicity_pos := by
-                have hc : 0 < current.multiplicity := current.multiplicity_pos
-                omega }
-          some ((roots.eraseIdx index).push merged)
-        else
-          mergeRootAux candidate (index + 1) fuel roots
+def mergeRootList (candidate : RootCount) :
+    List RootCount → Option (List RootCount)
+  | [] => some [candidate]
+  | current :: rest => do
+      let same ← sameValue? current.root candidate.root
+      if same then
+        let merged : RootCount :=
+          { root := current.root
+            multiplicity := candidate.multiplicity
+            multiplicity_pos := candidate.multiplicity_pos }
+        some (merged :: rest)
       else
-        some (roots.push candidate)
+        let tail ← mergeRootList candidate rest
+        some (current :: tail)
 
 /-- Merge one root using a complete scan of the current array. -/
 @[expose]
 def mergeRoot (roots : Array RootCount) (candidate : RootCount) :
-    Option (Array RootCount) :=
-  mergeRootAux candidate 0 (roots.size + 1) roots
+    Option (Array RootCount) := do
+  let merged ← mergeRootList candidate roots.toList
+  some merged.toArray
 
 /-- Lexicographic non-strict order on integer coefficient lists. -/
 @[expose]
@@ -260,7 +257,7 @@ def rootLe (a b : RootCount) : Bool :=
   else if a.root.rep.1.square.im != b.root.rep.1.square.im then
     decide (a.root.rep.1.square.im < b.root.rep.1.square.im)
   else
-    decide (a.root.rep.1.square.prec < b.root.rep.1.square.prec)
+    decide (a.root.rep.1.square.prec ≤ b.root.rep.1.square.prec)
 
 end Hex.QAdjoin.Roots
 
@@ -287,7 +284,7 @@ def roots? [ZPoly.CheckedIrreducible p]
         else
           none)
       #[]
-    some (.finite (roots.qsort Roots.rootLe))
+    some (.finite (roots.mergeSort Roots.rootLe))
 
 /-- Total fixed-field root API. The loud `.all` fallback is unreachable once
 the companion discharges `roots?_isSome`. -/

--- a/HexNumberFieldMathlib.lean
+++ b/HexNumberFieldMathlib.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexNumberFieldMathlib.Roots
+public import HexNumberFieldMathlib.ComponentRoots
 
 public section
 

--- a/HexNumberFieldMathlib/ComponentRoots.lean
+++ b/HexNumberFieldMathlib/ComponentRoots.lean
@@ -1,0 +1,1346 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexNumberFieldMathlib.Roots
+import Mathlib.Data.Prod.Lex
+
+public section
+
+/-!
+# Semantics of fixed-field component root isolation
+
+This module proves semantic contracts for the norm-isolation and selected-
+embedding filter used on one square-free Yun component.
+-/
+
+namespace Hex.QAdjoin.Roots
+
+variable {p : ZPoly} {x : SimpleRoot p}
+
+private theorem intListLe_iff (as bs : List Int) :
+    intListLe as bs ↔ as ≤ bs := by
+  induction as generalizing bs with
+  | nil =>
+      constructor
+      · intro _
+        apply le_of_not_gt
+        intro h
+        cases h
+      · intro _
+        trivial
+  | cons a as ih =>
+      cases bs with
+      | nil => simp [intListLe]
+      | cons b bs =>
+          by_cases hab : a < b
+          · constructor
+            · intro _
+              exact le_of_lt (List.Lex.rel hab)
+            · intro _
+              simp [intListLe, hab]
+          · by_cases hba : b < a
+            · constructor
+              · simp [intListLe, hab, hba]
+              · intro hle
+                exact (not_lt_of_ge hle (List.Lex.rel hba)).elim
+            · have heq : a = b :=
+                le_antisymm (le_of_not_gt hba) (le_of_not_gt hab)
+              subst b
+              rw [intListLe]
+              simp only [lt_irrefl, ↓reduceIte]
+              constructor
+              · intro hle
+                exact List.cons_le_cons a ((ih bs).mp hle)
+              · intro hle
+                rcases hle.lt_or_eq with hlt | heq
+                · cases hlt with
+                  | rel h => exact (lt_irrefl a h).elim
+                  | cons h => exact (ih bs).mpr (le_of_lt h)
+                · exact (ih bs).mpr (le_of_eq (congrArg List.tail heq))
+
+private noncomputable def rootKey (a : RootCount) :
+    List Int ×ₗ (Rat ×ₗ (Rat ×ₗ Int)) :=
+  toLex (a.root.p.toArray.toList,
+    toLex (a.root.rep.1.square.re.toRat,
+      toLex (a.root.rep.1.square.im.toRat, a.root.rep.1.square.prec)))
+
+private theorem rootPolynomial_eq_of_coefficients_eq (a b : RootCount)
+    (hcoeff : a.root.p.toArray.toList = b.root.p.toArray.toList) :
+    a.root.p = b.root.p := by
+  have harr : a.root.p.toArray = b.root.p.toArray :=
+    Array.toList_inj.mp hcoeff
+  apply DensePoly.ext_coeff
+  intro n
+  rw [← DensePoly.toArray_getD, harr, DensePoly.toArray_getD]
+
+private theorem rootLe_iff (a b : RootCount) :
+    rootLe a b ↔ rootKey a ≤ rootKey b := by
+  by_cases hp : a.root.p = b.root.p
+  · by_cases hre : a.root.rep.1.square.re = b.root.rep.1.square.re
+    · by_cases him : a.root.rep.1.square.im = b.root.rep.1.square.im
+      · simp [rootLe, rootKey, hp, hre, him,
+          Prod.Lex.toLex_le_toLex]
+      · have hratIm : a.root.rep.1.square.im.toRat ≠
+            b.root.rep.1.square.im.toRat := by
+          intro hrat
+          exact him (Dyadic.toRat_inj.mp hrat)
+        simp [rootLe, rootKey, hp, hre, him, hratIm,
+          Prod.Lex.toLex_le_toLex, Dyadic.toRat_lt_toRat_iff]
+    · have hratRe : a.root.rep.1.square.re.toRat ≠
+          b.root.rep.1.square.re.toRat := by
+        intro hrat
+        exact hre (Dyadic.toRat_inj.mp hrat)
+      simp [rootLe, rootKey, hp, hre, hratRe,
+        Prod.Lex.toLex_le_toLex, Dyadic.toRat_inj,
+        Dyadic.toRat_lt_toRat_iff]
+  · have hcoeff : a.root.p.toArray.toList ≠
+        b.root.p.toArray.toList := by
+      intro heq
+      exact hp (rootPolynomial_eq_of_coefficients_eq a b heq)
+    unfold rootKey
+    rw [rootLe, if_pos (by simpa using hp), intListLe_iff,
+      Prod.Lex.toLex_le_toLex]
+    constructor
+    · intro hle
+      exact Or.inl (lt_of_le_of_ne hle hcoeff)
+    · rintro (hlt | ⟨heq, _⟩)
+      · exact le_of_lt hlt
+      · exact (hcoeff heq).elim
+
+private theorem rootLe_trans (a b c : RootCount) :
+    rootLe a b → rootLe b c → rootLe a c := by
+  simpa only [rootLe_iff] using
+    (le_trans : rootKey a ≤ rootKey b →
+      rootKey b ≤ rootKey c → rootKey a ≤ rootKey c)
+
+private theorem rootLe_total (a b : RootCount) :
+    rootLe a b || rootLe b a := by
+  apply Bool.or_eq_true_iff.mpr
+  rcases le_total (rootKey a) (rootKey b) with hab | hba
+  · exact Or.inl (rootLe_iff a b |>.mpr hab)
+  · exact Or.inr (rootLe_iff b a |>.mpr hba)
+
+private theorem list_foldlM_sound {A B : Type*}
+    {step : B → A → Option B} {property : B → Prop}
+    (items : List A) (init final : B)
+    (hinit : property init)
+    (hstep : ∀ state item next, item ∈ items →
+      step state item = some next → property state → property next)
+    (hrun : items.foldlM step init = some final) :
+    property final := by
+  induction items generalizing init with
+  | nil =>
+      have hfinal : init = final := by simpa using hrun
+      simpa [hfinal] using hinit
+  | cons item items ih =>
+      cases hnext : step init item with
+      | none => simp [List.foldlM_cons, hnext] at hrun
+      | some next =>
+          have htail : items.foldlM step next = some final := by
+            simpa [List.foldlM_cons, hnext] using hrun
+          exact ih next (hstep init item next (by simp) hnext hinit)
+            (fun state tail next hmem =>
+              hstep state tail next (by simp [hmem])) htail
+
+private theorem list_foldlM_split {A B : Type*}
+    {step : B → A → Option B} {items : List A} {item : A}
+    {init final : B} (hitem : item ∈ items)
+    (hrun : items.foldlM step init = some final) :
+    ∃ pre suffix state next,
+      items = pre ++ item :: suffix ∧
+        pre.foldlM step init = some state ∧
+        step state item = some next ∧
+        suffix.foldlM step next = some final := by
+  obtain ⟨pre, suffix, rfl⟩ := List.mem_iff_append.mp hitem
+  cases hprefix : pre.foldlM step init with
+  | none => simp [List.foldlM_append, hprefix] at hrun
+  | some state =>
+      cases hnext : step state item with
+      | none =>
+          simp [List.foldlM_append, hprefix, List.foldlM_cons, hnext] at hrun
+      | some next =>
+          refine ⟨pre, suffix, state, next, rfl, hprefix, hnext, ?_⟩
+          simpa [List.foldlM_append, hprefix, List.foldlM_cons, hnext]
+            using hrun
+
+/-- Every entry returned by a successful component run is a root at the
+selected embedding and carries the requested multiplicity. -/
+theorem componentRoots?_sound [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (multiplicity : Nat)
+    (hMultiplicity : 0 < multiplicity) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) {roots : Array RootCount}
+    (hrun : componentRoots? f multiplicity hMultiplicity rep h = some roots) :
+    ∀ entry ∈ roots.toList,
+      Polynomial.eval entry.root.toComplex (QAdjoin.toPolynomialAt f rep h) = 0 ∧
+        entry.multiplicity = multiplicity := by
+  unfold componentRoots? at hrun
+  dsimp only at hrun
+  split at hrun
+  next hprim =>
+    change ZPoly.Primitive (ZPoly.squareFreeCore (normEliminant f)) at hprim
+    split at hrun
+    next hpos =>
+      split at hrun
+      next hdegree =>
+        split at hrun
+        next hsimple =>
+          cases hisolate : isolate (ZPoly.squareFreeCore (normEliminant f))
+              hsimple (separationDepth
+                (ZPoly.squareFreeCore (normEliminant f)) : Int) with
+          | none => simp [hisolate] at hrun
+          | some isolations =>
+              rw [hisolate] at hrun
+              simp only [Option.bind_eq_bind, Option.bind_some] at hrun
+              cases hrefined : isolations.mapM
+                  DyadicRootIsolation.toRefined? with
+              | none =>
+                  rw [hrefined] at hrun
+                  simp at hrun
+              | some refined =>
+                  rw [hrefined] at hrun
+                  simp only [Option.bind_some] at hrun
+                  rw [← Array.foldlM_toList] at hrun
+                  apply list_foldlM_sound refined.toList #[] roots (by simp)
+                    (hrun := hrun)
+                    (property := fun out => ∀ entry ∈ out.toList,
+                      Polynomial.eval entry.root.toComplex
+                          (QAdjoin.toPolynomialAt f rep h) = 0 ∧
+                        entry.multiplicity = multiplicity)
+                  · intro out candidateRep next _hcandidate hstep hout
+                    let candidate : AlgebraicRoot :=
+                      { p := ZPoly.squareFreeCore (normEliminant f)
+                        prim := hprim
+                        pos_lc := hpos
+                        pos_degree := hdegree
+                        squarefree := hsimple
+                        x := SimpleRoot.mk candidateRep
+                        rep := candidateRep
+                        rep_mk := rfl }
+                    cases hevaluation : evalRoot? f rep h candidate with
+                    | none => simp [candidate, hevaluation] at hstep
+                    | some evaluation =>
+                        cases hkeep : retainZero? evaluation.p
+                            (evalMajorant f candidate.p)
+                            (evalBall? f rep h candidate) with
+                        | none =>
+                            simp [candidate, hevaluation, hkeep] at hstep
+                        | some keep =>
+                            cases keep with
+                            | false =>
+                                have hnext : out = next := by
+                                  simpa [candidate, hevaluation, hkeep]
+                                    using hstep
+                                simpa [← hnext] using hout
+                            | true =>
+                                have hnext : out.push
+                                    { root := candidate
+                                      multiplicity
+                                      multiplicity_pos := hMultiplicity } = next := by
+                                  simpa [candidate, hevaluation, hkeep]
+                                    using hstep
+                                rw [← hnext]
+                                intro entry hentry
+                                rw [Array.toList_push, List.mem_append,
+                                  List.mem_singleton] at hentry
+                                rcases hentry with hentry | rfl
+                                · exact hout entry hentry
+                                · constructor
+                                  · exact (retainZero?_correct f rep h candidate
+                                      evaluation hevaluation hkeep).mp rfl
+                                  · rfl
+        next hsimple => simp at hrun
+      next hdegree => simp at hrun
+    next hpos => simp at hrun
+  next hprim => simp at hrun
+
+/-- Every semantic root of a nonzero component occurs in a successful
+component run with the requested multiplicity. -/
+theorem componentRoots?_complete [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (multiplicity : Nat)
+    (hMultiplicity : 0 < multiplicity) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) (hf : !f.isZero) {roots : Array RootCount}
+    (hrun : componentRoots? f multiplicity hMultiplicity rep h = some roots)
+    (z : ℂ) (hz : Polynomial.eval z (QAdjoin.toPolynomialAt f rep h) = 0) :
+    ∃ entry ∈ roots.toList,
+      entry.root.toComplex = z ∧ entry.multiplicity = multiplicity := by
+  have hnorm : normEliminant f ≠ 0 := normEliminant_ne_zero f hf
+  have hnormRoot :
+      (HexRootsMathlib.toPolyℂ (normEliminant f)).IsRoot z :=
+    normEliminant_isRoot f rep h z hf hz
+  have hcoreRoot :
+      (HexRootsMathlib.toPolyℂ
+        (ZPoly.squareFreeCore (normEliminant f))).IsRoot z :=
+    HexPolyZMathlib.isRoot_squareFreeCore hnorm hnormRoot
+  unfold componentRoots? at hrun
+  dsimp only at hrun
+  split at hrun
+  next hprim =>
+    change ZPoly.Primitive (ZPoly.squareFreeCore (normEliminant f)) at hprim
+    split at hrun
+    next hpos =>
+      split at hrun
+      next hdegree =>
+        split at hrun
+        next hsimple =>
+          cases hisolate : isolate (ZPoly.squareFreeCore (normEliminant f))
+              hsimple (separationDepth
+                (ZPoly.squareFreeCore (normEliminant f)) : Int) with
+          | none => simp [hisolate] at hrun
+          | some isolations =>
+              rw [hisolate] at hrun
+              simp only [Option.bind_eq_bind, Option.bind_some] at hrun
+              cases hrefined : isolations.mapM
+                  DyadicRootIsolation.toRefined? with
+              | none =>
+                  rw [hrefined] at hrun
+                  simp at hrun
+              | some refined =>
+                  rw [hrefined] at hrun
+                  simp only [Option.bind_some] at hrun
+                  rw [← Array.foldlM_toList] at hrun
+                  obtain ⟨iso, hiso, hisoRoot⟩ :=
+                    HexRootsMathlib.isolate_root_mem_of_pos
+                      (ZPoly.squareFreeCore (normEliminant f)) hsimple
+                      (separationDepth
+                        (ZPoly.squareFreeCore (normEliminant f)) : Int)
+                      .nkThenPellet hdegree hisolate hcoreRoot
+                  obtain ⟨i, hiList, hidx⟩ := List.getElem_of_mem hiso
+                  have hi : i < isolations.size := by simpa using hiList
+                  obtain ⟨hmapSize, hmapGet⟩ :=
+                    HexRootsMathlib.array_mapM_some_get hrefined
+                  have hj : i < refined.size := by
+                    simpa [← hmapSize] using hi
+                  have hto := hmapGet i hi hj
+                  have hrawIso : refined[i].1 = isolations[i] := by
+                    rw [DyadicRootIsolation.toRefined?] at hto
+                    split at hto
+                    · exact (congrArg Subtype.val (Option.some.inj hto)).symm
+                    · simp at hto
+                  have harrIso : isolations[i] = iso := by
+                    rw [← hidx]
+                    exact (Array.getElem_toList hi).symm
+                  have hrefinedRoot :
+                      HexRootsMathlib.RefinedIsolation.root refined[i] = z := by
+                    change HexRootsMathlib.DyadicRootIsolation.root
+                      refined[i].1 = z
+                    rw [hrawIso, harrIso]
+                    exact hisoRoot
+                  have hcandMem : refined[i] ∈ refined.toList :=
+                    Array.getElem_mem_toList hj
+                  obtain ⟨_prefix, suffix, state, next, _hitems, _hprefix,
+                      hcandidateStep, hsuffix⟩ :=
+                    list_foldlM_split hcandMem hrun
+                  let candidate : AlgebraicRoot :=
+                    { p := ZPoly.squareFreeCore (normEliminant f)
+                      prim := hprim
+                      pos_lc := hpos
+                      pos_degree := hdegree
+                      squarefree := hsimple
+                      x := SimpleRoot.mk refined[i]
+                      rep := refined[i]
+                      rep_mk := rfl }
+                  have hcandidateValue : candidate.toComplex = z := by
+                    exact hrefinedRoot
+                  obtain ⟨evaluation, hevaluation⟩ :=
+                    Option.isSome_iff_exists.mp
+                      (evalRoot?_isSome f rep h candidate)
+                  obtain ⟨keep, hkeep⟩ := Option.isSome_iff_exists.mp
+                    (retainZero?_isSome evaluation.p f rep h candidate)
+                  have hcandidateZero : Polynomial.eval candidate.toComplex
+                      (QAdjoin.toPolynomialAt f rep h) = 0 := by
+                    rw [hcandidateValue]
+                    exact hz
+                  have hkeepTrue : keep = true := by
+                    cases keep with
+                    | false =>
+                        have hfalse := (retainZero?_correct f rep h candidate
+                          evaluation hevaluation hkeep).mpr hcandidateZero
+                        simp at hfalse
+                    | true => rfl
+                  let selected : RootCount :=
+                    { root := candidate
+                      multiplicity
+                      multiplicity_pos := hMultiplicity }
+                  have hnext : state.push selected = next := by
+                    simpa [candidate, selected, hevaluation, hkeep, hkeepTrue]
+                      using hcandidateStep
+                  rw [← hnext] at hsuffix
+                  apply list_foldlM_sound suffix (state.push selected) roots
+                    (property := fun out => ∃ entry ∈ out.toList,
+                      entry.root.toComplex = z ∧
+                        entry.multiplicity = multiplicity)
+                    (by
+                      refine ⟨selected, ?_, ?_, rfl⟩
+                      · simp [selected]
+                      · exact hcandidateValue)
+                    (hrun := hsuffix)
+                  intro out candidateRep next _hcandidate hstep hout
+                  let candidate' : AlgebraicRoot :=
+                    { p := ZPoly.squareFreeCore (normEliminant f)
+                      prim := hprim
+                      pos_lc := hpos
+                      pos_degree := hdegree
+                      squarefree := hsimple
+                      x := SimpleRoot.mk candidateRep
+                      rep := candidateRep
+                      rep_mk := rfl }
+                  cases hevaluation' : evalRoot? f rep h candidate' with
+                  | none => simp [candidate', hevaluation'] at hstep
+                  | some evaluation' =>
+                      cases hkeep' : retainZero? evaluation'.p
+                          (evalMajorant f candidate'.p)
+                          (evalBall? f rep h candidate') with
+                      | none =>
+                          simp [candidate', hevaluation', hkeep'] at hstep
+                      | some keep' =>
+                          cases keep' with
+                          | false =>
+                              have hnext' : out = next := by
+                                simpa [candidate', hevaluation', hkeep']
+                                  using hstep
+                              simpa [← hnext'] using hout
+                          | true =>
+                              have hnext' : out.push
+                                  { root := candidate'
+                                    multiplicity
+                                    multiplicity_pos := hMultiplicity } = next := by
+                                simpa [candidate', hevaluation', hkeep']
+                                  using hstep
+                              rcases hout with ⟨entry, hentry, hvalue, hmult⟩
+                              refine ⟨entry, ?_, hvalue, hmult⟩
+                              rw [← hnext', Array.toList_push,
+                                List.mem_append]
+                              exact Or.inl hentry
+        next hsimple => simp at hrun
+      next hdegree => simp at hrun
+    next hpos => simp at hrun
+  next hprim => simp at hrun
+
+private theorem mergeRootList_contains (candidate : RootCount)
+    (roots out : List RootCount)
+    (hrun : mergeRootList candidate roots = some out) (z : ℂ) :
+    (∃ entry ∈ out, entry.root.toComplex = z) ↔
+      candidate.root.toComplex = z ∨
+        ∃ entry ∈ roots, entry.root.toComplex = z := by
+  induction roots generalizing out with
+  | nil =>
+      have hout : out = [candidate] := by
+        simpa [mergeRootList] using hrun.symm
+      subst out
+      simp
+  | cons current roots ih =>
+      cases hsame : sameValue? current.root candidate.root with
+      | none => simp [mergeRootList, hsame] at hrun
+      | some same =>
+          cases same with
+          | true =>
+              have hout : out =
+                  { root := current.root
+                    multiplicity := candidate.multiplicity
+                    multiplicity_pos := candidate.multiplicity_pos } :: roots := by
+                simpa [mergeRootList, hsame] using hrun.symm
+              subst out
+              have hvalue : current.root.toComplex =
+                  candidate.root.toComplex :=
+                (sameValue?_sound current.root candidate.root hsame).mp rfl
+              simp [hvalue]
+          | false =>
+              cases htail : mergeRootList candidate roots with
+              | none => simp [mergeRootList, hsame, htail] at hrun
+              | some tail =>
+                  have hout : out = current :: tail := by
+                    simpa [mergeRootList, hsame, htail] using hrun.symm
+                  subst out
+                  simp only [List.mem_cons, exists_eq_or_imp]
+                  rw [ih tail htail]
+                  tauto
+
+private theorem mergeRootList_value (candidate : RootCount)
+    (roots out : List RootCount)
+    (hrun : mergeRootList candidate roots = some out) (z : ℂ) (r : Nat)
+    (hroots : ∀ entry ∈ roots, entry.root.toComplex = z →
+      entry.multiplicity = r)
+    (hcandidate : candidate.root.toComplex = z →
+      candidate.multiplicity = r) :
+    ∀ entry ∈ out, entry.root.toComplex = z →
+      entry.multiplicity = r := by
+  induction roots generalizing out with
+  | nil =>
+      have hout : out = [candidate] := by
+        simpa [mergeRootList] using hrun.symm
+      subst out
+      simpa using hcandidate
+  | cons current roots ih =>
+      cases hsame : sameValue? current.root candidate.root with
+      | none => simp [mergeRootList, hsame] at hrun
+      | some same =>
+          cases same with
+          | true =>
+              have hout : out =
+                  { root := current.root
+                    multiplicity := candidate.multiplicity
+                    multiplicity_pos := candidate.multiplicity_pos } :: roots := by
+                simpa [mergeRootList, hsame] using hrun.symm
+              subst out
+              intro entry hentry hvalue
+              simp only [List.mem_cons] at hentry
+              rcases hentry with hentry | hentry
+              · subst entry
+                exact hcandidate <|
+                  ((sameValue?_sound current.root candidate.root hsame).mp
+                    rfl).symm.trans hvalue
+              · exact hroots entry (by simp [hentry]) hvalue
+          | false =>
+              cases htail : mergeRootList candidate roots with
+              | none => simp [mergeRootList, hsame, htail] at hrun
+              | some tail =>
+                  have hout : out = current :: tail := by
+                    simpa [mergeRootList, hsame, htail] using hrun.symm
+                  subst out
+                  intro entry hentry hvalue
+                  simp only [List.mem_cons] at hentry
+                  rcases hentry with hentry | hentry
+                  · subst entry
+                    exact hroots current (by simp) hvalue
+                  · apply ih tail htail
+                    · intro prior hprior
+                      exact hroots prior (by simp [hprior])
+                    · exact hentry
+                    · exact hvalue
+
+private theorem mergeRootList_nodup (candidate : RootCount)
+    (roots out : List RootCount)
+    (hrun : mergeRootList candidate roots = some out)
+    (hnodup : roots.Pairwise fun a b =>
+      a.root.toComplex ≠ b.root.toComplex) :
+    out.Pairwise fun a b => a.root.toComplex ≠ b.root.toComplex := by
+  induction roots generalizing out with
+  | nil =>
+      have hout : out = [candidate] := by
+        simpa [mergeRootList] using hrun.symm
+      subst out
+      simp
+  | cons current roots ih =>
+      have hpair := List.pairwise_cons.mp hnodup
+      cases hsame : sameValue? current.root candidate.root with
+      | none => simp [mergeRootList, hsame] at hrun
+      | some same =>
+          cases same with
+          | true =>
+              have hout : out =
+                  { root := current.root
+                    multiplicity := candidate.multiplicity
+                    multiplicity_pos := candidate.multiplicity_pos } :: roots := by
+                simpa [mergeRootList, hsame] using hrun.symm
+              subst out
+              exact List.pairwise_cons.mpr hpair
+          | false =>
+              cases htail : mergeRootList candidate roots with
+              | none => simp [mergeRootList, hsame, htail] at hrun
+              | some tail =>
+                  have hout : out = current :: tail := by
+                    simpa [mergeRootList, hsame, htail] using hrun.symm
+                  subst out
+                  apply List.pairwise_cons.mpr
+                  refine ⟨?_, ih tail htail hpair.2⟩
+                  intro entry hentry heq
+                  have hcontains := (mergeRootList_contains candidate roots
+                    tail htail entry.root.toComplex).mp
+                    ⟨entry, hentry, rfl⟩
+                  rcases hcontains with hcand | ⟨prior, hprior, hvalue⟩
+                  · have hcurCand : current.root.toComplex ≠
+                        candidate.root.toComplex := by
+                      intro hsameValue
+                      have hfalse :=
+                        (sameValue?_sound current.root candidate.root
+                          hsame).mpr hsameValue
+                      simp at hfalse
+                    exact hcurCand (heq.trans hcand.symm)
+                  · exact hpair.1 prior hprior (heq.trans hvalue.symm)
+
+private theorem mergeRoot_nodup (roots out : Array RootCount)
+    (candidate : RootCount) (hrun : mergeRoot roots candidate = some out)
+    (hnodup : roots.toList.Pairwise fun a b =>
+      a.root.toComplex ≠ b.root.toComplex) :
+    out.toList.Pairwise fun a b =>
+      a.root.toComplex ≠ b.root.toComplex := by
+  cases hmerged : mergeRootList candidate roots.toList with
+  | none => simp [mergeRoot, hmerged] at hrun
+  | some merged =>
+      have hout : out = merged.toArray := by
+        simpa [mergeRoot, hmerged] using hrun.symm
+      subst out
+      simpa using mergeRootList_nodup candidate roots.toList merged
+        hmerged hnodup
+
+private theorem mergeRoot_value (roots out : Array RootCount)
+    (candidate : RootCount) (hrun : mergeRoot roots candidate = some out)
+    (z : ℂ) (r : Nat)
+    (hroots : ∀ entry ∈ roots.toList, entry.root.toComplex = z →
+      entry.multiplicity = r)
+    (hcandidate : candidate.root.toComplex = z →
+      candidate.multiplicity = r) :
+    ∀ entry ∈ out.toList, entry.root.toComplex = z →
+      entry.multiplicity = r := by
+  cases hmerged : mergeRootList candidate roots.toList with
+  | none => simp [mergeRoot, hmerged] at hrun
+  | some merged =>
+      have hout : out = merged.toArray := by
+        simpa [mergeRoot, hmerged] using hrun.symm
+      subst out
+      simpa using mergeRootList_value candidate roots.toList merged
+        hmerged z r hroots hcandidate
+
+private theorem mergeRoot_contains (roots out : Array RootCount)
+    (candidate : RootCount) (hrun : mergeRoot roots candidate = some out)
+    (z : ℂ) :
+    (∃ entry ∈ out.toList, entry.root.toComplex = z) ↔
+      candidate.root.toComplex = z ∨
+        ∃ entry ∈ roots.toList, entry.root.toComplex = z := by
+  cases hmerged : mergeRootList candidate roots.toList with
+  | none => simp [mergeRoot, hmerged] at hrun
+  | some merged =>
+      have hout : out = merged.toArray := by
+        simpa [mergeRoot, hmerged] using hrun.symm
+      subst out
+      simpa using mergeRootList_contains candidate roots.toList merged
+        hmerged z
+
+private theorem mergeRoots_nodup (roots candidates out : Array RootCount)
+    (hrun : candidates.foldlM mergeRoot roots = some out)
+    (hnodup : roots.toList.Pairwise fun a b =>
+      a.root.toComplex ≠ b.root.toComplex) :
+    out.toList.Pairwise fun a b =>
+      a.root.toComplex ≠ b.root.toComplex := by
+  rw [← Array.foldlM_toList] at hrun
+  apply list_foldlM_sound candidates.toList roots out hnodup
+    (property := fun state => state.toList.Pairwise fun a b =>
+      a.root.toComplex ≠ b.root.toComplex)
+    (hrun := hrun)
+  intro state candidate next _ hstep hstate
+  exact mergeRoot_nodup state next candidate hstep hstate
+
+private theorem mergeRoots_value (roots candidates out : Array RootCount)
+    (hrun : candidates.foldlM mergeRoot roots = some out)
+    (z : ℂ) (r : Nat)
+    (hroots : ∀ entry ∈ roots.toList, entry.root.toComplex = z →
+      entry.multiplicity = r)
+    (hcandidates : ∀ entry ∈ candidates.toList,
+      entry.root.toComplex = z → entry.multiplicity = r) :
+    ∀ entry ∈ out.toList, entry.root.toComplex = z →
+      entry.multiplicity = r := by
+  rw [← Array.foldlM_toList] at hrun
+  apply list_foldlM_sound candidates.toList roots out hroots
+    (property := fun state => ∀ entry ∈ state.toList,
+      entry.root.toComplex = z → entry.multiplicity = r)
+    (hrun := hrun)
+  intro state candidate next hcandidate hstep hstate
+  exact mergeRoot_value state next candidate hstep z r hstate
+    (hcandidates candidate hcandidate)
+
+private theorem mergeRoots_contains (roots candidates out : Array RootCount)
+    (hrun : candidates.foldlM mergeRoot roots = some out) (z : ℂ) :
+    (∃ entry ∈ out.toList, entry.root.toComplex = z) ↔
+      (∃ entry ∈ roots.toList, entry.root.toComplex = z) ∨
+        ∃ entry ∈ candidates.toList, entry.root.toComplex = z := by
+  have list_contains : ∀ (items : List RootCount) (state : Array RootCount),
+      items.foldlM mergeRoot state = some out →
+        ((∃ entry ∈ out.toList, entry.root.toComplex = z) ↔
+          (∃ entry ∈ state.toList, entry.root.toComplex = z) ∨
+            ∃ entry ∈ items, entry.root.toComplex = z) := by
+    intro items
+    induction items with
+    | nil =>
+        intro state hlist
+        have hout : state = out := by simpa using hlist
+        subst out
+        simp
+    | cons candidate items ih =>
+        intro state hlist
+        cases hnext : mergeRoot state candidate with
+        | none => simp [List.foldlM_cons, hnext] at hlist
+        | some next =>
+            have htail : items.foldlM mergeRoot next = some out := by
+              simpa [List.foldlM_cons, hnext] using hlist
+            rw [ih next htail, mergeRoot_contains state next candidate hnext z]
+            simp only [List.mem_cons, exists_eq_or_imp]
+            constructor
+            · rintro ((hcandidate | hstate) | hitems)
+              · exact Or.inr (Or.inl hcandidate)
+              · exact Or.inl hstate
+              · exact Or.inr (Or.inr hitems)
+            · rintro (hstate | hcandidate | hitems)
+              · exact Or.inl (Or.inr hstate)
+              · exact Or.inl (Or.inl hcandidate)
+              · exact Or.inr hitems
+  exact list_contains candidates.toList roots (by simpa using hrun)
+
+private theorem componentFold_contains [ZPoly.CheckedIrreducible p]
+    (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x)
+    (components : List (DensePoly (QAdjoin p x) × Nat))
+    (hall : ∀ component ∈ components,
+      0 < component.1.degree?.getD 0 ∧ 0 < component.2)
+    (state out : Array RootCount)
+    (hrun : components.foldlM
+      (fun out component =>
+        if hm : 0 < component.2 then do
+          let found ← componentRoots? component.1 component.2 hm rep h
+          found.foldlM mergeRoot out
+        else
+          none)
+      state = some out) (z : ℂ) :
+    (∃ entry ∈ out.toList, entry.root.toComplex = z) ↔
+      (∃ entry ∈ state.toList, entry.root.toComplex = z) ∨
+        ∃ component ∈ components,
+          Polynomial.eval z
+            (QAdjoin.toPolynomialAt component.1 rep h) = 0 := by
+  induction components generalizing state with
+  | nil =>
+      have hout : state = out := by simpa using hrun
+      subst out
+      simp
+  | cons component components ih =>
+      have hcomponent := hall component (by simp)
+      rw [List.foldlM_cons, dif_pos hcomponent.2] at hrun
+      cases hfound : componentRoots? component.1 component.2 hcomponent.2 rep h with
+      | none => simp [hfound] at hrun
+      | some found =>
+          cases hnext : found.foldlM mergeRoot state with
+          | none => simp [hfound, hnext] at hrun
+          | some next =>
+              have htail : components.foldlM
+                  (fun out component =>
+                    if hm : 0 < component.2 then do
+                      let found ← componentRoots? component.1 component.2 hm rep h
+                      found.foldlM mergeRoot out
+                    else
+                      none)
+                  next = some out := by
+                simpa [hfound, hnext] using hrun
+              have hcomponentNonzero : !component.1.isZero := by
+                have hsize : 0 < component.1.size := by
+                  by_contra hzero
+                  have hsizeZero : component.1.size = 0 := by omega
+                  rw [(DensePoly.degree?_eq_none_iff component.1).2 hsizeZero]
+                    at hcomponent
+                  simp at hcomponent
+                have hfalse : component.1.isZero = false :=
+                  (DensePoly.isZero_eq_false_iff component.1).2 hsize
+                simp [hfalse]
+              have hfoundIff :
+                  (∃ entry ∈ found.toList, entry.root.toComplex = z) ↔
+                    Polynomial.eval z
+                      (QAdjoin.toPolynomialAt component.1 rep h) = 0 := by
+                constructor
+                · rintro ⟨entry, hentry, rfl⟩
+                  exact (componentRoots?_sound component.1 component.2
+                    hcomponent.2 rep h hfound entry hentry).1
+                · intro hzero
+                  obtain ⟨entry, hentry, hvalue, _hmult⟩ :=
+                    componentRoots?_complete component.1 component.2
+                      hcomponent.2 rep h hcomponentNonzero hfound z hzero
+                  exact ⟨entry, hentry, hvalue⟩
+              rw [ih (fun item hitem => hall item (by simp [hitem])) next htail,
+                mergeRoots_contains state found next hnext z, hfoundIff]
+              simp only [List.mem_cons, exists_eq_or_imp]
+              constructor
+              · rintro ((hstate | hcomponentRoot) | hcomponents)
+                · exact Or.inl hstate
+                · exact Or.inr (Or.inl hcomponentRoot)
+                · exact Or.inr (Or.inr hcomponents)
+              · rintro (hstate | hcomponentRoot | hcomponents)
+                · exact Or.inl (Or.inl hstate)
+                · exact Or.inl (Or.inr hcomponentRoot)
+                · exact Or.inr hcomponents
+
+private theorem componentFold_nodup [ZPoly.CheckedIrreducible p]
+    (rep : RefinedIsolation p) (h : SimpleRoot.mk rep = x)
+    (components : List (DensePoly (QAdjoin p x) × Nat))
+    (hall : ∀ component ∈ components,
+      0 < component.1.degree?.getD 0 ∧ 0 < component.2)
+    (state out : Array RootCount)
+    (hrun : components.foldlM
+      (fun out component =>
+        if hm : 0 < component.2 then do
+          let found ← componentRoots? component.1 component.2 hm rep h
+          found.foldlM mergeRoot out
+        else
+          none)
+      state = some out)
+    (hnodup : state.toList.Pairwise fun a b =>
+      a.root.toComplex ≠ b.root.toComplex) :
+    out.toList.Pairwise fun a b =>
+      a.root.toComplex ≠ b.root.toComplex := by
+  apply list_foldlM_sound components state out hnodup
+    (property := fun roots => roots.toList.Pairwise fun a b =>
+      a.root.toComplex ≠ b.root.toComplex)
+    (hrun := hrun)
+  intro roots component next hcomponent hstep hroots
+  have hpositive := (hall component hcomponent).2
+  rw [dif_pos hpositive] at hstep
+  cases hfound : componentRoots? component.1 component.2 hpositive rep h with
+  | none => simp [hfound] at hstep
+  | some found =>
+      rw [hfound] at hstep
+      exact mergeRoots_nodup roots found next hstep hroots
+
+private theorem componentFold_value [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x)
+    (hf : QAdjoin.toPolynomialAt f rep h ≠ 0)
+    (hdegree : 0 < f.degree?.getD 0)
+    (state out : Array RootCount)
+    (hrun : (yun f).toList.foldlM
+      (fun out component =>
+        if hm : 0 < component.2 then do
+          let found ← componentRoots? component.1 component.2 hm rep h
+          found.foldlM mergeRoot out
+        else
+          none)
+      state = some out) (z : ℂ)
+    (hstate : ∀ entry ∈ state.toList, entry.root.toComplex = z →
+      entry.multiplicity =
+        (QAdjoin.toPolynomialAt f rep h).rootMultiplicity z) :
+    ∀ entry ∈ out.toList, entry.root.toComplex = z →
+      entry.multiplicity =
+        (QAdjoin.toPolynomialAt f rep h).rootMultiplicity z := by
+  let embedding := QAdjoin.embedding rep h
+  have hmap (g : DensePoly (QAdjoin p x)) :
+      toPolynomialMap embedding g = QAdjoin.toPolynomialAt g rep h := by
+    rw [toPolynomialMap_eq_map]
+    exact (QAdjoin.toPolynomialAt_eq_map g rep h).symm
+  have hfMap : toPolynomialMap embedding f ≠ 0 := by
+    rw [hmap]
+    exact hf
+  apply list_foldlM_sound (yun f).toList state out hstate
+    (property := fun roots => ∀ entry ∈ roots.toList,
+      entry.root.toComplex = z → entry.multiplicity =
+        (QAdjoin.toPolynomialAt f rep h).rootMultiplicity z)
+    (hrun := hrun)
+  intro roots component next hcomponent hstep hroots
+  have hpositive := (yun_positive f component hcomponent).2
+  rw [dif_pos hpositive] at hstep
+  cases hfound : componentRoots? component.1 component.2 hpositive rep h with
+  | none => simp [hfound] at hstep
+  | some found =>
+      rw [hfound] at hstep
+      apply mergeRoots_value roots found next hstep z
+        ((QAdjoin.toPolynomialAt f rep h).rootMultiplicity z) hroots
+      intro entry hentry hvalue
+      have hentrySound := componentRoots?_sound component.1 component.2
+        hpositive rep h hfound entry hentry
+      have hcomponentRoot :
+          (toPolynomialMap embedding component.1).IsRoot z := by
+        rw [hmap]
+        rw [← hvalue]
+        exact hentrySound.1
+      rw [hentrySound.2,
+        yun_sound embedding f hfMap hdegree z component hcomponent
+          hcomponentRoot,
+        hmap]
+
+end Hex.QAdjoin.Roots
+
+namespace Hex.QAdjoin
+
+variable {p : ZPoly} {x : SimpleRoot p}
+
+private theorem findMultiplicity_eq (entries : List RootCount) (z : ℂ)
+    (r : Nat)
+    (hvalue : ∀ entry ∈ entries, entry.root.toComplex = z →
+      entry.multiplicity = r)
+    (hcontains : (∃ entry ∈ entries, entry.root.toComplex = z) ↔ 0 < r) :
+    ((entries.find? fun entry => entry.root.toComplex = z).map
+      (fun entry => entry.multiplicity)).getD 0 = r := by
+  classical
+  induction entries with
+  | nil =>
+      have hr : r = 0 := by
+        by_contra hr
+        have hrpos : 0 < r := Nat.pos_of_ne_zero hr
+        simpa using hcontains.mpr hrpos
+      simp [hr]
+  | cons entry entries ih =>
+      by_cases hz : entry.root.toComplex = z
+      · have hmultiplicity := hvalue entry (by simp) hz
+        simp [List.find?, hz, hmultiplicity]
+      · have htail := ih
+          (fun tail htail => hvalue tail (by simp [htail]))
+          (by simpa [hz] using hcontains)
+        simpa [List.find?, hz] using htail
+
+private theorem findMultiplicity_mem (entries : List RootCount)
+    (hnodup : entries.Pairwise fun a b =>
+      a.root.toComplex ≠ b.root.toComplex)
+    (entry : RootCount) (hentry : entry ∈ entries) :
+    ((entries.find? fun candidate =>
+      candidate.root.toComplex = entry.root.toComplex).map
+        (fun candidate => candidate.multiplicity)).getD 0 =
+      entry.multiplicity := by
+  classical
+  induction entries with
+  | nil => simp at hentry
+  | cons current entries ih =>
+      have hpair := List.pairwise_cons.mp hnodup
+      rcases List.mem_cons.mp hentry with rfl | hentry
+      · simp [List.find?]
+      · have hne := hpair.1 entry hentry
+        simpa [List.find?, hne] using ih hpair.2 hentry
+
+private theorem sum_eq_valueSum (entries : List RootCount)
+    (hnodup : entries.Pairwise fun a b =>
+      a.root.toComplex ≠ b.root.toComplex)
+    (value : ℂ → Nat)
+    (hvalue : ∀ entry ∈ entries,
+      value entry.root.toComplex = entry.multiplicity) :
+    (entries.map fun entry => entry.multiplicity).sum =
+      ∑ z ∈ (entries.map fun entry => entry.root.toComplex).toFinset,
+        value z := by
+  classical
+  induction entries with
+  | nil => simp
+  | cons entry entries ih =>
+      have hpair := List.pairwise_cons.mp hnodup
+      have hnotmem : entry.root.toComplex ∉
+          (entries.map fun tail => tail.root.toComplex).toFinset := by
+        intro hmem
+        rw [List.mem_toFinset] at hmem
+        obtain ⟨tail, htail, hvalue⟩ := List.mem_map.mp hmem
+        exact hpair.1 tail htail hvalue.symm
+      simp only [List.map_cons, List.sum_cons, List.toFinset_cons,
+        Finset.sum_insert hnotmem]
+      rw [hvalue entry (by simp),
+        ih hpair.2 (fun tail htail => hvalue tail (by simp [htail]))]
+
+private theorem foldlMultiplicity_eq_sum (entries : List RootCount) :
+    entries.foldl (fun total entry => total + entry.multiplicity) 0 =
+      (entries.map fun entry => entry.multiplicity).sum := by
+  have aux : ∀ (items : List RootCount) (total : Nat),
+      items.foldl (fun sum entry => sum + entry.multiplicity) total =
+        total + (items.map fun entry => entry.multiplicity).sum := by
+    intro items
+    induction items with
+    | nil => simp
+    | cons entry items ih =>
+        intro total
+        rw [List.foldl_cons, ih]
+        simp [Nat.add_assoc]
+  simpa using aux entries 0
+
+/-- Semantic membership in the fixed-field output is exactly polynomial
+vanishing. -/
+theorem contains_roots_iff [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) (z : ℂ) :
+    RootSet.Contains (QAdjoin.roots f rep h) z ↔
+      Polynomial.eval z (QAdjoin.toPolynomialAt f rep h) = 0 := by
+  by_cases hzero : QAdjoin.toPolynomialAt f rep h = 0
+  · have hall : QAdjoin.roots f rep h = .all :=
+      (roots_all_iff f rep h).2 hzero
+    rw [hall, hzero]
+    simp [RootSet.Contains]
+  · have hf : !f.isZero := by
+      by_contra hnot
+      have hisZero : f.isZero := by
+        cases hvalue : f.isZero <;> simp_all
+      exact hzero ((QAdjoin.poly_isZero_iff f rep h).1 hisZero)
+    have hdegreeEq : (QAdjoin.toPolynomialAt f rep h).natDegree =
+        f.degree?.getD 0 :=
+      QAdjoin.natDegree_toPolynomialAt f rep h hf
+    by_cases hdegree : f.degree?.getD 0 = 0
+    · have heq := roots?_eq_roots f rep h
+      have hfFalse : f.isZero = false := by
+        cases hvalue : f.isZero <;> simp_all
+      rw [QAdjoin.roots?, if_neg (by simpa using hfFalse),
+        if_pos hdegree] at heq
+      have hroots : QAdjoin.roots f rep h = .finite #[] :=
+        (Option.some.inj heq).symm
+      constructor
+      · simp [hroots, RootSet.Contains]
+      · intro hroot
+        have hnatDegree :
+            (QAdjoin.toPolynomialAt f rep h).natDegree = 0 := by
+          rw [hdegreeEq, hdegree]
+        have hconstant := Polynomial.eq_C_of_natDegree_eq_zero hnatDegree
+        rw [hconstant] at hroot
+        simp only [Polynomial.eval_C] at hroot
+        exfalso
+        apply hzero
+        rw [hconstant, hroot, Polynomial.C_0]
+    · have hdegreePos : 0 < f.degree?.getD 0 := Nat.pos_of_ne_zero hdegree
+      have heq := roots?_eq_roots f rep h
+      have hfFalse : f.isZero = false := by
+        cases hvalue : f.isZero <;> simp_all
+      rw [QAdjoin.roots?, if_neg (by simpa using hfFalse),
+        if_neg hdegree] at heq
+      cases hfold : (Roots.yun f).foldlM
+          (fun out component =>
+            if hm : 0 < component.2 then do
+              let found ← Roots.componentRoots? component.1 component.2 hm rep h
+              found.foldlM Roots.mergeRoot out
+            else
+              none)
+          #[] with
+      | none =>
+          rw [hfold] at heq
+          simp at heq
+      | some raw =>
+          rw [hfold] at heq
+          have hroots : QAdjoin.roots f rep h =
+              .finite (raw.mergeSort Roots.rootLe) :=
+            (Option.some.inj heq).symm
+          have hraw :
+              (∃ entry ∈ raw.toList, entry.root.toComplex = z) ↔
+                ∃ component ∈ (Roots.yun f).toList,
+                  Polynomial.eval z
+                    (QAdjoin.toPolynomialAt component.1 rep h) = 0 := by
+            have hfoldList : (Roots.yun f).toList.foldlM
+                (fun out component =>
+                  if hm : 0 < component.2 then do
+                    let found ← Roots.componentRoots? component.1 component.2
+                      hm rep h
+                    found.foldlM Roots.mergeRoot out
+                  else
+                    none)
+                #[] = some raw := by
+              simpa using hfold
+            simpa using Roots.componentFold_contains rep h
+              (Roots.yun f).toList
+              (fun component hcomponent =>
+                Roots.yun_positive f component hcomponent)
+              #[] raw hfoldList z
+          have hcomponents :
+              (∃ component ∈ (Roots.yun f).toList,
+                Polynomial.eval z
+                  (QAdjoin.toPolynomialAt component.1 rep h) = 0) ↔
+                Polynomial.eval z (QAdjoin.toPolynomialAt f rep h) = 0 := by
+            let embedding := QAdjoin.embedding rep h
+            have hmap (g : DensePoly (QAdjoin p x)) :
+                Roots.toPolynomialMap embedding g =
+                  QAdjoin.toPolynomialAt g rep h := by
+              rw [Roots.toPolynomialMap_eq_map]
+              exact (QAdjoin.toPolynomialAt_eq_map g rep h).symm
+            have hfMap : Roots.toPolynomialMap embedding f ≠ 0 := by
+              rw [hmap]
+              exact hzero
+            constructor
+            · rintro ⟨component, hcomponent, hcomponentRoot⟩
+              have hrootMap :
+                  (Roots.toPolynomialMap embedding component.1).IsRoot z := by
+                rw [hmap]
+                exact hcomponentRoot
+              have hm := Roots.yun_sound embedding f hfMap hdegreePos z
+                component hcomponent hrootMap
+              have hpositive := (Roots.yun_positive f component hcomponent).2
+              have hmultPositive : 0 <
+                  (Roots.toPolynomialMap embedding f).rootMultiplicity z := by
+                rwa [← hm]
+              have hinputRoot :=
+                (Polynomial.rootMultiplicity_pos hfMap).mp hmultPositive
+              rw [hmap] at hinputRoot
+              exact hinputRoot
+            · intro hinputRoot
+              have hinputMap :
+                  (Roots.toPolynomialMap embedding f).IsRoot z := by
+                rw [hmap]
+                exact hinputRoot
+              obtain ⟨component, hcomponent, hcomponentRoot, _hm⟩ :=
+                Roots.yun_complete embedding f hfMap hdegreePos z hinputMap
+              refine ⟨component, hcomponent, ?_⟩
+              rw [← hmap]
+              exact hcomponentRoot
+          rw [hroots, RootSet.Contains]
+          constructor
+          · rintro ⟨entry, hentry, hvalue⟩
+            apply hcomponents.mp
+            apply hraw.mp
+            refine ⟨entry, ?_, hvalue⟩
+            have hentrySorted : entry ∈ raw.mergeSort Roots.rootLe := by
+              simpa using hentry
+            have hentryArray : entry ∈ raw :=
+              (Array.mem_mergeSort (le := Roots.rootLe)).mp hentrySorted
+            simpa using hentryArray
+          · intro hinputRoot
+            obtain ⟨entry, hentry, hvalue⟩ :=
+              hraw.mpr (hcomponents.mpr hinputRoot)
+            refine ⟨entry, ?_, hvalue⟩
+            have hentryArray : entry ∈ raw := by
+              simpa using hentry
+            simpa using
+              ((Array.mem_mergeSort (le := Roots.rootLe)).mpr hentryArray)
+
+/-- Fixed-field root multiplicities agree with Mathlib multiplicities. -/
+theorem multiplicity_roots [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) (z : ℂ) :
+    (QAdjoin.roots f rep h).multiplicityOf z =
+      Polynomial.rootMultiplicity z (QAdjoin.toPolynomialAt f rep h) := by
+  classical
+  let polynomial := QAdjoin.toPolynomialAt f rep h
+  by_cases hzero : polynomial = 0
+  · have hall : QAdjoin.roots f rep h = .all :=
+      (roots_all_iff f rep h).2 hzero
+    rw [hall]
+    change RootSet.all.multiplicityOf z =
+      Polynomial.rootMultiplicity z polynomial
+    rw [hzero]
+    simp [RootSet.multiplicityOf]
+  · have hfinite : ∃ entries,
+        QAdjoin.roots f rep h = .finite entries := by
+      cases hroots : QAdjoin.roots f rep h with
+      | all =>
+          exact (hzero ((roots_all_iff f rep h).1 hroots)).elim
+      | finite entries => exact ⟨entries, rfl⟩
+    obtain ⟨entries, hroots⟩ := hfinite
+    rw [hroots, RootSet.multiplicityOf]
+    apply findMultiplicity_eq entries.toList z
+        (Polynomial.rootMultiplicity z polynomial)
+    · intro entry hentry hvalue
+      have hf : !f.isZero := by
+        by_contra hnot
+        have hisZero : f.isZero := by
+          cases hvalueZero : f.isZero <;> simp_all
+        exact hzero ((QAdjoin.poly_isZero_iff f rep h).1 hisZero)
+      have hdegreeEq : polynomial.natDegree = f.degree?.getD 0 :=
+        QAdjoin.natDegree_toPolynomialAt f rep h hf
+      by_cases hdegree : f.degree?.getD 0 = 0
+      · have hcontains : RootSet.Contains (QAdjoin.roots f rep h) z := by
+          rw [hroots, RootSet.Contains]
+          exact ⟨entry, hentry, hvalue⟩
+        have hroot := (contains_roots_iff f rep h z).mp hcontains
+        have hrootPoly : Polynomial.eval z polynomial = 0 := hroot
+        have hnatDegree : polynomial.natDegree = 0 := by
+          rw [hdegreeEq, hdegree]
+        have hconstant := Polynomial.eq_C_of_natDegree_eq_zero hnatDegree
+        rw [hconstant] at hrootPoly
+        simp only [Polynomial.eval_C] at hrootPoly
+        exact (hzero (by rw [hconstant, hrootPoly, Polynomial.C_0])).elim
+      · have hdegreePos : 0 < f.degree?.getD 0 :=
+          Nat.pos_of_ne_zero hdegree
+        have heq := roots?_eq_roots f rep h
+        have hfFalse : f.isZero = false := by
+          cases hvalueZero : f.isZero <;> simp_all
+        rw [QAdjoin.roots?, if_neg (by simpa using hfFalse),
+          if_neg hdegree] at heq
+        cases hfold : (Roots.yun f).foldlM
+            (fun out component =>
+              if hm : 0 < component.2 then do
+                let found ← Roots.componentRoots? component.1 component.2 hm rep h
+                found.foldlM Roots.mergeRoot out
+              else
+                none)
+            #[] with
+        | none =>
+            rw [hfold] at heq
+            simp at heq
+        | some raw =>
+            rw [hfold, hroots] at heq
+            have hentries : entries = raw.mergeSort Roots.rootLe := by
+              simpa using heq.symm
+            subst entries
+            have hentrySorted : entry ∈ raw.mergeSort Roots.rootLe := by
+              simpa using hentry
+            have hentryRaw : entry ∈ raw :=
+              (Array.mem_mergeSort (le := Roots.rootLe)).mp hentrySorted
+            have hfoldList : (Roots.yun f).toList.foldlM
+                (fun out component =>
+                  if hm : 0 < component.2 then do
+                    let found ← Roots.componentRoots? component.1 component.2
+                      hm rep h
+                    found.foldlM Roots.mergeRoot out
+                  else
+                    none)
+                #[] = some raw := by
+              simpa using hfold
+            apply Roots.componentFold_value f rep h hzero hdegreePos
+              #[] raw hfoldList z (by simp) entry (by simpa using hentryRaw)
+            exact hvalue
+    · have hsemantics := contains_roots_iff f rep h z
+      rw [hroots, RootSet.Contains] at hsemantics
+      have hpositive : 0 < Polynomial.rootMultiplicity z polynomial ↔
+          Polynomial.eval z polynomial = 0 := by
+        simpa [polynomial] using
+          (Polynomial.rootMultiplicity_pos hzero)
+      exact hsemantics.trans hpositive.symm
+
+/-- The fixed-field driver produces positive multiplicities. -/
+theorem roots_positive [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) :
+    RootSet.Positive (QAdjoin.roots f rep h) := by
+  cases hroots : QAdjoin.roots f rep h with
+  | all => trivial
+  | finite roots =>
+      intro entry _hentry
+      exact entry.multiplicity_pos
+
+/-- The fixed-field driver merges all semantic duplicates. -/
+theorem roots_noDuplicates [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) :
+    RootSet.NoDuplicates (QAdjoin.roots f rep h) := by
+  have heq := roots?_eq_roots f rep h
+  rw [QAdjoin.roots?] at heq
+  split at heq
+  next _ =>
+    have hroots : QAdjoin.roots f rep h = .all :=
+      (Option.some.inj heq).symm
+    rw [hroots]
+    trivial
+  next _ =>
+    split at heq
+    next _ =>
+      have hroots : QAdjoin.roots f rep h = .finite #[] :=
+        (Option.some.inj heq).symm
+      rw [hroots]
+      simp [RootSet.NoDuplicates]
+    next _ =>
+      cases hfold : (Roots.yun f).foldlM
+          (fun out component =>
+            if hm : 0 < component.2 then do
+              let found ← Roots.componentRoots? component.1 component.2 hm rep h
+              found.foldlM Roots.mergeRoot out
+            else
+              none)
+          #[] with
+      | none =>
+          rw [hfold] at heq
+          simp at heq
+      | some raw =>
+          rw [hfold] at heq
+          have hroots : QAdjoin.roots f rep h =
+              .finite (raw.mergeSort Roots.rootLe) :=
+            (Option.some.inj heq).symm
+          rw [hroots]
+          have hfoldList : (Roots.yun f).toList.foldlM
+              (fun out component =>
+                if hm : 0 < component.2 then do
+                  let found ← Roots.componentRoots? component.1 component.2
+                    hm rep h
+                  found.foldlM Roots.mergeRoot out
+                else
+                  none)
+              #[] = some raw := by
+            simpa using hfold
+          have hraw : raw.toList.Pairwise fun a b =>
+              a.root.toComplex ≠ b.root.toComplex :=
+            Roots.componentFold_nodup rep h (Roots.yun f).toList
+              (fun component hcomponent =>
+                Roots.yun_positive f component hcomponent)
+              #[] raw hfoldList (by simp)
+          rw [RootSet.NoDuplicates, Array.toList_mergeSort]
+          exact ((List.mergeSort_perm raw.toList Roots.rootLe).pairwise_iff
+            (fun hne => hne.symm)).mpr hraw
+
+/-- The fixed-field driver uses its deterministic canonical root order. -/
+theorem roots_ordered [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) :
+    RootSet.Ordered (QAdjoin.roots f rep h) := by
+  have heq := roots?_eq_roots f rep h
+  rw [QAdjoin.roots?] at heq
+  split at heq
+  next _ =>
+    have hroots : QAdjoin.roots f rep h = .all :=
+      (Option.some.inj heq).symm
+    rw [hroots]
+    trivial
+  next _ =>
+    split at heq
+    next _ =>
+      have hroots : QAdjoin.roots f rep h = .finite #[] :=
+        (Option.some.inj heq).symm
+      rw [hroots]
+      simp [RootSet.Ordered]
+    next _ =>
+      cases hfold : (Roots.yun f).foldlM
+          (fun out component =>
+            if hm : 0 < component.2 then do
+              let found ← Roots.componentRoots? component.1 component.2 hm rep h
+              found.foldlM Roots.mergeRoot out
+            else
+              none)
+          #[] with
+      | none =>
+          rw [hfold] at heq
+          simp at heq
+      | some raw =>
+          rw [hfold] at heq
+          have hroots : QAdjoin.roots f rep h =
+              .finite (raw.mergeSort Roots.rootLe) :=
+            (Option.some.inj heq).symm
+          rw [hroots, RootSet.Ordered]
+          exact Array.pairwise_mergeSort Roots.rootLe_trans Roots.rootLe_total
+
+/-- For a nonzero fixed-field polynomial, the output multiplicities sum to
+its degree. -/
+theorem totalMultiplicity_roots [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x)
+    (hf : QAdjoin.toPolynomialAt f rep h ≠ 0) :
+    (QAdjoin.roots f rep h).totalMultiplicity =
+      (QAdjoin.toPolynomialAt f rep h).natDegree := by
+  classical
+  let polynomial := QAdjoin.toPolynomialAt f rep h
+  have hfinite : ∃ entries,
+      QAdjoin.roots f rep h = .finite entries := by
+    cases hroots : QAdjoin.roots f rep h with
+    | all => exact (hf ((roots_all_iff f rep h).1 hroots)).elim
+    | finite entries => exact ⟨entries, rfl⟩
+  obtain ⟨entries, hroots⟩ := hfinite
+  have hnodup : entries.toList.Pairwise fun a b =>
+      a.root.toComplex ≠ b.root.toComplex := by
+    have hresult := roots_noDuplicates f rep h
+    rw [hroots, RootSet.NoDuplicates] at hresult
+    exact hresult
+  have hentryMultiplicity : ∀ entry ∈ entries.toList,
+      Polynomial.rootMultiplicity entry.root.toComplex polynomial =
+        entry.multiplicity := by
+    intro entry hentry
+    have hlookup : (RootSet.finite entries).multiplicityOf
+        entry.root.toComplex = entry.multiplicity := by
+      unfold RootSet.multiplicityOf
+      exact findMultiplicity_mem entries.toList hnodup entry hentry
+    rw [← hlookup, ← hroots]
+    exact (multiplicity_roots f rep h entry.root.toComplex).symm
+  have hsum :
+      (entries.toList.map fun entry => entry.multiplicity).sum =
+        ∑ z ∈ (entries.toList.map fun entry =>
+          entry.root.toComplex).toFinset,
+          Polynomial.rootMultiplicity z polynomial :=
+    sum_eq_valueSum entries.toList hnodup
+      (fun z => Polynomial.rootMultiplicity z polynomial)
+      hentryMultiplicity
+  have hvalues :
+      (entries.toList.map fun entry => entry.root.toComplex).toFinset =
+        polynomial.roots.toFinset := by
+    ext z
+    simp only [List.mem_toFinset, List.mem_map, Multiset.mem_toFinset]
+    constructor
+    · rintro ⟨entry, hentry, rfl⟩
+      apply (Polynomial.mem_roots hf).2
+      have hcontains : RootSet.Contains (QAdjoin.roots f rep h)
+          entry.root.toComplex := by
+        rw [hroots, RootSet.Contains]
+        exact ⟨entry, hentry, rfl⟩
+      exact (contains_roots_iff f rep h entry.root.toComplex).mp hcontains
+    · intro hroot
+      have heval := (Polynomial.mem_roots hf).1 hroot
+      have hcontains := (contains_roots_iff f rep h z).mpr heval
+      rw [hroots, RootSet.Contains] at hcontains
+      exact hcontains
+  have hcount :
+      (∑ z ∈ polynomial.roots.toFinset,
+        Polynomial.rootMultiplicity z polynomial) = polynomial.roots.card := by
+    simpa only [Polynomial.count_roots] using
+      (Multiset.toFinset_sum_count_eq polynomial.roots)
+  rw [hroots, RootSet.totalMultiplicity, ← Array.foldl_toList,
+    foldlMultiplicity_eq_sum entries.toList, hsum, hvalues, hcount]
+  exact IsAlgClosed.card_roots_eq_natDegree
+
+end Hex.QAdjoin

--- a/HexNumberFieldMathlib/Roots.lean
+++ b/HexNumberFieldMathlib/Roots.lean
@@ -8,6 +8,7 @@ module
 
 public import HexNumberFieldMathlib.AlgebraicPoly
 public import HexNumberFieldMathlib.RootDisambiguation
+public import HexNumberFieldMathlib.Yun
 public import Mathlib.Algebra.Polynomial.Div
 
 public section
@@ -395,24 +396,26 @@ theorem componentRoots?_total [ZPoly.CheckedIrreducible p]
   exact componentRoots?_isSome f multiplicity hMultiplicity rep h
     hprim hpos hdegree hsimple
 
-private theorem mergeRootAux_isSome (candidate : RootCount) (index fuel : Nat)
-    (roots : Array RootCount) :
-    (mergeRootAux candidate index fuel roots).isSome := by
-  induction fuel generalizing index roots with
-  | zero => simp [mergeRootAux]
-  | succ fuel ih =>
-      rw [mergeRootAux]
-      split
-      · rename_i hi
-        obtain ⟨same, hsame⟩ := Option.isSome_iff_exists.mp
-          (sameValue?_isSome roots[index].root candidate.root)
-        cases same <;> simp [hsame, ih]
-      · simp
+private theorem mergeRootList_isSome (candidate : RootCount)
+    (roots : List RootCount) :
+    (mergeRootList candidate roots).isSome := by
+  induction roots with
+  | nil => simp [mergeRootList]
+  | cons current roots ih =>
+      obtain ⟨same, hsame⟩ := Option.isSome_iff_exists.mp
+        (sameValue?_isSome current.root candidate.root)
+      cases same with
+      | true => simp [mergeRootList, hsame]
+      | false =>
+          obtain ⟨tail, htail⟩ := Option.isSome_iff_exists.mp ih
+          simp [mergeRootList, hsame, htail]
 
 /-- Merging a root through a complete semantic scan cannot fail. -/
 theorem mergeRoot_isSome (roots : Array RootCount) (candidate : RootCount) :
     (mergeRoot roots candidate).isSome := by
-  exact mergeRootAux_isSome candidate 0 (roots.size + 1) roots
+  obtain ⟨merged, hmerged⟩ := Option.isSome_iff_exists.mp
+    (mergeRootList_isSome candidate roots.toList)
+  simp [mergeRoot, hmerged]
 
 /-- Folding semantic root merging over a finite candidate array cannot fail. -/
 theorem mergeRoots_isSome (roots candidates : Array RootCount) :
@@ -666,7 +669,9 @@ theorem coeff_toPolynomialAt (f : DensePoly (QAdjoin p x))
     coeff_hornerAt, array_toList_getDAt]
   rfl
 
-private theorem toPolynomialAt_eq_map [ZPoly.CheckedIrreducible p]
+/-- Fixed-field Horner interpretation is polynomial coefficient mapping by
+the selected complex embedding. -/
+theorem toPolynomialAt_eq_map [ZPoly.CheckedIrreducible p]
     (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
     (h : SimpleRoot.mk rep = x) :
     QAdjoin.toPolynomialAt f rep h =
@@ -1312,7 +1317,7 @@ theorem roots?_isSome [ZPoly.CheckedIrreducible p]
       exact Roots.mergeRoots_isSome out found
     obtain ⟨roots, hroots⟩ := Option.isSome_iff_exists.mp hfold
     apply Option.isSome_iff_exists.mpr
-    refine ⟨.finite (roots.qsort Roots.rootLe), ?_⟩
+    refine ⟨.finite (roots.mergeSort Roots.rootLe), ?_⟩
     rw [show (Roots.yun f).foldlM
         (fun out component =>
           if hm : 0 < component.2 then do
@@ -1366,58 +1371,6 @@ theorem roots_all_iff [ZPoly.CheckedIrreducible p]
   rw [← QAdjoin.poly_isZero_iff f rep h,
     ← roots?_all_iff_isZero f rep h, roots?_eq_roots]
   simp
-
-/-- Semantic membership in the fixed-field output is exactly polynomial
-vanishing. -/
-theorem contains_roots_iff [ZPoly.CheckedIrreducible p]
-    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
-    (h : SimpleRoot.mk rep = x) (z : ℂ) :
-    RootSet.Contains (QAdjoin.roots f rep h) z ↔
-      Polynomial.eval z (QAdjoin.toPolynomialAt f rep h) = 0 := by
-  sorry
-
-/-- Fixed-field root multiplicities agree with Mathlib multiplicities. -/
-theorem multiplicity_roots [ZPoly.CheckedIrreducible p]
-    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
-    (h : SimpleRoot.mk rep = x) (z : ℂ) :
-    (QAdjoin.roots f rep h).multiplicityOf z =
-      Polynomial.rootMultiplicity z (QAdjoin.toPolynomialAt f rep h) := by
-  sorry
-
-/-- The fixed-field driver produces positive multiplicities. -/
-theorem roots_positive [ZPoly.CheckedIrreducible p]
-    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
-    (h : SimpleRoot.mk rep = x) :
-    RootSet.Positive (QAdjoin.roots f rep h) := by
-  cases hroots : QAdjoin.roots f rep h with
-  | all => trivial
-  | finite roots =>
-      intro entry _hentry
-      exact entry.multiplicity_pos
-
-/-- The fixed-field driver merges all semantic duplicates. -/
-theorem roots_noDuplicates [ZPoly.CheckedIrreducible p]
-    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
-    (h : SimpleRoot.mk rep = x) :
-    RootSet.NoDuplicates (QAdjoin.roots f rep h) := by
-  sorry
-
-/-- The fixed-field driver uses its deterministic canonical root order. -/
-theorem roots_ordered [ZPoly.CheckedIrreducible p]
-    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
-    (h : SimpleRoot.mk rep = x) :
-    RootSet.Ordered (QAdjoin.roots f rep h) := by
-  sorry
-
-/-- For a nonzero fixed-field polynomial, the output multiplicities sum to
-its degree. -/
-theorem totalMultiplicity_roots [ZPoly.CheckedIrreducible p]
-    (f : DensePoly (QAdjoin p x)) (rep : RefinedIsolation p)
-    (h : SimpleRoot.mk rep = x)
-    (hf : QAdjoin.toPolynomialAt f rep h ≠ 0) :
-    (QAdjoin.roots f rep h).totalMultiplicity =
-      (QAdjoin.toPolynomialAt f rep h).natDegree := by
-  sorry
 
 end QAdjoin
 

--- a/HexNumberFieldMathlib/Yun.lean
+++ b/HexNumberFieldMathlib/Yun.lean
@@ -1,0 +1,855 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexNumberField.Roots
+public import HexNumberFieldMathlib.AdjoinRoot
+public import HexPolyMathlib.Euclid
+public import Mathlib.Algebra.Polynomial.FieldDivision
+
+public section
+
+/-!
+# Semantics of the fixed-field Yun decomposition
+
+This module relates the executable dense-polynomial Yun loop to root
+multiplicities after an injective embedding of the coefficient field.
+-/
+
+namespace Hex.QAdjoin.Roots
+
+open scoped QAdjoinField
+
+variable {p : ZPoly} {x : SimpleRoot p}
+
+/-- Interpret an executable fixed-field polynomial after a field embedding. -/
+noncomputable def toPolynomialMap [ZPoly.CheckedIrreducible p]
+    {K : Type*} [Semiring K]
+    (embedding : QAdjoin p x →+* K) (f : DensePoly (QAdjoin p x)) :
+    Polynomial K :=
+  (HexPolyMathlib.toPolynomial f).map embedding
+
+/-- Unfolding rule for the polynomial interpretation used by the Yun proofs. -/
+theorem toPolynomialMap_eq_map [ZPoly.CheckedIrreducible p]
+    {K : Type*} [Semiring K]
+    (embedding : QAdjoin p x →+* K) (f : DensePoly (QAdjoin p x)) :
+    toPolynomialMap embedding f =
+      (HexPolyMathlib.toPolynomial f).map embedding := by
+  rfl
+
+private theorem rat_smul_natCast [ZPoly.CheckedIrreducible p]
+    (n : Nat) (a : QAdjoin p x) :
+    (n : Rat) • a = (n : QAdjoin p x) * a := by
+  let rep : RefinedIsolation p := Quot.out x
+  have hrep : SimpleRoot.mk rep = x := Quot.out_eq x
+  apply QAdjoin.toComplex_injective rep hrep
+  change QAdjoin.toComplex ((n : Rat) • a) rep hrep =
+    QAdjoin.toComplex (((n : Rat) • (1 : QAdjoin p x)) * a) rep hrep
+  rw [QAdjoin.map_smul, QAdjoin.map_mul, QAdjoin.map_smul,
+    QAdjoin.map_one, mul_one]
+
+private theorem derivative_eq_dense [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) :
+    derivative f = f.derivative := by
+  apply DensePoly.ext_coeff
+  intro n
+  unfold derivative
+  rw [DensePoly.coeff_ofCoeffs,
+    DensePoly.coeff_derivative f n (by exact mul_zero _)]
+  by_cases hn : n < f.size - 1
+  · simp [hn]
+    simpa only [Nat.cast_add, Nat.cast_one] using
+      rat_smul_natCast (p := p) (x := x) (n + 1) (f.coeff (n + 1))
+  · have hcoeff : f.coeff (n + 1) = 0 :=
+      DensePoly.coeff_eq_zero_of_size_le f (by omega)
+    simp [hn, hcoeff]
+    rfl
+
+/-- The executable fixed-field derivative agrees with the Mathlib derivative
+after dense-polynomial transport. -/
+theorem toPolynomial_derivative [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x)) :
+    HexPolyMathlib.toPolynomial (derivative f) =
+      Polynomial.derivative (HexPolyMathlib.toPolynomial f) := by
+  rw [derivative_eq_dense]
+  exact HexPolyMathlib.toPolynomial_derivative f
+
+/-- The multiplicity of a root of a polynomial gcd is the minimum of its
+multiplicities in the two nonzero inputs. -/
+theorem rootMultiplicity_gcd {K : Type*} [Field K] [DecidableEq K]
+    (f g : Polynomial K) (hf : f ≠ 0) (hg : g ≠ 0) (z : K) :
+    (EuclideanDomain.gcd f g).rootMultiplicity z =
+      min (f.rootMultiplicity z) (g.rootMultiplicity z) := by
+  classical
+  have hgcd : EuclideanDomain.gcd f g ≠ 0 := by
+    intro h
+    exact hf (EuclideanDomain.gcd_eq_zero_iff.mp h).1
+  apply le_antisymm
+  · exact le_min
+      (Polynomial.rootMultiplicity_le_rootMultiplicity_of_dvd hf
+        (EuclideanDomain.gcd_dvd_left f g) z)
+      (Polynomial.rootMultiplicity_le_rootMultiplicity_of_dvd
+        hg
+        (EuclideanDomain.gcd_dvd_right f g) z)
+  · rw [Polynomial.le_rootMultiplicity_iff hgcd]
+    apply EuclideanDomain.dvd_gcd
+    · rw [← Polynomial.le_rootMultiplicity_iff hf]
+      exact min_le_left _ _
+    · rw [← Polynomial.le_rootMultiplicity_iff hg]
+      exact min_le_right _ _
+
+/-- Root multiplicity subtracts across an exact polynomial quotient. -/
+theorem rootMultiplicity_of_mul_eq {K : Type*} [Field K]
+    (quotient divisor dividend : Polynomial K) (hdividend : dividend ≠ 0)
+    (hreconstruct : quotient * divisor = dividend) (z : K) :
+    quotient.rootMultiplicity z =
+      dividend.rootMultiplicity z - divisor.rootMultiplicity z := by
+  have hproduct : quotient * divisor ≠ 0 := by simpa [hreconstruct]
+  have hmultiplicity := Polynomial.rootMultiplicity_mul (x := z) hproduct
+  rw [hreconstruct] at hmultiplicity
+  omega
+
+/-- A root's multiplicity is bounded by the degree of a nonzero polynomial. -/
+theorem rootMultiplicity_le_natDegree {K : Type*} [Field K]
+    (f : Polynomial K) (hf : f ≠ 0) (z : K) :
+    f.rootMultiplicity z ≤ f.natDegree := by
+  have hdegree := Polynomial.natDegree_le_of_dvd
+    (Polynomial.pow_rootMultiplicity_dvd f z) hf
+  simpa using hdegree
+
+/-- Executable field division subtracts root multiplicities when the divisor
+is known to divide the nonzero dividend. -/
+theorem rootMultiplicity_div {K : Type*} [Field K] [DecidableEq K]
+    (dividend divisor : DensePoly K) (hdivisor : divisor ∣ dividend)
+    (hdividend : HexPolyMathlib.toPolynomial dividend ≠ 0) (z : K) :
+    (HexPolyMathlib.toPolynomial (dividend / divisor)).rootMultiplicity z =
+      (HexPolyMathlib.toPolynomial dividend).rootMultiplicity z -
+        (HexPolyMathlib.toPolynomial divisor).rootMultiplicity z := by
+  have hmod : dividend % divisor = 0 :=
+    DensePoly.mod_eq_zero_of_dvd dividend divisor hdivisor
+  have hreconstruct := DensePoly.div_mul_add_mod dividend divisor
+  rw [hmod] at hreconstruct
+  have hpolynomial := congrArg HexPolyMathlib.toPolynomial hreconstruct
+  simp only [HexPolyMathlib.toPolynomial_add,
+    HexPolyMathlib.toPolynomial_mul, HexPolyMathlib.toPolynomial_zero,
+    add_zero] at hpolynomial
+  exact rootMultiplicity_of_mul_eq _ _ _ hdividend hpolynomial z
+
+/-- Monic normalization changes a nonzero polynomial only by a nonzero
+constant factor, so it preserves every root multiplicity. -/
+theorem rootMultiplicity_monic [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x))
+    (hf : HexPolyMathlib.toPolynomial f ≠ 0) (z : QAdjoin p x) :
+    (HexPolyMathlib.toPolynomial (monic f)).rootMultiplicity z =
+      (HexPolyMathlib.toPolynomial f).rootMultiplicity z := by
+  unfold monic
+  split
+  · rename_i hzero
+    have hsize : f.size = 0 :=
+      (DensePoly.isZero_eq_true_iff f).mp (by simpa using hzero)
+    have hfzero : f = 0 := by
+      apply DensePoly.ext_coeff
+      intro n
+      rw [DensePoly.coeff_zero]
+      exact DensePoly.coeff_eq_zero_of_size_le f (by omega)
+    exact (hf (by simp [hfzero])).elim
+  · rw [HexPolyMathlib.toPolynomial_scale]
+    have hleading : f.leadingCoeff ≠ 0 := by
+      simpa only [← HexPolyMathlib.leadingCoeff_toPolynomial] using
+        Polynomial.leadingCoeff_ne_zero.mpr hf
+    have hconstant : Polynomial.C f.leadingCoeff⁻¹ ≠ 0 :=
+      Polynomial.C_ne_zero.mpr (inv_ne_zero hleading)
+    rw [Polynomial.rootMultiplicity_mul (mul_ne_zero hconstant hf),
+      Polynomial.rootMultiplicity_C, zero_add]
+
+/-- Monic normalization is associated to its nonzero input. -/
+theorem toPolynomial_monic_associated [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x))
+    (hf : HexPolyMathlib.toPolynomial f ≠ 0) :
+    Associated (HexPolyMathlib.toPolynomial (monic f))
+      (HexPolyMathlib.toPolynomial f) := by
+  unfold monic
+  split
+  · rename_i hzero
+    have hsize : f.size = 0 :=
+      (DensePoly.isZero_eq_true_iff f).mp (by simpa using hzero)
+    have hfzero : f = 0 := by
+      apply DensePoly.ext_coeff
+      intro n
+      rw [DensePoly.coeff_zero]
+      exact DensePoly.coeff_eq_zero_of_size_le f (by omega)
+    exact (hf (by simp [hfzero])).elim
+  · rw [HexPolyMathlib.toPolynomial_scale]
+    have hleading : f.leadingCoeff ≠ 0 := by
+      simpa only [← HexPolyMathlib.leadingCoeff_toPolynomial] using
+        Polynomial.leadingCoeff_ne_zero.mpr hf
+    exact associated_unit_mul_left _ _
+      (Polynomial.isUnit_C.mpr (inv_ne_zero hleading).isUnit)
+
+/-- Associated polynomials have the same root multiplicity. -/
+theorem rootMultiplicity_associated {K : Type*} [Field K] [DecidableEq K]
+    {f g : Polynomial K} (h : Associated f g) (z : K) :
+    f.rootMultiplicity z = g.rootMultiplicity z := by
+  rw [← Polynomial.count_roots, ← Polynomial.count_roots, h.roots_eq]
+
+/-- The executable monic gcd realizes the pointwise minimum of root
+multiplicities. -/
+theorem rootMultiplicity_monicGcd [ZPoly.CheckedIrreducible p]
+    (f g : DensePoly (QAdjoin p x))
+    (hf : HexPolyMathlib.toPolynomial f ≠ 0)
+    (hg : HexPolyMathlib.toPolynomial g ≠ 0) (z : QAdjoin p x) :
+    (HexPolyMathlib.toPolynomial (monic (DensePoly.gcd f g))).rootMultiplicity z =
+      min ((HexPolyMathlib.toPolynomial f).rootMultiplicity z)
+        ((HexPolyMathlib.toPolynomial g).rootMultiplicity z) := by
+  let raw := HexPolyMathlib.toPolynomial (DensePoly.gcd f g)
+  let normalized := EuclideanDomain.gcd
+    (HexPolyMathlib.toPolynomial f) (HexPolyMathlib.toPolynomial g)
+  have hassociated : Associated raw normalized := by
+    exact HexPolyMathlib.toPolynomial_gcd_associated f g
+  have hnormalized : normalized ≠ 0 := by
+    intro hzero
+    exact hf (EuclideanDomain.gcd_eq_zero_iff.mp hzero).1
+  have hraw : raw ≠ 0 := fun hzero =>
+    hnormalized (hassociated.eq_zero_iff.mp hzero)
+  calc
+    (HexPolyMathlib.toPolynomial
+        (monic (DensePoly.gcd f g))).rootMultiplicity z =
+        raw.rootMultiplicity z :=
+      rootMultiplicity_monic (DensePoly.gcd f g) hraw z
+    _ = normalized.rootMultiplicity z :=
+      rootMultiplicity_associated hassociated z
+    _ = min ((HexPolyMathlib.toPolynomial f).rootMultiplicity z)
+        ((HexPolyMathlib.toPolynomial g).rootMultiplicity z) :=
+      rootMultiplicity_gcd _ _ hf hg z
+
+/-- The executable monic gcd divides each nonzero input. -/
+theorem monicGcd_dvd [ZPoly.CheckedIrreducible p]
+    (f g : DensePoly (QAdjoin p x))
+    (hf : HexPolyMathlib.toPolynomial f ≠ 0) :
+    monic (DensePoly.gcd f g) ∣ f ∧ monic (DensePoly.gcd f g) ∣ g := by
+  let raw := HexPolyMathlib.toPolynomial (DensePoly.gcd f g)
+  let normalized := EuclideanDomain.gcd
+    (HexPolyMathlib.toPolynomial f) (HexPolyMathlib.toPolynomial g)
+  have hrawNormalized : Associated raw normalized :=
+    HexPolyMathlib.toPolynomial_gcd_associated f g
+  have hnormalized : normalized ≠ 0 := by
+    intro hzero
+    exact hf (EuclideanDomain.gcd_eq_zero_iff.mp hzero).1
+  have hraw : raw ≠ 0 := fun hzero =>
+    hnormalized (hrawNormalized.eq_zero_iff.mp hzero)
+  have hmonicRaw : Associated
+      (HexPolyMathlib.toPolynomial (monic (DensePoly.gcd f g))) raw :=
+    toPolynomial_monic_associated (DensePoly.gcd f g) hraw
+  have hmonicNormalized := hmonicRaw.trans hrawNormalized
+  constructor <;> rw [← HexPolyMathlib.toPolynomial_dvd_iff]
+  · exact hmonicNormalized.dvd.trans
+      (EuclideanDomain.gcd_dvd_left
+        (HexPolyMathlib.toPolynomial f) (HexPolyMathlib.toPolynomial g))
+  · exact hmonicNormalized.dvd.trans
+      (EuclideanDomain.gcd_dvd_right
+        (HexPolyMathlib.toPolynomial f) (HexPolyMathlib.toPolynomial g))
+
+/-- An exact quotient of a nonzero executable polynomial is nonzero. -/
+theorem toPolynomial_div_ne_zero {K : Type*} [Field K] [DecidableEq K]
+    (dividend divisor : DensePoly K) (hdivisor : divisor ∣ dividend)
+    (hdividend : HexPolyMathlib.toPolynomial dividend ≠ 0) :
+    HexPolyMathlib.toPolynomial (dividend / divisor) ≠ 0 := by
+  have hmod : dividend % divisor = 0 :=
+    DensePoly.mod_eq_zero_of_dvd dividend divisor hdivisor
+  have hreconstruct := DensePoly.div_mul_add_mod dividend divisor
+  rw [hmod] at hreconstruct
+  have hpolynomial := congrArg HexPolyMathlib.toPolynomial hreconstruct
+  simp only [HexPolyMathlib.toPolynomial_add,
+    HexPolyMathlib.toPolynomial_mul, HexPolyMathlib.toPolynomial_zero,
+    add_zero] at hpolynomial
+  intro hquotient
+  rw [hquotient, zero_mul] at hpolynomial
+  exact hdividend hpolynomial.symm
+
+/-- Monic normalization of a nonzero executable polynomial remains nonzero. -/
+theorem toPolynomial_monic_ne_zero [ZPoly.CheckedIrreducible p]
+    (f : DensePoly (QAdjoin p x))
+    (hf : HexPolyMathlib.toPolynomial f ≠ 0) :
+    HexPolyMathlib.toPolynomial (monic f) ≠ 0 := by
+  intro hzero
+  exact hf ((toPolynomial_monic_associated f hf).eq_zero_iff.mp hzero)
+
+/-- A monic exact quotient subtracts the divisor's root multiplicity. -/
+theorem rootMultiplicity_monicDiv [ZPoly.CheckedIrreducible p]
+    (dividend divisor : DensePoly (QAdjoin p x))
+    (hdivisor : divisor ∣ dividend)
+    (hdividend : HexPolyMathlib.toPolynomial dividend ≠ 0)
+    (z : QAdjoin p x) :
+    (HexPolyMathlib.toPolynomial (monic (dividend / divisor))).rootMultiplicity z =
+      (HexPolyMathlib.toPolynomial dividend).rootMultiplicity z -
+        (HexPolyMathlib.toPolynomial divisor).rootMultiplicity z := by
+  have hquotient := toPolynomial_div_ne_zero dividend divisor hdivisor hdividend
+  rw [rootMultiplicity_monic (dividend / divisor) hquotient z]
+  exact rootMultiplicity_div dividend divisor hdivisor hdividend z
+
+/-- A monic exact quotient of a nonzero executable polynomial is nonzero. -/
+theorem toPolynomial_monicDiv_ne_zero [ZPoly.CheckedIrreducible p]
+    (dividend divisor : DensePoly (QAdjoin p x))
+    (hdivisor : divisor ∣ dividend)
+    (hdividend : HexPolyMathlib.toPolynomial dividend ≠ 0) :
+    HexPolyMathlib.toPolynomial (monic (dividend / divisor)) ≠ 0 :=
+  toPolynomial_monic_ne_zero _
+    (toPolynomial_div_ne_zero dividend divisor hdivisor hdividend)
+
+/-- Monic normalization remains associated after any field embedding. -/
+theorem map_monic_associated [ZPoly.CheckedIrreducible p]
+    {K : Type*} [Field K] (embedding : QAdjoin p x →+* K)
+    (f : DensePoly (QAdjoin p x)) (hf : toPolynomialMap embedding f ≠ 0) :
+    Associated (toPolynomialMap embedding (monic f))
+      (toPolynomialMap embedding f) := by
+  have hfSource : HexPolyMathlib.toPolynomial f ≠ 0 := by
+    intro hzero
+    exact hf (by simp [toPolynomialMap, hzero])
+  exact Polynomial.associated_map_map embedding
+    (toPolynomial_monic_associated f hfSource)
+
+/-- Monic normalization preserves root multiplicity after any field
+embedding. -/
+theorem rootMultiplicity_map_monic [ZPoly.CheckedIrreducible p]
+    {K : Type*} [Field K] [DecidableEq K]
+    (embedding : QAdjoin p x →+* K) (f : DensePoly (QAdjoin p x))
+    (hf : toPolynomialMap embedding f ≠ 0) (z : K) :
+    (toPolynomialMap embedding (monic f)).rootMultiplicity z =
+      (toPolynomialMap embedding f).rootMultiplicity z :=
+  rootMultiplicity_associated (map_monic_associated embedding f hf) z
+
+/-- The executable monic gcd realizes the pointwise minimum of root
+multiplicities after any field embedding. -/
+theorem rootMultiplicity_map_monicGcd [ZPoly.CheckedIrreducible p]
+    {K : Type*} [Field K] [DecidableEq K]
+    (embedding : QAdjoin p x →+* K) (f g : DensePoly (QAdjoin p x))
+    (hf : toPolynomialMap embedding f ≠ 0)
+    (hg : toPolynomialMap embedding g ≠ 0) (z : K) :
+    (toPolynomialMap embedding (monic (DensePoly.gcd f g))).rootMultiplicity z =
+      min ((toPolynomialMap embedding f).rootMultiplicity z)
+        ((toPolynomialMap embedding g).rootMultiplicity z) := by
+  let sourceGcd := EuclideanDomain.gcd
+    (HexPolyMathlib.toPolynomial f) (HexPolyMathlib.toPolynomial g)
+  let targetGcd := EuclideanDomain.gcd
+    (toPolynomialMap embedding f) (toPolynomialMap embedding g)
+  have hfSource : HexPolyMathlib.toPolynomial f ≠ 0 := by
+    intro hzero
+    exact hf (by simp [toPolynomialMap, hzero])
+  have hsourceGcd : sourceGcd ≠ 0 := by
+    intro hzero
+    exact hfSource (EuclideanDomain.gcd_eq_zero_iff.mp hzero).1
+  have hrawSource : Associated
+      (HexPolyMathlib.toPolynomial (DensePoly.gcd f g)) sourceGcd :=
+    HexPolyMathlib.toPolynomial_gcd_associated f g
+  have hraw : HexPolyMathlib.toPolynomial (DensePoly.gcd f g) ≠ 0 :=
+    fun hzero => hsourceGcd (hrawSource.eq_zero_iff.mp hzero)
+  have hmonicSource : Associated
+      (HexPolyMathlib.toPolynomial (monic (DensePoly.gcd f g))) sourceGcd :=
+    (toPolynomial_monic_associated (DensePoly.gcd f g) hraw).trans hrawSource
+  have hmapped : Associated
+      (toPolynomialMap embedding (monic (DensePoly.gcd f g)))
+      (sourceGcd.map embedding) := by
+    exact Polynomial.associated_map_map embedding hmonicSource
+  have hmapGcd : sourceGcd.map embedding = targetGcd := by
+    exact (Polynomial.gcd_map (p := HexPolyMathlib.toPolynomial f)
+      (q := HexPolyMathlib.toPolynomial g) embedding).symm
+  calc
+    (toPolynomialMap embedding
+        (monic (DensePoly.gcd f g))).rootMultiplicity z =
+        (sourceGcd.map embedding).rootMultiplicity z :=
+      rootMultiplicity_associated hmapped z
+    _ = targetGcd.rootMultiplicity z := by rw [hmapGcd]
+    _ = min ((toPolynomialMap embedding f).rootMultiplicity z)
+        ((toPolynomialMap embedding g).rootMultiplicity z) :=
+      rootMultiplicity_gcd _ _ hf hg z
+
+/-- The monic gcd of two polynomials that remain nonzero after a field
+embedding also remains nonzero. -/
+theorem map_monicGcd_ne_zero [ZPoly.CheckedIrreducible p]
+    {K : Type*} [Field K] (embedding : QAdjoin p x →+* K)
+    (f g : DensePoly (QAdjoin p x))
+    (hf : toPolynomialMap embedding f ≠ 0) :
+    toPolynomialMap embedding (monic (DensePoly.gcd f g)) ≠ 0 := by
+  have hfSource : HexPolyMathlib.toPolynomial f ≠ 0 := by
+    intro hzero
+    exact hf (by simp [toPolynomialMap, hzero])
+  let sourceGcd := EuclideanDomain.gcd
+    (HexPolyMathlib.toPolynomial f) (HexPolyMathlib.toPolynomial g)
+  have hsourceGcd : sourceGcd ≠ 0 := by
+    intro hzero
+    exact hfSource (EuclideanDomain.gcd_eq_zero_iff.mp hzero).1
+  have hrawSource : Associated
+      (HexPolyMathlib.toPolynomial (DensePoly.gcd f g)) sourceGcd :=
+    HexPolyMathlib.toPolynomial_gcd_associated f g
+  have hraw : HexPolyMathlib.toPolynomial (DensePoly.gcd f g) ≠ 0 :=
+    fun hzero => hsourceGcd (hrawSource.eq_zero_iff.mp hzero)
+  have hmonic := toPolynomial_monic_ne_zero (DensePoly.gcd f g) hraw
+  simpa only [toPolynomialMap] using
+    (Polynomial.map_ne_zero_iff embedding.injective).mpr hmonic
+
+/-- The executable derivative commutes with every field embedding. -/
+theorem map_derivative [ZPoly.CheckedIrreducible p]
+    {K : Type*} [Field K] (embedding : QAdjoin p x →+* K)
+    (f : DensePoly (QAdjoin p x)) :
+    toPolynomialMap embedding (derivative f) =
+      Polynomial.derivative (toPolynomialMap embedding f) := by
+  simp only [toPolynomialMap, toPolynomial_derivative,
+    Polynomial.derivative_map]
+
+/-- Exact executable division remains an exact factorization after a field
+embedding. -/
+theorem map_div_mul [ZPoly.CheckedIrreducible p]
+    {K : Type*} [Field K] (embedding : QAdjoin p x →+* K)
+    (dividend divisor : DensePoly (QAdjoin p x))
+    (hdivisor : divisor ∣ dividend) :
+    toPolynomialMap embedding (dividend / divisor) *
+        toPolynomialMap embedding divisor =
+      toPolynomialMap embedding dividend := by
+  have hmod : dividend % divisor = 0 :=
+    DensePoly.mod_eq_zero_of_dvd dividend divisor hdivisor
+  have hreconstruct := DensePoly.div_mul_add_mod dividend divisor
+  rw [hmod] at hreconstruct
+  have hsource := congrArg HexPolyMathlib.toPolynomial hreconstruct
+  simp only [HexPolyMathlib.toPolynomial_add,
+    HexPolyMathlib.toPolynomial_mul, HexPolyMathlib.toPolynomial_zero,
+    add_zero] at hsource
+  have hmapped := congrArg (Polynomial.map embedding) hsource
+  simpa only [toPolynomialMap, Polynomial.map_mul] using hmapped
+
+/-- An exact quotient of a polynomial that stays nonzero after embedding also
+stays nonzero. -/
+theorem map_div_ne_zero [ZPoly.CheckedIrreducible p]
+    {K : Type*} [Field K] (embedding : QAdjoin p x →+* K)
+    (dividend divisor : DensePoly (QAdjoin p x))
+    (hdivisor : divisor ∣ dividend)
+    (hdividend : toPolynomialMap embedding dividend ≠ 0) :
+    toPolynomialMap embedding (dividend / divisor) ≠ 0 := by
+  intro hquotient
+  have hreconstruct := map_div_mul embedding dividend divisor hdivisor
+  rw [hquotient, zero_mul] at hreconstruct
+  exact hdividend hreconstruct.symm
+
+/-- Exact executable division subtracts root multiplicities after a field
+embedding. -/
+theorem rootMultiplicity_map_div [ZPoly.CheckedIrreducible p]
+    {K : Type*} [Field K] (embedding : QAdjoin p x →+* K)
+    (dividend divisor : DensePoly (QAdjoin p x))
+    (hdivisor : divisor ∣ dividend)
+    (hdividend : toPolynomialMap embedding dividend ≠ 0) (z : K) :
+    (toPolynomialMap embedding (dividend / divisor)).rootMultiplicity z =
+      (toPolynomialMap embedding dividend).rootMultiplicity z -
+        (toPolynomialMap embedding divisor).rootMultiplicity z :=
+  rootMultiplicity_of_mul_eq _ _ _ hdividend
+    (map_div_mul embedding dividend divisor hdivisor) z
+
+/-- A monic exact quotient subtracts root multiplicities after a field
+embedding. -/
+theorem rootMultiplicity_map_monicDiv [ZPoly.CheckedIrreducible p]
+    {K : Type*} [Field K] [DecidableEq K]
+    (embedding : QAdjoin p x →+* K)
+    (dividend divisor : DensePoly (QAdjoin p x))
+    (hdivisor : divisor ∣ dividend)
+    (hdividend : toPolynomialMap embedding dividend ≠ 0) (z : K) :
+    (toPolynomialMap embedding (monic (dividend / divisor))).rootMultiplicity z =
+      (toPolynomialMap embedding dividend).rootMultiplicity z -
+        (toPolynomialMap embedding divisor).rootMultiplicity z := by
+  have hquotient := map_div_ne_zero embedding dividend divisor hdivisor hdividend
+  rw [rootMultiplicity_map_monic embedding (dividend / divisor) hquotient z]
+  exact rootMultiplicity_map_div embedding dividend divisor hdivisor hdividend z
+
+/-- A monic exact quotient remains nonzero after a field embedding. -/
+theorem map_monicDiv_ne_zero [ZPoly.CheckedIrreducible p]
+    {K : Type*} [Field K] (embedding : QAdjoin p x →+* K)
+    (dividend divisor : DensePoly (QAdjoin p x))
+    (hdivisor : divisor ∣ dividend)
+    (hdividend : toPolynomialMap embedding dividend ≠ 0) :
+    toPolynomialMap embedding (monic (dividend / divisor)) ≠ 0 := by
+  have hquotient := map_div_ne_zero embedding dividend divisor hdivisor hdividend
+  intro hzero
+  exact hquotient ((map_monic_associated embedding
+    (dividend / divisor) hquotient).eq_zero_iff.mp hzero)
+
+/-- Pointwise semantic invariant of the Yun loop at multiplicity index `k`.
+The first polynomial contains the root once exactly while `k ≤ r`; the
+repeated part contains the remaining `r - k` copies. -/
+structure YunInvariant [ZPoly.CheckedIrreducible p]
+    {K : Type*} [Field K] (embedding : QAdjoin p x →+* K) (z : K)
+    (r k : Nat) (w repeated : DensePoly (QAdjoin p x)) : Prop where
+  w_ne : toPolynomialMap embedding w ≠ 0
+  repeated_ne : toPolynomialMap embedding repeated ≠ 0
+  w_multiplicity : (toPolynomialMap embedding w).rootMultiplicity z =
+    if k ≤ r then 1 else 0
+  repeated_multiplicity :
+    (toPolynomialMap embedding repeated).rootMultiplicity z = r - k
+
+/-- One executable Yun step advances the pointwise loop invariant. -/
+theorem YunInvariant.step [ZPoly.CheckedIrreducible p]
+    {K : Type*} [Field K] [DecidableEq K]
+    (embedding : QAdjoin p x →+* K) (z : K) (r k : Nat)
+    (w repeated : DensePoly (QAdjoin p x))
+    (invariant : YunInvariant embedding z r k w repeated) :
+    let shared := monic (DensePoly.gcd w repeated)
+    let nextRepeated := monic (repeated / shared)
+    YunInvariant embedding z r (k + 1) shared nextRepeated := by
+  let shared := monic (DensePoly.gcd w repeated)
+  let nextRepeated := monic (repeated / shared)
+  have hwSource : HexPolyMathlib.toPolynomial w ≠ 0 := by
+    intro hzero
+    exact invariant.w_ne (by simp [toPolynomialMap, hzero])
+  have hdivisors := monicGcd_dvd w repeated hwSource
+  have hsharedNe : toPolynomialMap embedding shared ≠ 0 :=
+    map_monicGcd_ne_zero embedding w repeated invariant.w_ne
+  have hnextNe : toPolynomialMap embedding nextRepeated ≠ 0 :=
+    map_monicDiv_ne_zero embedding repeated shared hdivisors.2 invariant.repeated_ne
+  have hsharedMultiplicity :
+      (toPolynomialMap embedding shared).rootMultiplicity z =
+        min ((toPolynomialMap embedding w).rootMultiplicity z)
+          ((toPolynomialMap embedding repeated).rootMultiplicity z) :=
+    rootMultiplicity_map_monicGcd embedding w repeated
+      invariant.w_ne invariant.repeated_ne z
+  have hnextMultiplicity :
+      (toPolynomialMap embedding nextRepeated).rootMultiplicity z =
+        (toPolynomialMap embedding repeated).rootMultiplicity z -
+          (toPolynomialMap embedding shared).rootMultiplicity z :=
+    rootMultiplicity_map_monicDiv embedding repeated shared
+      hdivisors.2 invariant.repeated_ne z
+  refine ⟨hsharedNe, hnextNe, ?_, ?_⟩
+  · rw [hsharedMultiplicity, invariant.w_multiplicity,
+      invariant.repeated_multiplicity]
+    by_cases hk : k ≤ r <;> by_cases hnext : k + 1 ≤ r <;>
+      simp [hk, hnext] <;> omega
+  · rw [hnextMultiplicity, invariant.repeated_multiplicity,
+      hsharedMultiplicity, invariant.w_multiplicity,
+      invariant.repeated_multiplicity]
+    by_cases hk : k ≤ r <;> simp [hk] <;> omega
+
+/-- The component produced at a Yun step contains the root exactly when the
+current index is its original multiplicity. -/
+theorem YunInvariant.component [ZPoly.CheckedIrreducible p]
+    {K : Type*} [Field K] [DecidableEq K]
+    (embedding : QAdjoin p x →+* K) (z : K) (r k : Nat)
+    (w repeated : DensePoly (QAdjoin p x))
+    (invariant : YunInvariant embedding z r k w repeated) :
+    let shared := monic (DensePoly.gcd w repeated)
+    let component := monic (w / shared)
+    (toPolynomialMap embedding component).rootMultiplicity z =
+      if k = r then 1 else 0 := by
+  let shared := monic (DensePoly.gcd w repeated)
+  let component := monic (w / shared)
+  change (toPolynomialMap embedding component).rootMultiplicity z =
+    if k = r then 1 else 0
+  have hwSource : HexPolyMathlib.toPolynomial w ≠ 0 := by
+    intro hzero
+    exact invariant.w_ne (by simp [toPolynomialMap, hzero])
+  have hdivisors := monicGcd_dvd w repeated hwSource
+  rw [rootMultiplicity_map_monicDiv embedding w shared
+      hdivisors.1 invariant.w_ne z,
+    rootMultiplicity_map_monicGcd embedding w repeated
+      invariant.w_ne invariant.repeated_ne z,
+    invariant.w_multiplicity, invariant.repeated_multiplicity]
+  by_cases hk : k ≤ r
+  · by_cases heq : k = r
+    · simp [heq]
+    · simp [hk, heq]
+      omega
+  · have heq : k ≠ r := by omega
+    simp [hk, heq]
+
+/-- The normalized derivative/gcd prelude establishes the Yun invariant at
+multiplicity index one. -/
+theorem YunInvariant.init [ZPoly.CheckedIrreducible p]
+    {K : Type*} [Field K] [CharZero K] [DecidableEq K]
+    (embedding : QAdjoin p x →+* K) (f : DensePoly (QAdjoin p x))
+    (hf : toPolynomialMap embedding f ≠ 0)
+    (hdegree : (toPolynomialMap embedding f).natDegree ≠ 0) (z : K) :
+    let normalized := monic f
+    let repeated := monic (DensePoly.gcd normalized (derivative normalized))
+    let distinct := monic (normalized / repeated)
+    YunInvariant embedding z
+      ((toPolynomialMap embedding f).rootMultiplicity z) 1
+      distinct repeated := by
+  let normalized := monic f
+  let repeated := monic (DensePoly.gcd normalized (derivative normalized))
+  let distinct := monic (normalized / repeated)
+  change YunInvariant embedding z
+    ((toPolynomialMap embedding f).rootMultiplicity z) 1 distinct repeated
+  have hnormalizedNe : toPolynomialMap embedding normalized ≠ 0 := by
+    intro hzero
+    exact hf ((map_monic_associated embedding f hf).eq_zero_iff.mp hzero)
+  have hnormalizedMultiplicity :
+      (toPolynomialMap embedding normalized).rootMultiplicity z =
+        (toPolynomialMap embedding f).rootMultiplicity z :=
+    rootMultiplicity_map_monic embedding f hf z
+  have hnormalizedDegree :
+      (toPolynomialMap embedding normalized).natDegree ≠ 0 := by
+    have hdegreeEq := Polynomial.degree_eq_degree_of_associated
+      (map_monic_associated embedding f hf)
+    have hnatDegreeEq := Polynomial.natDegree_eq_of_degree_eq hdegreeEq
+    intro hzero
+    apply hdegree
+    rw [← hnatDegreeEq, hzero]
+  have hderivativeNe :
+      toPolynomialMap embedding (derivative normalized) ≠ 0 := by
+    rw [map_derivative]
+    exact Polynomial.derivative_ne_zero.mpr hnormalizedDegree
+  have hrepeatedNe : toPolynomialMap embedding repeated ≠ 0 :=
+    map_monicGcd_ne_zero embedding normalized (derivative normalized)
+      hnormalizedNe
+  have hnormalizedSource : HexPolyMathlib.toPolynomial normalized ≠ 0 := by
+    intro hzero
+    exact hnormalizedNe (by simp [toPolynomialMap, hzero])
+  have hdivisor : repeated ∣ normalized :=
+    (monicGcd_dvd normalized (derivative normalized) hnormalizedSource).1
+  have hdistinctNe : toPolynomialMap embedding distinct ≠ 0 :=
+    map_monicDiv_ne_zero embedding normalized repeated hdivisor hnormalizedNe
+  have hrepeatedMultiplicity :
+      (toPolynomialMap embedding repeated).rootMultiplicity z =
+        (toPolynomialMap embedding f).rootMultiplicity z - 1 := by
+    rw [rootMultiplicity_map_monicGcd embedding normalized
+        (derivative normalized) hnormalizedNe hderivativeNe z,
+      map_derivative, hnormalizedMultiplicity]
+    by_cases hroot :
+        (toPolynomialMap embedding f).rootMultiplicity z = 0
+    · simp [hroot]
+    · have hpositive : 0 <
+          (toPolynomialMap embedding normalized).rootMultiplicity z := by
+        omega
+      have hisRoot : (toPolynomialMap embedding normalized).IsRoot z :=
+        (Polynomial.rootMultiplicity_pos hnormalizedNe).mp hpositive
+      rw [Polynomial.derivative_rootMultiplicity_of_root hisRoot,
+        hnormalizedMultiplicity]
+      omega
+  refine ⟨hdistinctNe, hrepeatedNe, ?_, hrepeatedMultiplicity⟩
+  rw [rootMultiplicity_map_monicDiv embedding normalized repeated
+      hdivisor hnormalizedNe z,
+    hnormalizedMultiplicity, hrepeatedMultiplicity]
+  by_cases hpositive : 1 ≤
+      (toPolynomialMap embedding f).rootMultiplicity z <;>
+    simp [hpositive] <;> omega
+
+/-- A nonzero embedded polynomial with a root has positive executable degree. -/
+theorem degree_pos_of_map_root [ZPoly.CheckedIrreducible p]
+    {K : Type*} [Field K] (embedding : QAdjoin p x →+* K)
+    (f : DensePoly (QAdjoin p x)) (hf : toPolynomialMap embedding f ≠ 0)
+    {z : K} (hroot : (toPolynomialMap embedding f).IsRoot z) :
+    0 < f.degree?.getD 0 := by
+  have hdegree := Polynomial.degree_pos_of_root hf hroot
+  have hnatDegree : 0 < (toPolynomialMap embedding f).natDegree :=
+    Polynomial.natDegree_pos_iff_degree_pos.mpr hdegree
+  rw [toPolynomialMap,
+    Polynomial.natDegree_map_eq_of_injective embedding.injective,
+    HexPolyMathlib.natDegree_toPolynomial] at hnatDegree
+  exact hnatDegree
+
+private theorem mem_yunAux_of_mem [ZPoly.CheckedIrreducible p]
+    (w repeated : DensePoly (QAdjoin p x)) (k fuel : Nat)
+    (out : Array (DensePoly (QAdjoin p x) × Nat)) {entry}
+    (hentry : entry ∈ out.toList) :
+    entry ∈ (yunAux w repeated k fuel out).toList := by
+  induction fuel generalizing w repeated k out with
+  | zero => simpa [yunAux] using hentry
+  | succ fuel ih =>
+      rw [yunAux]
+      split
+      · exact hentry
+      · dsimp only
+        split
+        · apply ih
+          rw [Array.toList_push, List.mem_append]
+          exact Or.inl hentry
+        · exact ih _ _ _ _ hentry
+
+private theorem yunAux_sound [ZPoly.CheckedIrreducible p]
+    {K : Type*} [Field K] [DecidableEq K]
+    (embedding : QAdjoin p x →+* K) (z : K) (r : Nat)
+    (w repeated : DensePoly (QAdjoin p x)) (k fuel : Nat)
+    (out : Array (DensePoly (QAdjoin p x) × Nat))
+    (invariant : YunInvariant embedding z r k w repeated)
+    (hOut : ∀ entry ∈ out.toList,
+      (toPolynomialMap embedding entry.1).IsRoot z → entry.2 = r) :
+    ∀ entry ∈ (yunAux w repeated k fuel out).toList,
+      (toPolynomialMap embedding entry.1).IsRoot z → entry.2 = r := by
+  induction fuel generalizing w repeated k out with
+  | zero => simpa [yunAux] using hOut
+  | succ fuel ih =>
+      rw [yunAux]
+      split
+      · exact hOut
+      · dsimp only
+        let shared := monic (DensePoly.gcd w repeated)
+        let component := monic (w / shared)
+        let nextRepeated := monic (repeated / shared)
+        have hwSource : HexPolyMathlib.toPolynomial w ≠ 0 := by
+          intro hzero
+          exact invariant.w_ne (by simp [toPolynomialMap, hzero])
+        have hdivisors := monicGcd_dvd w repeated hwSource
+        have hcomponentNe : toPolynomialMap embedding component ≠ 0 :=
+          map_monicDiv_ne_zero embedding w shared hdivisors.1 invariant.w_ne
+        have hcomponentMultiplicity :
+            (toPolynomialMap embedding component).rootMultiplicity z =
+              if k = r then 1 else 0 :=
+          invariant.component embedding z r k w repeated
+        have hcomponentSound :
+            (toPolynomialMap embedding component).IsRoot z → k = r := by
+          intro hroot
+          have hpositive :=
+            (Polynomial.rootMultiplicity_pos hcomponentNe).mpr hroot
+          rw [hcomponentMultiplicity] at hpositive
+          by_cases heq : k = r
+          · exact heq
+          · simp [heq] at hpositive
+        have hnextInvariant : YunInvariant embedding z r (k + 1)
+            shared nextRepeated :=
+          invariant.step embedding z r k w repeated
+        split
+        · apply ih shared nextRepeated (k + 1) _ hnextInvariant
+          intro entry hentry
+          rw [Array.toList_push, List.mem_append,
+            List.mem_singleton] at hentry
+          rcases hentry with hentry | rfl
+          · exact hOut entry hentry
+          · intro hroot
+            exact hcomponentSound hroot
+        · exact ih shared nextRepeated (k + 1) _ hnextInvariant hOut
+
+private theorem yunAux_complete [ZPoly.CheckedIrreducible p]
+    {K : Type*} [Field K] [DecidableEq K]
+    (embedding : QAdjoin p x →+* K) (z : K) (r : Nat)
+    (w repeated : DensePoly (QAdjoin p x)) (k fuel : Nat)
+    (out : Array (DensePoly (QAdjoin p x) × Nat))
+    (invariant : YunInvariant embedding z r k w repeated)
+    (hindex : k ≤ r) (hfuel : r < k + fuel) :
+    ∃ entry ∈ (yunAux w repeated k fuel out).toList,
+      (toPolynomialMap embedding entry.1).IsRoot z ∧ entry.2 = r := by
+  induction fuel generalizing w repeated k out with
+  | zero => omega
+  | succ fuel ih =>
+      have hnotOne : w ≠ 1 := by
+        intro hone
+        have hmultiplicity := invariant.w_multiplicity
+        rw [hone] at hmultiplicity
+        have honeMultiplicity :
+            Polynomial.rootMultiplicity z (1 : Polynomial K) = 0 := by
+          simpa only [Polynomial.C_1] using
+            Polynomial.rootMultiplicity_C (1 : K) z
+        simp only [toPolynomialMap, HexPolyMathlib.toPolynomial_one,
+          Polynomial.map_one, if_pos hindex] at hmultiplicity
+        omega
+      rw [yunAux, if_neg hnotOne]
+      dsimp only
+      let shared := monic (DensePoly.gcd w repeated)
+      let component := monic (w / shared)
+      let nextRepeated := monic (repeated / shared)
+      have hwSource : HexPolyMathlib.toPolynomial w ≠ 0 := by
+        intro hzero
+        exact invariant.w_ne (by simp [toPolynomialMap, hzero])
+      have hdivisors := monicGcd_dvd w repeated hwSource
+      have hcomponentNe : toPolynomialMap embedding component ≠ 0 :=
+        map_monicDiv_ne_zero embedding w shared hdivisors.1 invariant.w_ne
+      have hcomponentMultiplicity :
+          (toPolynomialMap embedding component).rootMultiplicity z =
+            if k = r then 1 else 0 :=
+        invariant.component embedding z r k w repeated
+      by_cases heq : k = r
+      · have hpositive : 0 <
+            (toPolynomialMap embedding component).rootMultiplicity z := by
+          rw [hcomponentMultiplicity]
+          simp [heq]
+        have hroot : (toPolynomialMap embedding component).IsRoot z :=
+          (Polynomial.rootMultiplicity_pos hcomponentNe).mp hpositive
+        have hdegree : 0 < component.degree?.getD 0 :=
+          degree_pos_of_map_root embedding component hcomponentNe hroot
+        rw [if_pos hdegree]
+        refine ⟨(component, k), ?_, hroot, heq⟩
+        apply mem_yunAux_of_mem
+        simp [component, shared]
+      · have hnextInvariant : YunInvariant embedding z r (k + 1)
+            shared nextRepeated :=
+          invariant.step embedding z r k w repeated
+        have hnextIndex : k + 1 ≤ r := by omega
+        have hnextFuel : r < k + 1 + fuel := by omega
+        split
+        · exact ih shared nextRepeated (k + 1) _ hnextInvariant
+            hnextIndex hnextFuel
+        · exact ih shared nextRepeated (k + 1) _ hnextInvariant
+            hnextIndex hnextFuel
+
+/-- Every root of an emitted Yun component is a root of the input with the
+component's stored multiplicity. -/
+theorem yun_sound [ZPoly.CheckedIrreducible p]
+    {K : Type*} [Field K] [CharZero K] [DecidableEq K]
+    (embedding : QAdjoin p x →+* K) (f : DensePoly (QAdjoin p x))
+    (hf : toPolynomialMap embedding f ≠ 0)
+    (hdegree : 0 < f.degree?.getD 0) (z : K) (entry)
+    (hentry : entry ∈ (yun f).toList)
+    (hroot : (toPolynomialMap embedding entry.1).IsRoot z) :
+    entry.2 = (toPolynomialMap embedding f).rootMultiplicity z := by
+  have hnatDegree : (toPolynomialMap embedding f).natDegree ≠ 0 := by
+    rw [toPolynomialMap,
+      Polynomial.natDegree_map_eq_of_injective embedding.injective,
+      HexPolyMathlib.natDegree_toPolynomial]
+    omega
+  let normalized := monic f
+  let repeated := monic (DensePoly.gcd normalized (derivative normalized))
+  let distinct := monic (normalized / repeated)
+  have invariant : YunInvariant embedding z
+      ((toPolynomialMap embedding f).rootMultiplicity z) 1
+      distinct repeated :=
+    YunInvariant.init embedding f hf hnatDegree z
+  unfold yun at hentry
+  rw [if_neg (by omega)] at hentry
+  exact yunAux_sound embedding z
+    ((toPolynomialMap embedding f).rootMultiplicity z)
+    distinct repeated 1 (f.size + 1) #[] invariant (by simp)
+    entry hentry hroot
+
+/-- Every root of a positive-degree input occurs in an emitted Yun component
+at its exact multiplicity. -/
+theorem yun_complete [ZPoly.CheckedIrreducible p]
+    {K : Type*} [Field K] [CharZero K] [DecidableEq K]
+    (embedding : QAdjoin p x →+* K) (f : DensePoly (QAdjoin p x))
+    (hf : toPolynomialMap embedding f ≠ 0)
+    (hdegree : 0 < f.degree?.getD 0) (z : K)
+    (hroot : (toPolynomialMap embedding f).IsRoot z) :
+    ∃ entry ∈ (yun f).toList,
+      (toPolynomialMap embedding entry.1).IsRoot z ∧
+        entry.2 = (toPolynomialMap embedding f).rootMultiplicity z := by
+  have hnatDegree : (toPolynomialMap embedding f).natDegree ≠ 0 := by
+    rw [toPolynomialMap,
+      Polynomial.natDegree_map_eq_of_injective embedding.injective,
+      HexPolyMathlib.natDegree_toPolynomial]
+    omega
+  let r := (toPolynomialMap embedding f).rootMultiplicity z
+  have hindex : 1 ≤ r := by
+    exact (Polynomial.rootMultiplicity_pos hf).mpr hroot
+  have hmultiplicityDegree : r ≤ (toPolynomialMap embedding f).natDegree :=
+    rootMultiplicity_le_natDegree _ hf z
+  have hsize : 0 < f.size := by
+    by_contra hzero
+    have hsizeZero : f.size = 0 := by omega
+    simp [DensePoly.degree?, hsizeZero] at hdegree
+  have hdenseDegree : f.degree?.getD 0 = f.size - 1 := by
+    rw [DensePoly.degree?_eq_some_of_pos_size f hsize]
+    rfl
+  have hdegreeEq : (toPolynomialMap embedding f).natDegree =
+      f.degree?.getD 0 := by
+    simp only [toPolynomialMap,
+      Polynomial.natDegree_map_eq_of_injective embedding.injective,
+      HexPolyMathlib.natDegree_toPolynomial]
+  have hfuel : r < 1 + (f.size + 1) := by omega
+  let normalized := monic f
+  let repeated := monic (DensePoly.gcd normalized (derivative normalized))
+  let distinct := monic (normalized / repeated)
+  have invariant : YunInvariant embedding z r 1 distinct repeated :=
+    YunInvariant.init embedding f hf hnatDegree z
+  have hcomplete := yunAux_complete embedding z r distinct repeated 1
+    (f.size + 1) #[] invariant hindex hfuel
+  unfold yun
+  rw [if_neg (by omega)]
+  exact hcomplete
+
+end Hex.QAdjoin.Roots

--- a/progress/20260802T144228Z_number-field-fixed-root-semantics.md
+++ b/progress/20260802T144228Z_number-field-fixed-root-semantics.md
@@ -1,0 +1,36 @@
+# Number-field fixed-root semantics
+
+## Accomplished
+
+- Proved soundness and completeness of the executable fixed-field Yun
+  decomposition, including exact transfer of Mathlib root multiplicities.
+- Proved soundness and completeness of component candidate isolation and the
+  selected-embedding filter.
+- Refactored semantic root merging to a structural list recursion, made
+  duplicate normalization idempotent on certified multiplicities, and proved
+  membership, multiplicity, and duplicate-freedom invariants through both
+  nested folds.
+- Replaced the final quicksort with stable merge sort, proved the executable
+  root comparator total and transitive, and closed all fixed-field membership,
+  multiplicity, positivity, duplicate-freedom, ordering, and degree-sum
+  contracts.
+- Verified `lake build HexNumberFieldMathlib.ComponentRoots`, the full
+  `lake build`, and `lake build HexConformance`.
+
+## Current frontier
+
+The fixed-field root driver is total and semantically complete. The seven
+remaining root API placeholders are confined to the downstream
+`AlgebraicPoly` driver, whose lift requires totality and semantic correctness
+of `Common.presentation?`.
+
+## Next step
+
+Land the fixed-field semantics PR as one cohesive change, then prove
+`Common.presentation?` total and coefficient-preserving before reusing the
+fixed-field contracts to close the `AlgebraicPoly` root API.
+
+## Blockers
+
+None for the fixed-field stage. The algebraic lift requires a substantive new
+presentation layer rather than a direct wrapper proof.


### PR DESCRIPTION
## Summary

- prove soundness and completeness of the executable fixed-field Yun decomposition and component root filter
- carry semantic membership, certified multiplicity, and duplicate-freedom through merging and stable sorting
- close all fixed-field root API contracts: membership, multiplicity, positivity, duplicate-freedom, ordering, and total multiplicity
- make duplicate normalization idempotent on already-certified Yun multiplicities

This is intentionally one cohesive fixed-field PR rather than a fan-out of smaller dependent PRs.

## Validation

- `lake build HexNumberFieldMathlib.ComponentRoots`
- `lake build`
- `lake build HexConformance`
- `git diff --check`

No new `sorry`, `axiom`, or `native_decide` is introduced.
