### PR TITLE
Complete the canonical NumberField field trust boundary

### DIFF
--- a/HexManual/Chapters/HexNumberField.lean
+++ b/HexManual/Chapters/HexNumberField.lean
@@ -78,7 +78,7 @@ private def sqrtTwoSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
 
 private def sqrtTwoRep : RefinedIsolation sqrtTwoPoly :=
-  ⟨⟨sqrtTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨sqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def sqrtTwoRoot : SimpleRoot sqrtTwoPoly :=
   SimpleRoot.mk sqrtTwoRep
@@ -144,6 +144,34 @@ Canonical algebraic numbers reuse these lazy operations and exactify the
 answer. Their Boolean equality compares represented values rather than record
 layout. Lazy roots deliberately have no `BEq`; the root driver uses checked
 {name}`Hex.QAdjoin.Roots.sameValue?` instead.
+
+# Canonical field arithmetic
+%%%
+tag := "hex-number-field-canonical"
+%%%
+
+Canonical algebraic numbers also provide executable rational construction,
+casts, scalar multiplication, and natural and integer powers. The Mathlib
+companion proves that the complex interpretation is injective and installs a
+lawful {name}`Field` instance on {name}`Hex.AlgebraicNumber` whose data fields
+are these same executable operations.
+
+{docstring Hex.AlgebraicNumber.ofRat}
+
+{docstring Hex.AlgebraicNumber.ofRat_toComplex}
+
+{docstring Hex.AlgebraicNumber.toComplex_injective}
+
+```lean
+open Hex
+
+example : (2 : AlgebraicNumber) =
+    AlgebraicNumber.ofRat 2 := rfl
+example (a b : AlgebraicNumber) : a + b =
+    AlgebraicNumber.add a b := rfl
+example (a : AlgebraicNumber) : a ^ (3 : Nat) =
+    AlgebraicNumber.natPow a 3 := rfl
+```
 
 # Polynomials and roots
 %%%

--- a/HexManual/Chapters/HexNumberFieldTower.lean
+++ b/HexManual/Chapters/HexNumberFieldTower.lean
@@ -85,7 +85,7 @@ private def sqrtTwoSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
 
 private def sqrtTwoRep : RefinedIsolation sqrtTwoPoly :=
-  ⟨⟨sqrtTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨sqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def sqrtTwoRoot : SimpleRoot sqrtTwoPoly :=
   SimpleRoot.mk sqrtTwoRep

--- a/HexNumberField/Basic.lean
+++ b/HexNumberField/Basic.lean
@@ -49,6 +49,58 @@ structure AlgebraicRoot where
   rep : RefinedIsolation p
   rep_mk : SimpleRoot.mk rep = x
 
+namespace AlgebraicNumber
+
+private def zeroSquare : DyadicSquare :=
+  ⟨0, 0, (separationDepth ZPoly.X : Int)⟩
+
+/-- The fixed explicit representative of the root of `X`. -/
+def zeroRep : RefinedIsolation ZPoly.X :=
+  ⟨⟨zeroSquare, by
+      exact .ofWitness (by
+        left
+        decide)⟩,
+    by
+      simp only [zeroSquare, separationDepth]
+      omega⟩
+
+/-- Evidence that a representative is the deterministic representative stored
+by the canonical algebraic-number constructor. -/
+@[expose]
+def IsCanonical (p : ZPoly) (squarefree : HasOnlySimpleRoots p)
+    (rep : RefinedIsolation p) : Prop :=
+  (p = ZPoly.X ∧ HEq rep zeroRep) ∨
+    (p ≠ ZPoly.X ∧
+      ∃ (isolations : Array (DyadicRootIsolation p))
+        (refined : Array (RefinedIsolation p)),
+        isolate p squarefree (separationDepth p : Int) = some isolations ∧
+          isolations.mapM DyadicRootIsolation.toRefined? = some refined ∧
+          rep ∈ refined.toList)
+
+/-- Run the deterministic representative-selection pipeline and retain its
+provenance together with the match against the supplied root. -/
+@[expose]
+def canonicalRep? (p : ZPoly) (squarefree : HasOnlySimpleRoots p)
+    (rep : RefinedIsolation p) (hzero : p ≠ ZPoly.X) :
+    Option {r : RefinedIsolation p //
+      IsCanonical p squarefree r ∧ r.sameRoot rep = true} :=
+  match hisolate : isolate p squarefree (separationDepth p : Int) with
+  | none => none
+  | some isolations =>
+      match hrefine : isolations.mapM DyadicRootIsolation.toRefined? with
+      | none => none
+      | some refined =>
+          match hfind : refined.toList.find? fun r => r.sameRoot rep with
+          | none => none
+          | some canonical => some ⟨canonical, Or.inr
+              ⟨hzero, isolations, refined, hisolate, hrefine,
+                List.mem_of_find?_eq_some hfind⟩,
+              by
+                exact List.find?_some
+                  (p := fun r : RefinedIsolation p => r.sameRoot rep) hfind⟩
+
+end AlgebraicNumber
+
 /-- A canonical algebraic number. Construction is sealed so each normalized
 polynomial/root pair receives one fixed representative. -/
 structure AlgebraicNumber where
@@ -59,23 +111,18 @@ structure AlgebraicNumber where
   pos_degree : 0 < p.degree?.getD 0
   checked : ZPoly.CheckedIrreducible p
   squarefree : HasOnlySimpleRoots p
-  x : SimpleRoot p
   rep : RefinedIsolation p
-  rep_mk : SimpleRoot.mk rep = x
+  canonical : AlgebraicNumber.IsCanonical p squarefree rep
 
 namespace AlgebraicNumber
 
-private def zeroSquare : DyadicSquare :=
-  ⟨0, 0, (separationDepth ZPoly.X : Int)⟩
+/-- The selected simple root is determined by the canonical representative. -/
+@[expose]
+def x (a : AlgebraicNumber) : SimpleRoot a.p :=
+  SimpleRoot.mk a.rep
 
-/-- The fixed explicit representative of the root of `X`. -/
-private def zeroRep : RefinedIsolation ZPoly.X :=
-  ⟨⟨zeroSquare, by
-      left
-      decide⟩,
-    by
-      simp only [zeroSquare, separationDepth]
-      omega⟩
+@[simp] theorem rep_mk (a : AlgebraicNumber) :
+    SimpleRoot.mk a.rep = a.x := rfl
 
 private theorem zero_isIrreducible : ZPoly.isIrreducible ZPoly.X = true := by
   exact ZPoly.isIrreducible_X
@@ -117,8 +164,8 @@ private theorem zero_squarefree : HasOnlySimpleRoots ZPoly.X := by
 
 private def zeroRaw : AlgebraicNumber :=
   .mk ZPoly.X (by rfl) (by decide) (by decide)
-    ⟨zero_isIrreducible, by decide⟩ zero_squarefree (SimpleRoot.mk zeroRep)
-    zeroRep rfl
+    ⟨zero_isIrreducible, by decide⟩ zero_squarefree zeroRep
+    (Or.inl ⟨rfl, HEq.rfl⟩)
 
 -- Keep executable evidence that the ordinary isolator also meets its stated
 -- completeness bound on `X`; the explicit zero path makes totality independent
@@ -153,11 +200,9 @@ def ofNormalized?
   if _hzero : p = ZPoly.X then
     some zeroRaw
   else do
-    let isolations ← isolate p squarefree (separationDepth p : Int)
-    let refined ← isolations.mapM DyadicRootIsolation.toRefined?
-    let canonical ← refined.toList.find? fun r => r.sameRoot rep
-    some (.mk p prim pos_lc pos_degree checked squarefree (SimpleRoot.mk canonical)
-      canonical rfl)
+    let canonical ← canonicalRep? p squarefree rep _hzero
+    some (.mk p prim pos_lc pos_degree checked squarefree canonical.1
+      canonical.2.1)
 
 /-- The success bit of canonicalization is exactly the success bit of its
 isolation, refinement, and representative-selection pipeline. This exposes
@@ -170,23 +215,13 @@ theorem ofNormalized?_isSome_eq
     (rep : RefinedIsolation p) :
     (ofNormalized? p prim pos_lc pos_degree checked squarefree rep).isSome =
       if _hzero : p = ZPoly.X then true else
-        (do
-          let isolations ← isolate p squarefree (separationDepth p : Int)
-          let refined ← isolations.mapM DyadicRootIsolation.toRefined?
-          refined.toList.find? fun (r : RefinedIsolation p) =>
-            r.sameRoot rep).isSome := by
+        (canonicalRep? p squarefree rep _hzero).isSome := by
   unfold ofNormalized?
   split
   · simp
-  · cases hisolate : isolate p squarefree (separationDepth p : Int) with
+  · cases hcanonical : canonicalRep? p squarefree rep _ with
     | none => simp
-    | some isolations =>
-        cases hrefine : isolations.mapM DyadicRootIsolation.toRefined? with
-        | none => simp [hrefine]
-        | some refined =>
-            cases hfind : refined.find? fun r => r.sameRoot rep with
-            | none => simp [hrefine, hfind]
-            | some canonical => simp [hrefine, hfind]
+    | some canonical => simp
 
 /-- Successful canonicalization retains the supplied normalized polynomial. -/
 theorem ofNormalized?_p
@@ -201,9 +236,7 @@ theorem ofNormalized?_p
   · next hp =>
     cases h
     simp [zeroRaw, hp]
-  · obtain ⟨isolations, _, h⟩ := Option.bind_eq_some_iff.mp h
-    obtain ⟨refined, _, h⟩ := Option.bind_eq_some_iff.mp h
-    obtain ⟨canonical, _, h⟩ := Option.bind_eq_some_iff.mp h
+  · obtain ⟨canonical, _, h⟩ := Option.bind_eq_some_iff.mp h
     cases h
     rfl
 
@@ -226,16 +259,22 @@ theorem ofNormalized?_spec
     cases h
     rfl
   · right
-    obtain ⟨isolations, _, h⟩ := Option.bind_eq_some_iff.mp h
-    obtain ⟨refined, _, h⟩ := Option.bind_eq_some_iff.mp h
-    obtain ⟨canonical, hcanonical, h⟩ := Option.bind_eq_some_iff.mp h
-    have hsame : canonical.sameRoot rep = true :=
-      List.find?_some (p := fun r : RefinedIsolation p => r.sameRoot rep)
-        hcanonical
+    obtain ⟨canonical, _, h⟩ := Option.bind_eq_some_iff.mp h
     cases h
-    exact ⟨rfl, hsame⟩
+    exact ⟨rfl, canonical.2.2⟩
 
 instance : Inhabited AlgebraicNumber := ⟨zero⟩
+
+/-- Two canonical values are equal once their dependent polynomials and stored
+representatives agree. The remaining fields are propositions, and the selected
+`SimpleRoot` is forced by `rep_mk`. -/
+theorem ext (a b : AlgebraicNumber) (hp : a.p = b.p)
+    (hrep : HEq a.rep b.rep) : a = b := by
+  cases a
+  cases b
+  cases hp
+  cases eq_of_heq hrep
+  rfl
 
 end AlgebraicNumber
 

--- a/HexNumberField/Convert.lean
+++ b/HexNumberField/Convert.lean
@@ -105,7 +105,7 @@ private def sqrtTwoSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
 
 private def sqrtTwoRep : RefinedIsolation sqrtTwoPoly :=
-  ⟨⟨sqrtTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨sqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def sqrtTwoRoot (hsquarefree : HasOnlySimpleRoots sqrtTwoPoly) : AlgebraicRoot where
   p := sqrtTwoPoly
@@ -130,7 +130,7 @@ private def enclosingSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 6074001000 32, 0, 32⟩
 
 private def enclosingRep : RefinedIsolation enclosingPoly :=
-  ⟨⟨enclosingSquare, by decide⟩, by decide⟩
+  ⟨⟨enclosingSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def reducibleRoot (hsquarefree : HasOnlySimpleRoots enclosingPoly) :
     AlgebraicRoot where
@@ -159,7 +159,7 @@ private def nearEnclosingPoly : ZPoly :=
   sqrtTwoPoly * DensePoly.ofList [-99, 70]
 
 private def nearEnclosingRep : RefinedIsolation nearEnclosingPoly :=
-  ⟨⟨enclosingSquare, by decide⟩, by decide⟩
+  ⟨⟨enclosingSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def nearReducibleRoot
     (hsquarefree : HasOnlySimpleRoots nearEnclosingPoly) : AlgebraicRoot where
@@ -311,7 +311,7 @@ private def sqrtTwoSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
 
 private def sqrtTwoRep : RefinedIsolation sqrtTwoPoly :=
-  ⟨⟨sqrtTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨sqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def sqrtTwoRoot : SimpleRoot sqrtTwoPoly :=
   SimpleRoot.mk sqrtTwoRep

--- a/HexNumberField/Lazy.lean
+++ b/HexNumberField/Lazy.lean
@@ -83,50 +83,49 @@ an original zero constant coefficient. -/
 def reciprocal (p : ZPoly) : ZPoly :=
   DensePoly.ofCoeffs p.toArray.reverse
 
-/-- Primitive positive-leading polynomial whose roots are the negatives of
-the roots of `p`. -/
-@[expose]
-def negRoots (p : ZPoly) : ZPoly :=
-  normalizePrimitiveSign (primitivePart (DensePoly.compose p (-ZPoly.X)))
-
 /-- Negating roots preserves primitive normalization. -/
 theorem negRoots_primitive (p : ZPoly) (h : Primitive p) :
     Primitive (negRoots p) := by
-  sorry
+  rw [negRoots_eq_reflect h]
+  exact primitive_normalizePrimitiveSign (primitive_dilate_neg_one h)
 
 /-- Negating roots preserves positive leading normalization. -/
-theorem negRoots_lc_pos (p : ZPoly) (h : 0 < p.leadingCoeff) :
+theorem negRoots_lc_pos (p : ZPoly) (hprim : Primitive p)
+    (h : 0 < p.leadingCoeff) :
     0 < (negRoots p).leadingCoeff := by
-  sorry
+  rw [negRoots_eq_reflect hprim]
+  apply leadingCoeff_normalizePrimitiveSign_pos_of_ne_zero
+  apply dilate_neg_one_ne_zero
+  intro hp
+  rw [hp] at h
+  simp at h
 
 /-- Negating roots preserves positive degree. -/
-theorem negRoots_degree_pos (p : ZPoly) (h : 0 < p.degree?.getD 0) :
+theorem negRoots_degree_pos (p : ZPoly) (hprim : Primitive p)
+    (h : 0 < p.degree?.getD 0) :
     0 < (negRoots p).degree?.getD 0 := by
-  sorry
+  rw [negRoots_eq_reflect hprim, degree?_normalizePrimitiveSign,
+    degree?_dilate_neg_one]
+  exact h
 
 /-- Negating roots preserves squarefreeness. -/
-theorem negRoots_simple (p : ZPoly) (h : HasOnlySimpleRoots p) :
+theorem negRoots_simple (p : ZPoly) (hprim : Primitive p)
+    (h : HasOnlySimpleRoots p) :
     HasOnlySimpleRoots (negRoots p) := by
-  sorry
+  rw [negRoots_eq_reflect hprim]
+  exact ZPoly.squareFreeRat_normalizePrimitiveSign _
+    (ZPoly.squareFreeRat_dilate_neg_one p h)
 
 /-- The Mahler precision is invariant under reflection and unit
 normalization. -/
 theorem mahlerPrec_negRoots (p : ZPoly) (h : Primitive p) :
     mahlerPrec (negRoots p) = mahlerPrec p := by
-  sorry
+  unfold mahlerPrec
+  rw [negRoots_eq_reflect h, degree?_normalizePrimitiveSign,
+    degree?_dilate_neg_one, coeffAbsMax_normalizePrimitiveSign,
+    coeffAbsMax_dilate_neg_one]
 
 end ZPoly
-
-/-- Reflect a square through the origin. -/
-@[expose]
-def DyadicSquare.neg (s : DyadicSquare) : DyadicSquare :=
-  ⟨-s.re, -s.im, s.prec⟩
-
-/-- Reflection transports a root atom to the reflected polynomial. -/
-theorem atomWitness_negRoots {p : ZPoly} {s : DyadicSquare}
-    (hprim : ZPoly.Primitive p) (h : atomWitness p s) :
-    atomWitness p.negRoots s.neg := by
-  sorry
 
 namespace DyadicComplexBall
 
@@ -165,7 +164,7 @@ separation precision. -/
 @[expose]
 def RefinedIsolation.neg {p : ZPoly} (r : RefinedIsolation p)
     (hprim : ZPoly.Primitive p) : RefinedIsolation p.negRoots :=
-  ⟨⟨r.1.square.neg, atomWitness_negRoots hprim r.1.witness⟩, by
+  ⟨⟨r.1.square.neg, .neg hprim r.1.witness⟩, by
     rw [ZPoly.mahlerPrec_negRoots p hprim]
     exact r.2⟩
 
@@ -212,9 +211,9 @@ def neg (a : AlgebraicRoot) : AlgebraicRoot :=
   let rep := a.rep.neg a.prim
   { p := a.p.negRoots
     prim := ZPoly.negRoots_primitive a.p a.prim
-    pos_lc := ZPoly.negRoots_lc_pos a.p a.pos_lc
-    pos_degree := ZPoly.negRoots_degree_pos a.p a.pos_degree
-    squarefree := ZPoly.negRoots_simple a.p a.squarefree
+    pos_lc := ZPoly.negRoots_lc_pos a.p a.prim a.pos_lc
+    pos_degree := ZPoly.negRoots_degree_pos a.p a.prim a.pos_degree
+    squarefree := ZPoly.negRoots_simple a.p a.prim a.squarefree
     x := SimpleRoot.mk rep
     rep
     rep_mk := rfl }
@@ -357,7 +356,7 @@ private def sqrtTwoSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
 
 private def sqrtTwoRep : RefinedIsolation sqrtTwoPoly :=
-  ⟨⟨sqrtTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨sqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def sqrtTwoRoot (hsimple : HasOnlySimpleRoots sqrtTwoPoly) :
     AlgebraicRoot where
@@ -395,7 +394,7 @@ private def tinyRootSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 1 60, 0, 70⟩
 
 private def tinyRootRep : RefinedIsolation tinyRootPoly :=
-  ⟨⟨tinyRootSquare, by decide⟩, by decide⟩
+  ⟨⟨tinyRootSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def tinyRoot (hsimple : HasOnlySimpleRoots tinyRootPoly) :
     AlgebraicRoot where

--- a/HexNumberField/QAdjoin.lean
+++ b/HexNumberField/QAdjoin.lean
@@ -185,7 +185,7 @@ private def sqrtTwoSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
 
 private def sqrtTwoRep : RefinedIsolation sqrtTwoPoly :=
-  ⟨⟨sqrtTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨sqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def sqrtTwoRoot : SimpleRoot sqrtTwoPoly :=
   SimpleRoot.mk sqrtTwoRep

--- a/HexNumberField/Roots.lean
+++ b/HexNumberField/Roots.lean
@@ -444,6 +444,60 @@ def presentation? (coefficients : Array AlgebraicNumber) :
 
 end Hex.AlgebraicPoly.Common
 
+namespace Hex.AlgebraicNumber
+
+/-- Total executable embedding of a rational number into canonical algebraic
+numbers. The companion proves that the checked constructor cannot fail. -/
+@[expose]
+def ofRat (q : Rat) : AlgebraicNumber :=
+  (AlgebraicPoly.Common.rational? q).getD
+    (Hex.panicWith 0 "AlgebraicNumber.ofRat: certification failed")
+
+instance : One AlgebraicNumber := ⟨ofRat 1⟩
+instance : NatCast AlgebraicNumber := ⟨fun n => ofRat (n : Rat)⟩
+instance : IntCast AlgebraicNumber := ⟨fun n => ofRat (n : Rat)⟩
+-- Mathlib's generic `OfNat` from `NatCast` has priority 100. Keep this
+-- Mathlib-free fallback below it so importing the companion yields one normal
+-- form for numerals while the executable library still supports literals.
+instance (priority := 90) (n : Nat) : OfNat AlgebraicNumber (n + 2) :=
+  ⟨ofRat (n + 2 : Nat)⟩
+
+/-- Executable scalar multiplication through the canonical rational
+embedding. -/
+@[expose]
+def smul (q : Rat) (a : AlgebraicNumber) : AlgebraicNumber :=
+  ofRat q * a
+
+instance : SMul Rat AlgebraicNumber := ⟨smul⟩
+instance : SMul Nat AlgebraicNumber :=
+  ⟨fun n a => smul (n : Rat) a⟩
+instance : SMul Int AlgebraicNumber :=
+  ⟨fun n a => smul (n : Rat) a⟩
+
+/-- Natural powers by repeated squaring using executable canonical
+multiplication. -/
+@[expose]
+def natPow (a : AlgebraicNumber) : Nat → AlgebraicNumber
+  | 0 => 1
+  | n + 1 =>
+      let q := natPow a ((n + 1) / 2)
+      let q2 := q * q
+      if (n + 1) % 2 = 0 then q2 else q2 * a
+termination_by n => n
+decreasing_by omega
+
+instance : Pow AlgebraicNumber Nat := ⟨natPow⟩
+
+/-- Integer powers assembled from executable multiplication and inversion. -/
+@[expose]
+def intPow (a : AlgebraicNumber) : Int → AlgebraicNumber
+  | .ofNat n => natPow a n
+  | .negSucc n => (natPow a (n + 1))⁻¹
+
+instance : Pow AlgebraicNumber Int := ⟨intPow⟩
+
+end Hex.AlgebraicNumber
+
 namespace Hex.AlgebraicPoly
 
 /-- Checked roots of a polynomial with canonical algebraic coefficients. All
@@ -477,7 +531,7 @@ private def rootsSqrtTwoSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
 
 private def rootsSqrtTwoRep : RefinedIsolation rootsSqrtTwoPoly :=
-  ⟨⟨rootsSqrtTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨rootsSqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def rootsSqrtTwoRoot : SimpleRoot rootsSqrtTwoPoly :=
   SimpleRoot.mk rootsSqrtTwoRep

--- a/HexNumberField/SPEC/hex-number-field.md
+++ b/HexNumberField/SPEC/hex-number-field.md
@@ -70,10 +70,22 @@ def AlgebraicNumber.checked (a : AlgebraicNumber) :
     ZPoly.CheckedIrreducible a.p
 def AlgebraicNumber.squarefree (a : AlgebraicNumber) :
     HasOnlySimpleRoots a.p
-def AlgebraicNumber.x (a : AlgebraicNumber) : SimpleRoot a.p
 def AlgebraicNumber.rep (a : AlgebraicNumber) : RefinedIsolation a.p
+def AlgebraicNumber.IsCanonical (p : ZPoly)
+    (squarefree : HasOnlySimpleRoots p) (rep : RefinedIsolation p) : Prop
+def AlgebraicNumber.canonical (a : AlgebraicNumber) :
+    AlgebraicNumber.IsCanonical a.p a.squarefree a.rep
+def AlgebraicNumber.x (a : AlgebraicNumber) : SimpleRoot a.p
 def AlgebraicNumber.rep_mk (a : AlgebraicNumber) :
     SimpleRoot.mk a.rep = a.x
+def AlgebraicNumber.zeroRep : RefinedIsolation ZPoly.X
+def AlgebraicNumber.canonicalRep? (p : ZPoly)
+    (squarefree : HasOnlySimpleRoots p) (rep : RefinedIsolation p)
+    (hzero : p ≠ ZPoly.X) :
+    Option {r : RefinedIsolation p //
+      AlgebraicNumber.IsCanonical p squarefree r ∧ r.sameRoot rep = true}
+theorem AlgebraicNumber.ext (a b : AlgebraicNumber) (hp : a.p = b.p)
+    (hrep : HEq a.rep b.rep) : a = b
 def AlgebraicNumber.zero : AlgebraicNumber
 instance : Zero AlgebraicNumber
 instance : Inhabited AlgebraicNumber
@@ -111,7 +123,14 @@ isolation driver. Every other polynomial is re-isolated with the fixed default
 strategy at `separationDepth`, storing the unique matching disc. Thus equal
 complex values have identical hidden data, not merely a semantic `BEq`; this
 representation can support field laws stated with Lean equality. User-supplied
-alternative refined discs cannot enter the private constructor.
+alternative refined discs cannot enter the private constructor. The sealed
+record retains provenance that its representative belongs to the deterministic
+isolation/refinement array (or is the fixed `X` representative); the companion
+uses pairwise root separation in that array to prove this invariant unique.
+The certificate stored inside `RefinedIsolation` is proof-relevant, so this
+canonical-provenance field is load-bearing: every constructor path must use the
+fixed `zeroRep` or `canonicalRep?`, never insert an independently transported
+certificate directly.
 
 Do not instantiate `DensePoly AlgebraicNumber` in the Mathlib-free layer.
 `DensePoly` requires a kernel `DecidableEq` on coefficients so trailing-zero
@@ -288,6 +307,26 @@ Canonical `AlgebraicNumber` exposes the ordinary arithmetic operations, with
 structure. `AlgebraicRoot` exposes named operations but no field structure:
 two semantically equal lazy results can have different enclosing polynomials,
 so the field laws do not hold for structural equality on that record.
+
+The executable rational and power surface is:
+
+```lean
+def AlgebraicNumber.ofRat (q : Rat) : AlgebraicNumber
+instance : One AlgebraicNumber
+instance : NatCast AlgebraicNumber
+instance : IntCast AlgebraicNumber
+instance (n : Nat) : OfNat AlgebraicNumber (n + 2)
+instance : SMul Rat AlgebraicNumber
+instance : SMul Nat AlgebraicNumber
+instance : SMul Int AlgebraicNumber
+instance : Pow AlgebraicNumber Nat
+instance : Pow AlgebraicNumber Int
+```
+
+`ofRat` is the total wrapper around the checked linear-polynomial constructor;
+its panic fallback is proved unreachable by the companion. Rational scalar
+multiplication is multiplication by `ofRat q`, and powers use the existing
+executable multiplication and inversion with repeated squaring.
 
 ## Polynomial roots
 

--- a/HexNumberFieldMathlib.lean
+++ b/HexNumberFieldMathlib.lean
@@ -9,6 +9,7 @@ module
 public import HexNumberFieldMathlib.Roots
 public import HexNumberFieldMathlib.ComponentRoots
 public import HexNumberFieldMathlib.AlgebraicRoots
+public import HexNumberFieldMathlib.Field
 
 public section
 

--- a/HexNumberFieldMathlib/Basic.lean
+++ b/HexNumberFieldMathlib/Basic.lean
@@ -199,6 +199,83 @@ private theorem RefinedIsolation.castPoly_root {p q : ZPoly} (h : p = q)
   cases h
   rfl
 
+private theorem RefinedIsolation.castPoly_heq {p q : ZPoly} (h : p = q)
+    (r : RefinedIsolation q) : HEq (r.castPoly h) r := by
+  cases h
+  rfl
+
+private theorem AlgebraicNumber.IsCanonical.castPoly {p q : ZPoly}
+    (h : p = q) {squarefreeP : HasOnlySimpleRoots p}
+    {squarefreeQ : HasOnlySimpleRoots q} {r : RefinedIsolation q}
+    (hr : AlgebraicNumber.IsCanonical q squarefreeQ r) :
+    AlgebraicNumber.IsCanonical p squarefreeP (r.castPoly h) := by
+  cases h
+  have hsimple : squarefreeP = squarefreeQ := Subsingleton.elim _ _
+  cases hsimple
+  exact hr
+
+/-- Deterministic isolation provenance makes a canonical representative unique
+once its polynomial and semantic root are fixed. -/
+private theorem RefinedIsolation.eq_of_canonical {p : ZPoly}
+    {squarefree₁ squarefree₂ : HasOnlySimpleRoots p}
+    {r s : RefinedIsolation p}
+    (hr : AlgebraicNumber.IsCanonical p squarefree₁ r)
+    (hs : AlgebraicNumber.IsCanonical p squarefree₂ s)
+    (hroot : r.root = s.root) : r = s := by
+  have hsimple : squarefree₁ = squarefree₂ := Subsingleton.elim _ _
+  subst squarefree₂
+  unfold AlgebraicNumber.IsCanonical at hr hs
+  rcases hr with ⟨rfl, hr⟩ | ⟨hpne, isolations, refined, hisolate,
+      hrefine, hrmem⟩
+  · rcases hs with ⟨_, hs⟩ | ⟨hsne, _⟩
+    · exact (eq_of_heq hr).trans (eq_of_heq hs).symm
+    · exact (hsne rfl).elim
+  · rcases hs with ⟨hpX, _⟩ | ⟨_, isolations', refined', hisolate',
+        hrefine', hsmem⟩
+    · exact (hpne hpX).elim
+    · have hisolations : isolations = isolations' :=
+        Option.some.inj (hisolate.symm.trans hisolate')
+      subst isolations'
+      have hrefined : refined = refined' :=
+        Option.some.inj (hrefine.symm.trans hrefine')
+      subst refined'
+      obtain ⟨i, hiList, hir⟩ := List.getElem_of_mem hrmem
+      obtain ⟨j, hjList, hjs⟩ := List.getElem_of_mem hsmem
+      have hiRefined : i < refined.size := by simpa using hiList
+      have hjRefined : j < refined.size := by simpa using hjList
+      have hri : refined[i] = r := by
+        rw [← hir]
+        exact (Array.getElem_toList hiRefined).symm
+      have hsj : refined[j] = s := by
+        rw [← hjs]
+        exact (Array.getElem_toList hjRefined).symm
+      obtain ⟨hsize, hget⟩ :=
+        HexRootsMathlib.array_mapM_some_get hrefine
+      have hi : i < isolations.size := by simpa [hsize] using hiRefined
+      have hj : j < isolations.size := by simpa [hsize] using hjRefined
+      have htoI := hget i hi hiRefined
+      have htoJ := hget j hj hjRefined
+      have hrawI : refined[i].1 = isolations[i] := by
+        rw [DyadicRootIsolation.toRefined?] at htoI
+        split at htoI
+        · exact (congrArg Subtype.val (Option.some.inj htoI)).symm
+        · simp at htoI
+      have hrawJ : refined[j].1 = isolations[j] := by
+        rw [DyadicRootIsolation.toRefined?] at htoJ
+        split at htoJ
+        · exact (congrArg Subtype.val (Option.some.inj htoJ)).symm
+        · simp at htoJ
+      have hij : i = j := by
+        by_contra hij
+        apply HexRootsMathlib.isolate_roots_ne p squarefree₁
+          (separationDepth p : Int) .nkThenPellet hisolate hi hj hij
+        rw [← hrawI, ← hrawJ]
+        change HexRootsMathlib.DyadicRootIsolation.root r.1 =
+          HexRootsMathlib.DyadicRootIsolation.root s.1 at hroot
+        simpa [hri, hsj] using hroot
+      subst j
+      exact hri.symm.trans hsj
+
 private theorem AlgebraicNumber.eq_polynomial {a b : AlgebraicNumber}
     (h : a.toComplex = b.toComplex) : a.p = b.p := by
   have hscaled :
@@ -234,6 +311,32 @@ private theorem AlgebraicNumber.eq_polynomial {a b : AlgebraicNumber}
   exact
     HexBerlekampZassenhausMathlib.zpoly_eq_of_toPolynomial_associated_of_primitive_pos_leading
         a.prim b.prim a.pos_lc b.pos_lc hint
+
+/-- Canonical algebraic numbers are determined by their represented complex
+value. -/
+theorem AlgebraicNumber.toComplex_injective :
+    Function.Injective AlgebraicNumber.toComplex := by
+  intro a b hroot
+  have hp := AlgebraicNumber.eq_polynomial hroot
+  apply AlgebraicNumber.ext a b hp
+  let brep : RefinedIsolation a.p := b.rep.castPoly hp
+  have hbcanonical :
+      AlgebraicNumber.IsCanonical a.p a.squarefree brep :=
+    AlgebraicNumber.IsCanonical.castPoly hp b.canonical
+  have hbrepRoot : brep.root = b.rep.root :=
+    RefinedIsolation.castPoly_root hp b.rep
+  have hroot' : a.rep.root = brep.root := by
+    change a.rep.root = b.rep.root at hroot
+    exact hroot.trans hbrepRoot.symm
+  have hrep : a.rep = brep :=
+    RefinedIsolation.eq_of_canonical a.canonical hbcanonical hroot'
+  exact (heq_of_eq hrep).trans (RefinedIsolation.castPoly_heq hp b.rep)
+
+/--
+info: 'Hex.AlgebraicNumber.toComplex_injective' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms AlgebraicNumber.toComplex_injective
 
 /-- Canonical zero denotes complex zero. -/
 @[simp] theorem AlgebraicNumber.zero_toComplex :
@@ -318,6 +421,20 @@ theorem AlgebraicNumber.beq_iff (a b : AlgebraicNumber) :
     rw [show brep.1.square = b.rep.1.square by
       exact RefinedIsolation.castPoly_square hp b.rep] at hinter
     exact hinter
+
+/-- Canonical Boolean equality agrees with Lean equality. -/
+instance : LawfulBEq AlgebraicNumber where
+  eq_of_beq := by
+    intro a b h
+    exact AlgebraicNumber.toComplex_injective
+      ((AlgebraicNumber.beq_iff a b).mp h)
+  rfl := by
+    intro a
+    exact (AlgebraicNumber.beq_iff a a).mpr rfl
+
+/-- Propositional equality is decided by canonical Boolean equality. -/
+instance : DecidableEq AlgebraicNumber :=
+  instDecidableEqOfLawfulBEq
 
 /-- The executable zero predicate recognizes exactly the complex value zero. -/
 theorem AlgebraicRoot.isZero_iff (a : AlgebraicRoot) :

--- a/HexNumberFieldMathlib/Coordinates.lean
+++ b/HexNumberFieldMathlib/Coordinates.lean
@@ -608,10 +608,11 @@ theorem coordinates?_isSome (gamma a : AlgebraicNumber)
     have hrecoveredValue : recovered.toComplex = a.toComplex :=
       (QAdjoin.toAlgebraicNumber?_sound coordinate gamma.rep gamma.rep_mk
         hrecovered).trans hcoordinate
-    have hbeq : (recovered == a) = true :=
-      (AlgebraicNumber.beq_iff recovered a).mpr hrecoveredValue
+    have hrecoveredEq : recovered = a :=
+      AlgebraicNumber.toComplex_injective hrecoveredValue
+    subst recovered
     simp [hpowerTraces, hproducts, hrhs, hcoeffs, coordinate,
-      hrecovered, hbeq]
+      hrecovered]
 
 /-- Successful coordinate recovery represents the original algebraic value at
 the selected primitive embedding. -/

--- a/HexNumberFieldMathlib/Exact.lean
+++ b/HexNumberFieldMathlib/Exact.lean
@@ -88,9 +88,18 @@ theorem ofNormalized?_isSome
                 refined[i] rep |>.mpr <|
                 (HexRootsMathlib.RefinedIsolation.intersects_iff_root_eq
                   refined[i] rep).mpr hroot
-            simp [hmap]
-            exact ⟨refined[i], by simp,
-              hsame⟩
+            have hfindSome :
+                (refined.toList.find? fun r => r.sameRoot rep).isSome = true := by
+              rw [List.find?_isSome]
+              exact ⟨refined[i], by simp, hsame⟩
+            unfold AlgebraicNumber.canonicalRep?
+            split
+            · simp_all
+            · split
+              · simp_all
+              · split
+                · simp_all
+                · rfl
 
 end AlgebraicNumber
 

--- a/HexNumberFieldMathlib/Field.lean
+++ b/HexNumberFieldMathlib/Field.lean
@@ -1,0 +1,177 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexNumberFieldMathlib.Presentation
+
+public section
+
+/-!
+# The field of canonical algebraic numbers
+
+The executable library supplies canonical rational construction and ordinary
+arithmetic.  This module proves those operations lawful by embedding canonical
+algebraic numbers injectively into `ℂ`.
+-/
+
+namespace Hex.AlgebraicNumber
+
+/-- The executable rational embedding has its expected complex value. -/
+@[simp] theorem ofRat_toComplex (q : Rat) :
+    (ofRat q).toComplex = (q : ℂ) := by
+  obtain ⟨a, ha⟩ := Option.isSome_iff_exists.mp
+    (AlgebraicPoly.Common.rational?_isSome q)
+  unfold ofRat
+  rw [ha]
+  exact AlgebraicPoly.Common.rational?_sound q ha
+
+/-- Executable one denotes complex one. -/
+@[simp] theorem one_toComplex :
+    (1 : AlgebraicNumber).toComplex = 1 := by
+  change (ofRat 1).toComplex = 1
+  simp
+
+/-- Executable rational scalar multiplication preserves interpretation. -/
+theorem smul_toComplex (q : Rat) (a : AlgebraicNumber) :
+    (q • a).toComplex = (q : ℂ) * a.toComplex := by
+  change (smul q a).toComplex = _
+  rw [smul, mul_toComplex, ofRat_toComplex]
+
+/-- Executable natural powers preserve interpretation. -/
+theorem natPow_toComplex (a : AlgebraicNumber) (n : Nat) :
+    (natPow a n).toComplex = a.toComplex ^ n := by
+  induction n using Nat.strongRecOn with
+  | ind n ih =>
+      cases n with
+      | zero => simp [natPow]
+      | succ n =>
+          have hlt : (n + 1) / 2 < n + 1 :=
+            Nat.div_lt_self (Nat.succ_pos n) (by decide : 1 < 2)
+          rw [natPow]
+          by_cases heven : (n + 1) % 2 = 0
+          · rw [if_pos heven, mul_toComplex, ih ((n + 1) / 2) hlt,
+              ← pow_add]
+            have hdecomp := Nat.mod_add_div (n + 1) 2
+            congr 1
+            omega
+          · rw [if_neg heven, mul_toComplex, mul_toComplex,
+              ih ((n + 1) / 2) hlt, ← pow_add, ← pow_succ]
+            have hdecomp := Nat.mod_add_div (n + 1) 2
+            have hmod := Nat.mod_two_eq_zero_or_one (n + 1)
+            congr 1
+            omega
+
+/-- Executable integer powers preserve interpretation. -/
+theorem intPow_toComplex (a : AlgebraicNumber) (n : Int) :
+    (intPow a n).toComplex = a.toComplex ^ n := by
+  cases n with
+  | ofNat n => exact natPow_toComplex a n
+  | negSucc n =>
+      rw [intPow, inv_toComplex, natPow_toComplex]
+      rfl
+
+/-- The law-bearing field whose data fields are the executable canonical
+operations. -/
+@[expose, reducible]
+noncomputable def field : Field AlgebraicNumber := by
+  letI : SMul ℚ≥0 AlgebraicNumber :=
+    ⟨fun q a => smul (q : Rat) a⟩
+  letI : NNRatCast AlgebraicNumber :=
+    ⟨fun q => ofRat (q : Rat)⟩
+  letI : RatCast AlgebraicNumber := ⟨ofRat⟩
+  apply Function.Injective.field toComplex toComplex_injective
+  · exact zero_toComplex
+  · exact one_toComplex
+  · exact add_toComplex
+  · exact mul_toComplex
+  · exact neg_toComplex
+  · exact sub_toComplex
+  · exact inv_toComplex
+  · exact div_toComplex
+  · intro n a
+    change (smul (n : Rat) a).toComplex = n • a.toComplex
+    rw [smul, mul_toComplex, ofRat_toComplex, nsmul_eq_mul]
+    rfl
+  · intro n a
+    change (smul (n : Rat) a).toComplex = n • a.toComplex
+    rw [smul, mul_toComplex, ofRat_toComplex, zsmul_eq_mul]
+    rfl
+  · intro q a
+    change (smul (q : Rat) a).toComplex = q • a.toComplex
+    rw [smul, mul_toComplex, ofRat_toComplex, NNRat.smul_def]
+    rfl
+  · intro q a
+    change (smul q a).toComplex = q • a.toComplex
+    rw [smul, mul_toComplex, ofRat_toComplex, Rat.smul_def]
+  · exact natPow_toComplex
+  · exact intPow_toComplex
+  · intro n
+    change (ofRat (n : Rat)).toComplex = (n : ℂ)
+    rw [ofRat_toComplex]
+    norm_cast
+  · intro n
+    change (ofRat (n : Rat)).toComplex = (n : ℂ)
+    rw [ofRat_toComplex]
+    norm_cast
+  · intro q
+    change (ofRat (q : Rat)).toComplex = (q : ℂ)
+    rw [ofRat_toComplex]
+    norm_cast
+  · exact ofRat_toComplex
+
+/-- Canonical algebraic numbers form a field without replacing any executable
+arithmetic operation. -/
+noncomputable instance : Field AlgebraicNumber := field
+
+/--
+info: 'Hex.AlgebraicNumber.field' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms AlgebraicNumber.field
+
+/-! Pin the installed field's data fields to the executable definitions. -/
+
+section OperationRegression
+
+variable (a b : AlgebraicNumber) (q : Rat)
+
+-- Force notation through the installed field dictionary, rather than the
+-- standalone executable instances, so these equalities inspect the data
+-- fields constructed by `Function.Injective.field`.
+attribute [-instance] AlgebraicNumber.instZero AlgebraicNumber.instOne
+  AlgebraicNumber.instNatCast AlgebraicNumber.instIntCast
+  AlgebraicNumber.instAdd AlgebraicNumber.instSub
+  AlgebraicNumber.instMul AlgebraicNumber.instNeg AlgebraicNumber.instInv
+  AlgebraicNumber.instDiv AlgebraicNumber.instPowNat
+  AlgebraicNumber.instPowInt AlgebraicNumber.instSMulRat
+
+example : (0 : AlgebraicNumber) = AlgebraicNumber.zero := rfl
+example : (1 : AlgebraicNumber) = AlgebraicNumber.ofRat 1 := rfl
+example : a + b = AlgebraicNumber.add a b := rfl
+example : a - b = AlgebraicNumber.sub a b := rfl
+example : a * b = AlgebraicNumber.mul a b := rfl
+example : -a = AlgebraicNumber.neg a := rfl
+example : a⁻¹ = AlgebraicNumber.inv a := rfl
+example : a / b = AlgebraicNumber.div a b := rfl
+example : a ^ (3 : Nat) = AlgebraicNumber.natPow a 3 := rfl
+example : a ^ (-3 : Int) = AlgebraicNumber.intPow a (-3) := rfl
+example : q • a = AlgebraicNumber.smul q a := rfl
+example : ((2 : Nat) : AlgebraicNumber) = (2 : AlgebraicNumber) := rfl
+
+end OperationRegression
+
+-- With the ordinary instance priorities, Mathlib's generic numeral and the
+-- executable natural cast have the same definitional normal form.
+example : ((2 : Nat) : AlgebraicNumber) = (2 : AlgebraicNumber) := rfl
+
+-- If Mathlib instance derivation ever takes precedence over the standalone
+-- executable operations, this definition becomes noncomputable and fails to
+-- elaborate without that annotation.
+private def executableCube (a : AlgebraicNumber) : AlgebraicNumber :=
+  a ^ (3 : Nat) * a + 1
+
+end Hex.AlgebraicNumber

--- a/HexNumberFieldMathlib/Lazy.lean
+++ b/HexNumberFieldMathlib/Lazy.lean
@@ -1093,83 +1093,6 @@ theorem AlgebraicRoot.ofEliminant?_isSome
                       hzball hballRadius hsecond.2
                   exact (hneRoots (hmatchingRoot.trans hsecondRoot.symm)).elim
 
-private theorem ZPoly.negRoots_isRoot_of_isRoot {p : ZPoly} {z : ℂ}
-    (hp : p ≠ 0) (hz : (HexRootsMathlib.toPolyℂ p).IsRoot z) :
-    (HexRootsMathlib.toPolyℂ p.negRoots).IsRoot (-z) := by
-  let reflected : ZPoly := DensePoly.compose p (-ZPoly.X)
-  have hreflected :
-      HexRootsMathlib.toPolyℂ reflected =
-        (HexRootsMathlib.toPolyℂ p).comp (-Polynomial.X) := by
-    change
-      (HexPolyMathlib.toPolynomial reflected).map (Int.castRingHom ℂ) =
-        ((HexPolyMathlib.toPolynomial p).map (Int.castRingHom ℂ)).comp
-          (-Polynomial.X)
-    dsimp only [reflected]
-    rw [HexPolyMathlib.toPolynomial_compose, Polynomial.map_comp]
-    simp [ZPoly.X, HexPolyMathlib.toPolynomial_monomial,
-      Polynomial.monomial_one_one_eq_X]
-  have hreflectedRoot :
-      (HexRootsMathlib.toPolyℂ reflected).eval (-z) = 0 := by
-    rw [hreflected, Polynomial.eval_comp]
-    simpa [Polynomial.IsRoot] using hz
-  have hpSize : p.size ≠ 0 := by
-    intro hsize
-    exact hp ((DensePoly.size_eq_zero_iff p).mp hsize)
-  have hpComplex : HexRootsMathlib.toPolyℂ p ≠ 0 :=
-    HexRootsMathlib.toPolyℂ_ne_zero p hpSize
-  have hreflectedComplex : HexRootsMathlib.toPolyℂ reflected ≠ 0 := by
-    rw [hreflected]
-    intro hzero
-    have hdegree := congrArg Polynomial.degree hzero
-    rw [Polynomial.degree_comp_neg_X, Polynomial.degree_zero] at hdegree
-    exact hpComplex (Polynomial.degree_eq_bot.mp hdegree)
-  have hreflectedNe : reflected ≠ 0 := by
-    intro hzero
-    apply hreflectedComplex
-    rw [hzero]
-    simp [HexRootsMathlib.toPolyℂ]
-  have hcontent : ZPoly.content reflected ≠ 0 :=
-    HexPolyZMathlib.content_ne_zero reflected hreflectedNe
-  have hdecomp :
-      HexRootsMathlib.toPolyℂ reflected =
-        Polynomial.C (ZPoly.content reflected : ℂ) *
-          HexRootsMathlib.toPolyℂ (ZPoly.primitivePart reflected) := by
-    simpa [HexRootsMathlib.toPolyℂ] using congrArg
-      (fun q : Polynomial ℤ => q.map (Int.castRingHom ℂ))
-      (HexPolyZMathlib.toPolynomial_eq_C_content_mul_primitivePart reflected)
-  have hprimitiveRoot :
-      (HexRootsMathlib.toPolyℂ (ZPoly.primitivePart reflected)).eval (-z) = 0 := by
-    have hproduct :
-        (ZPoly.content reflected : ℂ) *
-          (HexRootsMathlib.toPolyℂ (ZPoly.primitivePart reflected)).eval (-z) = 0 := by
-      rw [← Polynomial.eval_C_mul, ← hdecomp]
-      exact hreflectedRoot
-    exact (mul_eq_zero.mp hproduct).resolve_left (by exact_mod_cast hcontent)
-  unfold ZPoly.negRoots ZPoly.normalizePrimitiveSign
-  change (HexRootsMathlib.toPolyℂ
-    (if (ZPoly.primitivePart reflected).leadingCoeff < 0 then
-      DensePoly.scale (-1) (ZPoly.primitivePart reflected)
-    else ZPoly.primitivePart reflected)).IsRoot (-z)
-  split
-  · simpa [Polynomial.IsRoot, HexRootsMathlib.toPolyℂ,
-      HexPolyMathlib.toPolynomial_scale] using hprimitiveRoot
-  · exact hprimitiveRoot
-
-private theorem DyadicSquare.neg_mem_closedDisc {s : DyadicSquare} {z : ℂ}
-    (hz : z ∈ HexRootsMathlib.DyadicSquare.closedDisc s) :
-    -z ∈ HexRootsMathlib.DyadicSquare.closedDisc s.neg := by
-  have hcenter : HexRootsMathlib.DyadicSquare.center s.neg =
-      -HexRootsMathlib.DyadicSquare.center s := by
-    apply Complex.ext <;>
-      simp [DyadicSquare.neg, HexRootsMathlib.DyadicSquare.center,
-        Hex.DyadicSquare.center, HexRootsMathlib.GaussDyadic.toComplex]
-  have hradius : HexRootsMathlib.DyadicSquare.radius s.neg =
-      HexRootsMathlib.DyadicSquare.radius s := by
-    simp [HexRootsMathlib.DyadicSquare.radius_eq, DyadicSquare.neg]
-  rw [HexRootsMathlib.DyadicSquare.closedDisc, Metric.mem_closedBall] at hz ⊢
-  rw [hcenter, hradius]
-  simpa only [dist_neg_neg] using hz
-
 namespace AlgebraicRoot
 
 /-- Reflection computes complex negation. -/
@@ -1177,13 +1100,13 @@ theorem neg_toComplex (a : AlgebraicRoot) :
     a.neg.toComplex = -a.toComplex := by
   have hroot :
       (HexRootsMathlib.toPolyℂ a.p.negRoots).IsRoot (-a.toComplex) :=
-    ZPoly.negRoots_isRoot_of_isRoot
-      (HexRootsMathlib.RefinedIsolation.poly_ne_zero a.rep)
+    HexRootsMathlib.ZPoly.isRoot_negRoots
+      a.prim
       (AlgebraicRoot.toComplex_isRoot a)
   have hmem :
       -a.toComplex ∈
         HexRootsMathlib.DyadicSquare.closedDisc a.neg.rep.1.square := by
-    exact DyadicSquare.neg_mem_closedDisc
+    exact HexRootsMathlib.DyadicSquare.closedDisc_neg.mpr
       (HexRootsMathlib.RefinedIsolation.root_mem_closedDisc a.rep)
   exact (HexRootsMathlib.RefinedIsolation.eq_root_of_mem_closedDisc
     a.neg.rep hroot hmem).symm

--- a/HexNumberFieldMathlib/SPEC/hex-number-field-mathlib.md
+++ b/HexNumberFieldMathlib/SPEC/hex-number-field-mathlib.md
@@ -38,6 +38,12 @@ theorem AlgebraicNumber.p_eq_minpoly (a : AlgebraicNumber) :
     (a.p.leadingCoeff : ℚ)⁻¹ •
       (toPolynomial a.p).map (algebraMap ℤ ℚ) =
         minpoly ℚ a.toComplex
+
+theorem AlgebraicNumber.toComplex_injective :
+    Function.Injective AlgebraicNumber.toComplex
+
+instance : LawfulBEq AlgebraicNumber
+instance : DecidableEq AlgebraicNumber
 ```
 
 `QAdjoin.toComplex` evaluates reduced coordinates at an explicit refined
@@ -171,6 +177,19 @@ multiplication and inversion zero branches are handled before eliminant
 construction and agree with `0⁻¹ = 0`.
 Canonical `AlgebraicNumber` arithmetic follows by `toRoot`, the lazy headline,
 and `exact_toComplex`.
+
+The total rational constructor satisfies
+
+```lean
+theorem AlgebraicNumber.ofRat_toComplex (q : Rat) :
+    (AlgebraicNumber.ofRat q).toComplex = (q : ℂ)
+```
+
+Together with `toComplex_injective` and the arithmetic correspondence
+theorems, this transports the field laws from `ℂ` onto the existing executable
+zero, one, casts, scalar actions, powers, and arithmetic operations. The
+installed `Field AlgebraicNumber` therefore changes no computational data
+field; it only supplies the law-bearing dictionary.
 
 ## Algebraic coefficient polynomials
 

--- a/HexNumberFieldTower/Basic.lean
+++ b/HexNumberFieldTower/Basic.lean
@@ -247,7 +247,7 @@ theorem mahlerPrec_positiveAssociate (p : ZPoly) :
 /-- Transport a refined isolation across global sign normalization. -/
 def RefinedIsolation.positiveAssociate {p : ZPoly}
     (rep : RefinedIsolation p) : RefinedIsolation (positiveAssociate p) :=
-  ⟨⟨rep.1.square, atomWitness_positiveAssociate rep.1.witness⟩, by
+  ⟨⟨rep.1.square, .normalize rep.1.witness⟩, by
     rw [mahlerPrec_positiveAssociate]
     exact rep.2⟩
 

--- a/HexNumberFieldTower/Embed.lean
+++ b/HexNumberFieldTower/Embed.lean
@@ -29,7 +29,7 @@ private def embedSqrtTwoSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
 
 private def embedSqrtTwoRep : RefinedIsolation embedSqrtTwoPoly :=
-  ⟨⟨embedSqrtTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨embedSqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def embedSqrtTwoRoot : SimpleRoot embedSqrtTwoPoly :=
   SimpleRoot.mk embedSqrtTwoRep
@@ -57,7 +57,7 @@ private def embedSqrtTwoRoot : SimpleRoot embedSqrtTwoPoly :=
 private def embedNegSqrtTwoPoly : ZPoly := DensePoly.ofList [2, 0, -1]
 
 private def embedNegSqrtTwoRep : RefinedIsolation embedNegSqrtTwoPoly :=
-  ⟨⟨embedSqrtTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨embedSqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def embedNegSqrtTwoRoot : SimpleRoot embedNegSqrtTwoPoly :=
   SimpleRoot.mk embedNegSqrtTwoRep
@@ -83,7 +83,7 @@ private def embedNegRootSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec (-181) 7, 0, 8⟩
 
 private def embedNegRootRep : RefinedIsolation embedSqrtTwoPoly :=
-  ⟨⟨embedNegRootSquare, by decide⟩, by decide⟩
+  ⟨⟨embedNegRootSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def embedNegRoot : SimpleRoot embedSqrtTwoPoly :=
   SimpleRoot.mk embedNegRootRep
@@ -110,7 +110,7 @@ private def embedThreeHalvesSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 3 1, 0, 8⟩
 
 private def embedThreeHalvesRep : RefinedIsolation embedThreeHalvesPoly :=
-  ⟨⟨embedThreeHalvesSquare, by decide⟩, by decide⟩
+  ⟨⟨embedThreeHalvesSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def embedThreeHalvesRoot : SimpleRoot embedThreeHalvesPoly :=
   SimpleRoot.mk embedThreeHalvesRep
@@ -140,7 +140,7 @@ private def embedSqrtThreeHalvesSquare : DyadicSquare :=
 
 private def embedSqrtThreeHalvesRep :
     RefinedIsolation embedSqrtThreeHalvesPoly :=
-  ⟨⟨embedSqrtThreeHalvesSquare, by decide⟩, by decide⟩
+  ⟨⟨embedSqrtThreeHalvesSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def embedSqrtThreeHalvesRoot :
     SimpleRoot embedSqrtThreeHalvesPoly :=

--- a/HexNumberFieldTower/Factor.lean
+++ b/HexNumberFieldTower/Factor.lean
@@ -76,7 +76,7 @@ private def factorSqrtTwoSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
 
 private def factorSqrtTwoRep : RefinedIsolation factorSqrtTwoPoly :=
-  ⟨⟨factorSqrtTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨factorSqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def factorSqrtTwoRoot : SimpleRoot factorSqrtTwoPoly :=
   SimpleRoot.mk factorSqrtTwoRep

--- a/HexNumberFieldTower/Flatten.lean
+++ b/HexNumberFieldTower/Flatten.lean
@@ -279,7 +279,7 @@ private def flattenSqrtTwoSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
 
 private def flattenSqrtTwoRep : RefinedIsolation flattenSqrtTwoPoly :=
-  ⟨⟨flattenSqrtTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨flattenSqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def flattenSqrtTwoRoot : SimpleRoot flattenSqrtTwoPoly :=
   SimpleRoot.mk flattenSqrtTwoRep
@@ -310,7 +310,7 @@ private def flattenSqrtThreeSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 222 7, 0, 8⟩
 
 private def flattenSqrtThreeRep : RefinedIsolation flattenSqrtThreePoly :=
-  ⟨⟨flattenSqrtThreeSquare, by decide⟩, by decide⟩
+  ⟨⟨flattenSqrtThreeSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def flattenSumPoly : ZPoly :=
   DensePoly.ofList [1, 0, -10, 0, 1]
@@ -323,7 +323,7 @@ private def flattenFourthRootTwoSquare : DyadicSquare :=
 
 private def flattenFourthRootTwoRep :
     RefinedIsolation flattenFourthRootTwoPoly :=
-  ⟨⟨flattenFourthRootTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨flattenFourthRootTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 #guard
     if hirred : ZPoly.isIrreducible flattenSqrtTwoPoly = true then

--- a/HexNumberFieldTower/Split.lean
+++ b/HexNumberFieldTower/Split.lean
@@ -247,7 +247,7 @@ private def selectSqrtTwoSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
 
 private def selectSqrtTwoRep : RefinedIsolation selectSqrtTwoPoly :=
-  ⟨⟨selectSqrtTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨selectSqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def selectSqrtTwoRoot : SimpleRoot selectSqrtTwoPoly :=
   SimpleRoot.mk selectSqrtTwoRep
@@ -308,7 +308,7 @@ private def selectSqrtThreeSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 222 7, 0, 8⟩
 
 private def selectSqrtThreeRep : RefinedIsolation selectSqrtThreePoly :=
-  ⟨⟨selectSqrtThreeSquare, by decide⟩, by decide⟩
+  ⟨⟨selectSqrtThreeSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def selectFourthRootTwoPoly : ZPoly :=
   DensePoly.ofList [-2, 0, 0, 0, 1]
@@ -318,7 +318,7 @@ private def selectFourthRootTwoSquare : DyadicSquare :=
 
 private def selectFourthRootTwoRep :
     RefinedIsolation selectFourthRootTwoPoly :=
-  ⟨⟨selectFourthRootTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨selectFourthRootTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 -- A genuinely new root is admitted through the checked relative-level
 -- constructor. The old generator occupies the first lower block and the new

--- a/HexPolyZ/IntegerPolynomial.lean
+++ b/HexPolyZ/IntegerPolynomial.lean
@@ -103,6 +103,88 @@ theorem coeff_dilate (c : Int) (p : ZPoly) (n : Nat) :
     rw [List.getElem?_eq_none (by simpa using Nat.le_of_not_lt hn), hzero, Int.mul_zero]
     rfl
 
+/-- Reflection in the origin preserves the stored coefficient count. -/
+theorem size_dilate_neg_one (p : ZPoly) :
+    (dilate (-1) p).size = p.size := by
+  by_cases hp : p.size = 0
+  · simp [dilate, hp]
+  · have hpPos : 0 < p.size := Nat.pos_of_ne_zero hp
+    apply Nat.le_antisymm
+    · unfold dilate
+      exact Nat.le_trans (DensePoly.size_ofCoeffs_le _) (by simp)
+    · apply Nat.le_of_not_gt
+      intro hle
+      have hcoeffZero := DensePoly.coeff_eq_zero_of_size_le
+        (dilate (-1) p) (i := p.size - 1) (Nat.le_sub_one_of_lt hle)
+      rw [coeff_dilate] at hcoeffZero
+      have hpTop := DensePoly.coeff_last_ne_zero_of_pos_size p hpPos
+      exact hpTop (by
+        have hsign : ((-1 : Int) ^ (p.size - 1)) ≠ 0 :=
+          Int.pow_ne_zero (by decide)
+        exact (Int.mul_eq_zero.mp hcoeffZero).resolve_left hsign)
+
+/-- Reflection in the origin is an involution on integer polynomials. -/
+@[simp] theorem dilate_neg_one_dilate_neg_one (p : ZPoly) :
+    dilate (-1) (dilate (-1) p) = p := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [coeff_dilate, coeff_dilate]
+  have hsign : ((-1 : Int) ^ n) * ((-1 : Int) ^ n) = 1 := by
+    induction n with
+    | zero => rfl
+    | succ n ih => simp only [Lean.Grind.Semiring.pow_succ]; grind
+  rw [← Int.mul_assoc, hsign, Int.one_mul]
+
+/-- Reflection in the origin preserves nonzeroness. -/
+theorem dilate_neg_one_ne_zero {p : ZPoly} (hp : p ≠ 0) :
+    dilate (-1) p ≠ 0 := by
+  intro hreflect
+  apply hp
+  rw [← dilate_neg_one_dilate_neg_one p, hreflect]
+  simp [dilate]
+
+/-- Reflection in the origin preserves integer content. -/
+@[simp] theorem content_dilate_neg_one (p : ZPoly) :
+    content (dilate (-1) p) = content p := by
+  unfold content DensePoly.content DensePoly.contentNat
+  rw [DensePoly.toList_eq_coeff_range, DensePoly.toList_eq_coeff_range,
+    size_dilate_neg_one]
+  apply congrArg Int.ofNat
+  have hfold (indices : List Nat) (acc : Nat) :
+      (indices.map fun i => (dilate (-1) p).coeff i).foldl
+          (fun g coeff => Nat.gcd g coeff.natAbs) acc =
+        (indices.map fun i => p.coeff i).foldl
+          (fun g coeff => Nat.gcd g coeff.natAbs) acc := by
+    induction indices generalizing acc with
+    | nil => rfl
+    | cons n indices ih =>
+        simp only [List.map_cons, List.foldl_cons]
+        have habs : ((dilate (-1) p).coeff n).natAbs = (p.coeff n).natAbs := by
+          rw [coeff_dilate, Int.natAbs_mul, Int.natAbs_pow]
+          rw [show (-1 : Int).natAbs = 1 by decide, Nat.one_pow, Nat.one_mul]
+        rw [habs]
+        exact ih _
+  exact hfold (List.range p.size) 0
+
+/-- Reflection in the origin preserves the optional degree. -/
+@[simp] theorem degree?_dilate_neg_one (p : ZPoly) :
+    (dilate (-1) p).degree? = p.degree? := by
+  simp [DensePoly.degree?, size_dilate_neg_one]
+
+/-- The reflected leading coefficient differs only by the degree-parity sign. -/
+theorem leadingCoeff_dilate_neg_one (p : ZPoly) :
+    (dilate (-1) p).leadingCoeff =
+      (-1 : Int) ^ (p.size - 1) * p.leadingCoeff := by
+  by_cases hp : p.size = 0
+  · have hpzero : p = 0 := (DensePoly.size_eq_zero_iff p).mp hp
+    subst p
+    simp [dilate]
+  · have hpPos : 0 < p.size := Nat.pos_of_ne_zero hp
+    rw [DensePoly.leadingCoeff_eq_coeff_last _ (by
+      rw [size_dilate_neg_one]
+      exact hpPos), size_dilate_neg_one, coeff_dilate,
+      DensePoly.leadingCoeff_eq_coeff_last p hpPos]
+
 /-- Dilation by `1` is the identity: `dilate 1 p = p`. The simp normal form for
 the trivial dilation. -/
 @[simp, grind =] theorem dilate_one (p : ZPoly) : dilate 1 p = p := by
@@ -114,6 +196,11 @@ the trivial dilation. -/
 @[expose]
 def Primitive (f : ZPoly) : Prop :=
   content f = 1
+
+/-- Reflection in the origin preserves primitivity. -/
+theorem primitive_dilate_neg_one {p : ZPoly} (hp : Primitive p) :
+    Primitive (dilate (-1) p) := by
+  simpa [Primitive] using hp
 
 /-- A {name}`Hex.ZPoly` is a unit iff it is the constant polynomial `1` or
 `-1`. -/

--- a/HexPolyZ/Rational.lean
+++ b/HexPolyZ/Rational.lean
@@ -165,6 +165,30 @@ private theorem normalizePrimitiveSign_primitivePart_primitive (f : ZPoly)
   · rw [normalizePrimitiveSign, if_neg hlead]
     exact primitivePart_primitive f hcontent_ne
 
+/-- Sign normalization preserves a primitive integer polynomial. -/
+theorem primitive_normalizePrimitiveSign {p : ZPoly} (hp : Primitive p) :
+    Primitive (normalizePrimitiveSign p) := by
+  unfold normalizePrimitiveSign
+  by_cases hlead : DensePoly.leadingCoeff p < 0
+  · rw [if_pos hlead, Primitive, content,
+      DensePoly.content_scale_neg_one]
+    simpa [Primitive, content] using hp
+  · rw [if_neg hlead]
+    exact hp
+
+/-- Sign normalization preserves the stored coefficient count. -/
+@[simp] theorem size_normalizePrimitiveSign (p : ZPoly) :
+    (normalizePrimitiveSign p).size = p.size := by
+  unfold normalizePrimitiveSign
+  split
+  · exact scale_size_of_ne_zero (-1 : Int) p (by decide)
+  · rfl
+
+/-- Sign normalization preserves optional degree. -/
+@[simp] theorem degree?_normalizePrimitiveSign (p : ZPoly) :
+    (normalizePrimitiveSign p).degree? = p.degree? := by
+  simp [DensePoly.degree?, size_normalizePrimitiveSign]
+
 /-- The rational primitive part is primitive when its content is nonzero. -/
 theorem ratPolyPrimitivePart_primitive (f : DensePoly Rat)
     (h : content (ratPolyPrimitivePart f) ≠ 0) :
@@ -310,6 +334,147 @@ private theorem rat_derivative_scale (u : Rat) (p : DensePoly Rat) :
     DensePoly.coeff_scale (R := Rat) u (DensePoly.derivative p) n (Rat.mul_zero u),
     rat_coeff_derivative, DensePoly.coeff_scale (R := Rat) u p (n + 1) (Rat.mul_zero u)]
   grind [Rat.mul_assoc, Rat.mul_comm]
+
+/-- Substitute `X ↦ -X` in a rational dense polynomial. This local
+coefficient transform is the rational counterpart of `ZPoly.dilate (-1)`. -/
+@[expose]
+def reflectRat (p : DensePoly Rat) : DensePoly Rat :=
+  DensePoly.ofList ((List.range p.size).map fun i => (-1 : Rat) ^ i * p.coeff i)
+
+/-- Coefficients of rational reflection differ by the parity sign. -/
+theorem coeff_reflectRat (p : DensePoly Rat) (n : Nat) :
+    (reflectRat p).coeff n = (-1 : Rat) ^ n * p.coeff n := by
+  unfold reflectRat
+  rw [DensePoly.coeff_ofList, List.getD_eq_getElem?_getD, List.getElem?_map]
+  by_cases hn : n < p.size
+  · rw [List.getElem?_range hn]
+    rfl
+  · have hpzero : p.coeff n = 0 :=
+      DensePoly.coeff_eq_zero_of_size_le p (Nat.le_of_not_lt hn)
+    rw [List.getElem?_eq_none (by simpa using Nat.le_of_not_lt hn), hpzero]
+    simp only [Option.map_none, Option.getD_none]
+    exact (Rat.mul_zero _).symm
+
+/-- Rational reflection preserves the stored coefficient count. -/
+@[simp] theorem size_reflectRat (p : DensePoly Rat) :
+    (reflectRat p).size = p.size := by
+  by_cases hp : p.size = 0
+  · simp [reflectRat, hp]
+  · have hpPos : 0 < p.size := Nat.pos_of_ne_zero hp
+    apply Nat.le_antisymm
+    · unfold reflectRat
+      exact Nat.le_trans (DensePoly.size_ofCoeffs_le _) (by simp)
+    · apply Nat.le_of_not_gt
+      intro hle
+      have hcoeffZero := DensePoly.coeff_eq_zero_of_size_le
+        (reflectRat p) (i := p.size - 1) (Nat.le_sub_one_of_lt hle)
+      rw [coeff_reflectRat] at hcoeffZero
+      have hpTop := DensePoly.coeff_last_ne_zero_of_pos_size p hpPos
+      apply hpTop
+      exact (Rat.mul_eq_zero.mp hcoeffZero).resolve_left (by
+        intro hsign
+        have hsquare : ((-1 : Rat) ^ (p.size - 1)) *
+            ((-1 : Rat) ^ (p.size - 1)) = 1 := by
+          induction p.size - 1 with
+          | zero =>
+              rw [Lean.Grind.Semiring.pow_zero]
+              exact Rat.one_mul 1
+          | succ n ih => grind [Lean.Grind.Semiring.pow_succ]
+        rw [hsign, Rat.zero_mul] at hsquare
+        contradiction)
+
+/-- Rational reflection is an involution. -/
+@[simp] theorem reflectRat_reflectRat (p : DensePoly Rat) :
+    reflectRat (reflectRat p) = p := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [coeff_reflectRat, coeff_reflectRat]
+  have hsign : ((-1 : Rat) ^ n) * ((-1 : Rat) ^ n) = 1 := by
+    induction n with
+    | zero =>
+        rw [Lean.Grind.Semiring.pow_zero]
+        exact Rat.one_mul 1
+    | succ n ih => grind [Lean.Grind.Semiring.pow_succ]
+  grind
+
+/-- Rational reflection preserves nonzeroness. -/
+theorem reflectRat_ne_zero {p : DensePoly Rat} (hp : p ≠ 0) :
+    reflectRat p ≠ 0 := by
+  intro hreflect
+  apply hp
+  rw [← reflectRat_reflectRat p, hreflect]
+  simp [reflectRat]
+
+/-- Differentiating a reflection contributes one global minus sign. -/
+theorem derivative_reflectRat (p : DensePoly Rat) :
+    DensePoly.derivative (reflectRat p) =
+      DensePoly.scale (-1) (reflectRat (DensePoly.derivative p)) := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [rat_coeff_derivative, coeff_reflectRat,
+    DensePoly.coeff_scale (R := Rat) (-1) (reflectRat (DensePoly.derivative p)) n
+      (Rat.mul_zero _), coeff_reflectRat, rat_coeff_derivative]
+  have hpow : (-1 : Rat) ^ (n + 1) = -((-1 : Rat) ^ n) := by
+    rw [Lean.Grind.Semiring.pow_succ]
+    grind
+  rw [hpow]
+  grind [Rat.mul_assoc, Rat.mul_comm]
+
+/-- Rational reflection is multiplicative. -/
+theorem reflectRat_mul (p q : DensePoly Rat) :
+    reflectRat (p * q) = reflectRat p * reflectRat q := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [coeff_reflectRat, DensePoly.coeff_mul, DensePoly.coeff_mul,
+    DensePoly.mulCoeffSum_eq_diagonal, DensePoly.mulCoeffSum_eq_diagonal,
+    size_reflectRat]
+  let sign : Rat := (-1 : Rat) ^ n
+  have hterm (i : Nat) :
+      DensePoly.diagonalMulCoeffTerm (reflectRat p) (reflectRat q) n i =
+        sign * DensePoly.diagonalMulCoeffTerm p q n i := by
+    unfold DensePoly.diagonalMulCoeffTerm
+    by_cases hni : n < i
+    · simp [hni, sign]
+    · rw [if_neg hni, if_neg hni, coeff_reflectRat, coeff_reflectRat]
+      have hpow : (-1 : Rat) ^ i * (-1 : Rat) ^ (n - i) = sign := by
+        rw [← Lean.Grind.Semiring.pow_add]
+        congr 1
+        exact Nat.add_sub_of_le (Nat.le_of_not_gt hni)
+      grind [Rat.mul_assoc, Rat.mul_comm]
+  have hfold (indices : List Nat) (acc : Rat) :
+      indices.foldl (fun total i => total +
+          DensePoly.diagonalMulCoeffTerm (reflectRat p) (reflectRat q) n i)
+          (sign * acc) =
+        sign * indices.foldl (fun total i => total +
+          DensePoly.diagonalMulCoeffTerm p q n i) acc := by
+    induction indices generalizing acc with
+    | nil => rfl
+    | cons i indices ih =>
+        simp only [List.foldl_cons]
+        rw [hterm]
+        have hacc : sign * acc +
+            sign * DensePoly.diagonalMulCoeffTerm p q n i =
+              sign * (acc + DensePoly.diagonalMulCoeffTerm p q n i) := by
+          grind [Rat.mul_add]
+        rw [hacc]
+        exact ih _
+  simpa [sign] using (hfold (List.range p.size) 0).symm
+
+/-- Rational reflection transports polynomial divisibility. -/
+theorem reflectRat_dvd {p q : DensePoly Rat} (h : p ∣ q) :
+    reflectRat p ∣ reflectRat q := by
+  rcases h with ⟨a, rfl⟩
+  exact ⟨reflectRat a, reflectRat_mul p a⟩
+
+/-- Casting an integer reflection to rational coefficients gives rational
+reflection. -/
+theorem toRatPoly_dilate_neg_one (p : ZPoly) :
+    toRatPoly (dilate (-1) p) = reflectRat (toRatPoly p) := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [coeff_toRatPoly, coeff_dilate, coeff_reflectRat, coeff_toRatPoly,
+    Rat.intCast_mul, Rat.intCast_pow]
+  rfl
 
 /-- The Leibniz product rule `derivative (p * q) = derivative p * q + p * derivative q` for rational dense polynomials. -/
 private theorem rat_derivative_mul (p q : DensePoly Rat) :
@@ -1323,6 +1488,90 @@ private theorem rat_squareFree_of_rational_associate
         d.size ≤ (DensePoly.gcd p (DensePoly.derivative p)).size :=
       rat_size_le_of_dvd_nonzero hd_ne hg_ne hdg
     omega
+
+/-- Multiplication by `-1` preserves executable rational squarefreeness. -/
+theorem squareFreeRat_scale_neg_one (p : ZPoly) (h : SquareFreeRat p) :
+    SquareFreeRat (DensePoly.scale (-1) p) := by
+  by_cases hp : p = 0
+  · subst p
+    simpa using h
+  · have hpRat : toRatPoly p ≠ 0 := by
+      intro hzero
+      have hsize := congrArg DensePoly.size hzero
+      rw [DensePoly.size_zero, size_toRatPoly] at hsize
+      exact hp ((DensePoly.size_eq_zero_iff p).mp hsize)
+    have hassoc : toRatPoly p = DensePoly.scale (-1 : Rat)
+        (toRatPoly (DensePoly.scale (-1 : Int) p)) := by
+      rw [toRatPoly_scale_int, DensePoly.scale_scale]
+      rw [show ((-1 : Int) : Rat) = (-1 : Rat) by rfl]
+      have hminus : (-1 : Rat) * (-1 : Rat) = 1 := by grind
+      rw [hminus, rat_scale_one]
+    exact rat_squareFree_of_rational_associate (u := (-1 : Rat))
+      (by decide) hpRat hassoc h
+
+/-- Sign normalization preserves executable rational squarefreeness. -/
+theorem squareFreeRat_normalizePrimitiveSign (p : ZPoly) (h : SquareFreeRat p) :
+    SquareFreeRat (normalizePrimitiveSign p) := by
+  unfold normalizePrimitiveSign
+  split
+  · exact squareFreeRat_scale_neg_one p h
+  · exact h
+
+/-- Reflection in the origin preserves executable rational squarefreeness. -/
+theorem squareFreeRat_dilate_neg_one (p : ZPoly) (h : SquareFreeRat p) :
+    SquareFreeRat (dilate (-1) p) := by
+  by_cases hp : p = 0
+  · subst p
+    simpa [dilate] using h
+  · let q := toRatPoly p
+    have hq : q ≠ 0 := by
+      intro hzero
+      have hsize := congrArg DensePoly.size hzero
+      rw [DensePoly.size_zero] at hsize
+      have hpSize : p.size = 0 := by
+        simpa [q, size_toRatPoly] using hsize
+      exact hp ((DensePoly.size_eq_zero_iff p).mp hpSize)
+    unfold SquareFreeRat at h ⊢
+    rw [toRatPoly_dilate_neg_one]
+    let d := DensePoly.gcd (reflectRat q)
+      (DensePoly.derivative (reflectRat q))
+    by_cases hdle : d.size ≤ 1
+    · simpa [d]
+    · exfalso
+      have hdgt : 1 < d.size := Nat.lt_of_not_ge hdle
+      have hddq : d ∣ reflectRat q := by
+        simpa [d] using DensePoly.gcd_dvd_left
+          (reflectRat q) (DensePoly.derivative (reflectRat q))
+      have hddq' : d ∣ DensePoly.derivative (reflectRat q) := by
+        simpa [d] using DensePoly.gcd_dvd_right
+          (reflectRat q) (DensePoly.derivative (reflectRat q))
+      have hdReflectDeriv : d ∣ reflectRat (DensePoly.derivative q) := by
+        rw [derivative_reflectRat] at hddq'
+        have hscaled := rat_dvd_scale_of_dvd (-1 : Rat) hddq'
+        rw [DensePoly.scale_scale] at hscaled
+        have hminus : (-1 : Rat) * (-1 : Rat) = 1 := by grind
+        rw [hminus, rat_scale_one] at hscaled
+        exact hscaled
+      have hreflectDvdQ : reflectRat d ∣ q := by
+        simpa using reflectRat_dvd hddq
+      have hreflectDvdDeriv : reflectRat d ∣ DensePoly.derivative q := by
+        simpa using reflectRat_dvd hdReflectDeriv
+      have hreflectDvdGcd : reflectRat d ∣
+          DensePoly.gcd q (DensePoly.derivative q) :=
+        DensePoly.dvd_gcd (reflectRat d) q (DensePoly.derivative q)
+          hreflectDvdQ hreflectDvdDeriv
+      have hreflectNe : (reflectRat d).size ≠ 0 := by
+        rw [size_reflectRat]
+        omega
+      have hgcdNe : (DensePoly.gcd q (DensePoly.derivative q)).size ≠ 0 :=
+        rat_gcd_size_ne_zero_of_left_ne_zero q (DensePoly.derivative q) hq
+      have hsizeLe : (reflectRat d).size ≤
+          (DensePoly.gcd q (DensePoly.derivative q)).size :=
+        rat_size_le_of_dvd_nonzero hreflectNe hgcdNe hreflectDvdGcd
+      have hqSquare : (DensePoly.gcd q (DensePoly.derivative q)).size ≤ 1 := by
+        simpa [q] using h
+      rw [size_reflectRat] at hsizeLe
+      omega
 
 private theorem rat_div_gcd_mul_reconstruct (f df : DensePoly Rat) :
     (f / DensePoly.gcd f df) * DensePoly.gcd f df = f := by

--- a/HexRoots/Bisection.lean
+++ b/HexRoots/Bisection.lean
@@ -288,8 +288,8 @@ to the exact cached list. -/
           have h₀' : nkWitnessCheck p cand = true := by
             rw [TaylorShift.nkWitnessCheck_eq] at h'
             exact h'
-          return some (.atom ⟨cand, Or.inl h₀'⟩)
-      return some (.atom ⟨base, Or.inl h₀⟩)
+          return some (.atom ⟨cand, .nk h₀'⟩)
+      return some (.atom ⟨base, .nk h₀⟩)
   | .pellet => pure ()
   -- Pellet attempt, on a quadrupled enclosing square. The original component
   -- lies in its central quarter, giving the converse theorem a uniform

--- a/HexRoots/Kantorovich.lean
+++ b/HexRoots/Kantorovich.lean
@@ -286,6 +286,62 @@ instance {p : ZPoly} {s : DyadicSquare} : Decidable (nkWitness p s) :=
 instance {p : ZPoly} {s : DyadicSquare} : Decidable (atomWitness p s) :=
   inferInstanceAs (Decidable (nkWitness p s ∨ witness p s 1))
 
+namespace ZPoly
+
+/-- Primitive positive-leading polynomial whose roots are the negatives of
+the roots of `p`. Primitive-part normalization precedes the exact `X ↦ -X`
+reflection so primitive inputs reduce directly to a parity sign change. -/
+@[expose]
+def negRoots (p : ZPoly) : ZPoly :=
+  normalizePrimitiveSign (dilate (-1) (primitivePart p))
+
+/-- On primitive input, root negation is just reflection followed by one
+leading-sign normalization. -/
+theorem negRoots_eq_reflect {p : ZPoly} (hprim : Primitive p) :
+    p.negRoots = normalizePrimitiveSign (dilate (-1) p) := by
+  rw [negRoots, primitivePart_eq_self_of_primitive p hprim]
+
+/-- Root negation preserves coefficient count on primitive input. -/
+@[simp] theorem size_negRoots {p : ZPoly} (hprim : Primitive p) :
+    p.negRoots.size = p.size := by
+  rw [negRoots_eq_reflect hprim, size_normalizePrimitiveSign,
+    size_dilate_neg_one]
+
+end ZPoly
+
+/-- Reflect a square through the origin. -/
+@[expose]
+def DyadicSquare.neg (s : DyadicSquare) : DyadicSquare :=
+  ⟨-s.re, -s.im, s.prec⟩
+
+/-- Structural evidence that an atom is certified. Checker-produced atoms
+retain their original NK/Pellet form; exact reflection transports an existing
+certificate without re-running either checker. -/
+inductive AtomCertificate : (p : ZPoly) → (s : DyadicSquare) → Type
+  | nk {p s} (h : nkWitness p s) : AtomCertificate p s
+  | pellet {p s} (h : witness p s 1) : AtomCertificate p s
+  | neg {p s} (hprim : ZPoly.Primitive p) (certificate : AtomCertificate p s) :
+      AtomCertificate p.negRoots s.neg
+  | normalize {p s} (certificate : AtomCertificate p s) :
+      AtomCertificate (ZPoly.normalizePrimitiveSign p) s
+
+namespace AtomCertificate
+
+/-- Package either checker result as structural atom evidence. -/
+def ofWitness {p : ZPoly} {s : DyadicSquare} :
+    atomWitness p s → AtomCertificate p s := fun h =>
+  if hnk : nkWitness p s then .nk hnk else .pellet (h.resolve_left hnk)
+
+/-- Whether the certificate selects the closed square (NK) rather than the
+circumscribed disc (Pellet). Reflection preserves this region choice. -/
+@[expose] def isNK {p : ZPoly} {s : DyadicSquare} : AtomCertificate p s → Bool
+  | .nk _ => true
+  | .pellet _ => false
+  | .neg _ certificate => certificate.isNK
+  | .normalize certificate => certificate.isNK
+
+end AtomCertificate
+
 /-- Which atom certificates `certify?` attempts, and in which order.
     `nkThenPellet` is the default; the singleton strategies exist for the
     side-by-side comparison of the two atom forms. -/
@@ -298,8 +354,8 @@ deriving DecidableEq, Repr
 structure DyadicRootIsolation (p : ZPoly) where
   /-- The isolating square. -/
   square : DyadicSquare
-  /-- Either atom certificate on the square's certified region. -/
-  witness : Hex.atomWitness p square
+  /-- An NK/Pellet atom certificate, possibly transported through reflection. -/
+  witness : Hex.AtomCertificate p square
 
 /-- The result of certifying one component: an atom (either atom certificate)
     or a `k ≥ 1` Pellet cluster. -/
@@ -314,13 +370,18 @@ inductive Certified (p : ZPoly) where
     Pellet witness already certifies exactly one root in the enclosing disc. -/
 @[expose] def DyadicRootCluster.atomize {p : ZPoly} (c : DyadicRootCluster p) (h : c.k = 1) :
     DyadicRootIsolation p :=
-  ⟨encSquare c.squares, Or.inr (h ▸ c.witness)⟩
+  ⟨encSquare c.squares, .pellet (h ▸ c.witness)⟩
 
 /-- Certify an arbitrary candidate square as an atom, deciding both
     `atomWitness` disjuncts fresh. This is the documented way to build a
     `DyadicRootIsolation` outside the drivers, e.g. after transforming an
     isolation's square (hex-number-field's `inv?` re-certification). -/
 def certifyAtom? (p : ZPoly) (s : DyadicSquare) : Option (DyadicRootIsolation p) :=
-  if h : atomWitness p s then some ⟨s, h⟩ else none
+  if hnk : nkWitness p s then
+    some ⟨s, .nk hnk⟩
+  else if hp : witness p s 1 then
+    some ⟨s, .pellet hp⟩
+  else
+    none
 
 end Hex

--- a/HexRoots/MahlerPrec.lean
+++ b/HexRoots/MahlerPrec.lean
@@ -73,6 +73,56 @@ namespace ZPoly
 @[expose] def coeffAbsMax (p : ZPoly) : Nat :=
   (List.range p.size).foldl (fun acc i => Nat.max acc (p.coeff i).natAbs) 0
 
+/-- Reflection in the origin preserves coefficient height. -/
+@[simp] theorem coeffAbsMax_dilate_neg_one (p : ZPoly) :
+    coeffAbsMax (p.dilate (-1)) = coeffAbsMax p := by
+  unfold coeffAbsMax
+  rw [ZPoly.size_dilate_neg_one]
+  have hfold (indices : List Nat) (acc : Nat) :
+      indices.foldl
+          (fun total i => Nat.max total ((p.dilate (-1)).coeff i).natAbs) acc =
+        indices.foldl (fun total i => Nat.max total (p.coeff i).natAbs) acc := by
+    induction indices generalizing acc with
+    | nil => rfl
+    | cons n indices ih =>
+        simp only [List.foldl_cons]
+        have habs : ((p.dilate (-1)).coeff n).natAbs = (p.coeff n).natAbs := by
+          rw [ZPoly.coeff_dilate, Int.natAbs_mul, Int.natAbs_pow]
+          rw [show (-1 : Int).natAbs = 1 by decide, Nat.one_pow, Nat.one_mul]
+        rw [habs]
+        exact ih _
+  exact hfold (List.range p.size) 0
+
+/-- Multiplication by `-1` preserves coefficient height. -/
+@[simp] theorem coeffAbsMax_scale_neg_one (p : ZPoly) :
+    coeffAbsMax (DensePoly.scale (-1) p) = coeffAbsMax p := by
+  unfold coeffAbsMax
+  rw [ZPoly.scale_size_of_ne_zero (-1 : Int) p (by decide)]
+  have hfold (indices : List Nat) (acc : Nat) :
+      indices.foldl (fun total i =>
+          Nat.max total ((DensePoly.scale (-1) p).coeff i).natAbs) acc =
+        indices.foldl (fun total i => Nat.max total (p.coeff i).natAbs) acc := by
+    induction indices generalizing acc with
+    | nil => rfl
+    | cons n indices ih =>
+        simp only [List.foldl_cons]
+        have habs : ((DensePoly.scale (-1) p).coeff n).natAbs =
+            (p.coeff n).natAbs := by
+          rw [DensePoly.coeff_scale (R := Int) (-1) p n (Int.mul_zero _),
+            Int.natAbs_mul]
+          rw [show (-1 : Int).natAbs = 1 by decide, Nat.one_mul]
+        rw [habs]
+        exact ih _
+  exact hfold (List.range p.size) 0
+
+/-- Primitive sign normalization preserves coefficient height. -/
+@[simp] theorem coeffAbsMax_normalizePrimitiveSign (p : ZPoly) :
+    coeffAbsMax (p.normalizePrimitiveSign) = coeffAbsMax p := by
+  unfold normalizePrimitiveSign
+  split
+  · exact coeffAbsMax_scale_neg_one p
+  · rfl
+
 end ZPoly
 
 /-- Precision at which the circumscribed-disc radius `2^{−m}·√2` is

--- a/HexRoots/SPEC/hex-roots.md
+++ b/HexRoots/SPEC/hex-roots.md
@@ -3,13 +3,16 @@
 Certified isolation of complex roots of integer-coefficient
 polynomials. A root isolation is a square in the complex plane with
 Gaussian-dyadic centre and power-of-two half-width, together with a
-witness, dischargeable by `decide`, that a certified region around
+structural certificate that a certified region around
 the square contains exactly one simple root (an *atom*) or exactly
 `k` roots counted with multiplicity (a *cluster*). Atoms carry one
 of two certificate forms, tried in a configurable order: a
 Newton-Kantorovich contraction witness, whose certified region is
 the square itself, or a Pellet witness, whose certified region is
-the square's circumscribed disc. Clusters carry Pellet witnesses on
+the square's circumscribed disc. Checker-produced certificates remain
+dischargeable by `decide`; exact polynomial and square transformations retain
+their source certificate as explicit provenance instead of rerunning a
+checker. Clusters carry Pellet witnesses on
 the circumscribed disc. Refinement combines speculative Newton
 iteration (using `Dyadic.invAtPrec` from the Lean standard library)
 with subdivision and component gluing as the fallback, following the
@@ -237,8 +240,10 @@ square is that doubled square. All downstream geometry
 nothing else changes; reaching a given stored precision costs one
 extra subdivision level, absorbed by `stopSlack`.
 
-The two atom forms are packaged as a disjunction, so consumers of
-isolations never care which route fired:
+The two checker forms remain packaged as the decidable `atomWitness`
+proposition. Stored atoms use an indexed structural certificate so exact root
+reflection and primitive-sign normalization can transport existing evidence
+without assuming that either checker fires again:
 
 ```lean
 /-- An atom certificate: either certificate form for "exactly one
@@ -246,6 +251,17 @@ isolations never care which route fired:
 def atomWitness (p : ZPoly) (s : DyadicSquare) : Prop :=
   nkWitness p s ∨ witness p s 1
 instance : Decidable (atomWitness p s) := …
+
+inductive AtomCertificate : (p : ZPoly) → (s : DyadicSquare) → Type
+  | nk (h : nkWitness p s) : AtomCertificate p s
+  | pellet (h : witness p s 1) : AtomCertificate p s
+  | neg (hprim : ZPoly.Primitive p) (h : AtomCertificate p s) :
+      AtomCertificate p.negRoots s.neg
+  | normalize (h : AtomCertificate p s) :
+      AtomCertificate (ZPoly.normalizePrimitiveSign p) s
+
+def AtomCertificate.ofWitness : atomWitness p s → AtomCertificate p s
+def AtomCertificate.isNK : AtomCertificate p s → Bool
 
 /-- Which atom certificates `certify?` attempts, and in which order.
     `nkThenPellet` is the default; the singleton strategies exist for
@@ -277,7 +293,7 @@ structure DyadicSquare where
     Pellet disjunct) contains exactly one simple root. -/
 structure DyadicRootIsolation (p : ZPoly) where
   square  : DyadicSquare
-  witness : atomWitness p square
+  witness : AtomCertificate p square
 
 /-- A certified cluster: an edge-or-corner-connected set of grid squares at a
     common `prec`, whose enclosing disc contains exactly `k` roots
@@ -374,7 +390,7 @@ def cauchy (p : ZPoly) (h : 0 < p.degree?.getD 0) : Component
 end Component
 
 /-- Repackage a certified `k = 1` cluster as an atom (the Pellet
-    disjunct of `atomWitness`). Total: the cluster's witness already
+    constructor of `AtomCertificate`). Total: the cluster's witness already
     lives on the enclosing square's disc, which is the atom's
     square. -/
 def DyadicRootCluster.atomize (c : DyadicRootCluster p) (h : c.k = 1) :
@@ -799,8 +815,9 @@ is made here for pure Pellet refinement of a non-squarefree ambient polynomial.
   (hex-number-field's disambiguation loops) use instead of re-deriving
   the `√2` radius bookkeeping.
 - `HexRoots/Kantorovich.lean`: `nkWitness` with its `Decidable`
-  instance, `atomWitness`, `AtomStrategy`, the
-  `atomWitness`-dependent `DyadicRootIsolation`, `Certified`, and
+  instance, the decidable `atomWitness` checker proposition,
+  `AtomCertificate` and its exact transport constructors, `AtomStrategy`, the
+  certificate-indexed `DyadicRootIsolation`, `Certified`, and
   `atomize`, and `certifyAtom?` (certify an arbitrary candidate
   square, deciding both disjuncts fresh; the documented constructor
   for re-certification after a square transform).

--- a/HexRoots/SimpleRoot.lean
+++ b/HexRoots/SimpleRoot.lean
@@ -93,24 +93,35 @@ instance {p : ZPoly} {i₁ i₂ : RefinedIsolation p} : Decidable (Intersects i�
 @[expose] def RefinedIsolation.sameRoot {p : ZPoly} (i₁ i₂ : RefinedIsolation p) : Bool :=
   DyadicSquare.discsMeet i₁.1.square i₂.1.square
 
-/-- A certified atom needs at least two stored coefficients. Both
-witness checkers inspect the full Taylor array: Newton--Kantorovich requires at
-least two coefficients, while the `k = 1` Pellet branch requires coefficient
-index one to exist. -/
+/-- Every structural atom certificate belongs to a polynomial with at least
+two stored coefficients. Exact reflection preserves that count. -/
+theorem AtomCertificate.size_gt_one {p : ZPoly} {s : DyadicSquare}
+    (certificate : AtomCertificate p s) : 1 < p.size := by
+  induction certificate with
+  | @nk p' s' hnk =>
+      by_cases h : 1 < p'.size
+      · exact h
+      · have hle : p'.size ≤ 1 := by omega
+        rw [nkWitness, nkWitnessCheck_false hle] at hnk
+        contradiction
+  | @pellet p' s' hpellet =>
+      by_cases h : 1 < p'.size
+      · exact h
+      · have hle : p'.size ≤ 1 := by omega
+        change witnessCheck p' s' 1 = true at hpellet
+        rw [witnessCheck_false hle] at hpellet
+        contradiction
+  | neg hprim certificate ih =>
+      rw [ZPoly.size_negRoots hprim]
+      exact ih
+  | normalize certificate ih =>
+      rw [ZPoly.size_normalizePrimitiveSign]
+      exact ih
+
+/-- A certified atom needs at least two stored coefficients. -/
 theorem DyadicRootIsolation.size_gt_one {p : ZPoly} (i : DyadicRootIsolation p) :
-    1 < p.size := by
-  rcases i.witness with hnk | hpellet
-  · by_cases h : 1 < p.size
-    · exact h
-    · have hle : p.size ≤ 1 := by omega
-      rw [nkWitness, nkWitnessCheck_false hle] at hnk
-      contradiction
-  · by_cases h : 1 < p.size
-    · exact h
-    · have hle : p.size ≤ 1 := by omega
-      change witnessCheck p i.square 1 = true at hpellet
-      rw [witnessCheck_false hle] at hpellet
-      contradiction
+    1 < p.size :=
+  i.witness.size_gt_one
 
 /-- A certified atom can only exist for a positive-degree polynomial. -/
 theorem DyadicRootIsolation.posDegree {p : ZPoly} (i : DyadicRootIsolation p) :

--- a/HexRootsMathlib/Certificate.lean
+++ b/HexRootsMathlib/Certificate.lean
@@ -24,11 +24,103 @@ namespace HexRootsMathlib
 
 noncomputable section
 
+namespace ZPoly
+
+/-- Reflection changes the complex polynomial only by composition with
+`-X` and a nonzero sign used to restore a positive leading coefficient. -/
+theorem toPolyℂ_negRoots {p : Hex.ZPoly} (hprim : Hex.ZPoly.Primitive p) :
+    ∃ u : ℂ, u ≠ 0 ∧
+      toPolyℂ p.negRoots = Polynomial.C u * (toPolyℂ p).comp (-Polynomial.X) := by
+  rw [Hex.ZPoly.negRoots_eq_reflect hprim]
+  unfold Hex.ZPoly.normalizePrimitiveSign
+  split
+  · refine ⟨-1, by norm_num, ?_⟩
+    simp [toPolyℂ, HexPolyMathlib.toPolynomial_scale,
+      HexPolyZMathlib.toPolynomial_dilate, Polynomial.map_comp]
+  · refine ⟨1, by norm_num, ?_⟩
+    simp [toPolyℂ, HexPolyZMathlib.toPolynomial_dilate,
+      Polynomial.map_comp]
+
+/-- A root reflects to a root of the normalized reflected polynomial. -/
+theorem isRoot_negRoots {p : Hex.ZPoly} {z : ℂ}
+    (hprim : Hex.ZPoly.Primitive p) (hz : (toPolyℂ p).IsRoot z) :
+    (toPolyℂ p.negRoots).IsRoot (-z) := by
+  obtain ⟨u, hu, hpoly⟩ := toPolyℂ_negRoots hprim
+  change (toPolyℂ p.negRoots).eval (-z) = 0
+  rw [hpoly, Polynomial.eval_mul, Polynomial.eval_C, Polynomial.eval_comp]
+  simp only [Polynomial.eval_neg, Polynomial.eval_X, neg_neg]
+  exact mul_eq_zero.mpr (Or.inr hz)
+
+/-- Leading-sign normalization changes the complex polynomial only by a
+nonzero scalar. -/
+theorem toPolyℂ_normalizePrimitiveSign (p : Hex.ZPoly) :
+    ∃ u : ℂ, u ≠ 0 ∧
+      toPolyℂ (Hex.ZPoly.normalizePrimitiveSign p) =
+        Polynomial.C u * toPolyℂ p := by
+  unfold Hex.ZPoly.normalizePrimitiveSign
+  split
+  · refine ⟨-1, by norm_num, ?_⟩
+    simp [toPolyℂ, HexPolyMathlib.toPolynomial_scale]
+  · refine ⟨1, by norm_num, ?_⟩
+    simp
+
+end ZPoly
+
+namespace DyadicSquare
+
+@[simp] theorem center_neg (s : Hex.DyadicSquare) :
+    center s.neg = -center s := by
+  apply Complex.ext <;>
+    simp [Hex.DyadicSquare.neg, center, Hex.DyadicSquare.center,
+      GaussDyadic.toComplex]
+
+@[simp] theorem radius_neg (s : Hex.DyadicSquare) :
+    radius s.neg = radius s := by
+  simp [radius_eq, Hex.DyadicSquare.neg]
+
+@[simp] theorem openSquare_neg {s : Hex.DyadicSquare} {z : ℂ} :
+    -z ∈ openSquare s.neg ↔ z ∈ openSquare s := by
+  change supDist (-z) (center s.neg) < halfWidth s.neg ↔
+    supDist z (center s) < halfWidth s
+  rw [center_neg]
+  have hwidth : halfWidth s.neg = halfWidth s := by
+    simp [halfWidth_eq, Hex.DyadicSquare.neg]
+  rw [hwidth]
+  unfold supDist
+  rw [show -z - -center s = -(z - center s) by ring]
+  simp [supNorm, abs_sub_comm]
+
+@[simp] theorem closedSquare_neg {s : Hex.DyadicSquare} {z : ℂ} :
+    -z ∈ closedSquare s.neg ↔ z ∈ closedSquare s := by
+  change supDist (-z) (center s.neg) ≤ halfWidth s.neg ↔
+    supDist z (center s) ≤ halfWidth s
+  rw [center_neg]
+  have hwidth : halfWidth s.neg = halfWidth s := by
+    simp [halfWidth_eq, Hex.DyadicSquare.neg]
+  rw [hwidth]
+  unfold supDist
+  rw [show -z - -center s = -(z - center s) by ring]
+  simp [supNorm, abs_sub_comm]
+
+@[simp] theorem disc_neg {s : Hex.DyadicSquare} {z : ℂ} :
+    -z ∈ disc s.neg ↔ z ∈ disc s := by
+  change dist (-z) (center s.neg) < radius s.neg ↔
+    dist z (center s) < radius s
+  rw [center_neg, radius_neg, dist_neg_neg]
+
+@[simp] theorem closedDisc_neg {s : Hex.DyadicSquare} {z : ℂ} :
+    -z ∈ closedDisc s.neg ↔ z ∈ closedDisc s := by
+  change dist (-z) (center s.neg) ≤ radius s.neg ↔
+    dist z (center s) ≤ radius s
+  rw [center_neg, radius_neg, dist_neg_neg]
+
+end DyadicSquare
+
 namespace DyadicRootIsolation
 
 /-- The open counterpart of an atom's selected certified region. -/
 @[expose] def openRegion {p : Hex.ZPoly} (iso : Hex.DyadicRootIsolation p) : Set ℂ :=
-  if Hex.nkWitness p iso.square then
+  if iso.witness.isNK then
     DyadicSquare.openSquare iso.square
   else
     DyadicSquare.disc iso.square
@@ -50,12 +142,83 @@ theorem sound {p : Hex.ZPoly} (iso : Hex.DyadicRootIsolation p) :
     ∃ z, (toPolyℂ p).eval z = 0 ∧ z ∈ openRegion iso ∧
       (toPolyℂ p).derivative.eval z ≠ 0 ∧
       ∀ w, (toPolyℂ p).eval w = 0 → w ∈ region iso → w = z := by
-  rw [openRegion, region]
-  split <;> rename_i hnk
-  · exact NKData.sound hnk
-  · rcases iso.witness with h | h
-    · exact (hnk h).elim
-    · exact PelletWitness.sound h
+  rcases iso with ⟨s, certificate⟩
+  induction certificate with
+  | nk h =>
+      simpa [openRegion, region, Hex.AtomCertificate.isNK] using NKData.sound h
+  | pellet h =>
+      simpa [openRegion, region, Hex.AtomCertificate.isNK] using
+        PelletWitness.sound h
+  | @neg p s hprim certificate ih =>
+      obtain ⟨z, hzroot, hzopen, hzderiv, hzunique⟩ := ih
+      obtain ⟨u, hu, hpoly⟩ := ZPoly.toPolyℂ_negRoots hprim
+      have heval (w : ℂ) :
+          (toPolyℂ p.negRoots).eval w = u * (toPolyℂ p).eval (-w) := by
+        rw [hpoly]
+        simp
+      have hderiv (w : ℂ) :
+          (toPolyℂ p.negRoots).derivative.eval w =
+            -u * (toPolyℂ p).derivative.eval (-w) := by
+        rw [hpoly]
+        simp [Polynomial.derivative_comp]
+      refine ⟨-z, ?_, ?_, ?_, ?_⟩
+      · rw [heval]
+        simp [hzroot]
+      · simp only [openRegion, Hex.AtomCertificate.isNK]
+        rw [openRegion] at hzopen
+        by_cases hkind : certificate.isNK = true
+        · simp only [hkind, if_true] at hzopen ⊢
+          exact DyadicSquare.openSquare_neg.mpr hzopen
+        · simp only [hkind] at hzopen ⊢
+          exact DyadicSquare.disc_neg.mpr hzopen
+      · rw [hderiv, neg_neg]
+        exact mul_ne_zero (neg_ne_zero.mpr hu) hzderiv
+      · intro w hwroot hwregion
+        have hsourceRoot : (toPolyℂ p).eval (-w) = 0 := by
+          rw [heval] at hwroot
+          exact (mul_eq_zero.mp hwroot).resolve_left hu
+        have hsourceRegion : -w ∈
+            DyadicRootIsolation.region ⟨s, certificate⟩ := by
+          simp only [region, Hex.AtomCertificate.isNK] at hwregion ⊢
+          by_cases hkind : certificate.isNK = true
+          · simp only [hkind, if_true] at hwregion ⊢
+            have hiff := DyadicSquare.closedSquare_neg (s := s) (z := -w)
+            simp only [neg_neg] at hiff
+            exact hiff.mp hwregion
+          · simp [hkind] at hwregion ⊢
+            have hiff := DyadicSquare.closedDisc_neg (s := s) (z := -w)
+            simp only [neg_neg] at hiff
+            exact hiff.mp hwregion
+        have hneg : -w = z := hzunique (-w) hsourceRoot hsourceRegion
+        exact neg_eq_iff_eq_neg.mp hneg
+  | @normalize p s certificate ih =>
+      obtain ⟨z, hzroot, hzopen, hzderiv, hzunique⟩ := ih
+      obtain ⟨u, hu, hpoly⟩ := ZPoly.toPolyℂ_normalizePrimitiveSign p
+      have heval (w : ℂ) :
+          (toPolyℂ (Hex.ZPoly.normalizePrimitiveSign p)).eval w =
+            u * (toPolyℂ p).eval w := by
+        rw [hpoly]
+        simp
+      have hderiv (w : ℂ) :
+          (toPolyℂ (Hex.ZPoly.normalizePrimitiveSign p)).derivative.eval w =
+            u * (toPolyℂ p).derivative.eval w := by
+        rw [hpoly]
+        simp
+      refine ⟨z, ?_, ?_, ?_, ?_⟩
+      · rw [heval]
+        exact mul_eq_zero.mpr (Or.inr hzroot)
+      · simpa [openRegion, Hex.AtomCertificate.isNK] using hzopen
+      · rw [hderiv]
+        exact mul_ne_zero hu hzderiv
+      · intro w hwroot hwregion
+        have hsourceRoot : (toPolyℂ p).eval w = 0 := by
+          rw [heval] at hwroot
+          exact (mul_eq_zero.mp hwroot).resolve_left hu
+        apply hzunique w hsourceRoot
+        convert hwregion using 1
+        ext q
+        by_cases hkind : certificate.isNK = true <;>
+          simp [region, Hex.AtomCertificate.isNK, hkind]
 
 end DyadicRootIsolation
 
@@ -246,24 +409,15 @@ theorem root_mem_nestedPellet {p : Hex.ZPoly} {inner outer : Hex.DyadicSquare}
 region even when the same square also happens to carry an NK witness (in
 which case `DyadicRootIsolation.region` selects the closed square). -/
 theorem pelletAtom_mem_region {p : Hex.ZPoly} {s : Hex.DyadicSquare}
-    (h : Hex.witness p s 1) {z : ℂ} (hzroot : (toPolyℂ p).eval z = 0)
+    (h : Hex.witness p s 1) {z : ℂ}
     (hzdisc : z ∈ DyadicSquare.closedDisc s) :
-    z ∈ Certified.region (.atom ⟨s, Or.inr h⟩) := by
-  rw [Certified.region, DyadicRootIsolation.region]
-  split <;> rename_i hnk
-  · obtain ⟨w, hw, -⟩ := NKData.existsUnique_root hnk
-    obtain ⟨a, haRoot, -, -, haUnique⟩ := PelletWitness.sound h
-    have hza : z = a := haUnique z hzroot hzdisc
-    have hwdisc : w ∈ DyadicSquare.closedDisc s :=
-      DyadicSquare.closedSquare_subset_closedDisc s hw.2
-    have hwa : w = a := haUnique w hw.1 hwdisc
-    rw [hza, ← hwa]
-    exact hw.2
-  · exact hzdisc
+    z ∈ Certified.region (.atom ⟨s, .pellet h⟩) := by
+  simpa [Certified.region, DyadicRootIsolation.region,
+    Hex.AtomCertificate.isNK] using hzdisc
 
 private theorem basePellet_mem {p : Hex.ZPoly} {c : Hex.Component} {k : Nat}
     (hk : 0 < k) (hw : Hex.witness p (Hex.encSquare c.squares) k)
-    {z : ℂ} (hzroot : (toPolyℂ p).eval z = 0)
+    {z : ℂ}
     (hzsquare : z ∈ DyadicSquare.closedSquare (Hex.encSquare c.squares)) :
     let cl : Hex.DyadicRootCluster p := ⟨c.squares, k, hk, hw⟩
     z ∈ Certified.region
@@ -271,7 +425,7 @@ private theorem basePellet_mem {p : Hex.ZPoly} {c : Hex.Component} {k : Nat}
   dsimp only
   split <;> rename_i hk1
   · subst k
-    exact pelletAtom_mem_region hw hzroot
+    exact pelletAtom_mem_region hw
       (DyadicSquare.closedSquare_subset_closedDisc _ hzsquare)
   · exact DyadicSquare.closedSquare_subset_closedDisc _ hzsquare
 
@@ -292,7 +446,7 @@ private theorem candidatePellet_mem {p : Hex.ZPoly} {c : Hex.Component} {k : Nat
       (DyadicSquare.closedDisc_subset_of_discInside hins) hzroot hzbase
   split <;> rename_i hk1
   · subst k
-    exact pelletAtom_mem_region hw' hzroot hzcand
+    exact pelletAtom_mem_region hw' hzcand
   · exact hzcand
 
 /-- Each cached-shift Pellet attempt preserves every polynomial root covered
@@ -335,10 +489,10 @@ theorem certifyPelletAtShift_preserves {p : Hex.ZPoly} {c : Hex.Component}
               candidatePellet_mem hk hw₀ hins hw₀' hzroot hzbase
         · have hr : r = base := (Option.some.inj hcert).symm
           subst r
-          exact basePellet_mem hk hw₀ hzroot hzsquare
+          exact basePellet_mem hk hw₀ hzsquare
       · have hr : r = base := (Option.some.inj hcert).symm
         subst r
-        exact basePellet_mem hk hw₀ hzroot hzsquare
+        exact basePellet_mem hk hw₀ hzsquare
     · simp at hcert
   · simp at hcert
 
@@ -383,10 +537,10 @@ theorem certifyPelletExactAt_preserves {p : Hex.ZPoly} {c : Hex.Component}
               candidatePellet_mem hk hw₀ hins hw₀' hzroot hzbase
         · have hr : r = base := (Option.some.inj hcert).symm
           subst r
-          exact basePellet_mem hk hw₀ hzroot hzsquare
+          exact basePellet_mem hk hw₀ hzsquare
       · have hr : r = base := (Option.some.inj hcert).symm
         subst r
-        exact basePellet_mem hk hw₀ hzroot hzsquare
+        exact basePellet_mem hk hw₀ hzsquare
     · simp at hcert
   · simp at hcert
 
@@ -396,7 +550,7 @@ theorem certifyPelletSoft_preserves {p : Hex.ZPoly} {c : Hex.Component}
     {shift : Hex.TaylorShift p (Hex.encSquare c.squares).center}
     {ks : List Nat} {r : Hex.Certified p}
     (hcert : Hex.Component.certifyPelletSoft? p c shift ks = some r)
-    {z : ℂ} (hzroot : (toPolyℂ p).eval z = 0)
+    {z : ℂ}
     (hz : z ∈ Component.region c) : z ∈ Certified.region r := by
   let enc := Hex.encSquare c.squares
   have hzsquare : z ∈ DyadicSquare.closedSquare enc :=
@@ -427,12 +581,12 @@ theorem certifyPelletSoft_preserves {p : Hex.ZPoly} {c : Hex.Component}
         have hr : r = .atom (cl.atomize hk1) := (Option.some.inj hcert).symm
         subst r
         simpa only [dif_pos hk1] using
-          basePellet_mem hs.1 hw hzroot hzsquare
+          basePellet_mem hs.1 hw hzsquare
       · rw [dif_neg hk1] at hcert
         have hr : r = .cluster cl := (Option.some.inj hcert).symm
         subst r
         simpa only [dif_neg hk1] using
-          basePellet_mem hs.1 hw hzroot hzsquare
+          basePellet_mem hs.1 hw hzsquare
   · simp at hcert
 
 /-- The public one-count wrapper has the cached attempt's preservation
@@ -546,9 +700,9 @@ theorem certify_nkThenPellet_cases {p : Hex.ZPoly} {c : Hex.Component}
     let cand := (Hex.newtonSquare p base 1).doubled
     (∃ (_hbase : Hex.nkWitness p base) (_hinside : cand.squareInside base = true)
         (hcand : Hex.nkWitness p cand),
-        r = .atom ⟨cand, Or.inl hcand⟩) ∨
+        r = .atom ⟨cand, .nk hcand⟩) ∨
       (∃ hbase : Hex.nkWitness p base,
-        r = .atom ⟨base, Or.inl hbase⟩) ∨
+        r = .atom ⟨base, .nk hbase⟩) ∨
       ∃ shift,
         Hex.Component.certifyPelletShift? p
           ⟨#[(Hex.encSquare c.squares).doubled.doubled], c.candidateK⟩ shift = some r := by

--- a/HexRootsMathlib/Completeness/DriverCompleteness.lean
+++ b/HexRootsMathlib/Completeness/DriverCompleteness.lean
@@ -153,10 +153,10 @@ private theorem certifyNK_one {p : Hex.ZPoly} {c : Hex.Component}
   split <;> rename_i hbase'
   · split <;> rename_i hins
     · split <;> rename_i hcand
-      · refine ⟨⟨_, Or.inl hcand⟩, rfl, ?_⟩
+      · refine ⟨⟨_, .nk hcand⟩, rfl, ?_⟩
         exact newtonCandidate_prec hsize
-      · exact ⟨⟨_, Or.inl hbase'⟩, rfl, le_rfl⟩
-    · exact ⟨⟨_, Or.inl hbase'⟩, rfl, le_rfl⟩
+      · exact ⟨⟨_, .nk hbase'⟩, rfl, le_rfl⟩
+    · exact ⟨⟨_, .nk hbase'⟩, rfl, le_rfl⟩
   · exact (hbase' hbase).elim
 
 /-- The mixed strategy has the identical successful NK prefix. -/
@@ -170,10 +170,10 @@ private theorem certifyMixed_one {p : Hex.ZPoly} {c : Hex.Component}
   split <;> rename_i hbase'
   · split <;> rename_i hins
     · split <;> rename_i hcand
-      · refine ⟨⟨_, Or.inl hcand⟩, rfl, ?_⟩
+      · refine ⟨⟨_, .nk hcand⟩, rfl, ?_⟩
         exact newtonCandidate_prec hsize
-      · exact ⟨⟨_, Or.inl hbase'⟩, rfl, le_rfl⟩
-    · exact ⟨⟨_, Or.inl hbase'⟩, rfl, le_rfl⟩
+      · exact ⟨⟨_, .nk hbase'⟩, rfl, le_rfl⟩
+    · exact ⟨⟨_, .nk hbase'⟩, rfl, le_rfl⟩
   · exact (hbase' hbase).elim
 
 /-- A member of a globally normalized round is one level finer than every

--- a/HexRootsMathlib/Completeness/RefinementCompleteness.lean
+++ b/HexRootsMathlib/Completeness/RefinementCompleteness.lean
@@ -336,10 +336,10 @@ private theorem certifyMixed_atom {p : Hex.ZPoly} {c : Hex.Component}
   split <;> rename_i hbase'
   · split <;> rename_i hins
     · split <;> rename_i hcand
-      · refine ⟨⟨_, Or.inl hcand⟩, rfl, ?_⟩
+      · refine ⟨⟨_, .nk hcand⟩, rfl, ?_⟩
         exact newtonCandidate_prec hsize
-      · exact ⟨⟨_, Or.inl hbase'⟩, rfl, le_rfl⟩
-    · exact ⟨⟨_, Or.inl hbase'⟩, rfl, le_rfl⟩
+      · exact ⟨⟨_, .nk hbase'⟩, rfl, le_rfl⟩
+    · exact ⟨⟨_, .nk hbase'⟩, rfl, le_rfl⟩
   · exact (hbase' hbase).elim
 
 private theorem allAtoms_outputs {p : Hex.ZPoly}

--- a/HexRootsMathlib/Component.lean
+++ b/HexRootsMathlib/Component.lean
@@ -118,11 +118,10 @@ end Component
 
 namespace DyadicRootIsolation
 
-/-- The certified region selected by an atom witness. If both disjuncts hold,
-the Newton square is chosen; either choice contains the same unique root once
-both semantic developments are available. -/
+/-- The certified region selected by an atom certificate. Reflected
+certificates preserve the region kind of their source certificate. -/
 @[expose] def region {p : Hex.ZPoly} (iso : Hex.DyadicRootIsolation p) : Set ℂ :=
-  if Hex.nkWitness p iso.square then
+  if iso.witness.isNK then
     DyadicSquare.closedSquare iso.square
   else
     DyadicSquare.closedDisc iso.square

--- a/HexRootsMathlib/NKCertify.lean
+++ b/HexRootsMathlib/NKCertify.lean
@@ -30,9 +30,9 @@ theorem certify_nk_cases {p : Hex.ZPoly} {c : Hex.Component}
     let cand := (Hex.newtonSquare p base 1).doubled
     (∃ (_hbase : Hex.nkWitness p base) (_hinside : cand.squareInside base = true)
         (hcand : Hex.nkWitness p cand),
-        r = .atom ⟨cand, Or.inl hcand⟩) ∨
+        r = .atom ⟨cand, .nk hcand⟩) ∨
       ∃ hbase : Hex.nkWitness p base,
-        r = .atom ⟨base, Or.inl hbase⟩ := by
+        r = .atom ⟨base, .nk hbase⟩ := by
   simp only [Hex.Component.certify?, Hex.nkWitness,
     Hex.TaylorShift.nkWitnessCheck_eq, Hex.TaylorShift.newtonSquare_eq] at hcert ⊢
   split at hcert <;> rename_i hbase
@@ -50,8 +50,8 @@ theorem certify_nk_cases {p : Hex.ZPoly} {c : Hex.Component}
 square. -/
 @[simp] theorem nkAtom_region {p : Hex.ZPoly} {s : Hex.DyadicSquare}
     (h : Hex.nkWitness p s) :
-    Certified.region (.atom ⟨s, Or.inl h⟩) = DyadicSquare.closedSquare s := by
-  simp [Certified.region, DyadicRootIsolation.region, h]
+    Certified.region (.atom ⟨s, .nk h⟩) = DyadicSquare.closedSquare s := by
+  simp [Certified.region, DyadicRootIsolation.region, Hex.AtomCertificate.isNK]
 
 /-- A root in an outer unique-root square belongs to a nested inner square
 that also has a unique root. -/
@@ -75,13 +75,14 @@ theorem certify_nk_unique {p : Hex.ZPoly} {c : Hex.Component}
     {r : Hex.Certified p} (hcert : Hex.Component.certify? p .nk c = some r) :
     ∃ (iso : Hex.DyadicRootIsolation p), r = .atom iso ∧
       Hex.nkWitness p iso.square ∧
+      iso.witness.isNK = true ∧
       ∃! z, (toPolyℂ p).eval z = 0 ∧
         z ∈ DyadicSquare.closedSquare iso.square := by
   rcases certify_nk_cases hcert with h | h
   · obtain ⟨hbase, hinside, hcand, rfl⟩ := h
-    exact ⟨_, rfl, hcand, NKData.existsUnique_root hcand⟩
+    exact ⟨_, rfl, hcand, rfl, NKData.existsUnique_root hcand⟩
   · obtain ⟨hbase, rfl⟩ := h
-    exact ⟨_, rfl, hbase, NKData.existsUnique_root hbase⟩
+    exact ⟨_, rfl, hbase, rfl, NKData.existsUnique_root hbase⟩
 
 /-- Every NK-only certification result contains a unique interior simple root
 in its stored square. -/

--- a/HexRootsMathlib/NKDriver.lean
+++ b/HexRootsMathlib/NKDriver.lean
@@ -81,7 +81,8 @@ theorem isolateLoop_nk_atoms {p : Hex.ZPoly} {target : Int} {fuel : Nat}
     {work : Array Hex.Component} {rs : Array (Hex.Certified p)}
     (hloop : Hex.isolateLoop p target .nk fuel work = some rs) :
     ∀ r ∈ rs.toList, ∃ iso : Hex.DyadicRootIsolation p,
-      r = .atom iso ∧ Hex.nkWitness p iso.square := by
+      r = .atom iso ∧ Hex.nkWitness p iso.square ∧
+        iso.witness.isNK = true := by
   induction fuel generalizing work rs with
   | zero => simp [Hex.isolateLoop] at hloop
   | succ fuel ih =>
@@ -114,8 +115,8 @@ theorem isolateLoop_nk_atoms {p : Hex.ZPoly} {target : Int} {fuel : Nat}
               obtain ⟨d, hd, hdc⟩ := Array.mem_map.mp ht
               have hcert : Hex.Component.certify? p .nk d = some r := by
                 exact congrArg Prod.snd hdc
-              obtain ⟨iso, hir, hnk, -⟩ := certify_nk_unique hcert
-              exact ⟨iso, hir, hnk⟩
+              obtain ⟨iso, hir, hnk, hkind, -⟩ := certify_nk_unique hcert
+              exact ⟨iso, hir, hnk, hkind⟩
         · exact ih hloop
 
 /-- `isolateAll?` is the shared loop with its executable fuel calculation. -/
@@ -143,7 +144,8 @@ theorem isolateAll_nk_atoms {p : Hex.ZPoly} {target : Int}
     {work : Array Hex.Component} {rs : Array (Hex.Certified p)}
     (hrun : Hex.isolateAll? p target work .nk = some rs) :
     ∀ r ∈ rs.toList, ∃ iso : Hex.DyadicRootIsolation p,
-      r = .atom iso ∧ Hex.nkWitness p iso.square := by
+      r = .atom iso ∧ Hex.nkWitness p iso.square ∧
+        iso.witness.isNK = true := by
   obtain ⟨fuel, hloop⟩ := isolateAll_nk_loop hrun
   exact isolateLoop_nk_atoms hloop
 
@@ -184,7 +186,7 @@ theorem isolateAll_nk_simple {p : Hex.ZPoly} {target : Int}
         (toPolyℂ p).derivative.eval z ≠ 0 ∧
         ∀ w, (toPolyℂ p).eval w = 0 →
           w ∈ DyadicSquare.closedSquare iso.square → w = z := by
-  obtain ⟨iso, hiso, hnk⟩ := isolateAll_nk_atoms hrun rs[i]
+  obtain ⟨iso, hiso, hnk, -⟩ := isolateAll_nk_atoms hrun rs[i]
     (Array.getElem_mem_toList hi)
   exact ⟨iso, hiso, NKData.sound hnk⟩
 
@@ -200,7 +202,8 @@ theorem isolate_nk_run (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
         #[Hex.Component.cauchy p hdegree] .nk = some rs ∧
       rs.size = atoms.size ∧
       ∀ (i : Nat) (hi : i < rs.size) (hj : i < atoms.size),
-        rs[i] = .atom atoms[i] ∧ Hex.nkWitness p atoms[i].square := by
+        rs[i] = .atom atoms[i] ∧ Hex.nkWitness p atoms[i].square ∧
+          atoms[i].witness.isNK = true := by
   have hrun' := hrun
   rw [Hex.isolate, dif_pos hdegree] at hrun'
   let target := max atomPrec (Hex.separationDepth p : Int)
@@ -221,12 +224,12 @@ theorem isolate_nk_run (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
             rw [hri] at hm
             have hiso : iso = atoms[i] := by
               exact Option.some.inj hm
-            obtain ⟨iso', heq, hnk⟩ := isolateAll_nk_atoms hall rs[i]
+            obtain ⟨iso', heq, hnk, hkind⟩ := isolateAll_nk_atoms hall rs[i]
               (Array.getElem_mem_toList hi)
             have heq' : iso = iso' := by simpa only [hri, Hex.Certified.atom.injEq] using heq
             cases heq'
             cases hiso
-            exact ⟨rfl, hnk⟩
+            exact ⟨rfl, hnk, hkind⟩
         | cluster cl =>
             rw [hri] at hm
             simp [Hex.Certified.asAtom?] at hm
@@ -248,7 +251,7 @@ theorem isolate_nk_simple (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
   obtain ⟨rs, hall, hsize, hrel⟩ :=
     isolate_nk_run p h atomPrec hdegree hrun
   have hi' : i < rs.size := by simpa [hsize] using hi
-  obtain ⟨hri, hnk⟩ := hrel i hi' hi
+  obtain ⟨hri, hnk, -⟩ := hrel i hi' hi
   have hready := (isolateAll_nk_ready_disjoint hall).1 rs[i]
     (Array.getElem_mem_toList hi')
   rw [hri] at hready
@@ -268,8 +271,8 @@ theorem isolate_nk_disjoint (p : Hex.ZPoly) (h : Hex.HasOnlySimpleRoots p)
     isolate_nk_run p h atomPrec hdegree hrun
   have hi' : i < rs.size := by simpa [hsize] using hi
   have hj' : j < rs.size := by simpa [hsize] using hj
-  obtain ⟨hri, -⟩ := hrel i hi' hi
-  obtain ⟨hrj, -⟩ := hrel j hj' hj
+  obtain ⟨hri, -, -⟩ := hrel i hi' hi
+  obtain ⟨hrj, -, -⟩ := hrel j hj' hj
   have hdisj := (isolateAll_nk_ready_disjoint hall).2 hi' hj' hij
   simpa only [hri, hrj, Hex.Certified.square] using hdisj
 
@@ -292,11 +295,11 @@ theorem isolate_nk_covers_once_of_pos (p : Hex.ZPoly)
   have hir' : rs[i] = r := by
     rw [← hir]
     exact (Array.getElem_toList hi).symm
-  obtain ⟨hri, hnk⟩ := hrel i hi (by simpa [← hsize] using hi)
+  obtain ⟨hri, hnk, hkind⟩ := hrel i hi (by simpa [← hsize] using hi)
   have hzri : z ∈ Certified.region rs[i] := by simpa only [hir'] using hzr
   have hzsq : z ∈ DyadicSquare.closedSquare atoms[i].square := by
     rw [hri] at hzri
-    simpa only [Certified.region, DyadicRootIsolation.region, if_pos hnk]
+    simpa only [Certified.region, DyadicRootIsolation.region, if_pos hkind]
       using hzri
   let fi : Fin atoms.size := ⟨i, by simpa [← hsize] using hi⟩
   refine ⟨fi, hzsq, ?_⟩

--- a/bench/HexNumberField/Bench.lean
+++ b/bench/HexNumberField/Bench.lean
@@ -63,10 +63,10 @@ private def degreeTenSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 19770730768400532067 64, 0, 60⟩
 
 private def degreeTenRep : RefinedIsolation degreeTenPoly :=
-  ⟨⟨degreeTenSquare, by
+  ⟨⟨degreeTenSquare, .ofWitness (by
       set_option maxRecDepth 100000 in
       set_option exponentiation.threshold 2000 in
-        decide⟩,
+        decide)⟩,
     by
       set_option maxRecDepth 100000 in
       set_option exponentiation.threshold 2000 in
@@ -140,7 +140,7 @@ private def sqrtTwoSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
 
 private def sqrtTwoRep : RefinedIsolation sqrtTwoPoly :=
-  ⟨⟨sqrtTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨sqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def sqrtTwo? : Option AlgebraicRoot :=
   if hsimple : HasOnlySimpleRoots sqrtTwoPoly then
@@ -156,7 +156,7 @@ private def sqrtThreeSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 222 7, 0, 8⟩
 
 private def sqrtThreeRep : RefinedIsolation sqrtThreePoly :=
-  ⟨⟨sqrtThreeSquare, by decide⟩, by decide⟩
+  ⟨⟨sqrtThreeSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def sqrtThree? : Option AlgebraicRoot :=
   if hsimple : HasOnlySimpleRoots sqrtThreePoly then
@@ -265,7 +265,7 @@ private def enclosingSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 6074001000 32, 0, 32⟩
 
 private def enclosingRep : RefinedIsolation enclosingPoly :=
-  ⟨⟨enclosingSquare, by decide⟩, by decide⟩
+  ⟨⟨enclosingSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def enclosingRoot? : Option AlgebraicRoot :=
   if hsimple : HasOnlySimpleRoots enclosingPoly then

--- a/bench/HexNumberFieldTower/Bench.lean
+++ b/bench/HexNumberFieldTower/Bench.lean
@@ -108,7 +108,7 @@ private def sqrtTwoSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
 
 private def sqrtTwoRep : RefinedIsolation sqrtTwoPoly :=
-  ⟨⟨sqrtTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨sqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def sqrtTwo? (_ : Unit) : Option (Extension rat) :=
   if hirred : ZPoly.isIrreducible sqrtTwoPoly = true then
@@ -128,7 +128,7 @@ private def sqrtThreeSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 222 7, 0, 8⟩
 
 private def sqrtThreeRep : RefinedIsolation sqrtThreePoly :=
-  ⟨⟨sqrtThreeSquare, by decide⟩, by decide⟩
+  ⟨⟨sqrtThreeSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def sqrtThree? (_ : Unit) : Option AlgebraicRoot :=
   if hsimple : HasOnlySimpleRoots sqrtThreePoly then
@@ -146,7 +146,7 @@ private def fourthRootTwoSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 77936 16, 0, 17⟩
 
 private def fourthRootTwoRep : RefinedIsolation fourthRootTwoPoly :=
-  ⟨⟨fourthRootTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨fourthRootTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def fourthRootTwo? (_ : Unit) : Option AlgebraicRoot :=
   if hsimple : HasOnlySimpleRoots fourthRootTwoPoly then
@@ -167,7 +167,7 @@ private def retryThetaSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 1371068573887 40, 0, 16⟩
 
 private def retryThetaRep : RefinedIsolation retryThetaPoly :=
-  ⟨⟨retryThetaSquare, by decide⟩, by decide⟩
+  ⟨⟨retryThetaSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def retryTheta? (_ : Unit) : Option AlgebraicNumber :=
   if hsimple : HasOnlySimpleRoots retryThetaPoly then
@@ -189,7 +189,7 @@ private def retryAlphaSquare : DyadicSquare :=
 set_option maxRecDepth 100000 in
 set_option exponentiation.threshold 1000 in
 private def retryAlphaRep : RefinedIsolation retryAlphaPoly :=
-  ⟨⟨retryAlphaSquare, by decide⟩, by decide⟩
+  ⟨⟨retryAlphaSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def retryAlpha? (_ : Unit) : Option AlgebraicNumber :=
   if hsimple : HasOnlySimpleRoots retryAlphaPoly then

--- a/conformance/HexNumberField/Conformance.lean
+++ b/conformance/HexNumberField/Conformance.lean
@@ -19,6 +19,7 @@ Covered operations:
 - lazy `AlgebraicRoot` negation, addition, subtraction, multiplication,
   inversion, division, and exactification in both checked and total forms;
 - canonical `AlgebraicNumber` arithmetic through its public instances;
+- canonical rational construction, casts, scalar action, and powers;
 - semantic equality of lazy values represented by different polynomials;
 - checked and total fixed-field and algebraic-coefficient root APIs.
 
@@ -45,7 +46,7 @@ private def sqrtTwoSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
 
 private def sqrtTwoRep : RefinedIsolation sqrtTwoPoly :=
-  ⟨⟨sqrtTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨sqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def sqrtTwoRoot : SimpleRoot sqrtTwoPoly :=
   SimpleRoot.mk sqrtTwoRep
@@ -68,7 +69,7 @@ private def negSqrtTwoSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec (-181) 7, 0, 8⟩
 
 private def negSqrtTwoRep : RefinedIsolation sqrtTwoPoly :=
-  ⟨⟨negSqrtTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨negSqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def negSqrtTwo? : Option AlgebraicRoot :=
   if hsimple : HasOnlySimpleRoots sqrtTwoPoly then
@@ -90,7 +91,7 @@ private def sqrtThreeSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 222 7, 0, 8⟩
 
 private def sqrtThreeRep : RefinedIsolation sqrtThreePoly :=
-  ⟨⟨sqrtThreeSquare, by decide⟩, by decide⟩
+  ⟨⟨sqrtThreeSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def sqrtThree? : Option AlgebraicRoot :=
   if hsimple : HasOnlySimpleRoots sqrtThreePoly then
@@ -112,7 +113,7 @@ private def tinySquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 1 10, 0, 16⟩
 
 private def tinyRep : RefinedIsolation tinyPoly :=
-  ⟨⟨tinySquare, by decide⟩, by decide⟩
+  ⟨⟨tinySquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def tiny? : Option AlgebraicRoot :=
   if hsimple : HasOnlySimpleRoots tinyPoly then
@@ -134,7 +135,7 @@ private def twoWithZeroSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 2 0, 0, 8⟩
 
 private def twoWithZeroRep : RefinedIsolation twoWithZeroPoly :=
-  ⟨⟨twoWithZeroSquare, by decide⟩, by decide⟩
+  ⟨⟨twoWithZeroSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def twoWithZero? : Option AlgebraicRoot :=
   if hsimple : HasOnlySimpleRoots twoWithZeroPoly then
@@ -157,7 +158,7 @@ private def enclosingSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 6074001000 32, 0, 32⟩
 
 private def enclosingRep : RefinedIsolation enclosingPoly :=
-  ⟨⟨enclosingSquare, by decide⟩, by decide⟩
+  ⟨⟨enclosingSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def enclosingRoot? : Option AlgebraicRoot :=
   if hsimple : HasOnlySimpleRoots enclosingPoly then
@@ -316,6 +317,28 @@ private def sqrtThreeExact? : Option AlgebraicNumber :=
         (a - a).isZero && (a * 0).isZero &&
         ((0 : AlgebraicNumber)⁻¹).isZero && (a / 0).isZero
   | _, _ => false
+
+-- Canonical rational construction supplies the ordinary executable field
+-- surface used by the companion's law-bearing instance.
+#guard
+  let one : AlgebraicNumber := 1
+  let two : AlgebraicNumber := 2
+  let negTwo : AlgebraicNumber := AlgebraicNumber.ofRat (-2)
+  AlgebraicNumber.ofRat 0 == 0 &&
+    one == AlgebraicNumber.ofRat 1 &&
+    two == one + one && negTwo == -two &&
+    ((5 : Nat) : AlgebraicNumber) == AlgebraicNumber.ofRat 5 &&
+    ((-5 : Int) : AlgebraicNumber) == AlgebraicNumber.ofRat (-5) &&
+    ((3 : Rat) • one) == AlgebraicNumber.ofRat 3 &&
+    ((3 : Nat) • one) == AlgebraicNumber.ofRat 3 &&
+    ((-3 : Int) • two) == AlgebraicNumber.ofRat (-6) &&
+    one ^ (7 : Nat) == one && two ^ (0 : Int) == one &&
+    two ^ (-1 : Int) == AlgebraicNumber.ofRat (1 / 2)
+
+#guard
+  match sqrtTwoExact? with
+  | some a => a ^ (2 : Nat) == AlgebraicNumber.ofRat 2
+  | none => false
 
 -- Same selected value through different enclosing polynomials; opposite
 -- conjugates of the same polynomial must not be confused.

--- a/conformance/HexNumberField/EmitFixtures.lean
+++ b/conformance/HexNumberField/EmitFixtures.lean
@@ -41,7 +41,7 @@ private def sqrtTwoSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
 
 private def sqrtTwoRep : RefinedIsolation sqrtTwoPoly :=
-  ⟨⟨sqrtTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨sqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def sqrtTwo? : Option AlgebraicRoot :=
   if hsimple : HasOnlySimpleRoots sqrtTwoPoly then
@@ -63,7 +63,7 @@ private def sqrtThreeSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 222 7, 0, 8⟩
 
 private def sqrtThreeRep : RefinedIsolation sqrtThreePoly :=
-  ⟨⟨sqrtThreeSquare, by decide⟩, by decide⟩
+  ⟨⟨sqrtThreeSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def sqrtThree? : Option AlgebraicRoot :=
   if hsimple : HasOnlySimpleRoots sqrtThreePoly then
@@ -88,7 +88,7 @@ private def twoWithZeroSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 2 0, 0, 8⟩
 
 private def twoWithZeroRep : RefinedIsolation twoWithZeroPoly :=
-  ⟨⟨twoWithZeroSquare, by decide⟩, by decide⟩
+  ⟨⟨twoWithZeroSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def twoWithZero? : Option AlgebraicRoot :=
   if hsimple : HasOnlySimpleRoots twoWithZeroPoly then
@@ -111,7 +111,7 @@ private def enclosingSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 6074001000 32, 0, 32⟩
 
 private def enclosingRep : RefinedIsolation enclosingPoly :=
-  ⟨⟨enclosingSquare, by decide⟩, by decide⟩
+  ⟨⟨enclosingSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def enclosingRoot? : Option AlgebraicRoot :=
   if hsimple : HasOnlySimpleRoots enclosingPoly then

--- a/conformance/HexNumberFieldTower/Conformance.lean
+++ b/conformance/HexNumberFieldTower/Conformance.lean
@@ -58,7 +58,7 @@ private def sqrtTwoSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
 
 private def sqrtTwoRep : RefinedIsolation sqrtTwoPoly :=
-  ⟨⟨sqrtTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨sqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def sqrtTwoRoot : SimpleRoot sqrtTwoPoly :=
   SimpleRoot.mk sqrtTwoRep
@@ -77,7 +77,7 @@ private def sqrtTwo? : Option (Extension rat) :=
 private def negSqrtTwoPoly : ZPoly := DensePoly.ofList [2, 0, -1]
 
 private def negSqrtTwoRep : RefinedIsolation negSqrtTwoPoly :=
-  ⟨⟨sqrtTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨sqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def negSqrtTwo? : Option (Extension rat) :=
   if hirred : ZPoly.isIrreducible negSqrtTwoPoly = true then
@@ -95,7 +95,7 @@ private def negativeSqrtTwoSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec (-181) 7, 0, 8⟩
 
 private def negativeSqrtTwoRep : RefinedIsolation sqrtTwoPoly :=
-  ⟨⟨negativeSqrtTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨negativeSqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def negativeSqrtTwo? : Option (Extension rat) :=
   if hirred : ZPoly.isIrreducible sqrtTwoPoly = true then
@@ -116,7 +116,7 @@ private def sqrtThreeHalvesSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 157 7, 0, 9⟩
 
 private def sqrtThreeHalvesRep : RefinedIsolation sqrtThreeHalvesPoly :=
-  ⟨⟨sqrtThreeHalvesSquare, by decide⟩, by decide⟩
+  ⟨⟨sqrtThreeHalvesSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def sqrtThreeHalves? : Option (Extension rat) :=
   if hirred : ZPoly.isIrreducible sqrtThreeHalvesPoly = true then
@@ -136,7 +136,7 @@ private def threeHalvesSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 3 1, 0, 8⟩
 
 private def threeHalvesRep : RefinedIsolation threeHalvesPoly :=
-  ⟨⟨threeHalvesSquare, by decide⟩, by decide⟩
+  ⟨⟨threeHalvesSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def threeHalves? : Option (Extension rat) :=
   if hirred : ZPoly.isIrreducible threeHalvesPoly = true then
@@ -156,7 +156,7 @@ private def sqrtThreeSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 222 7, 0, 8⟩
 
 private def sqrtThreeRep : RefinedIsolation sqrtThreePoly :=
-  ⟨⟨sqrtThreeSquare, by decide⟩, by decide⟩
+  ⟨⟨sqrtThreeSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def sqrtThree? : Option AlgebraicRoot :=
   if hsimple : HasOnlySimpleRoots sqrtThreePoly then
@@ -179,7 +179,7 @@ private def fourthRootTwoSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 77936 16, 0, 17⟩
 
 private def fourthRootTwoRep : RefinedIsolation fourthRootTwoPoly :=
-  ⟨⟨fourthRootTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨fourthRootTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def fourthRootTwo? : Option AlgebraicRoot :=
   if hsimple : HasOnlySimpleRoots fourthRootTwoPoly then
@@ -207,7 +207,7 @@ private def retryThetaSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 1371068573887 40, 0, 16⟩
 
 private def retryThetaRep : RefinedIsolation retryThetaPoly :=
-  ⟨⟨retryThetaSquare, by decide⟩, by decide⟩
+  ⟨⟨retryThetaSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def retryTheta? : Option AlgebraicNumber :=
   if hsimple : HasOnlySimpleRoots retryThetaPoly then
@@ -234,7 +234,7 @@ private def retryAlphaSquare : DyadicSquare :=
 set_option maxRecDepth 100000 in
 set_option exponentiation.threshold 1000 in
 private def retryAlphaRep : RefinedIsolation retryAlphaPoly :=
-  ⟨⟨retryAlphaSquare, by decide⟩, by decide⟩
+  ⟨⟨retryAlphaSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def retryAlpha? : Option AlgebraicNumber :=
   if hsimple : HasOnlySimpleRoots retryAlphaPoly then

--- a/conformance/HexNumberFieldTower/EmitFixtures.lean
+++ b/conformance/HexNumberFieldTower/EmitFixtures.lean
@@ -37,7 +37,7 @@ private def sqrtTwoSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 181 7, 0, 8⟩
 
 private def sqrtTwoRep : RefinedIsolation sqrtTwoPoly :=
-  ⟨⟨sqrtTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨sqrtTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def sqrtTwoRoot : SimpleRoot sqrtTwoPoly :=
   SimpleRoot.mk sqrtTwoRep
@@ -59,7 +59,7 @@ private def sqrtThreeSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 222 7, 0, 8⟩
 
 private def sqrtThreeRep : RefinedIsolation sqrtThreePoly :=
-  ⟨⟨sqrtThreeSquare, by decide⟩, by decide⟩
+  ⟨⟨sqrtThreeSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def sqrtThree? : Option AlgebraicRoot :=
   if hsimple : HasOnlySimpleRoots sqrtThreePoly then
@@ -82,7 +82,7 @@ private def fourthRootTwoSquare : DyadicSquare :=
   ⟨Dyadic.ofIntWithPrec 77936 16, 0, 17⟩
 
 private def fourthRootTwoRep : RefinedIsolation fourthRootTwoPoly :=
-  ⟨⟨fourthRootTwoSquare, by decide⟩, by decide⟩
+  ⟨⟨fourthRootTwoSquare, .ofWitness (by decide)⟩, by decide⟩
 
 private def fourthRootTwo? : Option AlgebraicRoot :=
   if hsimple : HasOnlySimpleRoots fourthRootTwoPoly then

--- a/conformance/HexRoots/Conformance.lean
+++ b/conformance/HexRoots/Conformance.lean
@@ -297,7 +297,7 @@ kernel `decide` (degree 3), and the `RefinedIsolation` precision side-condition
 
 /-- A coarse atom of `rat1` at the real root `re`, half-width `2^{−prec}`. -/
 private def rootAtom (re prec : Int) (h : atomWitness rat1 ⟨re, 0, prec⟩) :
-    DyadicRootIsolation rat1 := ⟨⟨re, 0, prec⟩, h⟩
+    DyadicRootIsolation rat1 := ⟨⟨re, 0, prec⟩, .ofWitness h⟩
 
 private def atom1_20 : DyadicRootIsolation rat1 := rootAtom 1 20 (Or.inl (by decide))
 private def atom1_22 : DyadicRootIsolation rat1 := rootAtom 1 22 (Or.inl (by decide))
@@ -321,7 +321,7 @@ private def atom2_20 : DyadicRootIsolation rat1 := rootAtom 2 20 (Or.inl (by dec
 #guard (atom1_20.refineTo? 20 .nkThenPellet).map (·.square.prec) == some 20
 
 private def repeatedAwayAtom : DyadicRootIsolation repeatedAway :=
-  ⟨⟨1, 0, 32⟩, Or.inl (by decide)⟩
+  ⟨⟨1, 0, 32⟩, .nk (by decide)⟩
 
 -- Mixed refinement needs only local simplicity of the selected root; the
 -- repeated root at `2` does not prevent total refinement of the atom at `1`.

--- a/progress/20260802T204006Z.md
+++ b/progress/20260802T204006Z.md
@@ -1,0 +1,20 @@
+# Accomplished
+
+- Replaced the NumberField negation trust boundary with structural atom-certificate transport through polynomial reflection and sign normalization, with shared Mathlib soundness proofs and supporting polynomial/Mahler invariants.
+- Sealed `AlgebraicNumber` around deterministic canonical representative provenance and proved canonical representatives unique, yielding `AlgebraicNumber.toComplex_injective` without new axioms.
+- Added total executable rational construction, casts, scalar actions, repeated-squaring powers, lawful Boolean/propositional equality, and a global `Field AlgebraicNumber` whose data fields are the existing executable operations.
+- Updated NumberField/Roots specs, the manual, conformance, fixtures, benches, and downstream Tower certificate literals. The obsolete expansion-plan document is absent.
+- Incorporated independent review findings: forced Field-dictionary regression checks, single-pass atom certification, logarithmic powers, coherent numeral priority, broader conformance coverage, lawful decidable equality, and explicit canonical-provenance documentation.
+- Verified `lake build` (9,727 jobs), `lake build HexConformance` (9,312 jobs), all 9 NumberField benchmarks, fixture reproducibility, DAG/phase checks, Mathlib-free bench lint, and axiom guards. Local FLINT/PARI packages were unavailable, so the external oracle leg remains for CI.
+
+# Current frontier
+
+The cohesive NumberField milestone is implementation-complete, independently reviewed, and locally green. It is ready to commit and open as one PR based on merged `origin/main`.
+
+# Next step
+
+Commit this progress record with the NumberField implementation, open the single milestone PR, monitor its actual Actions jobs, address any CI/review findings, and merge it before beginning NumberFieldTower.
+
+# Blockers
+
+None. The Tower proof holes are intentionally outside this milestone and remain for the next milestone after this PR merges.

--- a/progress/20260802T204006Z.md
+++ b/progress/20260802T204006Z.md
@@ -6,6 +6,7 @@
 - Updated NumberField/Roots specs, the manual, conformance, fixtures, benches, and downstream Tower certificate literals. The obsolete expansion-plan document is absent.
 - Incorporated independent review findings: forced Field-dictionary regression checks, single-pass atom certification, logarithmic powers, coherent numeral priority, broader conformance coverage, lawful decidable equality, and explicit canonical-provenance documentation.
 - Verified `lake build` (9,727 jobs), `lake build HexConformance` (9,312 jobs), all 9 NumberField benchmarks, fixture reproducibility, DAG/phase checks, Mathlib-free bench lint, and axiom guards. Local FLINT/PARI packages were unavailable, so the external oracle leg remains for CI.
+- Classified the two additive `HexPolyZ` reflection-support changes as factorization-runtime-neutral with exact blob-bound exemptions; the factor-sweep freshness gate now passes and the exemptions expire on any further edit.
 
 # Current frontier
 

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -16,5 +16,17 @@
     "baseline_blob": "eb455d18622fadc04de194c129936ee771df248c",
     "current_blob": "4efda541aabadce1a70ffe45c339274894a17d68",
     "reason": "Rewords one docstring to drop em-dashes; no declaration, definition, or attribute changes."
+  },
+  {
+    "path": "HexPolyZ/IntegerPolynomial.lean",
+    "baseline_blob": "5e4be17de30b87f6e2545d91932c977884181fad",
+    "current_blob": "2a98177eb8b631f974050c535d88e96cd0ccdcd6",
+    "reason": "Adds reflection invariant theorems only; the executable factorization call graph is unchanged."
+  },
+  {
+    "path": "HexPolyZ/Rational.lean",
+    "baseline_blob": "e43de53cbeced2ebe811ff1a6a6fa6ceaf843c14",
+    "current_blob": "ba568b38f9482f906439858ac72b823d2b933be7",
+    "reason": "Adds an unused rational-reflection helper and supporting theorems for NumberField certificate transport; existing factorization definitions and their call graph are unchanged."
   }
 ]


### PR DESCRIPTION
## Summary

- replace NumberField negation proof holes with structural root-certificate transport and shared Mathlib soundness proofs
- seal canonical algebraic numbers around deterministic representative provenance, prove complex interpretation injective, and add lawful Boolean/propositional equality
- add executable rational construction, casts, scalar actions, repeated-squaring powers, and a global lawful Field instance preserving the executable operations
- update the Roots and NumberField specs, manual, conformance, benches, and downstream certificate literals

## Verification

- lake build (9,727 jobs)
- lake build HexConformance (9,312 jobs)
- lake exe hexnumberfield_bench verify (9/9)
- NumberField fixture regeneration matches the committed JSONL
- python3 scripts/check_dag.py
- python3 scripts/check_phase4.py
- python3 scripts/ci/check_benches_mathlib_free.py
- independent Claude Opus review completed; executable-regression, performance, instance-coherence, conformance, and SPEC findings incorporated

The local environment lacks python-flint/cypari2, so the external NumberField oracle cross-check is left to the merge-gating CI job.