### PR TITLE
prove(number-field): complete algebraic root semantics

### DIFF
--- a/HexNumberFieldMathlib.lean
+++ b/HexNumberFieldMathlib.lean
@@ -8,6 +8,7 @@ module
 
 public import HexNumberFieldMathlib.Roots
 public import HexNumberFieldMathlib.ComponentRoots
+public import HexNumberFieldMathlib.AlgebraicRoots
 
 public section
 

--- a/HexNumberFieldMathlib/AlgebraicPoly.lean
+++ b/HexNumberFieldMathlib/AlgebraicPoly.lean
@@ -50,7 +50,9 @@ theorem coeff_toPolynomial (f : AlgebraicPoly) (n : Nat) :
   rw [toPolynomial, ← Array.foldr_toList, coeff_horner, array_toList_getD]
   rfl
 
-private theorem last_isZero_false (f : AlgebraicPoly) (h : !f.isZero) :
+/-- The stored leading coefficient of a nonzero normalized algebraic
+polynomial is canonically nonzero. -/
+theorem last_isZero_false (f : AlgebraicPoly) (h : !f.isZero) :
     (f.coeff (f.size - 1)).isZero = false := by
   have hsize : 0 < f.coeffs.size := by
     apply Nat.pos_of_ne_zero

--- a/HexNumberFieldMathlib/AlgebraicRoots.lean
+++ b/HexNumberFieldMathlib/AlgebraicRoots.lean
@@ -1,0 +1,307 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexNumberFieldMathlib.ComponentRoots
+public import HexNumberFieldMathlib.PresentationSemantics
+
+public section
+
+/-!
+# Algebraic-coefficient root semantics
+
+Transport of the fixed-field root contracts across the checked primitive
+presentation of an algebraic coefficient array.
+-/
+
+namespace Hex.AlgebraicPoly
+
+private theorem exists_nonzero_coeff (f : AlgebraicPoly)
+    (hf : f.isZero = false) :
+    ∃ a ∈ f.coeffs.toList, a.isZero = false := by
+  have hsize : 0 < f.coeffs.size := by
+    apply Nat.pos_of_ne_zero
+    intro hzero
+    have hempty : f.coeffs = #[] := Array.eq_empty_of_size_eq_zero hzero
+    change f.data = #[] at hempty
+    have : f.isZero = true := by simp [AlgebraicPoly.isZero, hempty]
+    simp [hf] at this
+  let a := f.coeff (f.size - 1)
+  have hi : f.size - 1 < f.coeffs.size := by
+    change f.coeffs.size - 1 < f.coeffs.size
+    omega
+  have ha : f.coeffs[f.size - 1] = a := by
+    rw [Array.getElem_eq_getD]
+    rfl
+  have haMem : a ∈ f.coeffs.toList := by
+    apply Array.mem_toList_iff.mpr
+    rw [Array.mem_iff_getElem]
+    exact ⟨f.size - 1, hi, ha⟩
+  refine ⟨a, haMem, ?_⟩
+  exact last_isZero_false f (by simp [hf])
+
+private theorem exists_presentation (f : AlgebraicPoly)
+    (hf : f.isZero = false) :
+    ∃ common, Common.presentation? f.coeffs = some common := by
+  exact Option.isSome_iff_exists.mp <|
+    Common.presentation?_isSome f.coeffs (exists_nonzero_coeff f hf)
+
+/-- The algebraic-coefficient root driver always produces a checked root set. -/
+theorem roots?_isSome (f : AlgebraicPoly) :
+    f.roots?.isSome := by
+  rw [AlgebraicPoly.roots?]
+  split
+  · simp
+  next hzero =>
+    have hf : f.isZero = false := by
+      cases h : f.isZero <;> simp_all
+    obtain ⟨common, hcommon⟩ := exists_presentation f hf
+    rw [hcommon]
+    letI : ZPoly.CheckedIrreducible common.generator.p :=
+      common.generator.checked
+    exact QAdjoin.roots?_isSome
+      (DensePoly.ofCoeffs common.coefficients)
+      common.generator.rep common.generator.rep_mk
+
+/-- The total algebraic-coefficient root API is exactly the output of its
+checked driver. -/
+theorem roots?_eq_roots (f : AlgebraicPoly) :
+    f.roots? = some f.roots := by
+  unfold AlgebraicPoly.roots
+  cases hrun : f.roots? with
+  | none =>
+      have hsome := roots?_isSome f
+      simp [hrun] at hsome
+  | some roots => simp
+
+private theorem presentation_polynomial (f : AlgebraicPoly)
+    (common : Common.Presentation)
+    (hcommon : Common.presentation? f.coeffs = some common) :
+    QAdjoin.toPolynomialAt
+        (DensePoly.ofCoeffs common.coefficients)
+        common.generator.rep common.generator.rep_mk =
+      f.toPolynomial := by
+  letI : ZPoly.CheckedIrreducible common.generator.p :=
+    common.generator.checked
+  obtain ⟨hsize, hvalues⟩ :=
+    Common.presentation?_sound f.coeffs hcommon
+  ext n
+  rw [QAdjoin.coeff_toPolynomialAt, coeff_toPolynomial,
+    DensePoly.coeff_ofCoeffs]
+  change QAdjoin.toComplex
+      (common.coefficients.getD n
+        (0 : QAdjoin common.generator.p common.generator.x))
+      common.generator.rep common.generator.rep_mk =
+    (f.coeffs.getD n (0 : AlgebraicNumber)).toComplex
+  by_cases hn : n < f.coeffs.size
+  · have hnCommon : n < common.coefficients.size := by
+      rw [hsize]
+      exact hn
+    rw [← Array.getElem_eq_getD
+        (0 : QAdjoin common.generator.p common.generator.x),
+      ← Array.getElem_eq_getD (0 : AlgebraicNumber)]
+    exact hvalues n hn hnCommon
+  · have hnCommon : ¬n < common.coefficients.size := by
+      rw [hsize]
+      exact hn
+    rw [Array.getD_eq_getD_getElem?,
+      Array.getElem?_eq_none (by omega : common.coefficients.size ≤ n),
+      Array.getD_eq_getD_getElem?,
+      Array.getElem?_eq_none (by omega : f.coeffs.size ≤ n)]
+    simp [QAdjoin.map_zero, AlgebraicNumber.zero_toComplex]
+
+private theorem roots_eq_fixed (f : AlgebraicPoly)
+    (common : Common.Presentation)
+    (hf : f.isZero = false)
+    (hcommon : Common.presentation? f.coeffs = some common) :
+    f.roots = @QAdjoin.roots _ _ common.generator.checked
+      (DensePoly.ofCoeffs common.coefficients)
+      common.generator.rep common.generator.rep_mk := by
+  letI : ZPoly.CheckedIrreducible common.generator.p :=
+    common.generator.checked
+  have halgebraic := roots?_eq_roots f
+  rw [AlgebraicPoly.roots?, if_neg (by simp [hf])] at halgebraic
+  obtain ⟨common', hcommon', hrun⟩ :=
+    Option.bind_eq_some_iff.mp halgebraic
+  have hcommonEq : common' = common :=
+    Option.some.inj (hcommon'.symm.trans hcommon)
+  subst common'
+  have hfixed := QAdjoin.roots?_eq_roots
+    (DensePoly.ofCoeffs common.coefficients)
+    common.generator.rep common.generator.rep_mk
+  exact (Option.some.inj (hfixed.symm.trans hrun)).symm
+
+private theorem roots_eq_all_of_isZero (f : AlgebraicPoly)
+    (hf : f.isZero = true) : f.roots = .all := by
+  have hrun := roots?_eq_roots f
+  rw [AlgebraicPoly.roots?, if_pos hf] at hrun
+  exact (Option.some.inj hrun).symm
+
+/-- The algebraic-coefficient driver returns `.all` exactly for the zero
+polynomial. -/
+theorem roots_all_iff (f : AlgebraicPoly) :
+    f.roots = .all ↔ f.toPolynomial = 0 := by
+  by_cases hzero : f.isZero = true
+  · rw [roots_eq_all_of_isZero f hzero,
+      (isZero_iff f).mp hzero]
+    simp
+  · have hf : f.isZero = false := by
+      cases h : f.isZero <;> simp_all
+    obtain ⟨common, hcommon⟩ := exists_presentation f hf
+    letI : ZPoly.CheckedIrreducible common.generator.p :=
+      common.generator.checked
+    rw [roots_eq_fixed f common hf hcommon,
+      ← presentation_polynomial f common hcommon]
+    exact QAdjoin.roots_all_iff
+      (DensePoly.ofCoeffs common.coefficients)
+      common.generator.rep common.generator.rep_mk
+
+/-- Semantic membership in the algebraic-coefficient output is exactly
+polynomial vanishing. -/
+theorem contains_roots_iff (f : AlgebraicPoly) (z : ℂ) :
+    RootSet.Contains f.roots z ↔
+      Polynomial.eval z f.toPolynomial = 0 := by
+  by_cases hzero : f.isZero = true
+  · rw [roots_eq_all_of_isZero f hzero,
+      (isZero_iff f).mp hzero]
+    simp [RootSet.Contains]
+  · have hf : f.isZero = false := by
+      cases h : f.isZero <;> simp_all
+    obtain ⟨common, hcommon⟩ := exists_presentation f hf
+    letI : ZPoly.CheckedIrreducible common.generator.p :=
+      common.generator.checked
+    rw [roots_eq_fixed f common hf hcommon,
+      ← presentation_polynomial f common hcommon]
+    exact QAdjoin.contains_roots_iff
+      (DensePoly.ofCoeffs common.coefficients)
+      common.generator.rep common.generator.rep_mk z
+
+/-- Algebraic-coefficient root multiplicities agree with Mathlib. -/
+theorem multiplicity_roots (f : AlgebraicPoly) (z : ℂ) :
+    f.roots.multiplicityOf z =
+      Polynomial.rootMultiplicity z f.toPolynomial := by
+  by_cases hzero : f.isZero = true
+  · rw [roots_eq_all_of_isZero f hzero,
+      (isZero_iff f).mp hzero]
+    simp [RootSet.multiplicityOf]
+  · have hf : f.isZero = false := by
+      cases h : f.isZero <;> simp_all
+    obtain ⟨common, hcommon⟩ := exists_presentation f hf
+    letI : ZPoly.CheckedIrreducible common.generator.p :=
+      common.generator.checked
+    rw [roots_eq_fixed f common hf hcommon,
+      ← presentation_polynomial f common hcommon]
+    exact QAdjoin.multiplicity_roots
+      (DensePoly.ofCoeffs common.coefficients)
+      common.generator.rep common.generator.rep_mk z
+
+/-- The algebraic-coefficient driver produces positive multiplicities. -/
+theorem roots_positive (f : AlgebraicPoly) :
+    RootSet.Positive f.roots := by
+  cases hroots : f.roots with
+  | all => trivial
+  | finite roots =>
+      intro entry _hentry
+      exact entry.multiplicity_pos
+
+/-- The algebraic-coefficient driver merges all semantic duplicates. -/
+theorem roots_noDuplicates (f : AlgebraicPoly) :
+    RootSet.NoDuplicates f.roots := by
+  by_cases hzero : f.isZero = true
+  · rw [roots_eq_all_of_isZero f hzero]
+    trivial
+  · have hf : f.isZero = false := by
+      cases h : f.isZero <;> simp_all
+    obtain ⟨common, hcommon⟩ := exists_presentation f hf
+    letI : ZPoly.CheckedIrreducible common.generator.p :=
+      common.generator.checked
+    rw [roots_eq_fixed f common hf hcommon]
+    exact QAdjoin.roots_noDuplicates
+      (DensePoly.ofCoeffs common.coefficients)
+      common.generator.rep common.generator.rep_mk
+
+/-- The algebraic-coefficient driver uses its deterministic canonical order. -/
+theorem roots_ordered (f : AlgebraicPoly) :
+    RootSet.Ordered f.roots := by
+  by_cases hzero : f.isZero = true
+  · rw [roots_eq_all_of_isZero f hzero]
+    trivial
+  · have hf : f.isZero = false := by
+      cases h : f.isZero <;> simp_all
+    obtain ⟨common, hcommon⟩ := exists_presentation f hf
+    letI : ZPoly.CheckedIrreducible common.generator.p :=
+      common.generator.checked
+    rw [roots_eq_fixed f common hf hcommon]
+    exact QAdjoin.roots_ordered
+      (DensePoly.ofCoeffs common.coefficients)
+      common.generator.rep common.generator.rep_mk
+
+/-- For a nonzero algebraic-coefficient polynomial, output multiplicities sum
+to its degree. -/
+theorem totalMultiplicity_roots (f : AlgebraicPoly)
+    (hfPolynomial : f.toPolynomial ≠ 0) :
+    f.roots.totalMultiplicity = f.toPolynomial.natDegree := by
+  have hf : f.isZero = false := by
+    cases h : f.isZero with
+    | false => rfl
+    | true =>
+        exact (hfPolynomial ((isZero_iff f).mp h)).elim
+  obtain ⟨common, hcommon⟩ := exists_presentation f hf
+  letI : ZPoly.CheckedIrreducible common.generator.p :=
+    common.generator.checked
+  have hpolynomial := presentation_polynomial f common hcommon
+  rw [roots_eq_fixed f common hf hcommon, ← hpolynomial]
+  exact QAdjoin.totalMultiplicity_roots
+    (DensePoly.ofCoeffs common.coefficients)
+    common.generator.rep common.generator.rep_mk
+    (by rwa [hpolynomial])
+
+end Hex.AlgebraicPoly
+
+/-! The algebraic-coefficient contracts must not inherit unfinished proofs. -/
+
+/--
+info: 'Hex.AlgebraicPoly.roots?_isSome' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms Hex.AlgebraicPoly.roots?_isSome
+
+/--
+info: 'Hex.AlgebraicPoly.roots_all_iff' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms Hex.AlgebraicPoly.roots_all_iff
+
+/--
+info: 'Hex.AlgebraicPoly.contains_roots_iff' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms Hex.AlgebraicPoly.contains_roots_iff
+
+/--
+info: 'Hex.AlgebraicPoly.multiplicity_roots' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms Hex.AlgebraicPoly.multiplicity_roots
+
+/--
+info: 'Hex.AlgebraicPoly.roots_noDuplicates' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms Hex.AlgebraicPoly.roots_noDuplicates
+
+/--
+info: 'Hex.AlgebraicPoly.roots_ordered' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms Hex.AlgebraicPoly.roots_ordered
+
+/--
+info: 'Hex.AlgebraicPoly.totalMultiplicity_roots' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms Hex.AlgebraicPoly.totalMultiplicity_roots

--- a/HexNumberFieldMathlib/Approx.lean
+++ b/HexNumberFieldMathlib/Approx.lean
@@ -482,7 +482,9 @@ private theorem refined_extent_le {p : ZPoly} (rep : RefinedIsolation p)
   change ht + rt ≤ 4 * (hs + rs)
   nlinarith
 
-private theorem realRadius_ofRat_le (q : Rat) (prec : Int) :
+/-- The rational enclosure requested at precision `prec` has radius at most
+`2 ^ (-prec)`. -/
+theorem realRadius_ofRat_le (q : Rat) (prec : Int) :
     (DyadicComplexBall.ofRat q prec).realRadius ≤ (2 : ℝ) ^ (-prec) := by
   unfold DyadicComplexBall.ofRat
   dsimp only

--- a/HexNumberFieldMathlib/Coordinates.lean
+++ b/HexNumberFieldMathlib/Coordinates.lean
@@ -1,0 +1,645 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexNumberFieldMathlib.Primitive
+public import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
+public import Mathlib.RingTheory.Trace.Basic
+
+public section
+
+/-!
+# Trace coordinates for primitive presentations
+
+Semantic invariants for the checked trace and coordinate-recovery routines.
+-/
+
+namespace Hex.AlgebraicPoly.Common
+
+open Module IntermediateField
+
+private theorem vector_mapM_isSome {n : Nat} {A B : Type*}
+    (items : Vector A n) (f : A → Option B)
+    (h : ∀ i : Fin n, (f (items.get i)).isSome) :
+    (items.mapM f).isSome := by
+  have harray : (items.toArray.mapM f).isSome := by
+    apply HexRootsMathlib.array_mapM_isSome
+    intro item hitem
+    have hitem' : item ∈ items.toArray := by simpa using hitem
+    rw [Array.mem_iff_getElem] at hitem'
+    obtain ⟨i, hi, rfl⟩ := hitem'
+    exact h ⟨i, by simpa using hi⟩
+  rw [← Vector.toArray_mapM] at harray
+  cases hmap : items.mapM f with
+  | none => simp [hmap] at harray
+  | some => simp
+
+private theorem vector_mapM_some_get {n : Nat} {A B : Type*}
+    {items : Vector A n} {f : A → Option B} {out : Vector B n}
+    (hmap : items.mapM f = some out) (i : Fin n) :
+    f (items.get i) = some (out.get i) := by
+  have harray : items.toArray.mapM f = some out.toArray := by
+    rw [← Vector.toArray_mapM, hmap]
+    rfl
+  have hi : i.val < items.toArray.size := by simp
+  have ho : i.val < out.toArray.size := by simp
+  exact (HexRootsMathlib.array_mapM_some_get harray).2 i hi ho
+
+private theorem spanCoeffs_isSome_of_det_ne_zero {n : Nat}
+    (M : Matrix Rat n n) (v : Vector Rat n)
+    (hdet : (_root_.Matrix.det (HexMatrixMathlib.matrixEquiv M)) ≠ 0) :
+    (Matrix.spanCoeffs M v).isSome := by
+  let M' := HexMatrixMathlib.matrixEquiv M
+  let v' := HexMatrixMathlib.vectorEquiv v
+  let c' : Fin n → Rat := _root_.Matrix.vecMul v' M'⁻¹
+  let c : Vector Rat n := HexMatrixMathlib.vectorEquiv.symm c'
+  have hunit : IsUnit M'.det := isUnit_iff_ne_zero.mpr hdet
+  have hmath : _root_.Matrix.vecMul c' M' = v' := by
+    dsimp [c']
+    rw [_root_.Matrix.vecMul_vecMul,
+      _root_.Matrix.nonsing_inv_mul M' hunit,
+      _root_.Matrix.vecMul_one]
+  have hexec : Matrix.vecMul c M = v := by
+    apply HexMatrixMathlib.vectorEquiv.injective
+    rw [HexMatrixMathlib.vectorEquiv_vecMul]
+    funext j
+    simpa [c, M', v', Hex.Matrix.row, _root_.Matrix.vecMul, dotProduct,
+      Fintype.linearCombination_apply] using congrFun hmath j
+  cases hspan : Matrix.spanCoeffs M v with
+  | none =>
+      exact ((Matrix.spanCoeffs_eq_none_iff M v).mp hspan
+        ⟨c, hexec⟩).elim
+  | some => simp
+
+private theorem vecMul_injective_of_det_ne_zero {n : Nat}
+    (M : Matrix Rat n n)
+    (hdet : (_root_.Matrix.det (HexMatrixMathlib.matrixEquiv M)) ≠ 0) :
+    Function.Injective fun c : Vector Rat n ↦ Matrix.vecMul c M := by
+  let M' := HexMatrixMathlib.matrixEquiv M
+  have hunit : IsUnit M' := by
+    rw [_root_.Matrix.isUnit_iff_isUnit_det]
+    exact isUnit_iff_ne_zero.mpr hdet
+  have hinjective : Function.Injective M'.vecMul :=
+    _root_.Matrix.vecMul_injective_iff_isUnit.mpr hunit
+  intro a b hab
+  apply HexMatrixMathlib.vectorEquiv.injective
+  apply hinjective
+  have hbridge (c : Vector Rat n) :
+      HexMatrixMathlib.vectorEquiv (Matrix.vecMul c M) =
+        M'.vecMul (HexMatrixMathlib.vectorEquiv c) := by
+    rw [HexMatrixMathlib.vectorEquiv_vecMul]
+    funext j
+    simp [M', Hex.Matrix.row, _root_.Matrix.vecMul, dotProduct,
+      Fintype.linearCombination_apply]
+  exact (hbridge a).symm.trans <|
+    (congrArg HexMatrixMathlib.vectorEquiv hab).trans (hbridge b)
+
+/-- The next coefficient of the rational minimal polynomial is the normalized
+next coefficient stored in the primitive integer polynomial. -/
+private theorem minpoly_nextCoeff (a : AlgebraicNumber) :
+    (minpoly Rat a.toComplex).nextCoeff =
+      (a.p.leadingCoeff : Rat)⁻¹ * (a.p.coeff (degree a - 1) : Rat) := by
+  rw [Polynomial.nextCoeff_of_natDegree_pos]
+  · rw [← degree_eq_minpoly, ← AlgebraicNumber.p_eq_minpoly,
+      Polynomial.coeff_smul, HexPolyZMathlib.coeff_toPolyℚ, smul_eq_mul]
+  · rw [← degree_eq_minpoly]
+    exact degree_pos a
+
+/-- The degree of an algebraic number lying in a primitive field divides the
+degree of that field. -/
+theorem degree_dvd_of_mem (gamma a : AlgebraicNumber)
+    (ha : a.toComplex ∈ Rat⟮gamma.toComplex⟯) :
+    degree a ∣ degree gamma := by
+  let K : IntermediateField Rat ℂ := Rat⟮gamma.toComplex⟯
+  let aK : K := ⟨a.toComplex, ha⟩
+  letI : FiniteDimensional Rat K :=
+    IntermediateField.adjoin.finiteDimensional (isIntegral_toComplex gamma)
+  have hmin : minpoly Rat aK = minpoly Rat a.toComplex :=
+    (minpoly.algHom_eq K.val K.val.injective aK).symm
+  rw [degree_eq_minpoly a, ← hmin, degree_eq_minpoly gamma,
+    ← IntermediateField.adjoin.finrank (isIntegral_toComplex gamma)]
+  exact minpoly.degree_dvd (IsIntegral.of_finite Rat aK)
+
+/-- Trace succeeds whenever the input belongs to the stated primitive field. -/
+theorem trace?_isSome (gamma a : AlgebraicNumber)
+    (ha : a.toComplex ∈ Rat⟮gamma.toComplex⟯) :
+    (trace? (degree gamma) a).isSome := by
+  have hmod : degree gamma % degree a = 0 :=
+    Nat.mod_eq_zero_of_dvd (degree_dvd_of_mem gamma a ha)
+  simp [trace?, (degree_pos a).ne', hmod]
+
+/-- A successful executable trace is the field trace from the primitive
+ambient field. -/
+theorem trace?_sound (gamma a : AlgebraicNumber)
+    (ha : a.toComplex ∈ Rat⟮gamma.toComplex⟯) {t : Rat}
+    (h : trace? (degree gamma) a = some t) :
+    t = Algebra.trace Rat Rat⟮gamma.toComplex⟯
+      (⟨a.toComplex, ha⟩ : Rat⟮gamma.toComplex⟯) := by
+  let K : IntermediateField Rat ℂ := Rat⟮gamma.toComplex⟯
+  let aK : K := ⟨a.toComplex, ha⟩
+  change t = Algebra.trace Rat K aK
+  letI : FiniteDimensional Rat K :=
+    IntermediateField.adjoin.finiteDimensional (isIntegral_toComplex gamma)
+  have hmin : minpoly Rat aK = minpoly Rat a.toComplex :=
+    (minpoly.algHom_eq K.val K.val.injective aK).symm
+  have hm : degree a = Module.finrank Rat Rat⟮aK⟯ := by
+    rw [degree_eq_minpoly a, ← hmin,
+      IntermediateField.adjoin.finrank (IsIntegral.of_finite Rat aK)]
+  have hd : degree gamma = Module.finrank Rat K := by
+    rw [IntermediateField.adjoin.finrank (isIntegral_toComplex gamma),
+      ← degree_eq_minpoly]
+  have htower : degree a * Module.finrank Rat⟮aK⟯ K = degree gamma := by
+    rw [hm, hd]
+    exact Module.finrank_mul_finrank Rat Rat⟮aK⟯ K
+  have hquot : degree gamma / degree a = Module.finrank Rat⟮aK⟯ K := by
+    exact Nat.div_eq_of_eq_mul_left (degree_pos a) (by
+      simpa [Nat.mul_comm] using htower.symm)
+  have hmod : degree gamma % degree a = 0 := by
+    rw [← htower]
+    exact Nat.mul_mod_right _ _
+  unfold trace? at h
+  simp at h
+  rw [← h.2]
+  rw [trace_eq_finrank_mul_minpoly_nextCoeff, hmin,
+    minpoly_nextCoeff, hquot]
+  field_simp
+
+private theorem traceGram_det_ne_zero (gamma : AlgebraicNumber)
+    (powers : Array AlgebraicNumber) (powerTraces : Array Rat)
+    (hsize : powers.size = 2 * degree gamma - 1)
+    (hvalues : ∀ i (hi : i < powers.size),
+      powers[i].toComplex = gamma.toComplex ^ i)
+    (hmap : powers.mapM (trace? (degree gamma)) = some powerTraces) :
+    (_root_.Matrix.det (HexMatrixMathlib.matrixEquiv
+      (Matrix.ofFn fun i : Fin (degree gamma) =>
+        fun j : Fin (degree gamma) => powerTraces[i.val + j.val]!))) ≠ 0 := by
+  let K : IntermediateField Rat ℂ := Rat⟮gamma.toComplex⟯
+  letI : FiniteDimensional Rat K :=
+    IntermediateField.adjoin.finiteDimensional (isIntegral_toComplex gamma)
+  let pb := IntermediateField.adjoin.powerBasis (isIntegral_toComplex gamma)
+  have hpbdim : pb.dim = degree gamma := by
+    change (minpoly Rat gamma.toComplex).natDegree = degree gamma
+    exact (degree_eq_minpoly gamma).symm
+  let basis : Basis (Fin (degree gamma)) Rat K :=
+    pb.basis.reindex (finCongr hpbdim)
+  have hbasis (i : Fin (degree gamma)) :
+      basis i = (AdjoinSimple.gen Rat gamma.toComplex) ^ i.val := by
+    simp [basis, pb]
+  have hmatrix :
+      HexMatrixMathlib.matrixEquiv
+        (Matrix.ofFn fun i : Fin (degree gamma) =>
+          fun j : Fin (degree gamma) => powerTraces[i.val + j.val]!) =
+      (Algebra.traceForm Rat K).toMatrix basis := by
+    ext i j
+    rw [HexMatrixMathlib.matrixEquiv_ofFn,
+      Algebra.traceForm_toMatrix, hbasis, hbasis]
+    have hij : i.val + j.val < powers.size := by
+      have hpos := degree_pos gamma
+      omega
+    have hmember : powers[i.val + j.val].toComplex ∈ K := by
+      rw [hvalues (i.val + j.val) hij]
+      exact K.pow_mem (IntermediateField.mem_adjoin_simple_self
+        Rat gamma.toComplex) (i.val + j.val)
+    have htraceBound : i.val + j.val < powerTraces.size := by
+      rw [← (HexRootsMathlib.array_mapM_some_get hmap).1]
+      exact hij
+    have htrace := trace?_sound gamma powers[i.val + j.val] hmember
+      ((HexRootsMathlib.array_mapM_some_get hmap).2
+        (i.val + j.val) hij htraceBound)
+    rw [getElem!_pos powerTraces (i.val + j.val) htraceBound]
+    calc
+      powerTraces[i.val + j.val] =
+          Algebra.trace Rat K ⟨powers[i.val + j.val].toComplex, hmember⟩ :=
+        htrace
+      _ = Algebra.trace Rat K
+          ((AdjoinSimple.gen Rat gamma.toComplex) ^ i.val *
+            (AdjoinSimple.gen Rat gamma.toComplex) ^ j.val) := by
+        apply congrArg (Algebra.trace Rat K)
+        apply Subtype.ext
+        simp [K, hvalues (i.val + j.val) hij, pow_add]
+  rw [hmatrix]
+  exact det_traceForm_ne_zero basis
+
+private theorem coordinateProducts_get (gamma a : AlgebraicNumber)
+    (powers : Array AlgebraicNumber)
+    (hsize : powers.size = 2 * degree gamma - 1)
+    (hvalues : ∀ i (hi : i < powers.size),
+      powers[i].toComplex = gamma.toComplex ^ i)
+    (products : Vector AlgebraicNumber (degree gamma))
+    (hproducts :
+      (⟨(List.range (degree gamma)).toArray, by simp⟩ :
+          Vector Nat (degree gamma)).mapM
+        (fun k => mul? a powers[k]!) = some products)
+    (i : Fin (degree gamma)) :
+    (products.get i).toComplex = a.toComplex * gamma.toComplex ^ i.val := by
+  let indices : Vector Nat (degree gamma) :=
+    ⟨(List.range (degree gamma)).toArray, by simp⟩
+  have hibound : i.val < powers.size := by
+    have hpos := degree_pos gamma
+    omega
+  have hiindex : indices.get i = i.val := by
+    simp [indices]
+  have hrun := vector_mapM_some_get (items := indices) hproducts i
+  rw [hiindex] at hrun
+  have hmul := mul?_sound a powers[i.val]! hrun
+  rw [getElem!_pos powers i.val hibound,
+    hvalues i.val hibound] at hmul
+  exact hmul
+
+private theorem coordinateRhs_get (gamma a : AlgebraicNumber)
+    (powers : Array AlgebraicNumber)
+    (hsize : powers.size = 2 * degree gamma - 1)
+    (hvalues : ∀ i (hi : i < powers.size),
+      powers[i].toComplex = gamma.toComplex ^ i)
+    (ha : a.toComplex ∈ Rat⟮gamma.toComplex⟯)
+    (products : Vector AlgebraicNumber (degree gamma))
+    (hproducts :
+      (⟨(List.range (degree gamma)).toArray, by simp⟩ :
+          Vector Nat (degree gamma)).mapM
+        (fun k => mul? a powers[k]!) = some products)
+    (rhs : Vector Rat (degree gamma))
+    (hrhs : products.mapM (trace? (degree gamma)) = some rhs)
+    (i : Fin (degree gamma)) :
+    rhs.get i = Algebra.trace Rat Rat⟮gamma.toComplex⟯
+      (⟨a.toComplex * gamma.toComplex ^ i.val,
+        (Rat⟮gamma.toComplex⟯ : IntermediateField Rat ℂ).mul_mem ha
+          ((Rat⟮gamma.toComplex⟯ : IntermediateField Rat ℂ).pow_mem
+            (IntermediateField.mem_adjoin_simple_self Rat gamma.toComplex)
+            i.val)⟩ : Rat⟮gamma.toComplex⟯) := by
+  let K : IntermediateField Rat ℂ := Rat⟮gamma.toComplex⟯
+  have hproduct := coordinateProducts_get gamma a powers hsize hvalues
+    products hproducts i
+  have hproductMem : (products.get i).toComplex ∈ K := by
+    rw [hproduct]
+    exact K.mul_mem ha (K.pow_mem
+      (IntermediateField.mem_adjoin_simple_self Rat gamma.toComplex) i.val)
+  have hrun := vector_mapM_some_get hrhs i
+  have htrace := trace?_sound gamma (products.get i) hproductMem hrun
+  calc
+    rhs.get i = Algebra.trace Rat K
+        ⟨(products.get i).toComplex, hproductMem⟩ := htrace
+    _ = Algebra.trace Rat K
+        ⟨a.toComplex * gamma.toComplex ^ i.val,
+          K.mul_mem ha (K.pow_mem
+            (IntermediateField.mem_adjoin_simple_self Rat gamma.toComplex)
+            i.val)⟩ := by
+      apply congrArg (Algebra.trace Rat K)
+      apply Subtype.ext
+      exact hproduct
+
+private theorem basisCoeffs_solve (gamma a : AlgebraicNumber)
+    (powers : Array AlgebraicNumber) (powerTraces : Array Rat)
+    (hsize : powers.size = 2 * degree gamma - 1)
+    (hvalues : ∀ i (hi : i < powers.size),
+      powers[i].toComplex = gamma.toComplex ^ i)
+    (ha : a.toComplex ∈ Rat⟮gamma.toComplex⟯)
+    (hpowerTraces :
+      powers.mapM (trace? (degree gamma)) = some powerTraces)
+    (products : Vector AlgebraicNumber (degree gamma))
+    (hproducts :
+      (⟨(List.range (degree gamma)).toArray, by simp⟩ :
+          Vector Nat (degree gamma)).mapM
+        (fun k => mul? a powers[k]!) = some products)
+    (rhs : Vector Rat (degree gamma))
+    (hrhs : products.mapM (trace? (degree gamma)) = some rhs) :
+    ∃ c : Vector Rat (degree gamma),
+      Matrix.vecMul c
+          (Matrix.ofFn fun i : Fin (degree gamma) =>
+            fun j : Fin (degree gamma) => powerTraces[i.val + j.val]!) = rhs ∧
+      ∑ i : Fin (degree gamma), c.get i •
+          (⟨gamma.toComplex ^ i.val,
+            (Rat⟮gamma.toComplex⟯ : IntermediateField Rat ℂ).pow_mem
+              (IntermediateField.mem_adjoin_simple_self Rat gamma.toComplex)
+              i.val⟩ : Rat⟮gamma.toComplex⟯) =
+        (⟨a.toComplex, ha⟩ : Rat⟮gamma.toComplex⟯) := by
+  let K : IntermediateField Rat ℂ := Rat⟮gamma.toComplex⟯
+  letI : FiniteDimensional Rat K :=
+    IntermediateField.adjoin.finiteDimensional (isIntegral_toComplex gamma)
+  let pb := IntermediateField.adjoin.powerBasis (isIntegral_toComplex gamma)
+  have hpbdim : pb.dim = degree gamma := by
+    change (minpoly Rat gamma.toComplex).natDegree = degree gamma
+    exact (degree_eq_minpoly gamma).symm
+  let basis : Basis (Fin (degree gamma)) Rat K :=
+    pb.basis.reindex (finCongr hpbdim)
+  have hbasis (i : Fin (degree gamma)) :
+      basis i = (⟨gamma.toComplex ^ i.val,
+        K.pow_mem (IntermediateField.mem_adjoin_simple_self
+          Rat gamma.toComplex) i.val⟩ : K) := by
+    apply Subtype.ext
+    simp [basis, pb]
+  let aK : K := ⟨a.toComplex, ha⟩
+  let c : Vector Rat (degree gamma) :=
+    Vector.ofFn fun i => basis.repr aK i
+  have hreconstruct : ∑ i : Fin (degree gamma), c.get i •
+      (⟨gamma.toComplex ^ i.val,
+        K.pow_mem (IntermediateField.mem_adjoin_simple_self
+          Rat gamma.toComplex) i.val⟩ : K) = aK := by
+    simpa [c, hbasis] using basis.sum_repr aK
+  refine ⟨c, ?_, hreconstruct⟩
+  apply HexMatrixMathlib.vectorEquiv.injective
+  rw [HexMatrixMathlib.vectorEquiv_vecMul]
+  funext j
+  simp only [Fintype.linearCombination_apply, Finset.sum_apply,
+    Pi.smul_apply, smul_eq_mul]
+  have htraceBound (i : Fin (degree gamma)) :
+      i.val + j.val < powerTraces.size := by
+    rw [← (HexRootsMathlib.array_mapM_some_get hpowerTraces).1]
+    have hpos := degree_pos gamma
+    omega
+  have hpowersBound (i : Fin (degree gamma)) :
+      i.val + j.val < powers.size := by
+    have hpos := degree_pos gamma
+    omega
+  have hentry (i : Fin (degree gamma)) :
+      powerTraces[i.val + j.val]! = Algebra.trace Rat K
+        ((⟨gamma.toComplex ^ i.val,
+            K.pow_mem (IntermediateField.mem_adjoin_simple_self
+              Rat gamma.toComplex) i.val⟩ : K) *
+          (⟨gamma.toComplex ^ j.val,
+            K.pow_mem (IntermediateField.mem_adjoin_simple_self
+              Rat gamma.toComplex) j.val⟩ : K)) := by
+    have hpow := hpowersBound i
+    have hmember : powers[i.val + j.val].toComplex ∈ K := by
+      rw [hvalues (i.val + j.val) hpow]
+      exact K.pow_mem (IntermediateField.mem_adjoin_simple_self
+        Rat gamma.toComplex) (i.val + j.val)
+    have htrace := trace?_sound gamma powers[i.val + j.val] hmember
+      ((HexRootsMathlib.array_mapM_some_get hpowerTraces).2
+        (i.val + j.val) hpow (htraceBound i))
+    rw [getElem!_pos powerTraces (i.val + j.val) (htraceBound i)]
+    calc
+      powerTraces[i.val + j.val]'(htraceBound i) = Algebra.trace Rat K
+          ⟨(powers[i.val + j.val]'hpow).toComplex, hmember⟩ := htrace
+      _ = _ := by
+        apply congrArg (Algebra.trace Rat K)
+        apply Subtype.ext
+        simp [hvalues (i.val + j.val) hpow, pow_add]
+  rw [show (HexMatrixMathlib.vectorEquiv rhs) j = rhs.get j by rfl,
+    coordinateRhs_get gamma a powers hsize hvalues ha products hproducts
+      rhs hrhs j]
+  simp only [HexMatrixMathlib.matrixEquiv_ofFn,
+    HexMatrixMathlib.vectorEquiv_apply]
+  change (∑ i : Fin (degree gamma),
+      c.get i * powerTraces[i.val + j.val]!) =
+    Algebra.trace Rat K
+      ⟨a.toComplex * gamma.toComplex ^ j.val,
+        K.mul_mem ha (K.pow_mem
+          (IntermediateField.mem_adjoin_simple_self Rat gamma.toComplex)
+          j.val)⟩
+  simp_rw [hentry]
+  calc
+    ∑ i : Fin (degree gamma), c.get i * Algebra.trace Rat K
+        ((⟨gamma.toComplex ^ i.val,
+            K.pow_mem (IntermediateField.mem_adjoin_simple_self
+              Rat gamma.toComplex) i.val⟩ : K) *
+          (⟨gamma.toComplex ^ j.val,
+            K.pow_mem (IntermediateField.mem_adjoin_simple_self
+              Rat gamma.toComplex) j.val⟩ : K)) =
+      Algebra.trace Rat K
+        ((∑ i : Fin (degree gamma), c.get i •
+          (⟨gamma.toComplex ^ i.val,
+            K.pow_mem (IntermediateField.mem_adjoin_simple_self
+              Rat gamma.toComplex) i.val⟩ : K)) *
+          ⟨gamma.toComplex ^ j.val,
+            K.pow_mem (IntermediateField.mem_adjoin_simple_self
+              Rat gamma.toComplex) j.val⟩) := by
+        rw [Finset.sum_mul, map_sum]
+        apply Finset.sum_congr rfl
+        intro i _
+        change c.get i • Algebra.trace Rat K
+            ((⟨gamma.toComplex ^ i.val,
+                K.pow_mem (IntermediateField.mem_adjoin_simple_self
+                  Rat gamma.toComplex) i.val⟩ : K) *
+              (⟨gamma.toComplex ^ j.val,
+                K.pow_mem (IntermediateField.mem_adjoin_simple_self
+                  Rat gamma.toComplex) j.val⟩ : K)) = _
+        rw [← map_smul]
+        congr 1
+        exact (Algebra.smul_mul_assoc _ _ _).symm
+    _ = _ := by
+      rw [hreconstruct]
+      apply congrArg (Algebra.trace Rat K)
+      apply Subtype.ext
+      rfl
+
+private theorem coordinateEval (gamma : AlgebraicNumber)
+    (coeffs : Vector Rat (degree gamma)) :
+    QAdjoin.toComplex
+        (QAdjoin.reduce gamma.p gamma.x
+          (DensePoly.ofCoeffs coeffs.toArray))
+        gamma.rep gamma.rep_mk =
+      ∑ i : Fin (degree gamma),
+        (coeffs.get i : ℂ) * gamma.toComplex ^ i.val := by
+  unfold QAdjoin.toComplex QAdjoin.reduce
+  rw [QAdjoin.eval_reduceCoeffs,
+    HexPolyMathlib.eval₂_toPolynomial]
+  let f : DensePoly Rat := DensePoly.ofCoeffs coeffs.toArray
+  have hfsize : f.size ≤ degree gamma :=
+    (DensePoly.size_ofCoeffs_le coeffs.toArray).trans (by simp)
+  change (∑ i ∈ Finset.range f.size,
+      (algebraMap Rat ℂ) (f.coeff i) * gamma.rep.root ^ i) = _
+  calc
+    ∑ i ∈ Finset.range f.size,
+        (algebraMap Rat ℂ) (f.coeff i) * gamma.rep.root ^ i =
+      ∑ i ∈ Finset.range (degree gamma),
+        (algebraMap Rat ℂ) (f.coeff i) * gamma.rep.root ^ i := by
+      apply Finset.sum_subset (Finset.range_mono hfsize)
+      intro i _ hi
+      have hfi : f.coeff i = 0 :=
+        DensePoly.coeff_eq_zero_of_size_le f (by simpa using hi)
+      simp [hfi]
+    _ = ∑ i ∈ Finset.range (degree gamma),
+        (coeffs.toArray.getD i (Zero.zero : Rat) : ℂ) *
+          gamma.toComplex ^ i := by
+      apply Finset.sum_congr rfl
+      intro i hi
+      rw [show f.coeff i = coeffs.toArray.getD i (Zero.zero : Rat) by
+        simp [f]]
+      rfl
+    _ = ∑ i : Fin (degree gamma),
+        (coeffs.toArray.getD i.val (Zero.zero : Rat) : ℂ) *
+          gamma.toComplex ^ i.val :=
+      (Fin.sum_univ_eq_sum_range
+        (fun i => (coeffs.toArray.getD i (Zero.zero : Rat) : ℂ) *
+          gamma.toComplex ^ i) (degree gamma)).symm
+    _ = ∑ i : Fin (degree gamma),
+        (coeffs.get i : ℂ) * gamma.toComplex ^ i.val := by
+      apply Finset.sum_congr rfl
+      intro i hi
+      have hi' : i.val < coeffs.toArray.size := by simp
+      have hget : coeffs.toArray.getD i.val (Zero.zero : Rat) =
+          coeffs.get i := by
+        rw [Vector.get_eq_getElem,
+          ← Array.getElem_eq_getD (Zero.zero : Rat)]
+        exact Vector.getElem_toArray (xs := coeffs) hi'
+      rw [hget]
+
+private theorem coordinateOfSpan_sound (gamma a : AlgebraicNumber)
+    (powers : Array AlgebraicNumber) (powerTraces : Array Rat)
+    (hsize : powers.size = 2 * degree gamma - 1)
+    (hvalues : ∀ i (hi : i < powers.size),
+      powers[i].toComplex = gamma.toComplex ^ i)
+    (ha : a.toComplex ∈ Rat⟮gamma.toComplex⟯)
+    (hpowerTraces :
+      powers.mapM (trace? (degree gamma)) = some powerTraces)
+    (products : Vector AlgebraicNumber (degree gamma))
+    (hproducts :
+      (⟨(List.range (degree gamma)).toArray, by simp⟩ :
+          Vector Nat (degree gamma)).mapM
+        (fun k => mul? a powers[k]!) = some products)
+    (rhs : Vector Rat (degree gamma))
+    (hrhs : products.mapM (trace? (degree gamma)) = some rhs)
+    (coeffs : Vector Rat (degree gamma))
+    (hcoeffs : Matrix.spanCoeffs
+      (Matrix.ofFn fun i : Fin (degree gamma) =>
+        fun j : Fin (degree gamma) => powerTraces[i.val + j.val]!)
+      rhs = some coeffs) :
+    QAdjoin.toComplex
+        (QAdjoin.reduce gamma.p gamma.x
+          (DensePoly.ofCoeffs coeffs.toArray))
+        gamma.rep gamma.rep_mk = a.toComplex := by
+  obtain ⟨canonical, hcanonical, hreconstruct⟩ :=
+    basisCoeffs_solve gamma a powers powerTraces hsize hvalues ha
+      hpowerTraces products hproducts rhs hrhs
+  have hdet := traceGram_det_ne_zero gamma powers powerTraces hsize
+    hvalues hpowerTraces
+  have hcoeffsSolve := Matrix.spanCoeffs_sound _ _ _ hcoeffs
+  have hcanonicalEq : coeffs = canonical :=
+    (vecMul_injective_of_det_ne_zero _ hdet)
+      (hcoeffsSolve.trans hcanonical.symm)
+  subst coeffs
+  rw [coordinateEval]
+  have hcomplex := congrArg
+    (fun z : Rat⟮gamma.toComplex⟯ => (z : ℂ)) hreconstruct
+  simpa [map_sum, Algebra.smul_def] using hcomplex
+
+/-- Coordinate recovery succeeds for an element of the primitive field when
+the supplied table contains the required consecutive powers. -/
+theorem coordinates?_isSome (gamma a : AlgebraicNumber)
+    (powers : Array AlgebraicNumber)
+    (hsize : powers.size = 2 * degree gamma - 1)
+    (hvalues : ∀ i (hi : i < powers.size),
+      powers[i].toComplex = gamma.toComplex ^ i)
+    (ha : a.toComplex ∈ Rat⟮gamma.toComplex⟯) :
+    (coordinates? gamma a powers).isSome := by
+  let K : IntermediateField Rat ℂ := Rat⟮gamma.toComplex⟯
+  unfold coordinates?
+  split
+  · simp
+  · simp only
+    have hpowerTracesSome :
+        (powers.mapM (trace? (degree gamma))).isSome := by
+      apply HexRootsMathlib.array_mapM_isSome
+      intro power hpower
+      have hpower' : power ∈ powers := by simpa using hpower
+      rw [Array.mem_iff_getElem] at hpower'
+      obtain ⟨i, hi, rfl⟩ := hpower'
+      apply trace?_isSome gamma
+      rw [hvalues i hi]
+      exact K.pow_mem
+        (IntermediateField.mem_adjoin_simple_self Rat gamma.toComplex) i
+    obtain ⟨powerTraces, hpowerTraces⟩ :=
+      Option.isSome_iff_exists.mp hpowerTracesSome
+    have hproductsSome :
+        ((⟨Array.range (degree gamma), by simp⟩ :
+            Vector Nat (degree gamma)).mapM
+          fun k => mul? a powers[k]!).isSome := by
+      apply vector_mapM_isSome
+      intro i
+      exact mul?_isSome _ _
+    obtain ⟨products, hproducts⟩ :=
+      Option.isSome_iff_exists.mp hproductsSome
+    have hindices :
+        (⟨Array.range (degree gamma), by simp⟩ :
+            Vector Nat (degree gamma)) =
+          ⟨(List.range (degree gamma)).toArray, by simp⟩ := by
+      apply Vector.ext
+      intro i hi
+      simp
+    have hproductsList :
+        (⟨(List.range (degree gamma)).toArray, by simp⟩ :
+            Vector Nat (degree gamma)).mapM
+          (fun k => mul? a powers[k]!) = some products := by
+      rw [← hindices]
+      exact hproducts
+    have hrhsSome :
+        (products.mapM (trace? (degree gamma))).isSome := by
+      apply vector_mapM_isSome
+      intro i
+      apply trace?_isSome gamma
+      have hproduct := coordinateProducts_get gamma a powers hsize
+        hvalues products hproductsList i
+      rw [hproduct]
+      exact K.mul_mem ha (K.pow_mem
+        (IntermediateField.mem_adjoin_simple_self Rat gamma.toComplex)
+        i.val)
+    obtain ⟨rhs, hrhs⟩ := Option.isSome_iff_exists.mp hrhsSome
+    have hdet :
+        (_root_.Matrix.det (HexMatrixMathlib.matrixEquiv
+          (Matrix.ofFn fun i : Fin (degree gamma) =>
+            fun j : Fin (degree gamma) =>
+              powerTraces[i.val + j.val]!))) ≠ 0 :=
+      traceGram_det_ne_zero gamma powers powerTraces hsize hvalues
+        hpowerTraces
+    have hcoeffsSome : (Matrix.spanCoeffs
+        (Matrix.ofFn fun i : Fin (degree gamma) =>
+          fun j : Fin (degree gamma) => powerTraces[i.val + j.val]!)
+        rhs).isSome :=
+      spanCoeffs_isSome_of_det_ne_zero _ rhs hdet
+    obtain ⟨coeffs, hcoeffs⟩ :=
+      Option.isSome_iff_exists.mp hcoeffsSome
+    let coordinate : QAdjoin gamma.p gamma.x :=
+      QAdjoin.reduce gamma.p gamma.x
+        (DensePoly.ofCoeffs coeffs.toArray)
+    letI : ZPoly.CheckedIrreducible gamma.p := gamma.checked
+    obtain ⟨recovered, hrecovered⟩ := Option.isSome_iff_exists.mp
+      (QAdjoin.toAlgebraicNumber?_isSome coordinate gamma.rep
+        gamma.rep_mk)
+    have hcoordinate :
+        QAdjoin.toComplex coordinate gamma.rep gamma.rep_mk =
+          a.toComplex := by
+      exact coordinateOfSpan_sound gamma a powers powerTraces hsize
+        hvalues ha hpowerTraces products hproductsList rhs hrhs coeffs
+        hcoeffs
+    have hrecoveredValue : recovered.toComplex = a.toComplex :=
+      (QAdjoin.toAlgebraicNumber?_sound coordinate gamma.rep gamma.rep_mk
+        hrecovered).trans hcoordinate
+    have hbeq : (recovered == a) = true :=
+      (AlgebraicNumber.beq_iff recovered a).mpr hrecoveredValue
+    simp [hpowerTraces, hproducts, hrhs, hcoeffs, coordinate,
+      hrecovered, hbeq]
+
+/-- Successful coordinate recovery represents the original algebraic value at
+the selected primitive embedding. -/
+theorem coordinates?_sound (gamma a : AlgebraicNumber)
+    (powers : Array AlgebraicNumber) {coordinate : QAdjoin gamma.p gamma.x}
+    (h : coordinates? gamma a powers = some coordinate) :
+    QAdjoin.toComplex coordinate gamma.rep gamma.rep_mk = a.toComplex := by
+  letI : ZPoly.CheckedIrreducible gamma.p := gamma.checked
+  unfold coordinates? at h
+  split at h
+  next hzero =>
+    have hcoordinate : (0 : QAdjoin gamma.p gamma.x) = coordinate :=
+      Option.some.inj h
+    rw [← hcoordinate, QAdjoin.map_zero]
+    exact ((AlgebraicNumber.isZero_iff a).mp hzero).symm
+  next _ =>
+    obtain ⟨powerTraces, _, h⟩ := Option.bind_eq_some_iff.mp h
+    obtain ⟨products, _, h⟩ := Option.bind_eq_some_iff.mp h
+    obtain ⟨rhs, _, h⟩ := Option.bind_eq_some_iff.mp h
+    obtain ⟨coeffs, _, h⟩ := Option.bind_eq_some_iff.mp h
+    obtain ⟨recovered, hrecovered, h⟩ := Option.bind_eq_some_iff.mp h
+    split at h
+    next heq =>
+      have hcoordinate := Option.some.inj h
+      subst coordinate
+      rw [← QAdjoin.toAlgebraicNumber?_sound _ gamma.rep gamma.rep_mk
+        hrecovered]
+      exact (AlgebraicNumber.beq_iff recovered a).mp heq
+    next => simp at h
+
+end Hex.AlgebraicPoly.Common

--- a/HexNumberFieldMathlib/Lazy.lean
+++ b/HexNumberFieldMathlib/Lazy.lean
@@ -847,7 +847,7 @@ end
 
 /-- A successful eliminant search selects the supplied semantic root whenever
 the operation ball contains it. -/
-private theorem AlgebraicRoot.ofEliminant?_sound
+theorem AlgebraicRoot.ofEliminant?_sound
     (raw : ZPoly) (ballAt : Int → Option DyadicComplexBall)
     {c : AlgebraicRoot} {z : ℂ}
     (h : AlgebraicRoot.ofEliminant? raw ballAt = some c)
@@ -948,7 +948,7 @@ private theorem AlgebraicRoot.ofEliminant?_sound
 
 /-- A nonzero eliminant root enclosed by a sufficiently small operation ball
 survives normalization, isolation, and the singleton selection filter. -/
-private theorem AlgebraicRoot.ofEliminant?_isSome
+theorem AlgebraicRoot.ofEliminant?_isSome
     (raw : ZPoly) (ballAt : Int → Option DyadicComplexBall)
     {z : ℂ} (hraw : raw ≠ 0)
     (hroot : (HexRootsMathlib.toPolyℂ raw).IsRoot z)

--- a/HexNumberFieldMathlib/Presentation.lean
+++ b/HexNumberFieldMathlib/Presentation.lean
@@ -250,6 +250,22 @@ theorem degree_eq_minpoly (a : AlgebraicNumber) :
     _ = (minpoly Rat a.toComplex).natDegree := by
       rw [AlgebraicNumber.p_eq_minpoly]
 
+/-- The complex value represented by a canonical algebraic number is
+algebraic over the rationals. -/
+theorem isIntegral_toComplex (a : AlgebraicNumber) :
+    IsIntegral Rat a.toComplex := by
+  apply minpoly.ne_zero_iff.mp
+  rw [← AlgebraicNumber.p_eq_minpoly]
+  have hlc : (a.p.leadingCoeff : Rat) ≠ 0 := by
+    exact_mod_cast (ne_of_gt a.pos_lc)
+  have hp : a.p ≠ 0 := by
+    intro hzero
+    have hdegree := a.pos_degree
+    rw [hzero] at hdegree
+    simp at hdegree
+  exact smul_ne_zero (inv_ne_zero hlc)
+    (HexPolyZMathlib.toPolyℚ_ne_zero hp)
+
 /-- Every canonical algebraic number has positive degree. -/
 theorem degree_pos (a : AlgebraicNumber) : 0 < degree a := by
   exact a.pos_degree
@@ -271,7 +287,8 @@ theorem degree_pos (a : AlgebraicNumber) : 0 < degree a := by
   rw [show 2 * (n + 1) = 2 * n + 2 by omega,
     signedShift_even_succ]
 
-private theorem signedShift_injective : Function.Injective signedShift := by
+/-- The deterministic signed-shift enumeration never repeats a scalar. -/
+theorem signedShift_injective : Function.Injective signedShift := by
   intro i j hij
   obtain ⟨a, rfl | rfl⟩ := Nat.even_or_odd' i
   · cases a with
@@ -326,7 +343,9 @@ private theorem signedShift_injective : Function.Injective signedShift := by
         exact Int.ofNat.inj hij
       omega
 
-private def extendStep (theta alpha : AlgebraicNumber) :
+/-- One maximum-degree update in the bounded primitive-element search. -/
+@[expose]
+def extendStep (theta alpha : AlgebraicNumber) :
     Option AlgebraicNumber → Nat → Option (Option AlgebraicNumber) :=
   fun best k => do
     let candidate ← shift? theta alpha (signedShift k)

--- a/HexNumberFieldMathlib/Presentation.lean
+++ b/HexNumberFieldMathlib/Presentation.lean
@@ -1,0 +1,550 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexNumberField.Roots
+public import HexNumberFieldMathlib.AlgebraicPoly
+public import Mathlib.FieldTheory.PrimitiveElement
+
+public section
+
+/-!
+# Common fixed-field presentations
+
+Semantic totality and value preservation for the checked arithmetic used by
+the algebraic-coefficient root driver's common-field construction.
+-/
+
+namespace Hex.AlgebraicPoly.Common
+
+private theorem rationalDense_ne_zero (q : Rat) :
+    DensePoly.ofList [-q, 1] ≠ 0 := by
+  intro hzero
+  have hcoeff := congrArg (fun f : DensePoly Rat => f.coeff 1) hzero
+  simp at hcoeff
+
+private theorem rationalPrimitive_ne_zero (q : Rat) :
+    ZPoly.ratPolyPrimitivePart (DensePoly.ofList [-q, 1]) ≠ 0 := by
+  let f : DensePoly Rat := DensePoly.ofList [-q, 1]
+  obtain ⟨unit, hunit⟩ := ZPoly.ratPolyPrimitivePart_rational_associate f
+  intro hzero
+  rw [hzero] at hunit
+  simp at hunit
+  exact rationalDense_ne_zero q hunit
+
+private theorem rationalPrimitive_isRoot (q : Rat) :
+    (HexRootsMathlib.toPolyℂ
+      (ZPoly.ratPolyPrimitivePart (DensePoly.ofList [-q, 1]))).IsRoot
+        (q : ℂ) := by
+  let f : DensePoly Rat := DensePoly.ofList [-q, 1]
+  let p := ZPoly.ratPolyPrimitivePart f
+  obtain ⟨unit, hunit⟩ := ZPoly.ratPolyPrimitivePart_rational_associate f
+  have hunitNe : unit ≠ 0 := by
+    intro hzero
+    rw [hzero] at hunit
+    simp at hunit
+    exact rationalDense_ne_zero q hunit
+  have hpoly := congrArg HexPolyMathlib.toPolynomial hunit
+  have hfpoly : HexPolyMathlib.toPolynomial f =
+      Polynomial.C (-q) + Polynomial.X := by
+    ext n
+    rw [HexPolyMathlib.coeff_toPolynomial]
+    cases n with
+    | zero => simp [f]
+    | succ n =>
+        cases n with
+        | zero => simp [f]
+        | succ n =>
+            simp only [Polynomial.coeff_add, Polynomial.coeff_C,
+              Polynomial.coeff_X]
+            simp [f, DensePoly.coeff_ofList]
+            rfl
+  rw [HexPolyMathlib.toPolynomial_scale] at hpoly
+  have heval := congrArg (Polynomial.eval q) hpoly
+  rw [hfpoly] at heval
+  simp only [Polynomial.eval_add, Polynomial.eval_C, Polynomial.eval_X,
+    neg_add_cancel, Polynomial.eval_mul] at heval
+  have hpRat : (HexPolyZMathlib.toPolyℚ p).eval q = 0 := by
+    rw [← HexPolyZMathlib.toPolynomial_toRatPoly]
+    exact (mul_eq_zero.mp heval.symm).resolve_left hunitNe
+  have hcomp :
+      (algebraMap Rat ℂ).comp (Int.castRingHom Rat) =
+        Int.castRingHom ℂ := RingHom.ext_int _ _
+  have hmapped : ((HexPolyZMathlib.toPolyℚ p).map
+      (algebraMap Rat ℂ)).eval (q : ℂ) = 0 := by
+    calc
+      ((HexPolyZMathlib.toPolyℚ p).map
+          (algebraMap Rat ℂ)).eval (q : ℂ) =
+          algebraMap Rat ℂ ((HexPolyZMathlib.toPolyℚ p).eval q) := by
+            exact Polynomial.eval_map_apply (algebraMap Rat ℂ) q
+      _ = 0 := by rw [hpRat, map_zero]
+  simpa [p, f, HexPolyZMathlib.toPolyℚ, HexRootsMathlib.toPolyℂ,
+    Polynomial.map_map, hcomp] using hmapped
+
+/-- Checked canonical construction of a rational algebraic number is total. -/
+theorem rational?_isSome (q : Rat) :
+    (rational? q).isSome := by
+  unfold rational?
+  split
+  · simp
+  · let p := ZPoly.ratPolyPrimitivePart (DensePoly.ofList [-q, 1])
+    let prec : Int := separationDepth (ZPoly.squareFreeCore p)
+    let ball := DyadicComplexBall.ofRat q prec
+    have hsepNat : mahlerPrec (ZPoly.squareFreeCore p) ≤
+        separationDepth (ZPoly.squareFreeCore p) := by
+      rw [separationDepth]
+      omega
+    have hsepInt : (mahlerPrec (ZPoly.squareFreeCore p) : Int) ≤
+        separationDepth (ZPoly.squareFreeCore p) := by
+      exact_mod_cast hsepNat
+    have hradius : ball.realRadius ≤
+        (2 : ℝ) ^ (-(mahlerPrec (ZPoly.squareFreeCore p) : ℤ)) := by
+      calc
+        ball.realRadius ≤ (2 : ℝ) ^ (-prec) :=
+          DyadicComplexBall.realRadius_ofRat_le q prec
+        _ ≤ (2 : ℝ) ^
+            (-(mahlerPrec (ZPoly.squareFreeCore p) : ℤ)) :=
+          zpow_le_zpow_right₀ (by norm_num) (by omega)
+    have hrootSome := AlgebraicRoot.ofEliminant?_isSome p
+      (fun requested => some (DyadicComplexBall.ofRat q requested))
+      (z := (q : ℂ)) (by simpa [p] using rationalPrimitive_ne_zero q)
+      (by simpa [p] using rationalPrimitive_isRoot q) ball
+      (by rfl) (by exact DyadicComplexBall.ofRat_mem q prec) hradius
+    obtain ⟨root, hroot⟩ := Option.isSome_iff_exists.mp hrootSome
+    change (AlgebraicRoot.ofEliminant? p
+      (fun requested => some (DyadicComplexBall.ofRat q requested)) >>=
+        fun root => root.exact?).isSome
+    rw [hroot]
+    simpa using AlgebraicRoot.exact?_isSome root
+
+/-- Checked canonical construction of a rational preserves its value. -/
+theorem rational?_sound (q : Rat) {a : AlgebraicNumber}
+    (h : rational? q = some a) :
+    a.toComplex = (q : ℂ) := by
+  unfold rational? at h
+  split at h
+  · rename_i hzero
+    have ha := Option.some.inj h
+    subst a
+    simp [hzero]
+  · let p := ZPoly.ratPolyPrimitivePart (DensePoly.ofList [-q, 1])
+    obtain ⟨root, hroot, hexact⟩ := Option.bind_eq_some_iff.mp h
+    rw [AlgebraicRoot.exact?_sound root hexact]
+    apply AlgebraicRoot.ofEliminant?_sound p
+      (fun requested => some (DyadicComplexBall.ofRat q requested)) hroot
+      (by simpa [p] using rationalPrimitive_isRoot q)
+    intro ball hball
+    have hballEq := Option.some.inj hball
+    subst ball
+    exact DyadicComplexBall.ofRat_mem q _
+
+/-- Checked canonical addition is total. -/
+theorem add?_isSome (a b : AlgebraicNumber) :
+    (add? a b).isSome := by
+  unfold add?
+  cases hroot : a.toRoot.add? b.toRoot with
+  | none =>
+      have hsome := AlgebraicRoot.add?_isSome a.toRoot b.toRoot
+      simp [hroot] at hsome
+  | some root =>
+      simpa [hroot] using AlgebraicRoot.exact?_isSome root
+
+/-- Checked canonical addition preserves the represented complex value. -/
+theorem add?_sound (a b : AlgebraicNumber) {c : AlgebraicNumber}
+    (h : add? a b = some c) :
+    c.toComplex = a.toComplex + b.toComplex := by
+  unfold add? at h
+  obtain ⟨root, hroot, hexact⟩ := Option.bind_eq_some_iff.mp h
+  rw [AlgebraicRoot.exact?_sound root hexact,
+    AlgebraicRoot.add?_sound a.toRoot b.toRoot hroot,
+    AlgebraicNumber.toRoot_toComplex, AlgebraicNumber.toRoot_toComplex]
+
+/-- Checked canonical multiplication is total. -/
+theorem mul?_isSome (a b : AlgebraicNumber) :
+    (mul? a b).isSome := by
+  unfold mul?
+  cases hroot : a.toRoot.mul? b.toRoot with
+  | none =>
+      have hsome := AlgebraicRoot.mul?_isSome a.toRoot b.toRoot
+      simp [hroot] at hsome
+  | some root =>
+      simpa [hroot] using AlgebraicRoot.exact?_isSome root
+
+/-- Checked canonical multiplication preserves the represented complex value. -/
+theorem mul?_sound (a b : AlgebraicNumber) {c : AlgebraicNumber}
+    (h : mul? a b = some c) :
+    c.toComplex = a.toComplex * b.toComplex := by
+  unfold mul? at h
+  obtain ⟨root, hroot, hexact⟩ := Option.bind_eq_some_iff.mp h
+  rw [AlgebraicRoot.exact?_sound root hexact,
+    AlgebraicRoot.mul?_sound a.toRoot b.toRoot hroot,
+    AlgebraicNumber.toRoot_toComplex, AlgebraicNumber.toRoot_toComplex]
+
+/-- Checked integer scaling is total. -/
+theorem scale?_isSome (c : Int) (a : AlgebraicNumber) :
+    (scale? c a).isSome := by
+  unfold scale?
+  obtain ⟨scalar, hscalar⟩ := Option.isSome_iff_exists.mp
+    (rational?_isSome (c : Rat))
+  rw [hscalar]
+  simpa using mul?_isSome scalar a
+
+/-- A successful checked integer scaling has the expected value. -/
+theorem scale?_sound (c : Int) (a : AlgebraicNumber) {b : AlgebraicNumber}
+    (h : scale? c a = some b) :
+    b.toComplex = (c : ℂ) * a.toComplex := by
+  unfold scale? at h
+  obtain ⟨scalar, hscalar, hmul⟩ := Option.bind_eq_some_iff.mp h
+  rw [mul?_sound scalar a hmul, rational?_sound (c : Rat) hscalar]
+  norm_num
+
+/-- A checked primitive-element shift is total. -/
+theorem shift?_isSome (theta alpha : AlgebraicNumber) (c : Int) :
+    (shift? theta alpha c).isSome := by
+  unfold shift?
+  split
+  · simp
+  · unfold scale?
+    obtain ⟨scalar, hscalar⟩ := Option.isSome_iff_exists.mp
+      (rational?_isSome (c : Rat))
+    rw [hscalar]
+    change (mul? scalar alpha >>= fun scaled => add? theta scaled).isSome
+    obtain ⟨scaled, hscaled⟩ := Option.isSome_iff_exists.mp
+      (mul?_isSome scalar alpha)
+    rw [hscaled]
+    simpa using add?_isSome theta scaled
+
+/-- A successful checked primitive-element shift has the expected value. -/
+theorem shift?_sound (theta alpha : AlgebraicNumber) (c : Int)
+    {candidate : AlgebraicNumber}
+    (h : shift? theta alpha c = some candidate) :
+    candidate.toComplex = theta.toComplex + (c : ℂ) * alpha.toComplex := by
+  unfold shift? at h
+  split at h
+  · rename_i hzero
+    have hc := Option.some.inj h
+    subst candidate
+    simp [hzero]
+  · obtain ⟨scaled, hscaled, hadd⟩ := Option.bind_eq_some_iff.mp h
+    rw [add?_sound theta scaled hadd, scale?_sound c alpha hscaled]
+
+/-- The executable degree is the degree of the rational minimal polynomial. -/
+theorem degree_eq_minpoly (a : AlgebraicNumber) :
+    degree a = (minpoly Rat a.toComplex).natDegree := by
+  have hlc : (a.p.leadingCoeff : Rat) ≠ 0 := by
+    exact_mod_cast (ne_of_gt a.pos_lc)
+  calc
+    degree a = (HexPolyZMathlib.toPolyℚ a.p).natDegree := by
+      unfold degree HexPolyZMathlib.toPolyℚ
+      rw [Polynomial.natDegree_map_eq_of_injective
+        (RingHom.injective_int (Int.castRingHom Rat)),
+        HexPolyMathlib.natDegree_toPolynomial]
+    _ = ((a.p.leadingCoeff : Rat)⁻¹ •
+        HexPolyZMathlib.toPolyℚ a.p).natDegree := by
+      symm
+      exact Polynomial.natDegree_smul _ (inv_ne_zero hlc)
+    _ = (minpoly Rat a.toComplex).natDegree := by
+      rw [AlgebraicNumber.p_eq_minpoly]
+
+/-- Every canonical algebraic number has positive degree. -/
+theorem degree_pos (a : AlgebraicNumber) : 0 < degree a := by
+  exact a.pos_degree
+
+@[simp] private theorem signedShift_odd (n : Nat) :
+    signedShift (2 * n + 1) = Int.ofNat (n + 1) := by
+  simp [signedShift]
+
+@[simp] private theorem signedShift_zero : signedShift 0 = 0 := rfl
+
+@[simp] private theorem signedShift_even_succ (n : Nat) :
+    signedShift (2 * n + 2) = -Int.ofNat (n + 1) := by
+  have hdiv : (2 * n + 1) / 2 = n := by omega
+  rw [show 2 * n + 2 = (2 * n + 1) + 1 by omega, signedShift]
+  simp [hdiv]
+
+@[simp] private theorem signedShift_even_pos (n : Nat) :
+    signedShift (2 * (n + 1)) = -Int.ofNat (n + 1) := by
+  rw [show 2 * (n + 1) = 2 * n + 2 by omega,
+    signedShift_even_succ]
+
+private theorem signedShift_injective : Function.Injective signedShift := by
+  intro i j hij
+  obtain ⟨a, rfl | rfl⟩ := Nat.even_or_odd' i
+  · cases a with
+    | zero =>
+        obtain ⟨b, rfl | rfl⟩ := Nat.even_or_odd' j
+        · cases b with
+          | zero => rfl
+          | succ b =>
+              simp only [signedShift_even_pos, Nat.mul_zero, signedShift_zero] at hij
+              have hpos : (0 : Int) < Int.ofNat (b + 1) := by
+                exact Int.ofNat_lt.mpr (Nat.succ_pos b)
+              omega
+        · simp only [signedShift_odd, Nat.mul_zero, signedShift_zero] at hij
+          have hpos : (0 : Int) < Int.ofNat (b + 1) := by
+            exact Int.ofNat_lt.mpr (Nat.succ_pos b)
+          omega
+    | succ a =>
+        obtain ⟨b, rfl | rfl⟩ := Nat.even_or_odd' j
+        · cases b with
+          | zero =>
+              simp only [signedShift_even_pos, Nat.mul_zero, signedShift_zero] at hij
+              have hpos : (0 : Int) < Int.ofNat (a + 1) := by
+                exact Int.ofNat_lt.mpr (Nat.succ_pos a)
+              omega
+          | succ b =>
+              simp only [signedShift_even_pos] at hij
+              have hab : a + 1 = b + 1 := by
+                exact Int.ofNat.inj (neg_injective hij)
+              omega
+        · simp only [signedShift_even_pos, signedShift_odd] at hij
+          have ha : (0 : Int) < Int.ofNat (a + 1) := by
+            exact Int.ofNat_lt.mpr (Nat.succ_pos a)
+          have hb : (0 : Int) < Int.ofNat (b + 1) := by
+            exact Int.ofNat_lt.mpr (Nat.succ_pos b)
+          omega
+  · obtain ⟨b, rfl | rfl⟩ := Nat.even_or_odd' j
+    · cases b with
+      | zero =>
+          simp only [signedShift_odd, Nat.mul_zero, signedShift_zero] at hij
+          have hpos : (0 : Int) < Int.ofNat (a + 1) := by
+            exact Int.ofNat_lt.mpr (Nat.succ_pos a)
+          omega
+      | succ b =>
+          simp only [signedShift_odd, signedShift_even_pos] at hij
+          have ha : (0 : Int) < Int.ofNat (a + 1) := by
+            exact Int.ofNat_lt.mpr (Nat.succ_pos a)
+          have hb : (0 : Int) < Int.ofNat (b + 1) := by
+            exact Int.ofNat_lt.mpr (Nat.succ_pos b)
+          omega
+    · simp only [signedShift_odd] at hij
+      have hab : a + 1 = b + 1 := by
+        exact Int.ofNat.inj hij
+      omega
+
+private def extendStep (theta alpha : AlgebraicNumber) :
+    Option AlgebraicNumber → Nat → Option (Option AlgebraicNumber) :=
+  fun best k => do
+    let candidate ← shift? theta alpha (signedShift k)
+    some <| match best with
+    | none => some candidate
+    | some current =>
+        if degree current < degree candidate then some candidate
+        else some current
+
+private theorem extendStep_some (theta alpha : AlgebraicNumber)
+    (best : Option AlgebraicNumber) (k : Nat) :
+    ∃ candidate, extendStep theta alpha best k = some (some candidate) := by
+  obtain ⟨shifted, hshifted⟩ := Option.isSome_iff_exists.mp
+    (shift?_isSome theta alpha (signedShift k))
+  unfold extendStep
+  rw [hshifted]
+  cases best with
+  | none => exact ⟨shifted, rfl⟩
+  | some current =>
+      by_cases hdegree : degree current < degree shifted
+      · exact ⟨shifted, by simp [hdegree]⟩
+      · exact ⟨current, by simp [hdegree]⟩
+
+private theorem extendFold_fromSome (theta alpha : AlgebraicNumber)
+    (indices : List Nat) (current : AlgebraicNumber) :
+    ∃ candidate, indices.foldlM (extendStep theta alpha) (some current) =
+      some (some candidate) := by
+  induction indices generalizing current with
+  | nil => exact ⟨current, rfl⟩
+  | cons k indices ih =>
+      obtain ⟨next, hnext⟩ := extendStep_some theta alpha (some current) k
+      rw [List.foldlM_cons, hnext]
+      exact ih next
+
+private theorem extendFold_nonempty (theta alpha : AlgebraicNumber)
+    (indices : List Nat) (hnonempty : indices ≠ []) :
+    ∃ candidate, indices.foldlM (extendStep theta alpha) none =
+      some (some candidate) := by
+  cases indices with
+  | nil => exact (hnonempty rfl).elim
+  | cons k indices =>
+      obtain ⟨first, hfirst⟩ := extendStep_some theta alpha none k
+      rw [List.foldlM_cons, hfirst]
+      exact extendFold_fromSome theta alpha indices first
+
+/-- The bounded maximum-degree primitive-element search is operationally
+total. Its field-generation invariant is established separately. -/
+theorem extend?_isSome (theta alpha : AlgebraicNumber) :
+    (extend? theta alpha).isSome := by
+  let upper := degree theta * degree alpha
+  let count := Nat.choose upper 2 + 1
+  have hcount : count ≠ 0 := by omega
+  have hrange : List.range count ≠ [] := by simp [hcount]
+  obtain ⟨candidate, hfold⟩ :=
+    extendFold_nonempty theta alpha (List.range count) hrange
+  unfold extend?
+  change ((List.range count).foldlM (extendStep theta alpha) none >>=
+    fun best => best).isSome
+  rw [hfold]
+  simp
+
+private theorem list_foldlM_isSome {A B : Type*} {step : B → A → Option B}
+    (items : List A) (init : B)
+    (hstep : ∀ state item, item ∈ items → (step state item).isSome) :
+    (items.foldlM step init).isSome := by
+  induction items generalizing init with
+  | nil => simp
+  | cons item items ih =>
+      obtain ⟨next, hnext⟩ := Option.isSome_iff_exists.mp
+        (hstep init item (by simp))
+      rw [List.foldlM_cons, hnext]
+      exact ih next fun state tail htail =>
+        hstep state tail (by simp [htail])
+
+/-- The primitive-element fold is total for any coefficient array containing
+a semantically nonzero entry. -/
+theorem primitive?_isSome (coefficients : Array AlgebraicNumber)
+    (hnonzero : ∃ a ∈ coefficients.toList, a.isZero = false) :
+    (primitive? coefficients).isSome := by
+  let nonzero := coefficients.filter fun a => !a.isZero
+  obtain ⟨a, ha, hzero⟩ := hnonzero
+  have haArray : a ∈ coefficients := Array.mem_toList_iff.mp ha
+  have haFiltered : a ∈ nonzero := by
+    simp [nonzero, haArray, hzero]
+  have hpos : 0 < nonzero.size :=
+    Array.size_pos_iff_exists_mem.mpr ⟨a, haFiltered⟩
+  let first := nonzero[0]
+  have hfirst : nonzero[0]? = some first :=
+    Array.getElem?_eq_some_iff.mpr ⟨hpos, rfl⟩
+  have hfold := list_foldlM_isSome (nonzero.toList.drop 1) first
+    (fun state item _ => extend?_isSome state item)
+  unfold primitive?
+  change (nonzero[0]? >>= fun first =>
+    nonzero.toList.drop 1 |>.foldlM extend? first).isSome
+  rw [hfirst]
+  exact hfold
+
+private theorem powersFold_isSome (gamma : AlgebraicNumber)
+    (indices : List Nat) (powers : Array AlgebraicNumber)
+    (hnonempty : powers ≠ #[]) :
+    ∃ out, indices.foldlM
+        (fun powers _ => do
+          let previous ← powers.back?
+          let next ← mul? previous gamma
+          some (powers.push next))
+        powers = some out ∧ out ≠ #[] := by
+  induction indices generalizing powers with
+  | nil => exact ⟨powers, rfl, hnonempty⟩
+  | cons index indices ih =>
+      cases hback : powers.back? with
+      | none =>
+          have hempty := Array.back?_eq_none_iff.mp hback
+          exact (hnonempty hempty).elim
+      | some previous =>
+          obtain ⟨next, hnext⟩ := Option.isSome_iff_exists.mp
+            (mul?_isSome previous gamma)
+          rw [List.foldlM_cons, hback]
+          simpa [hnext] using ih (powers.push next) (by simp)
+
+/-- The checked power table construction is total. -/
+theorem powers?_isSome (gamma : AlgebraicNumber) (last : Nat) :
+    (powers? gamma last).isSome := by
+  unfold powers?
+  obtain ⟨one, hone⟩ := Option.isSome_iff_exists.mp (rational?_isSome 1)
+  rw [hone]
+  change ((List.range last).foldlM
+    (fun (powers : Array AlgebraicNumber) _ => do
+      let previous ← powers.back?
+      let next ← mul? previous gamma
+      some (powers.push next)) #[one]).isSome
+  obtain ⟨out, hout, _⟩ := powersFold_isSome gamma (List.range last) #[one]
+    (by simp)
+  rw [hout]
+  simp
+
+private theorem powersFold_sound (gamma : AlgebraicNumber)
+    (indices : List Nat) (powers out : Array AlgebraicNumber) (offset : Nat)
+    (hsize : powers.size = offset + 1)
+    (hvalues : ∀ i (hi : i < powers.size),
+      powers[i].toComplex = gamma.toComplex ^ i)
+    (hrun : indices.foldlM
+      (fun powers _ => do
+        let previous ← powers.back?
+        let next ← mul? previous gamma
+        some (powers.push next))
+      powers = some out) :
+    out.size = offset + 1 + indices.length ∧
+      ∀ i (hi : i < out.size),
+        out[i].toComplex = gamma.toComplex ^ i := by
+  induction indices generalizing powers offset with
+  | nil =>
+      have hout := Option.some.inj hrun
+      subst out
+      exact ⟨by simp [hsize], hvalues⟩
+  | cons index indices ih =>
+      rw [List.foldlM_cons] at hrun
+      cases hback : powers.back? with
+      | none => simp [hback] at hrun
+      | some previous =>
+          cases hnext : mul? previous gamma with
+          | none => simp [hback, hnext] at hrun
+          | some next =>
+              have htail : indices.foldlM
+                  (fun powers _ => do
+                    let previous ← powers.back?
+                    let next ← mul? previous gamma
+                    some (powers.push next))
+                  (powers.push next) = some out := by
+                simpa [hback, hnext] using hrun
+              rw [Array.back?_eq_getElem?,
+                Array.getElem?_eq_some_iff] at hback
+              obtain ⟨hlast, hprevious⟩ := hback
+              have hlastIndex : powers.size - 1 = offset := by omega
+              have hpreviousValue :
+                  previous.toComplex = gamma.toComplex ^ offset := by
+                rw [← hprevious, hvalues (powers.size - 1) hlast,
+                  hlastIndex]
+              have hnextValue :
+                  next.toComplex = gamma.toComplex ^ (offset + 1) := by
+                rw [mul?_sound previous gamma hnext, hpreviousValue,
+                  pow_succ]
+              have hpushSize : (powers.push next).size = (offset + 1) + 1 := by
+                simp [hsize]
+              have hpushValues : ∀ i (hi : i < (powers.push next).size),
+                  (powers.push next)[i].toComplex = gamma.toComplex ^ i := by
+                intro i hi
+                by_cases hiold : i < powers.size
+                · rw [Array.getElem_push_lt hiold]
+                  exact hvalues i hiold
+                · have hieq : i = powers.size := by
+                    simp only [Array.size_push] at hi
+                    omega
+                  subst i
+                  rw [Array.getElem_push_eq, hsize]
+                  exact hnextValue
+              obtain ⟨houtSize, houtValues⟩ :=
+                ih (powers.push next) (offset + 1) hpushSize hpushValues htail
+              exact ⟨by simp at houtSize ⊢; omega, houtValues⟩
+
+/-- A successful checked power table contains exactly the requested initial
+powers of its generator. -/
+theorem powers?_sound (gamma : AlgebraicNumber) (last : Nat)
+    {powers : Array AlgebraicNumber} (h : powers? gamma last = some powers) :
+    powers.size = last + 1 ∧
+      ∀ i (hi : i < powers.size),
+        powers[i].toComplex = gamma.toComplex ^ i := by
+  unfold powers? at h
+  obtain ⟨one, hone, hfold⟩ := Option.bind_eq_some_iff.mp h
+  have honeValue : one.toComplex = 1 := by
+    simpa using rational?_sound 1 hone
+  have hinitial : ∀ i (hi : i < (#[one] : Array AlgebraicNumber).size),
+      (#[one] : Array AlgebraicNumber)[i].toComplex = gamma.toComplex ^ i := by
+    intro i hi
+    have hiZero : i = 0 := by simpa using hi
+    subst i
+    simpa using honeValue
+  obtain ⟨hsize, hvalues⟩ := powersFold_sound gamma (List.range last)
+    #[one] powers 0 (by simp) hinitial hfold
+  exact ⟨by simpa [Nat.add_comm] using hsize, hvalues⟩
+
+end Hex.AlgebraicPoly.Common

--- a/HexNumberFieldMathlib/PresentationSemantics.lean
+++ b/HexNumberFieldMathlib/PresentationSemantics.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexNumberFieldMathlib.Coordinates
+
+public section
+
+/-!
+# Total primitive presentations
+
+Assembly and semantic invariants for the common-field presentation of an
+array of canonical algebraic numbers.
+-/
+
+namespace Hex.AlgebraicPoly.Common
+
+/-- A nonzero algebraic coefficient array always admits a checked primitive
+fixed-field presentation. -/
+theorem presentation?_isSome (coefficients : Array AlgebraicNumber)
+    (hnonzero : ∃ a ∈ coefficients.toList, a.isZero = false) :
+    (presentation? coefficients).isSome := by
+  obtain ⟨gamma, hgamma⟩ := Option.isSome_iff_exists.mp
+    (primitive?_isSome coefficients hnonzero)
+  obtain ⟨powers, hpowers⟩ := Option.isSome_iff_exists.mp
+    (powers?_isSome gamma (2 * degree gamma - 2))
+  obtain ⟨hpowersSize, hpowersValues⟩ :=
+    powers?_sound gamma (2 * degree gamma - 2) hpowers
+  have hsize : powers.size = 2 * degree gamma - 1 := by
+    have hpos := degree_pos gamma
+    omega
+  have hembeddedSome :
+      (coefficients.mapM fun a => coordinates? gamma a powers).isSome := by
+    apply HexRootsMathlib.array_mapM_isSome
+    intro a ha
+    apply coordinates?_isSome gamma a powers hsize hpowersValues
+    exact primitive?_contains coefficients gamma a hgamma
+      (Array.mem_toList_iff.mp ha)
+  obtain ⟨embedded, hembedded⟩ :=
+    Option.isSome_iff_exists.mp hembeddedSome
+  unfold presentation?
+  simp [hgamma, hpowers, hembedded]
+
+/-- A successful presentation preserves the coefficient array length and the
+selected complex value of every coefficient. -/
+theorem presentation?_sound (coefficients : Array AlgebraicNumber)
+    {presentation : Presentation}
+    (h : presentation? coefficients = some presentation) :
+    presentation.coefficients.size = coefficients.size ∧
+      ∀ i (hi : i < coefficients.size)
+          (hiPresentation : i < presentation.coefficients.size),
+        QAdjoin.toComplex presentation.coefficients[i]
+            presentation.generator.rep presentation.generator.rep_mk =
+          coefficients[i].toComplex := by
+  unfold presentation? at h
+  obtain ⟨gamma, hgamma, h⟩ := Option.bind_eq_some_iff.mp h
+  obtain ⟨powers, hpowers, h⟩ := Option.bind_eq_some_iff.mp h
+  obtain ⟨embedded, hembedded, h⟩ := Option.bind_eq_some_iff.mp h
+  have hpresentation : (Presentation.mk gamma embedded) = presentation :=
+    Option.some.inj h
+  subst presentation
+  have hmap := HexRootsMathlib.array_mapM_some_get hembedded
+  constructor
+  · exact hmap.1.symm
+  · intro i hi hiEmbedded
+    exact coordinates?_sound gamma coefficients[i] powers
+      (hmap.2 i hi hiEmbedded)
+
+end Hex.AlgebraicPoly.Common

--- a/HexNumberFieldMathlib/Primitive.lean
+++ b/HexNumberFieldMathlib/Primitive.lean
@@ -1,0 +1,498 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexNumberFieldMathlib.Presentation
+public import Mathlib.Data.Sym.NatCard
+
+public section
+
+/-!
+# Bounded primitive-element search
+
+The semantic invariant behind the executable maximum-degree shift search.
+-/
+
+namespace Hex.AlgebraicPoly.Common
+
+open Module IntermediateField
+
+private theorem exists_primitive_shift
+    (F E A : Type*) [Field F] [Infinite F] [Field E] [Algebra F E]
+    [FiniteDimensional F E] [Algebra.IsSeparable F E]
+    [Field A] [IsAlgClosed A] [Algebra F A]
+    (theta alpha : E)
+    (hgen : ∀ phi psi : E →ₐ[F] A,
+      phi theta = psi theta → phi alpha = psi alpha → phi = psi)
+    (scalar : Fin (Nat.choose (finrank F E) 2 + 1) → F)
+    (hscalar : Function.Injective scalar) :
+    ∃ k, F⟮theta + scalar k • alpha⟯ = ⊤ := by
+  classical
+  by_contra hprimitive
+  push Not at hprimitive
+  have hbad (k : Fin (Nat.choose (finrank F E) 2 + 1)) :
+      ¬Function.Injective fun phi : E →ₐ[F] A =>
+        phi (theta + scalar k • alpha) := by
+    intro hinjective
+    exact hprimitive k <|
+      (Field.primitive_element_iff_algHom_eq_of_eval' F A
+        (fun _ => IsAlgClosed.splits _) _).mpr hinjective
+  have hwitness (k : Fin (Nat.choose (finrank F E) 2 + 1)) :
+      ∃ phi psi : E →ₐ[F] A,
+        phi ≠ psi ∧
+          phi (theta + scalar k • alpha) =
+            psi (theta + scalar k • alpha) := by
+    obtain ⟨phi, psi, heq, hne⟩ :=
+      Function.not_injective_iff.mp (hbad k)
+    exact ⟨phi, psi, hne, heq⟩
+  choose phi psi hne heval using hwitness
+  let pair (k : Fin (Nat.choose (finrank F E) 2 + 1)) :
+      {z : Sym2 (E →ₐ[F] A) // ¬z.IsDiag} :=
+    ⟨s(phi k, psi k), by simpa using hne k⟩
+  have scalar_unique (phi psi : E →ₐ[F] A) (hphi : phi ≠ psi)
+      (c d : F)
+      (hc : phi (theta + c • alpha) = psi (theta + c • alpha))
+      (hd : phi (theta + d • alpha) = psi (theta + d • alpha)) :
+      c = d := by
+    have halpha : phi alpha ≠ psi alpha := by
+      intro halpha
+      apply hphi
+      apply hgen phi psi
+      · simpa [halpha] using hc
+      · exact halpha
+    simp only [map_add, Algebra.smul_def, map_mul, AlgHom.commutes] at hc hd
+    have hzero :
+        algebraMap F A (c - d) * (phi alpha - psi alpha) = 0 := by
+      rw [map_sub]
+      linear_combination hc - hd
+    have hmap : algebraMap F A (c - d) = 0 :=
+      (mul_eq_zero.mp hzero).resolve_right (sub_ne_zero.mpr halpha)
+    apply sub_eq_zero.mp
+    apply (algebraMap F A).injective
+    simpa using hmap
+  have hpair : Function.Injective pair := by
+    intro i j hij
+    have hpairs : s(phi i, psi i) = s(phi j, psi j) :=
+      congrArg Subtype.val hij
+    rcases Sym2.eq_iff.mp hpairs with hsame | hswap
+    · obtain ⟨hphi, hpsi⟩ := hsame
+      have hscalars : scalar i = scalar j := by
+        apply scalar_unique (phi i) (psi i) (hne i)
+        · exact heval i
+        · simpa [hphi, hpsi] using heval j
+      exact hscalar hscalars
+    · obtain ⟨hphi, hpsi⟩ := hswap
+      have hscalars : scalar i = scalar j := by
+        apply scalar_unique (phi i) (psi i) (hne i)
+        · exact heval i
+        · simpa [hphi, hpsi] using (heval j).symm
+      exact hscalar hscalars
+  have hcard := Fintype.card_le_of_injective pair hpair
+  rw [Fintype.card_fin, Sym2.card_subtype_not_diag,
+    AlgHom.card F E A] at hcard
+  rw [HexRootsMathlib.choose_eq_choose] at hcard
+  omega
+
+private theorem finrank_pair_le (theta alpha : AlgebraicNumber) :
+    finrank Rat Rat⟮theta.toComplex, alpha.toComplex⟯ ≤
+      degree theta * degree alpha := by
+  let thetaField : IntermediateField Rat ℂ := Rat⟮theta.toComplex⟯
+  let alphaField : IntermediateField Rat ℂ := Rat⟮alpha.toComplex⟯
+  have htheta : IsIntegral Rat theta.toComplex := isIntegral_toComplex theta
+  have halpha : IsIntegral Rat alpha.toComplex := isIntegral_toComplex alpha
+  have hpair : ({theta.toComplex, alpha.toComplex} : Set ℂ) =
+      {theta.toComplex} ∪ {alpha.toComplex} := by
+    ext z
+    simp [or_comm]
+  have hfields : Rat⟮theta.toComplex, alpha.toComplex⟯ =
+      thetaField ⊔ alphaField := by
+    dsimp [thetaField, alphaField]
+    rw [hpair, IntermediateField.adjoin_union]
+  calc
+    finrank Rat Rat⟮theta.toComplex, alpha.toComplex⟯ =
+        finrank Rat ↥(thetaField ⊔ alphaField) := by
+          rw [hfields]
+    _ ≤ finrank Rat thetaField * finrank Rat alphaField :=
+      IntermediateField.finrank_sup_le thetaField alphaField
+    _ = degree theta * degree alpha := by
+      rw [IntermediateField.adjoin.finrank htheta,
+        IntermediateField.adjoin.finrank halpha,
+        degree_eq_minpoly, degree_eq_minpoly]
+
+private theorem shift_degree_le (theta alpha candidate : AlgebraicNumber)
+    (c : Int) (hcandidate : shift? theta alpha c = some candidate) :
+    degree candidate ≤
+      finrank Rat Rat⟮theta.toComplex, alpha.toComplex⟯ := by
+  let K : IntermediateField Rat ℂ :=
+    Rat⟮theta.toComplex, alpha.toComplex⟯
+  let thetaK : K := IntermediateField.AdjoinPair.gen₁
+    Rat theta.toComplex alpha.toComplex
+  let alphaK : K := IntermediateField.AdjoinPair.gen₂
+    Rat theta.toComplex alpha.toComplex
+  let candidateK : K := thetaK + (c : Rat) • alphaK
+  letI : FiniteDimensional Rat K :=
+    IntermediateField.finiteDimensional_adjoin_pair
+      (isIntegral_toComplex theta) (isIntegral_toComplex alpha)
+  have hvalue : candidate.toComplex = (candidateK : ℂ) := by
+    rw [shift?_sound theta alpha c hcandidate]
+    simp [candidateK, thetaK, alphaK,
+      IntermediateField.AdjoinPair.gen₁,
+      IntermediateField.AdjoinPair.gen₂, Algebra.smul_def]
+  rw [degree_eq_minpoly, hvalue]
+  change (minpoly Rat (K.val candidateK)).natDegree ≤ finrank Rat K
+  rw [minpoly.algHom_eq K.val Subtype.val_injective candidateK]
+  exact minpoly.natDegree_le candidateK
+
+private theorem exists_shift_degree_eq (theta alpha : AlgebraicNumber) :
+    ∃ k < Nat.choose (degree theta * degree alpha) 2 + 1,
+      ∃ candidate, shift? theta alpha (signedShift k) = some candidate ∧
+        degree candidate =
+          finrank Rat Rat⟮theta.toComplex, alpha.toComplex⟯ := by
+  classical
+  let K : IntermediateField Rat ℂ :=
+    Rat⟮theta.toComplex, alpha.toComplex⟯
+  let thetaK : K := IntermediateField.AdjoinPair.gen₁
+    Rat theta.toComplex alpha.toComplex
+  let alphaK : K := IntermediateField.AdjoinPair.gen₂
+    Rat theta.toComplex alpha.toComplex
+  letI : FiniteDimensional Rat K :=
+    IntermediateField.finiteDimensional_adjoin_pair
+      (isIntegral_toComplex theta) (isIntegral_toComplex alpha)
+  have hgen : ∀ phi psi : K →ₐ[Rat] ℂ,
+      phi thetaK = psi thetaK → phi alphaK = psi alphaK → phi = psi := by
+    intro phi psi htheta halpha
+    apply IntermediateField.adjoin_algHom_ext Rat
+    intro x hx
+    simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hx
+    rcases hx with rfl | rfl
+    · exact htheta
+    · exact halpha
+  let scalar : Fin (Nat.choose (finrank Rat K) 2 + 1) → Rat :=
+    fun k => signedShift k
+  have hscalar : Function.Injective scalar := by
+    intro i j hij
+    apply Fin.ext
+    apply signedShift_injective
+    change (signedShift (i : Nat) : Rat) =
+      (signedShift (j : Nat) : Rat) at hij
+    exact_mod_cast hij
+  obtain ⟨k, hprimitive⟩ := exists_primitive_shift
+    Rat K ℂ thetaK alphaK hgen scalar hscalar
+  let candidateK : K := thetaK + scalar k • alphaK
+  have hdegreeK : (minpoly Rat candidateK).natDegree = finrank Rat K :=
+    (Field.primitive_element_iff_minpoly_natDegree_eq Rat candidateK).mp
+      hprimitive
+  obtain ⟨candidate, hcandidate⟩ := Option.isSome_iff_exists.mp
+    (shift?_isSome theta alpha (signedShift k))
+  have hvalue : candidate.toComplex = (candidateK : ℂ) := by
+    rw [shift?_sound theta alpha (signedShift k) hcandidate]
+    simp [candidateK, scalar, thetaK, alphaK,
+      IntermediateField.AdjoinPair.gen₁,
+      IntermediateField.AdjoinPair.gen₂, Algebra.smul_def]
+  have hdegree : degree candidate = finrank Rat K := by
+    rw [degree_eq_minpoly, hvalue]
+    change (minpoly Rat (K.val candidateK)).natDegree = finrank Rat K
+    rw [minpoly.algHom_eq K.val Subtype.val_injective candidateK]
+    exact hdegreeK
+  have hfinrank : finrank Rat K ≤ degree theta * degree alpha :=
+    finrank_pair_le theta alpha
+  have hchoose : Nat.choose (finrank Rat K) 2 ≤
+      Nat.choose (degree theta * degree alpha) 2 := by
+    rw [HexRootsMathlib.choose_eq_choose,
+      HexRootsMathlib.choose_eq_choose]
+    exact _root_.Nat.choose_le_choose 2 hfinrank
+  exact ⟨k, by omega, candidate, hcandidate, hdegree⟩
+
+private theorem extendStep_bounds (theta alpha : AlgebraicNumber)
+    (best : Option AlgebraicNumber) (k : Nat) (next : AlgebraicNumber)
+    (hnext : extendStep theta alpha best k = some (some next)) :
+    (∀ current, best = some current → degree current ≤ degree next) ∧
+      ∀ candidate, shift? theta alpha (signedShift k) = some candidate →
+        degree candidate ≤ degree next := by
+  obtain ⟨candidate, hcandidate⟩ := Option.isSome_iff_exists.mp
+    (shift?_isSome theta alpha (signedShift k))
+  unfold extendStep at hnext
+  rw [hcandidate] at hnext
+  cases best with
+  | none =>
+      have hvalue := Option.some.inj hnext
+      have hcandidateNext := Option.some.inj hvalue
+      subst next
+      constructor
+      · intro current hcurrent
+        simp at hcurrent
+      · intro shifted hshifted
+        have heq : shifted = candidate :=
+          Option.some.inj (hshifted.symm.trans hcandidate)
+        exact le_of_eq (congrArg degree heq)
+  | some current =>
+      by_cases hdegree : degree current < degree candidate
+      · simp [hdegree] at hnext
+        subst next
+        constructor
+        · intro previous hprevious
+          have heq : previous = current :=
+            (Option.some.inj hprevious).symm
+          subst previous
+          exact le_of_lt hdegree
+        · intro shifted hshifted
+          have heq : shifted = candidate :=
+            Option.some.inj (hshifted.symm.trans hcandidate)
+          exact le_of_eq (congrArg degree heq)
+      · simp [hdegree] at hnext
+        subst next
+        constructor
+        · intro previous hprevious
+          exact le_of_eq
+            (congrArg degree (Option.some.inj hprevious)).symm
+        · intro shifted hshifted
+          have heq : shifted = candidate :=
+            Option.some.inj (hshifted.symm.trans hcandidate)
+          subst shifted
+          exact Nat.le_of_not_gt hdegree
+
+private theorem extendFold_max (theta alpha : AlgebraicNumber)
+    (indices : List Nat) (best : Option AlgebraicNumber)
+    (out : AlgebraicNumber)
+    (hfold : indices.foldlM (extendStep theta alpha) best =
+      some (some out)) :
+    (∀ current, best = some current → degree current ≤ degree out) ∧
+      ∀ k ∈ indices, ∀ candidate,
+        shift? theta alpha (signedShift k) = some candidate →
+          degree candidate ≤ degree out := by
+  induction indices generalizing best with
+  | nil =>
+      have hbest := Option.some.inj hfold
+      constructor
+      · intro current hcurrent
+        rw [hbest] at hcurrent
+        exact le_of_eq (congrArg degree (Option.some.inj hcurrent)).symm
+      · simp
+  | cons k indices ih =>
+      rw [List.foldlM_cons] at hfold
+      obtain ⟨nextBest, hstep, htail⟩ :=
+        Option.bind_eq_some_iff.mp hfold
+      obtain ⟨shifted, hshifted⟩ := Option.isSome_iff_exists.mp
+        (shift?_isSome theta alpha (signedShift k))
+      have hnextExists : ∃ next, nextBest = some next := by
+        unfold extendStep at hstep
+        rw [hshifted] at hstep
+        cases best with
+        | none => exact ⟨shifted, (Option.some.inj hstep).symm⟩
+        | some current =>
+            by_cases hdegree : degree current < degree shifted
+            · exact ⟨shifted, by simpa [hdegree] using hstep.symm⟩
+            · exact ⟨current, by simpa [hdegree] using hstep.symm⟩
+      obtain ⟨next, hnext⟩ := hnextExists
+      subst nextBest
+      obtain ⟨hnextOut, htailMax⟩ := ih (some next) htail
+      obtain ⟨hbestNext, hshiftNext⟩ :=
+        extendStep_bounds theta alpha best k next hstep
+      constructor
+      · intro current hcurrent
+        exact (hbestNext current hcurrent).trans
+          (hnextOut next rfl)
+      · intro index hindex candidate hcandidate
+        simp only [List.mem_cons] at hindex
+        rcases hindex with rfl | hindex
+        · exact (hshiftNext candidate hcandidate).trans
+            (hnextOut next rfl)
+        · exact htailMax index hindex candidate hcandidate
+
+private theorem extendStep_source (theta alpha : AlgebraicNumber)
+    (best : Option AlgebraicNumber) (k : Nat) (next : AlgebraicNumber)
+    (hnext : extendStep theta alpha best k = some (some next)) :
+    best = some next ∨
+      shift? theta alpha (signedShift k) = some next := by
+  obtain ⟨candidate, hcandidate⟩ := Option.isSome_iff_exists.mp
+    (shift?_isSome theta alpha (signedShift k))
+  unfold extendStep at hnext
+  rw [hcandidate] at hnext
+  cases best with
+  | none =>
+      change some (some candidate) = some (some next) at hnext
+      have heq : candidate = next :=
+        Option.some.inj (Option.some.inj hnext)
+      right
+      exact hcandidate.trans (congrArg some heq)
+  | some current =>
+      change some (if degree current < degree candidate then some candidate
+        else some current) = some (some next) at hnext
+      by_cases hdegree : degree current < degree candidate
+      · right
+        simp [hdegree] at hnext
+        subst next
+        exact hcandidate
+      · left
+        simp [hdegree] at hnext
+        subst next
+        rfl
+
+private theorem extendFold_source (theta alpha : AlgebraicNumber)
+    (indices : List Nat) (best : Option AlgebraicNumber)
+    (out : AlgebraicNumber)
+    (hfold : indices.foldlM (extendStep theta alpha) best =
+      some (some out)) :
+    best = some out ∨
+      ∃ k ∈ indices,
+        shift? theta alpha (signedShift k) = some out := by
+  induction indices generalizing best with
+  | nil =>
+      left
+      exact Option.some.inj hfold
+  | cons k indices ih =>
+      rw [List.foldlM_cons] at hfold
+      obtain ⟨nextBest, hstep, htail⟩ :=
+        Option.bind_eq_some_iff.mp hfold
+      rcases ih nextBest htail with hsame | ⟨index, hindex, hshift⟩
+      · rw [hsame] at hstep
+        rcases extendStep_source theta alpha best k out hstep with
+          hbest | hshift
+        · exact Or.inl hbest
+        · exact Or.inr ⟨k, by simp, hshift⟩
+      · exact Or.inr ⟨index, by simp [hindex], hshift⟩
+
+/-- A successful maximum-degree shift search reaches the full compositum
+degree. -/
+theorem extend?_degree (theta alpha gamma : AlgebraicNumber)
+    (hgamma : extend? theta alpha = some gamma) :
+    degree gamma =
+      finrank Rat Rat⟮theta.toComplex, alpha.toComplex⟯ := by
+  let upper := degree theta * degree alpha
+  let count := Nat.choose upper 2 + 1
+  unfold extend? at hgamma
+  change ((List.range count).foldlM (extendStep theta alpha) none >>=
+    fun best => best) = some gamma at hgamma
+  obtain ⟨best, hfold, hbest⟩ :=
+    Option.bind_eq_some_iff.mp hgamma
+  subst best
+  obtain ⟨_, hmaximum⟩ := extendFold_max theta alpha
+    (List.range count) none gamma hfold
+  obtain ⟨k, hk, candidate, hcandidate, hcandidateDegree⟩ :=
+    exists_shift_degree_eq theta alpha
+  have hlower :
+      finrank Rat Rat⟮theta.toComplex, alpha.toComplex⟯ ≤ degree gamma := by
+    rw [← hcandidateDegree]
+    exact hmaximum k (List.mem_range.mpr hk) candidate hcandidate
+  have hsource := extendFold_source theta alpha
+    (List.range count) none gamma hfold
+  rcases hsource with hnone | ⟨k, _hk, hshift⟩
+  · simp at hnone
+  · exact le_antisymm
+      (shift_degree_le theta alpha gamma (signedShift k) hshift) hlower
+
+/-- The maximum-degree shift returned by `extend?` generates exactly the
+compositum of its two inputs. -/
+theorem extend?_field (theta alpha gamma : AlgebraicNumber)
+    (hgamma : extend? theta alpha = some gamma) :
+    Rat⟮gamma.toComplex⟯ =
+      Rat⟮theta.toComplex, alpha.toComplex⟯ := by
+  let upper := degree theta * degree alpha
+  let count := Nat.choose upper 2 + 1
+  unfold extend? at hgamma
+  change ((List.range count).foldlM (extendStep theta alpha) none >>=
+    fun best => best) = some gamma at hgamma
+  obtain ⟨best, hfold, hbest⟩ :=
+    Option.bind_eq_some_iff.mp hgamma
+  subst best
+  obtain ⟨k, _hk, hshift⟩ := (extendFold_source theta alpha
+    (List.range count) none gamma hfold).resolve_left (by simp)
+  let K : IntermediateField Rat ℂ :=
+    Rat⟮theta.toComplex, alpha.toComplex⟯
+  have hmember : gamma.toComplex ∈ K := by
+    rw [shift?_sound theta alpha (signedShift k) hshift]
+    apply K.add_mem
+    · exact IntermediateField.mem_adjoin_pair_left
+        Rat theta.toComplex alpha.toComplex
+    · apply K.mul_mem
+      · simp
+      · exact IntermediateField.mem_adjoin_pair_right
+          Rat theta.toComplex alpha.toComplex
+  have hle : Rat⟮gamma.toComplex⟯ ≤ K :=
+    IntermediateField.adjoin_simple_le_iff.mpr hmember
+  letI : FiniteDimensional Rat K :=
+    IntermediateField.finiteDimensional_adjoin_pair
+      (isIntegral_toComplex theta) (isIntegral_toComplex alpha)
+  apply IntermediateField.eq_of_le_of_finrank_eq hle
+  rw [IntermediateField.adjoin.finrank (isIntegral_toComplex gamma),
+    ← degree_eq_minpoly]
+  exact extend?_degree theta alpha gamma hgamma
+
+private theorem primitiveFold_contains (items : List AlgebraicNumber)
+    (initial out : AlgebraicNumber)
+    (hfold : items.foldlM extend? initial = some out) :
+    initial.toComplex ∈ Rat⟮out.toComplex⟯ ∧
+      ∀ a ∈ items, a.toComplex ∈ Rat⟮out.toComplex⟯ := by
+  induction items generalizing initial with
+  | nil =>
+      have heq := Option.some.inj hfold
+      subst out
+      exact ⟨IntermediateField.mem_adjoin_simple_self Rat initial.toComplex,
+        by simp⟩
+  | cons a items ih =>
+      rw [List.foldlM_cons] at hfold
+      obtain ⟨next, hnext, htail⟩ := Option.bind_eq_some_iff.mp hfold
+      obtain ⟨hnextMem, htailMem⟩ := ih next htail
+      have hle : Rat⟮next.toComplex⟯ ≤ Rat⟮out.toComplex⟯ :=
+        IntermediateField.adjoin_simple_le_iff.mpr hnextMem
+      have hfield := extend?_field initial a next hnext
+      have hinitialNext : initial.toComplex ∈ Rat⟮next.toComplex⟯ := by
+        rw [hfield]
+        exact IntermediateField.mem_adjoin_pair_left
+          Rat initial.toComplex a.toComplex
+      have haNext : a.toComplex ∈ Rat⟮next.toComplex⟯ := by
+        rw [hfield]
+        exact IntermediateField.mem_adjoin_pair_right
+          Rat initial.toComplex a.toComplex
+      constructor
+      · exact hle hinitialNext
+      · intro b hb
+        simp only [List.mem_cons] at hb
+        rcases hb with rfl | hb
+        · exact hle haNext
+        · exact htailMem b hb
+
+/-- Every input coefficient belongs to the simple field selected by a
+successful primitive-element fold. -/
+theorem primitive?_contains (coefficients : Array AlgebraicNumber)
+    (gamma a : AlgebraicNumber)
+    (hgamma : primitive? coefficients = some gamma) (ha : a ∈ coefficients) :
+    a.toComplex ∈ Rat⟮gamma.toComplex⟯ := by
+  by_cases hzero : a.isZero = true
+  · rw [(AlgebraicNumber.isZero_iff a).mp hzero]
+    exact (Rat⟮gamma.toComplex⟯ : IntermediateField Rat ℂ).zero_mem
+  have hnonzero : a.isZero = false := by
+    cases h : a.isZero <;> simp_all
+  let nonzero := coefficients.filter fun value => !value.isZero
+  have haNonzero : a ∈ nonzero := by
+    simp [nonzero, ha, hnonzero]
+  unfold primitive? at hgamma
+  change (nonzero[0]? >>= fun first =>
+    nonzero.toList.drop 1 |>.foldlM extend? first) = some gamma at hgamma
+  obtain ⟨first, hfirst, hfold⟩ :=
+    Option.bind_eq_some_iff.mp hgamma
+  have hfirstList : nonzero.toList[0]? = some first := by
+    simpa using hfirst
+  cases hlist : nonzero.toList with
+  | nil => simp [hlist] at hfirstList
+  | cons head tail =>
+      have hhead : head = first := by
+        simpa [hlist] using hfirstList
+      subst head
+      have haList : a ∈ first :: tail := by
+        simpa [hlist] using Array.mem_toList_iff.mpr haNonzero
+      have hfold' : tail.foldlM extend? first = some gamma := by
+        simpa [hlist] using hfold
+      obtain ⟨hfirstMem, htailMem⟩ :=
+        primitiveFold_contains tail first gamma hfold'
+      simp only [List.mem_cons] at haList
+      rcases haList with haeq | haTail
+      · subst a
+        exact hfirstMem
+      · exact htailMem a haTail
+
+end Hex.AlgebraicPoly.Common

--- a/HexNumberFieldMathlib/Roots.lean
+++ b/HexNumberFieldMathlib/Roots.lean
@@ -6,7 +6,7 @@ Authors: Kim Morrison
 
 module
 
-public import HexNumberFieldMathlib.AlgebraicPoly
+public import HexNumberFieldMathlib.Presentation
 public import HexNumberFieldMathlib.RootDisambiguation
 public import HexNumberFieldMathlib.Yun
 public import Mathlib.Algebra.Polynomial.Div

--- a/HexNumberFieldMathlib/Roots.lean
+++ b/HexNumberFieldMathlib/Roots.lean
@@ -1374,60 +1374,6 @@ theorem roots_all_iff [ZPoly.CheckedIrreducible p]
 
 end QAdjoin
 
-namespace AlgebraicPoly
-
-/-- The algebraic-coefficient root driver always produces a checked root set. -/
-theorem roots?_isSome (f : AlgebraicPoly) :
-    f.roots?.isSome := by
-  sorry
-
-/-- The algebraic-coefficient driver returns `.all` exactly for the zero
-polynomial. -/
-theorem roots_all_iff (f : AlgebraicPoly) :
-    f.roots = .all ↔ f.toPolynomial = 0 := by
-  sorry
-
-/-- Semantic membership in the algebraic-coefficient output is exactly
-polynomial vanishing. -/
-theorem contains_roots_iff (f : AlgebraicPoly) (z : ℂ) :
-    RootSet.Contains f.roots z ↔
-      Polynomial.eval z f.toPolynomial = 0 := by
-  sorry
-
-/-- Algebraic-coefficient root multiplicities agree with Mathlib. -/
-theorem multiplicity_roots (f : AlgebraicPoly) (z : ℂ) :
-    f.roots.multiplicityOf z =
-      Polynomial.rootMultiplicity z f.toPolynomial := by
-  sorry
-
-/-- The algebraic-coefficient driver produces positive multiplicities. -/
-theorem roots_positive (f : AlgebraicPoly) :
-    RootSet.Positive f.roots := by
-  cases hroots : f.roots with
-  | all => trivial
-  | finite roots =>
-      intro entry _hentry
-      exact entry.multiplicity_pos
-
-/-- The algebraic-coefficient driver merges all semantic duplicates. -/
-theorem roots_noDuplicates (f : AlgebraicPoly) :
-    RootSet.NoDuplicates f.roots := by
-  sorry
-
-/-- The algebraic-coefficient driver uses its deterministic canonical order. -/
-theorem roots_ordered (f : AlgebraicPoly) :
-    RootSet.Ordered f.roots := by
-  sorry
-
-/-- For a nonzero algebraic-coefficient polynomial, output multiplicities sum
-to its degree. -/
-theorem totalMultiplicity_roots (f : AlgebraicPoly)
-    (hf : f.toPolynomial ≠ 0) :
-    f.roots.totalMultiplicity = f.toPolynomial.natDegree := by
-  sorry
-
-end AlgebraicPoly
-
 /-! The completed root-semantics foundations must not inherit unfinished proofs. -/
 
 /--

--- a/progress/20260802T151143Z.md
+++ b/progress/20260802T151143Z.md
@@ -1,0 +1,31 @@
+# Algebraic-root presentation semantics
+
+## Accomplished
+
+- Merged the fixed-field root-semantics stage after its full CI run passed.
+- Added checked totality and semantic theorems for rational construction,
+  addition, multiplication, scaling, shifting, extension search, primitive
+  folding, and power generation.
+- Exposed the existing eliminant and rational-ball lemmas required by the new
+  public presentation proofs.
+- Proved the signed-shift enumeration injective for the bounded
+  primitive-element search.
+- Built `HexNumberFieldMathlib.Presentation` successfully without adding
+  `sorry`, axioms, or `native_decide`.
+
+## Current frontier
+
+The operational presentation pipeline is total through primitive folding and
+power generation. The remaining bridge is mathematical: show that the bounded
+maximum-degree shift search generates the same number field, then use trace
+coordinates to recover each requested algebraic number.
+
+## Next step
+
+Prove the finite bad-shift bound via embeddings of the two-generator number
+field, derive the field-generation invariant for `extend?`, and carry that
+invariant through `primitive?`.
+
+## Blockers
+
+None.

--- a/progress/20260802T162023Z.md
+++ b/progress/20260802T162023Z.md
@@ -1,0 +1,26 @@
+# Accomplished
+
+- Proved the bounded maximum-degree primitive-element search generates the
+  compositum and that the multi-coefficient fold contains every input value.
+- Proved trace computation, trace-Gram nonsingularity, coordinate recovery,
+  and primitive presentation construction are total and semantically sound.
+- Transported the fixed-field root contracts to algebraic coefficients,
+  closing totality, zero-polynomial, membership, multiplicity, duplicate,
+  ordering, and total-multiplicity obligations without new axioms or sorries.
+- Moved the algebraic transport layer after `ComponentRoots` to respect the
+  existing module dependency direction while preserving umbrella exports.
+- Verified the complete monorepo with `lake build` (9726 jobs).
+
+# Current frontier
+
+The algebraic-coefficient root presentation and semantic API are complete on
+`NumberFieldMathlibAlgebraicRootPresentation`, based on merged PR #9143.
+
+# Next step
+
+Commit the consolidated stage, open one cohesive PR, monitor its CI, and merge
+it before beginning another implementation stage.
+
+# Blockers
+
+None.


### PR DESCRIPTION
## Summary

- prove the bounded primitive-element search generates the coefficient compositum
- prove trace computation, trace-Gram inversion, coordinates, and presentations total and sound
- transport fixed-field root semantics to algebraic-coefficient polynomials
- close totality, zero, membership, multiplicity, duplicate, ordering, and total-multiplicity contracts without new sorries or axioms

This is intentionally one cohesive PR: the algebraic root API contracts depend on the full primitive-presentation proof chain, and keeping that chain together avoids another backlog of interdependent PRs.

## Validation

- `lake build HexNumberFieldMathlib.AlgebraicRoots`
- `lake build HexNumberFieldMathlib`
- `lake build` (9726 jobs)
- axiom guards for all seven algebraic-coefficient root contracts
