### PR TITLE
perf: pack the Berlekamp fixed-space matrix into UInt32 words

### DIFF
--- a/HexBerlekamp.lean
+++ b/HexBerlekamp.lean
@@ -6,7 +6,7 @@ Authors: Kim Morrison
 
 module
 
-public import HexBerlekamp.BerlekampMatrix
+public import HexBerlekamp.PackedKernel
 public import HexBerlekamp.CertificateSyntax
 public import HexBerlekamp.Factored
 public import HexBerlekamp.PolynomialTactic

--- a/HexBerlekamp/BerlekampMatrix.lean
+++ b/HexBerlekamp/BerlekampMatrix.lean
@@ -680,23 +680,10 @@ Berlekamp-local linear-algebra implementation.
 -/
 @[expose]
 def fixedSpaceKernelVectors (f : FpPoly p) (hmonic : DensePoly.Monic f)
-    [inst : Lean.Grind.Field (ZMod64 p)] :
+    [ZMod64.PrimeModulus p] :
     Vector (Vector (ZMod64 p) (basisSize f))
       (basisSize f - Matrix.rowReduce_rank (fixedSpaceMatrix f hmonic)) :=
   Matrix.nullspace (fixedSpaceMatrix f hmonic)
-
-/-- The fixed-space kernel basis converted back to polynomial representatives.
-
-Compute the vector basis once and map the conversion over it. Keep the basis
-outside any per-index body so matrix construction and row reduction remain
-shared; mapping also carries its dependent length without recomputing rank. -/
-@[expose]
-def fixedSpaceKernel (f : FpPoly p) (hmonic : DensePoly.Monic f)
-    [inst : Lean.Grind.Field (ZMod64 p)] :
-    Vector (FpPoly p)
-      (basisSize f - Matrix.rowReduce_rank (fixedSpaceMatrix f hmonic)) :=
-  let vectors := fixedSpaceKernelVectors f hmonic
-  vectors.map vectorToPoly
 
 /-- Vector-level executable Berlekamp kernel condition for the fixed-space
 matrix `Q_f - I`. -/
@@ -747,21 +734,6 @@ theorem fixedSpaceKernelVectors_sound (f : FpPoly p) (hmonic : DensePoly.Monic f
     IsFixedSpaceKernelVector f hmonic ((fixedSpaceKernelVectors f hmonic).get k) := by
   unfold IsFixedSpaceKernelVector fixedSpaceKernelVectors
   exact Matrix.nullspace_sound (fixedSpaceMatrix f hmonic) k
-
-/-- Every polynomial representative returned by `fixedSpaceKernel` satisfies the
-executable fixed-space kernel condition. -/
-theorem fixedSpaceKernel_sound (f : FpPoly p) (hmonic : DensePoly.Monic f)
-    [ZMod64.PrimeModulus p]
-    (k : Fin (basisSize f -
-      Matrix.rowReduce_rank (fixedSpaceMatrix f hmonic))) :
-    IsFixedSpaceKernelPolynomial f hmonic ((fixedSpaceKernel f hmonic).get k) := by
-  have hk : (fixedSpaceKernel f hmonic).get k =
-      vectorToPoly ((fixedSpaceKernelVectors f hmonic).get k) := by
-    unfold fixedSpaceKernel
-    exact Vector.getElem_map vectorToPoly k.isLt
-  unfold IsFixedSpaceKernelPolynomial
-  rw [hk, coeffVector_vectorToPoly]
-  exact fixedSpaceKernelVectors_sound f hmonic k
 
 /-- Every vector satisfying the executable fixed-space kernel condition is a
 linear combination of the public nullspace-basis matrix for `Q_f - I`. -/

--- a/HexBerlekamp/Factor.lean
+++ b/HexBerlekamp/Factor.lean
@@ -965,7 +965,6 @@ splitting preserves `factorProduct` without using square-freeness, so the
 product equality holds for every monic input. -/
 theorem factorProduct_berlekampFactor
     [ZMod64.PrimeModulus p]
-    [ZMod64.PrimeModulus p]
     (f : FpPoly p) (hmonic : DensePoly.Monic f) :
     factorProduct (berlekampFactor f hmonic).factors = f :=
   factorProduct_fullySplit ((fixedSpaceKernel f hmonic).toList) (f.size + 1) f
@@ -976,7 +975,6 @@ product of the returned factors for any monic input.
 -/
 theorem prod_berlekampFactor
     (f : FpPoly p) (hmonic : DensePoly.Monic f)
-    [ZMod64.PrimeModulus p]
     [ZMod64.PrimeModulus p] :
     (berlekampFactor f hmonic).product = f := by
   simp only [Factorization.product_def]
@@ -1260,7 +1258,6 @@ Mathlib-free finite-field module.
 theorem kernelWitnessSplit?_none_of_berlekampFactor_factors_length_le_one
     (f : FpPoly p) (hmonic : DensePoly.Monic f)
     [ZMod64.PrimeModulus p]
-    [ZMod64.PrimeModulus p]
     (hsmall : (berlekampFactor f hmonic).factors.length ≤ 1) :
     ∀ w ∈ (fixedSpaceKernel f hmonic).toList,
       kernelWitnessSplit? f w = none := by
@@ -1498,7 +1495,6 @@ discharges this hypothesis from `gcd f f' = 1`; see
 theorem berlekampFactor_factors_nodup_of_no_squared
     (f : FpPoly p) (hmonic : DensePoly.Monic f)
     [ZMod64.PrimeModulus p]
-    [ZMod64.PrimeModulus p]
     (h_no_squared : ∀ g : FpPoly p,
         g * g ∣ f → ¬ (0 < g.degree?.getD 0)) :
     (berlekampFactor f hmonic).factors.Nodup := by
@@ -1585,7 +1581,6 @@ irreducibility chain discharges the no-squared hypothesis from
 `isUnitPolynomial_of_squareFree_of_squared_dvd`. -/
 theorem berlekampFactor_factors_pairwise_coprime
     [ZMod64.PrimeModulus p]
-    [ZMod64.PrimeModulus p]
     (f : FpPoly p) (hmonic : DensePoly.Monic f)
     (h_no_squared : ∀ g : FpPoly p,
         g * g ∣ f → ¬ (0 < g.degree?.getD 0)) :
@@ -1648,7 +1643,6 @@ needed by `berlekampFactor_factors_nodup_of_no_squared` is not needed here:
 positivity is preserved by every split regardless of square-freeness. -/
 theorem berlekampFactor_factors_pos_degree
     [ZMod64.PrimeModulus p]
-    [ZMod64.PrimeModulus p]
     (f : FpPoly p) (hmonic : DensePoly.Monic f)
     (hf_pos : 0 < f.degree?.getD 0) :
     ∀ g ∈ (berlekampFactor f hmonic).factors, 0 < g.degree?.getD 0 :=
@@ -1659,7 +1653,6 @@ exactly the singleton `[f]`.  A polynomial of size ≤ 1 has no positive-degree
 divisors, so it admits no kernel-witness split and `fullySplit` emits it as a
 leaf. -/
 theorem berlekampFactor_factors_eq_singleton_of_size_le_one
-    [ZMod64.PrimeModulus p]
     [ZMod64.PrimeModulus p]
     (f : FpPoly p) (hmonic : DensePoly.Monic f)
     (hsize : f.size ≤ 1) :
@@ -1688,7 +1681,6 @@ degree case (where every factor has positive degree via
 `berlekampFactor_factors_pos_degree`) from the size-≤-1 case (where the factor
 list is the singleton `[f]` and `f` is monic, hence nonzero). -/
 theorem berlekampFactor_factors_ne_zero
-    [ZMod64.PrimeModulus p]
     [ZMod64.PrimeModulus p]
     (f : FpPoly p) (hmonic : DensePoly.Monic f) :
     ∀ g ∈ (berlekampFactor f hmonic).factors, g ≠ 0 := by

--- a/HexBerlekamp/Factor.lean
+++ b/HexBerlekamp/Factor.lean
@@ -7,7 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexBasic
-public import HexBerlekamp.BerlekampMatrix
+public import HexBerlekamp.PackedKernel
 
 public section
 
@@ -375,7 +375,7 @@ building the fixed-space kernel of `Q_f - I` and fully splitting the input
 with the resulting kernel representatives.
 -/
 def berlekampFactor (f : FpPoly p) (hmonic : DensePoly.Monic f)
-    [Lean.Grind.Field (ZMod64 p)] : Factorization p :=
+    [ZMod64.PrimeModulus p] : Factorization p :=
   let witnesses := (fixedSpaceKernel f hmonic).toList
   { input := f
     factors := fullySplit witnesses (f.size + 1) f }
@@ -964,7 +964,7 @@ private theorem factorProduct_fullySplit
 splitting preserves `factorProduct` without using square-freeness, so the
 product equality holds for every monic input. -/
 theorem factorProduct_berlekampFactor
-    [Lean.Grind.Field (ZMod64 p)]
+    [ZMod64.PrimeModulus p]
     [ZMod64.PrimeModulus p]
     (f : FpPoly p) (hmonic : DensePoly.Monic f) :
     factorProduct (berlekampFactor f hmonic).factors = f :=
@@ -976,7 +976,7 @@ product of the returned factors for any monic input.
 -/
 theorem prod_berlekampFactor
     (f : FpPoly p) (hmonic : DensePoly.Monic f)
-    [Lean.Grind.Field (ZMod64 p)]
+    [ZMod64.PrimeModulus p]
     [ZMod64.PrimeModulus p] :
     (berlekampFactor f hmonic).product = f := by
   simp only [Factorization.product_def]
@@ -1025,7 +1025,7 @@ private theorem fullySplit_succ_eq_self_of_none
 /-- Executable Berlekamp factorization always retains at least one factor. -/
 theorem berlekampFactor_factors_ne_nil
     (f : FpPoly p) (hmonic : DensePoly.Monic f)
-    [Lean.Grind.Field (ZMod64 p)] :
+    [ZMod64.PrimeModulus p] :
     (berlekampFactor f hmonic).factors ≠ [] :=
   fullySplit_ne_nil ((fixedSpaceKernel f hmonic).toList) (f.size + 1) f
 
@@ -1260,7 +1260,7 @@ Mathlib-free finite-field module.
 theorem kernelWitnessSplit?_none_of_berlekampFactor_factors_length_le_one
     (f : FpPoly p) (hmonic : DensePoly.Monic f)
     [ZMod64.PrimeModulus p]
-    [Lean.Grind.Field (ZMod64 p)]
+    [ZMod64.PrimeModulus p]
     (hsmall : (berlekampFactor f hmonic).factors.length ≤ 1) :
     ∀ w ∈ (fixedSpaceKernel f hmonic).toList,
       kernelWitnessSplit? f w = none := by
@@ -1497,7 +1497,7 @@ discharges this hypothesis from `gcd f f' = 1`; see
 `HexBerlekamp/RabinSoundness.lean`. -/
 theorem berlekampFactor_factors_nodup_of_no_squared
     (f : FpPoly p) (hmonic : DensePoly.Monic f)
-    [Lean.Grind.Field (ZMod64 p)]
+    [ZMod64.PrimeModulus p]
     [ZMod64.PrimeModulus p]
     (h_no_squared : ∀ g : FpPoly p,
         g * g ∣ f → ¬ (0 < g.degree?.getD 0)) :
@@ -1584,7 +1584,7 @@ irreducibility chain discharges the no-squared hypothesis from
 `gcd f f' = 1`; see callers that pair this with
 `isUnitPolynomial_of_squareFree_of_squared_dvd`. -/
 theorem berlekampFactor_factors_pairwise_coprime
-    [Lean.Grind.Field (ZMod64 p)]
+    [ZMod64.PrimeModulus p]
     [ZMod64.PrimeModulus p]
     (f : FpPoly p) (hmonic : DensePoly.Monic f)
     (h_no_squared : ∀ g : FpPoly p,
@@ -1647,7 +1647,7 @@ Berlekamp factor list has positive degree.  The squareness-free hypothesis
 needed by `berlekampFactor_factors_nodup_of_no_squared` is not needed here:
 positivity is preserved by every split regardless of square-freeness. -/
 theorem berlekampFactor_factors_pos_degree
-    [Lean.Grind.Field (ZMod64 p)]
+    [ZMod64.PrimeModulus p]
     [ZMod64.PrimeModulus p]
     (f : FpPoly p) (hmonic : DensePoly.Monic f)
     (hf_pos : 0 < f.degree?.getD 0) :
@@ -1659,7 +1659,7 @@ exactly the singleton `[f]`.  A polynomial of size ≤ 1 has no positive-degree
 divisors, so it admits no kernel-witness split and `fullySplit` emits it as a
 leaf. -/
 theorem berlekampFactor_factors_eq_singleton_of_size_le_one
-    [Lean.Grind.Field (ZMod64 p)]
+    [ZMod64.PrimeModulus p]
     [ZMod64.PrimeModulus p]
     (f : FpPoly p) (hmonic : DensePoly.Monic f)
     (hsize : f.size ≤ 1) :
@@ -1688,7 +1688,7 @@ degree case (where every factor has positive degree via
 `berlekampFactor_factors_pos_degree`) from the size-≤-1 case (where the factor
 list is the singleton `[f]` and `f` is monic, hence nonzero). -/
 theorem berlekampFactor_factors_ne_zero
-    [Lean.Grind.Field (ZMod64 p)]
+    [ZMod64.PrimeModulus p]
     [ZMod64.PrimeModulus p]
     (f : FpPoly p) (hmonic : DensePoly.Monic f) :
     ∀ g ∈ (berlekampFactor f hmonic).factors, g ≠ 0 := by
@@ -1775,7 +1775,7 @@ private theorem fullySplit_unsplittable
 factorization of a monic input resists every fixed-space kernel-witness split.
 The `f.size + 1` fuel always suffices to reach the witness-irreducible leaves. -/
 theorem kernelWitnessSplit?_none_of_berlekampFactor_factors
-    [Lean.Grind.Field (ZMod64 p)] [ZMod64.PrimeModulus p]
+    [ZMod64.PrimeModulus p]
     (f : FpPoly p) (hmonic : DensePoly.Monic f) :
     ∀ g ∈ (berlekampFactor f hmonic).factors,
       ∀ w ∈ (fixedSpaceKernel f hmonic).toList, kernelWitnessSplit? g w = none := by
@@ -1795,7 +1795,7 @@ theorem kernelWitnessSplit?_none_of_berlekampFactor_factors
 /-- Every factor returned by the executable Berlekamp factorization divides the
 input.  Immediate from `factorProduct_berlekampFactor`. -/
 theorem berlekampFactor_factors_dvd
-    [Lean.Grind.Field (ZMod64 p)] [ZMod64.PrimeModulus p]
+    [ZMod64.PrimeModulus p]
     (f : FpPoly p) (hmonic : DensePoly.Monic f) :
     ∀ g ∈ (berlekampFactor f hmonic).factors, g ∣ f := by
   intro g hg

--- a/HexBerlekamp/Irreducibility.lean
+++ b/HexBerlekamp/Irreducibility.lean
@@ -68,7 +68,7 @@ Berlekamp's executable rank criterion: a nonconstant monic `f` passes when
 `rank(Q_f - I) = deg(f) - 1`.
 -/
 def berlekampRankTest (f : FpPoly p) (hmonic : DensePoly.Monic f)
-    [ZMod64.PrimeModulus p] : Bool :=
+    [Lean.Grind.Field (ZMod64 p)] : Bool :=
   let n := basisSize f
   decide (0 < n ∧ Matrix.rowReduce_rank (fixedSpaceMatrix f hmonic) = n - 1)
 
@@ -308,7 +308,7 @@ def buildIrreducibilityCertificate? (f : FpPoly p) (hmonic : DensePoly.Monic f) 
 /-- `berlekampRankTest` succeeds exactly when the fixed-space matrix has rank
 `deg(f) - 1`, the Berlekamp rank criterion. -/
 theorem berlekampRankTest_spec (f : FpPoly p) (hmonic : DensePoly.Monic f)
-    [ZMod64.PrimeModulus p] :
+    [Lean.Grind.Field (ZMod64 p)] :
     berlekampRankTest f hmonic = true ↔
       0 < basisSize f ∧
       Matrix.rowReduce_rank (fixedSpaceMatrix f hmonic) = basisSize f - 1 := by

--- a/HexBerlekamp/Irreducibility.lean
+++ b/HexBerlekamp/Irreducibility.lean
@@ -6,7 +6,7 @@ Authors: Kim Morrison
 
 module
 
-public import HexBerlekamp.BerlekampMatrix
+public import HexBerlekamp.PackedKernel
 
 public section
 
@@ -68,7 +68,7 @@ Berlekamp's executable rank criterion: a nonconstant monic `f` passes when
 `rank(Q_f - I) = deg(f) - 1`.
 -/
 def berlekampRankTest (f : FpPoly p) (hmonic : DensePoly.Monic f)
-    [Lean.Grind.Field (ZMod64 p)] : Bool :=
+    [ZMod64.PrimeModulus p] : Bool :=
   let n := basisSize f
   decide (0 < n ∧ Matrix.rowReduce_rank (fixedSpaceMatrix f hmonic) = n - 1)
 
@@ -308,7 +308,7 @@ def buildIrreducibilityCertificate? (f : FpPoly p) (hmonic : DensePoly.Monic f) 
 /-- `berlekampRankTest` succeeds exactly when the fixed-space matrix has rank
 `deg(f) - 1`, the Berlekamp rank criterion. -/
 theorem berlekampRankTest_spec (f : FpPoly p) (hmonic : DensePoly.Monic f)
-    [Lean.Grind.Field (ZMod64 p)] :
+    [ZMod64.PrimeModulus p] :
     berlekampRankTest f hmonic = true ↔
       0 < basisSize f ∧
       Matrix.rowReduce_rank (fixedSpaceMatrix f hmonic) = basisSize f - 1 := by

--- a/HexBerlekamp/PackedKernel.lean
+++ b/HexBerlekamp/PackedKernel.lean
@@ -1,0 +1,907 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexBerlekamp.BerlekampMatrix
+public import HexRowReduce.Pivot
+public import HexRowReduce.Loop
+public import HexRowReduce.Nullspace
+public import HexRowReduce.RowEchelon
+import all HexBerlekamp.BerlekampMatrix
+import all HexRowReduce.Pivot
+import all HexRowReduce.Loop
+import all HexRowReduce.Nullspace
+import all HexRowReduce.RowEchelon
+
+public section
+
+/-!
+A packed finite-field matrix for Berlekamp's fixed space.
+
+`Hex.Matrix (ZMod64 p)` stores one boxed residue per entry, and
+`Hex.Matrix.rowReduce` maintains an `n x n` transform in lockstep that the
+nullspace never reads. Both costs dominate the Berlekamp split on the large
+cyclotomic rows of the factorization corpus.
+
+This module keeps the same flat row-major backing but stores each residue as a
+`UInt32` word, faithful because `ZMod64.Bounds` caps the modulus at `2^31` and
+allocation-free because `lean_box_uint32` is a tagged immediate on a 64-bit
+runtime. The reduction loop is specialized end to end -- pivot search, swap,
+scale, elimination, and the nullspace readback -- and drops the transform.
+
+Every packed step is proved to interpret to the corresponding step of the
+generic development, and the whole file lands on one equality,
+`Hex.Berlekamp.fixedSpaceKernelVectors_eq_packed`, registered `@[csimp]` so
+that compiled code runs the packed path while the Berlekamp soundness and
+completeness proofs keep reasoning about ordinary matrices.
+-/
+
+namespace Hex
+
+namespace Berlekamp
+
+namespace Packed
+
+/-! # Modular arithmetic on packed words
+
+Residues are held as `UInt32` words below the modulus word `q`. The modulus
+bound `p < 2^31` makes the unreduced sum of two residues fit in a `UInt32` and
+the unreduced product of two arbitrary words fit in a `UInt64`, so neither
+operation needs a widening beyond `UInt64` and only the product needs a
+division.
+-/
+
+/-- Modular product of two packed words. The operands are widened to `UInt64`,
+where their product is exact for any `UInt32` inputs. -/
+@[inline] def mulMod (q a b : UInt32) : UInt32 :=
+  ((a.toUInt64 * b.toUInt64) % q.toUInt64).toUInt32
+
+/-- Modular sum of two packed residues below `q`. The unreduced sum fits in a
+`UInt32` because `q < 2^31`, so one conditional subtraction canonicalizes it. -/
+@[inline] def addMod (q a b : UInt32) : UInt32 :=
+  let s := a + b
+  if s < q then s else s - q
+
+/-- Modular negation of a packed residue below `q`. -/
+@[inline] def negMod (q a : UInt32) : UInt32 :=
+  if a == 0 then 0 else q - a
+
+/-! ## Word/residue conversion -/
+
+variable {p : Nat} [ZMod64.Bounds p]
+
+/-- The modulus as a packed word. -/
+@[inline] def modWord (p : Nat) [ZMod64.Bounds p] : UInt32 :=
+  UInt32.ofNat p
+
+/-- Read a packed word as a residue. -/
+@[inline] def toZMod (p : Nat) [ZMod64.Bounds p] (a : UInt32) : ZMod64 p :=
+  ZMod64.ofNat p a.toNat
+
+/-- Write a residue as a packed word. -/
+@[inline] def ofZMod (a : ZMod64 p) : UInt32 :=
+  a.val.toUInt32
+
+theorem toNat_lt_two_pow_32 (a : ZMod64 p) : a.toNat < 2 ^ 32 :=
+  Nat.lt_trans a.isLt (Nat.lt_trans (ZMod64.Bounds.pLtR (p := p)) (by decide))
+
+@[simp] theorem toNat_ofZMod (a : ZMod64 p) : (ofZMod a).toNat = a.toNat := by
+  show (a.val.toUInt32).toNat = a.toNat
+  rw [UInt64.toNat_toUInt32]
+  exact Nat.mod_eq_of_lt (toNat_lt_two_pow_32 a)
+
+@[simp] theorem toZMod_ofZMod (a : ZMod64 p) : toZMod p (ofZMod a) = a := by
+  rw [toZMod, toNat_ofZMod, ZMod64.ofNat_toNat]
+
+@[simp] theorem toNat_toZMod (a : UInt32) : (toZMod p a).toNat = a.toNat % p := by
+  simp [toZMod]
+
+@[simp] theorem toNat_modWord : (modWord p).toNat = p := by
+  show (UInt32.ofNat p).toNat = p
+  rw [UInt32.toNat_ofNat']
+  exact Nat.mod_eq_of_lt
+    (Nat.lt_trans (ZMod64.Bounds.pLtR (p := p)) (by decide))
+
+/-- Every packed word is below `2 ^ 32`. -/
+theorem toNat_lt_size (a : UInt32) : a.toNat < 2 ^ 32 := by
+  simpa [UInt32.size] using a.toNat_lt_size
+
+/-- The modulus is below `2 ^ 32`, so it is faithful as a packed word. -/
+theorem pLt32 : p < 2 ^ 32 :=
+  Nat.lt_trans (ZMod64.Bounds.pLtR (p := p)) (by decide)
+
+/-- A packed word below the modulus is recovered exactly by `toZMod`. -/
+theorem toNat_toZMod_of_lt {a : UInt32} (h : a.toNat < p) :
+    (toZMod p a).toNat = a.toNat := by
+  rw [toNat_toZMod, Nat.mod_eq_of_lt h]
+
+/-! ## Correctness of the packed operations -/
+
+theorem toNat_mulMod {q a b : UInt32} (hq : q.toNat = p) :
+    (mulMod q a b).toNat = (a.toNat * b.toNat) % p := by
+  have hprod : (a.toUInt64 * b.toUInt64).toNat = a.toNat * b.toNat := by
+    rw [UInt64.toNat_mul, UInt32.toNat_toUInt64, UInt32.toNat_toUInt64]
+    refine Nat.mod_eq_of_lt ?_
+    have ha : a.toNat < 2 ^ 32 := toNat_lt_size a
+    have hb : b.toNat < 2 ^ 32 := toNat_lt_size b
+    calc a.toNat * b.toNat < 2 ^ 32 * 2 ^ 32 :=
+          Nat.mul_lt_mul_of_lt_of_lt ha hb
+      _ = 2 ^ 64 := by decide +kernel
+  have hmod : ((a.toUInt64 * b.toUInt64) % q.toUInt64).toNat = (a.toNat * b.toNat) % p := by
+    rw [UInt64.toNat_mod, hprod, UInt32.toNat_toUInt64, hq]
+  show (((a.toUInt64 * b.toUInt64) % q.toUInt64).toUInt32).toNat = _
+  rw [UInt64.toNat_toUInt32, hmod]
+  exact Nat.mod_eq_of_lt
+    (Nat.lt_trans (Nat.mod_lt _ (ZMod64.Bounds.pPos (p := p))) (pLt32 (p := p)))
+
+theorem mulMod_lt {q a b : UInt32} (hq : q.toNat = p) : (mulMod q a b).toNat < p := by
+  rw [toNat_mulMod hq]
+  exact Nat.mod_lt _ (ZMod64.Bounds.pPos (p := p))
+
+theorem toNat_addMod {q a b : UInt32} (hq : q.toNat = p)
+    (ha : a.toNat < p) (hb : b.toNat < p) :
+    (addMod q a b).toNat = (a.toNat + b.toNat) % p := by
+  have hp31 : p < 2 ^ 31 := ZMod64.Bounds.pLtR (p := p)
+  have hsum : (a + b).toNat = a.toNat + b.toNat := by
+    rw [UInt32.toNat_add]
+    exact Nat.mod_eq_of_lt (by omega)
+  unfold addMod
+  by_cases hlt : a + b < q
+  · rw [if_pos hlt]
+    have hlt' : (a + b).toNat < q.toNat := UInt32.lt_iff_toNat_lt.mp hlt
+    rw [hq, hsum] at hlt'
+    rw [hsum, Nat.mod_eq_of_lt hlt']
+  · rw [if_neg hlt]
+    have hge : p ≤ a.toNat + b.toNat :=
+      Nat.le_of_not_lt fun hcon =>
+        hlt (UInt32.lt_iff_toNat_lt.mpr (by rw [hq, hsum]; exact hcon))
+    rw [UInt32.toNat_sub, hsum, hq]
+    rw [show 2 ^ 32 - p + (a.toNat + b.toNat)
+          = (a.toNat + b.toNat - p) + 2 ^ 32 by omega,
+      Nat.add_mod_right, Nat.mod_eq_of_lt (by omega : a.toNat + b.toNat - p < 2 ^ 32)]
+    rw [Nat.mod_eq_sub_mod hge, Nat.mod_eq_of_lt (by omega)]
+
+theorem addMod_lt {q a b : UInt32} (hq : q.toNat = p)
+    (ha : a.toNat < p) (hb : b.toNat < p) : (addMod q a b).toNat < p := by
+  rw [toNat_addMod hq ha hb]
+  exact Nat.mod_lt _ (ZMod64.Bounds.pPos (p := p))
+
+theorem toNat_negMod {q a : UInt32} (hq : q.toNat = p) (ha : a.toNat < p) :
+    (negMod q a).toNat = (p - a.toNat) % p := by
+  have hp32 : p < 2 ^ 32 := pLt32 (p := p)
+  unfold negMod
+  by_cases h : a == 0
+  · rw [if_pos h]
+    have ha0 : a.toNat = 0 := by
+      have : a = 0 := by simpa using h
+      simp [this]
+    simp [ha0]
+  · rw [if_neg h]
+    have ha0 : a.toNat ≠ 0 := by
+      intro hz
+      exact h (by simpa using UInt32.toNat_inj.mp (by simpa using hz))
+    rw [UInt32.toNat_sub, hq]
+    rw [show 2 ^ 32 - a.toNat + p = (p - a.toNat) + 2 ^ 32 by omega,
+      Nat.add_mod_right, Nat.mod_eq_of_lt (by omega : p - a.toNat < 2 ^ 32)]
+    exact (Nat.mod_eq_of_lt (by omega)).symm
+
+theorem negMod_lt {q a : UInt32} (hq : q.toNat = p) (ha : a.toNat < p) :
+    (negMod q a).toNat < p := by
+  rw [toNat_negMod hq ha]
+  exact Nat.mod_lt _ (ZMod64.Bounds.pPos (p := p))
+
+/-- The packed negation of a packed residue is the packed negated residue. -/
+theorem toZMod_negMod {q a : UInt32} (hq : q.toNat = p) (ha : a.toNat < p) :
+    toZMod p (negMod q a) = -(toZMod p a) := by
+  apply ZMod64.ext_toNat
+  rw [toNat_toZMod_of_lt (negMod_lt hq ha), toNat_negMod hq ha]
+  show _ = (ZMod64.neg (toZMod p a)).toNat
+  rw [ZMod64.toNat_neg, toNat_toZMod_of_lt ha]
+
+/-- The packed product of packed residues is the packed product residue. -/
+theorem toZMod_mulMod {q a b : UInt32} (hq : q.toNat = p)
+    (ha : a.toNat < p) (hb : b.toNat < p) :
+    toZMod p (mulMod q a b) = toZMod p a * toZMod p b := by
+  apply ZMod64.ext_toNat
+  rw [toNat_toZMod_of_lt (mulMod_lt hq), toNat_mulMod hq]
+  show _ = (ZMod64.mul (toZMod p a) (toZMod p b)).toNat
+  rw [ZMod64.toNat_mul, toNat_toZMod_of_lt ha, toNat_toZMod_of_lt hb]
+
+/-- The packed sum of packed residues is the packed sum residue. -/
+theorem toZMod_addMod {q a b : UInt32} (hq : q.toNat = p)
+    (ha : a.toNat < p) (hb : b.toNat < p) :
+    toZMod p (addMod q a b) = toZMod p a + toZMod p b := by
+  apply ZMod64.ext_toNat
+  rw [toNat_toZMod_of_lt (addMod_lt hq ha hb), toNat_addMod hq ha hb]
+  show _ = (ZMod64.add (toZMod p a) (toZMod p b)).toNat
+  rw [ZMod64.toNat_add, toNat_toZMod_of_lt ha, toNat_toZMod_of_lt hb]
+
+/-- Modular inverse of a packed residue, routed through {name}`Hex.ZMod64.inv`.
+This runs once per pivot column, so it never appears in the inner loop and does
+not need a word-level extended-Euclid specialization. -/
+@[inline] def invMod (p : Nat) [ZMod64.Bounds p] (a : UInt32) : UInt32 :=
+  ofZMod (ZMod64.inv (toZMod p a))
+
+@[simp] theorem toZMod_invMod (a : UInt32) :
+    toZMod p (invMod p a) = (toZMod p a)⁻¹ := by
+  rw [invMod, toZMod_ofZMod]
+  rfl
+
+theorem invMod_lt (a : UInt32) : (invMod p a).toNat < p := by
+  rw [invMod, toNat_ofZMod]
+  exact (ZMod64.inv (toZMod p a)).isLt
+
+/-- A packed word is zero exactly when the residue it represents is zero. -/
+theorem toZMod_eq_zero_iff {a : UInt32} (ha : a.toNat < p) :
+    toZMod p a = 0 ↔ a = 0 := by
+  constructor
+  · intro h
+    have := congrArg ZMod64.toNat h
+    rw [toNat_toZMod_of_lt ha] at this
+    have hz : a.toNat = 0 := by
+      rw [this]
+      exact ZMod64.toNat_zero (p := p)
+    exact UInt32.toNat_inj.mp (by simpa using hz)
+  · intro h
+    subst h
+    apply ZMod64.ext_toNat
+    rw [toNat_toZMod_of_lt ha]
+    exact (ZMod64.toNat_zero (p := p)).symm
+
+/-! # Packed matrices and their interpretation
+
+A packed matrix is a {name}`Hex.Matrix` of `UInt32` words: the same flat
+row-major backing buffer, with one tagged-immediate word per entry instead of
+one boxed residue. `Rep` says that a packed matrix represents a residue matrix
+entry for entry; because residues are canonical, it also carries the invariant
+that every packed word is below the modulus.
+-/
+
+variable {n m : Nat}
+
+/-- The packed matrix `A` represents the residue matrix `E`. -/
+def Rep (A : Matrix UInt32 n m) (E : Matrix (ZMod64 p) n m) : Prop :=
+  ∀ (i : Fin n) (j : Fin m), A[i][j].toNat = E[i][j].toNat
+
+theorem Rep.lt {A : Matrix UInt32 n m} {E : Matrix (ZMod64 p) n m}
+    (h : Rep A E) (i : Fin n) (j : Fin m) : A[i][j].toNat < p := by
+  rw [h i j]
+  exact E[i][j].isLt
+
+theorem Rep.toZMod_eq {A : Matrix UInt32 n m} {E : Matrix (ZMod64 p) n m}
+    (h : Rep A E) (i : Fin n) (j : Fin m) : toZMod p A[i][j] = E[i][j] :=
+  ZMod64.ext_toNat (by rw [toNat_toZMod_of_lt (h.lt i j), h i j])
+
+/-- Scale row `i` of a packed matrix by the packed residue `c`. Mirrors
+{name}`Hex.Matrix.rowScale`, which is the same per-entry in-place
+{name}`Hex.Matrix.modifyEntries` with the generic product replaced by the
+modular one. -/
+@[expose]
+def rowScale (q : UInt32) (A : Matrix UInt32 n m) (i : Fin n) (c : UInt32) :
+    Matrix UInt32 n m :=
+  A.modifyEntries i.val fun _ x => mulMod q c x
+
+/-- Replace row `dst` of a packed matrix by `row dst + c * row src`. Mirrors
+{name}`Hex.Matrix.rowAdd`: the source row is read once, then the destination
+row's entries are updated in place. -/
+@[expose]
+def rowAdd (q : UInt32) (A : Matrix UInt32 n m) (src dst : Fin n) (c : UInt32) :
+    Matrix UInt32 n m :=
+  let rsrc := Matrix.getRow A src
+  A.modifyEntries dst.val fun k x => addMod q x (mulMod q c rsrc[k])
+
+theorem getElem_rowScale (q : UInt32) (A : Matrix UInt32 n m) (i r : Fin n)
+    (c : UInt32) (k : Fin m) :
+    (rowScale q A i c)[r][k] = if r = i then mulMod q c A[i][k] else A[r][k] := by
+  rw [rowScale, Matrix.getElem_modifyEntries]
+  by_cases h : r = i
+  · rw [if_pos (congrArg Fin.val h), if_pos h, h]
+  · rw [if_neg (fun hv => h (Fin.ext hv)), if_neg h]
+
+theorem getElem_rowAdd (q : UInt32) (A : Matrix UInt32 n m) (src dst r : Fin n)
+    (c : UInt32) (k : Fin m) :
+    (rowAdd q A src dst c)[r][k] =
+      if r = dst then addMod q A[dst][k] (mulMod q c A[src][k]) else A[r][k] := by
+  rw [rowAdd, Matrix.getElem_modifyEntries]
+  by_cases h : r = dst
+  · rw [if_pos (congrArg Fin.val h), if_pos h, h]
+    rw [show (Matrix.getRow A src)[k] = A[src][k] from rfl]
+  · rw [if_neg (fun hv => h (Fin.ext hv)), if_neg h]
+
+/-! ## The packed elementary operations interpret to the generic ones -/
+
+theorem Rep.rowSwap {A : Matrix UInt32 n m} {E : Matrix (ZMod64 p) n m}
+    (h : Rep A E) (i j : Fin n) :
+    Rep (Matrix.rowSwap A i j) (Matrix.rowSwap E i j) := by
+  intro r k
+  rw [Matrix.getElem_rowSwap, Matrix.getElem_rowSwap]
+  by_cases hrj : r = j
+  · simp only [if_pos hrj]; exact h i k
+  · by_cases hri : r = i
+    · simp only [if_neg hrj, if_pos hri]; exact h j k
+    · simp only [if_neg hrj, if_neg hri]; exact h r k
+
+theorem Rep.rowScale {q : UInt32} (hq : q.toNat = p)
+    {A : Matrix UInt32 n m} {E : Matrix (ZMod64 p) n m} (h : Rep A E)
+    (i : Fin n) {c : UInt32} {γ : ZMod64 p} (hc : c.toNat = γ.toNat) :
+    Rep (rowScale q A i c) (Matrix.rowScale E i γ) := by
+  intro r k
+  rw [getElem_rowScale, Matrix.getElem_rowScale]
+  by_cases hri : r = i
+  · rw [if_pos hri, if_pos hri, toNat_mulMod hq]
+    show _ = (ZMod64.mul γ E[i][k]).toNat
+    rw [ZMod64.toNat_mul, hc, h i k]
+  · rw [if_neg hri, if_neg hri]; exact h r k
+
+theorem Rep.rowAdd {q : UInt32} (hq : q.toNat = p)
+    {A : Matrix UInt32 n m} {E : Matrix (ZMod64 p) n m} (h : Rep A E)
+    (src dst : Fin n) {c : UInt32} {γ : ZMod64 p} (hc : c.toNat = γ.toNat) :
+    Rep (rowAdd q A src dst c) (Matrix.rowAdd E src dst γ) := by
+  have hγ : γ.toNat < p := γ.isLt
+  intro r k
+  rw [getElem_rowAdd, Matrix.getElem_rowAdd]
+  by_cases hrd : r = dst
+  · rw [if_pos hrd, if_pos hrd]
+    rw [toNat_addMod hq (h.lt dst k) (mulMod_lt hq), toNat_mulMod hq]
+    show _ = (ZMod64.add E[dst][k] (ZMod64.mul γ E[src][k])).toNat
+    rw [ZMod64.toNat_add, ZMod64.toNat_mul, h dst k, hc, h src k]
+  · rw [if_neg hrd, if_neg hrd]; exact h r k
+
+/-! # Packed Gauss-Jordan
+
+The packed loop mirrors {name}`Hex.Matrix.rowReduceLoop` step for step, with two
+differences: the entries are packed words rather than residues, and the `n x n`
+transform is dropped, because {name}`Hex.Matrix.nullspace` reads only the rank,
+the echelon form, and the pivot columns.
+
+Entries are read through the `O(1)` flat pair accessor `A[(i, j)]`; the nested
+row accessor `A[i]` is deliberately noncomputable in `HexMatrix` because it
+would materialize a row per read.
+-/
+
+/-- Packed pivot search: the first row at or below `start` whose `col` entry is
+nonzero. Mirrors `Hex.Matrix.findPivotAux`. -/
+def findPivotAux (A : Matrix UInt32 n m) (col : Fin m) (start fuel : Nat) :
+    Option (Fin n) :=
+  match fuel with
+  | 0 => none
+  | fuel + 1 =>
+      if h : start < n then
+        let i : Fin n := ⟨start, h⟩
+        if A[(i, col)] == 0 then
+          findPivotAux A col (start + 1) fuel
+        else
+          some i
+      else
+        none
+
+/-- Packed pivot search from `start`. Mirrors `Hex.Matrix.findPivot?`. -/
+def findPivot? (A : Matrix UInt32 n m) (col : Fin m) (start : Nat) : Option (Fin n) :=
+  findPivotAux A col start (n - start)
+
+/-- Eliminate every non-pivot entry of a packed pivot column. Mirrors
+`Hex.Matrix.eliminateColumn` with the transform component dropped. -/
+def eliminateColumn (q : UInt32) (A : Matrix UInt32 n m) (pivotRow : Fin n)
+    (col : Fin m) : Matrix UInt32 n m :=
+  (List.finRange n).foldl
+    (fun A j =>
+      if j = pivotRow then
+        A
+      else
+        let c := negMod q A[(j, col)]
+        if c == 0 then A else rowAdd q A pivotRow j c)
+    A
+
+/-- Running state of the packed Gauss-Jordan loop. Mirrors
+{name}`Hex.Matrix.RowReduceState` without the transform. -/
+structure State (n m : Nat) where
+  /-- Rows already assigned a pivot. -/
+  row : Nat
+  /-- The partially reduced packed matrix. -/
+  echelon : Matrix UInt32 n m
+  /-- Pivot columns found so far, in increasing order. -/
+  pivots : List (Fin m)
+
+/-- The packed Gauss-Jordan loop. Mirrors {name}`Hex.Matrix.rowReduceLoop`. -/
+def reduceLoop (p : Nat) [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
+    (q : UInt32) (col fuel : Nat) (s : State n m) : State n m :=
+  match fuel with
+  | 0 => s
+  | fuel + 1 =>
+      if hRow : s.row < n then
+        if hCol : col < m then
+          let colFin : Fin m := ⟨col, hCol⟩
+          match findPivot? s.echelon colFin s.row with
+          | none =>
+              reduceLoop p q (col + 1) fuel s
+          | some pivot =>
+              let target : Fin n := ⟨s.row, hRow⟩
+              let swapped := Matrix.rowSwap s.echelon target pivot
+              let pivotVal := swapped[(target, colFin)]
+              let scaled := rowScale q swapped target (invMod p pivotVal)
+              let eliminated := eliminateColumn q scaled target colFin
+              reduceLoop p q (col + 1) fuel
+                { row := s.row + 1
+                  echelon := eliminated
+                  pivots := s.pivots.concat colFin }
+        else
+          s
+      else
+        s
+
+/-! ## The packed loop simulates the generic one -/
+
+section Simulation
+
+variable [ZMod64.PrimeModulus p]
+
+omit [ZMod64.PrimeModulus p] in
+/-- A packed entry is zero exactly when the residue entry it represents is. -/
+private theorem rep_eq_zero_iff {A : Matrix UInt32 n m} {E : Matrix (ZMod64 p) n m}
+    (h : Rep A E) (i : Fin n) (j : Fin m) : A[(i, j)] = 0 ↔ E[(i, j)] = 0 := by
+  rw [Matrix.getElem_pair_eq_nested, Matrix.getElem_pair_eq_nested,
+    ← h.toZMod_eq i j]
+  exact (toZMod_eq_zero_iff (h.lt i j)).symm
+
+/-- Packed pivot search agrees with the reference pivot search. -/
+private theorem findPivotAux_eq {A : Matrix UInt32 n m} {E : Matrix (ZMod64 p) n m}
+    (h : Rep A E) (col : Fin m) :
+    ∀ start fuel, findPivotAux A col start fuel = Hex.Matrix.findPivotAux E col start fuel := by
+  intro start fuel
+  induction fuel generalizing start with
+  | zero => rfl
+  | succ fuel ih =>
+      unfold findPivotAux Hex.Matrix.findPivotAux
+      by_cases hstart : start < n
+      · rw [dif_pos hstart, dif_pos hstart]
+        have hiff := rep_eq_zero_iff h ⟨start, hstart⟩ col
+        show (if (A[((⟨start, hstart⟩ : Fin n), col)] == 0) = true then
+              findPivotAux A col (start + 1) fuel else some ⟨start, hstart⟩)
+            = (if E[((⟨start, hstart⟩ : Fin n), col)] = 0 then
+              Hex.Matrix.findPivotAux E col (start + 1) fuel else some ⟨start, hstart⟩)
+        by_cases hA : A[((⟨start, hstart⟩ : Fin n), col)] = 0
+        · rw [if_pos (beq_iff_eq.mpr hA), if_pos (hiff.mp hA)]
+          exact ih (start + 1)
+        · rw [if_neg (fun hb => hA (beq_iff_eq.mp hb)),
+            if_neg (fun hE => hA (hiff.mpr hE))]
+      · rw [dif_neg hstart, dif_neg hstart]
+
+/-- Packed pivot search agrees with the reference pivot search. -/
+private theorem findPivot?_eq {A : Matrix UInt32 n m} {E : Matrix (ZMod64 p) n m}
+    (h : Rep A E) (col : Fin m) (start : Nat) :
+    findPivot? A col start = Hex.Matrix.findPivot? E col start :=
+  findPivotAux_eq h col start (n - start)
+
+omit [ZMod64.PrimeModulus p] in
+/-- One elimination step of the packed fold represents one elimination step of
+the reference fold. -/
+private theorem rep_elim_step {q : UInt32} (hq : q.toNat = p)
+    {A : Matrix UInt32 n m} {st : Matrix (ZMod64 p) n m × Matrix (ZMod64 p) n n}
+    (h : Rep A st.1) (pivotRow : Fin n) (col : Fin m) (j : Fin n) :
+    Rep
+      (if j = pivotRow then A
+        else
+          let c := negMod q A[(j, col)]
+          if c == 0 then A else rowAdd q A pivotRow j c)
+      (if _hj : j = pivotRow then st
+        else
+          have coeff := -st.1[(j, col)]
+          if coeff = 0 then st
+          else (Matrix.rowAdd st.1 pivotRow j coeff, Matrix.rowAdd st.2 pivotRow j coeff)).1 := by
+  by_cases hj : j = pivotRow
+  · rw [if_pos hj, dif_pos hj]; exact h
+  · rw [if_neg hj, dif_neg hj]
+    have hcoeff : (negMod q A[(j, col)]).toNat = (-st.1[(j, col)]).toNat := by
+      rw [Matrix.getElem_pair_eq_nested, Matrix.getElem_pair_eq_nested,
+        toNat_negMod hq (h.lt j col), h j col]
+      show _ = (ZMod64.neg st.1[j][col]).toNat
+      rw [ZMod64.toNat_neg]
+    have hiff : negMod q A[(j, col)] = 0 ↔ -st.1[(j, col)] = 0 := by
+      constructor
+      · intro hz
+        apply ZMod64.ext_toNat
+        rw [← hcoeff, hz]
+        exact (ZMod64.toNat_zero (p := p)).symm
+      · intro hz
+        apply UInt32.toNat_inj.mp
+        rw [hcoeff, hz]
+        exact ZMod64.toNat_zero (p := p)
+    by_cases hA : negMod q A[(j, col)] = 0
+    · rw [if_pos (beq_iff_eq.mpr hA), if_pos (hiff.mp hA)]
+      exact h
+    · rw [if_neg (fun hb => hA (beq_iff_eq.mp hb)),
+        if_neg (fun hE => hA (hiff.mpr hE))]
+      exact h.rowAdd hq pivotRow j hcoeff
+
+omit [ZMod64.PrimeModulus p] in
+/-- The packed column elimination represents the reference column elimination. -/
+theorem rep_eliminateColumn_foldl {q : UInt32} (hq : q.toNat = p) (pivotRow : Fin n)
+    (col : Fin m) :
+    ∀ (xs : List (Fin n)) (A : Matrix UInt32 n m)
+      (st : Matrix (ZMod64 p) n m × Matrix (ZMod64 p) n n),
+      Rep A st.1 →
+      Rep
+        (xs.foldl
+          (fun A j =>
+            if j = pivotRow then A
+            else
+              let c := negMod q A[(j, col)]
+              if c == 0 then A else rowAdd q A pivotRow j c) A)
+        (xs.foldl
+          (fun st j =>
+            if _hj : j = pivotRow then st
+            else
+              have coeff := -st.1[(j, col)]
+              if coeff = 0 then st
+              else (Matrix.rowAdd st.1 pivotRow j coeff, Matrix.rowAdd st.2 pivotRow j coeff))
+          st).1 := by
+  intro xs
+  induction xs with
+  | nil => intro A st h; exact h
+  | cons x xs ih =>
+      intro A st h
+      simp only [List.foldl_cons]
+      exact ih _ _ (rep_elim_step hq h pivotRow col x)
+
+/-- The packed column elimination represents the reference column elimination. -/
+private theorem rep_eliminateColumn {q : UInt32} (hq : q.toNat = p)
+    {A : Matrix UInt32 n m} {E : Matrix (ZMod64 p) n m} (h : Rep A E)
+    (T : Matrix (ZMod64 p) n n) (pivotRow : Fin n) (col : Fin m) :
+    Rep (eliminateColumn q A pivotRow col)
+      (Hex.Matrix.eliminateColumn E T pivotRow col).1 := by
+  unfold eliminateColumn Hex.Matrix.eliminateColumn
+  exact rep_eliminateColumn_foldl hq pivotRow col (List.finRange n) A (E, T) h
+
+
+omit [ZMod64.PrimeModulus p] in
+/-- The packed inverse of a packed residue is the packed inverse residue. -/
+private theorem toNat_invMod_eq {a : UInt32} {γ : ZMod64 p} (h : toZMod p a = γ) :
+    (invMod p a).toNat = (γ⁻¹).toNat := by
+  rw [invMod, toNat_ofZMod, h]
+  rfl
+
+/-- The packed Gauss-Jordan loop simulates {name}`Hex.Matrix.rowReduceLoop`: it
+finds the same pivot columns in the same order, advances the same row counter,
+and its packed buffer represents the reference echelon matrix at every step.
+The reference transform is carried along on the right and never inspected. -/
+theorem reduceLoop_sim {q : UInt32} (hq : q.toNat = p) :
+    ∀ (fuel col row : Nat) (pivots : List (Fin m)) (A : Matrix UInt32 n m)
+      (E : Matrix (ZMod64 p) n m) (T : Matrix (ZMod64 p) n n),
+      Rep A E →
+      (reduceLoop p q col fuel ⟨row, A, pivots⟩).row
+          = (Matrix.rowReduceLoop col fuel ⟨row, E, T, pivots⟩).row ∧
+        (reduceLoop p q col fuel ⟨row, A, pivots⟩).pivots
+          = (Matrix.rowReduceLoop col fuel ⟨row, E, T, pivots⟩).pivots ∧
+        Rep (reduceLoop p q col fuel ⟨row, A, pivots⟩).echelon
+          (Matrix.rowReduceLoop col fuel ⟨row, E, T, pivots⟩).echelon := by
+  intro fuel
+  induction fuel with
+  | zero =>
+      intro col row pivots A E T h
+      exact ⟨rfl, rfl, h⟩
+  | succ fuel ih =>
+      intro col row pivots A E T h
+      by_cases hRow : row < n
+      · by_cases hCol : col < m
+        · have hfp := findPivot?_eq h ⟨col, hCol⟩ row
+          cases hpv : Hex.Matrix.findPivot? E ⟨col, hCol⟩ row with
+          | none =>
+              simp only [reduceLoop, Matrix.rowReduceLoop, dif_pos hRow, dif_pos hCol,
+                hfp, hpv]
+              exact ih (col + 1) row pivots A E T h
+          | some pivot =>
+              simp only [reduceLoop, Matrix.rowReduceLoop, dif_pos hRow, dif_pos hCol,
+                hfp, hpv]
+              have hswap := h.rowSwap (⟨row, hRow⟩ : Fin n) pivot
+              have hinv :
+                  (invMod p
+                      (Matrix.rowSwap A (⟨row, hRow⟩ : Fin n) pivot)[((⟨row, hRow⟩ : Fin n),
+                        (⟨col, hCol⟩ : Fin m))]).toNat
+                    = ((Matrix.rowSwap E (⟨row, hRow⟩ : Fin n) pivot)[((⟨row, hRow⟩ : Fin n),
+                        (⟨col, hCol⟩ : Fin m))]⁻¹).toNat := by
+                apply toNat_invMod_eq
+                rw [Matrix.getElem_pair_eq_nested, Matrix.getElem_pair_eq_nested]
+                exact hswap.toZMod_eq (⟨row, hRow⟩ : Fin n) (⟨col, hCol⟩ : Fin m)
+              have hscale := hswap.rowScale hq (⟨row, hRow⟩ : Fin n) hinv
+              have helim :=
+                rep_eliminateColumn hq hscale
+                  (Matrix.rowScale (Matrix.rowSwap T (⟨row, hRow⟩ : Fin n) pivot)
+                    (⟨row, hRow⟩ : Fin n)
+                    ((Matrix.rowSwap E (⟨row, hRow⟩ : Fin n) pivot)[((⟨row, hRow⟩ : Fin n),
+                      (⟨col, hCol⟩ : Fin m))]⁻¹))
+                  (⟨row, hRow⟩ : Fin n) (⟨col, hCol⟩ : Fin m)
+              exact ih (col + 1) (row + 1) (pivots.concat (⟨col, hCol⟩ : Fin m)) _ _ _ helim
+        · simp only [reduceLoop, Matrix.rowReduceLoop, dif_pos hRow, dif_neg hCol]
+          exact ⟨trivial, trivial, h⟩
+      · simp only [reduceLoop, Matrix.rowReduceLoop, dif_neg hRow]
+        exact ⟨trivial, trivial, h⟩
+
+end Simulation
+
+/-! ## The finished packed reduction -/
+
+/-- Packed Gauss-Jordan elimination of `A`. Mirrors {name}`Hex.Matrix.rowReduce`
+without the transform. -/
+def reduce (p : Nat) [ZMod64.Bounds p] [ZMod64.PrimeModulus p] (q : UInt32)
+    (A : Matrix UInt32 n m) : State n m :=
+  reduceLoop p q 0 m { row := 0, echelon := A, pivots := [] }
+
+variable [ZMod64.PrimeModulus p]
+
+/-- The packed reduction finds the reference pivot columns. -/
+theorem reduce_pivots {q : UInt32} (hq : q.toNat = p)
+    {A : Matrix UInt32 n m} {E : Matrix (ZMod64 p) n m} (h : Rep A E) :
+    (reduce p q A).pivots = (Matrix.rowReduce E).pivotCols.toList := by
+  have := (reduceLoop_sim hq m 0 0 [] A E (Matrix.identity n) h).2.1
+  simpa [reduce, Matrix.rowReduce] using this
+
+/-- The packed reduction finds the reference rank. -/
+theorem reduce_rank {q : UInt32} (hq : q.toNat = p)
+    {A : Matrix UInt32 n m} {E : Matrix (ZMod64 p) n m} (h : Rep A E) :
+    (reduce p q A).pivots.length = (Matrix.rowReduce E).rank := by
+  rw [reduce_pivots hq h]
+  simp
+
+/-- The packed reduction's buffer represents the reference echelon form. -/
+theorem reduce_rep {q : UInt32} (hq : q.toNat = p)
+    {A : Matrix UInt32 n m} {E : Matrix (ZMod64 p) n m} (h : Rep A E) :
+    Rep (reduce p q A).echelon (Matrix.rowReduce E).echelon := by
+  have := (reduceLoop_sim hq m 0 0 [] A E (Matrix.identity n) h).2.2
+  simpa [reduce, Matrix.rowReduce] using this
+
+/-! # The packed nullspace basis
+
+The readback mirrors {name}`Hex.Matrix.IsRowReduced.nullspaceMatrix` column for
+column, but assembles the basis vectors directly out of packed words instead of
+materializing an `m x (m - rank)` residue matrix and then slicing it. The pivot
+columns are carried as a plain list, so nothing here is indexed by the rank.
+-/
+
+/-- The pivot row of column `j`, searching from row `i`. Mirrors
+`Hex.Matrix.IsRowReduced.pivotIndexAux` walking the pivot-column list. -/
+def pivotRowOf : List (Fin m) → Fin m → Nat → Option Nat
+  | [], _, _ => none
+  | c :: cs, j, i => if c = j then some i else pivotRowOf cs j (i + 1)
+
+/-- The non-pivot columns, in increasing order. Mirrors
+{name}`Hex.Matrix.IsEchelonForm.freeColsList` with the echelon witness dropped. -/
+def freeColsList (pivots : List (Fin m)) : List (Fin m) :=
+  (List.finRange m).filter fun j => j ∉ pivots
+
+/-- The nullspace basis read straight off a reduced packed buffer: one vector
+per free column, with a `1` in its own free column, the negated pivot-row entry
+in each pivot column, and `0` elsewhere.
+
+The `i < n` test is never false on a reduction's own output -- there are at most
+`n` pivots -- and `nullspaceArray_eq` discharges it. -/
+def nullspaceArray (q : UInt32) (A : Matrix UInt32 n m) (pivots : List (Fin m)) :
+    Array (Vector (ZMod64 p) m) :=
+  (freeColsList pivots).toArray.map fun fc =>
+    Vector.ofFn fun j =>
+      if j = fc then
+        1
+      else
+        match pivotRowOf pivots j 0 with
+        | some i =>
+            if hi : i < n then toZMod p (negMod q A[((⟨i, hi⟩ : Fin n), fc)]) else 0
+        | none => 0
+
+section Basis
+
+omit [ZMod64.PrimeModulus p] in
+/-- Walking the pivot-column list from `start` is the reference pivot-index
+search from `start`. -/
+private theorem pivotRowOf_drop (D : Matrix.RowEchelonData (ZMod64 p) n m) (j : Fin m) :
+    ∀ (fuel start : Nat), start + fuel = D.rank →
+      pivotRowOf (D.pivotCols.toList.drop start) j start
+        = (Matrix.IsRowReduced.pivotIndexAux D j start fuel).map Fin.val := by
+  intro fuel
+  induction fuel with
+  | zero =>
+      intro start hstart
+      have hdrop : D.pivotCols.toList.drop start = [] := by
+        apply List.drop_eq_nil_of_le
+        simp [Vector.length_toList]
+        omega
+      rw [hdrop]
+      rfl
+  | succ fuel ih =>
+      intro start hstart
+      have hlt : start < D.rank := by omega
+      have hlen : start < D.pivotCols.toList.length := by
+        simpa [Vector.length_toList] using hlt
+      have hdrop : D.pivotCols.toList.drop start
+          = D.pivotCols.toList[start] :: D.pivotCols.toList.drop (start + 1) :=
+        (List.drop_eq_getElem_cons hlen)
+      have hget : D.pivotCols.toList[start] = D.pivotCols.get ⟨start, hlt⟩ := by
+        simp [Vector.get]
+      rw [hdrop, hget, pivotRowOf, Matrix.IsRowReduced.pivotIndexAux, dif_pos hlt]
+      show (if D.pivotCols.get ⟨start, hlt⟩ = j then some start
+            else pivotRowOf (D.pivotCols.toList.drop (start + 1)) j (start + 1))
+          = Option.map Fin.val
+              (if D.pivotCols.get ⟨start, hlt⟩ = j then some ⟨start, hlt⟩
+               else Matrix.IsRowReduced.pivotIndexAux D j (start + 1) fuel)
+      by_cases hc : D.pivotCols.get ⟨start, hlt⟩ = j
+      · rw [if_pos hc, if_pos hc]; rfl
+      · rw [if_neg hc, if_neg hc]
+        exact ih (start + 1) (by omega)
+
+omit [ZMod64.PrimeModulus p] in
+/-- Walking the pivot-column list is the reference pivot-index search. -/
+private theorem pivotRowOf_eq (D : Matrix.RowEchelonData (ZMod64 p) n m) (j : Fin m) :
+    pivotRowOf D.pivotCols.toList j 0
+      = (Matrix.IsRowReduced.pivotIndex? D j).map Fin.val := by
+  have := pivotRowOf_drop D j D.rank 0 (by omega)
+  simpa [Matrix.IsRowReduced.pivotIndex?] using this
+
+/-- The packed nullspace readback reproduces {name}`Hex.Matrix.nullspace`. -/
+theorem nullspaceArray_eq {q : UInt32} (hq : q.toNat = p)
+    {E : Matrix (ZMod64 p) n m} {A : Matrix UInt32 n m}
+    (h : Rep A (Matrix.rowReduce E).echelon)
+    {pivots : List (Fin m)} (hpv : pivots = (Matrix.rowReduce E).pivotCols.toList) :
+    nullspaceArray q A pivots = (Matrix.nullspace E).toArray := by
+  subst hpv
+  have hE := Matrix.rowReduce_isRowReduced E
+  have hrank := Matrix.rowReduce_rank_le_n E
+  have hfree : freeColsList (Matrix.rowReduce E).pivotCols.toList
+      = hE.toIsEchelonForm.freeColsList := rfl
+  have hlen : (freeColsList (Matrix.rowReduce E).pivotCols.toList).length
+      = m - (Matrix.rowReduce E).rank := by
+    rw [hfree]; exact hE.toIsEchelonForm.freeColsList_length
+  unfold nullspaceArray
+  apply Array.ext
+  · simp only [Array.size_map, List.size_toArray, hlen]
+    rw [Matrix.nullspace]
+    simp [Matrix.rowReduce_rank]
+  · intro k hk1 hk2
+    have hklt : k < m - (Matrix.rowReduce E).rank := by
+      simpa [hlen] using hk1
+    have hkfree : k < (freeColsList (Matrix.rowReduce E).pivotCols.toList).length := by omega
+    have hgetfree :
+        (freeColsList (Matrix.rowReduce E).pivotCols.toList)[k]'hkfree
+          = hE.toIsEchelonForm.freeCols.get ⟨k, hklt⟩ := by
+      rw [Matrix.IsEchelonForm.freeCols]
+      simp [Vector.get, hfree]
+    have harr : (Matrix.nullspace E).toArray
+        = Array.ofFn (fun t : Fin (m - (Matrix.rowReduce E).rank) =>
+            Matrix.col (Matrix.IsRowReduced.nullspaceMatrix hE) t) := rfl
+    simp only [Array.getElem_map, List.getElem_toArray, harr, Array.getElem_ofFn]
+    apply Vector.ext
+    intro j hj
+    rw [Vector.getElem_ofFn]
+    simp only [Matrix.col, Vector.getElem_ofFn, Matrix.IsRowReduced.nullspaceMatrix,
+      Matrix.getElem_pair_eq_nested, Matrix.getElem_ofFn]
+    rw [hgetfree]
+    by_cases hjf : (⟨j, hj⟩ : Fin m) = hE.toIsEchelonForm.freeCols.get ⟨k, hklt⟩
+    · rw [if_pos hjf, dif_pos hjf]
+    · rw [if_neg hjf, dif_neg hjf, pivotRowOf_eq (Matrix.rowReduce E) ⟨j, hj⟩]
+      cases hpi : Matrix.IsRowReduced.pivotIndex? (Matrix.rowReduce E) (⟨j, hj⟩ : Fin m) with
+      | none => rfl
+      | some i =>
+          have hin : i.val < n := Nat.lt_of_lt_of_le i.isLt hrank
+          show (if hi : i.val < n then toZMod p (negMod q _) else 0) = _
+          rw [dif_pos hin, toZMod_negMod hq (h.lt _ _), h.toZMod_eq _ _]
+          rfl
+
+end Basis
+
+
+
+/-! # The packed fixed-space matrix and kernel
+
+The packed buffer is filled straight from the Berlekamp column polynomials: no
+`Matrix (ZMod64 p)` is ever built, so neither the conversion into the generic
+representation nor a separate packing pass is paid.
+-/
+
+/-- The fixed-space matrix `Q_f - I`, built directly into a packed buffer from
+the Berlekamp column polynomials. -/
+@[expose]
+def fixedSpace (p : Nat) [ZMod64.Bounds p] (f : FpPoly p) (hmonic : DensePoly.Monic f) :
+    Matrix UInt32 (basisSize f) (basisSize f) :=
+  let frobX := FpPoly.frobeniusXMod f hmonic
+  let polys := berlekampColumnPolys f hmonic frobX (basisSize f) 1 #[]
+  Matrix.ofFn fun i j =>
+    ofZMod ((polys[j.val]?.getD 0).coeff i.val - (if i = j then 1 else 0))
+
+omit [ZMod64.PrimeModulus p] in
+/-- The packed fixed-space buffer represents
+{name}`Hex.Berlekamp.fixedSpaceMatrix`. -/
+theorem fixedSpace_rep (f : FpPoly p) (hmonic : DensePoly.Monic f) :
+    Rep (fixedSpace p f hmonic) (fixedSpaceMatrix f hmonic) := by
+  intro i j
+  rw [fixedSpace, Matrix.getElem_ofFn, toNat_ofZMod, getElem_fixedSpaceMatrix,
+    berlekampMatrix_entry_eq_columnPolys_coeff]
+
+/-- The Berlekamp fixed-space kernel basis, computed on the packed
+representation: build the packed `Q_f - I`, reduce it in place with the
+specialized Gauss-Jordan loop, and read the basis off the reduced buffer. -/
+@[expose]
+def kernelArray (p : Nat) [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
+    (f : FpPoly p) (hmonic : DensePoly.Monic f) :
+    Array (Vector (ZMod64 p) (basisSize f)) :=
+  let q := modWord p
+  let r := reduce p q (fixedSpace p f hmonic)
+  nullspaceArray q r.echelon r.pivots
+
+/-- **The correspondence theorem.** The packed kernel computation returns
+exactly {name}`Hex.Matrix.nullspace` of the fixed-space matrix. -/
+theorem kernelArray_eq (f : FpPoly p) (hmonic : DensePoly.Monic f) :
+    kernelArray p f hmonic = (Matrix.nullspace (fixedSpaceMatrix f hmonic)).toArray := by
+  have hq : (modWord p).toNat = p := toNat_modWord
+  have hrep := fixedSpace_rep f hmonic
+  exact nullspaceArray_eq hq (reduce_rep hq hrep) (reduce_pivots hq hrep)
+
+end Packed
+
+
+/-! # The fast path
+
+`fixedSpaceKernelVectorsPacked` has the same type as
+{name}`Hex.Berlekamp.fixedSpaceKernelVectors`, with the size index discharged by
+the correspondence theorem rather than recomputed: the returned array's length
+is only ever mentioned inside an erased proof, so nothing at runtime demands
+`basisSize f - Matrix.rowReduce_rank (fixedSpaceMatrix f hmonic)`, which would
+run a second full row reduction.
+-/
+
+variable {p : Nat} [ZMod64.Bounds p]
+
+/-- The packed implementation of
+{name}`Hex.Berlekamp.fixedSpaceKernelVectors`, selected in compiled code by the
+`@[csimp]` theorem `fixedSpaceKernelVectors_eq_packed` below. -/
+@[expose]
+def fixedSpaceKernelVectorsPacked (f : FpPoly p) (hmonic : DensePoly.Monic f)
+    [ZMod64.PrimeModulus p] :
+    Vector (Vector (ZMod64 p) (basisSize f))
+      (basisSize f - Matrix.rowReduce_rank (fixedSpaceMatrix f hmonic)) :=
+  ⟨Packed.kernelArray p f hmonic, by
+    rw [Packed.kernelArray_eq]
+    exact (Matrix.nullspace (fixedSpaceMatrix f hmonic)).size_toArray⟩
+
+/-- The packed fixed-space kernel is the generic one. Registered `@[csimp]`, so
+compiled code runs the packed reduction while every Berlekamp soundness and
+completeness proof keeps reasoning about `Matrix (ZMod64 p)` and
+{name}`Hex.Matrix.nullspace`. -/
+@[csimp] theorem fixedSpaceKernelVectors_eq_packed :
+    @fixedSpaceKernelVectors = @fixedSpaceKernelVectorsPacked := by
+  funext p _ f hmonic _
+  apply Vector.toArray_inj.mp
+  exact (Packed.kernelArray_eq f hmonic).symm
+
+
+/-- The fixed-space kernel basis converted back to polynomial representatives.
+
+Compute the vector basis once and map the conversion over it. Keep the basis
+outside any per-index body so matrix construction and row reduction remain
+shared; mapping also carries its dependent length without recomputing rank. -/
+@[expose]
+def fixedSpaceKernel (f : FpPoly p) (hmonic : DensePoly.Monic f)
+    [ZMod64.PrimeModulus p] :
+    Vector (FpPoly p)
+      (basisSize f - Matrix.rowReduce_rank (fixedSpaceMatrix f hmonic)) :=
+  let vectors := fixedSpaceKernelVectors f hmonic
+  vectors.map vectorToPoly
+
+/-- Every polynomial representative returned by `fixedSpaceKernel` satisfies the
+executable fixed-space kernel condition. -/
+theorem fixedSpaceKernel_sound (f : FpPoly p) (hmonic : DensePoly.Monic f)
+    [ZMod64.PrimeModulus p]
+    (k : Fin (basisSize f -
+      Matrix.rowReduce_rank (fixedSpaceMatrix f hmonic))) :
+    IsFixedSpaceKernelPolynomial f hmonic ((fixedSpaceKernel f hmonic).get k) := by
+  have hk : (fixedSpaceKernel f hmonic).get k =
+      vectorToPoly ((fixedSpaceKernelVectors f hmonic).get k) := by
+    unfold fixedSpaceKernel
+    exact Vector.getElem_map vectorToPoly k.isLt
+  unfold IsFixedSpaceKernelPolynomial
+  rw [hk, coeffVector_vectorToPoly]
+  exact fixedSpaceKernelVectors_sound f hmonic k
+
+end Berlekamp
+
+end Hex

--- a/HexBerlekampZassenhaus/ChoosePrimeData.lean
+++ b/HexBerlekampZassenhaus/ChoosePrimeData.lean
@@ -1045,8 +1045,7 @@ def factorsModPBerlekampForm
       ((@Berlekamp.berlekampFactor data.p data.bounds
         (monicModularImage (ZPoly.modP data.p f))
         (monicModularImage_monic hprime (ZPoly.modP data.p f) hzero)
-        (@zmod64FieldOfPrime data.p data.bounds
-          (ZMod64.primeModulusOfPrime hprime))).factors.map monicModularImage).toArray
+        (ZMod64.primeModulusOfPrime hprime)).factors.map monicModularImage).toArray
 
 private theorem primeChoiceDataScore_factorsModPBerlekampForm
     (f : ZPoly) (c : SmallPrimeCandidate) (score : PrimeChoiceDataScore)
@@ -1188,9 +1187,7 @@ theorem choosePrimeDataAdaptive?_form
           (monicModularImage_monic
             (choosePrimeDataAdaptive?_prime f extra data hdata)
             (ZPoly.modP data.p f) hzero)
-          (@zmod64FieldOfPrime data.p data.bounds
-            (ZMod64.primeModulusOfPrime
-              (choosePrimeDataAdaptive?_prime f extra data hdata)))).factors.map
+          (ZMod64.primeModulusOfPrime (choosePrimeDataAdaptive?_prime f extra data hdata))).factors.map
                 monicModularImage).toArray := by
   obtain ⟨score, rfl, hform⟩ := choosePrimeDataAdaptive?_property f extra data
     (fun score => factorsModPBerlekampForm f score.data)
@@ -1217,9 +1214,7 @@ theorem choosePrimeData?_factorsModP_berlekamp_form
           (monicModularImage_monic
             (choosePrimeData?_prime f data hdata)
             (ZPoly.modP data.p f) hzero)
-          (@zmod64FieldOfPrime data.p data.bounds
-            (ZMod64.primeModulusOfPrime
-              (choosePrimeData?_prime f data hdata)))).factors.map
+          (ZMod64.primeModulusOfPrime (choosePrimeData?_prime f data hdata))).factors.map
                 monicModularImage).toArray := by
   unfold choosePrimeData? at hdata
   cases hscore :
@@ -1270,9 +1265,7 @@ theorem choosePrimeData?_berlekampFactor_factors_length_le_one_of_small
         (monicModularImage_monic
           (choosePrimeData?_prime f data hdata)
           (@ZPoly.modP data.p data.bounds f) hzero)
-        (@zmod64FieldOfPrime data.p data.bounds
-          (ZMod64.primeModulusOfPrime
-            (choosePrimeData?_prime f data hdata)))).factors.length ≤ 1 := by
+        (ZMod64.primeModulusOfPrime (choosePrimeData?_prime f data hdata))).factors.length ≤ 1 := by
   letI := data.bounds
   obtain ⟨hzero, hform⟩ :=
     choosePrimeData?_factorsModP_berlekamp_form f data hdata
@@ -1284,9 +1277,7 @@ theorem choosePrimeData?_berlekampFactor_factors_length_le_one_of_small
         (monicModularImage_monic
           (choosePrimeData?_prime f data hdata)
           (@ZPoly.modP data.p data.bounds f) hzero)
-        (@zmod64FieldOfPrime data.p data.bounds
-          (ZMod64.primeModulusOfPrime
-            (choosePrimeData?_prime f data hdata)))).factors.length ≤ 1 := by
+        (ZMod64.primeModulusOfPrime (choosePrimeData?_prime f data hdata))).factors.length ≤ 1 := by
     simpa [hform] using hsmall
   exact hlen
 

--- a/HexBerlekampZassenhaus/PrimeSelection.lean
+++ b/HexBerlekampZassenhaus/PrimeSelection.lean
@@ -507,13 +507,6 @@ private theorem prime_seventy_one : Nat.Prime 71 := by
     | 71 => exact Or.inr rfl
     | _ + 72 => omega
 
-/-- Thin adapter promoting a `Nat.Prime p` witness to the shared
-`ZMod64.PrimeModulus p` instance the Berlekamp kernel is parameterised by. -/
-@[reducible]
-private def primeModulusOfNatPrime {p : Nat} [ZMod64.Bounds p] (hp : Nat.Prime p) :
-    ZMod64.PrimeModulus p :=
-  ZMod64.primeModulusOfPrime hp
-
 /--
 A small-prime candidate for the Berlekamp-Zassenhaus prime-selection hot path.
 
@@ -976,7 +969,7 @@ theorem factorProduct_map_monicModularImage_eq_monicModularImage_factorProduct
 private def berlekampFactorsModP (f : ZPoly) (c : SmallPrimeCandidate) :
     Array (@FpPoly c.p c.bounds) :=
   letI := c.bounds
-  letI := primeModulusOfNatPrime c.prime
+  letI := ZMod64.primeModulusOfPrime c.prime
   let fModP := ZPoly.modP c.p f
   if hzero : fModP.isZero = false then
     ((Berlekamp.berlekampFactor
@@ -999,7 +992,7 @@ the normalisation step to this call site without touching
 private theorem berlekampFactorsModP_eq_of_isZero_false
     (f : ZPoly) (c : SmallPrimeCandidate) :
     letI := c.bounds
-    letI := primeModulusOfNatPrime c.prime
+    letI := ZMod64.primeModulusOfPrime c.prime
     ∀ (hzero : (ZPoly.modP c.p f).isZero = false),
       berlekampFactorsModP f c =
         ((Berlekamp.berlekampFactor
@@ -1007,7 +1000,7 @@ private theorem berlekampFactorsModP_eq_of_isZero_false
           (monicModularImage_monic c.prime (ZPoly.modP c.p f) hzero)).factors.map
             monicModularImage).toArray := by
   letI := c.bounds
-  letI := primeModulusOfNatPrime c.prime
+  letI := ZMod64.primeModulusOfPrime c.prime
   intro hzero
   unfold berlekampFactorsModP
   rw [dif_pos hzero]

--- a/HexBerlekampZassenhaus/PrimeSelection.lean
+++ b/HexBerlekampZassenhaus/PrimeSelection.lean
@@ -508,12 +508,11 @@ private theorem prime_seventy_one : Nat.Prime 71 := by
     | _ + 72 => omega
 
 /-- Thin adapter promoting a `Nat.Prime p` witness to the shared
-`Lean.Grind.Field (ZMod64 p)` instance via `ZMod64.primeModulusOfPrime`. -/
+`ZMod64.PrimeModulus p` instance the Berlekamp kernel is parameterised by. -/
 @[reducible]
-private def fieldOfNatPrime {p : Nat} [ZMod64.Bounds p] (hp : Nat.Prime p) :
-    Lean.Grind.Field (ZMod64 p) :=
-  letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
-  inferInstance
+private def primeModulusOfNatPrime {p : Nat} [ZMod64.Bounds p] (hp : Nat.Prime p) :
+    ZMod64.PrimeModulus p :=
+  ZMod64.primeModulusOfPrime hp
 
 /--
 A small-prime candidate for the Berlekamp-Zassenhaus prime-selection hot path.
@@ -977,7 +976,7 @@ theorem factorProduct_map_monicModularImage_eq_monicModularImage_factorProduct
 private def berlekampFactorsModP (f : ZPoly) (c : SmallPrimeCandidate) :
     Array (@FpPoly c.p c.bounds) :=
   letI := c.bounds
-  letI := fieldOfNatPrime c.prime
+  letI := primeModulusOfNatPrime c.prime
   let fModP := ZPoly.modP c.p f
   if hzero : fModP.isZero = false then
     ((Berlekamp.berlekampFactor
@@ -1000,7 +999,7 @@ the normalisation step to this call site without touching
 private theorem berlekampFactorsModP_eq_of_isZero_false
     (f : ZPoly) (c : SmallPrimeCandidate) :
     letI := c.bounds
-    letI := fieldOfNatPrime c.prime
+    letI := primeModulusOfNatPrime c.prime
     ∀ (hzero : (ZPoly.modP c.p f).isZero = false),
       berlekampFactorsModP f c =
         ((Berlekamp.berlekampFactor
@@ -1008,7 +1007,7 @@ private theorem berlekampFactorsModP_eq_of_isZero_false
           (monicModularImage_monic c.prime (ZPoly.modP c.p f) hzero)).factors.map
             monicModularImage).toArray := by
   letI := c.bounds
-  letI := fieldOfNatPrime c.prime
+  letI := primeModulusOfNatPrime c.prime
   intro hzero
   unfold berlekampFactorsModP
   rw [dif_pos hzero]

--- a/HexBerlekampZassenhausMathlib/IntReductionMod/Descent.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod/Descent.lean
@@ -540,8 +540,8 @@ theorem irreducible_of_smallMod_form
   letI : Hex.ZMod64.PrimeModulus primeData.p := Hex.ZMod64.primeModulusOfPrime hprime_hex
   have hformCopy := hform
   obtain ⟨_, hzero, hfactors_eq⟩ := hformCopy
-  let hfield := @Hex.zmod64FieldOfPrime primeData.p primeData.bounds
-    (Hex.ZMod64.primeModulusOfPrime hprime_hex)
+  let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
+    Hex.ZMod64.primeModulusOfPrime hprime_hex
   letI := hfield
   -- Translate factorsModP.size ≤ 1 into bfact.factors.length ≤ 1.
   have hfactors_len_le :

--- a/HexBerlekampZassenhausMathlib/ModPPartition.lean
+++ b/HexBerlekampZassenhausMathlib/ModPPartition.lean
@@ -160,8 +160,8 @@ theorem exists_factor_of_modPIndex
   have hcore_modP_iszero :
       (@Hex.ZPoly.modP primeData.p primeData.bounds core).isZero = false :=
     Hex.isGoodPrime_modP_isZero_false core primeData.p hgood
-  let hfield := @Hex.zmod64FieldOfPrime primeData.p primeData.bounds
-    (Hex.ZMod64.primeModulusOfPrime hprime)
+  let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
+    Hex.ZMod64.primeModulusOfPrime hprime
   letI := hfield
   set f : ModPFactorIndex primeData → Polynomial (ZMod primeData.p) :=
       fun i => HexBerlekampMathlib.toMathlibPolynomial (modPFactor primeData i)
@@ -334,8 +334,8 @@ theorem existsUnique_modPFactorSubset_of_choosePrimeData_of_some
   have hzero : (@Hex.ZPoly.modP primeData.p primeData.bounds core).isZero = false :=
     Hex.isGoodPrime_modP_isZero_false core primeData.p hgood
   have hnodup : primeData.factorsModP.toList.Nodup := hval.nodup
-  let hfield := @Hex.zmod64FieldOfPrime primeData.p primeData.bounds
-    (Hex.ZMod64.primeModulusOfPrime hprime)
+  let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
+    Hex.ZMod64.primeModulusOfPrime hprime
   letI := hfield
   -- Set up abbreviations.
   set f : ModPFactorIndex primeData → Polynomial (ZMod primeData.p) :=

--- a/HexBerlekampZassenhausMathlib/Modular/FactorCoprimality.lean
+++ b/HexBerlekampZassenhausMathlib/Modular/FactorCoprimality.lean
@@ -244,8 +244,8 @@ theorem factorsModP_coprime_of_factorsModPBerlekampForm
       primeData.factorsModP.toList := by
   letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   obtain ⟨hprime, hzero, heq⟩ := hform
-  let hfield := @Hex.zmod64FieldOfPrime primeData.p primeData.bounds
-    (Hex.ZMod64.primeModulusOfPrime hprime)
+  let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
+    Hex.ZMod64.primeModulusOfPrime hprime
   letI : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   -- The modular image is square-free under `isGoodPrime`.
@@ -368,8 +368,8 @@ theorem factorsModP_monic_of_factorsModPBerlekampForm
     ∀ g ∈ primeData.factorsModP, Hex.DensePoly.Monic g := by
   letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   obtain ⟨hprime, hzero, heq⟩ := hform
-  let hfield := @Hex.zmod64FieldOfPrime primeData.p primeData.bounds
-    (Hex.ZMod64.primeModulusOfPrime hprime)
+  let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
+    Hex.ZMod64.primeModulusOfPrime hprime
   letI : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   have hmonicImage_monic :
@@ -600,8 +600,8 @@ theorem factors_irreducible_of_factorsModPBerlekampForm
     monicModularImage_modP_degree?_pos_of_factorsModPBerlekampForm
       core primeData hform hgood hcore_pos
   obtain ⟨hprime, hzero, heq⟩ := hform
-  let hfield := @Hex.zmod64FieldOfPrime primeData.p primeData.bounds
-    (Hex.ZMod64.primeModulusOfPrime hprime)
+  let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
+    Hex.ZMod64.primeModulusOfPrime hprime
   letI : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   have hprime_root : _root_.Nat.Prime primeData.p := by

--- a/HexBerlekampZassenhausMathlib/Modular/FactorProduct.lean
+++ b/HexBerlekampZassenhausMathlib/Modular/FactorProduct.lean
@@ -172,8 +172,8 @@ theorem factorsModP_nodup_of_factorsModPBerlekampForm
     data.factorsModP.toList.Nodup := by
   letI : Hex.ZMod64.Bounds data.p := data.bounds
   obtain ⟨hprime, hzero, heq⟩ := hform
-  let hfield := @Hex.zmod64FieldOfPrime data.p data.bounds
-    (Hex.ZMod64.primeModulusOfPrime hprime)
+  let hfield : Hex.ZMod64.PrimeModulus data.p :=
+    Hex.ZMod64.primeModulusOfPrime hprime
   letI : Hex.ZMod64.PrimeModulus data.p := Hex.ZMod64.primeModulusOfPrime hprime
   -- Square-free precondition on the modular image, extracted from `isGoodPrime`.
   have hsf_common :
@@ -487,8 +487,8 @@ theorem factorsModP_natDegree_pos_of_factorsModPBerlekampForm
       0 < (Hex.monicModularImage (Hex.ZPoly.modP data.p f)).degree?.getD 0 :=
     monicModularImage_modP_degree?_pos_of_factorsModPBerlekampForm f data hform hgood hf_pos
   obtain ⟨hprime, hzero, heq⟩ := hform
-  let hfield := @Hex.zmod64FieldOfPrime data.p data.bounds
-    (Hex.ZMod64.primeModulusOfPrime hprime)
+  let hfield : Hex.ZMod64.PrimeModulus data.p :=
+    Hex.ZMod64.primeModulusOfPrime hprime
   letI : Hex.ZMod64.PrimeModulus data.p := Hex.ZMod64.primeModulusOfPrime hprime
   -- Step B: positivity for every entry in the Berlekamp factor list.
   have hFactorsPos :
@@ -744,8 +744,8 @@ theorem factorsModP_polyProduct_congr_of_factorsModPBerlekampForm_of_primitive_p
       primeData.p := by
   letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   obtain ⟨hprime, hzero, heq⟩ := hform
-  let hfield := @Hex.zmod64FieldOfPrime primeData.p primeData.bounds
-    (Hex.ZMod64.primeModulusOfPrime hprime)
+  let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
+    Hex.ZMod64.primeModulusOfPrime hprime
   letI : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   -- `monicModularImage (modP p core)` is monic.
@@ -812,8 +812,8 @@ theorem factorsModP_polyProduct_congr_monicImage_of_factorsModPBerlekampForm
       primeData.p := by
   letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   obtain ⟨hprime, hzero, heq⟩ := hform
-  let hfield := @Hex.zmod64FieldOfPrime primeData.p primeData.bounds
-    (Hex.ZMod64.primeModulusOfPrime hprime)
+  let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
+    Hex.ZMod64.primeModulusOfPrime hprime
   letI : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   have hmonicImage_monic :
@@ -914,8 +914,8 @@ theorem factorsModP_polyProduct_congr_of_factorsModPBerlekampForm
       core primeData.p := by
   letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   obtain ⟨hprime, hzero, heq⟩ := hform
-  let hfield := @Hex.zmod64FieldOfPrime primeData.p primeData.bounds
-    (Hex.ZMod64.primeModulusOfPrime hprime)
+  let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
+    Hex.ZMod64.primeModulusOfPrime hprime
   letI : Hex.ZMod64.PrimeModulus primeData.p :=
     Hex.ZMod64.primeModulusOfPrime hprime
   have hp : 1 < primeData.p := by have := hprime.two_le; omega
@@ -957,8 +957,8 @@ theorem factorsModP_ne_nil_of_factorsModPBerlekampForm
     primeData.factorsModP.toList ≠ [] := by
   letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
   obtain ⟨hprime, hzero, heq⟩ := hform
-  let hfield := @Hex.zmod64FieldOfPrime primeData.p primeData.bounds
-    (Hex.ZMod64.primeModulusOfPrime hprime)
+  let hfield : Hex.ZMod64.PrimeModulus primeData.p :=
+    Hex.ZMod64.primeModulusOfPrime hprime
   have hbl_ne :
       (@Hex.Berlekamp.berlekampFactor primeData.p primeData.bounds
         (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))

--- a/progress/2026-08-04T00-02-47Z.md
+++ b/progress/2026-08-04T00-02-47Z.md
@@ -1,0 +1,20 @@
+# PR #9158 packed-kernel review
+
+## Accomplished
+
+- Reviewed `HexBerlekamp/PackedKernel.lean`, the affected public signatures, generated C, and the released-repo manifest.
+- Checked the instance-pinning argument against `Lean.Grind.Field` and the canonical `zmod64FieldOfPrime` instance.
+- Verified the packed arithmetic invariants, loop simulation branches, nullspace dead branch, and generated in-place row-update path.
+- Built `HexBerlekamp.PackedKernel`, `HexBerlekamp.Factor`, `HexBerlekamp.Irreducibility`, `HexBerlekamp.Conformance`, and `HexBench.BerlekampKernel`.
+
+## Current frontier
+
+- Review complete. Concrete findings are redundant duplicate `PrimeModulus` binders in public `Factor.lean` theorems, the new `defProp` linter warning for `primeModulusOfNatPrime`, and the intentionally breaking/narrowing public instance API (unnecessary for `berlekampRankTest`).
+
+## Next step
+
+- Remove duplicate instance binders, make or eliminate the proposition-valued adapter, and decide whether to retain compatibility wrappers / the generic binder on `berlekampRankTest`.
+
+## Blockers
+
+- None.

--- a/progress/20260804T000000Z_issue-9150.md
+++ b/progress/20260804T000000Z_issue-9150.md
@@ -1,0 +1,108 @@
+# 2026-08-04 — issue #9150, the packed finite-field matrix
+
+## Accomplished
+
+The Berlekamp fixed-space kernel now runs on a packed `UInt32` matrix, behind
+an unchanged `fixedSpaceKernelVectors` boundary and a `@[csimp]`-proved
+equality. `HexBerlekamp/PackedKernel.lean` holds the whole development.
+
+- `Hex.Berlekamp.Packed` — modular word arithmetic (`mulMod`, `addMod`,
+  `negMod`, `invMod`) with `toNat`-level correctness; the representation
+  relation `Rep A E` ("packed word `i,j` and residue `i,j` have the same
+  `toNat`"), which carries reducedness for free because residues are
+  canonical; packed `rowScale`/`rowAdd` mirroring `HexMatrix`'s, and their
+  `Rep` lemmas.
+- The packed matrix is a `Hex.Matrix UInt32 n m`, not a bare `Array`. Reusing
+  `Hex.Matrix`'s flat row-major backing means `Matrix.rowSwap`,
+  `Matrix.modifyEntries` and their entrywise read lemmas are already proved,
+  and the in-place update on a uniquely referenced buffer is the one the
+  generic path already relies on. That is what kept the correspondence to
+  ~900 lines.
+- `Packed.reduceLoop` mirrors `Matrix.rowReduceLoop` step for step without the
+  transform; `Packed.reduceLoop_sim` is the one induction relating them under
+  `Rep`, with the reference's transform carried on the right and never
+  inspected.
+- `Packed.nullspaceArray` reads the basis off the reduced buffer;
+  `Packed.nullspaceArray_eq` proves it equals `(Matrix.nullspace E).toArray`.
+- `Packed.fixedSpace` fills the buffer straight from `berlekampColumnPolys`,
+  so no `Matrix (ZMod64 p)` is built on the fast path.
+- `Packed.kernelArray_eq` is the single correspondence theorem;
+  `fixedSpaceKernelVectors_eq_packed` is the `@[csimp]`.
+- `reports/hexbz-packed-fp-matrix-integration.md`, with a fresh phase profile
+  and full sweep at this revision.
+
+Measured, same driver and host as the prototype page: `fixedSpaceKernelVectors`
+on `cyclo_phi385` 327.823 ms → 53.886 ms (6.08x), whole factorization
+434.641 ms → 167.124 ms (2.60x). No row of the 24-row representative set
+regresses above 5% on either span.
+
+## Decisions made
+
+**The field instance had to be pinned.** `fixedSpaceKernelVectors` took an
+opaque `[Lean.Grind.Field (ZMod64 p)]`. `Lean.Grind.Field` bundles `Add`,
+`Mul` and `Inv` as structure fields, so `rowReduceLoop`'s arithmetic is
+whatever dictionary the caller supplies, and *no* packed implementation can be
+correct for every dictionary — a packed word only stands for a residue under
+the canonical `ZMod64` arithmetic. The Berlekamp kernel path is now
+parameterised by `[ZMod64.PrimeModulus p]` instead. Every call site already
+had a primality witness in scope and was already building
+`zmod64FieldOfPrime` from it, so this is a strengthening of an existing
+hypothesis, not a new one, and `PrimeModulus` is a `Prop` class so nothing new
+is passed at runtime.
+
+This is the one part of the issue's premise that did not survive contact: the
+issue asks for a `@[csimp]` at the `fixedSpaceKernelVectors` boundary without
+noting that the boundary's instance parameter makes such a theorem false as
+stated.
+
+**`@[csimp]` is order-sensitive.** It rewrites calls in code generated *after*
+the attribute is declared. `fixedSpaceKernel` (the only runtime consumer) had
+to move out of `BerlekampMatrix.lean` and below the `@[csimp]`, into
+`PackedKernel.lean`. Verified by reading the generated C: `fixedSpaceKernel`
+now calls `Packed.kernelArray` directly.
+
+## Key patterns discovered
+
+- A public declaration may not *mention* a `private`-imported constant, so the
+  lemmas naming `Matrix.findPivot?`/`eliminateColumn` are `private`. Their
+  consumers are public; proofs are not part of the exported interface.
+- `Matrix`'s `M[i]` row accessor is deliberately `noncomputable`. Definitions
+  must use the flat pair accessor `M[(i, j)]`; `Matrix.getElem_pair_eq_nested`
+  is the bridge to the lemma library, and it is *not* `rfl`.
+- Stating a simulation lemma against a definition that uses `let` in its body
+  requires writing `have` in the lemma, not `let`: the two elaborate
+  differently and unification will not bridge them inside a `Rep` argument.
+- Returning `Array` rather than `Vector` from the packed layers removes all
+  dependent-index friction; the length is recovered once, at the very end,
+  from the correspondence theorem.
+
+## Current frontier
+
+The implementation is **2.6x slower than the benchmark prototype** on the rows
+where the reduction dominates (47.683 ms against 18.164 ms on `cyclo_phi385`),
+measured in the same process. Three named causes, in the order worth fixing:
+
+1. `Matrix.rowAdd` copies the source row with `getRow` on every row addition.
+   The pivot row is invariant across a column's elimination, so hoisting one
+   `getRow` per pivot column removes `n - 1` of every `n` copies. One extra
+   invariant in the elimination induction.
+2. The pivot columns are a boxed `List (Fin m)`, mirroring `rowReduceLoop`'s
+   own representation.
+3. The basis readback is `O(m * rank)` per vector because it mirrors
+   `IsRowReduced.nullspaceMatrix`'s `pivotIndex?` scan. Not a regression (the
+   reference pays the same), but a scatter would be `O(m + rank)`.
+
+## Next step
+
+Follow-up issues for the three above, largest first. The zero-entry skip
+(1.70x on `cyclo_phi385` in the prototype) is still orthogonal and still owed
+its own evidence, including on dense matrices where it buys nothing.
+
+## Blockers
+
+Design points 2 (`UInt32` versus `UInt64` entries) and 5 (Barrett versus the
+hardware remainder) are **not** re-measured against the integrated
+implementation, as the issue asks. Separating them needs a second and third
+compiled variant of the packed loop that nothing would ship. The prototype's
+2.42x and 1.01x remain the only evidence for those two choices, and the
+integration report says so.

--- a/progress/20260804T000000Z_issue-9150.md
+++ b/progress/20260804T000000Z_issue-9150.md
@@ -32,9 +32,11 @@ equality. `HexBerlekamp/PackedKernel.lean` holds the whole development.
   and full sweep at this revision.
 
 Measured, same driver and host as the prototype page: `fixedSpaceKernelVectors`
-on `cyclo_phi385` 327.823 ms → 53.886 ms (6.08x), whole factorization
-434.641 ms → 167.124 ms (2.60x). No row of the 24-row representative set
-regresses above 5% on either span.
+on `cyclo_phi385` 327.823 ms → 54.057 ms (6.06x), whole factorization
+434.641 ms → 165.854 ms (2.62x). No row of the 24-row representative set
+regresses above 5% on either span. The full 392-instance sweep is an
+anti-regression check only: its solved-instance total moves less than two runs
+of the same code differ from each other.
 
 ## Decisions made
 
@@ -97,6 +99,18 @@ measured in the same process. Three named causes, in the order worth fixing:
 Follow-up issues for the three above, largest first. The zero-entry skip
 (1.70x on `cyclo_phi385` in the prototype) is still orthogonal and still owed
 its own evidence, including on dense matrices where it buys nothing.
+
+## Second opinion
+
+Codex reviewed the branch and found no correctness defect in the packed kernel
+or the simulation, and independently confirmed both structural claims (the
+instance pinning and the `@[csimp]` ordering, the latter by reading the
+generated C). Its three findings were taken: the duplicated
+`[ZMod64.PrimeModulus p]` binders my mechanical replacement left on eight
+`Factor.lean` declarations, a proposition-valued `def` adapter in
+`PrimeSelection.lean` that only renamed `ZMod64.primeModulusOfPrime`, and the
+observation that `berlekampRankTest` never reaches the fixed-space kernel and
+so did not need its binder narrowed -- its opaque `Field` binder is restored.
 
 ## Blockers
 

--- a/reports/bench-results/hexbz-factor-sweep-433dba23-hex-chungus2.json
+++ b/reports/bench-results/hexbz-factor-sweep-433dba23-hex-chungus2.json
@@ -1,0 +1,6018 @@
+{
+  "env": {
+    "lean_version": null,
+    "lean_toolchain": "leanprover/lean4:v4.33.0-rc1",
+    "platform_target": null,
+    "os": "linux",
+    "arch": "x86_64",
+    "cpu_model": null,
+    "cpu_cores": 96,
+    "hostname": "chungus2",
+    "exe_name": "factor_sweep",
+    "lean_bench_version": null,
+    "git_commit": "433dba23042d14c4c8c6b26036893d2a9dadff10",
+    "git_dirty": false,
+    "timestamp_unix_ms": 1785801393470,
+    "timestamp_iso": "2026-08-03T23:56:33Z"
+  },
+  "config": {
+    "cutoff_seconds": 10.0,
+    "repeats_policy": "median-of-5 when first call < 1s, else single call",
+    "overhead_repeats": 21,
+    "corpus_path": "bench/corpus/hexbz-factor-corpus.jsonl",
+    "corpus_sha256": "619913904240834c912489e6cc23ba136e8cc5ebf0ea95f83397e0682387284d",
+    "early_terminate_run": 0,
+    "early_terminate_families": [],
+    "systems": [
+      "hex-factor"
+    ],
+    "system_versions": {
+      "hex-factor": "leanprover/lean4:v4.33.0-rc1"
+    },
+    "per_system_overhead_nanos": {
+      "hex-factor": 19839
+    }
+  },
+  "results": [
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi5",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 33661,
+      "min_nanos": 32428,
+      "max_nanos": 54271,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi7",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 42543,
+      "min_nanos": 39228,
+      "max_nanos": 46359,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi11",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 95342,
+      "min_nanos": 93128,
+      "max_nanos": 134509,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi15",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 99627,
+      "min_nanos": 96963,
+      "max_nanos": 107089,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi13",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 231433,
+      "min_nanos": 215350,
+      "max_nanos": 250211,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi17",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 104595,
+      "min_nanos": 102652,
+      "max_nanos": 111415,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi19",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 115771,
+      "min_nanos": 115031,
+      "max_nanos": 128290,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi23",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 247046,
+      "min_nanos": 245093,
+      "max_nanos": 284031,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi35",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 389497,
+      "min_nanos": 381375,
+      "max_nanos": 425351,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi29",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 217022,
+      "min_nanos": 216801,
+      "max_nanos": 232044,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi37",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 667619,
+      "min_nanos": 648912,
+      "max_nanos": 712166,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi41",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 1975359,
+      "min_nanos": 1966756,
+      "max_nanos": 1994036,
+      "factor_count": 1,
+      "factor_degrees": [
+        40
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi53",
+      "degree": 52,
+      "status": "ok",
+      "median_nanos": 607270,
+      "min_nanos": 604887,
+      "max_nanos": 628532,
+      "factor_count": 1,
+      "factor_degrees": [
+        52
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi64",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 332913,
+      "min_nanos": 327466,
+      "max_nanos": 338672,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi61",
+      "degree": 60,
+      "status": "ok",
+      "median_nanos": 6369764,
+      "min_nanos": 6354822,
+      "max_nanos": 6406869,
+      "factor_count": 1,
+      "factor_degrees": [
+        60
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi105",
+      "degree": 48,
+      "status": "ok",
+      "median_nanos": 5561236,
+      "min_nanos": 5551621,
+      "max_nanos": 5571751,
+      "factor_count": 1,
+      "factor_degrees": [
+        48
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi89",
+      "degree": 88,
+      "status": "ok",
+      "median_nanos": 1558681,
+      "min_nanos": 1545611,
+      "max_nanos": 1573754,
+      "factor_count": 1,
+      "factor_degrees": [
+        88
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi128",
+      "degree": 64,
+      "status": "ok",
+      "median_nanos": 1062906,
+      "min_nanos": 1034324,
+      "max_nanos": 1076035,
+      "factor_count": 1,
+      "factor_degrees": [
+        64
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi121",
+      "degree": 110,
+      "status": "ok",
+      "median_nanos": 45269509,
+      "min_nanos": 44651963,
+      "max_nanos": 45501242,
+      "factor_count": 1,
+      "factor_degrees": [
+        110
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi165",
+      "degree": 80,
+      "status": "ok",
+      "median_nanos": 10458627,
+      "min_nanos": 10439067,
+      "max_nanos": 10475572,
+      "factor_count": 1,
+      "factor_degrees": [
+        80
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi151",
+      "degree": 150,
+      "status": "ok",
+      "median_nanos": 40722848,
+      "min_nanos": 40577523,
+      "max_nanos": 40798440,
+      "factor_count": 1,
+      "factor_degrees": [
+        150
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi179",
+      "degree": 178,
+      "status": "ok",
+      "median_nanos": 42551609,
+      "min_nanos": 42390390,
+      "max_nanos": 42682253,
+      "factor_count": 1,
+      "factor_degrees": [
+        178
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi256",
+      "degree": 128,
+      "status": "ok",
+      "median_nanos": 4184343,
+      "min_nanos": 4166868,
+      "max_nanos": 4223923,
+      "factor_count": 1,
+      "factor_degrees": [
+        128
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi257",
+      "degree": 256,
+      "status": "ok",
+      "median_nanos": 12067182,
+      "min_nanos": 12043377,
+      "max_nanos": 12303181,
+      "factor_count": 1,
+      "factor_degrees": [
+        256
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi385",
+      "degree": 240,
+      "status": "ok",
+      "median_nanos": 168298328,
+      "min_nanos": 168007837,
+      "max_nanos": 168719663,
+      "factor_count": 1,
+      "factor_degrees": [
+        240
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi331",
+      "degree": 330,
+      "status": "ok",
+      "median_nanos": 20529288,
+      "min_nanos": 20388279,
+      "max_nanos": 21192911,
+      "factor_count": 1,
+      "factor_degrees": [
+        330
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi509",
+      "degree": 508,
+      "status": "ok",
+      "median_nanos": 48751161,
+      "min_nanos": 48668699,
+      "max_nanos": 49668201,
+      "factor_count": 1,
+      "factor_degrees": [
+        508
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi1031",
+      "degree": 1030,
+      "status": "ok",
+      "median_nanos": 3873484322,
+      "min_nanos": 3873484322,
+      "max_nanos": 3873484322,
+      "factor_count": 1,
+      "factor_degrees": [
+        1030
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi25",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 141230,
+      "min_nanos": 139036,
+      "max_nanos": 233035,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi49",
+      "degree": 42,
+      "status": "ok",
+      "median_nanos": 451259,
+      "min_nanos": 445601,
+      "max_nanos": 461044,
+      "factor_count": 1,
+      "factor_degrees": [
+        42
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi81",
+      "degree": 54,
+      "status": "ok",
+      "median_nanos": 762681,
+      "min_nanos": 753428,
+      "max_nanos": 766075,
+      "factor_count": 1,
+      "factor_degrees": [
+        54
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi243",
+      "degree": 162,
+      "status": "ok",
+      "median_nanos": 6122517,
+      "min_nanos": 6108848,
+      "max_nanos": 6147224,
+      "factor_count": 1,
+      "factor_degrees": [
+        162
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi275",
+      "degree": 200,
+      "status": "ok",
+      "median_nanos": 829227656,
+      "min_nanos": 818873264,
+      "max_nanos": 836505306,
+      "factor_count": 1,
+      "factor_degrees": [
+        200
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi625",
+      "degree": 500,
+      "status": "ok",
+      "median_nanos": 59577613,
+      "min_nanos": 59181275,
+      "max_nanos": 60042362,
+      "factor_count": 1,
+      "factor_degrees": [
+        500
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow6_minus1",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 91576,
+      "min_nanos": 88692,
+      "max_nanos": 151915,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow12_minus1",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 232825,
+      "min_nanos": 226085,
+      "max_nanos": 245384,
+      "factor_count": 6,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow15_minus1",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 276410,
+      "min_nanos": 271993,
+      "max_nanos": 309198,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow20_minus1",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 454834,
+      "min_nanos": 434023,
+      "max_nanos": 489766,
+      "factor_count": 6,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        4,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow24_minus1",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 2351256,
+      "min_nanos": 2335502,
+      "max_nanos": 2382802,
+      "factor_count": 8,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow30_minus1",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 1715473,
+      "min_nanos": 1703746,
+      "max_nanos": 1763444,
+      "factor_count": 8,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        4,
+        4,
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow36_minus1",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 2652784,
+      "min_nanos": 2636809,
+      "max_nanos": 2675898,
+      "factor_count": 9,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        6,
+        6,
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow48_minus1",
+      "degree": 48,
+      "status": "ok",
+      "median_nanos": 10572706,
+      "min_nanos": 10564243,
+      "max_nanos": 10787544,
+      "factor_count": 10,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        8,
+        8,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow60_minus1",
+      "degree": 60,
+      "status": "ok",
+      "median_nanos": 5669535,
+      "min_nanos": 5656206,
+      "max_nanos": 5678880,
+      "factor_count": 12,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        4,
+        8,
+        8,
+        8,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow105_minus1",
+      "degree": 105,
+      "status": "ok",
+      "median_nanos": 46759558,
+      "min_nanos": 46652089,
+      "max_nanos": 46906566,
+      "factor_count": 8,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        6,
+        8,
+        12,
+        24,
+        48
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow120_minus1",
+      "degree": 120,
+      "status": "ok",
+      "median_nanos": 148880978,
+      "min_nanos": 148649936,
+      "max_nanos": 150037343,
+      "factor_count": 16,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        4,
+        4,
+        8,
+        8,
+        8,
+        8,
+        16,
+        16,
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi7_x_phi11",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 257252,
+      "min_nanos": 248258,
+      "max_nanos": 325052,
+      "factor_count": 2,
+      "factor_degrees": [
+        6,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi12_x_phi13",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 379573,
+      "min_nanos": 373864,
+      "max_nanos": 404971,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi15_x_phi17",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 662021,
+      "min_nanos": 655612,
+      "max_nanos": 695551,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi24_x_phi35",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 9134544,
+      "min_nanos": 9125290,
+      "max_nanos": 9152791,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi32_x_phi45",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 2710679,
+      "min_nanos": 2685101,
+      "max_nanos": 2721716,
+      "factor_count": 2,
+      "factor_degrees": [
+        16,
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi64_x_phi105",
+      "degree": 80,
+      "status": "ok",
+      "median_nanos": 46828129,
+      "min_nanos": 46789132,
+      "max_nanos": 46964742,
+      "factor_count": 2,
+      "factor_degrees": [
+        32,
+        48
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi105_x_phi128",
+      "degree": 112,
+      "status": "ok",
+      "median_nanos": 88471963,
+      "min_nanos": 87711315,
+      "max_nanos": 88657018,
+      "factor_count": 2,
+      "factor_degrees": [
+        48,
+        64
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi128_x_phi165",
+      "degree": 144,
+      "status": "ok",
+      "median_nanos": 84911514,
+      "min_nanos": 84786770,
+      "max_nanos": 85662167,
+      "factor_count": 2,
+      "factor_degrees": [
+        64,
+        80
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd2",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 47531,
+      "min_nanos": 43754,
+      "max_nanos": 92907,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd3",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 161921,
+      "min_nanos": 158264,
+      "max_nanos": 184163,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd4",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 864963,
+      "min_nanos": 852884,
+      "max_nanos": 897861,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd5",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 70572404,
+      "min_nanos": 70328653,
+      "max_nanos": 70955253,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd6",
+      "degree": 64,
+      "status": "ok",
+      "median_nanos": 8473652319,
+      "min_nanos": 8473652319,
+      "max_nanos": 8473652319,
+      "factor_count": 1,
+      "factor_degrees": [
+        64
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd7",
+      "degree": 128,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd2_shift1",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 62293,
+      "min_nanos": 46309,
+      "max_nanos": 21628748,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd3_shift1",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 158154,
+      "min_nanos": 152927,
+      "max_nanos": 185855,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd3_shift2",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 152807,
+      "min_nanos": 150604,
+      "max_nanos": 158615,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd4_shift1",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 795690,
+      "min_nanos": 777783,
+      "max_nanos": 923188,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd4_shift3",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 862268,
+      "min_nanos": 847627,
+      "max_nanos": 910560,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd5_shift1",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 64762410,
+      "min_nanos": 64009493,
+      "max_nanos": 65101993,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd5_shift2",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 67817069,
+      "min_nanos": 67642860,
+      "max_nanos": 67915294,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd6_shift1",
+      "degree": 64,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd6_shift5",
+      "degree": 64,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd2_x_sd2shift1",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 139617,
+      "min_nanos": 130032,
+      "max_nanos": 22992429,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd3_x_sd3shift1",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 872353,
+      "min_nanos": 859545,
+      "max_nanos": 930570,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd4_x_sd4shift1",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 18456615,
+      "min_nanos": 18422875,
+      "max_nanos": 18533499,
+      "factor_count": 2,
+      "factor_degrees": [
+        16,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd5_x_sd5shift1",
+      "degree": 64,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd6_x_sd6shift1",
+      "degree": 128,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd2_x_phi12",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 130213,
+      "min_nanos": 120990,
+      "max_nanos": 22204933,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd3_x_phi15",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 498349,
+      "min_nanos": 479401,
+      "max_nanos": 545108,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd3_x_phi24",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 571537,
+      "min_nanos": 543115,
+      "max_nanos": 586550,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd4_x_phi17",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 6536171,
+      "min_nanos": 6514779,
+      "max_nanos": 6628087,
+      "factor_count": 2,
+      "factor_degrees": [
+        16,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd4_x_phi35",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 17808864,
+      "min_nanos": 17715286,
+      "max_nanos": 17907330,
+      "factor_count": 2,
+      "factor_degrees": [
+        16,
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd5_x_phi11",
+      "degree": 42,
+      "status": "ok",
+      "median_nanos": 141479795,
+      "min_nanos": 140992552,
+      "max_nanos": 142068728,
+      "factor_count": 2,
+      "factor_degrees": [
+        10,
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd5_x_phi45",
+      "degree": 56,
+      "status": "ok",
+      "median_nanos": 322819587,
+      "min_nanos": 322017237,
+      "max_nanos": 323778408,
+      "factor_count": 2,
+      "factor_degrees": [
+        24,
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd6_x_phi13",
+      "degree": 76,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd6_x_phi105",
+      "degree": 112,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 38887,
+      "min_nanos": 28983,
+      "max_nanos": 22049241,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 25648,
+      "min_nanos": 23685,
+      "max_nanos": 27881,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 32368,
+      "min_nanos": 30946,
+      "max_nanos": 43354,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 54922,
+      "min_nanos": 48101,
+      "max_nanos": 78226,
+      "factor_count": 2,
+      "factor_degrees": [
+        2,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 32518,
+      "min_nanos": 31857,
+      "max_nanos": 39068,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 60470,
+      "min_nanos": 58567,
+      "max_nanos": 69513,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 87751,
+      "min_nanos": 83654,
+      "max_nanos": 100649,
+      "factor_count": 2,
+      "factor_degrees": [
+        2,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 64876,
+      "min_nanos": 63634,
+      "max_nanos": 70214,
+      "factor_count": 2,
+      "factor_degrees": [
+        3,
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 64445,
+      "min_nanos": 61631,
+      "max_nanos": 66348,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 61051,
+      "min_nanos": 59198,
+      "max_nanos": 65647,
+      "factor_count": 3,
+      "factor_degrees": [
+        1,
+        2,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 53370,
+      "min_nanos": 51667,
+      "max_nanos": 61451,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 136493,
+      "min_nanos": 131044,
+      "max_nanos": 147269,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        1,
+        3,
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 84466,
+      "min_nanos": 82632,
+      "max_nanos": 93299,
+      "factor_count": 3,
+      "factor_degrees": [
+        1,
+        2,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 104625,
+      "min_nanos": 101360,
+      "max_nanos": 111365,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        2,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 138716,
+      "min_nanos": 135481,
+      "max_nanos": 161209,
+      "factor_count": 2,
+      "factor_degrees": [
+        2,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 108180,
+      "min_nanos": 106868,
+      "max_nanos": 123763,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 156361,
+      "min_nanos": 151635,
+      "max_nanos": 169662,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 175761,
+      "min_nanos": 172466,
+      "max_nanos": 188169,
+      "factor_count": 2,
+      "factor_degrees": [
+        6,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 279354,
+      "min_nanos": 269260,
+      "max_nanos": 301186,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 194098,
+      "min_nanos": 191054,
+      "max_nanos": 207098,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 131325,
+      "min_nanos": 128891,
+      "max_nanos": 140789,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 224062,
+      "min_nanos": 215520,
+      "max_nanos": 245394,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 483327,
+      "min_nanos": 464448,
+      "max_nanos": 536085,
+      "factor_count": 3,
+      "factor_degrees": [
+        2,
+        4,
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 265674,
+      "min_nanos": 260416,
+      "max_nanos": 299424,
+      "factor_count": 2,
+      "factor_degrees": [
+        9,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 519070,
+      "min_nanos": 499921,
+      "max_nanos": 561903,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 698886,
+      "min_nanos": 680950,
+      "max_nanos": 735320,
+      "factor_count": 6,
+      "factor_degrees": [
+        1,
+        1,
+        3,
+        3,
+        6,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 422076,
+      "min_nanos": 417098,
+      "max_nanos": 452631,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 570856,
+      "min_nanos": 554312,
+      "max_nanos": 611637,
+      "factor_count": 4,
+      "factor_degrees": [
+        2,
+        2,
+        10,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 35413,
+      "min_nanos": 34451,
+      "max_nanos": 42833,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 38988,
+      "min_nanos": 34261,
+      "max_nanos": 45468,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 62893,
+      "min_nanos": 61601,
+      "max_nanos": 67820,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 90424,
+      "min_nanos": 87950,
+      "max_nanos": 100298,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 74119,
+      "min_nanos": 72657,
+      "max_nanos": 82172,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 161410,
+      "min_nanos": 157994,
+      "max_nanos": 170173,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 175240,
+      "min_nanos": 170253,
+      "max_nanos": 182421,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 281527,
+      "min_nanos": 274797,
+      "max_nanos": 296620,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 225655,
+      "min_nanos": 220787,
+      "max_nanos": 237252,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 618978,
+      "min_nanos": 609925,
+      "max_nanos": 650915,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 531669,
+      "min_nanos": 524998,
+      "max_nanos": 558408,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 2176557,
+      "min_nanos": 2172071,
+      "max_nanos": 2224438,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 2852199,
+      "min_nanos": 2802565,
+      "max_nanos": 2906219,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 985150,
+      "min_nanos": 974575,
+      "max_nanos": 1037198,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 1753811,
+      "min_nanos": 1745578,
+      "max_nanos": 1797675,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 7082221,
+      "min_nanos": 7072075,
+      "max_nanos": 7181017,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 1915870,
+      "min_nanos": 1888130,
+      "max_nanos": 2001998,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 8582184,
+      "min_nanos": 8498350,
+      "max_nanos": 8700459,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P34",
+      "degree": 34,
+      "status": "ok",
+      "median_nanos": 3072315,
+      "min_nanos": 3039647,
+      "max_nanos": 3177922,
+      "factor_count": 1,
+      "factor_degrees": [
+        34
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P38",
+      "degree": 38,
+      "status": "ok",
+      "median_nanos": 3868125,
+      "min_nanos": 3842928,
+      "max_nanos": 3927012,
+      "factor_count": 1,
+      "factor_degrees": [
+        38
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 31957,
+      "min_nanos": 31326,
+      "max_nanos": 50115,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 54320,
+      "min_nanos": 53229,
+      "max_nanos": 66229,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 81521,
+      "min_nanos": 79478,
+      "max_nanos": 91836,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 96614,
+      "min_nanos": 95191,
+      "max_nanos": 109041,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 144124,
+      "min_nanos": 140768,
+      "max_nanos": 156211,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 116582,
+      "min_nanos": 113468,
+      "max_nanos": 123423,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 119417,
+      "min_nanos": 118336,
+      "max_nanos": 124014,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 228979,
+      "min_nanos": 224082,
+      "max_nanos": 244953,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 172796,
+      "min_nanos": 170753,
+      "max_nanos": 178054,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 353143,
+      "min_nanos": 350379,
+      "max_nanos": 375988,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 384170,
+      "min_nanos": 378772,
+      "max_nanos": 406863,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 553321,
+      "min_nanos": 544027,
+      "max_nanos": 632277,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 748750,
+      "min_nanos": 742922,
+      "max_nanos": 789060,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 972371,
+      "min_nanos": 962076,
+      "max_nanos": 1006963,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 1063346,
+      "min_nanos": 1052131,
+      "max_nanos": 1106400,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 1758127,
+      "min_nanos": 1746380,
+      "max_nanos": 1788842,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 975376,
+      "min_nanos": 974165,
+      "max_nanos": 990138,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 1755362,
+      "min_nanos": 1737356,
+      "max_nanos": 1796203,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 2973629,
+      "min_nanos": 2959628,
+      "max_nanos": 3035320,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L32",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 5541887,
+      "min_nanos": 5534666,
+      "max_nanos": 5555848,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 81481,
+      "min_nanos": 76984,
+      "max_nanos": 106778,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 129392,
+      "min_nanos": 127249,
+      "max_nanos": 140589,
+      "factor_count": 6,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 195831,
+      "min_nanos": 191414,
+      "max_nanos": 209691,
+      "factor_count": 8,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 448465,
+      "min_nanos": 438801,
+      "max_nanos": 470117,
+      "factor_count": 10,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 593930,
+      "min_nanos": 588552,
+      "max_nanos": 615853,
+      "factor_count": 12,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 828118,
+      "min_nanos": 823762,
+      "max_nanos": 870691,
+      "factor_count": 14,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 1117797,
+      "min_nanos": 1107542,
+      "max_nanos": 1152028,
+      "factor_count": 16,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 1713591,
+      "min_nanos": 1702835,
+      "max_nanos": 1749194,
+      "factor_count": 18,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 2263036,
+      "min_nanos": 2259170,
+      "max_nanos": 2295033,
+      "factor_count": 20,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 3526679,
+      "min_nanos": 3501221,
+      "max_nanos": 3539117,
+      "factor_count": 24,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 6530172,
+      "min_nanos": 6519316,
+      "max_nanos": 6534878,
+      "factor_count": 28,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_32",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 8337692,
+      "min_nanos": 8332694,
+      "max_nanos": 8365803,
+      "factor_count": 32,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_40",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 13568698,
+      "min_nanos": 13562168,
+      "max_nanos": 13593094,
+      "factor_count": 40,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_48",
+      "degree": 48,
+      "status": "ok",
+      "median_nanos": 24492554,
+      "min_nanos": 24389150,
+      "max_nanos": 24639802,
+      "factor_count": 48,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_56",
+      "degree": 56,
+      "status": "ok",
+      "median_nanos": 33008971,
+      "min_nanos": 32965766,
+      "max_nanos": 33055079,
+      "factor_count": 56,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_00",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 824262,
+      "min_nanos": 796932,
+      "max_nanos": 896068,
+      "factor_count": 3,
+      "factor_degrees": [
+        5,
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_01",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 278052,
+      "min_nanos": 266835,
+      "max_nanos": 318723,
+      "factor_count": 2,
+      "factor_degrees": [
+        6,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_02",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 771423,
+      "min_nanos": 761420,
+      "max_nanos": 807026,
+      "factor_count": 2,
+      "factor_degrees": [
+        9,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_03",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 741079,
+      "min_nanos": 730574,
+      "max_nanos": 774388,
+      "factor_count": 4,
+      "factor_degrees": [
+        2,
+        2,
+        4,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_04",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 341457,
+      "min_nanos": 332563,
+      "max_nanos": 355837,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_05",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 325052,
+      "min_nanos": 313615,
+      "max_nanos": 361826,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_06",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 365311,
+      "min_nanos": 358291,
+      "max_nanos": 387164,
+      "factor_count": 3,
+      "factor_degrees": [
+        4,
+        4,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_07",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 152486,
+      "min_nanos": 150693,
+      "max_nanos": 160829,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_08",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 357510,
+      "min_nanos": 348838,
+      "max_nanos": 374225,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_09",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 300465,
+      "min_nanos": 293175,
+      "max_nanos": 326324,
+      "factor_count": 3,
+      "factor_degrees": [
+        3,
+        4,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_10",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 619439,
+      "min_nanos": 601401,
+      "max_nanos": 664054,
+      "factor_count": 2,
+      "factor_degrees": [
+        10,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_11",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 390850,
+      "min_nanos": 379903,
+      "max_nanos": 425230,
+      "factor_count": 3,
+      "factor_degrees": [
+        1,
+        7,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_12",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 426081,
+      "min_nanos": 408115,
+      "max_nanos": 462986,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        3,
+        7,
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_13",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 205494,
+      "min_nanos": 201669,
+      "max_nanos": 232305,
+      "factor_count": 3,
+      "factor_degrees": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_14",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 206296,
+      "min_nanos": 199386,
+      "max_nanos": 233476,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_15",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 682592,
+      "min_nanos": 668111,
+      "max_nanos": 719947,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        5,
+        7,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_16",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 228408,
+      "min_nanos": 221929,
+      "max_nanos": 242099,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_17",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 250762,
+      "min_nanos": 247457,
+      "max_nanos": 274708,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_18",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 1024209,
+      "min_nanos": 1004409,
+      "max_nanos": 1057478,
+      "factor_count": 3,
+      "factor_degrees": [
+        6,
+        6,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_19",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 249450,
+      "min_nanos": 242039,
+      "max_nanos": 274568,
+      "factor_count": 2,
+      "factor_degrees": [
+        7,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_20",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 324431,
+      "min_nanos": 314356,
+      "max_nanos": 335197,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_21",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 1412965,
+      "min_nanos": 1407246,
+      "max_nanos": 1446454,
+      "factor_count": 3,
+      "factor_degrees": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_22",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 205656,
+      "min_nanos": 198925,
+      "max_nanos": 217012,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_23",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 173046,
+      "min_nanos": 166657,
+      "max_nanos": 180828,
+      "factor_count": 2,
+      "factor_degrees": [
+        3,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_24",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 482656,
+      "min_nanos": 470928,
+      "max_nanos": 521794,
+      "factor_count": 3,
+      "factor_degrees": [
+        3,
+        5,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_25",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 170192,
+      "min_nanos": 167809,
+      "max_nanos": 183652,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_26",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 96773,
+      "min_nanos": 94139,
+      "max_nanos": 107058,
+      "factor_count": 2,
+      "factor_degrees": [
+        3,
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_27",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 447313,
+      "min_nanos": 429516,
+      "max_nanos": 460703,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_28",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 566460,
+      "min_nanos": 550165,
+      "max_nanos": 656333,
+      "factor_count": 5,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_29",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 323630,
+      "min_nanos": 319593,
+      "max_nanos": 342738,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_P7",
+      "degree": 384,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_M12_f132",
+      "degree": 132,
+      "status": "ok",
+      "median_nanos": 1032738401,
+      "min_nanos": 1032738401,
+      "max_nanos": 1032738401,
+      "factor_count": 1,
+      "factor_degrees": [
+        132
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F190",
+      "degree": 190,
+      "status": "ok",
+      "median_nanos": 3435928449,
+      "min_nanos": 3435928449,
+      "max_nanos": 3435928449,
+      "factor_count": 3,
+      "factor_degrees": [
+        10,
+        90,
+        90
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F192",
+      "degree": 192,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F256",
+      "degree": 256,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F351",
+      "degree": 351,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F630",
+      "degree": 630,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_S7",
+      "degree": 128,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_S8",
+      "degree": 256,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_S9",
+      "degree": 512,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 30956,
+      "min_nanos": 22603,
+      "max_nanos": 22446881,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 27370,
+      "min_nanos": 24837,
+      "max_nanos": 38467,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 37315,
+      "min_nanos": 35633,
+      "max_nanos": 76824,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 48512,
+      "min_nanos": 42102,
+      "max_nanos": 55462,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 49443,
+      "min_nanos": 48482,
+      "max_nanos": 55042,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 44226,
+      "min_nanos": 43324,
+      "max_nanos": 48663,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 66007,
+      "min_nanos": 63123,
+      "max_nanos": 73129,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 101450,
+      "min_nanos": 99688,
+      "max_nanos": 115642,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 84866,
+      "min_nanos": 80339,
+      "max_nanos": 93699,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 108861,
+      "min_nanos": 104595,
+      "max_nanos": 117204,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 124585,
+      "min_nanos": 116633,
+      "max_nanos": 138004,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 129001,
+      "min_nanos": 125546,
+      "max_nanos": 141530,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 93048,
+      "min_nanos": 92787,
+      "max_nanos": 105096,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 161909,
+      "min_nanos": 153698,
+      "max_nanos": 170804,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 248148,
+      "min_nanos": 227697,
+      "max_nanos": 368396,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 138766,
+      "min_nanos": 125697,
+      "max_nanos": 167909,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n17",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 261869,
+      "min_nanos": 251323,
+      "max_nanos": 295939,
+      "factor_count": 1,
+      "factor_degrees": [
+        17
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 349238,
+      "min_nanos": 339884,
+      "max_nanos": 391841,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n19",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 291652,
+      "min_nanos": 283901,
+      "max_nanos": 304201,
+      "factor_count": 1,
+      "factor_degrees": [
+        19
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 352082,
+      "min_nanos": 341446,
+      "max_nanos": 382547,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n21",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 300656,
+      "min_nanos": 290180,
+      "max_nanos": 327616,
+      "factor_count": 1,
+      "factor_degrees": [
+        21
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 517697,
+      "min_nanos": 499371,
+      "max_nanos": 559720,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n23",
+      "degree": 23,
+      "status": "ok",
+      "median_nanos": 470387,
+      "min_nanos": 460743,
+      "max_nanos": 510637,
+      "factor_count": 1,
+      "factor_degrees": [
+        23
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 412742,
+      "min_nanos": 400283,
+      "max_nanos": 446943,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n25",
+      "degree": 25,
+      "status": "ok",
+      "median_nanos": 643735,
+      "min_nanos": 614171,
+      "max_nanos": 673979,
+      "factor_count": 1,
+      "factor_degrees": [
+        25
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 538388,
+      "min_nanos": 517407,
+      "max_nanos": 581812,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n27",
+      "degree": 27,
+      "status": "ok",
+      "median_nanos": 622903,
+      "min_nanos": 617426,
+      "max_nanos": 664205,
+      "factor_count": 1,
+      "factor_degrees": [
+        27
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 344691,
+      "min_nanos": 340575,
+      "max_nanos": 355216,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n29",
+      "degree": 29,
+      "status": "ok",
+      "median_nanos": 412351,
+      "min_nanos": 399753,
+      "max_nanos": 442836,
+      "factor_count": 1,
+      "factor_degrees": [
+        29
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 803201,
+      "min_nanos": 775450,
+      "max_nanos": 841628,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n31",
+      "degree": 31,
+      "status": "ok",
+      "median_nanos": 780517,
+      "min_nanos": 761268,
+      "max_nanos": 803992,
+      "factor_count": 1,
+      "factor_degrees": [
+        31
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n32",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 679117,
+      "min_nanos": 655942,
+      "max_nanos": 725486,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n33",
+      "degree": 33,
+      "status": "ok",
+      "median_nanos": 1267519,
+      "min_nanos": 1254160,
+      "max_nanos": 1291635,
+      "factor_count": 1,
+      "factor_degrees": [
+        33
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n34",
+      "degree": 34,
+      "status": "ok",
+      "median_nanos": 991730,
+      "min_nanos": 977779,
+      "max_nanos": 1028775,
+      "factor_count": 1,
+      "factor_degrees": [
+        34
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n35",
+      "degree": 35,
+      "status": "ok",
+      "median_nanos": 1066281,
+      "min_nanos": 1052160,
+      "max_nanos": 1154021,
+      "factor_count": 1,
+      "factor_degrees": [
+        35
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n36",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 1057117,
+      "min_nanos": 1039791,
+      "max_nanos": 1092409,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n37",
+      "degree": 37,
+      "status": "ok",
+      "median_nanos": 1341079,
+      "min_nanos": 1333166,
+      "max_nanos": 1369701,
+      "factor_count": 1,
+      "factor_degrees": [
+        37
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n38",
+      "degree": 38,
+      "status": "ok",
+      "median_nanos": 1781281,
+      "min_nanos": 1768872,
+      "max_nanos": 1899556,
+      "factor_count": 1,
+      "factor_degrees": [
+        38
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n39",
+      "degree": 39,
+      "status": "ok",
+      "median_nanos": 686117,
+      "min_nanos": 677895,
+      "max_nanos": 691155,
+      "factor_count": 1,
+      "factor_degrees": [
+        39
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n40",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 1505081,
+      "min_nanos": 1493394,
+      "max_nanos": 1527114,
+      "factor_count": 1,
+      "factor_degrees": [
+        40
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 20651,
+      "min_nanos": 20340,
+      "max_nanos": 24717,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 24276,
+      "min_nanos": 23765,
+      "max_nanos": 30305,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 26399,
+      "min_nanos": 25688,
+      "max_nanos": 28783,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 32739,
+      "min_nanos": 32258,
+      "max_nanos": 36995,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 38667,
+      "min_nanos": 36224,
+      "max_nanos": 39198,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 42924,
+      "min_nanos": 42383,
+      "max_nanos": 45778,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 46458,
+      "min_nanos": 45658,
+      "max_nanos": 49313,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 58707,
+      "min_nanos": 57305,
+      "max_nanos": 61762,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 63474,
+      "min_nanos": 61912,
+      "max_nanos": 72067,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 74540,
+      "min_nanos": 74070,
+      "max_nanos": 82663,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 69162,
+      "min_nanos": 66098,
+      "max_nanos": 70684,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 91276,
+      "min_nanos": 87790,
+      "max_nanos": 92787,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 81612,
+      "min_nanos": 77955,
+      "max_nanos": 84315,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 122291,
+      "min_nanos": 121450,
+      "max_nanos": 130314,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 124064,
+      "min_nanos": 118856,
+      "max_nanos": 125366,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 140338,
+      "min_nanos": 137674,
+      "max_nanos": 145395,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n17",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 115371,
+      "min_nanos": 114890,
+      "max_nanos": 123433,
+      "factor_count": 1,
+      "factor_degrees": [
+        17
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 168330,
+      "min_nanos": 165976,
+      "max_nanos": 175991,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n19",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 137714,
+      "min_nanos": 136101,
+      "max_nanos": 144044,
+      "factor_count": 1,
+      "factor_degrees": [
+        19
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 211243,
+      "min_nanos": 210472,
+      "max_nanos": 219997,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n21",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 213036,
+      "min_nanos": 210532,
+      "max_nanos": 219405,
+      "factor_count": 1,
+      "factor_degrees": [
+        21
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 242269,
+      "min_nanos": 234558,
+      "max_nanos": 250612,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n23",
+      "degree": 23,
+      "status": "ok",
+      "median_nanos": 200337,
+      "min_nanos": 198024,
+      "max_nanos": 204282,
+      "factor_count": 1,
+      "factor_degrees": [
+        23
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 270161,
+      "min_nanos": 267967,
+      "max_nanos": 277562,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n25",
+      "degree": 25,
+      "status": "ok",
+      "median_nanos": 259795,
+      "min_nanos": 258664,
+      "max_nanos": 265484,
+      "factor_count": 1,
+      "factor_degrees": [
+        25
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 329489,
+      "min_nanos": 327145,
+      "max_nanos": 335678,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n27",
+      "degree": 27,
+      "status": "ok",
+      "median_nanos": 236902,
+      "min_nanos": 235870,
+      "max_nanos": 243061,
+      "factor_count": 1,
+      "factor_degrees": [
+        27
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 366424,
+      "min_nanos": 363690,
+      "max_nanos": 372222,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n29",
+      "degree": 29,
+      "status": "ok",
+      "median_nanos": 272754,
+      "min_nanos": 271362,
+      "max_nanos": 278142,
+      "factor_count": 1,
+      "factor_degrees": [
+        29
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 446061,
+      "min_nanos": 442205,
+      "max_nanos": 462186,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n31",
+      "degree": 31,
+      "status": "ok",
+      "median_nanos": 341596,
+      "min_nanos": 340365,
+      "max_nanos": 353785,
+      "factor_count": 1,
+      "factor_degrees": [
+        31
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n32",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 604967,
+      "min_nanos": 446432,
+      "max_nanos": 754569,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n33",
+      "degree": 33,
+      "status": "ok",
+      "median_nanos": 492981,
+      "min_nanos": 488965,
+      "max_nanos": 501804,
+      "factor_count": 1,
+      "factor_degrees": [
+        33
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n34",
+      "degree": 34,
+      "status": "ok",
+      "median_nanos": 563376,
+      "min_nanos": 559770,
+      "max_nanos": 587572,
+      "factor_count": 1,
+      "factor_degrees": [
+        34
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n35",
+      "degree": 35,
+      "status": "ok",
+      "median_nanos": 524327,
+      "min_nanos": 520552,
+      "max_nanos": 525279,
+      "factor_count": 1,
+      "factor_degrees": [
+        35
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n36",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 673558,
+      "min_nanos": 665667,
+      "max_nanos": 1079640,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n37",
+      "degree": 37,
+      "status": "ok",
+      "median_nanos": 587411,
+      "min_nanos": 515845,
+      "max_nanos": 867607,
+      "factor_count": 1,
+      "factor_degrees": [
+        37
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n38",
+      "degree": 38,
+      "status": "ok",
+      "median_nanos": 706628,
+      "min_nanos": 702812,
+      "max_nanos": 784593,
+      "factor_count": 1,
+      "factor_degrees": [
+        38
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n39",
+      "degree": 39,
+      "status": "ok",
+      "median_nanos": 637775,
+      "min_nanos": 636554,
+      "max_nanos": 642032,
+      "factor_count": 1,
+      "factor_degrees": [
+        39
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n40",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 768640,
+      "min_nanos": 765425,
+      "max_nanos": 780688,
+      "factor_count": 1,
+      "factor_degrees": [
+        40
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 19719,
+      "min_nanos": 19629,
+      "max_nanos": 23365,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 24406,
+      "min_nanos": 23775,
+      "max_nanos": 29854,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 28933,
+      "min_nanos": 27661,
+      "max_nanos": 32338,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 48822,
+      "min_nanos": 47320,
+      "max_nanos": 69703,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 66479,
+      "min_nanos": 63965,
+      "max_nanos": 80600,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 52938,
+      "min_nanos": 51937,
+      "max_nanos": 55853,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 53119,
+      "min_nanos": 52588,
+      "max_nanos": 56133,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 78847,
+      "min_nanos": 78145,
+      "max_nanos": 89733,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 96733,
+      "min_nanos": 89583,
+      "max_nanos": 105216,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 71556,
+      "min_nanos": 69222,
+      "max_nanos": 80269,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 77895,
+      "min_nanos": 77254,
+      "max_nanos": 82262,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 341226,
+      "min_nanos": 264773,
+      "max_nanos": 350229,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 115591,
+      "min_nanos": 115171,
+      "max_nanos": 122311,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 152517,
+      "min_nanos": 150853,
+      "max_nanos": 161359,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 148741,
+      "min_nanos": 145305,
+      "max_nanos": 171725,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 303761,
+      "min_nanos": 294096,
+      "max_nanos": 335708,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n17",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 434474,
+      "min_nanos": 421365,
+      "max_nanos": 465510,
+      "factor_count": 1,
+      "factor_degrees": [
+        17
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 257171,
+      "min_nanos": 255179,
+      "max_nanos": 268428,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n19",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 361416,
+      "min_nanos": 351250,
+      "max_nanos": 397519,
+      "factor_count": 1,
+      "factor_degrees": [
+        19
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 298453,
+      "min_nanos": 288548,
+      "max_nanos": 311061,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n21",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 310711,
+      "min_nanos": 301607,
+      "max_nanos": 348337,
+      "factor_count": 1,
+      "factor_degrees": [
+        21
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 452190,
+      "min_nanos": 415326,
+      "max_nanos": 696302,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n23",
+      "degree": 23,
+      "status": "ok",
+      "median_nanos": 256210,
+      "min_nanos": 250171,
+      "max_nanos": 377539,
+      "factor_count": 1,
+      "factor_degrees": [
+        23
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 524237,
+      "min_nanos": 502585,
+      "max_nanos": 564687,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n25",
+      "degree": 25,
+      "status": "ok",
+      "median_nanos": 546229,
+      "min_nanos": 527862,
+      "max_nanos": 572269,
+      "factor_count": 1,
+      "factor_degrees": [
+        25
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 564687,
+      "min_nanos": 549745,
+      "max_nanos": 590004,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n27",
+      "degree": 27,
+      "status": "ok",
+      "median_nanos": 455525,
+      "min_nanos": 446011,
+      "max_nanos": 458010,
+      "factor_count": 1,
+      "factor_degrees": [
+        27
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 896549,
+      "min_nanos": 889448,
+      "max_nanos": 926493,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n29",
+      "degree": 29,
+      "status": "ok",
+      "median_nanos": 432702,
+      "min_nanos": 424179,
+      "max_nanos": 436438,
+      "factor_count": 1,
+      "factor_degrees": [
+        29
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 971881,
+      "min_nanos": 957640,
+      "max_nanos": 1004519,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n31",
+      "degree": 31,
+      "status": "ok",
+      "median_nanos": 366033,
+      "min_nanos": 364220,
+      "max_nanos": 368456,
+      "factor_count": 1,
+      "factor_degrees": [
+        31
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n33",
+      "degree": 33,
+      "status": "ok",
+      "median_nanos": 699557,
+      "min_nanos": 694319,
+      "max_nanos": 707439,
+      "factor_count": 1,
+      "factor_degrees": [
+        33
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n35",
+      "degree": 35,
+      "status": "ok",
+      "median_nanos": 741790,
+      "min_nanos": 738455,
+      "max_nanos": 750413,
+      "factor_count": 1,
+      "factor_degrees": [
+        35
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n36",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 1121593,
+      "min_nanos": 1104959,
+      "max_nanos": 1166901,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n37",
+      "degree": 37,
+      "status": "ok",
+      "median_nanos": 594792,
+      "min_nanos": 588893,
+      "max_nanos": 597266,
+      "factor_count": 1,
+      "factor_degrees": [
+        37
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n39",
+      "degree": 39,
+      "status": "ok",
+      "median_nanos": 1369030,
+      "min_nanos": 1366607,
+      "max_nanos": 1392064,
+      "factor_count": 1,
+      "factor_degrees": [
+        39
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 23926,
+      "min_nanos": 22634,
+      "max_nanos": 34602,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 36344,
+      "min_nanos": 34061,
+      "max_nanos": 42904,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 43474,
+      "min_nanos": 40270,
+      "max_nanos": 49163,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 49093,
+      "min_nanos": 47851,
+      "max_nanos": 57606,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 66468,
+      "min_nanos": 66278,
+      "max_nanos": 73279,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 72958,
+      "min_nanos": 70795,
+      "max_nanos": 81361,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 70074,
+      "min_nanos": 64837,
+      "max_nanos": 74511,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 74711,
+      "min_nanos": 73799,
+      "max_nanos": 81981,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 103794,
+      "min_nanos": 101861,
+      "max_nanos": 112096,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 167409,
+      "min_nanos": 161529,
+      "max_nanos": 177773,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 159206,
+      "min_nanos": 152917,
+      "max_nanos": 169512,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 181780,
+      "min_nanos": 175490,
+      "max_nanos": 191824,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 223741,
+      "min_nanos": 214688,
+      "max_nanos": 250060,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 183823,
+      "min_nanos": 172857,
+      "max_nanos": 190733,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 200306,
+      "min_nanos": 196121,
+      "max_nanos": 210623,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 278964,
+      "min_nanos": 270450,
+      "max_nanos": 307476,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n17",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 310180,
+      "min_nanos": 297772,
+      "max_nanos": 340735,
+      "factor_count": 1,
+      "factor_degrees": [
+        17
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 293705,
+      "min_nanos": 287125,
+      "max_nanos": 324240,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n19",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 139367,
+      "min_nanos": 136342,
+      "max_nanos": 197603,
+      "factor_count": 1,
+      "factor_degrees": [
+        19
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 267948,
+      "min_nanos": 257391,
+      "max_nanos": 449807,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n21",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 279144,
+      "min_nanos": 264643,
+      "max_nanos": 305062,
+      "factor_count": 1,
+      "factor_degrees": [
+        21
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 450518,
+      "min_nanos": 435105,
+      "max_nanos": 487392,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n23",
+      "degree": 23,
+      "status": "ok",
+      "median_nanos": 309028,
+      "min_nanos": 301096,
+      "max_nanos": 328947,
+      "factor_count": 1,
+      "factor_degrees": [
+        23
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 503216,
+      "min_nanos": 495955,
+      "max_nanos": 531147,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n25",
+      "degree": 25,
+      "status": "ok",
+      "median_nanos": 480762,
+      "min_nanos": 472831,
+      "max_nanos": 507272,
+      "factor_count": 1,
+      "factor_degrees": [
+        25
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 576063,
+      "min_nanos": 540901,
+      "max_nanos": 606139,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n27",
+      "degree": 27,
+      "status": "ok",
+      "median_nanos": 647710,
+      "min_nanos": 610485,
+      "max_nanos": 680859,
+      "factor_count": 1,
+      "factor_degrees": [
+        27
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 710674,
+      "min_nanos": 688441,
+      "max_nanos": 750222,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n29",
+      "degree": 29,
+      "status": "ok",
+      "median_nanos": 360304,
+      "min_nanos": 353754,
+      "max_nanos": 396167,
+      "factor_count": 1,
+      "factor_degrees": [
+        29
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 1007664,
+      "min_nanos": 988296,
+      "max_nanos": 1032951,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n31",
+      "degree": 31,
+      "status": "ok",
+      "median_nanos": 709232,
+      "min_nanos": 698596,
+      "max_nanos": 737974,
+      "factor_count": 1,
+      "factor_degrees": [
+        31
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n35",
+      "degree": 35,
+      "status": "ok",
+      "median_nanos": 1614734,
+      "min_nanos": 1607644,
+      "max_nanos": 1624078,
+      "factor_count": 1,
+      "factor_degrees": [
+        35
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n36",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 1581064,
+      "min_nanos": 1569556,
+      "max_nanos": 1650848,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n37",
+      "degree": 37,
+      "status": "ok",
+      "median_nanos": 976848,
+      "min_nanos": 970488,
+      "max_nanos": 988336,
+      "factor_count": 1,
+      "factor_degrees": [
+        37
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 22624,
+      "min_nanos": 21772,
+      "max_nanos": 31216,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 27351,
+      "min_nanos": 26079,
+      "max_nanos": 33319,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 50065,
+      "min_nanos": 44676,
+      "max_nanos": 53589,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 60169,
+      "min_nanos": 57275,
+      "max_nanos": 65357,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 49023,
+      "min_nanos": 47991,
+      "max_nanos": 57486,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 49813,
+      "min_nanos": 45047,
+      "max_nanos": 53820,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 83384,
+      "min_nanos": 81230,
+      "max_nanos": 94130,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 107489,
+      "min_nanos": 103804,
+      "max_nanos": 116202,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 21602,
+      "min_nanos": 19829,
+      "max_nanos": 25267,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 34932,
+      "min_nanos": 34230,
+      "max_nanos": 37536,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 29674,
+      "min_nanos": 28563,
+      "max_nanos": 32228,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 68020,
+      "min_nanos": 64085,
+      "max_nanos": 73569,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 43324,
+      "min_nanos": 38498,
+      "max_nanos": 47741,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 67160,
+      "min_nanos": 65768,
+      "max_nanos": 82893,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 71907,
+      "min_nanos": 65977,
+      "max_nanos": 75662,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 75352,
+      "min_nanos": 73218,
+      "max_nanos": 79628,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 19649,
+      "min_nanos": 19429,
+      "max_nanos": 23836,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 39919,
+      "min_nanos": 35312,
+      "max_nanos": 45988,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 31607,
+      "min_nanos": 30015,
+      "max_nanos": 34070,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 34521,
+      "min_nanos": 33040,
+      "max_nanos": 37235,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 54721,
+      "min_nanos": 50986,
+      "max_nanos": 58777,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 47801,
+      "min_nanos": 45458,
+      "max_nanos": 50736,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 74200,
+      "min_nanos": 69403,
+      "max_nanos": 80239,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 89402,
+      "min_nanos": 88191,
+      "max_nanos": 100349,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 20761,
+      "min_nanos": 20020,
+      "max_nanos": 27891,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 35593,
+      "min_nanos": 34040,
+      "max_nanos": 38747,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 41531,
+      "min_nanos": 39829,
+      "max_nanos": 45117,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 37676,
+      "min_nanos": 36193,
+      "max_nanos": 39969,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 58337,
+      "min_nanos": 55873,
+      "max_nanos": 64175,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 82302,
+      "min_nanos": 80259,
+      "max_nanos": 90544,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 72037,
+      "min_nanos": 68351,
+      "max_nanos": 77565,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 104705,
+      "min_nanos": 101941,
+      "max_nanos": 109893,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p65537_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 21532,
+      "min_nanos": 21071,
+      "max_nanos": 24406,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p65537_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 38326,
+      "min_nanos": 36544,
+      "max_nanos": 42613,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p65537_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 48693,
+      "min_nanos": 41822,
+      "max_nanos": 118646,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p65537_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 86158,
+      "min_nanos": 69924,
+      "max_nanos": 111445,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "certificate-boundary",
+      "name": "quartic_a4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 49182,
+      "min_nanos": 47240,
+      "max_nanos": 52728,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    }
+  ],
+  "cross_check": {
+    "mismatches": [],
+    "ok": true
+  }
+}

--- a/reports/bench-results/hexbz-factor-sweep-a5e0ebe4-hex-chungus2.json
+++ b/reports/bench-results/hexbz-factor-sweep-a5e0ebe4-hex-chungus2.json
@@ -1,0 +1,6018 @@
+{
+  "env": {
+    "lean_version": null,
+    "lean_toolchain": "leanprover/lean4:v4.33.0-rc1",
+    "platform_target": null,
+    "os": "linux",
+    "arch": "x86_64",
+    "cpu_model": null,
+    "cpu_cores": 96,
+    "hostname": "chungus2",
+    "exe_name": "factor_sweep",
+    "lean_bench_version": null,
+    "git_commit": "a5e0ebe49399708a8286b8acb1c6a0877e9dc4c3",
+    "git_dirty": false,
+    "timestamp_unix_ms": 1785802394818,
+    "timestamp_iso": "2026-08-04T00:13:14Z"
+  },
+  "config": {
+    "cutoff_seconds": 10.0,
+    "repeats_policy": "median-of-5 when first call < 1s, else single call",
+    "overhead_repeats": 21,
+    "corpus_path": "bench/corpus/hexbz-factor-corpus.jsonl",
+    "corpus_sha256": "619913904240834c912489e6cc23ba136e8cc5ebf0ea95f83397e0682387284d",
+    "early_terminate_run": 0,
+    "early_terminate_families": [],
+    "systems": [
+      "hex-factor"
+    ],
+    "system_versions": {
+      "hex-factor": "leanprover/lean4:v4.33.0-rc1"
+    },
+    "per_system_overhead_nanos": {
+      "hex-factor": 18377
+    }
+  },
+  "results": [
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi5",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 32628,
+      "min_nanos": 31516,
+      "max_nanos": 51135,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi7",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 39209,
+      "min_nanos": 38617,
+      "max_nanos": 44706,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi11",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 101540,
+      "min_nanos": 93479,
+      "max_nanos": 128701,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi15",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 96483,
+      "min_nanos": 94159,
+      "max_nanos": 106328,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi13",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 208028,
+      "min_nanos": 201158,
+      "max_nanos": 241869,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi17",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 100730,
+      "min_nanos": 98867,
+      "max_nanos": 107689,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi19",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 114740,
+      "min_nanos": 112477,
+      "max_nanos": 120299,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi23",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 247267,
+      "min_nanos": 241518,
+      "max_nanos": 278924,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi35",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 377960,
+      "min_nanos": 376067,
+      "max_nanos": 417238,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi29",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 215049,
+      "min_nanos": 211874,
+      "max_nanos": 222160,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi37",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 676824,
+      "min_nanos": 652137,
+      "max_nanos": 778133,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi41",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 1979215,
+      "min_nanos": 1961719,
+      "max_nanos": 2802275,
+      "factor_count": 1,
+      "factor_degrees": [
+        40
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi53",
+      "degree": 52,
+      "status": "ok",
+      "median_nanos": 606500,
+      "min_nanos": 597466,
+      "max_nanos": 626890,
+      "factor_count": 1,
+      "factor_degrees": [
+        52
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi64",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 329970,
+      "min_nanos": 323930,
+      "max_nanos": 345572,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi61",
+      "degree": 60,
+      "status": "ok",
+      "median_nanos": 6302004,
+      "min_nanos": 6294543,
+      "max_nanos": 6351528,
+      "factor_count": 1,
+      "factor_degrees": [
+        60
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi105",
+      "degree": 48,
+      "status": "ok",
+      "median_nanos": 5491382,
+      "min_nanos": 5472985,
+      "max_nanos": 5505352,
+      "factor_count": 1,
+      "factor_degrees": [
+        48
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi89",
+      "degree": 88,
+      "status": "ok",
+      "median_nanos": 1546152,
+      "min_nanos": 1529487,
+      "max_nanos": 1565321,
+      "factor_count": 1,
+      "factor_degrees": [
+        88
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi128",
+      "degree": 64,
+      "status": "ok",
+      "median_nanos": 1047834,
+      "min_nanos": 1032210,
+      "max_nanos": 1054223,
+      "factor_count": 1,
+      "factor_degrees": [
+        64
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi121",
+      "degree": 110,
+      "status": "ok",
+      "median_nanos": 45238377,
+      "min_nanos": 44491900,
+      "max_nanos": 45263524,
+      "factor_count": 1,
+      "factor_degrees": [
+        110
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi165",
+      "degree": 80,
+      "status": "ok",
+      "median_nanos": 10396906,
+      "min_nanos": 10371879,
+      "max_nanos": 10428873,
+      "factor_count": 1,
+      "factor_degrees": [
+        80
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi151",
+      "degree": 150,
+      "status": "ok",
+      "median_nanos": 41131307,
+      "min_nanos": 41016797,
+      "max_nanos": 41201611,
+      "factor_count": 1,
+      "factor_degrees": [
+        150
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi179",
+      "degree": 178,
+      "status": "ok",
+      "median_nanos": 42970103,
+      "min_nanos": 42874952,
+      "max_nanos": 43061419,
+      "factor_count": 1,
+      "factor_degrees": [
+        178
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi256",
+      "degree": 128,
+      "status": "ok",
+      "median_nanos": 4151776,
+      "min_nanos": 4142973,
+      "max_nanos": 4222060,
+      "factor_count": 1,
+      "factor_degrees": [
+        128
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi257",
+      "degree": 256,
+      "status": "ok",
+      "median_nanos": 12069346,
+      "min_nanos": 11987895,
+      "max_nanos": 12458643,
+      "factor_count": 1,
+      "factor_degrees": [
+        256
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi385",
+      "degree": 240,
+      "status": "ok",
+      "median_nanos": 167545756,
+      "min_nanos": 165734590,
+      "max_nanos": 167939831,
+      "factor_count": 1,
+      "factor_degrees": [
+        240
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi331",
+      "degree": 330,
+      "status": "ok",
+      "median_nanos": 20955531,
+      "min_nanos": 20861972,
+      "max_nanos": 21019877,
+      "factor_count": 1,
+      "factor_degrees": [
+        330
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi509",
+      "degree": 508,
+      "status": "ok",
+      "median_nanos": 50045394,
+      "min_nanos": 49807081,
+      "max_nanos": 50129439,
+      "factor_count": 1,
+      "factor_degrees": [
+        508
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi1031",
+      "degree": 1030,
+      "status": "ok",
+      "median_nanos": 3867763436,
+      "min_nanos": 3867763436,
+      "max_nanos": 3867763436,
+      "factor_count": 1,
+      "factor_degrees": [
+        1030
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi25",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 147058,
+      "min_nanos": 139677,
+      "max_nanos": 229571,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi49",
+      "degree": 42,
+      "status": "ok",
+      "median_nanos": 447593,
+      "min_nanos": 440804,
+      "max_nanos": 453793,
+      "factor_count": 1,
+      "factor_degrees": [
+        42
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi81",
+      "degree": 54,
+      "status": "ok",
+      "median_nanos": 747238,
+      "min_nanos": 745305,
+      "max_nanos": 758945,
+      "factor_count": 1,
+      "factor_degrees": [
+        54
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi243",
+      "degree": 162,
+      "status": "ok",
+      "median_nanos": 6038804,
+      "min_nanos": 6029580,
+      "max_nanos": 6109198,
+      "factor_count": 1,
+      "factor_degrees": [
+        162
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi275",
+      "degree": 200,
+      "status": "ok",
+      "median_nanos": 825519057,
+      "min_nanos": 822782369,
+      "max_nanos": 829351260,
+      "factor_count": 1,
+      "factor_degrees": [
+        200
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic",
+      "name": "cyclo_phi625",
+      "degree": 500,
+      "status": "ok",
+      "median_nanos": 60865738,
+      "min_nanos": 59894587,
+      "max_nanos": 61156729,
+      "factor_count": 1,
+      "factor_degrees": [
+        500
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow6_minus1",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 91125,
+      "min_nanos": 87870,
+      "max_nanos": 150193,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow12_minus1",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 228548,
+      "min_nanos": 224062,
+      "max_nanos": 248739,
+      "factor_count": 6,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow15_minus1",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 276711,
+      "min_nanos": 269099,
+      "max_nanos": 302779,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow20_minus1",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 450468,
+      "min_nanos": 431840,
+      "max_nanos": 488735,
+      "factor_count": 6,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        4,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow24_minus1",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 2335583,
+      "min_nanos": 2315062,
+      "max_nanos": 2359950,
+      "factor_count": 8,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow30_minus1",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 1730616,
+      "min_nanos": 1722784,
+      "max_nanos": 1770825,
+      "factor_count": 8,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        4,
+        4,
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow36_minus1",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 2691931,
+      "min_nanos": 2672172,
+      "max_nanos": 2716718,
+      "factor_count": 9,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        6,
+        6,
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow48_minus1",
+      "degree": 48,
+      "status": "ok",
+      "median_nanos": 10586246,
+      "min_nanos": 10581790,
+      "max_nanos": 10729930,
+      "factor_count": 10,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        8,
+        8,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow60_minus1",
+      "degree": 60,
+      "status": "ok",
+      "median_nanos": 5645421,
+      "min_nanos": 5642737,
+      "max_nanos": 5679331,
+      "factor_count": 12,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        4,
+        8,
+        8,
+        8,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow105_minus1",
+      "degree": 105,
+      "status": "ok",
+      "median_nanos": 46725802,
+      "min_nanos": 46680555,
+      "max_nanos": 46892920,
+      "factor_count": 8,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        6,
+        8,
+        12,
+        24,
+        48
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "xpow120_minus1",
+      "degree": 120,
+      "status": "ok",
+      "median_nanos": 148050840,
+      "min_nanos": 147579681,
+      "max_nanos": 148534528,
+      "factor_count": 16,
+      "factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        4,
+        4,
+        8,
+        8,
+        8,
+        8,
+        16,
+        16,
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi7_x_phi11",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 257963,
+      "min_nanos": 247266,
+      "max_nanos": 327056,
+      "factor_count": 2,
+      "factor_degrees": [
+        6,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi12_x_phi13",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 379443,
+      "min_nanos": 368517,
+      "max_nanos": 400985,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi15_x_phi17",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 659869,
+      "min_nanos": 647901,
+      "max_nanos": 682091,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi24_x_phi35",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 8962409,
+      "min_nanos": 8952434,
+      "max_nanos": 8981106,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi32_x_phi45",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 2671801,
+      "min_nanos": 2659012,
+      "max_nanos": 2687996,
+      "factor_count": 2,
+      "factor_degrees": [
+        16,
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi64_x_phi105",
+      "degree": 80,
+      "status": "ok",
+      "median_nanos": 46382873,
+      "min_nanos": 46322244,
+      "max_nanos": 46400700,
+      "factor_count": 2,
+      "factor_degrees": [
+        32,
+        48
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi105_x_phi128",
+      "degree": 112,
+      "status": "ok",
+      "median_nanos": 88584798,
+      "min_nanos": 88298764,
+      "max_nanos": 89125690,
+      "factor_count": 2,
+      "factor_degrees": [
+        48,
+        64
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "cyclotomic-products",
+      "name": "cyclo_phi128_x_phi165",
+      "degree": 144,
+      "status": "ok",
+      "median_nanos": 86494659,
+      "min_nanos": 86414770,
+      "max_nanos": 86622959,
+      "factor_count": 2,
+      "factor_degrees": [
+        64,
+        80
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd2",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 43494,
+      "min_nanos": 41972,
+      "max_nanos": 80759,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd3",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 154029,
+      "min_nanos": 152737,
+      "max_nanos": 184714,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd4",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 844352,
+      "min_nanos": 833096,
+      "max_nanos": 878652,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd5",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 70499432,
+      "min_nanos": 70288579,
+      "max_nanos": 71266379,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd6",
+      "degree": 64,
+      "status": "ok",
+      "median_nanos": 9852849380,
+      "min_nanos": 9852849380,
+      "max_nanos": 9852849380,
+      "factor_count": 1,
+      "factor_degrees": [
+        64
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd7",
+      "degree": 128,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd2_shift1",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 62913,
+      "min_nanos": 49323,
+      "max_nanos": 22548353,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd3_shift1",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 164844,
+      "min_nanos": 154859,
+      "max_nanos": 196892,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd3_shift2",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 156923,
+      "min_nanos": 151284,
+      "max_nanos": 162581,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd4_shift1",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 783702,
+      "min_nanos": 770392,
+      "max_nanos": 837562,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd4_shift3",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 852214,
+      "min_nanos": 842749,
+      "max_nanos": 874967,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd5_shift1",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 64882584,
+      "min_nanos": 64644971,
+      "max_nanos": 65021420,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd5_shift2",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 67860288,
+      "min_nanos": 67728493,
+      "max_nanos": 68391155,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd6_shift1",
+      "degree": 64,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "swinnerton-dyer",
+      "name": "sd6_shift5",
+      "degree": 64,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd2_x_sd2shift1",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 240386,
+      "min_nanos": 197453,
+      "max_nanos": 23279146,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd3_x_sd3shift1",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 1360497,
+      "min_nanos": 1347448,
+      "max_nanos": 1408268,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd4_x_sd4shift1",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 18324460,
+      "min_nanos": 18258603,
+      "max_nanos": 29248578,
+      "factor_count": 2,
+      "factor_degrees": [
+        16,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd5_x_sd5shift1",
+      "degree": 64,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd6_x_sd6shift1",
+      "degree": 128,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd2_x_phi12",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 152396,
+      "min_nanos": 126808,
+      "max_nanos": 22786867,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd3_x_phi15",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 493863,
+      "min_nanos": 479141,
+      "max_nanos": 561232,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd3_x_phi24",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 561693,
+      "min_nanos": 551357,
+      "max_nanos": 597807,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd4_x_phi17",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 6657271,
+      "min_nanos": 6635448,
+      "max_nanos": 6693294,
+      "factor_count": 2,
+      "factor_degrees": [
+        16,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd4_x_phi35",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 18055562,
+      "min_nanos": 18015572,
+      "max_nanos": 18210181,
+      "factor_count": 2,
+      "factor_degrees": [
+        16,
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd5_x_phi11",
+      "degree": 42,
+      "status": "ok",
+      "median_nanos": 142570542,
+      "min_nanos": 141748885,
+      "max_nanos": 143076213,
+      "factor_count": 2,
+      "factor_degrees": [
+        10,
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd5_x_phi45",
+      "degree": 56,
+      "status": "ok",
+      "median_nanos": 325119753,
+      "min_nanos": 321256705,
+      "max_nanos": 327346615,
+      "factor_count": 2,
+      "factor_degrees": [
+        24,
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd6_x_phi13",
+      "degree": 76,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "sd-products",
+      "name": "sd6_x_phi105",
+      "degree": 112,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 51005,
+      "min_nanos": 32017,
+      "max_nanos": 22375697,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 25628,
+      "min_nanos": 23825,
+      "max_nanos": 43315,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 31586,
+      "min_nanos": 31026,
+      "max_nanos": 57044,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 50014,
+      "min_nanos": 48442,
+      "max_nanos": 79178,
+      "factor_count": 2,
+      "factor_degrees": [
+        2,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 32929,
+      "min_nanos": 32368,
+      "max_nanos": 44206,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 59909,
+      "min_nanos": 57735,
+      "max_nanos": 70214,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 101620,
+      "min_nanos": 89372,
+      "max_nanos": 210852,
+      "factor_count": 2,
+      "factor_degrees": [
+        2,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 68522,
+      "min_nanos": 65918,
+      "max_nanos": 89713,
+      "factor_count": 2,
+      "factor_degrees": [
+        3,
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 63735,
+      "min_nanos": 63294,
+      "max_nanos": 68902,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 62152,
+      "min_nanos": 58898,
+      "max_nanos": 76764,
+      "factor_count": 3,
+      "factor_degrees": [
+        1,
+        2,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 53509,
+      "min_nanos": 52849,
+      "max_nanos": 62322,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 139737,
+      "min_nanos": 134600,
+      "max_nanos": 150453,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        1,
+        3,
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 87269,
+      "min_nanos": 83153,
+      "max_nanos": 96763,
+      "factor_count": 3,
+      "factor_degrees": [
+        1,
+        2,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 105306,
+      "min_nanos": 103403,
+      "max_nanos": 117944,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        2,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 150303,
+      "min_nanos": 138535,
+      "max_nanos": 176893,
+      "factor_count": 2,
+      "factor_degrees": [
+        2,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 110734,
+      "min_nanos": 107669,
+      "max_nanos": 124355,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 155821,
+      "min_nanos": 153187,
+      "max_nanos": 178054,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 179386,
+      "min_nanos": 175179,
+      "max_nanos": 192566,
+      "factor_count": 2,
+      "factor_degrees": [
+        6,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 281417,
+      "min_nanos": 278413,
+      "max_nanos": 307215,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 201729,
+      "min_nanos": 194969,
+      "max_nanos": 212165,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 131304,
+      "min_nanos": 128640,
+      "max_nanos": 143503,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 222149,
+      "min_nanos": 218954,
+      "max_nanos": 257332,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 487613,
+      "min_nanos": 467363,
+      "max_nanos": 538508,
+      "factor_count": 3,
+      "factor_degrees": [
+        2,
+        4,
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 283831,
+      "min_nanos": 263250,
+      "max_nanos": 302087,
+      "factor_count": 2,
+      "factor_degrees": [
+        9,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 527482,
+      "min_nanos": 506330,
+      "max_nanos": 591828,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 706247,
+      "min_nanos": 687259,
+      "max_nanos": 758384,
+      "factor_count": 6,
+      "factor_degrees": [
+        1,
+        1,
+        3,
+        3,
+        6,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_T24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 427133,
+      "min_nanos": 416818,
+      "max_nanos": 452040,
+      "factor_count": 2,
+      "factor_degrees": [
+        8,
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "chebyshev",
+      "name": "chebyshev_U24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 595523,
+      "min_nanos": 566240,
+      "max_nanos": 625758,
+      "factor_count": 4,
+      "factor_degrees": [
+        2,
+        2,
+        10,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 36134,
+      "min_nanos": 35262,
+      "max_nanos": 51877,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 36685,
+      "min_nanos": 35152,
+      "max_nanos": 43083,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 63264,
+      "min_nanos": 63154,
+      "max_nanos": 71136,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 92968,
+      "min_nanos": 89343,
+      "max_nanos": 103414,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 75232,
+      "min_nanos": 72859,
+      "max_nanos": 81060,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 164053,
+      "min_nanos": 160147,
+      "max_nanos": 172947,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 175150,
+      "min_nanos": 171744,
+      "max_nanos": 184584,
+      "factor_count": 2,
+      "factor_degrees": [
+        1,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 286284,
+      "min_nanos": 281668,
+      "max_nanos": 302218,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 229130,
+      "min_nanos": 220247,
+      "max_nanos": 237943,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 720809,
+      "min_nanos": 638807,
+      "max_nanos": 1019262,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 888066,
+      "min_nanos": 886013,
+      "max_nanos": 908337,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 3633618,
+      "min_nanos": 3212132,
+      "max_nanos": 3704823,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 2980489,
+      "min_nanos": 2794173,
+      "max_nanos": 3919882,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 975887,
+      "min_nanos": 964400,
+      "max_nanos": 1040462,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 1780289,
+      "min_nanos": 1764046,
+      "max_nanos": 1893468,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 7218413,
+      "min_nanos": 7156171,
+      "max_nanos": 7356838,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 1918745,
+      "min_nanos": 1907207,
+      "max_nanos": 1959926,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 8804615,
+      "min_nanos": 8603497,
+      "max_nanos": 9092051,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P34",
+      "degree": 34,
+      "status": "ok",
+      "median_nanos": 3067017,
+      "min_nanos": 3026408,
+      "max_nanos": 3155389,
+      "factor_count": 1,
+      "factor_degrees": [
+        34
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "legendre",
+      "name": "legendre_P38",
+      "degree": 38,
+      "status": "ok",
+      "median_nanos": 3805713,
+      "min_nanos": 3783039,
+      "max_nanos": 4078417,
+      "factor_count": 1,
+      "factor_degrees": [
+        38
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 31176,
+      "min_nanos": 30995,
+      "max_nanos": 46089,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 54951,
+      "min_nanos": 54471,
+      "max_nanos": 67349,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 83964,
+      "min_nanos": 81371,
+      "max_nanos": 97304,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 97574,
+      "min_nanos": 94681,
+      "max_nanos": 107159,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 145326,
+      "min_nanos": 142251,
+      "max_nanos": 165705,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 116944,
+      "min_nanos": 113508,
+      "max_nanos": 124415,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 118666,
+      "min_nanos": 117835,
+      "max_nanos": 125086,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 227708,
+      "min_nanos": 224303,
+      "max_nanos": 248418,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 171555,
+      "min_nanos": 169151,
+      "max_nanos": 178054,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 356729,
+      "min_nanos": 348457,
+      "max_nanos": 383088,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 386914,
+      "min_nanos": 378551,
+      "max_nanos": 406282,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 570496,
+      "min_nanos": 540081,
+      "max_nanos": 688171,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 755480,
+      "min_nanos": 742160,
+      "max_nanos": 792995,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 979833,
+      "min_nanos": 966073,
+      "max_nanos": 1031970,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 1114062,
+      "min_nanos": 1072461,
+      "max_nanos": 1246728,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 1767751,
+      "min_nanos": 1757526,
+      "max_nanos": 1811066,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 971140,
+      "min_nanos": 968757,
+      "max_nanos": 988936,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 1785407,
+      "min_nanos": 1748001,
+      "max_nanos": 1863933,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 3016993,
+      "min_nanos": 2956033,
+      "max_nanos": 3153376,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "laguerre",
+      "name": "laguerre_L32",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 5569288,
+      "min_nanos": 5544831,
+      "max_nanos": 5864325,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 79828,
+      "min_nanos": 77575,
+      "max_nanos": 113439,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 138555,
+      "min_nanos": 131385,
+      "max_nanos": 147990,
+      "factor_count": 6,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 201078,
+      "min_nanos": 198164,
+      "max_nanos": 212325,
+      "factor_count": 8,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 467393,
+      "min_nanos": 457318,
+      "max_nanos": 485360,
+      "factor_count": 10,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 644265,
+      "min_nanos": 621882,
+      "max_nanos": 674269,
+      "factor_count": 12,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 885874,
+      "min_nanos": 867246,
+      "max_nanos": 907695,
+      "factor_count": 14,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 1208462,
+      "min_nanos": 1168513,
+      "max_nanos": 1302080,
+      "factor_count": 16,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 1770054,
+      "min_nanos": 1757777,
+      "max_nanos": 1790865,
+      "factor_count": 18,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 2347230,
+      "min_nanos": 2336835,
+      "max_nanos": 2402632,
+      "factor_count": 20,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 3669290,
+      "min_nanos": 3654769,
+      "max_nanos": 3683992,
+      "factor_count": 24,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 6713444,
+      "min_nanos": 6704411,
+      "max_nanos": 6791550,
+      "factor_count": 28,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_32",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 8585430,
+      "min_nanos": 8580352,
+      "max_nanos": 8670887,
+      "factor_count": 32,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_40",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 14153235,
+      "min_nanos": 14078895,
+      "max_nanos": 14295196,
+      "factor_count": 40,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_48",
+      "degree": 48,
+      "status": "ok",
+      "median_nanos": 25382825,
+      "min_nanos": 25313753,
+      "max_nanos": 25405669,
+      "factor_count": 48,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "wilkinson",
+      "name": "wilkinson_56",
+      "degree": 56,
+      "status": "ok",
+      "median_nanos": 34421909,
+      "min_nanos": 34377693,
+      "max_nanos": 34513354,
+      "factor_count": 56,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_00",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 831182,
+      "min_nanos": 822389,
+      "max_nanos": 914776,
+      "factor_count": 3,
+      "factor_degrees": [
+        5,
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_01",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 276449,
+      "min_nanos": 271452,
+      "max_nanos": 316108,
+      "factor_count": 2,
+      "factor_degrees": [
+        6,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_02",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 786376,
+      "min_nanos": 776902,
+      "max_nanos": 823541,
+      "factor_count": 2,
+      "factor_degrees": [
+        9,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_03",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 765045,
+      "min_nanos": 753537,
+      "max_nanos": 791293,
+      "factor_count": 4,
+      "factor_degrees": [
+        2,
+        2,
+        4,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_04",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 342018,
+      "min_nanos": 338712,
+      "max_nanos": 363679,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_05",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 327235,
+      "min_nanos": 318582,
+      "max_nanos": 357741,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_06",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 374605,
+      "min_nanos": 363539,
+      "max_nanos": 397229,
+      "factor_count": 3,
+      "factor_degrees": [
+        4,
+        4,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_07",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 155050,
+      "min_nanos": 152467,
+      "max_nanos": 165716,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_08",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 368026,
+      "min_nanos": 360544,
+      "max_nanos": 382708,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_09",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 301447,
+      "min_nanos": 299134,
+      "max_nanos": 326244,
+      "factor_count": 3,
+      "factor_degrees": [
+        3,
+        4,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_10",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 618988,
+      "min_nanos": 612799,
+      "max_nanos": 664765,
+      "factor_count": 2,
+      "factor_degrees": [
+        10,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_11",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 396909,
+      "min_nanos": 389487,
+      "max_nanos": 423948,
+      "factor_count": 3,
+      "factor_degrees": [
+        1,
+        7,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_12",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 424720,
+      "min_nanos": 411470,
+      "max_nanos": 461935,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        3,
+        7,
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_13",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 210622,
+      "min_nanos": 203121,
+      "max_nanos": 228358,
+      "factor_count": 3,
+      "factor_degrees": [
+        1,
+        4,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_14",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 216771,
+      "min_nanos": 201028,
+      "max_nanos": 231753,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_15",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 691095,
+      "min_nanos": 680499,
+      "max_nanos": 734168,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        5,
+        7,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_16",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 232275,
+      "min_nanos": 226886,
+      "max_nanos": 245965,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_17",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 257722,
+      "min_nanos": 250351,
+      "max_nanos": 280015,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_18",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 1044769,
+      "min_nanos": 1027503,
+      "max_nanos": 1076736,
+      "factor_count": 3,
+      "factor_degrees": [
+        6,
+        6,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_19",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 261047,
+      "min_nanos": 247637,
+      "max_nanos": 281548,
+      "factor_count": 2,
+      "factor_degrees": [
+        7,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_20",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 328828,
+      "min_nanos": 323300,
+      "max_nanos": 372592,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_21",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 1449890,
+      "min_nanos": 1431523,
+      "max_nanos": 1472213,
+      "factor_count": 3,
+      "factor_degrees": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_22",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 220757,
+      "min_nanos": 209180,
+      "max_nanos": 225995,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_23",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 175800,
+      "min_nanos": 170332,
+      "max_nanos": 186427,
+      "factor_count": 2,
+      "factor_degrees": [
+        3,
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_24",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 503928,
+      "min_nanos": 483147,
+      "max_nanos": 534882,
+      "factor_count": 3,
+      "factor_degrees": [
+        3,
+        5,
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_25",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 172486,
+      "min_nanos": 169291,
+      "max_nanos": 186266,
+      "factor_count": 2,
+      "factor_degrees": [
+        4,
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_26",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 96553,
+      "min_nanos": 93518,
+      "max_nanos": 116313,
+      "factor_count": 2,
+      "factor_degrees": [
+        3,
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_27",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 457678,
+      "min_nanos": 440714,
+      "max_nanos": 471419,
+      "factor_count": 4,
+      "factor_degrees": [
+        1,
+        2,
+        4,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_28",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 572749,
+      "min_nanos": 560050,
+      "max_nanos": 670514,
+      "factor_count": 5,
+      "factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "random-products",
+      "name": "randprod_29",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 330380,
+      "min_nanos": 321566,
+      "max_nanos": 356899,
+      "factor_count": 2,
+      "factor_degrees": [
+        5,
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_P7",
+      "degree": 384,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_M12_f132",
+      "degree": 132,
+      "status": "ok",
+      "median_nanos": 1024721856,
+      "min_nanos": 1024721856,
+      "max_nanos": 1024721856,
+      "factor_count": 1,
+      "factor_degrees": [
+        132
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F190",
+      "degree": 190,
+      "status": "ok",
+      "median_nanos": 3389966971,
+      "min_nanos": 3389966971,
+      "max_nanos": 3389966971,
+      "factor_count": 3,
+      "factor_degrees": [
+        10,
+        90,
+        90
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F192",
+      "degree": 192,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F256",
+      "degree": 256,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F351",
+      "degree": 351,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_F630",
+      "degree": 630,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_S7",
+      "degree": 128,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_S8",
+      "degree": 256,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "hoeij-zimmermann",
+      "name": "hoeij_S9",
+      "degree": 512,
+      "status": "timeout",
+      "median_nanos": null,
+      "min_nanos": null,
+      "max_nanos": null,
+      "factor_count": null,
+      "factor_degrees": null
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 60891,
+      "min_nanos": 22844,
+      "max_nanos": 22296930,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 28673,
+      "min_nanos": 24386,
+      "max_nanos": 50275,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 39067,
+      "min_nanos": 35833,
+      "max_nanos": 80820,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 44136,
+      "min_nanos": 42232,
+      "max_nanos": 56984,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 49384,
+      "min_nanos": 48543,
+      "max_nanos": 55882,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 44737,
+      "min_nanos": 43674,
+      "max_nanos": 49142,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 64726,
+      "min_nanos": 61631,
+      "max_nanos": 77125,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 100870,
+      "min_nanos": 98266,
+      "max_nanos": 115802,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 82882,
+      "min_nanos": 81621,
+      "max_nanos": 89463,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 104405,
+      "min_nanos": 103283,
+      "max_nanos": 115351,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 118646,
+      "min_nanos": 117585,
+      "max_nanos": 145265,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 130774,
+      "min_nanos": 126978,
+      "max_nanos": 139527,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 93819,
+      "min_nanos": 90454,
+      "max_nanos": 98626,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 155571,
+      "min_nanos": 153788,
+      "max_nanos": 169922,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 215980,
+      "min_nanos": 211053,
+      "max_nanos": 244462,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 125586,
+      "min_nanos": 123153,
+      "max_nanos": 133718,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n17",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 263630,
+      "min_nanos": 250872,
+      "max_nanos": 288378,
+      "factor_count": 1,
+      "factor_degrees": [
+        17
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 346263,
+      "min_nanos": 338993,
+      "max_nanos": 380744,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n19",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 286064,
+      "min_nanos": 283791,
+      "max_nanos": 303410,
+      "factor_count": 1,
+      "factor_degrees": [
+        19
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 347505,
+      "min_nanos": 337029,
+      "max_nanos": 380414,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n21",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 291342,
+      "min_nanos": 288548,
+      "max_nanos": 319264,
+      "factor_count": 1,
+      "factor_degrees": [
+        21
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 506631,
+      "min_nanos": 491419,
+      "max_nanos": 548403,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n23",
+      "degree": 23,
+      "status": "ok",
+      "median_nanos": 476297,
+      "min_nanos": 463417,
+      "max_nanos": 513291,
+      "factor_count": 1,
+      "factor_degrees": [
+        23
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 403087,
+      "min_nanos": 399542,
+      "max_nanos": 440673,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n25",
+      "degree": 25,
+      "status": "ok",
+      "median_nanos": 629012,
+      "min_nanos": 612058,
+      "max_nanos": 666318,
+      "factor_count": 1,
+      "factor_degrees": [
+        25
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 531198,
+      "min_nanos": 515885,
+      "max_nanos": 578588,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n27",
+      "degree": 27,
+      "status": "ok",
+      "median_nanos": 616774,
+      "min_nanos": 606349,
+      "max_nanos": 653769,
+      "factor_count": 1,
+      "factor_degrees": [
+        27
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 342598,
+      "min_nanos": 339363,
+      "max_nanos": 348276,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n29",
+      "degree": 29,
+      "status": "ok",
+      "median_nanos": 406923,
+      "min_nanos": 400874,
+      "max_nanos": 432942,
+      "factor_count": 1,
+      "factor_degrees": [
+        29
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 785455,
+      "min_nanos": 774298,
+      "max_nanos": 837692,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n31",
+      "degree": 31,
+      "status": "ok",
+      "median_nanos": 772295,
+      "min_nanos": 758615,
+      "max_nanos": 810391,
+      "factor_count": 1,
+      "factor_degrees": [
+        31
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n32",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 680159,
+      "min_nanos": 642542,
+      "max_nanos": 713018,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n33",
+      "degree": 33,
+      "status": "ok",
+      "median_nanos": 1264455,
+      "min_nanos": 1259528,
+      "max_nanos": 1291625,
+      "factor_count": 1,
+      "factor_degrees": [
+        33
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n34",
+      "degree": 34,
+      "status": "ok",
+      "median_nanos": 986453,
+      "min_nanos": 962497,
+      "max_nanos": 1010839,
+      "factor_count": 1,
+      "factor_degrees": [
+        34
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n35",
+      "degree": 35,
+      "status": "ok",
+      "median_nanos": 1035635,
+      "min_nanos": 1024579,
+      "max_nanos": 1059240,
+      "factor_count": 1,
+      "factor_degrees": [
+        35
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n36",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 1049606,
+      "min_nanos": 1034184,
+      "max_nanos": 1080191,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n37",
+      "degree": 37,
+      "status": "ok",
+      "median_nanos": 1342961,
+      "min_nanos": 1337494,
+      "max_nanos": 1352465,
+      "factor_count": 1,
+      "factor_degrees": [
+        37
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n38",
+      "degree": 38,
+      "status": "ok",
+      "median_nanos": 1775533,
+      "min_nanos": 1765438,
+      "max_nanos": 1803544,
+      "factor_count": 1,
+      "factor_degrees": [
+        38
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n39",
+      "degree": 39,
+      "status": "ok",
+      "median_nanos": 676984,
+      "min_nanos": 674220,
+      "max_nanos": 680719,
+      "factor_count": 1,
+      "factor_degrees": [
+        39
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p2_n40",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 1496759,
+      "min_nanos": 1481757,
+      "max_nanos": 1508257,
+      "factor_count": 1,
+      "factor_degrees": [
+        40
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 21002,
+      "min_nanos": 20470,
+      "max_nanos": 24616,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 24556,
+      "min_nanos": 23885,
+      "max_nanos": 29824,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 25948,
+      "min_nanos": 25838,
+      "max_nanos": 28742,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 33970,
+      "min_nanos": 32938,
+      "max_nanos": 35943,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 36304,
+      "min_nanos": 35913,
+      "max_nanos": 56674,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 42844,
+      "min_nanos": 42423,
+      "max_nanos": 46519,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 45657,
+      "min_nanos": 45477,
+      "max_nanos": 47971,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 56874,
+      "min_nanos": 56314,
+      "max_nanos": 59468,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 60760,
+      "min_nanos": 60229,
+      "max_nanos": 67300,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 76434,
+      "min_nanos": 73238,
+      "max_nanos": 77434,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 69033,
+      "min_nanos": 66739,
+      "max_nanos": 72097,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 89232,
+      "min_nanos": 88251,
+      "max_nanos": 98076,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 79698,
+      "min_nanos": 77605,
+      "max_nanos": 82302,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 120588,
+      "min_nanos": 119467,
+      "max_nanos": 126728,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 121700,
+      "min_nanos": 119197,
+      "max_nanos": 125927,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 136663,
+      "min_nanos": 135501,
+      "max_nanos": 138155,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n17",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 115431,
+      "min_nanos": 113969,
+      "max_nanos": 122331,
+      "factor_count": 1,
+      "factor_degrees": [
+        17
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 167248,
+      "min_nanos": 167008,
+      "max_nanos": 170843,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n19",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 136964,
+      "min_nanos": 135271,
+      "max_nanos": 140879,
+      "factor_count": 1,
+      "factor_degrees": [
+        19
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 211854,
+      "min_nanos": 209691,
+      "max_nanos": 217082,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n21",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 211704,
+      "min_nanos": 208479,
+      "max_nanos": 214538,
+      "factor_count": 1,
+      "factor_degrees": [
+        21
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 232164,
+      "min_nanos": 229720,
+      "max_nanos": 235659,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n23",
+      "degree": 23,
+      "status": "ok",
+      "median_nanos": 197202,
+      "min_nanos": 194899,
+      "max_nanos": 200878,
+      "factor_count": 1,
+      "factor_degrees": [
+        23
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 272364,
+      "min_nanos": 268057,
+      "max_nanos": 350891,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n25",
+      "degree": 25,
+      "status": "ok",
+      "median_nanos": 259695,
+      "min_nanos": 252955,
+      "max_nanos": 281046,
+      "factor_count": 1,
+      "factor_degrees": [
+        25
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 325243,
+      "min_nanos": 320465,
+      "max_nanos": 354195,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n27",
+      "degree": 27,
+      "status": "ok",
+      "median_nanos": 232144,
+      "min_nanos": 230963,
+      "max_nanos": 237623,
+      "factor_count": 1,
+      "factor_degrees": [
+        27
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 359433,
+      "min_nanos": 355647,
+      "max_nanos": 362768,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n29",
+      "degree": 29,
+      "status": "ok",
+      "median_nanos": 267507,
+      "min_nanos": 265324,
+      "max_nanos": 270632,
+      "factor_count": 1,
+      "factor_degrees": [
+        29
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 441495,
+      "min_nanos": 434524,
+      "max_nanos": 442846,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n31",
+      "degree": 31,
+      "status": "ok",
+      "median_nanos": 338271,
+      "min_nanos": 334236,
+      "max_nanos": 345743,
+      "factor_count": 1,
+      "factor_degrees": [
+        31
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n32",
+      "degree": 32,
+      "status": "ok",
+      "median_nanos": 440593,
+      "min_nanos": 436367,
+      "max_nanos": 444640,
+      "factor_count": 1,
+      "factor_degrees": [
+        32
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n33",
+      "degree": 33,
+      "status": "ok",
+      "median_nanos": 465810,
+      "min_nanos": 461645,
+      "max_nanos": 472290,
+      "factor_count": 1,
+      "factor_degrees": [
+        33
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n34",
+      "degree": 34,
+      "status": "ok",
+      "median_nanos": 536085,
+      "min_nanos": 529565,
+      "max_nanos": 538729,
+      "factor_count": 1,
+      "factor_degrees": [
+        34
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n35",
+      "degree": 35,
+      "status": "ok",
+      "median_nanos": 498780,
+      "min_nanos": 492069,
+      "max_nanos": 504257,
+      "factor_count": 1,
+      "factor_degrees": [
+        35
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n36",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 639298,
+      "min_nanos": 634592,
+      "max_nanos": 640730,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n37",
+      "degree": 37,
+      "status": "ok",
+      "median_nanos": 510416,
+      "min_nanos": 504948,
+      "max_nanos": 517216,
+      "factor_count": 1,
+      "factor_degrees": [
+        37
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n38",
+      "degree": 38,
+      "status": "ok",
+      "median_nanos": 699567,
+      "min_nanos": 694169,
+      "max_nanos": 700038,
+      "factor_count": 1,
+      "factor_degrees": [
+        38
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n39",
+      "degree": 39,
+      "status": "ok",
+      "median_nanos": 635011,
+      "min_nanos": 628091,
+      "max_nanos": 638667,
+      "factor_count": 1,
+      "factor_degrees": [
+        39
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p3_n40",
+      "degree": 40,
+      "status": "ok",
+      "median_nanos": 764203,
+      "min_nanos": 754739,
+      "max_nanos": 773908,
+      "factor_count": 1,
+      "factor_degrees": [
+        40
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 19799,
+      "min_nanos": 19780,
+      "max_nanos": 24005,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 24566,
+      "min_nanos": 24216,
+      "max_nanos": 30586,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 31015,
+      "min_nanos": 27961,
+      "max_nanos": 33360,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 48963,
+      "min_nanos": 46830,
+      "max_nanos": 65377,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 65868,
+      "min_nanos": 65067,
+      "max_nanos": 77014,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 54972,
+      "min_nanos": 52679,
+      "max_nanos": 60219,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 55342,
+      "min_nanos": 52808,
+      "max_nanos": 61531,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 77846,
+      "min_nanos": 76453,
+      "max_nanos": 85887,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 97585,
+      "min_nanos": 91866,
+      "max_nanos": 106048,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 71166,
+      "min_nanos": 70225,
+      "max_nanos": 74250,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 80400,
+      "min_nanos": 77535,
+      "max_nanos": 86618,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 204022,
+      "min_nanos": 198844,
+      "max_nanos": 228499,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 111145,
+      "min_nanos": 109543,
+      "max_nanos": 114110,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 147008,
+      "min_nanos": 145286,
+      "max_nanos": 153718,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 150804,
+      "min_nanos": 140609,
+      "max_nanos": 156452,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 296850,
+      "min_nanos": 281757,
+      "max_nanos": 318051,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n17",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 430278,
+      "min_nanos": 412702,
+      "max_nanos": 463537,
+      "factor_count": 1,
+      "factor_degrees": [
+        17
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 242329,
+      "min_nanos": 236090,
+      "max_nanos": 266876,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n19",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 352523,
+      "min_nanos": 338221,
+      "max_nanos": 399212,
+      "factor_count": 1,
+      "factor_degrees": [
+        19
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 284522,
+      "min_nanos": 275238,
+      "max_nanos": 297992,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n21",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 299394,
+      "min_nanos": 292313,
+      "max_nanos": 328487,
+      "factor_count": 1,
+      "factor_degrees": [
+        21
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 408716,
+      "min_nanos": 392332,
+      "max_nanos": 439932,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n23",
+      "degree": 23,
+      "status": "ok",
+      "median_nanos": 242400,
+      "min_nanos": 238944,
+      "max_nanos": 244582,
+      "factor_count": 1,
+      "factor_degrees": [
+        23
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 494583,
+      "min_nanos": 480553,
+      "max_nanos": 535885,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n25",
+      "degree": 25,
+      "status": "ok",
+      "median_nanos": 523255,
+      "min_nanos": 499991,
+      "max_nanos": 562184,
+      "factor_count": 1,
+      "factor_degrees": [
+        25
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 541362,
+      "min_nanos": 525760,
+      "max_nanos": 577576,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n27",
+      "degree": 27,
+      "status": "ok",
+      "median_nanos": 437639,
+      "min_nanos": 434033,
+      "max_nanos": 444339,
+      "factor_count": 1,
+      "factor_degrees": [
+        27
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 868398,
+      "min_nanos": 853095,
+      "max_nanos": 902939,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n29",
+      "degree": 29,
+      "status": "ok",
+      "median_nanos": 410077,
+      "min_nanos": 407865,
+      "max_nanos": 413353,
+      "factor_count": 1,
+      "factor_degrees": [
+        29
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 946984,
+      "min_nanos": 935827,
+      "max_nanos": 980684,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n31",
+      "degree": 31,
+      "status": "ok",
+      "median_nanos": 346214,
+      "min_nanos": 344912,
+      "max_nanos": 352252,
+      "factor_count": 1,
+      "factor_degrees": [
+        31
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n33",
+      "degree": 33,
+      "status": "ok",
+      "median_nanos": 676964,
+      "min_nanos": 672126,
+      "max_nanos": 678697,
+      "factor_count": 1,
+      "factor_degrees": [
+        33
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n35",
+      "degree": 35,
+      "status": "ok",
+      "median_nanos": 713438,
+      "min_nanos": 708530,
+      "max_nanos": 718305,
+      "factor_count": 1,
+      "factor_degrees": [
+        35
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n36",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 1090657,
+      "min_nanos": 1081494,
+      "max_nanos": 1126962,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n37",
+      "degree": 37,
+      "status": "ok",
+      "median_nanos": 567692,
+      "min_nanos": 563426,
+      "max_nanos": 569525,
+      "factor_count": 1,
+      "factor_degrees": [
+        37
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p5_n39",
+      "degree": 39,
+      "status": "ok",
+      "median_nanos": 1336372,
+      "min_nanos": 1319216,
+      "max_nanos": 1350222,
+      "factor_count": 1,
+      "factor_degrees": [
+        39
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 20951,
+      "min_nanos": 20781,
+      "max_nanos": 24557,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 33720,
+      "min_nanos": 32088,
+      "max_nanos": 41081,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 38437,
+      "min_nanos": 37816,
+      "max_nanos": 45437,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 46679,
+      "min_nanos": 44707,
+      "max_nanos": 51927,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 63414,
+      "min_nanos": 61571,
+      "max_nanos": 70835,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 70454,
+      "min_nanos": 68231,
+      "max_nanos": 82843,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 61782,
+      "min_nanos": 60530,
+      "max_nanos": 68181,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 72488,
+      "min_nanos": 71416,
+      "max_nanos": 78336,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n9",
+      "degree": 9,
+      "status": "ok",
+      "median_nanos": 100429,
+      "min_nanos": 98596,
+      "max_nanos": 107499,
+      "factor_count": 1,
+      "factor_degrees": [
+        9
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n10",
+      "degree": 10,
+      "status": "ok",
+      "median_nanos": 160738,
+      "min_nanos": 155610,
+      "max_nanos": 171394,
+      "factor_count": 1,
+      "factor_degrees": [
+        10
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n11",
+      "degree": 11,
+      "status": "ok",
+      "median_nanos": 148611,
+      "min_nanos": 144926,
+      "max_nanos": 160859,
+      "factor_count": 1,
+      "factor_degrees": [
+        11
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n12",
+      "degree": 12,
+      "status": "ok",
+      "median_nanos": 172356,
+      "min_nanos": 168190,
+      "max_nanos": 180978,
+      "factor_count": 1,
+      "factor_degrees": [
+        12
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n13",
+      "degree": 13,
+      "status": "ok",
+      "median_nanos": 212746,
+      "min_nanos": 207347,
+      "max_nanos": 243071,
+      "factor_count": 1,
+      "factor_degrees": [
+        13
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n14",
+      "degree": 14,
+      "status": "ok",
+      "median_nanos": 170423,
+      "min_nanos": 169371,
+      "max_nanos": 174409,
+      "factor_count": 1,
+      "factor_degrees": [
+        14
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n15",
+      "degree": 15,
+      "status": "ok",
+      "median_nanos": 195670,
+      "min_nanos": 193347,
+      "max_nanos": 204674,
+      "factor_count": 1,
+      "factor_degrees": [
+        15
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n16",
+      "degree": 16,
+      "status": "ok",
+      "median_nanos": 270001,
+      "min_nanos": 264752,
+      "max_nanos": 304141,
+      "factor_count": 1,
+      "factor_degrees": [
+        16
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n17",
+      "degree": 17,
+      "status": "ok",
+      "median_nanos": 297562,
+      "min_nanos": 292624,
+      "max_nanos": 325562,
+      "factor_count": 1,
+      "factor_degrees": [
+        17
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n18",
+      "degree": 18,
+      "status": "ok",
+      "median_nanos": 287726,
+      "min_nanos": 283000,
+      "max_nanos": 319814,
+      "factor_count": 1,
+      "factor_degrees": [
+        18
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n19",
+      "degree": 19,
+      "status": "ok",
+      "median_nanos": 135741,
+      "min_nanos": 134259,
+      "max_nanos": 138215,
+      "factor_count": 1,
+      "factor_degrees": [
+        19
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n20",
+      "degree": 20,
+      "status": "ok",
+      "median_nanos": 256390,
+      "min_nanos": 252114,
+      "max_nanos": 276670,
+      "factor_count": 1,
+      "factor_degrees": [
+        20
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n21",
+      "degree": 21,
+      "status": "ok",
+      "median_nanos": 266705,
+      "min_nanos": 262439,
+      "max_nanos": 298743,
+      "factor_count": 1,
+      "factor_degrees": [
+        21
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n22",
+      "degree": 22,
+      "status": "ok",
+      "median_nanos": 436898,
+      "min_nanos": 426833,
+      "max_nanos": 471990,
+      "factor_count": 1,
+      "factor_degrees": [
+        22
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n23",
+      "degree": 23,
+      "status": "ok",
+      "median_nanos": 302028,
+      "min_nanos": 294968,
+      "max_nanos": 326364,
+      "factor_count": 1,
+      "factor_degrees": [
+        23
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n24",
+      "degree": 24,
+      "status": "ok",
+      "median_nanos": 523336,
+      "min_nanos": 495514,
+      "max_nanos": 592598,
+      "factor_count": 1,
+      "factor_degrees": [
+        24
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n25",
+      "degree": 25,
+      "status": "ok",
+      "median_nanos": 471920,
+      "min_nanos": 462055,
+      "max_nanos": 506160,
+      "factor_count": 1,
+      "factor_degrees": [
+        25
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n26",
+      "degree": 26,
+      "status": "ok",
+      "median_nanos": 553681,
+      "min_nanos": 529325,
+      "max_nanos": 601291,
+      "factor_count": 1,
+      "factor_degrees": [
+        26
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n27",
+      "degree": 27,
+      "status": "ok",
+      "median_nanos": 620150,
+      "min_nanos": 593980,
+      "max_nanos": 661000,
+      "factor_count": 1,
+      "factor_degrees": [
+        27
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n28",
+      "degree": 28,
+      "status": "ok",
+      "median_nanos": 699267,
+      "min_nanos": 676814,
+      "max_nanos": 743583,
+      "factor_count": 1,
+      "factor_degrees": [
+        28
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n29",
+      "degree": 29,
+      "status": "ok",
+      "median_nanos": 351751,
+      "min_nanos": 349428,
+      "max_nanos": 393594,
+      "factor_count": 1,
+      "factor_degrees": [
+        29
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n30",
+      "degree": 30,
+      "status": "ok",
+      "median_nanos": 991230,
+      "min_nanos": 976447,
+      "max_nanos": 1023738,
+      "factor_count": 1,
+      "factor_degrees": [
+        30
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n31",
+      "degree": 31,
+      "status": "ok",
+      "median_nanos": 702722,
+      "min_nanos": 674921,
+      "max_nanos": 727749,
+      "factor_count": 1,
+      "factor_degrees": [
+        31
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n35",
+      "degree": 35,
+      "status": "ok",
+      "median_nanos": 1584029,
+      "min_nanos": 1571620,
+      "max_nanos": 1603728,
+      "factor_count": 1,
+      "factor_degrees": [
+        35
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n36",
+      "degree": 36,
+      "status": "ok",
+      "median_nanos": 1530198,
+      "min_nanos": 1521947,
+      "max_nanos": 1565230,
+      "factor_count": 1,
+      "factor_degrees": [
+        36
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p7_n37",
+      "degree": 37,
+      "status": "ok",
+      "median_nanos": 934636,
+      "min_nanos": 922137,
+      "max_nanos": 954715,
+      "factor_count": 1,
+      "factor_degrees": [
+        37
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 20150,
+      "min_nanos": 20060,
+      "max_nanos": 24386,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 24356,
+      "min_nanos": 24006,
+      "max_nanos": 28322,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 41822,
+      "min_nanos": 41201,
+      "max_nanos": 49473,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 56244,
+      "min_nanos": 55672,
+      "max_nanos": 64716,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 43946,
+      "min_nanos": 42483,
+      "max_nanos": 48021,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 42903,
+      "min_nanos": 42263,
+      "max_nanos": 45467,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 76413,
+      "min_nanos": 73889,
+      "max_nanos": 84184,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p11_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 96914,
+      "min_nanos": 94560,
+      "max_nanos": 110243,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 19669,
+      "min_nanos": 17305,
+      "max_nanos": 22143,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 31487,
+      "min_nanos": 30825,
+      "max_nanos": 34091,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 26329,
+      "min_nanos": 25618,
+      "max_nanos": 29223,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 57615,
+      "min_nanos": 57054,
+      "max_nanos": 71195,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 36043,
+      "min_nanos": 34982,
+      "max_nanos": 38197,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 61280,
+      "min_nanos": 60811,
+      "max_nanos": 68531,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 61691,
+      "min_nanos": 60941,
+      "max_nanos": 67640,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p13_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 68581,
+      "min_nanos": 67771,
+      "max_nanos": 72898,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 19258,
+      "min_nanos": 18167,
+      "max_nanos": 21271,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 34061,
+      "min_nanos": 33239,
+      "max_nanos": 37285,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 29033,
+      "min_nanos": 27901,
+      "max_nanos": 34161,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 33269,
+      "min_nanos": 32177,
+      "max_nanos": 34531,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 50505,
+      "min_nanos": 49604,
+      "max_nanos": 55453,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 43214,
+      "min_nanos": 42773,
+      "max_nanos": 46680,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 68130,
+      "min_nanos": 65787,
+      "max_nanos": 75001,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p97_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 84005,
+      "min_nanos": 83113,
+      "max_nanos": 91496,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 19389,
+      "min_nanos": 18467,
+      "max_nanos": 22183,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 32768,
+      "min_nanos": 32247,
+      "max_nanos": 36144,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 37987,
+      "min_nanos": 36795,
+      "max_nanos": 43985,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 35242,
+      "min_nanos": 34882,
+      "max_nanos": 37826,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n5",
+      "degree": 5,
+      "status": "ok",
+      "median_nanos": 54581,
+      "min_nanos": 53700,
+      "max_nanos": 58717,
+      "factor_count": 1,
+      "factor_degrees": [
+        5
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n6",
+      "degree": 6,
+      "status": "ok",
+      "median_nanos": 80680,
+      "min_nanos": 77465,
+      "max_nanos": 86689,
+      "factor_count": 1,
+      "factor_degrees": [
+        6
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n7",
+      "degree": 7,
+      "status": "ok",
+      "median_nanos": 67420,
+      "min_nanos": 65217,
+      "max_nanos": 75702,
+      "factor_count": 1,
+      "factor_degrees": [
+        7
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p521_n8",
+      "degree": 8,
+      "status": "ok",
+      "median_nanos": 99798,
+      "min_nanos": 96293,
+      "max_nanos": 105426,
+      "factor_count": 1,
+      "factor_degrees": [
+        8
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p65537_n1",
+      "degree": 1,
+      "status": "ok",
+      "median_nanos": 19398,
+      "min_nanos": 18017,
+      "max_nanos": 23134,
+      "factor_count": 1,
+      "factor_degrees": [
+        1
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p65537_n2",
+      "degree": 2,
+      "status": "ok",
+      "median_nanos": 35573,
+      "min_nanos": 34592,
+      "max_nanos": 37495,
+      "factor_count": 1,
+      "factor_degrees": [
+        2
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p65537_n3",
+      "degree": 3,
+      "status": "ok",
+      "median_nanos": 29133,
+      "min_nanos": 28973,
+      "max_nanos": 31186,
+      "factor_count": 1,
+      "factor_degrees": [
+        3
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "conway",
+      "name": "conway_p65537_n4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 65848,
+      "min_nanos": 63994,
+      "max_nanos": 71857,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    },
+    {
+      "system": "hex-factor",
+      "family": "certificate-boundary",
+      "name": "quartic_a4",
+      "degree": 4,
+      "status": "ok",
+      "median_nanos": 45768,
+      "min_nanos": 44015,
+      "max_nanos": 48442,
+      "factor_count": 1,
+      "factor_degrees": [
+        4
+      ]
+    }
+  ],
+  "cross_check": {
+    "mismatches": [],
+    "ok": true
+  }
+}

--- a/reports/bench-results/hexbz-phase-profile-2c4c6e4f-chungus2.json
+++ b/reports/bench-results/hexbz-phase-profile-2c4c6e4f-chungus2.json
@@ -1,0 +1,10091 @@
+{
+  "config": {
+    "controls": [
+      "chebyshev_T24",
+      "chebyshev_U24",
+      "legendre_P30",
+      "legendre_P38",
+      "cyclo_phi17",
+      "cyclo_phi41",
+      "xpow24_minus1",
+      "randprod_10",
+      "randprod_21"
+    ],
+    "corpus": "bench/corpus/hexbz-factor-corpus.jsonl",
+    "corpus_sha256": "619913904240834c912489e6cc23ba136e8cc5ebf0ea95f83397e0682387284d",
+    "cpu": 1,
+    "cutoff_seconds": 120.0,
+    "hex_exe_sha256": "c22f80f3683e4e9c7b7c7432e6af80543e920aa9402b8cd37ea4686d3d6360c4",
+    "kernel_repeats": 3,
+    "names": [
+      "sd5",
+      "sd5_shift1",
+      "sd5_shift2",
+      "sd4_x_sd4shift1",
+      "sd5_x_phi11",
+      "xpow48_minus1",
+      "xpow105_minus1",
+      "xpow120_minus1",
+      "cyclo_phi179",
+      "cyclo_phi64_x_phi105",
+      "cyclo_phi128_x_phi165",
+      "cyclo_phi385",
+      "wilkinson_40",
+      "wilkinson_48",
+      "wilkinson_56",
+      "chebyshev_T24",
+      "chebyshev_U24",
+      "legendre_P30",
+      "legendre_P38",
+      "cyclo_phi17",
+      "cyclo_phi41",
+      "xpow24_minus1",
+      "randprod_10",
+      "randprod_21"
+    ],
+    "plan_repeats": 3,
+    "repeat_ceiling_nanos": 1000000000,
+    "repeats": 5,
+    "representative": [
+      "sd5",
+      "sd5_shift1",
+      "sd5_shift2",
+      "sd4_x_sd4shift1",
+      "sd5_x_phi11",
+      "xpow48_minus1",
+      "xpow105_minus1",
+      "xpow120_minus1",
+      "cyclo_phi179",
+      "cyclo_phi64_x_phi105",
+      "cyclo_phi128_x_phi165",
+      "cyclo_phi385",
+      "wilkinson_40",
+      "wilkinson_48",
+      "wilkinson_56"
+    ],
+    "sampling_profiles": [
+      "sd5",
+      "sd5_x_phi11",
+      "xpow120_minus1",
+      "cyclo_phi179",
+      "cyclo_phi64_x_phi105",
+      "cyclo_phi385",
+      "wilkinson_56"
+    ],
+    "validate_cutoff_seconds": 2.0,
+    "warmup": 1
+  },
+  "counterfactuals": [],
+  "env": {
+    "arch": "x86_64",
+    "cpu_cores": 96,
+    "cpu_model": null,
+    "exe_name": "hexbz_factor_service",
+    "git_commit": "2c4c6e4fa0378ee34cf6399a91c720b4e63cf84d",
+    "git_dirty": false,
+    "hostname": "chungus2",
+    "lean_bench_version": null,
+    "lean_toolchain": "leanprover/lean4:v4.33.0-rc1",
+    "lean_version": null,
+    "os": "linux",
+    "platform_target": null,
+    "timestamp_iso": "2026-08-03T23:48:35Z",
+    "timestamp_unix_ms": 1785800915133
+  },
+  "kernels": [
+    {
+      "degree": 32,
+      "family": "swinnerton-dyer",
+      "kernel": {
+        "kernel": {
+          "basisSize": 32,
+          "basisToPolynomials": {
+            "nanos": 4687,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1213910,
+            "smallAllocs": 120747
+          },
+          "berlekampSplit": {
+            "nanos": 3273493,
+            "smallAllocs": 279386
+          },
+          "columnPolys": {
+            "nanos": 1171828,
+            "smallAllocs": 116346
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 819,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 276088,
+              "smallAllocs": 15527
+            },
+            "rowAdds": 215,
+            "rowAddsSkipped": 281,
+            "rowSwapScale": {
+              "nanos": 26952,
+              "smallAllocs": 1625
+            },
+            "stagedNanos": 303546,
+            "wall": {
+              "nanos": 321056,
+              "smallAllocs": 17591
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 913,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 506113,
+              "smallAllocs": 29287
+            },
+            "rowAdds": 215,
+            "rowAddsSkipped": 281,
+            "rowSwapScale": {
+              "nanos": 38124,
+              "smallAllocs": 2137
+            },
+            "stagedNanos": 545150,
+            "wall": {
+              "nanos": 564177,
+              "smallAllocs": 31866
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 27730,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1338875,
+            "smallAllocs": 121100
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1241230,
+            "smallAllocs": 121804
+          },
+          "frobeniusPower": {
+            "nanos": 26139,
+            "smallAllocs": 2354
+          },
+          "kernelDimension": 16,
+          "matrixConversionNanos": 18537,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1272898,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 35783,
+          "nullspaceBasisNanos": 35783,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2624,
+            "packNanos": 40890,
+            "rank": 16,
+            "reduceNanos": 35864,
+            "rowAdds": 215,
+            "smallAllocs": 1466,
+            "totalNanos": 79378
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1903,
+            "packNanos": 40440,
+            "rank": 16,
+            "reduceNanos": 33199,
+            "rowAdds": 215,
+            "smallAllocs": 1466,
+            "totalNanos": 75933
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1802,
+            "packNanos": 40330,
+            "rank": 16,
+            "reduceNanos": 25187,
+            "rowAdds": 215,
+            "smallAllocs": 1466,
+            "totalNanos": 67270
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5468,
+            "packNanos": 39819,
+            "rank": 16,
+            "reduceNanos": 66479,
+            "rowAdds": 215,
+            "smallAllocs": 8858,
+            "totalNanos": 111766
+          },
+          "peakResidentBytes": 63287296,
+          "productionMatrixRebuild": {
+            "nanos": 1267710,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 591337,
+            "smallAllocs": 31823
+          },
+          "productionRowReduce": {
+            "nanos": 550616,
+            "smallAllocs": 30631
+          },
+          "rank": 16,
+          "residentBytesAfter": 63098880,
+          "residentBytesBefore": 62939136,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1266698,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 16
+        },
+        "modularDegree": 32,
+        "modularFactorCount": 16,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd5",
+      "status": "ok"
+    },
+    {
+      "degree": 32,
+      "family": "swinnerton-dyer",
+      "kernel": {
+        "kernel": {
+          "basisSize": 32,
+          "basisToPolynomials": {
+            "nanos": 4527,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1542948,
+            "smallAllocs": 149530
+          },
+          "berlekampSplit": {
+            "nanos": 3108609,
+            "smallAllocs": 258979
+          },
+          "columnPolys": {
+            "nanos": 1499062,
+            "smallAllocs": 145131
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 770,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 542318,
+              "smallAllocs": 30737
+            },
+            "rowAdds": 449,
+            "rowAddsSkipped": 47,
+            "rowSwapScale": {
+              "nanos": 26088,
+              "smallAllocs": 1617
+            },
+            "stagedNanos": 569025,
+            "wall": {
+              "nanos": 586319,
+              "smallAllocs": 32793
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 791,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 996598,
+              "smallAllocs": 59473
+            },
+            "rowAdds": 449,
+            "rowAddsSkipped": 47,
+            "rowSwapScale": {
+              "nanos": 36144,
+              "smallAllocs": 2129
+            },
+            "stagedNanos": 1033542,
+            "wall": {
+              "nanos": 1049877,
+              "smallAllocs": 62044
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 23114,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1749614,
+            "smallAllocs": 149883
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1565721,
+            "smallAllocs": 150587
+          },
+          "frobeniusPower": {
+            "nanos": 25498,
+            "smallAllocs": 2352
+          },
+          "kernelDimension": 16,
+          "matrixConversionNanos": 19389,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1568074,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 44436,
+          "nullspaceBasisNanos": 44436,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2403,
+            "packNanos": 40771,
+            "rank": 16,
+            "reduceNanos": 60300,
+            "rowAdds": 449,
+            "smallAllocs": 1232,
+            "totalNanos": 103564
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1933,
+            "packNanos": 40540,
+            "rank": 16,
+            "reduceNanos": 58126,
+            "rowAdds": 449,
+            "smallAllocs": 1232,
+            "totalNanos": 100649
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1843,
+            "packNanos": 40380,
+            "rank": 16,
+            "reduceNanos": 51316,
+            "rowAdds": 449,
+            "smallAllocs": 1232,
+            "totalNanos": 93719
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5188,
+            "packNanos": 39549,
+            "rank": 16,
+            "reduceNanos": 122341,
+            "rowAdds": 449,
+            "smallAllocs": 16080,
+            "totalNanos": 166627
+          },
+          "peakResidentBytes": 63434752,
+          "productionMatrixRebuild": {
+            "nanos": 1598600,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 1100512,
+            "smallAllocs": 62101
+          },
+          "productionRowReduce": {
+            "nanos": 1056076,
+            "smallAllocs": 60809
+          },
+          "rank": 16,
+          "residentBytesAfter": 63434752,
+          "residentBytesBefore": 63332352,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1616226,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 16
+        },
+        "modularDegree": 32,
+        "modularFactorCount": 16,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd5_shift1",
+      "status": "ok"
+    },
+    {
+      "degree": 32,
+      "family": "swinnerton-dyer",
+      "kernel": {
+        "kernel": {
+          "basisSize": 32,
+          "basisToPolynomials": {
+            "nanos": 4547,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1565921,
+            "smallAllocs": 149061
+          },
+          "berlekampSplit": {
+            "nanos": 4595323,
+            "smallAllocs": 381697
+          },
+          "columnPolys": {
+            "nanos": 1512613,
+            "smallAllocs": 144662
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 821,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 555961,
+              "smallAllocs": 31127
+            },
+            "rowAdds": 455,
+            "rowAddsSkipped": 41,
+            "rowSwapScale": {
+              "nanos": 25868,
+              "smallAllocs": 1617
+            },
+            "stagedNanos": 582650,
+            "wall": {
+              "nanos": 599859,
+              "smallAllocs": 33183
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 779,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 1020865,
+              "smallAllocs": 60247
+            },
+            "rowAdds": 455,
+            "rowAddsSkipped": 41,
+            "rowSwapScale": {
+              "nanos": 35825,
+              "smallAllocs": 2129
+            },
+            "stagedNanos": 1057677,
+            "wall": {
+              "nanos": 1074173,
+              "smallAllocs": 62818
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 21341,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1762493,
+            "smallAllocs": 149414
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1583028,
+            "smallAllocs": 150118
+          },
+          "frobeniusPower": {
+            "nanos": 25578,
+            "smallAllocs": 2352
+          },
+          "kernelDimension": 16,
+          "matrixConversionNanos": 27730,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1578991,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 41342,
+          "nullspaceBasisNanos": 41342,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2283,
+            "packNanos": 40991,
+            "rank": 16,
+            "reduceNanos": 60820,
+            "rowAdds": 455,
+            "smallAllocs": 1226,
+            "totalNanos": 104074
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1863,
+            "packNanos": 40440,
+            "rank": 16,
+            "reduceNanos": 58797,
+            "rowAdds": 455,
+            "smallAllocs": 1226,
+            "totalNanos": 101160
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1783,
+            "packNanos": 40750,
+            "rank": 16,
+            "reduceNanos": 51907,
+            "rowAdds": 455,
+            "smallAllocs": 1226,
+            "totalNanos": 97134
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5128,
+            "packNanos": 39328,
+            "rank": 16,
+            "reduceNanos": 123633,
+            "rowAdds": 455,
+            "smallAllocs": 16266,
+            "totalNanos": 168470
+          },
+          "peakResidentBytes": 63438848,
+          "productionMatrixRebuild": {
+            "nanos": 1603698,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 1115243,
+            "smallAllocs": 62874
+          },
+          "productionRowReduce": {
+            "nanos": 1073942,
+            "smallAllocs": 61583
+          },
+          "rank": 16,
+          "residentBytesAfter": 63406080,
+          "residentBytesBefore": 63373312,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1613242,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 16
+        },
+        "modularDegree": 32,
+        "modularFactorCount": 16,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd5_shift2",
+      "status": "ok"
+    },
+    {
+      "degree": 32,
+      "family": "sd-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 32,
+          "basisToPolynomials": {
+            "nanos": 4467,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1593903,
+            "smallAllocs": 149683
+          },
+          "berlekampSplit": {
+            "nanos": 3900834,
+            "smallAllocs": 320808
+          },
+          "columnPolys": {
+            "nanos": 1539893,
+            "smallAllocs": 145284
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 809,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 540411,
+              "smallAllocs": 30412
+            },
+            "rowAdds": 444,
+            "rowAddsSkipped": 52,
+            "rowSwapScale": {
+              "nanos": 26137,
+              "smallAllocs": 1618
+            },
+            "stagedNanos": 567300,
+            "wall": {
+              "nanos": 584457,
+              "smallAllocs": 32469
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 861,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 996148,
+              "smallAllocs": 58828
+            },
+            "rowAdds": 444,
+            "rowAddsSkipped": 52,
+            "rowSwapScale": {
+              "nanos": 35624,
+              "smallAllocs": 2130
+            },
+            "stagedNanos": 1032471,
+            "wall": {
+              "nanos": 1049486,
+              "smallAllocs": 61400
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 15623,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1771247,
+            "smallAllocs": 150036
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1602596,
+            "smallAllocs": 150740
+          },
+          "frobeniusPower": {
+            "nanos": 25969,
+            "smallAllocs": 2352
+          },
+          "kernelDimension": 16,
+          "matrixConversionNanos": 26829,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1607103,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 41741,
+          "nullspaceBasisNanos": 41741,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2404,
+            "packNanos": 40601,
+            "rank": 16,
+            "reduceNanos": 59829,
+            "rowAdds": 444,
+            "smallAllocs": 1237,
+            "totalNanos": 102853
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1893,
+            "packNanos": 40420,
+            "rank": 16,
+            "reduceNanos": 57726,
+            "rowAdds": 444,
+            "smallAllocs": 1237,
+            "totalNanos": 99908
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1832,
+            "packNanos": 40389,
+            "rank": 16,
+            "reduceNanos": 51367,
+            "rowAdds": 444,
+            "smallAllocs": 1237,
+            "totalNanos": 93688
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5489,
+            "packNanos": 39518,
+            "rank": 16,
+            "reduceNanos": 121190,
+            "rowAdds": 444,
+            "smallAllocs": 15925,
+            "totalNanos": 168140
+          },
+          "peakResidentBytes": 63467520,
+          "productionMatrixRebuild": {
+            "nanos": 1621835,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 1086020,
+            "smallAllocs": 61452
+          },
+          "productionRowReduce": {
+            "nanos": 1044279,
+            "smallAllocs": 60165
+          },
+          "rank": 16,
+          "residentBytesAfter": 63463424,
+          "residentBytesBefore": 63418368,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1620633,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 16
+        },
+        "modularDegree": 32,
+        "modularFactorCount": 16,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd4_x_sd4shift1",
+      "status": "ok"
+    },
+    {
+      "degree": 42,
+      "family": "sd-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 42,
+          "basisToPolynomials": {
+            "nanos": 5037,
+            "smallAllocs": 444
+          },
+          "berlekampMatrixWall": {
+            "nanos": 2779931,
+            "smallAllocs": 263817
+          },
+          "berlekampSplit": {
+            "nanos": 7651886,
+            "smallAllocs": 625572
+          },
+          "columnPolys": {
+            "nanos": 2702988,
+            "smallAllocs": 258009
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 17,
+            "pivotSearch": {
+              "nanos": 1051,
+              "smallAllocs": 84
+            },
+            "pivots": 25,
+            "rowAdd": {
+              "nanos": 1446635,
+              "smallAllocs": 82650
+            },
+            "rowAdds": 935,
+            "rowAddsSkipped": 90,
+            "rowSwapScale": {
+              "nanos": 51509,
+              "smallAllocs": 3279
+            },
+            "stagedNanos": 1499256,
+            "wall": {
+              "nanos": 1527315,
+              "smallAllocs": 86460
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 17,
+            "pivotSearch": {
+              "nanos": 1049,
+              "smallAllocs": 84
+            },
+            "pivots": 25,
+            "rowAdd": {
+              "nanos": 2752064,
+              "smallAllocs": 161190
+            },
+            "rowAdds": 935,
+            "rowAddsSkipped": 90,
+            "rowSwapScale": {
+              "nanos": 71617,
+              "smallAllocs": 4329
+            },
+            "stagedNanos": 2825067,
+            "wall": {
+              "nanos": 2850496,
+              "smallAllocs": 166053
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 30264,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 3307134,
+            "smallAllocs": 264369
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 2800713,
+            "smallAllocs": 265624
+          },
+          "frobeniusPower": {
+            "nanos": 25077,
+            "smallAllocs": 2281
+          },
+          "kernelDimension": 17,
+          "matrixConversionNanos": 33880,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 2908682,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 70795,
+          "nullspaceBasisNanos": 70795,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3476,
+            "packNanos": 72738,
+            "rank": 25,
+            "reduceNanos": 154549,
+            "rowAdds": 935,
+            "smallAllocs": 2064,
+            "totalNanos": 231203
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2944,
+            "packNanos": 72468,
+            "rank": 25,
+            "reduceNanos": 151875,
+            "rowAdds": 935,
+            "smallAllocs": 2064,
+            "totalNanos": 227157
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2894,
+            "packNanos": 72428,
+            "rank": 25,
+            "reduceNanos": 137013,
+            "rowAdds": 935,
+            "smallAllocs": 2064,
+            "totalNanos": 212715
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 8432,
+            "packNanos": 70415,
+            "rank": 25,
+            "reduceNanos": 323720,
+            "rowAdds": 935,
+            "smallAllocs": 42384,
+            "totalNanos": 402487
+          },
+          "peakResidentBytes": 63860736,
+          "productionMatrixRebuild": {
+            "nanos": 2862934,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 2935823,
+            "smallAllocs": 166027
+          },
+          "productionRowReduce": {
+            "nanos": 2871038,
+            "smallAllocs": 163665
+          },
+          "rank": 25,
+          "residentBytesAfter": 63746048,
+          "residentBytesBefore": 63549440,
+          "rowReduceMatrixRebuild": {
+            "nanos": 2872910,
+            "smallAllocs": 0
+          },
+          "sink": 20,
+          "splitFactors": 17
+        },
+        "modularDegree": 42,
+        "modularFactorCount": 17,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd5_x_phi11",
+      "status": "ok"
+    },
+    {
+      "degree": 48,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 48,
+          "basisToPolynomials": {
+            "nanos": 6720,
+            "smallAllocs": 686
+          },
+          "berlekampMatrixWall": {
+            "nanos": 537597,
+            "smallAllocs": 51263
+          },
+          "berlekampSplit": {
+            "nanos": 1912937,
+            "smallAllocs": 163103
+          },
+          "columnPolys": {
+            "nanos": 476367,
+            "smallAllocs": 46071
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 19,
+            "pivotSearch": {
+              "nanos": 1212,
+              "smallAllocs": 96
+            },
+            "pivots": 29,
+            "rowAdd": {
+              "nanos": 119590,
+              "smallAllocs": 7891
+            },
+            "rowAdds": 38,
+            "rowAddsSkipped": 1325,
+            "rowSwapScale": {
+              "nanos": 67556,
+              "smallAllocs": 4425
+            },
+            "stagedNanos": 188369,
+            "wall": {
+              "nanos": 224583,
+              "smallAllocs": 13028
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 19,
+            "pivotSearch": {
+              "nanos": 1142,
+              "smallAllocs": 96
+            },
+            "pivots": 29,
+            "rowAdd": {
+              "nanos": 183563,
+              "smallAllocs": 11539
+            },
+            "rowAdds": 38,
+            "rowAddsSkipped": 1325,
+            "rowSwapScale": {
+              "nanos": 91364,
+              "smallAllocs": 5817
+            },
+            "stagedNanos": 276012,
+            "wall": {
+              "nanos": 308538,
+              "smallAllocs": 18071
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 36884,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 618196,
+            "smallAllocs": 51959
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 572619,
+            "smallAllocs": 53616
+          },
+          "frobeniusPower": {
+            "nanos": 7702,
+            "smallAllocs": 585
+          },
+          "kernelDimension": 19,
+          "matrixConversionNanos": 53429,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 579399,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 11,
+          "nullspaceBasisMagnitudeNanos": 59778,
+          "nullspaceBasisNanos": 59778,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 4166,
+            "packNanos": 96213,
+            "rank": 29,
+            "reduceNanos": 27591,
+            "rowAdds": 38,
+            "smallAllocs": 3867,
+            "totalNanos": 127820
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3635,
+            "packNanos": 95582,
+            "rank": 29,
+            "reduceNanos": 26400,
+            "rowAdds": 38,
+            "smallAllocs": 3867,
+            "totalNanos": 125716
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3585,
+            "packNanos": 95792,
+            "rank": 29,
+            "reduceNanos": 24376,
+            "rowAdds": 38,
+            "smallAllocs": 3867,
+            "totalNanos": 124445
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 10395,
+            "packNanos": 91866,
+            "rank": 29,
+            "reduceNanos": 42483,
+            "rowAdds": 38,
+            "smallAllocs": 7083,
+            "totalNanos": 145065
+          },
+          "peakResidentBytes": 64086016,
+          "productionMatrixRebuild": {
+            "nanos": 571718,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 333965,
+            "smallAllocs": 17567
+          },
+          "productionRowReduce": {
+            "nanos": 274187,
+            "smallAllocs": 14957
+          },
+          "rank": 29,
+          "residentBytesAfter": 64020480,
+          "residentBytesBefore": 63913984,
+          "rowReduceMatrixRebuild": {
+            "nanos": 582915,
+            "smallAllocs": 0
+          },
+          "sink": 20,
+          "splitFactors": 19
+        },
+        "modularDegree": 48,
+        "modularFactorCount": 19,
+        "prime": 11,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "xpow48_minus1",
+      "status": "ok"
+    },
+    {
+      "degree": 105,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 105,
+          "basisToPolynomials": {
+            "nanos": 7121,
+            "smallAllocs": 657
+          },
+          "berlekampMatrixWall": {
+            "nanos": 3561791,
+            "smallAllocs": 337638
+          },
+          "berlekampSplit": {
+            "nanos": 8840398,
+            "smallAllocs": 750003
+          },
+          "columnPolys": {
+            "nanos": 3286203,
+            "smallAllocs": 314148
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 14,
+            "pivotSearch": {
+              "nanos": 2624,
+              "smallAllocs": 210
+            },
+            "pivots": 91,
+            "rowAdd": {
+              "nanos": 979082,
+              "smallAllocs": 65681
+            },
+            "rowAdds": 175,
+            "rowAddsSkipped": 9289,
+            "rowSwapScale": {
+              "nanos": 439480,
+              "smallAllocs": 29307
+            },
+            "stagedNanos": 1421249,
+            "wall": {
+              "nanos": 1560804,
+              "smallAllocs": 95903
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 14,
+            "pivotSearch": {
+              "nanos": 2624,
+              "smallAllocs": 210
+            },
+            "pivots": 91,
+            "rowAdd": {
+              "nanos": 1575145,
+              "smallAllocs": 102431
+            },
+            "rowAdds": 175,
+            "rowAddsSkipped": 9289,
+            "rowSwapScale": {
+              "nanos": 600943,
+              "smallAllocs": 38862
+            },
+            "stagedNanos": 2178685,
+            "wall": {
+              "nanos": 2305839,
+              "smallAllocs": 142211
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 188630,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 3968755,
+            "smallAllocs": 339228
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 3750201,
+            "smallAllocs": 348769
+          },
+          "frobeniusPower": {
+            "nanos": 17155,
+            "smallAllocs": 1441
+          },
+          "kernelDimension": 14,
+          "matrixConversionNanos": 258293,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 3786634,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 17,
+          "nullspaceBasisMagnitudeNanos": 218454,
+          "nullspaceBasisNanos": 218454,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 12117,
+            "packNanos": 493461,
+            "rank": 91,
+            "reduceNanos": 180398,
+            "rowAdds": 175,
+            "smallAllocs": 20842,
+            "totalNanos": 686117
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 11366,
+            "packNanos": 489256,
+            "rank": 91,
+            "reduceNanos": 178375,
+            "rowAdds": 175,
+            "smallAllocs": 20842,
+            "totalNanos": 678686
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 11367,
+            "packNanos": 493221,
+            "rank": 91,
+            "reduceNanos": 150553,
+            "rowAdds": 175,
+            "smallAllocs": 20842,
+            "totalNanos": 657956
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 51356,
+            "packNanos": 492410,
+            "rank": 91,
+            "reduceNanos": 321557,
+            "rowAdds": 175,
+            "smallAllocs": 48772,
+            "totalNanos": 864061
+          },
+          "peakResidentBytes": 65224704,
+          "productionMatrixRebuild": {
+            "nanos": 3760065,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 2331978,
+            "smallAllocs": 134628
+          },
+          "productionRowReduce": {
+            "nanos": 2136267,
+            "smallAllocs": 122300
+          },
+          "rank": 91,
+          "residentBytesAfter": 64913408,
+          "residentBytesBefore": 64090112,
+          "rowReduceMatrixRebuild": {
+            "nanos": 3770771,
+            "smallAllocs": 0
+          },
+          "sink": 16,
+          "splitFactors": 14
+        },
+        "modularDegree": 105,
+        "modularFactorCount": 14,
+        "prime": 17,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "xpow105_minus1",
+      "status": "ok"
+    },
+    {
+      "degree": 120,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 120,
+          "basisToPolynomials": {
+            "nanos": 29493,
+            "smallAllocs": 2778
+          },
+          "berlekampMatrixWall": {
+            "nanos": 2369143,
+            "smallAllocs": 214939
+          },
+          "berlekampSplit": {
+            "nanos": 15959874,
+            "smallAllocs": 1312571
+          },
+          "columnPolys": {
+            "nanos": 2029288,
+            "smallAllocs": 185863
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 39,
+            "pivotSearch": {
+              "nanos": 2981,
+              "smallAllocs": 240
+            },
+            "pivots": 81,
+            "rowAdd": {
+              "nanos": 841268,
+              "smallAllocs": 57197
+            },
+            "rowAdds": 116,
+            "rowAddsSkipped": 9523,
+            "rowSwapScale": {
+              "nanos": 454496,
+              "smallAllocs": 30075
+            },
+            "stagedNanos": 1298143,
+            "wall": {
+              "nanos": 1492063,
+              "smallAllocs": 89910
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 39,
+            "pivotSearch": {
+              "nanos": 3135,
+              "smallAllocs": 240
+            },
+            "pivots": 81,
+            "rowAdd": {
+              "nanos": 1310416,
+              "smallAllocs": 85037
+            },
+            "rowAdds": 116,
+            "rowAddsSkipped": 9523,
+            "rowSwapScale": {
+              "nanos": 621174,
+              "smallAllocs": 39795
+            },
+            "stagedNanos": 1930378,
+            "wall": {
+              "nanos": 2120634,
+              "smallAllocs": 127473
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 231573,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 3003353,
+            "smallAllocs": 218459
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 2599254,
+            "smallAllocs": 229460
+          },
+          "frobeniusPower": {
+            "nanos": 4406,
+            "smallAllocs": 277
+          },
+          "kernelDimension": 39,
+          "matrixConversionNanos": 335458,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 2660665,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 7,
+          "nullspaceBasisMagnitudeNanos": 497318,
+          "nullspaceBasisNanos": 497318,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 20120,
+            "packNanos": 649553,
+            "rank": 81,
+            "reduceNanos": 169150,
+            "rowAdds": 116,
+            "smallAllocs": 24501,
+            "totalNanos": 838463
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 19489,
+            "packNanos": 649774,
+            "rank": 81,
+            "reduceNanos": 167668,
+            "rowAdds": 116,
+            "smallAllocs": 24501,
+            "totalNanos": 835770
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 19139,
+            "packNanos": 646088,
+            "rank": 81,
+            "reduceNanos": 147318,
+            "rowAdds": 116,
+            "smallAllocs": 24501,
+            "totalNanos": 812985
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 68391,
+            "packNanos": 633349,
+            "rank": 81,
+            "reduceNanos": 293095,
+            "rowAdds": 116,
+            "smallAllocs": 48141,
+            "totalNanos": 998129
+          },
+          "peakResidentBytes": 65728512,
+          "productionMatrixRebuild": {
+            "nanos": 2595808,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 2441380,
+            "smallAllocs": 123505
+          },
+          "productionRowReduce": {
+            "nanos": 1944062,
+            "smallAllocs": 107187
+          },
+          "rank": 81,
+          "residentBytesAfter": 65495040,
+          "residentBytesBefore": 63930368,
+          "rowReduceMatrixRebuild": {
+            "nanos": 2626905,
+            "smallAllocs": 0
+          },
+          "sink": 20,
+          "splitFactors": 39
+        },
+        "modularDegree": 120,
+        "modularFactorCount": 39,
+        "prime": 7,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "xpow120_minus1",
+      "status": "ok"
+    },
+    {
+      "degree": 178,
+      "family": "cyclotomic",
+      "kernel": {
+        "kernel": {
+          "basisSize": 178,
+          "basisToPolynomials": {
+            "nanos": 3304,
+            "smallAllocs": 371
+          },
+          "berlekampMatrixWall": {
+            "nanos": 3137062,
+            "smallAllocs": 274190
+          },
+          "berlekampSplit": {
+            "nanos": 6541309,
+            "smallAllocs": 339370
+          },
+          "columnPolys": {
+            "nanos": 2420038,
+            "smallAllocs": 210706
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 2,
+            "pivotSearch": {
+              "nanos": 4440,
+              "smallAllocs": 356
+            },
+            "pivots": 176,
+            "rowAdd": {
+              "nanos": 7852690,
+              "smallAllocs": 491858
+            },
+            "rowAdds": 1114,
+            "rowAddsSkipped": 30038,
+            "rowSwapScale": {
+              "nanos": 1436464,
+              "smallAllocs": 95034
+            },
+            "stagedNanos": 9289838,
+            "wall": {
+              "nanos": 9692261,
+              "smallAllocs": 587969
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 2,
+            "pivotSearch": {
+              "nanos": 4601,
+              "smallAllocs": 356
+            },
+            "pivots": 176,
+            "rowAdd": {
+              "nanos": 14549327,
+              "smallAllocs": 888442
+            },
+            "rowAdds": 1114,
+            "rowAddsSkipped": 30038,
+            "rowSwapScale": {
+              "nanos": 1994419,
+              "smallAllocs": 126362
+            },
+            "stagedNanos": 16549315,
+            "wall": {
+              "nanos": 16921590,
+              "smallAllocs": 1015884
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 544489,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 5811487,
+            "smallAllocs": 275077
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 3703160,
+            "smallAllocs": 306053
+          },
+          "frobeniusPower": {
+            "nanos": 2644,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 2,
+          "matrixConversionNanos": 716853,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 3743731,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 338172,
+          "nullspaceBasisNanos": 338172,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 21912,
+            "packNanos": 1468628,
+            "rank": 176,
+            "reduceNanos": 1050467,
+            "rowAdds": 1114,
+            "smallAllocs": 62627,
+            "totalNanos": 2539576
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 21482,
+            "packNanos": 1463730,
+            "rank": 176,
+            "reduceNanos": 1041023,
+            "rowAdds": 1114,
+            "smallAllocs": 62627,
+            "totalNanos": 2527197
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 21422,
+            "packNanos": 1468738,
+            "rank": 176,
+            "reduceNanos": 710344,
+            "rowAdds": 1114,
+            "smallAllocs": 62627,
+            "totalNanos": 2218710
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 115061,
+            "packNanos": 1405324,
+            "rank": 176,
+            "reduceNanos": 2119623,
+            "rowAdds": 1114,
+            "smallAllocs": 291357,
+            "totalNanos": 3639226
+          },
+          "peakResidentBytes": 67493888,
+          "productionMatrixRebuild": {
+            "nanos": 3744722,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 16882052,
+            "smallAllocs": 984110
+          },
+          "productionRowReduce": {
+            "nanos": 16618391,
+            "smallAllocs": 951807
+          },
+          "rank": 176,
+          "residentBytesAfter": 67842048,
+          "residentBytesBefore": 65761280,
+          "rowReduceMatrixRebuild": {
+            "nanos": 3738634,
+            "smallAllocs": 0
+          },
+          "sink": 4,
+          "splitFactors": 2
+        },
+        "modularDegree": 178,
+        "modularFactorCount": 2,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi179",
+      "status": "ok"
+    },
+    {
+      "degree": 80,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 80,
+          "basisToPolynomials": {
+            "nanos": 3875,
+            "smallAllocs": 307
+          },
+          "berlekampMatrixWall": {
+            "nanos": 3682290,
+            "smallAllocs": 346439
+          },
+          "berlekampSplit": {
+            "nanos": 10258220,
+            "smallAllocs": 586770
+          },
+          "columnPolys": {
+            "nanos": 3571956,
+            "smallAllocs": 333055
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 10,
+            "pivotSearch": {
+              "nanos": 1948,
+              "smallAllocs": 160
+            },
+            "pivots": 70,
+            "rowAdd": {
+              "nanos": 11880194,
+              "smallAllocs": 705467
+            },
+            "rowAdds": 4277,
+            "rowAddsSkipped": 1253,
+            "rowSwapScale": {
+              "nanos": 266023,
+              "smallAllocs": 17180
+            },
+            "stagedNanos": 12148030,
+            "wall": {
+              "nanos": 12232097,
+              "smallAllocs": 723226
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 10,
+            "pivotSearch": {
+              "nanos": 2019,
+              "smallAllocs": 160
+            },
+            "pivots": 70,
+            "rowAdd": {
+              "nanos": 22836349,
+              "smallAllocs": 1389787
+            },
+            "rowAdds": 4277,
+            "rowAddsSkipped": 1253,
+            "rowSwapScale": {
+              "nanos": 368195,
+              "smallAllocs": 22780
+            },
+            "stagedNanos": 23204178,
+            "wall": {
+              "nanos": 23281981,
+              "smallAllocs": 1413149
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 93678,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 7505729,
+            "smallAllocs": 347380
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 3759865,
+            "smallAllocs": 352920
+          },
+          "frobeniusPower": {
+            "nanos": 7932,
+            "smallAllocs": 585
+          },
+          "kernelDimension": 10,
+          "matrixConversionNanos": 121180,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 3831761,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 11,
+          "nullspaceBasisMagnitudeNanos": 7631,
+          "nullspaceBasisNanos": 0,
+          "nullspaceBasisNegative": true,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 7421,
+            "packNanos": 279224,
+            "rank": 70,
+            "reduceNanos": 1267910,
+            "rowAdds": 4277,
+            "smallAllocs": 8060,
+            "totalNanos": 1554555
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 6920,
+            "packNanos": 277862,
+            "rank": 70,
+            "reduceNanos": 1249893,
+            "rowAdds": 4277,
+            "smallAllocs": 8060,
+            "totalNanos": 1534675
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 6820,
+            "packNanos": 277411,
+            "rank": 70,
+            "reduceNanos": 1008836,
+            "rowAdds": 4277,
+            "smallAllocs": 8060,
+            "totalNanos": 1293217
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 26490,
+            "packNanos": 266565,
+            "rank": 70,
+            "reduceNanos": 2785520,
+            "rowAdds": 4277,
+            "smallAllocs": 355100,
+            "totalNanos": 3080127
+          },
+          "peakResidentBytes": 67022848,
+          "productionMatrixRebuild": {
+            "nanos": 3837510,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 23597238,
+            "smallAllocs": 1408888
+          },
+          "productionRowReduce": {
+            "nanos": 23591069,
+            "smallAllocs": 1401336
+          },
+          "rank": 70,
+          "residentBytesAfter": 64540672,
+          "residentBytesBefore": 67514368,
+          "rowReduceMatrixRebuild": {
+            "nanos": 3826364,
+            "smallAllocs": 0
+          },
+          "sink": 4,
+          "splitFactors": 10
+        },
+        "modularDegree": 80,
+        "modularFactorCount": 10,
+        "prime": 11,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi64_x_phi105",
+      "status": "ok"
+    },
+    {
+      "degree": 144,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 144,
+          "basisToPolynomials": {
+            "nanos": 5027,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 7822518,
+            "smallAllocs": 722207
+          },
+          "berlekampSplit": {
+            "nanos": 33822599,
+            "smallAllocs": 1239327
+          },
+          "columnPolys": {
+            "nanos": 7344840,
+            "smallAllocs": 680459
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 8,
+            "pivotSearch": {
+              "nanos": 3718,
+              "smallAllocs": 288
+            },
+            "pivots": 136,
+            "rowAdd": {
+              "nanos": 66306288,
+              "smallAllocs": 3858949
+            },
+            "rowAdds": 13149,
+            "rowAddsSkipped": 6299,
+            "rowSwapScale": {
+              "nanos": 925480,
+              "smallAllocs": 59552
+            },
+            "stagedNanos": 67221660,
+            "wall": {
+              "nanos": 67509728,
+              "smallAllocs": 3919428
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 8,
+            "pivotSearch": {
+              "nanos": 3874,
+              "smallAllocs": 288
+            },
+            "pivots": 136,
+            "rowAdd": {
+              "nanos": 130948935,
+              "smallAllocs": 7645861
+            },
+            "rowAdds": 13149,
+            "rowAddsSkipped": 6299,
+            "rowSwapScale": {
+              "nanos": 1305454,
+              "smallAllocs": 79136
+            },
+            "stagedNanos": 132232859,
+            "wall": {
+              "nanos": 132536664,
+              "smallAllocs": 7725927
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 319725,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 28100275,
+            "smallAllocs": 723728
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 8141973,
+            "smallAllocs": 743088
+          },
+          "frobeniusPower": {
+            "nanos": 5048,
+            "smallAllocs": 277
+          },
+          "kernelDimension": 8,
+          "matrixConversionNanos": 472480,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 8227529,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 7,
+          "nullspaceBasisMagnitudeNanos": 771865,
+          "nullspaceBasisNanos": 771865,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 17686,
+            "packNanos": 944191,
+            "rank": 136,
+            "reduceNanos": 6829887,
+            "rowAdds": 13149,
+            "smallAllocs": 27764,
+            "totalNanos": 7797281
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 17115,
+            "packNanos": 945702,
+            "rank": 136,
+            "reduceNanos": 6725953,
+            "rowAdds": 13149,
+            "smallAllocs": 27764,
+            "totalNanos": 7688169
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 16925,
+            "packNanos": 945431,
+            "rank": 136,
+            "reduceNanos": 5092641,
+            "rowAdds": 13149,
+            "smallAllocs": 27764,
+            "totalNanos": 6057452
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 99077,
+            "packNanos": 902108,
+            "rank": 136,
+            "reduceNanos": 15284362,
+            "rowAdds": 13149,
+            "smallAllocs": 1938068,
+            "totalNanos": 16291155
+          },
+          "peakResidentBytes": 67022848,
+          "productionMatrixRebuild": {
+            "nanos": 8276071,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 134519114,
+            "smallAllocs": 7708346
+          },
+          "productionRowReduce": {
+            "nanos": 132706546,
+            "smallAllocs": 7685628
+          },
+          "rank": 136,
+          "residentBytesAfter": 65662976,
+          "residentBytesBefore": 64331776,
+          "rowReduceMatrixRebuild": {
+            "nanos": 8245886,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 8
+        },
+        "modularDegree": 144,
+        "modularFactorCount": 8,
+        "prime": 7,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi128_x_phi165",
+      "status": "ok"
+    },
+    {
+      "degree": 240,
+      "family": "cyclotomic",
+      "kernel": {
+        "kernel": {
+          "basisSize": 240,
+          "basisToPolynomials": {
+            "nanos": 6439,
+            "smallAllocs": 523
+          },
+          "berlekampMatrixWall": {
+            "nanos": 7535963,
+            "smallAllocs": 660179
+          },
+          "berlekampSplit": {
+            "nanos": 57851627,
+            "smallAllocs": 1030964
+          },
+          "columnPolys": {
+            "nanos": 6199232,
+            "smallAllocs": 544863
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 6238,
+              "smallAllocs": 480
+            },
+            "pivots": 236,
+            "rowAdd": {
+              "nanos": 151465980,
+              "smallAllocs": 8803144
+            },
+            "rowAdds": 17948,
+            "rowAddsSkipped": 38456,
+            "rowSwapScale": {
+              "nanos": 2735165,
+              "smallAllocs": 171267
+            },
+            "stagedNanos": 154207293,
+            "wall": {
+              "nanos": 155083744,
+              "smallAllocs": 8975874
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 6526,
+              "smallAllocs": 480
+            },
+            "pivots": 236,
+            "rowAdd": {
+              "nanos": 297411536,
+              "smallAllocs": 17418184
+            },
+            "rowAdds": 17948,
+            "rowAddsSkipped": 38456,
+            "rowSwapScale": {
+              "nanos": 3769174,
+              "smallAllocs": 227907
+            },
+            "stagedNanos": 301146407,
+            "wall": {
+              "nanos": 301969174,
+              "smallAllocs": 17647557
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 924200,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 53885537,
+            "smallAllocs": 661844
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 8345864,
+            "smallAllocs": 718020
+          },
+          "frobeniusPower": {
+            "nanos": 3214,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 4,
+          "matrixConversionNanos": 1275401,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 8718868,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 666168,
+          "nullspaceBasisNanos": 666168,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 40119,
+            "packNanos": 2712182,
+            "rank": 236,
+            "reduceNanos": 15602494,
+            "rowAdds": 17948,
+            "smallAllocs": 97269,
+            "totalNanos": 18384589
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 39168,
+            "packNanos": 2704009,
+            "rank": 236,
+            "reduceNanos": 15420484,
+            "rowAdds": 17948,
+            "smallAllocs": 97269,
+            "totalNanos": 18163661
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 38977,
+            "packNanos": 2718019,
+            "rank": 236,
+            "reduceNanos": 9198449,
+            "rowAdds": 17948,
+            "smallAllocs": 97269,
+            "totalNanos": 11967674
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 285753,
+            "packNanos": 2683098,
+            "rank": 236,
+            "reduceNanos": 37638828,
+            "rowAdds": 17948,
+            "smallAllocs": 4446309,
+            "totalNanos": 40609502
+          },
+          "peakResidentBytes": 71143424,
+          "productionMatrixRebuild": {
+            "nanos": 8523098,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 305951949,
+            "smallAllocs": 17591476
+          },
+          "productionRowReduce": {
+            "nanos": 306776431,
+            "smallAllocs": 17532366
+          },
+          "rank": 236,
+          "residentBytesAfter": 69439488,
+          "residentBytesBefore": 66330624,
+          "rowReduceMatrixRebuild": {
+            "nanos": 8738727,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 4
+        },
+        "modularDegree": 240,
+        "modularFactorCount": 4,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi385",
+      "status": "ok"
+    },
+    {
+      "degree": 40,
+      "family": "wilkinson",
+      "kernel": {
+        "kernel": {
+          "basisSize": 40,
+          "basisToPolynomials": {
+            "nanos": 18778,
+            "smallAllocs": 1843
+          },
+          "berlekampMatrixWall": {
+            "nanos": 191765,
+            "smallAllocs": 17281
+          },
+          "berlekampSplit": {
+            "nanos": 1717276,
+            "smallAllocs": 146136
+          },
+          "columnPolys": {
+            "nanos": 74260,
+            "smallAllocs": 6155
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 40,
+            "pivotSearch": {
+              "nanos": 953,
+              "smallAllocs": 80
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 953,
+            "wall": {
+              "nanos": 42794,
+              "smallAllocs": 1807
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 40,
+            "pivotSearch": {
+              "nanos": 1000,
+              "smallAllocs": 80
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 1000,
+            "wall": {
+              "nanos": 40730,
+              "smallAllocs": 1810
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 31787,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 224763,
+            "smallAllocs": 17402
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 221238,
+            "smallAllocs": 18922
+          },
+          "frobeniusPower": {
+            "nanos": 83554,
+            "smallAllocs": 7927
+          },
+          "kernelDimension": 40,
+          "matrixConversionNanos": 33839,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 220537,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 47,
+          "nullspaceBasisMagnitudeNanos": 38858,
+          "nullspaceBasisNanos": 38858,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2023,
+            "packNanos": 66169,
+            "rank": 0,
+            "reduceNanos": 4857,
+            "rowAdds": 0,
+            "smallAllocs": 1777,
+            "totalNanos": 73479
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1662,
+            "packNanos": 65888,
+            "rank": 0,
+            "reduceNanos": 4356,
+            "rowAdds": 0,
+            "smallAllocs": 1777,
+            "totalNanos": 71976
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1632,
+            "packNanos": 65707,
+            "rank": 0,
+            "reduceNanos": 4257,
+            "rowAdds": 0,
+            "smallAllocs": 1777,
+            "totalNanos": 71596
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5959,
+            "packNanos": 63404,
+            "rank": 0,
+            "reduceNanos": 4988,
+            "rowAdds": 0,
+            "smallAllocs": 1777,
+            "totalNanos": 74651
+          },
+          "peakResidentBytes": 70402048,
+          "productionMatrixRebuild": {
+            "nanos": 218865,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 83614,
+            "smallAllocs": 1728
+          },
+          "productionRowReduce": {
+            "nanos": 44846,
+            "smallAllocs": 1607
+          },
+          "rank": 0,
+          "residentBytesAfter": 69775360,
+          "residentBytesBefore": 69775360,
+          "rowReduceMatrixRebuild": {
+            "nanos": 223752,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 40
+        },
+        "modularDegree": 40,
+        "modularFactorCount": 40,
+        "prime": 47,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "wilkinson_40",
+      "status": "ok"
+    },
+    {
+      "degree": 48,
+      "family": "wilkinson",
+      "kernel": {
+        "kernel": {
+          "basisSize": 48,
+          "basisToPolynomials": {
+            "nanos": 25808,
+            "smallAllocs": 2595
+          },
+          "berlekampMatrixWall": {
+            "nanos": 272894,
+            "smallAllocs": 24749
+          },
+          "berlekampSplit": {
+            "nanos": 2734254,
+            "smallAllocs": 235614
+          },
+          "columnPolys": {
+            "nanos": 103844,
+            "smallAllocs": 8727
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 48,
+            "pivotSearch": {
+              "nanos": 1111,
+              "smallAllocs": 96
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 1111,
+            "wall": {
+              "nanos": 60721,
+              "smallAllocs": 2551
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 48,
+            "pivotSearch": {
+              "nanos": 1131,
+              "smallAllocs": 96
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 1131,
+            "wall": {
+              "nanos": 56473,
+              "smallAllocs": 2554
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 39579,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 318171,
+            "smallAllocs": 24894
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 312343,
+            "smallAllocs": 27102
+          },
+          "frobeniusPower": {
+            "nanos": 120078,
+            "smallAllocs": 11415
+          },
+          "kernelDimension": 48,
+          "matrixConversionNanos": 47902,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 314516,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 61,
+          "nullspaceBasisMagnitudeNanos": 58037,
+          "nullspaceBasisNanos": 58037,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2463,
+            "packNanos": 97745,
+            "rank": 0,
+            "reduceNanos": 6429,
+            "rowAdds": 0,
+            "smallAllocs": 2513,
+            "totalNanos": 106768
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2163,
+            "packNanos": 96953,
+            "rank": 0,
+            "reduceNanos": 5929,
+            "rowAdds": 0,
+            "smallAllocs": 2513,
+            "totalNanos": 104955
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2113,
+            "packNanos": 96823,
+            "rank": 0,
+            "reduceNanos": 5919,
+            "rowAdds": 0,
+            "smallAllocs": 2513,
+            "totalNanos": 104825
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 8162,
+            "packNanos": 93108,
+            "rank": 0,
+            "reduceNanos": 6430,
+            "rowAdds": 0,
+            "smallAllocs": 2513,
+            "totalNanos": 107970
+          },
+          "peakResidentBytes": 70402048,
+          "productionMatrixRebuild": {
+            "nanos": 313555,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 121030,
+            "smallAllocs": 2456
+          },
+          "productionRowReduce": {
+            "nanos": 64136,
+            "smallAllocs": 2311
+          },
+          "rank": 0,
+          "residentBytesAfter": 69890048,
+          "residentBytesBefore": 69787648,
+          "rowReduceMatrixRebuild": {
+            "nanos": 312884,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 48
+        },
+        "modularDegree": 48,
+        "modularFactorCount": 48,
+        "prime": 61,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "wilkinson_48",
+      "status": "ok"
+    },
+    {
+      "degree": 56,
+      "family": "wilkinson",
+      "kernel": {
+        "kernel": {
+          "basisSize": 56,
+          "basisToPolynomials": {
+            "nanos": 33499,
+            "smallAllocs": 3475
+          },
+          "berlekampMatrixWall": {
+            "nanos": 444479,
+            "smallAllocs": 40562
+          },
+          "berlekampSplit": {
+            "nanos": 4144746,
+            "smallAllocs": 360583
+          },
+          "columnPolys": {
+            "nanos": 139667,
+            "smallAllocs": 11747
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 56,
+            "pivotSearch": {
+              "nanos": 1343,
+              "smallAllocs": 112
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 1343,
+            "wall": {
+              "nanos": 81070,
+              "smallAllocs": 3423
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 56,
+            "pivotSearch": {
+              "nanos": 1378,
+              "smallAllocs": 112
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 1378,
+            "wall": {
+              "nanos": 77064,
+              "smallAllocs": 3426
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 52959,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 501855,
+            "smallAllocs": 40731
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 497498,
+            "smallAllocs": 43755
+          },
+          "frobeniusPower": {
+            "nanos": 236941,
+            "smallAllocs": 22544
+          },
+          "kernelDimension": 56,
+          "matrixConversionNanos": 68862,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 498830,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 67,
+          "nullspaceBasisMagnitudeNanos": 75101,
+          "nullspaceBasisNanos": 75101,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3025,
+            "packNanos": 135120,
+            "rank": 0,
+            "reduceNanos": 8773,
+            "rowAdds": 0,
+            "smallAllocs": 3377,
+            "totalNanos": 146707
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2644,
+            "packNanos": 134098,
+            "rank": 0,
+            "reduceNanos": 7962,
+            "rowAdds": 0,
+            "smallAllocs": 3377,
+            "totalNanos": 145787
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2604,
+            "packNanos": 134279,
+            "rank": 0,
+            "reduceNanos": 8082,
+            "rowAdds": 0,
+            "smallAllocs": 3377,
+            "totalNanos": 145025
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 11697,
+            "packNanos": 128200,
+            "rank": 0,
+            "reduceNanos": 8573,
+            "rowAdds": 0,
+            "smallAllocs": 3377,
+            "totalNanos": 148491
+          },
+          "peakResidentBytes": 70402048,
+          "productionMatrixRebuild": {
+            "nanos": 493922,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 159556,
+            "smallAllocs": 3312
+          },
+          "productionRowReduce": {
+            "nanos": 83604,
+            "smallAllocs": 3143
+          },
+          "rank": 0,
+          "residentBytesAfter": 69890048,
+          "residentBytesBefore": 69890048,
+          "rowReduceMatrixRebuild": {
+            "nanos": 504028,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 56
+        },
+        "modularDegree": 56,
+        "modularFactorCount": 56,
+        "prime": 67,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "wilkinson_56",
+      "status": "ok"
+    },
+    {
+      "degree": 24,
+      "family": "chebyshev",
+      "kernel": {
+        "kernel": {
+          "basisSize": 24,
+          "basisToPolynomials": {
+            "nanos": 1201,
+            "smallAllocs": 90
+          },
+          "berlekampMatrixWall": {
+            "nanos": 119367,
+            "smallAllocs": 10805
+          },
+          "berlekampSplit": {
+            "nanos": 196681,
+            "smallAllocs": 13395
+          },
+          "columnPolys": {
+            "nanos": 103924,
+            "smallAllocs": 9437
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 3,
+            "pivotSearch": {
+              "nanos": 599,
+              "smallAllocs": 48
+            },
+            "pivots": 21,
+            "rowAdd": {
+              "nanos": 127541,
+              "smallAllocs": 7021
+            },
+            "rowAdds": 112,
+            "rowAddsSkipped": 371,
+            "rowSwapScale": {
+              "nanos": 26529,
+              "smallAllocs": 1639
+            },
+            "stagedNanos": 154598,
+            "wall": {
+              "nanos": 164004,
+              "smallAllocs": 8826
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 3,
+            "pivotSearch": {
+              "nanos": 629,
+              "smallAllocs": 48
+            },
+            "pivots": 21,
+            "rowAdd": {
+              "nanos": 216439,
+              "smallAllocs": 12397
+            },
+            "rowAdds": 112,
+            "rowAddsSkipped": 371,
+            "rowSwapScale": {
+              "nanos": 35766,
+              "smallAllocs": 2143
+            },
+            "stagedNanos": 254005,
+            "wall": {
+              "nanos": 262879,
+              "smallAllocs": 14709
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 11366,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 170353,
+            "smallAllocs": 10941
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 131104,
+            "smallAllocs": 11406
+          },
+          "frobeniusPower": {
+            "nanos": 3405,
+            "smallAllocs": 217
+          },
+          "kernelDimension": 3,
+          "matrixConversionNanos": 11507,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 131605,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 5,
+          "nullspaceBasisMagnitudeNanos": 10235,
+          "nullspaceBasisNanos": 10235,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1212,
+            "packNanos": 21743,
+            "rank": 21,
+            "reduceNanos": 18928,
+            "rowAdds": 112,
+            "smallAllocs": 1081,
+            "totalNanos": 41842
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 831,
+            "packNanos": 21722,
+            "rank": 21,
+            "reduceNanos": 17937,
+            "rowAdds": 112,
+            "smallAllocs": 1081,
+            "totalNanos": 40440
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 821,
+            "packNanos": 21562,
+            "rank": 21,
+            "reduceNanos": 14481,
+            "rowAdds": 112,
+            "smallAllocs": 1081,
+            "totalNanos": 37556
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2834,
+            "packNanos": 20821,
+            "rank": 21,
+            "reduceNanos": 32058,
+            "rowAdds": 112,
+            "smallAllocs": 4129,
+            "totalNanos": 55743
+          },
+          "peakResidentBytes": 70402048,
+          "productionMatrixRebuild": {
+            "nanos": 130433,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 254357,
+            "smallAllocs": 14185
+          },
+          "productionRowReduce": {
+            "nanos": 245124,
+            "smallAllocs": 13515
+          },
+          "rank": 21,
+          "residentBytesAfter": 69971968,
+          "residentBytesBefore": 69971968,
+          "rowReduceMatrixRebuild": {
+            "nanos": 130333,
+            "smallAllocs": 0
+          },
+          "sink": 20,
+          "splitFactors": 3
+        },
+        "modularDegree": 24,
+        "modularFactorCount": 3,
+        "prime": 5,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "chebyshev_T24",
+      "status": "ok"
+    },
+    {
+      "degree": 24,
+      "family": "chebyshev",
+      "kernel": {
+        "kernel": {
+          "basisSize": 24,
+          "basisToPolynomials": {
+            "nanos": 1151,
+            "smallAllocs": 99
+          },
+          "berlekampMatrixWall": {
+            "nanos": 89833,
+            "smallAllocs": 7348
+          },
+          "berlekampSplit": {
+            "nanos": 191153,
+            "smallAllocs": 12764
+          },
+          "columnPolys": {
+            "nanos": 71176,
+            "smallAllocs": 6080
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 627,
+              "smallAllocs": 48
+            },
+            "pivots": 20,
+            "rowAdd": {
+              "nanos": 113650,
+              "smallAllocs": 6262
+            },
+            "rowAdds": 98,
+            "rowAddsSkipped": 362,
+            "rowSwapScale": {
+              "nanos": 25338,
+              "smallAllocs": 1560
+            },
+            "stagedNanos": 139637,
+            "wall": {
+              "nanos": 148781,
+              "smallAllocs": 7993
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 601,
+              "smallAllocs": 48
+            },
+            "pivots": 20,
+            "rowAdd": {
+              "nanos": 192635,
+              "smallAllocs": 10966
+            },
+            "rowAdds": 98,
+            "rowAddsSkipped": 362,
+            "rowSwapScale": {
+              "nanos": 34512,
+              "smallAllocs": 2040
+            },
+            "stagedNanos": 227599,
+            "wall": {
+              "nanos": 236520,
+              "smallAllocs": 13180
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 6510,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 128962,
+            "smallAllocs": 7501
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 96233,
+            "smallAllocs": 7949
+          },
+          "frobeniusPower": {
+            "nanos": 2063,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 4,
+          "matrixConversionNanos": 16925,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 96363,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 12689,
+          "nullspaceBasisNanos": 12689,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1082,
+            "packNanos": 21813,
+            "rank": 20,
+            "reduceNanos": 17065,
+            "rowAdds": 98,
+            "smallAllocs": 1071,
+            "totalNanos": 39889
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 892,
+            "packNanos": 21732,
+            "rank": 20,
+            "reduceNanos": 15903,
+            "rowAdds": 98,
+            "smallAllocs": 1071,
+            "totalNanos": 39028
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 872,
+            "packNanos": 21642,
+            "rank": 20,
+            "reduceNanos": 12829,
+            "rowAdds": 98,
+            "smallAllocs": 1071,
+            "totalNanos": 35293
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2744,
+            "packNanos": 20871,
+            "rank": 20,
+            "reduceNanos": 28572,
+            "rowAdds": 98,
+            "smallAllocs": 3687,
+            "totalNanos": 52187
+          },
+          "peakResidentBytes": 70402048,
+          "productionMatrixRebuild": {
+            "nanos": 100049,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 234498,
+            "smallAllocs": 12726
+          },
+          "productionRowReduce": {
+            "nanos": 221809,
+            "smallAllocs": 12037
+          },
+          "rank": 20,
+          "residentBytesAfter": 69971968,
+          "residentBytesBefore": 69971968,
+          "rowReduceMatrixRebuild": {
+            "nanos": 96583,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 4
+        },
+        "modularDegree": 24,
+        "modularFactorCount": 4,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "chebyshev_U24",
+      "status": "ok"
+    },
+    {
+      "degree": 30,
+      "family": "legendre",
+      "kernel": {
+        "kernel": {
+          "basisSize": 30,
+          "basisToPolynomials": {
+            "nanos": 1753,
+            "smallAllocs": 146
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1216243,
+            "smallAllocs": 116780
+          },
+          "berlekampSplit": {
+            "nanos": 1964623,
+            "smallAllocs": 167769
+          },
+          "columnPolys": {
+            "nanos": 1103126,
+            "smallAllocs": 106059
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 7,
+            "pivotSearch": {
+              "nanos": 723,
+              "smallAllocs": 60
+            },
+            "pivots": 23,
+            "rowAdd": {
+              "nanos": 388631,
+              "smallAllocs": 21308
+            },
+            "rowAdds": 315,
+            "rowAddsSkipped": 352,
+            "rowSwapScale": {
+              "nanos": 38038,
+              "smallAllocs": 2201
+            },
+            "stagedNanos": 429890,
+            "wall": {
+              "nanos": 444069,
+              "smallAllocs": 23741
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 7,
+            "pivotSearch": {
+              "nanos": 781,
+              "smallAllocs": 60
+            },
+            "pivots": 23,
+            "rowAdd": {
+              "nanos": 697978,
+              "smallAllocs": 40208
+            },
+            "rowAdds": 315,
+            "rowAddsSkipped": 352,
+            "rowSwapScale": {
+              "nanos": 48472,
+              "smallAllocs": 2891
+            },
+            "stagedNanos": 747322,
+            "wall": {
+              "nanos": 760518,
+              "smallAllocs": 43334
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 17897,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1362520,
+            "smallAllocs": 117032
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1231697,
+            "smallAllocs": 117711
+          },
+          "frobeniusPower": {
+            "nanos": 95591,
+            "smallAllocs": 8922
+          },
+          "kernelDimension": 7,
+          "matrixConversionNanos": 15993,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1238897,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 67,
+          "nullspaceBasisMagnitudeNanos": 24696,
+          "nullspaceBasisNanos": 24696,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1763,
+            "packNanos": 35372,
+            "rank": 23,
+            "reduceNanos": 46589,
+            "rowAdds": 315,
+            "smallAllocs": 1412,
+            "totalNanos": 83924
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1422,
+            "packNanos": 35162,
+            "rank": 23,
+            "reduceNanos": 45207,
+            "rowAdds": 315,
+            "smallAllocs": 1412,
+            "totalNanos": 81761
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1413,
+            "packNanos": 35182,
+            "rank": 23,
+            "reduceNanos": 33329,
+            "rowAdds": 315,
+            "smallAllocs": 1412,
+            "totalNanos": 69944
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 4436,
+            "packNanos": 34130,
+            "rank": 23,
+            "reduceNanos": 90054,
+            "rowAdds": 315,
+            "smallAllocs": 11552,
+            "totalNanos": 129151
+          },
+          "peakResidentBytes": 70402048,
+          "productionMatrixRebuild": {
+            "nanos": 1250003,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 769140,
+            "smallAllocs": 42855
+          },
+          "productionRowReduce": {
+            "nanos": 748610,
+            "smallAllocs": 41732
+          },
+          "rank": 23,
+          "residentBytesAfter": 69971968,
+          "residentBytesBefore": 69971968,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1236223,
+            "smallAllocs": 0
+          },
+          "sink": 20,
+          "splitFactors": 7
+        },
+        "modularDegree": 30,
+        "modularFactorCount": 7,
+        "prime": 67,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "legendre_P30",
+      "status": "ok"
+    },
+    {
+      "degree": 38,
+      "family": "legendre",
+      "kernel": {
+        "kernel": {
+          "basisSize": 38,
+          "basisToPolynomials": {
+            "nanos": 1312,
+            "smallAllocs": 100
+          },
+          "berlekampMatrixWall": {
+            "nanos": 2364656,
+            "smallAllocs": 232849
+          },
+          "berlekampSplit": {
+            "nanos": 2915072,
+            "smallAllocs": 251152
+          },
+          "columnPolys": {
+            "nanos": 2188064,
+            "smallAllocs": 215798
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 3,
+            "pivotSearch": {
+              "nanos": 942,
+              "smallAllocs": 76
+            },
+            "pivots": 35,
+            "rowAdd": {
+              "nanos": 909430,
+              "smallAllocs": 51765
+            },
+            "rowAdds": 620,
+            "rowAddsSkipped": 675,
+            "rowSwapScale": {
+              "nanos": 65158,
+              "smallAllocs": 4185
+            },
+            "stagedNanos": 975607,
+            "wall": {
+              "nanos": 997048,
+              "smallAllocs": 56191
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 3,
+            "pivotSearch": {
+              "nanos": 1011,
+              "smallAllocs": 76
+            },
+            "pivots": 35,
+            "rowAdd": {
+              "nanos": 1675063,
+              "smallAllocs": 98885
+            },
+            "rowAdds": 620,
+            "rowAddsSkipped": 675,
+            "rowSwapScale": {
+              "nanos": 90724,
+              "smallAllocs": 5515
+            },
+            "stagedNanos": 1765638,
+            "wall": {
+              "nanos": 1785537,
+              "smallAllocs": 104644
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 23465,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 2711571,
+            "smallAllocs": 233069
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 2401400,
+            "smallAllocs": 234332
+          },
+          "frobeniusPower": {
+            "nanos": 146908,
+            "smallAllocs": 14164
+          },
+          "kernelDimension": 3,
+          "matrixConversionNanos": 29684,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 2440398,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 79,
+          "nullspaceBasisMagnitudeNanos": 25277,
+          "nullspaceBasisNanos": 25277,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2173,
+            "packNanos": 60009,
+            "rank": 35,
+            "reduceNanos": 104835,
+            "rowAdds": 620,
+            "smallAllocs": 2323,
+            "totalNanos": 170112
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1543,
+            "packNanos": 59468,
+            "rank": 35,
+            "reduceNanos": 104675,
+            "rowAdds": 620,
+            "smallAllocs": 2323,
+            "totalNanos": 166207
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1512,
+            "packNanos": 59658,
+            "rank": 35,
+            "reduceNanos": 74120,
+            "rowAdds": 620,
+            "smallAllocs": 2323,
+            "totalNanos": 135241
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5868,
+            "packNanos": 56764,
+            "rank": 35,
+            "reduceNanos": 210682,
+            "rowAdds": 620,
+            "smallAllocs": 27175,
+            "totalNanos": 273806
+          },
+          "peakResidentBytes": 70402048,
+          "productionMatrixRebuild": {
+            "nanos": 2434770,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 1775062,
+            "smallAllocs": 103304
+          },
+          "productionRowReduce": {
+            "nanos": 1742894,
+            "smallAllocs": 101686
+          },
+          "rank": 35,
+          "residentBytesAfter": 64802816,
+          "residentBytesBefore": 69996544,
+          "rowReduceMatrixRebuild": {
+            "nanos": 2439237,
+            "smallAllocs": 0
+          },
+          "sink": 18,
+          "splitFactors": 3
+        },
+        "modularDegree": 38,
+        "modularFactorCount": 3,
+        "prime": 79,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "legendre_P38",
+      "status": "ok"
+    },
+    {
+      "degree": 16,
+      "family": "cyclotomic",
+      "kernel": {
+        "kernel": {
+          "basisSize": 16,
+          "basisToPolynomials": {
+            "nanos": 591,
+            "smallAllocs": 40
+          },
+          "berlekampMatrixWall": {
+            "nanos": 33219,
+            "smallAllocs": 2759
+          },
+          "berlekampSplit": {
+            "nanos": 50615,
+            "smallAllocs": 2865
+          },
+          "columnPolys": {
+            "nanos": 25558,
+            "smallAllocs": 2131
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 1,
+            "pivotSearch": {
+              "nanos": 419,
+              "smallAllocs": 32
+            },
+            "pivots": 15,
+            "rowAdd": {
+              "nanos": 45918,
+              "smallAllocs": 2385
+            },
+            "rowAdds": 50,
+            "rowAddsSkipped": 175,
+            "rowSwapScale": {
+              "nanos": 13502,
+              "smallAllocs": 808
+            },
+            "stagedNanos": 59839,
+            "wall": {
+              "nanos": 64295,
+              "smallAllocs": 3296
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 1,
+            "pivotSearch": {
+              "nanos": 442,
+              "smallAllocs": 32
+            },
+            "pivots": 15,
+            "rowAdd": {
+              "nanos": 74507,
+              "smallAllocs": 3985
+            },
+            "rowAdds": 50,
+            "rowAddsSkipped": 175,
+            "rowSwapScale": {
+              "nanos": 18368,
+              "smallAllocs": 1048
+            },
+            "stagedNanos": 93317,
+            "wall": {
+              "nanos": 97825,
+              "smallAllocs": 5139
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 5358,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 50605,
+            "smallAllocs": 2823
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 38448,
+            "smallAllocs": 3032
+          },
+          "frobeniusPower": {
+            "nanos": 1983,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 1,
+          "matrixConversionNanos": 5728,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 38507,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 3976,
+          "nullspaceBasisNanos": 3976,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 551,
+            "packNanos": 8723,
+            "rank": 15,
+            "reduceNanos": 7972,
+            "rowAdds": 50,
+            "smallAllocs": 527,
+            "totalNanos": 17246
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 431,
+            "packNanos": 8513,
+            "rank": 15,
+            "reduceNanos": 7541,
+            "rowAdds": 50,
+            "smallAllocs": 527,
+            "totalNanos": 16435
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 390,
+            "packNanos": 8512,
+            "rank": 15,
+            "reduceNanos": 6109,
+            "rowAdds": 50,
+            "smallAllocs": 527,
+            "totalNanos": 15002
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1262,
+            "packNanos": 8763,
+            "rank": 15,
+            "reduceNanos": 12819,
+            "rowAdds": 50,
+            "smallAllocs": 1551,
+            "totalNanos": 23775
+          },
+          "peakResidentBytes": 70402048,
+          "productionMatrixRebuild": {
+            "nanos": 38247,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 93098,
+            "smallAllocs": 4820
+          },
+          "productionRowReduce": {
+            "nanos": 88361,
+            "smallAllocs": 4531
+          },
+          "rank": 15,
+          "residentBytesAfter": 64843776,
+          "residentBytesBefore": 64843776,
+          "rowReduceMatrixRebuild": {
+            "nanos": 38306,
+            "smallAllocs": 0
+          },
+          "sink": 20,
+          "splitFactors": 1
+        },
+        "modularDegree": 16,
+        "modularFactorCount": 1,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi17",
+      "status": "ok"
+    },
+    {
+      "degree": 40,
+      "family": "cyclotomic",
+      "kernel": {
+        "kernel": {
+          "basisSize": 40,
+          "basisToPolynomials": {
+            "nanos": 1673,
+            "smallAllocs": 142
+          },
+          "berlekampMatrixWall": {
+            "nanos": 170603,
+            "smallAllocs": 14819
+          },
+          "berlekampSplit": {
+            "nanos": 453012,
+            "smallAllocs": 32512
+          },
+          "columnPolys": {
+            "nanos": 132156,
+            "smallAllocs": 11503
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 5,
+            "pivotSearch": {
+              "nanos": 971,
+              "smallAllocs": 80
+            },
+            "pivots": 35,
+            "rowAdd": {
+              "nanos": 200930,
+              "smallAllocs": 12335
+            },
+            "rowAdds": 100,
+            "rowAddsSkipped": 1265,
+            "rowSwapScale": {
+              "nanos": 68882,
+              "smallAllocs": 4412
+            },
+            "stagedNanos": 270821,
+            "wall": {
+              "nanos": 293775,
+              "smallAllocs": 17021
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 5,
+            "pivotSearch": {
+              "nanos": 1013,
+              "smallAllocs": 80
+            },
+            "pivots": 35,
+            "rowAdd": {
+              "nanos": 334073,
+              "smallAllocs": 20335
+            },
+            "rowAdds": 100,
+            "rowAddsSkipped": 1265,
+            "rowSwapScale": {
+              "nanos": 92890,
+              "smallAllocs": 5812
+            },
+            "stagedNanos": 427599,
+            "wall": {
+              "nanos": 448756,
+              "smallAllocs": 26424
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 27101,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 254197,
+            "smallAllocs": 15115
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 197192,
+            "smallAllocs": 16460
+          },
+          "frobeniusPower": {
+            "nanos": 2023,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 5,
+          "matrixConversionNanos": 35823,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 200187,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 27371,
+          "nullspaceBasisNanos": 27371,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2293,
+            "packNanos": 66258,
+            "rank": 35,
+            "reduceNanos": 34892,
+            "rowAdds": 100,
+            "smallAllocs": 3077,
+            "totalNanos": 103494
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1833,
+            "packNanos": 65737,
+            "rank": 35,
+            "reduceNanos": 33319,
+            "rowAdds": 100,
+            "smallAllocs": 3077,
+            "totalNanos": 100850
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1793,
+            "packNanos": 65577,
+            "rank": 35,
+            "reduceNanos": 28222,
+            "rowAdds": 100,
+            "smallAllocs": 3077,
+            "totalNanos": 95752
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 6559,
+            "packNanos": 63234,
+            "rank": 35,
+            "reduceNanos": 60289,
+            "rowAdds": 100,
+            "smallAllocs": 8397,
+            "totalNanos": 129722
+          },
+          "peakResidentBytes": 70402048,
+          "productionMatrixRebuild": {
+            "nanos": 196411,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 448405,
+            "smallAllocs": 25145
+          },
+          "productionRowReduce": {
+            "nanos": 421655,
+            "smallAllocs": 23316
+          },
+          "rank": 35,
+          "residentBytesAfter": 64843776,
+          "residentBytesBefore": 64843776,
+          "rowReduceMatrixRebuild": {
+            "nanos": 198985,
+            "smallAllocs": 0
+          },
+          "sink": 18,
+          "splitFactors": 5
+        },
+        "modularDegree": 40,
+        "modularFactorCount": 5,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi41",
+      "status": "ok"
+    },
+    {
+      "degree": 24,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 24,
+          "basisToPolynomials": {
+            "nanos": 3155,
+            "smallAllocs": 308
+          },
+          "berlekampMatrixWall": {
+            "nanos": 147388,
+            "smallAllocs": 14147
+          },
+          "berlekampSplit": {
+            "nanos": 567781,
+            "smallAllocs": 46939
+          },
+          "columnPolys": {
+            "nanos": 128530,
+            "smallAllocs": 12411
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 13,
+            "pivotSearch": {
+              "nanos": 581,
+              "smallAllocs": 48
+            },
+            "pivots": 11,
+            "rowAdd": {
+              "nanos": 21421,
+              "smallAllocs": 1342
+            },
+            "rowAdds": 11,
+            "rowAddsSkipped": 242,
+            "rowSwapScale": {
+              "nanos": 14282,
+              "smallAllocs": 876
+            },
+            "stagedNanos": 36276,
+            "wall": {
+              "nanos": 47390,
+              "smallAllocs": 2543
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 13,
+            "pivotSearch": {
+              "nanos": 580,
+              "smallAllocs": 48
+            },
+            "pivots": 11,
+            "rowAdd": {
+              "nanos": 30505,
+              "smallAllocs": 1870
+            },
+            "rowAdds": 11,
+            "rowAddsSkipped": 242,
+            "rowSwapScale": {
+              "nanos": 18526,
+              "smallAllocs": 1140
+            },
+            "stagedNanos": 49583,
+            "wall": {
+              "nanos": 59979,
+              "smallAllocs": 3338
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 10866,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 165265,
+            "smallAllocs": 14363
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 158445,
+            "smallAllocs": 14748
+          },
+          "frobeniusPower": {
+            "nanos": 7441,
+            "smallAllocs": 585
+          },
+          "kernelDimension": 13,
+          "matrixConversionNanos": 10717,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 158194,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 11,
+          "nullspaceBasisMagnitudeNanos": 17206,
+          "nullspaceBasisNanos": 17206,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1392,
+            "packNanos": 21812,
+            "rank": 11,
+            "reduceNanos": 6590,
+            "rowAdds": 11,
+            "smallAllocs": 942,
+            "totalNanos": 29704
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1162,
+            "packNanos": 21492,
+            "rank": 11,
+            "reduceNanos": 5899,
+            "rowAdds": 11,
+            "smallAllocs": 942,
+            "totalNanos": 28583
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1152,
+            "packNanos": 21652,
+            "rank": 11,
+            "reduceNanos": 5658,
+            "rowAdds": 11,
+            "smallAllocs": 942,
+            "totalNanos": 28462
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3415,
+            "packNanos": 20991,
+            "rank": 11,
+            "reduceNanos": 9253,
+            "rowAdds": 11,
+            "smallAllocs": 1470,
+            "totalNanos": 33790
+          },
+          "peakResidentBytes": 70402048,
+          "productionMatrixRebuild": {
+            "nanos": 158155,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 68321,
+            "smallAllocs": 3266
+          },
+          "productionRowReduce": {
+            "nanos": 51396,
+            "smallAllocs": 2654
+          },
+          "rank": 11,
+          "residentBytesAfter": 64851968,
+          "residentBytesBefore": 64847872,
+          "rowReduceMatrixRebuild": {
+            "nanos": 161229,
+            "smallAllocs": 0
+          },
+          "sink": 20,
+          "splitFactors": 13
+        },
+        "modularDegree": 24,
+        "modularFactorCount": 13,
+        "prime": 11,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "xpow24_minus1",
+      "status": "ok"
+    },
+    {
+      "degree": 20,
+      "family": "random-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 20,
+          "basisToPolynomials": {
+            "nanos": 1001,
+            "smallAllocs": 75
+          },
+          "berlekampMatrixWall": {
+            "nanos": 168370,
+            "smallAllocs": 15130
+          },
+          "berlekampSplit": {
+            "nanos": 335657,
+            "smallAllocs": 23484
+          },
+          "columnPolys": {
+            "nanos": 153658,
+            "smallAllocs": 14054
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 530,
+              "smallAllocs": 40
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 203392,
+              "smallAllocs": 10529
+            },
+            "rowAdds": 233,
+            "rowAddsSkipped": 71,
+            "rowSwapScale": {
+              "nanos": 16910,
+              "smallAllocs": 1043
+            },
+            "stagedNanos": 220848,
+            "wall": {
+              "nanos": 227738,
+              "smallAllocs": 11711
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 530,
+              "smallAllocs": 40
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 358312,
+              "smallAllocs": 19849
+            },
+            "rowAdds": 233,
+            "rowAddsSkipped": 71,
+            "rowSwapScale": {
+              "nanos": 23104,
+              "smallAllocs": 1363
+            },
+            "stagedNanos": 381956,
+            "wall": {
+              "nanos": 388576,
+              "smallAllocs": 21354
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 5067,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 232915,
+            "smallAllocs": 15255
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 172997,
+            "smallAllocs": 15551
+          },
+          "frobeniusPower": {
+            "nanos": 3926,
+            "smallAllocs": 277
+          },
+          "kernelDimension": 4,
+          "matrixConversionNanos": 10786,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 173117,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 7,
+          "nullspaceBasisMagnitudeNanos": 14992,
+          "nullspaceBasisNanos": 14992,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 971,
+            "packNanos": 14391,
+            "rank": 16,
+            "reduceNanos": 22944,
+            "rowAdds": 233,
+            "smallAllocs": 584,
+            "totalNanos": 38236
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 701,
+            "packNanos": 14261,
+            "rank": 16,
+            "reduceNanos": 22103,
+            "rowAdds": 233,
+            "smallAllocs": 584,
+            "totalNanos": 37035
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 691,
+            "packNanos": 14221,
+            "rank": 16,
+            "reduceNanos": 18217,
+            "rowAdds": 233,
+            "smallAllocs": 584,
+            "totalNanos": 33099
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2234,
+            "packNanos": 14010,
+            "rank": 16,
+            "reduceNanos": 44266,
+            "rowAdds": 233,
+            "smallAllocs": 5524,
+            "totalNanos": 60891
+          },
+          "peakResidentBytes": 70402048,
+          "productionMatrixRebuild": {
+            "nanos": 173157,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 392732,
+            "smallAllocs": 21079
+          },
+          "productionRowReduce": {
+            "nanos": 377740,
+            "smallAllocs": 20563
+          },
+          "rank": 16,
+          "residentBytesAfter": 64851968,
+          "residentBytesBefore": 64851968,
+          "rowReduceMatrixRebuild": {
+            "nanos": 172686,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 4
+        },
+        "modularDegree": 20,
+        "modularFactorCount": 4,
+        "prime": 7,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "randprod_10",
+      "status": "ok"
+    },
+    {
+      "degree": 24,
+      "family": "random-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 24,
+          "basisToPolynomials": {
+            "nanos": 1693,
+            "smallAllocs": 128
+          },
+          "berlekampMatrixWall": {
+            "nanos": 564948,
+            "smallAllocs": 52728
+          },
+          "berlekampSplit": {
+            "nanos": 868929,
+            "smallAllocs": 68180
+          },
+          "columnPolys": {
+            "nanos": 533110,
+            "smallAllocs": 49657
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 7,
+            "pivotSearch": {
+              "nanos": 610,
+              "smallAllocs": 48
+            },
+            "pivots": 17,
+            "rowAdd": {
+              "nanos": 345662,
+              "smallAllocs": 18538
+            },
+            "rowAdds": 353,
+            "rowAddsSkipped": 38,
+            "rowSwapScale": {
+              "nanos": 21174,
+              "smallAllocs": 1310
+            },
+            "stagedNanos": 367386,
+            "wall": {
+              "nanos": 376819,
+              "smallAllocs": 20041
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 7,
+            "pivotSearch": {
+              "nanos": 591,
+              "smallAllocs": 48
+            },
+            "pivots": 17,
+            "rowAdd": {
+              "nanos": 627486,
+              "smallAllocs": 35482
+            },
+            "rowAdds": 353,
+            "rowAddsSkipped": 38,
+            "rowSwapScale": {
+              "nanos": 28733,
+              "smallAllocs": 1718
+            },
+            "stagedNanos": 656673,
+            "wall": {
+              "nanos": 665897,
+              "smallAllocs": 37396
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 10996,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 681290,
+            "smallAllocs": 52920
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 579419,
+            "smallAllocs": 53329
+          },
+          "frobeniusPower": {
+            "nanos": 21662,
+            "smallAllocs": 1920
+          },
+          "kernelDimension": 7,
+          "matrixConversionNanos": 13420,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 575223,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 17,
+          "nullspaceBasisMagnitudeNanos": 25838,
+          "nullspaceBasisNanos": 25838,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1332,
+            "packNanos": 21743,
+            "rank": 17,
+            "reduceNanos": 37215,
+            "rowAdds": 353,
+            "smallAllocs": 744,
+            "totalNanos": 60290
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1022,
+            "packNanos": 21693,
+            "rank": 17,
+            "reduceNanos": 36183,
+            "rowAdds": 353,
+            "smallAllocs": 744,
+            "totalNanos": 58898
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1052,
+            "packNanos": 21562,
+            "rank": 17,
+            "reduceNanos": 31066,
+            "rowAdds": 353,
+            "smallAllocs": 744,
+            "totalNanos": 53680
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3075,
+            "packNanos": 20951,
+            "rank": 17,
+            "reduceNanos": 75301,
+            "rowAdds": 353,
+            "smallAllocs": 9576,
+            "totalNanos": 99308
+          },
+          "peakResidentBytes": 70402048,
+          "productionMatrixRebuild": {
+            "nanos": 576444,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 675682,
+            "smallAllocs": 37192
+          },
+          "productionRowReduce": {
+            "nanos": 651376,
+            "smallAllocs": 36406
+          },
+          "rank": 17,
+          "residentBytesAfter": 64851968,
+          "residentBytesBefore": 64851968,
+          "rowReduceMatrixRebuild": {
+            "nanos": 575083,
+            "smallAllocs": 0
+          },
+          "sink": 18,
+          "splitFactors": 7
+        },
+        "modularDegree": 24,
+        "modularFactorCount": 7,
+        "prime": 17,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "randprod_21",
+      "status": "ok"
+    }
+  ],
+  "results": [
+    {
+      "degree": 32,
+      "end_to_end": {
+        "max_nanos": 69578796,
+        "median_nanos": 69402295,
+        "min_nanos": 69181878,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        32
+      ],
+      "family": "swinnerton-dyer",
+      "instrumentation_ratio": 1.0146109289325376,
+      "name": "sd5",
+      "phase_profile": {
+        "profile": {
+          "degree": 32,
+          "factorDegrees": [
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 16,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 93,
+            "modulusBits": 93,
+            "precision": 19,
+            "prime": 29,
+            "treeInternalLifts": 15,
+            "treeLeaves": 16,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 3218451,
+              "smallAllocs": 279386
+            },
+            "berlekampMatrix": {
+              "nanos": 1793,
+              "smallAllocs": 108
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 19469,
+              "smallAllocs": 1600
+            },
+            "kernelDimension": 16,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 32,
+            "modularImage": {
+              "nanos": 1702,
+              "smallAllocs": 78
+            },
+            "prime": 29,
+            "rowReduction": {
+              "nanos": 1582046,
+              "smallAllocs": 152147
+            },
+            "splittingNanos": 1634612
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 7792,
+              "smallAllocs": 332
+            },
+            "henselLift": {
+              "nanos": 1798477,
+              "smallAllocs": 61662
+            },
+            "normalization": {
+              "nanos": 35903,
+              "smallAllocs": 1647
+            },
+            "primeWalk": {
+              "nanos": 6539296,
+              "smallAllocs": 569263
+            },
+            "quadratic": {
+              "nanos": 681,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 62000630,
+              "smallAllocs": 2749638
+            },
+            "total": {
+              "nanos": 70416327,
+              "smallAllocs": 3383502
+            },
+            "validation": {
+              "nanos": 6209,
+              "smallAllocs": 201
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 19,
+                "modularFactorCount": 16,
+                "prime": 29,
+                "reachableProperDegrees": 15,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 21,
+                "modularFactorCount": 16,
+                "prime": 19,
+                "reachableProperDegrees": 15,
+                "selected": false
+              }
+            ],
+            "coeffBound": 221306743312056565676926650,
+            "coeffBoundBits": 88,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 32639,
+              "degreeSurvivors": 32768,
+              "exactDivisionsAttempted": 1,
+              "nodes": 32768,
+              "productsMaterialized": 129,
+              "recordable": 129,
+              "trailingSurvivors": 129
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 70952793,
+        "total_nanos_median": 70416327,
+        "total_nanos_min": 69746324
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "mirror_factor_degrees": [
+          32
+        ],
+        "mirror_nodes": 32768,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 32768,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "production_factor_degrees": [
+          32
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 32,
+      "end_to_end": {
+        "max_nanos": 64463671,
+        "median_nanos": 64424614,
+        "min_nanos": 63903181,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        32
+      ],
+      "family": "swinnerton-dyer",
+      "instrumentation_ratio": 1.021457000890995,
+      "name": "sd5_shift1",
+      "phase_profile": {
+        "profile": {
+          "degree": 32,
+          "factorDegrees": [
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 16,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 93,
+            "modulusBits": 93,
+            "precision": 19,
+            "prime": 29,
+            "treeInternalLifts": 15,
+            "treeLeaves": 16,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 3037343,
+              "smallAllocs": 258979
+            },
+            "berlekampMatrix": {
+              "nanos": 1893,
+              "smallAllocs": 108
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 33079,
+              "smallAllocs": 2696
+            },
+            "kernelDimension": 16,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 32,
+            "modularImage": {
+              "nanos": 2534,
+              "smallAllocs": 84
+            },
+            "prime": 29,
+            "rowReduction": {
+              "nanos": 2241193,
+              "smallAllocs": 211116
+            },
+            "splittingNanos": 794257
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 10546,
+              "smallAllocs": 382
+            },
+            "henselLift": {
+              "nanos": 1824315,
+              "smallAllocs": 63318
+            },
+            "normalization": {
+              "nanos": 52838,
+              "smallAllocs": 2827
+            },
+            "primeWalk": {
+              "nanos": 6905239,
+              "smallAllocs": 588320
+            },
+            "quadratic": {
+              "nanos": 641,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 56977252,
+              "smallAllocs": 2560916
+            },
+            "total": {
+              "nanos": 65806973,
+              "smallAllocs": 3216770
+            },
+            "validation": {
+              "nanos": 7731,
+              "smallAllocs": 229
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 19,
+                "modularFactorCount": 16,
+                "prime": 29,
+                "reachableProperDegrees": 15,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 21,
+                "modularFactorCount": 16,
+                "prime": 19,
+                "reachableProperDegrees": 15,
+                "selected": false
+              }
+            ],
+            "coeffBound": 343800744604764214921668900,
+            "coeffBoundBits": 89,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 32767,
+              "degreeSurvivors": 32768,
+              "exactDivisionsAttempted": 1,
+              "nodes": 32768,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 66593810,
+        "total_nanos_median": 65806973,
+        "total_nanos_min": 65428001
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "mirror_factor_degrees": [
+          32
+        ],
+        "mirror_nodes": 32768,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 32768,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "production_factor_degrees": [
+          32
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 32,
+      "end_to_end": {
+        "max_nanos": 68952256,
+        "median_nanos": 67696676,
+        "min_nanos": 67625359,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        32
+      ],
+      "family": "swinnerton-dyer",
+      "instrumentation_ratio": 1.0210736343982385,
+      "name": "sd5_shift2",
+      "phase_profile": {
+        "profile": {
+          "degree": 32,
+          "factorDegrees": [
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 16,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 93,
+            "modulusBits": 93,
+            "precision": 19,
+            "prime": 29,
+            "treeInternalLifts": 15,
+            "treeLeaves": 16,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 4537638,
+              "smallAllocs": 381697
+            },
+            "berlekampMatrix": {
+              "nanos": 2133,
+              "smallAllocs": 108
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 32979,
+              "smallAllocs": 2673
+            },
+            "kernelDimension": 16,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 32,
+            "modularImage": {
+              "nanos": 2624,
+              "smallAllocs": 85
+            },
+            "prime": 29,
+            "rowReduction": {
+              "nanos": 2291648,
+              "smallAllocs": 211421
+            },
+            "splittingNanos": 2243857
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 11276,
+              "smallAllocs": 391
+            },
+            "henselLift": {
+              "nanos": 1833528,
+              "smallAllocs": 63079
+            },
+            "normalization": {
+              "nanos": 50726,
+              "smallAllocs": 2834
+            },
+            "primeWalk": {
+              "nanos": 8631379,
+              "smallAllocs": 715621
+            },
+            "quadratic": {
+              "nanos": 540,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 58557895,
+              "smallAllocs": 2594103
+            },
+            "total": {
+              "nanos": 69123291,
+              "smallAllocs": 3377052
+            },
+            "validation": {
+              "nanos": 8533,
+              "smallAllocs": 234
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 19,
+                "modularFactorCount": 16,
+                "prime": 29,
+                "reachableProperDegrees": 15,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 22,
+                "modularFactorCount": 16,
+                "prime": 19,
+                "reachableProperDegrees": 15,
+                "selected": false
+              }
+            ],
+            "coeffBound": 1319504980517760399369866460,
+            "coeffBoundBits": 91,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 32767,
+              "degreeSurvivors": 32768,
+              "exactDivisionsAttempted": 1,
+              "nodes": 32768,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 69410436,
+        "total_nanos_median": 69123291,
+        "total_nanos_min": 68760112
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "mirror_factor_degrees": [
+          32
+        ],
+        "mirror_nodes": 32768,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 32768,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "production_factor_degrees": [
+          32
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 32,
+      "end_to_end": {
+        "max_nanos": 18263319,
+        "median_nanos": 18172214,
+        "min_nanos": 18090834,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        16,
+        16
+      ],
+      "family": "sd-products",
+      "instrumentation_ratio": 0.9881710065708009,
+      "name": "sd4_x_sd4shift1",
+      "phase_profile": {
+        "profile": {
+          "degree": 32,
+          "factorDegrees": [
+            16,
+            16
+          ],
+          "hensel": {
+            "liftedFactorCount": 16,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 83,
+            "modulusBits": 83,
+            "precision": 17,
+            "prime": 29,
+            "treeInternalLifts": 15,
+            "treeLeaves": 16,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 3875947,
+              "smallAllocs": 320808
+            },
+            "berlekampMatrix": {
+              "nanos": 1563,
+              "smallAllocs": 108
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 34121,
+              "smallAllocs": 2770
+            },
+            "kernelDimension": 16,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 32,
+            "modularImage": {
+              "nanos": 2304,
+              "smallAllocs": 82
+            },
+            "prime": 29,
+            "rowReduction": {
+              "nanos": 2282224,
+              "smallAllocs": 210624
+            },
+            "splittingNanos": 1592160
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 22353,
+              "smallAllocs": 901
+            },
+            "henselLift": {
+              "nanos": 1777215,
+              "smallAllocs": 60552
+            },
+            "normalization": {
+              "nanos": 50194,
+              "smallAllocs": 2814
+            },
+            "primeWalk": {
+              "nanos": 6773193,
+              "smallAllocs": 562027
+            },
+            "quadratic": {
+              "nanos": 521,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 9288122,
+              "smallAllocs": 528057
+            },
+            "total": {
+              "nanos": 17957255,
+              "smallAllocs": 1155836
+            },
+            "validation": {
+              "nanos": 20841,
+              "smallAllocs": 745
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 17,
+                "modularFactorCount": 16,
+                "prime": 29,
+                "reachableProperDegrees": 15,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 22,
+                "modularFactorCount": 16,
+                "prime": 13,
+                "reachableProperDegrees": 15,
+                "selected": false
+              }
+            ],
+            "coeffBound": 489391641089022941499420,
+            "coeffBoundBits": 79,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 10530,
+              "degreeSurvivors": 10540,
+              "exactDivisionsAttempted": 2,
+              "nodes": 10540,
+              "productsMaterialized": 10,
+              "recordable": 10,
+              "trailingSurvivors": 10
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 18018006,
+        "total_nanos_median": 17957255,
+        "total_nanos_min": 17938508
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "mirror_factor_degrees": [
+          16,
+          16
+        ],
+        "mirror_nodes": 10540,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 10540,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "production_factor_degrees": [
+          16,
+          16
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 42,
+      "end_to_end": {
+        "max_nanos": 141770626,
+        "median_nanos": 140317732,
+        "min_nanos": 139790790,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        10,
+        32
+      ],
+      "family": "sd-products",
+      "instrumentation_ratio": 1.0122047226361954,
+      "name": "sd5_x_phi11",
+      "phase_profile": {
+        "profile": {
+          "degree": 42,
+          "factorDegrees": [
+            10,
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 17,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              10,
+              2
+            ],
+            "liftedMaxCoeffBits": 102,
+            "modulusBits": 103,
+            "precision": 21,
+            "prime": 29,
+            "treeInternalLifts": 16,
+            "treeLeaves": 17,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 7512599,
+              "smallAllocs": 625572
+            },
+            "berlekampMatrix": {
+              "nanos": 2243,
+              "smallAllocs": 138
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 51867,
+              "smallAllocs": 4248
+            },
+            "kernelDimension": 17,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 42,
+            "modularImage": {
+              "nanos": 3225,
+              "smallAllocs": 108
+            },
+            "prime": 29,
+            "rowReduction": {
+              "nanos": 4575264,
+              "smallAllocs": 428628
+            },
+            "splittingNanos": 2935092
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 29214,
+              "smallAllocs": 1170
+            },
+            "henselLift": {
+              "nanos": 2799040,
+              "smallAllocs": 88829
+            },
+            "normalization": {
+              "nanos": 75983,
+              "smallAllocs": 4551
+            },
+            "primeWalk": {
+              "nanos": 16147412,
+              "smallAllocs": 1372794
+            },
+            "quadratic": {
+              "nanos": 561,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 122915919,
+              "smallAllocs": 6175336
+            },
+            "total": {
+              "nanos": 142030271,
+              "smallAllocs": 7644637
+            },
+            "validation": {
+              "nanos": 30515,
+              "smallAllocs": 1070
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  10,
+                  2
+                ],
+                "forcedSubsetCost": 65536,
+                "henselPrecision": 21,
+                "modularFactorCount": 17,
+                "prime": 29,
+                "reachableProperDegrees": 20,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  10,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 65536,
+                "henselPrecision": 24,
+                "modularFactorCount": 17,
+                "prime": 19,
+                "reachableProperDegrees": 20,
+                "selected": false
+              }
+            ],
+            "coeffBound": 210602981274948990483361217040,
+            "coeffBoundBits": 98,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 65264,
+              "degreeSurvivors": 65522,
+              "exactDivisionsAttempted": 2,
+              "nodes": 65522,
+              "productsMaterialized": 258,
+              "recordable": 258,
+              "trailingSurvivors": 258
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 143065626,
+        "total_nanos_median": 142030271,
+        "total_nanos_min": 141453766
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "mirror_factor_degrees": [
+          10,
+          32
+        ],
+        "mirror_nodes": 65522,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 65522,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "production_factor_degrees": [
+          10,
+          32
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 48,
+      "end_to_end": {
+        "max_nanos": 10449163,
+        "median_nanos": 10399570,
+        "min_nanos": 10370757,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        8,
+        8,
+        16
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 0.9876032374415481,
+      "name": "xpow48_minus1",
+      "phase_profile": {
+        "profile": {
+          "degree": 48,
+          "factorDegrees": [
+            2,
+            2,
+            2,
+            8,
+            8,
+            16,
+            1,
+            1,
+            4,
+            4
+          ],
+          "hensel": {
+            "liftedFactorCount": 19,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              4,
+              4,
+              2,
+              2,
+              4,
+              2,
+              2,
+              4,
+              4,
+              4,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 49,
+            "modulusBits": 49,
+            "precision": 14,
+            "prime": 11,
+            "treeInternalLifts": 18,
+            "treeLeaves": 19,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 1921239,
+              "smallAllocs": 163103
+            },
+            "berlekampMatrix": {
+              "nanos": 2223,
+              "smallAllocs": 156
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 5749,
+              "smallAllocs": 510
+            },
+            "kernelDimension": 19,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 48,
+            "modularImage": {
+              "nanos": 1182,
+              "smallAllocs": 104
+            },
+            "prime": 11,
+            "rowReduction": {
+              "nanos": 735140,
+              "smallAllocs": 67517
+            },
+            "splittingNanos": 1183876
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 23855,
+              "smallAllocs": 2409
+            },
+            "henselLift": {
+              "nanos": 1087853,
+              "smallAllocs": 57567
+            },
+            "normalization": {
+              "nanos": 12999,
+              "smallAllocs": 563
+            },
+            "primeWalk": {
+              "nanos": 3922596,
+              "smallAllocs": 339781
+            },
+            "quadratic": {
+              "nanos": 341,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 5190927,
+              "smallAllocs": 270316
+            },
+            "total": {
+              "nanos": 10270649,
+              "smallAllocs": 673042
+            },
+            "validation": {
+              "nanos": 18598,
+              "smallAllocs": 1688
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  1,
+                  1,
+                  4,
+                  4,
+                  2,
+                  2,
+                  4,
+                  2,
+                  2,
+                  4,
+                  4,
+                  4,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 262144,
+                "henselPrecision": 14,
+                "modularFactorCount": 19,
+                "prime": 11,
+                "reachableProperDegrees": 47,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  4,
+                  4,
+                  2,
+                  2,
+                  4,
+                  2,
+                  1,
+                  1,
+                  4,
+                  2,
+                  2,
+                  1,
+                  1,
+                  4,
+                  2,
+                  2,
+                  2,
+                  2,
+                  4,
+                  2
+                ],
+                "forcedSubsetCost": 524288,
+                "henselPrecision": 21,
+                "modularFactorCount": 20,
+                "prime": 5,
+                "reachableProperDegrees": 47,
+                "selected": false
+              }
+            ],
+            "coeffBound": 64495207366200,
+            "coeffBoundBits": 46,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 11
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              0,
+              1,
+              2,
+              0,
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 268,
+              "exactDivisionsAttempted": 10,
+              "nodes": 268,
+              "productsMaterialized": 268,
+              "recordable": 268,
+              "trailingSurvivors": 268
+            },
+            "successfulDivisors": 10
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 10294324,
+        "total_nanos_median": 10270649,
+        "total_nanos_min": 10264770
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          0,
+          1,
+          2,
+          0,
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          8,
+          8,
+          16
+        ],
+        "mirror_nodes": 268,
+        "mirror_prime": 11,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 268,
+        "production_completed_levels": [
+          0,
+          0,
+          0,
+          1,
+          2,
+          0,
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          8,
+          8,
+          16
+        ],
+        "production_prime": 11
+      }
+    },
+    {
+      "degree": 105,
+      "end_to_end": {
+        "max_nanos": 46264427,
+        "median_nanos": 46123529,
+        "min_nanos": 45877593,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        2,
+        4,
+        6,
+        8,
+        12,
+        24,
+        48
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 1.005585890880119,
+      "name": "xpow105_minus1",
+      "phase_profile": {
+        "profile": {
+          "degree": 105,
+          "factorDegrees": [
+            4,
+            24,
+            2,
+            12,
+            48,
+            8,
+            6,
+            1
+          ],
+          "hensel": {
+            "liftedFactorCount": 14,
+            "liftedFactorDegrees": [
+              1,
+              6,
+              4,
+              12,
+              12,
+              4,
+              12,
+              12,
+              6,
+              2,
+              6,
+              12,
+              12,
+              4
+            ],
+            "liftedMaxCoeffBits": 107,
+            "modulusBits": 107,
+            "precision": 26,
+            "prime": 17,
+            "treeInternalLifts": 13,
+            "treeLeaves": 14,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 8809823,
+              "smallAllocs": 750003
+            },
+            "berlekampMatrix": {
+              "nanos": 4987,
+              "smallAllocs": 327
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 11767,
+              "smallAllocs": 1080
+            },
+            "kernelDimension": 14,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 105,
+            "modularImage": {
+              "nanos": 2233,
+              "smallAllocs": 218
+            },
+            "prime": 17,
+            "rowReduction": {
+              "nanos": 5115174,
+              "smallAllocs": 462407
+            },
+            "splittingNanos": 3689662
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 58497,
+              "smallAllocs": 6483
+            },
+            "henselLift": {
+              "nanos": 11893245,
+              "smallAllocs": 346450
+            },
+            "normalization": {
+              "nanos": 26939,
+              "smallAllocs": 1190
+            },
+            "primeWalk": {
+              "nanos": 29488463,
+              "smallAllocs": 2624521
+            },
+            "quadratic": {
+              "nanos": 591,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 4830943,
+              "smallAllocs": 266987
+            },
+            "total": {
+              "nanos": 46381170,
+              "smallAllocs": 3252061
+            },
+            "validation": {
+              "nanos": 51927,
+              "smallAllocs": 5196
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  1,
+                  6,
+                  4,
+                  12,
+                  12,
+                  4,
+                  12,
+                  12,
+                  6,
+                  2,
+                  6,
+                  12,
+                  12,
+                  4
+                ],
+                "forcedSubsetCost": 8192,
+                "henselPrecision": 26,
+                "modularFactorCount": 14,
+                "prime": 17,
+                "reachableProperDegrees": 104,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  1,
+                  2,
+                  3,
+                  6,
+                  3,
+                  6,
+                  2,
+                  1,
+                  6,
+                  3,
+                  6,
+                  3,
+                  3,
+                  6,
+                  1,
+                  2,
+                  3,
+                  6,
+                  2,
+                  1,
+                  6,
+                  3,
+                  6,
+                  3,
+                  6,
+                  3,
+                  6,
+                  3,
+                  2,
+                  1
+                ],
+                "forcedSubsetCost": 536870912,
+                "henselPrecision": 30,
+                "modularFactorCount": 30,
+                "prime": 11,
+                "reachableProperDegrees": 104,
+                "selected": false
+              }
+            ],
+            "coeffBound": 6272525058612251449529907677520,
+            "coeffBoundBits": 103,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 17
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              1,
+              2,
+              0,
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 60,
+              "exactDivisionsAttempted": 8,
+              "nodes": 60,
+              "productsMaterialized": 60,
+              "recordable": 60,
+              "trailingSurvivors": 60
+            },
+            "successfulDivisors": 8
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 46434789,
+        "total_nanos_median": 46381170,
+        "total_nanos_min": 46151880
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          0,
+          0
+        ],
+        "mirror_factor_degrees": [
+          1,
+          2,
+          4,
+          6,
+          8,
+          12,
+          24,
+          48
+        ],
+        "mirror_nodes": 60,
+        "mirror_prime": 17,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 60,
+        "production_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          0,
+          0
+        ],
+        "production_factor_degrees": [
+          1,
+          2,
+          4,
+          6,
+          8,
+          12,
+          24,
+          48
+        ],
+        "production_prime": 17
+      }
+    },
+    {
+      "degree": 120,
+      "end_to_end": {
+        "max_nanos": 148589906,
+        "median_nanos": 148232778,
+        "min_nanos": 146186343,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        4,
+        4,
+        8,
+        8,
+        8,
+        8,
+        16,
+        16,
+        32
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 0.9961417507806539,
+      "name": "xpow120_minus1",
+      "phase_profile": {
+        "profile": {
+          "degree": 120,
+          "factorDegrees": [
+            16,
+            4,
+            32,
+            8,
+            8,
+            2,
+            8,
+            2,
+            4,
+            16,
+            4,
+            1,
+            4,
+            1,
+            2,
+            8
+          ],
+          "hensel": {
+            "liftedFactorCount": 39,
+            "liftedFactorDegrees": [
+              4,
+              4,
+              2,
+              1,
+              4,
+              1,
+              4,
+              4,
+              4,
+              2,
+              1,
+              4,
+              1,
+              4,
+              2,
+              4,
+              4,
+              2,
+              4,
+              4,
+              4,
+              4,
+              2,
+              1,
+              4,
+              1,
+              4,
+              2,
+              4,
+              4,
+              2,
+              4,
+              4,
+              2,
+              4,
+              4,
+              2,
+              4,
+              4
+            ],
+            "liftedMaxCoeffBits": 121,
+            "modulusBits": 121,
+            "precision": 43,
+            "prime": 7,
+            "treeInternalLifts": 38,
+            "treeLeaves": 39,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 15779517,
+              "smallAllocs": 1312571
+            },
+            "berlekampMatrix": {
+              "nanos": 6249,
+              "smallAllocs": 372
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 13611,
+              "smallAllocs": 1230
+            },
+            "kernelDimension": 39,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 120,
+            "modularImage": {
+              "nanos": 2614,
+              "smallAllocs": 248
+            },
+            "prime": 7,
+            "rowReduction": {
+              "nanos": 3749319,
+              "smallAllocs": 329059
+            },
+            "splittingNanos": 12023949
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 104145,
+              "smallAllocs": 11833
+            },
+            "henselLift": {
+              "nanos": 16465614,
+              "smallAllocs": 507435
+            },
+            "normalization": {
+              "nanos": 30906,
+              "smallAllocs": 1355
+            },
+            "primeWalk": {
+              "nanos": 18380233,
+              "smallAllocs": 1584783
+            },
+            "quadratic": {
+              "nanos": 671,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 112568186,
+              "smallAllocs": 5264950
+            },
+            "total": {
+              "nanos": 147660859,
+              "smallAllocs": 7379735
+            },
+            "validation": {
+              "nanos": 79688,
+              "smallAllocs": 8230
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  4,
+                  4,
+                  2,
+                  1,
+                  4,
+                  1,
+                  4,
+                  4,
+                  4,
+                  2,
+                  1,
+                  4,
+                  1,
+                  4,
+                  2,
+                  4,
+                  4,
+                  2,
+                  4,
+                  4,
+                  4,
+                  4,
+                  2,
+                  1,
+                  4,
+                  1,
+                  4,
+                  2,
+                  4,
+                  4,
+                  2,
+                  4,
+                  4,
+                  2,
+                  4,
+                  4,
+                  2,
+                  4,
+                  4
+                ],
+                "forcedSubsetCost": 274877906944,
+                "henselPrecision": 43,
+                "modularFactorCount": 39,
+                "prime": 7,
+                "reachableProperDegrees": 119,
+                "selected": true
+              }
+            ],
+            "coeffBound": 193229817680726645207786279042745312,
+            "coeffBoundBits": 118,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 7
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              1,
+              2,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              2,
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              0,
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 3538,
+              "degreeSurvivors": 5339,
+              "exactDivisionsAttempted": 16,
+              "nodes": 5339,
+              "productsMaterialized": 1801,
+              "recordable": 1801,
+              "trailingSurvivors": 1801
+            },
+            "successfulDivisors": 16
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 148128703,
+        "total_nanos_median": 147660859,
+        "total_nanos_min": 147075001
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          2,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          0,
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          4,
+          4,
+          8,
+          8,
+          8,
+          8,
+          16,
+          16,
+          32
+        ],
+        "mirror_nodes": 5339,
+        "mirror_prime": 7,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 5339,
+        "production_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          2,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          0,
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          4,
+          4,
+          8,
+          8,
+          8,
+          8,
+          16,
+          16,
+          32
+        ],
+        "production_prime": 7
+      }
+    },
+    {
+      "degree": 178,
+      "end_to_end": {
+        "max_nanos": 42747823,
+        "median_nanos": 42336353,
+        "min_nanos": 42288422,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        178
+      ],
+      "family": "cyclotomic",
+      "instrumentation_ratio": 0.9970740512296843,
+      "name": "cyclo_phi179",
+      "phase_profile": {
+        "profile": {
+          "degree": 178,
+          "factorDegrees": [
+            178
+          ],
+          "hensel": {
+            "liftedFactorCount": 2,
+            "liftedFactorDegrees": [
+              89,
+              89
+            ],
+            "liftedMaxCoeffBits": 180,
+            "modulusBits": 180,
+            "precision": 113,
+            "prime": 3,
+            "treeInternalLifts": 1,
+            "treeLeaves": 2,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 6426329,
+              "smallAllocs": 339370
+            },
+            "berlekampMatrix": {
+              "nanos": 8663,
+              "smallAllocs": 546
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 34761,
+              "smallAllocs": 3356
+            },
+            "kernelDimension": 2,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 178,
+            "modularImage": {
+              "nanos": 3516,
+              "smallAllocs": 364
+            },
+            "prime": 3,
+            "rowReduction": {
+              "nanos": 13613915,
+              "smallAllocs": 1226531
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 20150,
+              "smallAllocs": 1446
+            },
+            "henselLift": {
+              "nanos": 34488387,
+              "smallAllocs": 740896
+            },
+            "normalization": {
+              "nanos": 64696,
+              "smallAllocs": 3772
+            },
+            "primeWalk": {
+              "nanos": 6408552,
+              "smallAllocs": 344914
+            },
+            "quadratic": {
+              "nanos": 601,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 1160290,
+              "smallAllocs": 46831
+            },
+            "total": {
+              "nanos": 42212479,
+              "smallAllocs": 1140116
+            },
+            "validation": {
+              "nanos": 17536,
+              "smallAllocs": 901
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  89,
+                  89
+                ],
+                "forcedSubsetCost": 2,
+                "henselPrecision": 113,
+                "modularFactorCount": 2,
+                "prime": 3,
+                "reachableProperDegrees": 1,
+                "selected": true
+              }
+            ],
+            "coeffBound": 320322439463041003620181335381340475329049688753516000,
+            "coeffBoundBits": 178,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 2,
+              "exactDivisionsAttempted": 1,
+              "nodes": 2,
+              "productsMaterialized": 2,
+              "recordable": 2,
+              "trailingSurvivors": 2
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 42836094,
+        "total_nanos_median": 42212479,
+        "total_nanos_min": 42152000
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0
+        ],
+        "mirror_factor_degrees": [
+          178
+        ],
+        "mirror_nodes": 2,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 2,
+        "production_completed_levels": [
+          0
+        ],
+        "production_factor_degrees": [
+          178
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 80,
+      "end_to_end": {
+        "max_nanos": 46256685,
+        "median_nanos": 45864644,
+        "min_nanos": 45443520,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        32,
+        48
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 1.0079497183058916,
+      "name": "cyclo_phi64_x_phi105",
+      "phase_profile": {
+        "profile": {
+          "degree": 80,
+          "factorDegrees": [
+            48,
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 10,
+            "liftedFactorDegrees": [
+              16,
+              16,
+              6,
+              6,
+              6,
+              6,
+              6,
+              6,
+              6,
+              6
+            ],
+            "liftedMaxCoeffBits": 84,
+            "modulusBits": 84,
+            "precision": 24,
+            "prime": 11,
+            "treeInternalLifts": 9,
+            "treeLeaves": 10,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 10371308,
+              "smallAllocs": 586770
+            },
+            "berlekampMatrix": {
+              "nanos": 3866,
+              "smallAllocs": 252
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 158905,
+              "smallAllocs": 13406
+            },
+            "kernelDimension": 10,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 80,
+            "modularImage": {
+              "nanos": 1903,
+              "smallAllocs": 168
+            },
+            "prime": 11,
+            "rowReduction": {
+              "nanos": 18901886,
+              "smallAllocs": 1749247
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 25518,
+              "smallAllocs": 2390
+            },
+            "henselLift": {
+              "nanos": 6100295,
+              "smallAllocs": 196912
+            },
+            "normalization": {
+              "nanos": 187948,
+              "smallAllocs": 14419
+            },
+            "primeWalk": {
+              "nanos": 37538269,
+              "smallAllocs": 3197479
+            },
+            "quadratic": {
+              "nanos": 491,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 2335573,
+              "smallAllocs": 89872
+            },
+            "total": {
+              "nanos": 46229255,
+              "smallAllocs": 3503772
+            },
+            "validation": {
+              "nanos": 22223,
+              "smallAllocs": 2017
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  16,
+                  16,
+                  6,
+                  6,
+                  6,
+                  6,
+                  6,
+                  6,
+                  6,
+                  6
+                ],
+                "forcedSubsetCost": 512,
+                "henselPrecision": 24,
+                "modularFactorCount": 10,
+                "prime": 11,
+                "reachableProperDegrees": 25,
+                "selected": true
+              }
+            ],
+            "coeffBound": 1075072087333361764616200,
+            "coeffBoundBits": 80,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 11
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 102,
+              "degreeSurvivors": 130,
+              "exactDivisionsAttempted": 2,
+              "nodes": 130,
+              "productsMaterialized": 28,
+              "recordable": 28,
+              "trailingSurvivors": 28
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 46398286,
+        "total_nanos_median": 46229255,
+        "total_nanos_min": 45687331
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "mirror_factor_degrees": [
+          32,
+          48
+        ],
+        "mirror_nodes": 130,
+        "mirror_prime": 11,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 130,
+        "production_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "production_factor_degrees": [
+          32,
+          48
+        ],
+        "production_prime": 11
+      }
+    },
+    {
+      "degree": 144,
+      "end_to_end": {
+        "max_nanos": 85436057,
+        "median_nanos": 84693777,
+        "min_nanos": 84481802,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        64,
+        80
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 1.0104214032159646,
+      "name": "cyclo_phi128_x_phi165",
+      "phase_profile": {
+        "profile": {
+          "degree": 144,
+          "factorDegrees": [
+            64,
+            80
+          ],
+          "hensel": {
+            "liftedFactorCount": 8,
+            "liftedFactorDegrees": [
+              20,
+              16,
+              20,
+              20,
+              16,
+              20,
+              16,
+              16
+            ],
+            "liftedMaxCoeffBits": 146,
+            "modulusBits": 146,
+            "precision": 52,
+            "prime": 7,
+            "treeInternalLifts": 7,
+            "treeLeaves": 8,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 33969057,
+              "smallAllocs": 1239327
+            },
+            "berlekampMatrix": {
+              "nanos": 6990,
+              "smallAllocs": 444
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 453563,
+              "smallAllocs": 39896
+            },
+            "kernelDimension": 8,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 144,
+            "modularImage": {
+              "nanos": 3284,
+              "smallAllocs": 296
+            },
+            "prime": 7,
+            "rowReduction": {
+              "nanos": 89636926,
+              "smallAllocs": 8409957
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 59438,
+              "smallAllocs": 6582
+            },
+            "henselLift": {
+              "nanos": 43995653,
+              "smallAllocs": 956356
+            },
+            "normalization": {
+              "nanos": 557907,
+              "smallAllocs": 44226
+            },
+            "primeWalk": {
+              "nanos": 35027176,
+              "smallAllocs": 1326123
+            },
+            "quadratic": {
+              "nanos": 821,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 5839368,
+              "smallAllocs": 275130
+            },
+            "total": {
+              "nanos": 85576405,
+              "smallAllocs": 2615526
+            },
+            "validation": {
+              "nanos": 56714,
+              "smallAllocs": 6017
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  20,
+                  16,
+                  20,
+                  20,
+                  16,
+                  20,
+                  16,
+                  16
+                ],
+                "forcedSubsetCost": 128,
+                "henselPrecision": 52,
+                "modularFactorCount": 8,
+                "prime": 7,
+                "reachableProperDegrees": 23,
+                "selected": true
+              }
+            ],
+            "coeffBound": 20722981978283006659913436536756243128265400,
+            "coeffBoundBits": 144,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 7
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 29,
+              "degreeSurvivors": 54,
+              "exactDivisionsAttempted": 2,
+              "nodes": 54,
+              "productsMaterialized": 25,
+              "recordable": 25,
+              "trailingSurvivors": 25
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 85732787,
+        "total_nanos_median": 85576405,
+        "total_nanos_min": 84618825
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          64,
+          80
+        ],
+        "mirror_nodes": 54,
+        "mirror_prime": 7,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 54,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          64,
+          80
+        ],
+        "production_prime": 7
+      }
+    },
+    {
+      "degree": 240,
+      "end_to_end": {
+        "max_nanos": 167664759,
+        "median_nanos": 167123626,
+        "min_nanos": 164447689,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        240
+      ],
+      "family": "cyclotomic",
+      "instrumentation_ratio": 1.003498296524514,
+      "name": "cyclo_phi385",
+      "phase_profile": {
+        "profile": {
+          "degree": 240,
+          "factorDegrees": [
+            240
+          ],
+          "hensel": {
+            "liftedFactorCount": 4,
+            "liftedFactorDegrees": [
+              60,
+              60,
+              60,
+              60
+            ],
+            "liftedMaxCoeffBits": 241,
+            "modulusBits": 241,
+            "precision": 152,
+            "prime": 3,
+            "treeInternalLifts": 3,
+            "treeLeaves": 4,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 58007839,
+              "smallAllocs": 1030964
+            },
+            "berlekampMatrix": {
+              "nanos": 11517,
+              "smallAllocs": 732
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 736112,
+              "smallAllocs": 68654
+            },
+            "kernelDimension": 4,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 240,
+            "modularImage": {
+              "nanos": 4847,
+              "smallAllocs": 488
+            },
+            "prime": 3,
+            "rowReduction": {
+              "nanos": 204736446,
+              "smallAllocs": 18194276
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 28292,
+              "smallAllocs": 1942
+            },
+            "henselLift": {
+              "nanos": 97594195,
+              "smallAllocs": 2094825
+            },
+            "normalization": {
+              "nanos": 1139149,
+              "smallAllocs": 101209
+            },
+            "primeWalk": {
+              "nanos": 58841345,
+              "smallAllocs": 1103050
+            },
+            "quadratic": {
+              "nanos": 731,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 10012405,
+              "smallAllocs": 401834
+            },
+            "total": {
+              "nanos": 167708274,
+              "smallAllocs": 3705856
+            },
+            "validation": {
+              "nanos": 25137,
+              "smallAllocs": 1211
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  60,
+                  60,
+                  60,
+                  60
+                ],
+                "forcedSubsetCost": 8,
+                "henselPrecision": 152,
+                "modularFactorCount": 4,
+                "prime": 3,
+                "reachableProperDegrees": 3,
+                "selected": true
+              }
+            ],
+            "coeffBound": 1636264530784946322237683636362414673514576776816417689604042467199320800,
+            "coeffBoundBits": 240,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 8,
+              "exactDivisionsAttempted": 1,
+              "nodes": 8,
+              "productsMaterialized": 8,
+              "recordable": 8,
+              "trailingSurvivors": 8
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 167762043,
+        "total_nanos_median": 167708274,
+        "total_nanos_min": 167531852
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          240
+        ],
+        "mirror_nodes": 8,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 8,
+        "production_completed_levels": [
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          240
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 40,
+      "end_to_end": {
+        "max_nanos": 13525314,
+        "median_nanos": 13518464,
+        "min_nanos": 13497232,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "family": "wilkinson",
+      "instrumentation_ratio": 0.9920428090055201,
+      "name": "wilkinson_40",
+      "phase_profile": {
+        "profile": {
+          "degree": 40,
+          "factorDegrees": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "method": "replay",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 1727752,
+              "smallAllocs": 146136
+            },
+            "berlekampMatrix": {
+              "nanos": 1862,
+              "smallAllocs": 132
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 21633,
+              "smallAllocs": 1610
+            },
+            "kernelDimension": 40,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 40,
+            "modularImage": {
+              "nanos": 3865,
+              "smallAllocs": 106
+            },
+            "prime": 47,
+            "rowReduction": {
+              "nanos": 252895,
+              "smallAllocs": 20522
+            },
+            "splittingNanos": 1472995
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 204903,
+              "smallAllocs": 9051
+            },
+            "normalization": {
+              "nanos": 75853,
+              "smallAllocs": 4275
+            },
+            "primeWalk": {
+              "nanos": 4153469,
+              "smallAllocs": 342474
+            },
+            "proposal": {
+              "nanos": 8917613,
+              "smallAllocs": 260187
+            },
+            "quadratic": {
+              "nanos": 480,
+              "smallAllocs": 17
+            },
+            "total": {
+              "nanos": 13410895,
+              "smallAllocs": 617317
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 549755813888,
+                "henselPrecision": 37,
+                "modularFactorCount": 40,
+                "prime": 47,
+                "reachableProperDegrees": 39,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 549755813888,
+                "henselPrecision": 38,
+                "modularFactorCount": 40,
+                "prime": 41,
+                "reachableProperDegrees": 39,
+                "selected": false
+              }
+            ],
+            "coeffBound": 1921680168406855965121530973574373218685937570507447116882060,
+            "coeffBoundBits": 201,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 47
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 13478715,
+        "total_nanos_median": 13410895,
+        "total_nanos_min": 13402743
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": false,
+        "reason": "profiled run did not answer from the direct classical tier"
+      }
+    },
+    {
+      "degree": 48,
+      "end_to_end": {
+        "max_nanos": 24635658,
+        "median_nanos": 24388762,
+        "min_nanos": 24154875,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "family": "wilkinson",
+      "instrumentation_ratio": 0.9926122941377672,
+      "name": "wilkinson_48",
+      "phase_profile": {
+        "profile": {
+          "degree": 48,
+          "factorDegrees": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "method": "replay",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 2747594,
+              "smallAllocs": 235614
+            },
+            "berlekampMatrix": {
+              "nanos": 2193,
+              "smallAllocs": 156
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 37195,
+              "smallAllocs": 2906
+            },
+            "kernelDimension": 48,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 48,
+            "modularImage": {
+              "nanos": 4717,
+              "smallAllocs": 126
+            },
+            "prime": 61,
+            "rowReduction": {
+              "nanos": 361496,
+              "smallAllocs": 29406
+            },
+            "splittingNanos": 2383905
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 309990,
+              "smallAllocs": 13013
+            },
+            "normalization": {
+              "nanos": 99788,
+              "smallAllocs": 5905
+            },
+            "primeWalk": {
+              "nanos": 6575139,
+              "smallAllocs": 550764
+            },
+            "proposal": {
+              "nanos": 17147204,
+              "smallAllocs": 401527
+            },
+            "quadratic": {
+              "nanos": 501,
+              "smallAllocs": 17
+            },
+            "total": {
+              "nanos": 24208585,
+              "smallAllocs": 972820
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 140737488355328,
+                "henselPrecision": 43,
+                "modularFactorCount": 48,
+                "prime": 61,
+                "reachableProperDegrees": 47,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 140737488355328,
+                "henselPrecision": 45,
+                "modularFactorCount": 48,
+                "prime": 53,
+                "reachableProperDegrees": 47,
+                "selected": false
+              }
+            ],
+            "coeffBound": 8049068376844036118970558829637315745156559359405185594804704581012213098100,
+            "coeffBoundBits": 253,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 61
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 24594477,
+        "total_nanos_median": 24208585,
+        "total_nanos_min": 24101235
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": false,
+        "reason": "profiled run did not answer from the direct classical tier"
+      }
+    },
+    {
+      "degree": 56,
+      "end_to_end": {
+        "max_nanos": 32727855,
+        "median_nanos": 32685914,
+        "min_nanos": 32558084,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "family": "wilkinson",
+      "instrumentation_ratio": 1.0013009579600558,
+      "name": "wilkinson_56",
+      "phase_profile": {
+        "profile": {
+          "degree": 56,
+          "factorDegrees": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "method": "replay",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 4219276,
+              "smallAllocs": 360583
+            },
+            "berlekampMatrix": {
+              "nanos": 2513,
+              "smallAllocs": 180
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 39749,
+              "smallAllocs": 3046
+            },
+            "kernelDimension": 56,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 56,
+            "modularImage": {
+              "nanos": 5569,
+              "smallAllocs": 146
+            },
+            "prime": 67,
+            "rowReduction": {
+              "nanos": 575794,
+              "smallAllocs": 46891
+            },
+            "splittingNanos": 3640969
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 429668,
+              "smallAllocs": 17680
+            },
+            "normalization": {
+              "nanos": 128381,
+              "smallAllocs": 7789
+            },
+            "primeWalk": {
+              "nanos": 9750898,
+              "smallAllocs": 818295
+            },
+            "proposal": {
+              "nanos": 22326824,
+              "smallAllocs": 527455
+            },
+            "quadratic": {
+              "nanos": 560,
+              "smallAllocs": 17
+            },
+            "total": {
+              "nanos": 32728437,
+              "smallAllocs": 1373120
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 36028797018963968,
+                "henselPrecision": 51,
+                "modularFactorCount": 56,
+                "prime": 67,
+                "reachableProperDegrees": 55,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 36028797018963968,
+                "henselPrecision": 53,
+                "modularFactorCount": 56,
+                "prime": 59,
+                "reachableProperDegrees": 55,
+                "selected": false
+              }
+            ],
+            "coeffBound": 125617627049250877181363592865834692949611771037125750170085410352200700179789256897773224080,
+            "coeffBoundBits": 306,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 67
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 32769888,
+        "total_nanos_median": 32728437,
+        "total_nanos_min": 32584093
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": false,
+        "reason": "profiled run did not answer from the direct classical tier"
+      }
+    },
+    {
+      "degree": 24,
+      "end_to_end": {
+        "max_nanos": 456557,
+        "median_nanos": 441454,
+        "min_nanos": 433022,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        8,
+        16
+      ],
+      "family": "chebyshev",
+      "instrumentation_ratio": 0.8899749464270343,
+      "name": "chebyshev_T24",
+      "phase_profile": {
+        "profile": {
+          "degree": 24,
+          "factorDegrees": [
+            16,
+            8
+          ],
+          "hensel": {
+            "liftedFactorCount": 3,
+            "liftedFactorDegrees": [
+              8,
+              8,
+              8
+            ],
+            "liftedMaxCoeffBits": 52,
+            "modulusBits": 52,
+            "precision": 22,
+            "prime": 5,
+            "treeInternalLifts": 2,
+            "treeLeaves": 3,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 192145,
+              "smallAllocs": 13395
+            },
+            "berlekampMatrix": {
+              "nanos": 1002,
+              "smallAllocs": 84
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 11677,
+              "smallAllocs": 1040
+            },
+            "kernelDimension": 3,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 24,
+            "modularImage": {
+              "nanos": 751,
+              "smallAllocs": 56
+            },
+            "prime": 5,
+            "rowReduction": {
+              "nanos": 284171,
+              "smallAllocs": 24421
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 5188,
+              "smallAllocs": 414
+            },
+            "henselLift": {
+              "nanos": 120618,
+              "smallAllocs": 7201
+            },
+            "normalization": {
+              "nanos": 16665,
+              "smallAllocs": 1007
+            },
+            "primeWalk": {
+              "nanos": 210713,
+              "smallAllocs": 14959
+            },
+            "quadratic": {
+              "nanos": 280,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 28482,
+              "smallAllocs": 1407
+            },
+            "total": {
+              "nanos": 392883,
+              "smallAllocs": 25597
+            },
+            "validation": {
+              "nanos": 4306,
+              "smallAllocs": 281
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  8,
+                  8,
+                  8
+                ],
+                "forcedSubsetCost": 4,
+                "henselPrecision": 22,
+                "modularFactorCount": 3,
+                "prime": 5,
+                "reachableProperDegrees": 2,
+                "selected": true
+              }
+            ],
+            "coeffBound": 910214580246244,
+            "coeffBoundBits": 50,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 5
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 1,
+              "degreeSurvivors": 3,
+              "exactDivisionsAttempted": 2,
+              "nodes": 3,
+              "productsMaterialized": 2,
+              "recordable": 2,
+              "trailingSurvivors": 2
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 411660,
+        "total_nanos_median": 392883,
+        "total_nanos_min": 384840
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0
+        ],
+        "mirror_factor_degrees": [
+          8,
+          16
+        ],
+        "mirror_nodes": 3,
+        "mirror_prime": 5,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 3,
+        "production_completed_levels": [
+          0
+        ],
+        "production_factor_degrees": [
+          8,
+          16
+        ],
+        "production_prime": 5
+      }
+    },
+    {
+      "degree": 24,
+      "end_to_end": {
+        "max_nanos": 630665,
+        "median_nanos": 589554,
+        "min_nanos": 564477,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        2,
+        2,
+        10,
+        10
+      ],
+      "family": "chebyshev",
+      "instrumentation_ratio": 0.9256980700665248,
+      "name": "chebyshev_U24",
+      "phase_profile": {
+        "profile": {
+          "degree": 24,
+          "factorDegrees": [
+            10,
+            2,
+            10,
+            2
+          ],
+          "hensel": {
+            "liftedFactorCount": 4,
+            "liftedFactorDegrees": [
+              2,
+              10,
+              2,
+              10
+            ],
+            "liftedMaxCoeffBits": 53,
+            "modulusBits": 53,
+            "precision": 33,
+            "prime": 3,
+            "treeInternalLifts": 3,
+            "treeLeaves": 4,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 189631,
+              "smallAllocs": 12764
+            },
+            "berlekampMatrix": {
+              "nanos": 1022,
+              "smallAllocs": 84
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 6029,
+              "smallAllocs": 510
+            },
+            "kernelDimension": 4,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 24,
+            "modularImage": {
+              "nanos": 661,
+              "smallAllocs": 56
+            },
+            "prime": 3,
+            "rowReduction": {
+              "nanos": 237802,
+              "smallAllocs": 19531
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 6931,
+              "smallAllocs": 612
+            },
+            "henselLift": {
+              "nanos": 267697,
+              "smallAllocs": 14169
+            },
+            "normalization": {
+              "nanos": 17336,
+              "smallAllocs": 1009
+            },
+            "primeWalk": {
+              "nanos": 202330,
+              "smallAllocs": 13682
+            },
+            "quadratic": {
+              "nanos": 290,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 38076,
+              "smallAllocs": 2144
+            },
+            "total": {
+              "nanos": 545749,
+              "smallAllocs": 32349
+            },
+            "validation": {
+              "nanos": 5668,
+              "smallAllocs": 389
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  10,
+                  2,
+                  10
+                ],
+                "forcedSubsetCost": 8,
+                "henselPrecision": 33,
+                "modularFactorCount": 4,
+                "prime": 3,
+                "reachableProperDegrees": 7,
+                "selected": true
+              }
+            ],
+            "coeffBound": 1560748913788064,
+            "coeffBoundBits": 51,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 4,
+              "exactDivisionsAttempted": 4,
+              "nodes": 4,
+              "productsMaterialized": 4,
+              "recordable": 4,
+              "trailingSurvivors": 4
+            },
+            "successfulDivisors": 4
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 571687,
+        "total_nanos_median": 545749,
+        "total_nanos_min": 526891
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [],
+        "mirror_factor_degrees": [
+          2,
+          2,
+          10,
+          10
+        ],
+        "mirror_nodes": 4,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 4,
+        "production_completed_levels": [],
+        "production_factor_degrees": [
+          2,
+          2,
+          10,
+          10
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 30,
+      "end_to_end": {
+        "max_nanos": 8572841,
+        "median_nanos": 8559902,
+        "min_nanos": 8532421,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        30
+      ],
+      "family": "legendre",
+      "instrumentation_ratio": 0.9865429534123171,
+      "name": "legendre_P30",
+      "phase_profile": {
+        "profile": {
+          "degree": 30,
+          "factorDegrees": [
+            30
+          ],
+          "hensel": {
+            "liftedFactorCount": 7,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              6,
+              14,
+              2
+            ],
+            "liftedMaxCoeffBits": 91,
+            "modulusBits": 91,
+            "precision": 15,
+            "prime": 67,
+            "treeInternalLifts": 6,
+            "treeLeaves": 7,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 1921189,
+              "smallAllocs": 167769
+            },
+            "berlekampMatrix": {
+              "nanos": 1372,
+              "smallAllocs": 102
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 18067,
+              "smallAllocs": 1485
+            },
+            "kernelDimension": 7,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 30,
+            "modularImage": {
+              "nanos": 1683,
+              "smallAllocs": 75
+            },
+            "prime": 67,
+            "rowReduction": {
+              "nanos": 1662915,
+              "smallAllocs": 158865
+            },
+            "splittingNanos": 256902
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 7862,
+              "smallAllocs": 329
+            },
+            "henselLift": {
+              "nanos": 1181161,
+              "smallAllocs": 34755
+            },
+            "normalization": {
+              "nanos": 29233,
+              "smallAllocs": 1502
+            },
+            "primeWalk": {
+              "nanos": 7020449,
+              "smallAllocs": 627656
+            },
+            "quadratic": {
+              "nanos": 391,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 175280,
+              "smallAllocs": 6057
+            },
+            "total": {
+              "nanos": 8444711,
+              "smallAllocs": 671195
+            },
+            "validation": {
+              "nanos": 5938,
+              "smallAllocs": 198
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  6,
+                  14,
+                  2
+                ],
+                "forcedSubsetCost": 64,
+                "henselPrecision": 15,
+                "modularFactorCount": 7,
+                "prime": 67,
+                "reachableProperDegrees": 14,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 16384,
+                "henselPrecision": 15,
+                "modularFactorCount": 15,
+                "prime": 61,
+                "reachableProperDegrees": 14,
+                "selected": false
+              }
+            ],
+            "coeffBound": 124543935812132452094555520,
+            "coeffBoundBits": 87,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 67
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 63,
+              "degreeSurvivors": 64,
+              "exactDivisionsAttempted": 1,
+              "nodes": 64,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 8474456,
+        "total_nanos_median": 8444711,
+        "total_nanos_min": 8423079
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5
+        ],
+        "mirror_factor_degrees": [
+          30
+        ],
+        "mirror_nodes": 64,
+        "mirror_prime": 67,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 64,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5
+        ],
+        "production_factor_degrees": [
+          30
+        ],
+        "production_prime": 67
+      }
+    },
+    {
+      "degree": 38,
+      "end_to_end": {
+        "max_nanos": 3826424,
+        "median_nanos": 3819873,
+        "min_nanos": 3791141,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        38
+      ],
+      "family": "legendre",
+      "instrumentation_ratio": 0.9838238077548651,
+      "name": "legendre_P38",
+      "phase_profile": {
+        "profile": {
+          "degree": 38,
+          "factorDegrees": [
+            38
+          ],
+          "hensel": {
+            "liftedFactorCount": 3,
+            "liftedFactorDegrees": [
+              36,
+              1,
+              1
+            ],
+            "liftedMaxCoeffBits": 120,
+            "modulusBits": 120,
+            "precision": 19,
+            "prime": 79,
+            "treeInternalLifts": 2,
+            "treeLeaves": 3,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 2911527,
+              "smallAllocs": 251152
+            },
+            "berlekampMatrix": {
+              "nanos": 1843,
+              "smallAllocs": 126
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 26259,
+              "smallAllocs": 2184
+            },
+            "kernelDimension": 3,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 38,
+            "modularImage": {
+              "nanos": 2173,
+              "smallAllocs": 94
+            },
+            "prime": 79,
+            "rowReduction": {
+              "nanos": 3526318,
+              "smallAllocs": 334731
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 9895,
+              "smallAllocs": 431
+            },
+            "henselLift": {
+              "nanos": 591026,
+              "smallAllocs": 18938
+            },
+            "normalization": {
+              "nanos": 39989,
+              "smallAllocs": 2237
+            },
+            "primeWalk": {
+              "nanos": 3013980,
+              "smallAllocs": 259247
+            },
+            "quadratic": {
+              "nanos": 420,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 60620,
+              "smallAllocs": 1980
+            },
+            "total": {
+              "nanos": 3758082,
+              "smallAllocs": 283791
+            },
+            "validation": {
+              "nanos": 7511,
+              "smallAllocs": 265
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  36,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 4,
+                "henselPrecision": 19,
+                "modularFactorCount": 3,
+                "prime": 79,
+                "reachableProperDegrees": 4,
+                "selected": true
+              }
+            ],
+            "coeffBound": 14065077854436543582494269671679200,
+            "coeffBoundBits": 114,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 79
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 3,
+              "degreeSurvivors": 4,
+              "exactDivisionsAttempted": 1,
+              "nodes": 4,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 3797390,
+        "total_nanos_median": 3758082,
+        "total_nanos_min": 3724432
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1
+        ],
+        "mirror_factor_degrees": [
+          38
+        ],
+        "mirror_nodes": 4,
+        "mirror_prime": 79,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 4,
+        "production_completed_levels": [
+          0,
+          1
+        ],
+        "production_factor_degrees": [
+          38
+        ],
+        "production_prime": 79
+      }
+    },
+    {
+      "degree": 16,
+      "end_to_end": {
+        "max_nanos": 113919,
+        "median_nanos": 104535,
+        "min_nanos": 101100,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        16
+      ],
+      "family": "cyclotomic",
+      "instrumentation_ratio": 0.7700674415267613,
+      "name": "cyclo_phi17",
+      "phase_profile": {
+        "profile": {
+          "degree": 16,
+          "factorDegrees": [
+            16
+          ],
+          "hensel": {
+            "liftedFactorCount": 1,
+            "liftedFactorDegrees": [
+              16
+            ],
+            "liftedMaxCoeffBits": 1,
+            "modulusBits": 18,
+            "precision": 11,
+            "prime": 3,
+            "treeInternalLifts": 0,
+            "treeLeaves": 1,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 49274,
+              "smallAllocs": 2865
+            },
+            "berlekampMatrix": {
+              "nanos": 701,
+              "smallAllocs": 60
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 3846,
+              "smallAllocs": 332
+            },
+            "kernelDimension": 1,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 16,
+            "modularImage": {
+              "nanos": 440,
+              "smallAllocs": 40
+            },
+            "prime": 3,
+            "rowReduction": {
+              "nanos": 91946,
+              "smallAllocs": 7303
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 2163,
+              "smallAllocs": 150
+            },
+            "henselLift": {
+              "nanos": 2203,
+              "smallAllocs": 72
+            },
+            "normalization": {
+              "nanos": 7111,
+              "smallAllocs": 370
+            },
+            "primeWalk": {
+              "nanos": 56394,
+              "smallAllocs": 3415
+            },
+            "quadratic": {
+              "nanos": 200,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 6490,
+              "smallAllocs": 424
+            },
+            "total": {
+              "nanos": 80499,
+              "smallAllocs": 4799
+            },
+            "validation": {
+              "nanos": 1823,
+              "smallAllocs": 91
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  16
+                ],
+                "forcedSubsetCost": 1,
+                "henselPrecision": 11,
+                "modularFactorCount": 1,
+                "prime": 3,
+                "reachableProperDegrees": 0,
+                "selected": true
+              }
+            ],
+            "coeffBound": 64350,
+            "coeffBoundBits": 16,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 1,
+              "exactDivisionsAttempted": 1,
+              "nodes": 1,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 88812,
+        "total_nanos_median": 80499,
+        "total_nanos_min": 78897
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [],
+        "mirror_factor_degrees": [
+          16
+        ],
+        "mirror_nodes": 1,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 1,
+        "production_completed_levels": [],
+        "production_factor_degrees": [
+          16
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 40,
+      "end_to_end": {
+        "max_nanos": 1995949,
+        "median_nanos": 1979295,
+        "min_nanos": 1975159,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        40
+      ],
+      "family": "cyclotomic",
+      "instrumentation_ratio": 0.9848915901874152,
+      "name": "cyclo_phi41",
+      "phase_profile": {
+        "profile": {
+          "degree": 40,
+          "factorDegrees": [
+            40
+          ],
+          "hensel": {
+            "liftedFactorCount": 5,
+            "liftedFactorDegrees": [
+              8,
+              8,
+              8,
+              8,
+              8
+            ],
+            "liftedMaxCoeffBits": 42,
+            "modulusBits": 42,
+            "precision": 26,
+            "prime": 3,
+            "treeInternalLifts": 4,
+            "treeLeaves": 5,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 452251,
+              "smallAllocs": 32512
+            },
+            "berlekampMatrix": {
+              "nanos": 1762,
+              "smallAllocs": 132
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 8722,
+              "smallAllocs": 780
+            },
+            "kernelDimension": 5,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 40,
+            "modularImage": {
+              "nanos": 982,
+              "smallAllocs": 88
+            },
+            "prime": 3,
+            "rowReduction": {
+              "nanos": 453943,
+              "smallAllocs": 38465
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 5278,
+              "smallAllocs": 342
+            },
+            "henselLift": {
+              "nanos": 645858,
+              "smallAllocs": 30651
+            },
+            "normalization": {
+              "nanos": 17657,
+              "smallAllocs": 874
+            },
+            "primeWalk": {
+              "nanos": 472230,
+              "smallAllocs": 33974
+            },
+            "quadratic": {
+              "nanos": 400,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 793777,
+              "smallAllocs": 32169
+            },
+            "total": {
+              "nanos": 1949391,
+              "smallAllocs": 98623
+            },
+            "validation": {
+              "nanos": 4276,
+              "smallAllocs": 211
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  8,
+                  8,
+                  8,
+                  8,
+                  8
+                ],
+                "forcedSubsetCost": 16,
+                "henselPrecision": 26,
+                "modularFactorCount": 5,
+                "prime": 3,
+                "reachableProperDegrees": 4,
+                "selected": true
+              }
+            ],
+            "coeffBound": 964925701740,
+            "coeffBoundBits": 40,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 16,
+              "exactDivisionsAttempted": 1,
+              "nodes": 16,
+              "productsMaterialized": 16,
+              "recordable": 16,
+              "trailingSurvivors": 16
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 1964362,
+        "total_nanos_median": 1949391,
+        "total_nanos_min": 1940287
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "mirror_factor_degrees": [
+          40
+        ],
+        "mirror_nodes": 16,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 16,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "production_factor_degrees": [
+          40
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 24,
+      "end_to_end": {
+        "max_nanos": 2315784,
+        "median_nanos": 2293300,
+        "min_nanos": 2282404,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        8
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 0.9985762874460384,
+      "name": "xpow24_minus1",
+      "phase_profile": {
+        "profile": {
+          "degree": 24,
+          "factorDegrees": [
+            2,
+            1,
+            4,
+            4,
+            8,
+            1,
+            2,
+            2
+          ],
+          "hensel": {
+            "liftedFactorCount": 13,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              1,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              2
+            ],
+            "liftedMaxCoeffBits": 25,
+            "modulusBits": 25,
+            "precision": 7,
+            "prime": 11,
+            "treeInternalLifts": 12,
+            "treeLeaves": 13,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 578989,
+              "smallAllocs": 46939
+            },
+            "berlekampMatrix": {
+              "nanos": 1072,
+              "smallAllocs": 84
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 3184,
+              "smallAllocs": 270
+            },
+            "kernelDimension": 13,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 24,
+            "modularImage": {
+              "nanos": 701,
+              "smallAllocs": 56
+            },
+            "prime": 11,
+            "rowReduction": {
+              "nanos": 196391,
+              "smallAllocs": 17216
+            },
+            "splittingNanos": 381526
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 10465,
+              "smallAllocs": 937
+            },
+            "henselLift": {
+              "nanos": 293315,
+              "smallAllocs": 17594
+            },
+            "normalization": {
+              "nanos": 7601,
+              "smallAllocs": 299
+            },
+            "primeWalk": {
+              "nanos": 1102124,
+              "smallAllocs": 89442
+            },
+            "quadratic": {
+              "nanos": 391,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 859104,
+              "smallAllocs": 48267
+            },
+            "total": {
+              "nanos": 2290035,
+              "smallAllocs": 157626
+            },
+            "validation": {
+              "nanos": 8062,
+              "smallAllocs": 574
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  1,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  1,
+                  2
+                ],
+                "forcedSubsetCost": 4096,
+                "henselPrecision": 7,
+                "modularFactorCount": 13,
+                "prime": 11,
+                "reachableProperDegrees": 23,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  1,
+                  1,
+                  2,
+                  2,
+                  1,
+                  2,
+                  2,
+                  2,
+                  2,
+                  1
+                ],
+                "forcedSubsetCost": 8192,
+                "henselPrecision": 11,
+                "modularFactorCount": 14,
+                "prime": 5,
+                "reachableProperDegrees": 23,
+                "selected": false
+              }
+            ],
+            "coeffBound": 5408312,
+            "coeffBoundBits": 23,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 11
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              0,
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 113,
+              "exactDivisionsAttempted": 8,
+              "nodes": 113,
+              "productsMaterialized": 113,
+              "recordable": 113,
+              "trailingSurvivors": 113
+            },
+            "successfulDivisors": 8
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 2301622,
+        "total_nanos_median": 2290035,
+        "total_nanos_min": 2279721
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          0,
+          0
+        ],
+        "mirror_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          8
+        ],
+        "mirror_nodes": 113,
+        "mirror_prime": 11,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 113,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          0,
+          0
+        ],
+        "production_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          8
+        ],
+        "production_prime": 11
+      }
+    },
+    {
+      "degree": 20,
+      "end_to_end": {
+        "max_nanos": 677385,
+        "median_nanos": 640029,
+        "min_nanos": 604867,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        10,
+        10
+      ],
+      "family": "random-products",
+      "instrumentation_ratio": 0.9086494518217143,
+      "name": "randprod_10",
+      "phase_profile": {
+        "profile": {
+          "degree": 20,
+          "factorDegrees": [
+            10,
+            10
+          ],
+          "hensel": {
+            "liftedFactorCount": 4,
+            "liftedFactorDegrees": [
+              3,
+              4,
+              7,
+              6
+            ],
+            "liftedMaxCoeffBits": 31,
+            "modulusBits": 31,
+            "precision": 11,
+            "prime": 7,
+            "treeInternalLifts": 3,
+            "treeLeaves": 4,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 338702,
+              "smallAllocs": 23484
+            },
+            "berlekampMatrix": {
+              "nanos": 811,
+              "smallAllocs": 72
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 12319,
+              "smallAllocs": 1018
+            },
+            "kernelDimension": 4,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 20,
+            "modularImage": {
+              "nanos": 621,
+              "smallAllocs": 48
+            },
+            "prime": 7,
+            "rowReduction": {
+              "nanos": 421565,
+              "smallAllocs": 35832
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 4386,
+              "smallAllocs": 338
+            },
+            "henselLift": {
+              "nanos": 159877,
+              "smallAllocs": 9769
+            },
+            "normalization": {
+              "nanos": 20080,
+              "smallAllocs": 1219
+            },
+            "primeWalk": {
+              "nanos": 356809,
+              "smallAllocs": 24950
+            },
+            "quadratic": {
+              "nanos": 290,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 30436,
+              "smallAllocs": 1357
+            },
+            "total": {
+              "nanos": 581562,
+              "smallAllocs": 38183
+            },
+            "validation": {
+              "nanos": 3766,
+              "smallAllocs": 237
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  3,
+                  4,
+                  7,
+                  6
+                ],
+                "forcedSubsetCost": 8,
+                "henselPrecision": 11,
+                "modularFactorCount": 4,
+                "prime": 7,
+                "reachableProperDegrees": 11,
+                "selected": true
+              }
+            ],
+            "coeffBound": 161291988,
+            "coeffBoundBits": 28,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 7
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 3,
+              "degreeSurvivors": 5,
+              "exactDivisionsAttempted": 2,
+              "nodes": 5,
+              "productsMaterialized": 2,
+              "recordable": 2,
+              "trailingSurvivors": 2
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 613139,
+        "total_nanos_median": 581562,
+        "total_nanos_min": 563966
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0
+        ],
+        "mirror_factor_degrees": [
+          10,
+          10
+        ],
+        "mirror_nodes": 5,
+        "mirror_prime": 7,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 5,
+        "production_completed_levels": [
+          0,
+          0
+        ],
+        "production_factor_degrees": [
+          10,
+          10
+        ],
+        "production_prime": 7
+      }
+    },
+    {
+      "degree": 24,
+      "end_to_end": {
+        "max_nanos": 1438773,
+        "median_nanos": 1401528,
+        "min_nanos": 1381839,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        7,
+        8,
+        9
+      ],
+      "family": "random-products",
+      "instrumentation_ratio": 0.9699092704533909,
+      "name": "randprod_21",
+      "phase_profile": {
+        "profile": {
+          "degree": 24,
+          "factorDegrees": [
+            7,
+            8,
+            9
+          ],
+          "hensel": {
+            "liftedFactorCount": 7,
+            "liftedFactorDegrees": [
+              9,
+              7,
+              1,
+              1,
+              1,
+              4,
+              1
+            ],
+            "liftedMaxCoeffBits": 37,
+            "modulusBits": 37,
+            "precision": 9,
+            "prime": 17,
+            "treeInternalLifts": 6,
+            "treeLeaves": 7,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 879685,
+              "smallAllocs": 68180
+            },
+            "berlekampMatrix": {
+              "nanos": 1011,
+              "smallAllocs": 84
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 19019,
+              "smallAllocs": 1592
+            },
+            "kernelDimension": 7,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 24,
+            "modularImage": {
+              "nanos": 781,
+              "smallAllocs": 56
+            },
+            "prime": 17,
+            "rowReduction": {
+              "nanos": 1002837,
+              "smallAllocs": 89421
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 6840,
+              "smallAllocs": 531
+            },
+            "henselLift": {
+              "nanos": 316839,
+              "smallAllocs": 17842
+            },
+            "normalization": {
+              "nanos": 25928,
+              "smallAllocs": 1651
+            },
+            "primeWalk": {
+              "nanos": 946803,
+              "smallAllocs": 74367
+            },
+            "quadratic": {
+              "nanos": 301,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 49183,
+              "smallAllocs": 2297
+            },
+            "total": {
+              "nanos": 1359355,
+              "smallAllocs": 97424
+            },
+            "validation": {
+              "nanos": 5648,
+              "smallAllocs": 386
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  9,
+                  7,
+                  1,
+                  1,
+                  1,
+                  4,
+                  1
+                ],
+                "forcedSubsetCost": 64,
+                "henselPrecision": 9,
+                "modularFactorCount": 7,
+                "prime": 17,
+                "reachableProperDegrees": 23,
+                "selected": true
+              }
+            ],
+            "coeffBound": 41749464484,
+            "coeffBoundBits": 36,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 17
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 10,
+              "degreeSurvivors": 13,
+              "exactDivisionsAttempted": 3,
+              "nodes": 13,
+              "productsMaterialized": 3,
+              "recordable": 3,
+              "trailingSurvivors": 3
+            },
+            "successfulDivisors": 3
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 1385404,
+        "total_nanos_median": 1359355,
+        "total_nanos_min": 1356441
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          7,
+          8,
+          9
+        ],
+        "mirror_nodes": 13,
+        "mirror_prime": 17,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 13,
+        "production_completed_levels": [
+          0,
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          7,
+          8,
+          9
+        ],
+        "production_prime": 17
+      }
+    }
+  ],
+  "schema": "hexbz-phase-profile/3",
+  "scouts": [],
+  "validation": {
+    "disagreements": [],
+    "factors_agree": 368,
+    "instrumentation_ratio_max": 1.021457000890995,
+    "instrumentation_ratio_median": 0.9943770224592106,
+    "kernel_disagreements": [],
+    "kernel_mirror_agree": 24,
+    "kernel_packed_agree": 24,
+    "kernel_rows": 24,
+    "levels_agree": 368,
+    "nodes_agree": 368,
+    "prime_agree": 368,
+    "sample_size": 368,
+    "scout_disagreements": [],
+    "scout_patterns_agree": 0,
+    "scout_rows": 0
+  }
+}

--- a/reports/bench-results/hexbz-phase-profile-a5e0ebe4-chungus2.json
+++ b/reports/bench-results/hexbz-phase-profile-a5e0ebe4-chungus2.json
@@ -1,0 +1,10091 @@
+{
+  "config": {
+    "controls": [
+      "chebyshev_T24",
+      "chebyshev_U24",
+      "legendre_P30",
+      "legendre_P38",
+      "cyclo_phi17",
+      "cyclo_phi41",
+      "xpow24_minus1",
+      "randprod_10",
+      "randprod_21"
+    ],
+    "corpus": "bench/corpus/hexbz-factor-corpus.jsonl",
+    "corpus_sha256": "619913904240834c912489e6cc23ba136e8cc5ebf0ea95f83397e0682387284d",
+    "cpu": 9,
+    "cutoff_seconds": 120.0,
+    "hex_exe_sha256": "c22f80f3683e4e9c7b7c7432e6af80543e920aa9402b8cd37ea4686d3d6360c4",
+    "kernel_repeats": 3,
+    "names": [
+      "sd5",
+      "sd5_shift1",
+      "sd5_shift2",
+      "sd4_x_sd4shift1",
+      "sd5_x_phi11",
+      "xpow48_minus1",
+      "xpow105_minus1",
+      "xpow120_minus1",
+      "cyclo_phi179",
+      "cyclo_phi64_x_phi105",
+      "cyclo_phi128_x_phi165",
+      "cyclo_phi385",
+      "wilkinson_40",
+      "wilkinson_48",
+      "wilkinson_56",
+      "chebyshev_T24",
+      "chebyshev_U24",
+      "legendre_P30",
+      "legendre_P38",
+      "cyclo_phi17",
+      "cyclo_phi41",
+      "xpow24_minus1",
+      "randprod_10",
+      "randprod_21"
+    ],
+    "plan_repeats": 3,
+    "repeat_ceiling_nanos": 1000000000,
+    "repeats": 5,
+    "representative": [
+      "sd5",
+      "sd5_shift1",
+      "sd5_shift2",
+      "sd4_x_sd4shift1",
+      "sd5_x_phi11",
+      "xpow48_minus1",
+      "xpow105_minus1",
+      "xpow120_minus1",
+      "cyclo_phi179",
+      "cyclo_phi64_x_phi105",
+      "cyclo_phi128_x_phi165",
+      "cyclo_phi385",
+      "wilkinson_40",
+      "wilkinson_48",
+      "wilkinson_56"
+    ],
+    "sampling_profiles": [
+      "sd5",
+      "sd5_x_phi11",
+      "xpow120_minus1",
+      "cyclo_phi179",
+      "cyclo_phi64_x_phi105",
+      "cyclo_phi385",
+      "wilkinson_56"
+    ],
+    "validate_cutoff_seconds": 2.0,
+    "warmup": 1
+  },
+  "counterfactuals": [],
+  "env": {
+    "arch": "x86_64",
+    "cpu_cores": 96,
+    "cpu_model": null,
+    "exe_name": "hexbz_factor_service",
+    "git_commit": "a5e0ebe49399708a8286b8acb1c6a0877e9dc4c3",
+    "git_dirty": true,
+    "hostname": "chungus2",
+    "lean_bench_version": null,
+    "lean_toolchain": "leanprover/lean4:v4.33.0-rc1",
+    "lean_version": null,
+    "os": "linux",
+    "platform_target": null,
+    "timestamp_iso": "2026-08-04T00:14:27Z",
+    "timestamp_unix_ms": 1785802467158
+  },
+  "kernels": [
+    {
+      "degree": 32,
+      "family": "swinnerton-dyer",
+      "kernel": {
+        "kernel": {
+          "basisSize": 32,
+          "basisToPolynomials": {
+            "nanos": 4627,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1226329,
+            "smallAllocs": 120747
+          },
+          "berlekampSplit": {
+            "nanos": 3282788,
+            "smallAllocs": 279386
+          },
+          "columnPolys": {
+            "nanos": 1181252,
+            "smallAllocs": 116346
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 811,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 277770,
+              "smallAllocs": 15527
+            },
+            "rowAdds": 215,
+            "rowAddsSkipped": 281,
+            "rowSwapScale": {
+              "nanos": 26457,
+              "smallAllocs": 1625
+            },
+            "stagedNanos": 305721,
+            "wall": {
+              "nanos": 323199,
+              "smallAllocs": 17591
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 822,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 505779,
+              "smallAllocs": 29287
+            },
+            "rowAdds": 215,
+            "rowAddsSkipped": 281,
+            "rowSwapScale": {
+              "nanos": 36053,
+              "smallAllocs": 2137
+            },
+            "stagedNanos": 542385,
+            "wall": {
+              "nanos": 558949,
+              "smallAllocs": 31866
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 21844,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1358774,
+            "smallAllocs": 121100
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1255452,
+            "smallAllocs": 121804
+          },
+          "frobeniusPower": {
+            "nanos": 26389,
+            "smallAllocs": 2354
+          },
+          "kernelDimension": 16,
+          "matrixConversionNanos": 21203,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1267840,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 37565,
+          "nullspaceBasisNanos": 37565,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2163,
+            "packNanos": 41612,
+            "rank": 16,
+            "reduceNanos": 35182,
+            "rowAdds": 215,
+            "smallAllocs": 1466,
+            "totalNanos": 78957
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1662,
+            "packNanos": 40800,
+            "rank": 16,
+            "reduceNanos": 33400,
+            "rowAdds": 215,
+            "smallAllocs": 1466,
+            "totalNanos": 75902
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1573,
+            "packNanos": 40801,
+            "rank": 16,
+            "reduceNanos": 25237,
+            "rowAdds": 215,
+            "smallAllocs": 1466,
+            "totalNanos": 67690
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5308,
+            "packNanos": 40610,
+            "rank": 16,
+            "reduceNanos": 68131,
+            "rowAdds": 215,
+            "smallAllocs": 8858,
+            "totalNanos": 113899
+          },
+          "peakResidentBytes": 63115264,
+          "productionMatrixRebuild": {
+            "nanos": 1277875,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 592619,
+            "smallAllocs": 31823
+          },
+          "productionRowReduce": {
+            "nanos": 558919,
+            "smallAllocs": 30631
+          },
+          "rank": 16,
+          "residentBytesAfter": 62930944,
+          "residentBytesBefore": 62763008,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1271555,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 16
+        },
+        "modularDegree": 32,
+        "modularFactorCount": 16,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd5",
+      "status": "ok"
+    },
+    {
+      "degree": 32,
+      "family": "swinnerton-dyer",
+      "kernel": {
+        "kernel": {
+          "basisSize": 32,
+          "basisToPolynomials": {
+            "nanos": 4707,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1591510,
+            "smallAllocs": 149530
+          },
+          "berlekampSplit": {
+            "nanos": 3163200,
+            "smallAllocs": 258979
+          },
+          "columnPolys": {
+            "nanos": 1543829,
+            "smallAllocs": 145131
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 739,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 564786,
+              "smallAllocs": 30737
+            },
+            "rowAdds": 449,
+            "rowAddsSkipped": 47,
+            "rowSwapScale": {
+              "nanos": 26560,
+              "smallAllocs": 1617
+            },
+            "stagedNanos": 592637,
+            "wall": {
+              "nanos": 610355,
+              "smallAllocs": 32793
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 843,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 1039178,
+              "smallAllocs": 59473
+            },
+            "rowAdds": 449,
+            "rowAddsSkipped": 47,
+            "rowSwapScale": {
+              "nanos": 36575,
+              "smallAllocs": 2129
+            },
+            "stagedNanos": 1075813,
+            "wall": {
+              "nanos": 1092700,
+              "smallAllocs": 62044
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 19079,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1787500,
+            "smallAllocs": 149883
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1615345,
+            "smallAllocs": 150587
+          },
+          "frobeniusPower": {
+            "nanos": 26459,
+            "smallAllocs": 2352
+          },
+          "kernelDimension": 16,
+          "matrixConversionNanos": 13921,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1620102,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 47050,
+          "nullspaceBasisNanos": 47050,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2404,
+            "packNanos": 41862,
+            "rank": 16,
+            "reduceNanos": 60400,
+            "rowAdds": 449,
+            "smallAllocs": 1232,
+            "totalNanos": 104666
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1762,
+            "packNanos": 41291,
+            "rank": 16,
+            "reduceNanos": 58407,
+            "rowAdds": 449,
+            "smallAllocs": 1232,
+            "totalNanos": 101380
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1652,
+            "packNanos": 41181,
+            "rank": 16,
+            "reduceNanos": 51156,
+            "rowAdds": 449,
+            "smallAllocs": 1232,
+            "totalNanos": 93969
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5528,
+            "packNanos": 40580,
+            "rank": 16,
+            "reduceNanos": 121540,
+            "rowAdds": 449,
+            "smallAllocs": 16080,
+            "totalNanos": 167648
+          },
+          "peakResidentBytes": 63258624,
+          "productionMatrixRebuild": {
+            "nanos": 1637829,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 1140541,
+            "smallAllocs": 62101
+          },
+          "productionRowReduce": {
+            "nanos": 1093491,
+            "smallAllocs": 60809
+          },
+          "rank": 16,
+          "residentBytesAfter": 63258624,
+          "residentBytesBefore": 63164416,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1634633,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 16
+        },
+        "modularDegree": 32,
+        "modularFactorCount": 16,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd5_shift1",
+      "status": "ok"
+    },
+    {
+      "degree": 32,
+      "family": "swinnerton-dyer",
+      "kernel": {
+        "kernel": {
+          "basisSize": 32,
+          "basisToPolynomials": {
+            "nanos": 4517,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1583147,
+            "smallAllocs": 149061
+          },
+          "berlekampSplit": {
+            "nanos": 4614011,
+            "smallAllocs": 381697
+          },
+          "columnPolys": {
+            "nanos": 1531301,
+            "smallAllocs": 144662
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 812,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 565410,
+              "smallAllocs": 31127
+            },
+            "rowAdds": 455,
+            "rowAddsSkipped": 41,
+            "rowSwapScale": {
+              "nanos": 26359,
+              "smallAllocs": 1617
+            },
+            "stagedNanos": 592559,
+            "wall": {
+              "nanos": 610045,
+              "smallAllocs": 33183
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 799,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 1047302,
+              "smallAllocs": 60247
+            },
+            "rowAdds": 455,
+            "rowAddsSkipped": 41,
+            "rowSwapScale": {
+              "nanos": 36315,
+              "smallAllocs": 2129
+            },
+            "stagedNanos": 1084387,
+            "wall": {
+              "nanos": 1101032,
+              "smallAllocs": 62818
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 21712,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1787470,
+            "smallAllocs": 149414
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1598621,
+            "smallAllocs": 150118
+          },
+          "frobeniusPower": {
+            "nanos": 26489,
+            "smallAllocs": 2352
+          },
+          "kernelDimension": 16,
+          "matrixConversionNanos": 22604,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1596007,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 43905,
+          "nullspaceBasisNanos": 43905,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2074,
+            "packNanos": 41672,
+            "rank": 16,
+            "reduceNanos": 60790,
+            "rowAdds": 455,
+            "smallAllocs": 1226,
+            "totalNanos": 104335
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1763,
+            "packNanos": 41191,
+            "rank": 16,
+            "reduceNanos": 59097,
+            "rowAdds": 455,
+            "smallAllocs": 1226,
+            "totalNanos": 102232
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1672,
+            "packNanos": 41111,
+            "rank": 16,
+            "reduceNanos": 51737,
+            "rowAdds": 455,
+            "smallAllocs": 1226,
+            "totalNanos": 94560
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5268,
+            "packNanos": 40310,
+            "rank": 16,
+            "reduceNanos": 124364,
+            "rowAdds": 455,
+            "smallAllocs": 16266,
+            "totalNanos": 170232
+          },
+          "peakResidentBytes": 63262720,
+          "productionMatrixRebuild": {
+            "nanos": 1631399,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 1148333,
+            "smallAllocs": 62874
+          },
+          "productionRowReduce": {
+            "nanos": 1103326,
+            "smallAllocs": 61583
+          },
+          "rank": 16,
+          "residentBytesAfter": 63238144,
+          "residentBytesBefore": 63205376,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1631849,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 16
+        },
+        "modularDegree": 32,
+        "modularFactorCount": 16,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd5_shift2",
+      "status": "ok"
+    },
+    {
+      "degree": 32,
+      "family": "sd-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 32,
+          "basisToPolynomials": {
+            "nanos": 4426,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1587113,
+            "smallAllocs": 149683
+          },
+          "berlekampSplit": {
+            "nanos": 3906552,
+            "smallAllocs": 320808
+          },
+          "columnPolys": {
+            "nanos": 1536168,
+            "smallAllocs": 145284
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 809,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 555114,
+              "smallAllocs": 30412
+            },
+            "rowAdds": 444,
+            "rowAddsSkipped": 52,
+            "rowSwapScale": {
+              "nanos": 26731,
+              "smallAllocs": 1618
+            },
+            "stagedNanos": 582765,
+            "wall": {
+              "nanos": 600570,
+              "smallAllocs": 32469
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 16,
+            "pivotSearch": {
+              "nanos": 831,
+              "smallAllocs": 64
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 1014201,
+              "smallAllocs": 58828
+            },
+            "rowAdds": 444,
+            "rowAddsSkipped": 52,
+            "rowSwapScale": {
+              "nanos": 36326,
+              "smallAllocs": 2130
+            },
+            "stagedNanos": 1051367,
+            "wall": {
+              "nanos": 1069155,
+              "smallAllocs": 61400
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 15023,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1796714,
+            "smallAllocs": 150036
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1600984,
+            "smallAllocs": 150740
+          },
+          "frobeniusPower": {
+            "nanos": 26309,
+            "smallAllocs": 2352
+          },
+          "kernelDimension": 16,
+          "matrixConversionNanos": 27339,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1604409,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 48411,
+          "nullspaceBasisNanos": 48411,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2092,
+            "packNanos": 41331,
+            "rank": 16,
+            "reduceNanos": 59879,
+            "rowAdds": 444,
+            "smallAllocs": 1237,
+            "totalNanos": 103374
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1732,
+            "packNanos": 41151,
+            "rank": 16,
+            "reduceNanos": 57906,
+            "rowAdds": 444,
+            "smallAllocs": 1237,
+            "totalNanos": 100620
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1652,
+            "packNanos": 41071,
+            "rank": 16,
+            "reduceNanos": 51476,
+            "rowAdds": 444,
+            "smallAllocs": 1237,
+            "totalNanos": 94179
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5498,
+            "packNanos": 39899,
+            "rank": 16,
+            "reduceNanos": 123122,
+            "rowAdds": 444,
+            "smallAllocs": 15925,
+            "totalNanos": 168790
+          },
+          "peakResidentBytes": 63303680,
+          "productionMatrixRebuild": {
+            "nanos": 1632571,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 1128384,
+            "smallAllocs": 61452
+          },
+          "productionRowReduce": {
+            "nanos": 1081885,
+            "smallAllocs": 60165
+          },
+          "rank": 16,
+          "residentBytesAfter": 63299584,
+          "residentBytesBefore": 63246336,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1627574,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 16
+        },
+        "modularDegree": 32,
+        "modularFactorCount": 16,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd4_x_sd4shift1",
+      "status": "ok"
+    },
+    {
+      "degree": 42,
+      "family": "sd-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 42,
+          "basisToPolynomials": {
+            "nanos": 5078,
+            "smallAllocs": 444
+          },
+          "berlekampMatrixWall": {
+            "nanos": 2771078,
+            "smallAllocs": 263817
+          },
+          "berlekampSplit": {
+            "nanos": 7642462,
+            "smallAllocs": 625572
+          },
+          "columnPolys": {
+            "nanos": 2713904,
+            "smallAllocs": 258009
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 17,
+            "pivotSearch": {
+              "nanos": 1043,
+              "smallAllocs": 84
+            },
+            "pivots": 25,
+            "rowAdd": {
+              "nanos": 1464542,
+              "smallAllocs": 82650
+            },
+            "rowAdds": 935,
+            "rowAddsSkipped": 90,
+            "rowSwapScale": {
+              "nanos": 53310,
+              "smallAllocs": 3279
+            },
+            "stagedNanos": 1518874,
+            "wall": {
+              "nanos": 1547665,
+              "smallAllocs": 86460
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 17,
+            "pivotSearch": {
+              "nanos": 1023,
+              "smallAllocs": 84
+            },
+            "pivots": 25,
+            "rowAdd": {
+              "nanos": 2785029,
+              "smallAllocs": 161190
+            },
+            "rowAdds": 935,
+            "rowAddsSkipped": 90,
+            "rowSwapScale": {
+              "nanos": 72557,
+              "smallAllocs": 4329
+            },
+            "stagedNanos": 2859040,
+            "wall": {
+              "nanos": 2885208,
+              "smallAllocs": 166053
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 30025,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 3298441,
+            "smallAllocs": 264369
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 2800613,
+            "smallAllocs": 265624
+          },
+          "frobeniusPower": {
+            "nanos": 25408,
+            "smallAllocs": 2281
+          },
+          "kernelDimension": 17,
+          "matrixConversionNanos": 31766,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 2871818,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 29,
+          "nullspaceBasisMagnitudeNanos": 80459,
+          "nullspaceBasisNanos": 80459,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3215,
+            "packNanos": 75743,
+            "rank": 25,
+            "reduceNanos": 155751,
+            "rowAdds": 935,
+            "smallAllocs": 2064,
+            "totalNanos": 235089
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2704,
+            "packNanos": 74821,
+            "rank": 25,
+            "reduceNanos": 151294,
+            "rowAdds": 935,
+            "smallAllocs": 2064,
+            "totalNanos": 229080
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2664,
+            "packNanos": 74991,
+            "rank": 25,
+            "reduceNanos": 137764,
+            "rowAdds": 935,
+            "smallAllocs": 2064,
+            "totalNanos": 216902
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 8553,
+            "packNanos": 72218,
+            "rank": 25,
+            "reduceNanos": 327886,
+            "rowAdds": 935,
+            "smallAllocs": 42384,
+            "totalNanos": 408776
+          },
+          "peakResidentBytes": 63569920,
+          "productionMatrixRebuild": {
+            "nanos": 2833381,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 2989733,
+            "smallAllocs": 166027
+          },
+          "productionRowReduce": {
+            "nanos": 2904186,
+            "smallAllocs": 163665
+          },
+          "rank": 25,
+          "residentBytesAfter": 63565824,
+          "residentBytesBefore": 63369216,
+          "rowReduceMatrixRebuild": {
+            "nanos": 2845750,
+            "smallAllocs": 0
+          },
+          "sink": 20,
+          "splitFactors": 17
+        },
+        "modularDegree": 42,
+        "modularFactorCount": 17,
+        "prime": 29,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "sd5_x_phi11",
+      "status": "ok"
+    },
+    {
+      "degree": 48,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 48,
+          "basisToPolynomials": {
+            "nanos": 7110,
+            "smallAllocs": 686
+          },
+          "berlekampMatrixWall": {
+            "nanos": 537837,
+            "smallAllocs": 51263
+          },
+          "berlekampSplit": {
+            "nanos": 1943392,
+            "smallAllocs": 163103
+          },
+          "columnPolys": {
+            "nanos": 483007,
+            "smallAllocs": 46071
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 19,
+            "pivotSearch": {
+              "nanos": 1164,
+              "smallAllocs": 96
+            },
+            "pivots": 29,
+            "rowAdd": {
+              "nanos": 120719,
+              "smallAllocs": 7891
+            },
+            "rowAdds": 38,
+            "rowAddsSkipped": 1325,
+            "rowSwapScale": {
+              "nanos": 70533,
+              "smallAllocs": 4425
+            },
+            "stagedNanos": 192166,
+            "wall": {
+              "nanos": 228589,
+              "smallAllocs": 13028
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 19,
+            "pivotSearch": {
+              "nanos": 1203,
+              "smallAllocs": 96
+            },
+            "pivots": 29,
+            "rowAdd": {
+              "nanos": 180879,
+              "smallAllocs": 11539
+            },
+            "rowAdds": 38,
+            "rowAddsSkipped": 1325,
+            "rowSwapScale": {
+              "nanos": 94019,
+              "smallAllocs": 5817
+            },
+            "stagedNanos": 275651,
+            "wall": {
+              "nanos": 308577,
+              "smallAllocs": 18071
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 41582,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 623765,
+            "smallAllocs": 51959
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 581052,
+            "smallAllocs": 53616
+          },
+          "frobeniusPower": {
+            "nanos": 7901,
+            "smallAllocs": 585
+          },
+          "kernelDimension": 19,
+          "matrixConversionNanos": 46929,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 591457,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 11,
+          "nullspaceBasisMagnitudeNanos": 58777,
+          "nullspaceBasisNanos": 58777,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 4056,
+            "packNanos": 99277,
+            "rank": 29,
+            "reduceNanos": 27961,
+            "rowAdds": 38,
+            "smallAllocs": 3867,
+            "totalNanos": 131385
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3365,
+            "packNanos": 98877,
+            "rank": 29,
+            "reduceNanos": 26649,
+            "rowAdds": 38,
+            "smallAllocs": 3867,
+            "totalNanos": 129622
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3605,
+            "packNanos": 98677,
+            "rank": 29,
+            "reduceNanos": 24447,
+            "rowAdds": 38,
+            "smallAllocs": 3867,
+            "totalNanos": 126678
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 11166,
+            "packNanos": 95512,
+            "rank": 29,
+            "reduceNanos": 42453,
+            "rowAdds": 38,
+            "smallAllocs": 7083,
+            "totalNanos": 149192
+          },
+          "peakResidentBytes": 63700992,
+          "productionMatrixRebuild": {
+            "nanos": 580611,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 333895,
+            "smallAllocs": 17567
+          },
+          "productionRowReduce": {
+            "nanos": 275098,
+            "smallAllocs": 14957
+          },
+          "rank": 29,
+          "residentBytesAfter": 63627264,
+          "residentBytesBefore": 63504384,
+          "rowReduceMatrixRebuild": {
+            "nanos": 591287,
+            "smallAllocs": 0
+          },
+          "sink": 20,
+          "splitFactors": 19
+        },
+        "modularDegree": 48,
+        "modularFactorCount": 19,
+        "prime": 11,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "xpow48_minus1",
+      "status": "ok"
+    },
+    {
+      "degree": 105,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 105,
+          "basisToPolynomials": {
+            "nanos": 7641,
+            "smallAllocs": 657
+          },
+          "berlekampMatrixWall": {
+            "nanos": 3621921,
+            "smallAllocs": 337638
+          },
+          "berlekampSplit": {
+            "nanos": 8875080,
+            "smallAllocs": 750003
+          },
+          "columnPolys": {
+            "nanos": 3328275,
+            "smallAllocs": 314148
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 14,
+            "pivotSearch": {
+              "nanos": 2558,
+              "smallAllocs": 210
+            },
+            "pivots": 91,
+            "rowAdd": {
+              "nanos": 988906,
+              "smallAllocs": 65681
+            },
+            "rowAdds": 175,
+            "rowAddsSkipped": 9289,
+            "rowSwapScale": {
+              "nanos": 451919,
+              "smallAllocs": 29307
+            },
+            "stagedNanos": 1444390,
+            "wall": {
+              "nanos": 1594023,
+              "smallAllocs": 95903
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 14,
+            "pivotSearch": {
+              "nanos": 2637,
+              "smallAllocs": 210
+            },
+            "pivots": 91,
+            "rowAdd": {
+              "nanos": 1592663,
+              "smallAllocs": 102431
+            },
+            "rowAdds": 175,
+            "rowAddsSkipped": 9289,
+            "rowSwapScale": {
+              "nanos": 608086,
+              "smallAllocs": 38862
+            },
+            "stagedNanos": 2203386,
+            "wall": {
+              "nanos": 2335283,
+              "smallAllocs": 142211
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 190041,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 4072098,
+            "smallAllocs": 339228
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 3808086,
+            "smallAllocs": 348769
+          },
+          "frobeniusPower": {
+            "nanos": 17617,
+            "smallAllocs": 1441
+          },
+          "kernelDimension": 14,
+          "matrixConversionNanos": 246806,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 3832172,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 17,
+          "nullspaceBasisMagnitudeNanos": 217843,
+          "nullspaceBasisNanos": 217843,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 11017,
+            "packNanos": 501964,
+            "rank": 91,
+            "reduceNanos": 185915,
+            "rowAdds": 175,
+            "smallAllocs": 20842,
+            "totalNanos": 697674
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 10095,
+            "packNanos": 503366,
+            "rank": 91,
+            "reduceNanos": 178014,
+            "rowAdds": 175,
+            "smallAllocs": 20842,
+            "totalNanos": 692146
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 10466,
+            "packNanos": 500602,
+            "rank": 91,
+            "reduceNanos": 155641,
+            "rowAdds": 175,
+            "smallAllocs": 20842,
+            "totalNanos": 666188
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 53459,
+            "packNanos": 498599,
+            "rank": 91,
+            "reduceNanos": 317791,
+            "rowAdds": 175,
+            "smallAllocs": 48772,
+            "totalNanos": 869849
+          },
+          "peakResidentBytes": 64937984,
+          "productionMatrixRebuild": {
+            "nanos": 3817319,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 2368482,
+            "smallAllocs": 134628
+          },
+          "productionRowReduce": {
+            "nanos": 2150709,
+            "smallAllocs": 122300
+          },
+          "rank": 91,
+          "residentBytesAfter": 64618496,
+          "residentBytesBefore": 63709184,
+          "rowReduceMatrixRebuild": {
+            "nanos": 3838832,
+            "smallAllocs": 0
+          },
+          "sink": 16,
+          "splitFactors": 14
+        },
+        "modularDegree": 105,
+        "modularFactorCount": 14,
+        "prime": 17,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "xpow105_minus1",
+      "status": "ok"
+    },
+    {
+      "degree": 120,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 120,
+          "basisToPolynomials": {
+            "nanos": 30885,
+            "smallAllocs": 2778
+          },
+          "berlekampMatrixWall": {
+            "nanos": 2392337,
+            "smallAllocs": 214939
+          },
+          "berlekampSplit": {
+            "nanos": 16077529,
+            "smallAllocs": 1312571
+          },
+          "columnPolys": {
+            "nanos": 2030911,
+            "smallAllocs": 185863
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 39,
+            "pivotSearch": {
+              "nanos": 2971,
+              "smallAllocs": 240
+            },
+            "pivots": 81,
+            "rowAdd": {
+              "nanos": 822079,
+              "smallAllocs": 57197
+            },
+            "rowAdds": 116,
+            "rowAddsSkipped": 9523,
+            "rowSwapScale": {
+              "nanos": 450277,
+              "smallAllocs": 30075
+            },
+            "stagedNanos": 1275282,
+            "wall": {
+              "nanos": 1474736,
+              "smallAllocs": 89910
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 39,
+            "pivotSearch": {
+              "nanos": 3018,
+              "smallAllocs": 240
+            },
+            "pivots": 81,
+            "rowAdd": {
+              "nanos": 1280563,
+              "smallAllocs": 85037
+            },
+            "rowAdds": 116,
+            "rowAddsSkipped": 9523,
+            "rowSwapScale": {
+              "nanos": 611218,
+              "smallAllocs": 39795
+            },
+            "stagedNanos": 1902175,
+            "wall": {
+              "nanos": 2095627,
+              "smallAllocs": 127473
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 226555,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 3048400,
+            "smallAllocs": 218459
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 2651211,
+            "smallAllocs": 229460
+          },
+          "frobeniusPower": {
+            "nanos": 4456,
+            "smallAllocs": 277
+          },
+          "kernelDimension": 39,
+          "matrixConversionNanos": 350791,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 2687485,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 7,
+          "nullspaceBasisMagnitudeNanos": 499340,
+          "nullspaceBasisNanos": 499340,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 18748,
+            "packNanos": 664836,
+            "rank": 81,
+            "reduceNanos": 172286,
+            "rowAdds": 116,
+            "smallAllocs": 24501,
+            "totalNanos": 855949
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 19228,
+            "packNanos": 662542,
+            "rank": 81,
+            "reduceNanos": 169651,
+            "rowAdds": 116,
+            "smallAllocs": 24501,
+            "totalNanos": 850962
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 18047,
+            "packNanos": 664605,
+            "rank": 81,
+            "reduceNanos": 148180,
+            "rowAdds": 116,
+            "smallAllocs": 24501,
+            "totalNanos": 829460
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 71305,
+            "packNanos": 646608,
+            "rank": 81,
+            "reduceNanos": 287887,
+            "rowAdds": 116,
+            "smallAllocs": 48141,
+            "totalNanos": 1004669
+          },
+          "peakResidentBytes": 65515520,
+          "productionMatrixRebuild": {
+            "nanos": 2632453,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 2432026,
+            "smallAllocs": 123505
+          },
+          "productionRowReduce": {
+            "nanos": 1975889,
+            "smallAllocs": 107187
+          },
+          "rank": 81,
+          "residentBytesAfter": 65282048,
+          "residentBytesBefore": 63717376,
+          "rowReduceMatrixRebuild": {
+            "nanos": 2656989,
+            "smallAllocs": 0
+          },
+          "sink": 20,
+          "splitFactors": 39
+        },
+        "modularDegree": 120,
+        "modularFactorCount": 39,
+        "prime": 7,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "xpow120_minus1",
+      "status": "ok"
+    },
+    {
+      "degree": 178,
+      "family": "cyclotomic",
+      "kernel": {
+        "kernel": {
+          "basisSize": 178,
+          "basisToPolynomials": {
+            "nanos": 4126,
+            "smallAllocs": 371
+          },
+          "berlekampMatrixWall": {
+            "nanos": 3200175,
+            "smallAllocs": 274190
+          },
+          "berlekampSplit": {
+            "nanos": 6513358,
+            "smallAllocs": 339370
+          },
+          "columnPolys": {
+            "nanos": 2418146,
+            "smallAllocs": 210706
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 2,
+            "pivotSearch": {
+              "nanos": 4386,
+              "smallAllocs": 356
+            },
+            "pivots": 176,
+            "rowAdd": {
+              "nanos": 7723490,
+              "smallAllocs": 491858
+            },
+            "rowAdds": 1114,
+            "rowAddsSkipped": 30038,
+            "rowSwapScale": {
+              "nanos": 1412469,
+              "smallAllocs": 95034
+            },
+            "stagedNanos": 9138092,
+            "wall": {
+              "nanos": 9562739,
+              "smallAllocs": 587969
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 2,
+            "pivotSearch": {
+              "nanos": 4604,
+              "smallAllocs": 356
+            },
+            "pivots": 176,
+            "rowAdd": {
+              "nanos": 14160819,
+              "smallAllocs": 888442
+            },
+            "rowAdds": 1114,
+            "rowAddsSkipped": 30038,
+            "rowSwapScale": {
+              "nanos": 1935021,
+              "smallAllocs": 126362
+            },
+            "stagedNanos": 16099259,
+            "wall": {
+              "nanos": 16472875,
+              "smallAllocs": 1015884
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 505028,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 5770876,
+            "smallAllocs": 275077
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 3673957,
+            "smallAllocs": 306053
+          },
+          "frobeniusPower": {
+            "nanos": 2644,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 2,
+          "matrixConversionNanos": 741570,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 3788297,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 201128,
+          "nullspaceBasisNanos": 201128,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 18738,
+            "packNanos": 1494095,
+            "rank": 176,
+            "reduceNanos": 1053402,
+            "rowAdds": 1114,
+            "smallAllocs": 62627,
+            "totalNanos": 2565153
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 21382,
+            "packNanos": 1486644,
+            "rank": 176,
+            "reduceNanos": 1042756,
+            "rowAdds": 1114,
+            "smallAllocs": 62627,
+            "totalNanos": 2556090
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 21141,
+            "packNanos": 1492473,
+            "rank": 176,
+            "reduceNanos": 726507,
+            "rowAdds": 1114,
+            "smallAllocs": 62627,
+            "totalNanos": 2239140
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 128951,
+            "packNanos": 1446585,
+            "rank": 176,
+            "reduceNanos": 2141856,
+            "rowAdds": 1114,
+            "smallAllocs": 291357,
+            "totalNanos": 3712334
+          },
+          "peakResidentBytes": 67321856,
+          "productionMatrixRebuild": {
+            "nanos": 3745574,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 16852858,
+            "smallAllocs": 984110
+          },
+          "productionRowReduce": {
+            "nanos": 16507405,
+            "smallAllocs": 951807
+          },
+          "rank": 176,
+          "residentBytesAfter": 67674112,
+          "residentBytesBefore": 65548288,
+          "rowReduceMatrixRebuild": {
+            "nanos": 3825081,
+            "smallAllocs": 0
+          },
+          "sink": 4,
+          "splitFactors": 2
+        },
+        "modularDegree": 178,
+        "modularFactorCount": 2,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi179",
+      "status": "ok"
+    },
+    {
+      "degree": 80,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 80,
+          "basisToPolynomials": {
+            "nanos": 4177,
+            "smallAllocs": 307
+          },
+          "berlekampMatrixWall": {
+            "nanos": 3725794,
+            "smallAllocs": 346439
+          },
+          "berlekampSplit": {
+            "nanos": 10415884,
+            "smallAllocs": 586770
+          },
+          "columnPolys": {
+            "nanos": 3584165,
+            "smallAllocs": 333055
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 10,
+            "pivotSearch": {
+              "nanos": 1967,
+              "smallAllocs": 160
+            },
+            "pivots": 70,
+            "rowAdd": {
+              "nanos": 12069268,
+              "smallAllocs": 705467
+            },
+            "rowAdds": 4277,
+            "rowAddsSkipped": 1253,
+            "rowSwapScale": {
+              "nanos": 265504,
+              "smallAllocs": 17180
+            },
+            "stagedNanos": 12339616,
+            "wall": {
+              "nanos": 12426495,
+              "smallAllocs": 723226
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 10,
+            "pivotSearch": {
+              "nanos": 2105,
+              "smallAllocs": 160
+            },
+            "pivots": 70,
+            "rowAdd": {
+              "nanos": 23353384,
+              "smallAllocs": 1389787
+            },
+            "rowAdds": 4277,
+            "rowAddsSkipped": 1253,
+            "rowSwapScale": {
+              "nanos": 363175,
+              "smallAllocs": 22780
+            },
+            "stagedNanos": 23718802,
+            "wall": {
+              "nanos": 23799858,
+              "smallAllocs": 1413149
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 116093,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 7669942,
+            "smallAllocs": 347380
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 3880164,
+            "smallAllocs": 352920
+          },
+          "frobeniusPower": {
+            "nanos": 8293,
+            "smallAllocs": 585
+          },
+          "kernelDimension": 10,
+          "matrixConversionNanos": 137984,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 3932411,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 11,
+          "nullspaceBasisMagnitudeNanos": 75092,
+          "nullspaceBasisNanos": 75092,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 6961,
+            "packNanos": 285984,
+            "rank": 70,
+            "reduceNanos": 1273898,
+            "rowAdds": 4277,
+            "smallAllocs": 8060,
+            "totalNanos": 1566713
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 6771,
+            "packNanos": 286124,
+            "rank": 70,
+            "reduceNanos": 1257894,
+            "rowAdds": 4277,
+            "smallAllocs": 8060,
+            "totalNanos": 1550789
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 6540,
+            "packNanos": 285594,
+            "rank": 70,
+            "reduceNanos": 1010728,
+            "rowAdds": 4277,
+            "smallAllocs": 8060,
+            "totalNanos": 1302511
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 27641,
+            "packNanos": 275458,
+            "rank": 70,
+            "reduceNanos": 2803837,
+            "rowAdds": 4277,
+            "smallAllocs": 355100,
+            "totalNanos": 3103612
+          },
+          "peakResidentBytes": 67006464,
+          "productionMatrixRebuild": {
+            "nanos": 3899953,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 24232911,
+            "smallAllocs": 1408888
+          },
+          "productionRowReduce": {
+            "nanos": 24157819,
+            "smallAllocs": 1401336
+          },
+          "rank": 70,
+          "residentBytesAfter": 64397312,
+          "residentBytesBefore": 67342336,
+          "rowReduceMatrixRebuild": {
+            "nanos": 3938209,
+            "smallAllocs": 0
+          },
+          "sink": 4,
+          "splitFactors": 10
+        },
+        "modularDegree": 80,
+        "modularFactorCount": 10,
+        "prime": 11,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi64_x_phi105",
+      "status": "ok"
+    },
+    {
+      "degree": 144,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 144,
+          "basisToPolynomials": {
+            "nanos": 5338,
+            "smallAllocs": 387
+          },
+          "berlekampMatrixWall": {
+            "nanos": 7940564,
+            "smallAllocs": 722207
+          },
+          "berlekampSplit": {
+            "nanos": 34123856,
+            "smallAllocs": 1239327
+          },
+          "columnPolys": {
+            "nanos": 7466811,
+            "smallAllocs": 680459
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 8,
+            "pivotSearch": {
+              "nanos": 3665,
+              "smallAllocs": 288
+            },
+            "pivots": 136,
+            "rowAdd": {
+              "nanos": 64719029,
+              "smallAllocs": 3858949
+            },
+            "rowAdds": 13149,
+            "rowAddsSkipped": 6299,
+            "rowSwapScale": {
+              "nanos": 918667,
+              "smallAllocs": 59552
+            },
+            "stagedNanos": 65641361,
+            "wall": {
+              "nanos": 65945948,
+              "smallAllocs": 3919428
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 8,
+            "pivotSearch": {
+              "nanos": 3851,
+              "smallAllocs": 288
+            },
+            "pivots": 136,
+            "rowAdd": {
+              "nanos": 128355104,
+              "smallAllocs": 7645861
+            },
+            "rowAdds": 13149,
+            "rowAddsSkipped": 6299,
+            "rowSwapScale": {
+              "nanos": 1294380,
+              "smallAllocs": 79136
+            },
+            "stagedNanos": 129642150,
+            "wall": {
+              "nanos": 129938400,
+              "smallAllocs": 7725927
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 350329,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 28512055,
+            "smallAllocs": 723728
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 8290632,
+            "smallAllocs": 743088
+          },
+          "frobeniusPower": {
+            "nanos": 5949,
+            "smallAllocs": 277
+          },
+          "kernelDimension": 8,
+          "matrixConversionNanos": 489495,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 8375188,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 7,
+          "nullspaceBasisMagnitudeNanos": 1876571,
+          "nullspaceBasisNanos": 1876571,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 16434,
+            "packNanos": 989968,
+            "rank": 136,
+            "reduceNanos": 6872029,
+            "rowAdds": 13149,
+            "smallAllocs": 27764,
+            "totalNanos": 7885652
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 15603,
+            "packNanos": 959182,
+            "rank": 136,
+            "reduceNanos": 6749597,
+            "rowAdds": 13149,
+            "smallAllocs": 27764,
+            "totalNanos": 7723692
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 16935,
+            "packNanos": 957599,
+            "rank": 136,
+            "reduceNanos": 5188603,
+            "rowAdds": 13149,
+            "smallAllocs": 27764,
+            "totalNanos": 6162658
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 120158,
+            "packNanos": 930680,
+            "rank": 136,
+            "reduceNanos": 15489417,
+            "rowAdds": 13149,
+            "smallAllocs": 1938068,
+            "totalNanos": 16540255
+          },
+          "peakResidentBytes": 67006464,
+          "productionMatrixRebuild": {
+            "nanos": 8333556,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 131391735,
+            "smallAllocs": 7708346
+          },
+          "productionRowReduce": {
+            "nanos": 130742393,
+            "smallAllocs": 7685628
+          },
+          "rank": 136,
+          "residentBytesAfter": 65859584,
+          "residentBytesBefore": 64282624,
+          "rowReduceMatrixRebuild": {
+            "nanos": 8431241,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 8
+        },
+        "modularDegree": 144,
+        "modularFactorCount": 8,
+        "prime": 7,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi128_x_phi165",
+      "status": "ok"
+    },
+    {
+      "degree": 240,
+      "family": "cyclotomic",
+      "kernel": {
+        "kernel": {
+          "basisSize": 240,
+          "basisToPolynomials": {
+            "nanos": 6170,
+            "smallAllocs": 523
+          },
+          "berlekampMatrixWall": {
+            "nanos": 7523616,
+            "smallAllocs": 660179
+          },
+          "berlekampSplit": {
+            "nanos": 58227063,
+            "smallAllocs": 1030964
+          },
+          "columnPolys": {
+            "nanos": 6301483,
+            "smallAllocs": 544863
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 6167,
+              "smallAllocs": 480
+            },
+            "pivots": 236,
+            "rowAdd": {
+              "nanos": 150777467,
+              "smallAllocs": 8803144
+            },
+            "rowAdds": 17948,
+            "rowAddsSkipped": 38456,
+            "rowSwapScale": {
+              "nanos": 2730834,
+              "smallAllocs": 171267
+            },
+            "stagedNanos": 153514585,
+            "wall": {
+              "nanos": 154348413,
+              "smallAllocs": 8975874
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 6467,
+              "smallAllocs": 480
+            },
+            "pivots": 236,
+            "rowAdd": {
+              "nanos": 297868182,
+              "smallAllocs": 17418184
+            },
+            "rowAdds": 17948,
+            "rowAddsSkipped": 38456,
+            "rowSwapScale": {
+              "nanos": 3773193,
+              "smallAllocs": 227907
+            },
+            "stagedNanos": 301647932,
+            "wall": {
+              "nanos": 302485437,
+              "smallAllocs": 17647557
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 939262,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 54056690,
+            "smallAllocs": 661844
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 8405533,
+            "smallAllocs": 718020
+          },
+          "frobeniusPower": {
+            "nanos": 3175,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 4,
+          "matrixConversionNanos": 1200170,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 8723385,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 708841,
+          "nullspaceBasisNanos": 708841,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 40400,
+            "packNanos": 2784208,
+            "rank": 236,
+            "reduceNanos": 15636174,
+            "rowAdds": 17948,
+            "smallAllocs": 97269,
+            "totalNanos": 18462625
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 39038,
+            "packNanos": 2788585,
+            "rank": 236,
+            "reduceNanos": 15404441,
+            "rowAdds": 17948,
+            "smallAllocs": 97269,
+            "totalNanos": 18232003
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 39038,
+            "packNanos": 2778090,
+            "rank": 236,
+            "reduceNanos": 9290725,
+            "rowAdds": 17948,
+            "smallAllocs": 97269,
+            "totalNanos": 12107853
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 282118,
+            "packNanos": 2713383,
+            "rank": 236,
+            "reduceNanos": 37122302,
+            "rowAdds": 17948,
+            "smallAllocs": 4446309,
+            "totalNanos": 40100137
+          },
+          "peakResidentBytes": 70430720,
+          "productionMatrixRebuild": {
+            "nanos": 8765527,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 308176826,
+            "smallAllocs": 17591476
+          },
+          "productionRowReduce": {
+            "nanos": 304026502,
+            "smallAllocs": 17532366
+          },
+          "rank": 236,
+          "residentBytesAfter": 69103616,
+          "residentBytesBefore": 65794048,
+          "rowReduceMatrixRebuild": {
+            "nanos": 8930151,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 4
+        },
+        "modularDegree": 240,
+        "modularFactorCount": 4,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi385",
+      "status": "ok"
+    },
+    {
+      "degree": 40,
+      "family": "wilkinson",
+      "kernel": {
+        "kernel": {
+          "basisSize": 40,
+          "basisToPolynomials": {
+            "nanos": 18437,
+            "smallAllocs": 1843
+          },
+          "berlekampMatrixWall": {
+            "nanos": 193677,
+            "smallAllocs": 17281
+          },
+          "berlekampSplit": {
+            "nanos": 1732990,
+            "smallAllocs": 146136
+          },
+          "columnPolys": {
+            "nanos": 74090,
+            "smallAllocs": 6155
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 40,
+            "pivotSearch": {
+              "nanos": 932,
+              "smallAllocs": 80
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 932,
+            "wall": {
+              "nanos": 43234,
+              "smallAllocs": 1807
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 40,
+            "pivotSearch": {
+              "nanos": 993,
+              "smallAllocs": 80
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 993,
+            "wall": {
+              "nanos": 41622,
+              "smallAllocs": 1810
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 28372,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 224202,
+            "smallAllocs": 17402
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 221268,
+            "smallAllocs": 18922
+          },
+          "frobeniusPower": {
+            "nanos": 84425,
+            "smallAllocs": 7927
+          },
+          "kernelDimension": 40,
+          "matrixConversionNanos": 35472,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 223271,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 47,
+          "nullspaceBasisMagnitudeNanos": 40070,
+          "nullspaceBasisNanos": 40070,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2013,
+            "packNanos": 66459,
+            "rank": 0,
+            "reduceNanos": 4798,
+            "rowAdds": 0,
+            "smallAllocs": 1777,
+            "totalNanos": 73178
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1633,
+            "packNanos": 66399,
+            "rank": 0,
+            "reduceNanos": 4357,
+            "rowAdds": 0,
+            "smallAllocs": 1777,
+            "totalNanos": 72457
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1642,
+            "packNanos": 66468,
+            "rank": 0,
+            "reduceNanos": 4276,
+            "rowAdds": 0,
+            "smallAllocs": 1777,
+            "totalNanos": 72457
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5958,
+            "packNanos": 64555,
+            "rank": 0,
+            "reduceNanos": 4928,
+            "rowAdds": 0,
+            "smallAllocs": 1777,
+            "totalNanos": 75441
+          },
+          "peakResidentBytes": 70258688,
+          "productionMatrixRebuild": {
+            "nanos": 223762,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 85127,
+            "smallAllocs": 1728
+          },
+          "productionRowReduce": {
+            "nanos": 45057,
+            "smallAllocs": 1607
+          },
+          "rank": 0,
+          "residentBytesAfter": 69840896,
+          "residentBytesBefore": 69767168,
+          "rowReduceMatrixRebuild": {
+            "nanos": 228739,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 40
+        },
+        "modularDegree": 40,
+        "modularFactorCount": 40,
+        "prime": 47,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "wilkinson_40",
+      "status": "ok"
+    },
+    {
+      "degree": 48,
+      "family": "wilkinson",
+      "kernel": {
+        "kernel": {
+          "basisSize": 48,
+          "basisToPolynomials": {
+            "nanos": 26569,
+            "smallAllocs": 2595
+          },
+          "berlekampMatrixWall": {
+            "nanos": 277922,
+            "smallAllocs": 24749
+          },
+          "berlekampSplit": {
+            "nanos": 2767103,
+            "smallAllocs": 235614
+          },
+          "columnPolys": {
+            "nanos": 104124,
+            "smallAllocs": 8727
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 48,
+            "pivotSearch": {
+              "nanos": 1127,
+              "smallAllocs": 96
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 1127,
+            "wall": {
+              "nanos": 63163,
+              "smallAllocs": 2551
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 48,
+            "pivotSearch": {
+              "nanos": 1128,
+              "smallAllocs": 96
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 1128,
+            "wall": {
+              "nanos": 58808,
+              "smallAllocs": 2554
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 40160,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 320114,
+            "smallAllocs": 24894
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 316039,
+            "smallAllocs": 27102
+          },
+          "frobeniusPower": {
+            "nanos": 122021,
+            "smallAllocs": 11415
+          },
+          "kernelDimension": 48,
+          "matrixConversionNanos": 49775,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 321758,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 61,
+          "nullspaceBasisMagnitudeNanos": 56494,
+          "nullspaceBasisNanos": 56494,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2453,
+            "packNanos": 97835,
+            "rank": 0,
+            "reduceNanos": 6410,
+            "rowAdds": 0,
+            "smallAllocs": 2513,
+            "totalNanos": 106638
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2143,
+            "packNanos": 97375,
+            "rank": 0,
+            "reduceNanos": 5938,
+            "rowAdds": 0,
+            "smallAllocs": 2513,
+            "totalNanos": 105456
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2123,
+            "packNanos": 100269,
+            "rank": 0,
+            "reduceNanos": 5879,
+            "rowAdds": 0,
+            "smallAllocs": 2513,
+            "totalNanos": 108271
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 7712,
+            "packNanos": 93649,
+            "rank": 0,
+            "reduceNanos": 6390,
+            "rowAdds": 0,
+            "smallAllocs": 2513,
+            "totalNanos": 107730
+          },
+          "peakResidentBytes": 70258688,
+          "productionMatrixRebuild": {
+            "nanos": 320255,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 122031,
+            "smallAllocs": 2456
+          },
+          "productionRowReduce": {
+            "nanos": 65537,
+            "smallAllocs": 2311
+          },
+          "rank": 0,
+          "residentBytesAfter": 69906432,
+          "residentBytesBefore": 69857280,
+          "rowReduceMatrixRebuild": {
+            "nanos": 320836,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 48
+        },
+        "modularDegree": 48,
+        "modularFactorCount": 48,
+        "prime": 61,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "wilkinson_48",
+      "status": "ok"
+    },
+    {
+      "degree": 56,
+      "family": "wilkinson",
+      "kernel": {
+        "kernel": {
+          "basisSize": 56,
+          "basisToPolynomials": {
+            "nanos": 34791,
+            "smallAllocs": 3475
+          },
+          "berlekampMatrixWall": {
+            "nanos": 449797,
+            "smallAllocs": 40562
+          },
+          "berlekampSplit": {
+            "nanos": 4199607,
+            "smallAllocs": 360583
+          },
+          "columnPolys": {
+            "nanos": 139276,
+            "smallAllocs": 11747
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 56,
+            "pivotSearch": {
+              "nanos": 1321,
+              "smallAllocs": 112
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 1321,
+            "wall": {
+              "nanos": 84856,
+              "smallAllocs": 3423
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 56,
+            "pivotSearch": {
+              "nanos": 1325,
+              "smallAllocs": 112
+            },
+            "pivots": 0,
+            "rowAdd": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "rowAdds": 0,
+            "rowAddsSkipped": 0,
+            "rowSwapScale": {
+              "nanos": 0,
+              "smallAllocs": 0
+            },
+            "stagedNanos": 1325,
+            "wall": {
+              "nanos": 80409,
+              "smallAllocs": 3426
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 52087,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 507522,
+            "smallAllocs": 40731
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 502395,
+            "smallAllocs": 43755
+          },
+          "frobeniusPower": {
+            "nanos": 239736,
+            "smallAllocs": 22544
+          },
+          "kernelDimension": 56,
+          "matrixConversionNanos": 72488,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 507072,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 67,
+          "nullspaceBasisMagnitudeNanos": 74931,
+          "nullspaceBasisNanos": 74931,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2964,
+            "packNanos": 136653,
+            "rank": 0,
+            "reduceNanos": 8372,
+            "rowAdds": 0,
+            "smallAllocs": 3377,
+            "totalNanos": 148039
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2654,
+            "packNanos": 136832,
+            "rank": 0,
+            "reduceNanos": 7952,
+            "rowAdds": 0,
+            "smallAllocs": 3377,
+            "totalNanos": 147368
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2583,
+            "packNanos": 136252,
+            "rank": 0,
+            "reduceNanos": 7931,
+            "rowAdds": 0,
+            "smallAllocs": 3377,
+            "totalNanos": 146737
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 11016,
+            "packNanos": 129812,
+            "rank": 0,
+            "reduceNanos": 8543,
+            "rowAdds": 0,
+            "smallAllocs": 3377,
+            "totalNanos": 149351
+          },
+          "peakResidentBytes": 70258688,
+          "productionMatrixRebuild": {
+            "nanos": 503787,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 163763,
+            "smallAllocs": 3312
+          },
+          "productionRowReduce": {
+            "nanos": 89562,
+            "smallAllocs": 3143
+          },
+          "rank": 0,
+          "residentBytesAfter": 69906432,
+          "residentBytesBefore": 69906432,
+          "rowReduceMatrixRebuild": {
+            "nanos": 510066,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 56
+        },
+        "modularDegree": 56,
+        "modularFactorCount": 56,
+        "prime": 67,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "wilkinson_56",
+      "status": "ok"
+    },
+    {
+      "degree": 24,
+      "family": "chebyshev",
+      "kernel": {
+        "kernel": {
+          "basisSize": 24,
+          "basisToPolynomials": {
+            "nanos": 1132,
+            "smallAllocs": 90
+          },
+          "berlekampMatrixWall": {
+            "nanos": 120879,
+            "smallAllocs": 10805
+          },
+          "berlekampSplit": {
+            "nanos": 201479,
+            "smallAllocs": 13395
+          },
+          "columnPolys": {
+            "nanos": 106467,
+            "smallAllocs": 9437
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 3,
+            "pivotSearch": {
+              "nanos": 602,
+              "smallAllocs": 48
+            },
+            "pivots": 21,
+            "rowAdd": {
+              "nanos": 128009,
+              "smallAllocs": 7021
+            },
+            "rowAdds": 112,
+            "rowAddsSkipped": 371,
+            "rowSwapScale": {
+              "nanos": 26743,
+              "smallAllocs": 1639
+            },
+            "stagedNanos": 155204,
+            "wall": {
+              "nanos": 164925,
+              "smallAllocs": 8826
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 3,
+            "pivotSearch": {
+              "nanos": 623,
+              "smallAllocs": 48
+            },
+            "pivots": 21,
+            "rowAdd": {
+              "nanos": 218346,
+              "smallAllocs": 12397
+            },
+            "rowAdds": 112,
+            "rowAddsSkipped": 371,
+            "rowSwapScale": {
+              "nanos": 36402,
+              "smallAllocs": 2143
+            },
+            "stagedNanos": 257203,
+            "wall": {
+              "nanos": 266976,
+              "smallAllocs": 14709
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 11317,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 170012,
+            "smallAllocs": 10941
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 132076,
+            "smallAllocs": 11406
+          },
+          "frobeniusPower": {
+            "nanos": 3375,
+            "smallAllocs": 217
+          },
+          "kernelDimension": 3,
+          "matrixConversionNanos": 11959,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 132497,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 5,
+          "nullspaceBasisMagnitudeNanos": 13521,
+          "nullspaceBasisNanos": 13521,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1252,
+            "packNanos": 22013,
+            "rank": 21,
+            "reduceNanos": 20871,
+            "rowAdds": 112,
+            "smallAllocs": 1081,
+            "totalNanos": 44616
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 851,
+            "packNanos": 21902,
+            "rank": 21,
+            "reduceNanos": 18027,
+            "rowAdds": 112,
+            "smallAllocs": 1081,
+            "totalNanos": 40780
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 851,
+            "packNanos": 21792,
+            "rank": 21,
+            "reduceNanos": 14552,
+            "rowAdds": 112,
+            "smallAllocs": 1081,
+            "totalNanos": 37145
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2915,
+            "packNanos": 21041,
+            "rank": 21,
+            "reduceNanos": 31727,
+            "rowAdds": 112,
+            "smallAllocs": 4129,
+            "totalNanos": 55683
+          },
+          "peakResidentBytes": 70258688,
+          "productionMatrixRebuild": {
+            "nanos": 132276,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 261158,
+            "smallAllocs": 14185
+          },
+          "productionRowReduce": {
+            "nanos": 248188,
+            "smallAllocs": 13515
+          },
+          "rank": 21,
+          "residentBytesAfter": 69910528,
+          "residentBytesBefore": 69910528,
+          "rowReduceMatrixRebuild": {
+            "nanos": 133268,
+            "smallAllocs": 0
+          },
+          "sink": 20,
+          "splitFactors": 3
+        },
+        "modularDegree": 24,
+        "modularFactorCount": 3,
+        "prime": 5,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "chebyshev_T24",
+      "status": "ok"
+    },
+    {
+      "degree": 24,
+      "family": "chebyshev",
+      "kernel": {
+        "kernel": {
+          "basisSize": 24,
+          "basisToPolynomials": {
+            "nanos": 1171,
+            "smallAllocs": 99
+          },
+          "berlekampMatrixWall": {
+            "nanos": 85406,
+            "smallAllocs": 7348
+          },
+          "berlekampSplit": {
+            "nanos": 192926,
+            "smallAllocs": 12764
+          },
+          "columnPolys": {
+            "nanos": 70425,
+            "smallAllocs": 6080
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 581,
+              "smallAllocs": 48
+            },
+            "pivots": 20,
+            "rowAdd": {
+              "nanos": 112558,
+              "smallAllocs": 6262
+            },
+            "rowAdds": 98,
+            "rowAddsSkipped": 362,
+            "rowSwapScale": {
+              "nanos": 25327,
+              "smallAllocs": 1560
+            },
+            "stagedNanos": 138508,
+            "wall": {
+              "nanos": 148099,
+              "smallAllocs": 7993
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 630,
+              "smallAllocs": 48
+            },
+            "pivots": 20,
+            "rowAdd": {
+              "nanos": 192145,
+              "smallAllocs": 10966
+            },
+            "rowAdds": 98,
+            "rowAddsSkipped": 362,
+            "rowSwapScale": {
+              "nanos": 34549,
+              "smallAllocs": 2040
+            },
+            "stagedNanos": 226847,
+            "wall": {
+              "nanos": 235939,
+              "smallAllocs": 13180
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 10547,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 129172,
+            "smallAllocs": 7501
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 95843,
+            "smallAllocs": 7949
+          },
+          "frobeniusPower": {
+            "nanos": 1993,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 4,
+          "matrixConversionNanos": 13008,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 95652,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 13420,
+          "nullspaceBasisNanos": 13420,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1072,
+            "packNanos": 21882,
+            "rank": 20,
+            "reduceNanos": 17175,
+            "rowAdds": 98,
+            "smallAllocs": 1071,
+            "totalNanos": 40359
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 891,
+            "packNanos": 21743,
+            "rank": 20,
+            "reduceNanos": 15984,
+            "rowAdds": 98,
+            "smallAllocs": 1071,
+            "totalNanos": 38547
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 871,
+            "packNanos": 21733,
+            "rank": 20,
+            "reduceNanos": 13130,
+            "rowAdds": 98,
+            "smallAllocs": 1071,
+            "totalNanos": 35713
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2734,
+            "packNanos": 20931,
+            "rank": 20,
+            "reduceNanos": 28242,
+            "rowAdds": 98,
+            "smallAllocs": 3687,
+            "totalNanos": 51847
+          },
+          "peakResidentBytes": 70258688,
+          "productionMatrixRebuild": {
+            "nanos": 95812,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 234378,
+            "smallAllocs": 12726
+          },
+          "productionRowReduce": {
+            "nanos": 220988,
+            "smallAllocs": 12037
+          },
+          "rank": 20,
+          "residentBytesAfter": 69910528,
+          "residentBytesBefore": 69910528,
+          "rowReduceMatrixRebuild": {
+            "nanos": 98997,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 4
+        },
+        "modularDegree": 24,
+        "modularFactorCount": 4,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "chebyshev_U24",
+      "status": "ok"
+    },
+    {
+      "degree": 30,
+      "family": "legendre",
+      "kernel": {
+        "kernel": {
+          "basisSize": 30,
+          "basisToPolynomials": {
+            "nanos": 1902,
+            "smallAllocs": 146
+          },
+          "berlekampMatrixWall": {
+            "nanos": 1226448,
+            "smallAllocs": 116780
+          },
+          "berlekampSplit": {
+            "nanos": 1969981,
+            "smallAllocs": 167769
+          },
+          "columnPolys": {
+            "nanos": 1111448,
+            "smallAllocs": 106059
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 7,
+            "pivotSearch": {
+              "nanos": 750,
+              "smallAllocs": 60
+            },
+            "pivots": 23,
+            "rowAdd": {
+              "nanos": 381638,
+              "smallAllocs": 21308
+            },
+            "rowAdds": 315,
+            "rowAddsSkipped": 352,
+            "rowSwapScale": {
+              "nanos": 35283,
+              "smallAllocs": 2201
+            },
+            "stagedNanos": 417671,
+            "wall": {
+              "nanos": 432331,
+              "smallAllocs": 23741
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 7,
+            "pivotSearch": {
+              "nanos": 730,
+              "smallAllocs": 60
+            },
+            "pivots": 23,
+            "rowAdd": {
+              "nanos": 691319,
+              "smallAllocs": 40208
+            },
+            "rowAdds": 315,
+            "rowAddsSkipped": 352,
+            "rowSwapScale": {
+              "nanos": 48733,
+              "smallAllocs": 2891
+            },
+            "stagedNanos": 740837,
+            "wall": {
+              "nanos": 755190,
+              "smallAllocs": 43334
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 11597,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 1355961,
+            "smallAllocs": 117032
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 1238476,
+            "smallAllocs": 117711
+          },
+          "frobeniusPower": {
+            "nanos": 95232,
+            "smallAllocs": 8922
+          },
+          "kernelDimension": 7,
+          "matrixConversionNanos": 18708,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 1236604,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 67,
+          "nullspaceBasisMagnitudeNanos": 22634,
+          "nullspaceBasisNanos": 22634,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1773,
+            "packNanos": 36425,
+            "rank": 23,
+            "reduceNanos": 46659,
+            "rowAdds": 315,
+            "smallAllocs": 1412,
+            "totalNanos": 84626
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1462,
+            "packNanos": 36073,
+            "rank": 23,
+            "reduceNanos": 45097,
+            "rowAdds": 315,
+            "smallAllocs": 1412,
+            "totalNanos": 82602
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1412,
+            "packNanos": 35973,
+            "rank": 23,
+            "reduceNanos": 33220,
+            "rowAdds": 315,
+            "smallAllocs": 1412,
+            "totalNanos": 70594
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 4297,
+            "packNanos": 34531,
+            "rank": 23,
+            "reduceNanos": 89753,
+            "rowAdds": 315,
+            "smallAllocs": 11552,
+            "totalNanos": 128701
+          },
+          "peakResidentBytes": 70258688,
+          "productionMatrixRebuild": {
+            "nanos": 1239127,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 762361,
+            "smallAllocs": 42855
+          },
+          "productionRowReduce": {
+            "nanos": 739035,
+            "smallAllocs": 41732
+          },
+          "rank": 23,
+          "residentBytesAfter": 63959040,
+          "residentBytesBefore": 63885312,
+          "rowReduceMatrixRebuild": {
+            "nanos": 1240299,
+            "smallAllocs": 0
+          },
+          "sink": 20,
+          "splitFactors": 7
+        },
+        "modularDegree": 30,
+        "modularFactorCount": 7,
+        "prime": 67,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "legendre_P30",
+      "status": "ok"
+    },
+    {
+      "degree": 38,
+      "family": "legendre",
+      "kernel": {
+        "kernel": {
+          "basisSize": 38,
+          "basisToPolynomials": {
+            "nanos": 1202,
+            "smallAllocs": 100
+          },
+          "berlekampMatrixWall": {
+            "nanos": 2416183,
+            "smallAllocs": 232849
+          },
+          "berlekampSplit": {
+            "nanos": 2948802,
+            "smallAllocs": 251152
+          },
+          "columnPolys": {
+            "nanos": 2237107,
+            "smallAllocs": 215798
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 3,
+            "pivotSearch": {
+              "nanos": 911,
+              "smallAllocs": 76
+            },
+            "pivots": 35,
+            "rowAdd": {
+              "nanos": 911961,
+              "smallAllocs": 51765
+            },
+            "rowAdds": 620,
+            "rowAddsSkipped": 675,
+            "rowSwapScale": {
+              "nanos": 65829,
+              "smallAllocs": 4185
+            },
+            "stagedNanos": 978559,
+            "wall": {
+              "nanos": 999733,
+              "smallAllocs": 56191
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 3,
+            "pivotSearch": {
+              "nanos": 960,
+              "smallAllocs": 76
+            },
+            "pivots": 35,
+            "rowAdd": {
+              "nanos": 1673521,
+              "smallAllocs": 98885
+            },
+            "rowAdds": 620,
+            "rowAddsSkipped": 675,
+            "rowSwapScale": {
+              "nanos": 90054,
+              "smallAllocs": 5515
+            },
+            "stagedNanos": 1764545,
+            "wall": {
+              "nanos": 1785037,
+              "smallAllocs": 104644
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 29184,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 2748134,
+            "smallAllocs": 233069
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 2447408,
+            "smallAllocs": 234332
+          },
+          "frobeniusPower": {
+            "nanos": 150393,
+            "smallAllocs": 14164
+          },
+          "kernelDimension": 3,
+          "matrixConversionNanos": 30086,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 2467358,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 79,
+          "nullspaceBasisMagnitudeNanos": 24016,
+          "nullspaceBasisNanos": 24016,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1843,
+            "packNanos": 59839,
+            "rank": 35,
+            "reduceNanos": 107309,
+            "rowAdds": 620,
+            "smallAllocs": 2323,
+            "totalNanos": 168971
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1513,
+            "packNanos": 59628,
+            "rank": 35,
+            "reduceNanos": 103454,
+            "rowAdds": 620,
+            "smallAllocs": 2323,
+            "totalNanos": 164624
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1492,
+            "packNanos": 59308,
+            "rank": 35,
+            "reduceNanos": 73669,
+            "rowAdds": 620,
+            "smallAllocs": 2323,
+            "totalNanos": 134620
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 5738,
+            "packNanos": 58097,
+            "rank": 35,
+            "reduceNanos": 208489,
+            "rowAdds": 620,
+            "smallAllocs": 27175,
+            "totalNanos": 272575
+          },
+          "peakResidentBytes": 70258688,
+          "productionMatrixRebuild": {
+            "nanos": 2468661,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 1786499,
+            "smallAllocs": 103304
+          },
+          "productionRowReduce": {
+            "nanos": 1761992,
+            "smallAllocs": 101686
+          },
+          "rank": 35,
+          "residentBytesAfter": 64110592,
+          "residentBytesBefore": 64069632,
+          "rowReduceMatrixRebuild": {
+            "nanos": 2480107,
+            "smallAllocs": 0
+          },
+          "sink": 18,
+          "splitFactors": 3
+        },
+        "modularDegree": 38,
+        "modularFactorCount": 3,
+        "prime": 79,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "legendre_P38",
+      "status": "ok"
+    },
+    {
+      "degree": 16,
+      "family": "cyclotomic",
+      "kernel": {
+        "kernel": {
+          "basisSize": 16,
+          "basisToPolynomials": {
+            "nanos": 641,
+            "smallAllocs": 40
+          },
+          "berlekampMatrixWall": {
+            "nanos": 33189,
+            "smallAllocs": 2759
+          },
+          "berlekampSplit": {
+            "nanos": 50695,
+            "smallAllocs": 2865
+          },
+          "columnPolys": {
+            "nanos": 25648,
+            "smallAllocs": 2131
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 1,
+            "pivotSearch": {
+              "nanos": 410,
+              "smallAllocs": 32
+            },
+            "pivots": 15,
+            "rowAdd": {
+              "nanos": 44636,
+              "smallAllocs": 2385
+            },
+            "rowAdds": 50,
+            "rowAddsSkipped": 175,
+            "rowSwapScale": {
+              "nanos": 13411,
+              "smallAllocs": 808
+            },
+            "stagedNanos": 58656,
+            "wall": {
+              "nanos": 63214,
+              "smallAllocs": 3296
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 1,
+            "pivotSearch": {
+              "nanos": 391,
+              "smallAllocs": 32
+            },
+            "pivots": 15,
+            "rowAdd": {
+              "nanos": 72849,
+              "smallAllocs": 3985
+            },
+            "rowAdds": 50,
+            "rowAddsSkipped": 175,
+            "rowSwapScale": {
+              "nanos": 18406,
+              "smallAllocs": 1048
+            },
+            "stagedNanos": 91787,
+            "wall": {
+              "nanos": 96433,
+              "smallAllocs": 5139
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 5048,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 50474,
+            "smallAllocs": 2823
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 38497,
+            "smallAllocs": 3032
+          },
+          "frobeniusPower": {
+            "nanos": 2133,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 1,
+          "matrixConversionNanos": 5568,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 38337,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 3785,
+          "nullspaceBasisNanos": 3785,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 581,
+            "packNanos": 8493,
+            "rank": 15,
+            "reduceNanos": 8202,
+            "rowAdds": 50,
+            "smallAllocs": 527,
+            "totalNanos": 17276
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 391,
+            "packNanos": 8403,
+            "rank": 15,
+            "reduceNanos": 7681,
+            "rowAdds": 50,
+            "smallAllocs": 527,
+            "totalNanos": 16414
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 390,
+            "packNanos": 8392,
+            "rank": 15,
+            "reduceNanos": 6260,
+            "rowAdds": 50,
+            "smallAllocs": 527,
+            "totalNanos": 15012
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1292,
+            "packNanos": 8273,
+            "rank": 15,
+            "reduceNanos": 12708,
+            "rowAdds": 50,
+            "smallAllocs": 1551,
+            "totalNanos": 22273
+          },
+          "peakResidentBytes": 70258688,
+          "productionMatrixRebuild": {
+            "nanos": 38166,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 90594,
+            "smallAllocs": 4820
+          },
+          "productionRowReduce": {
+            "nanos": 86809,
+            "smallAllocs": 4531
+          },
+          "rank": 15,
+          "residentBytesAfter": 63950848,
+          "residentBytesBefore": 63938560,
+          "rowReduceMatrixRebuild": {
+            "nanos": 38307,
+            "smallAllocs": 0
+          },
+          "sink": 20,
+          "splitFactors": 1
+        },
+        "modularDegree": 16,
+        "modularFactorCount": 1,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi17",
+      "status": "ok"
+    },
+    {
+      "degree": 40,
+      "family": "cyclotomic",
+      "kernel": {
+        "kernel": {
+          "basisSize": 40,
+          "basisToPolynomials": {
+            "nanos": 1702,
+            "smallAllocs": 142
+          },
+          "berlekampMatrixWall": {
+            "nanos": 168971,
+            "smallAllocs": 14819
+          },
+          "berlekampSplit": {
+            "nanos": 461364,
+            "smallAllocs": 32512
+          },
+          "columnPolys": {
+            "nanos": 133879,
+            "smallAllocs": 11503
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 5,
+            "pivotSearch": {
+              "nanos": 970,
+              "smallAllocs": 80
+            },
+            "pivots": 35,
+            "rowAdd": {
+              "nanos": 202405,
+              "smallAllocs": 12335
+            },
+            "rowAdds": 100,
+            "rowAddsSkipped": 1265,
+            "rowSwapScale": {
+              "nanos": 68161,
+              "smallAllocs": 4412
+            },
+            "stagedNanos": 272095,
+            "wall": {
+              "nanos": 295208,
+              "smallAllocs": 17021
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 5,
+            "pivotSearch": {
+              "nanos": 1082,
+              "smallAllocs": 80
+            },
+            "pivots": 35,
+            "rowAdd": {
+              "nanos": 328153,
+              "smallAllocs": 20335
+            },
+            "rowAdds": 100,
+            "rowAddsSkipped": 1265,
+            "rowSwapScale": {
+              "nanos": 90724,
+              "smallAllocs": 5812
+            },
+            "stagedNanos": 419752,
+            "wall": {
+              "nanos": 440974,
+              "smallAllocs": 26424
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 26478,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 253887,
+            "smallAllocs": 15115
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 195329,
+            "smallAllocs": 16460
+          },
+          "frobeniusPower": {
+            "nanos": 2063,
+            "smallAllocs": 117
+          },
+          "kernelDimension": 5,
+          "matrixConversionNanos": 32889,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 202480,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 3,
+          "nullspaceBasisMagnitudeNanos": 30986,
+          "nullspaceBasisNanos": 30986,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2143,
+            "packNanos": 65968,
+            "rank": 35,
+            "reduceNanos": 34922,
+            "rowAdds": 100,
+            "smallAllocs": 3077,
+            "totalNanos": 103033
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1833,
+            "packNanos": 65868,
+            "rank": 35,
+            "reduceNanos": 33730,
+            "rowAdds": 100,
+            "smallAllocs": 3077,
+            "totalNanos": 101841
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1873,
+            "packNanos": 65698,
+            "rank": 35,
+            "reduceNanos": 28132,
+            "rowAdds": 100,
+            "smallAllocs": 3077,
+            "totalNanos": 95552
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 6480,
+            "packNanos": 63304,
+            "rank": 35,
+            "reduceNanos": 58016,
+            "rowAdds": 100,
+            "smallAllocs": 8397,
+            "totalNanos": 127610
+          },
+          "peakResidentBytes": 70258688,
+          "productionMatrixRebuild": {
+            "nanos": 200217,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 448135,
+            "smallAllocs": 25145
+          },
+          "productionRowReduce": {
+            "nanos": 417989,
+            "smallAllocs": 23316
+          },
+          "rank": 35,
+          "residentBytesAfter": 63987712,
+          "residentBytesBefore": 63950848,
+          "rowReduceMatrixRebuild": {
+            "nanos": 199595,
+            "smallAllocs": 0
+          },
+          "sink": 18,
+          "splitFactors": 5
+        },
+        "modularDegree": 40,
+        "modularFactorCount": 5,
+        "prime": 3,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "cyclo_phi41",
+      "status": "ok"
+    },
+    {
+      "degree": 24,
+      "family": "cyclotomic-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 24,
+          "basisToPolynomials": {
+            "nanos": 3235,
+            "smallAllocs": 308
+          },
+          "berlekampMatrixWall": {
+            "nanos": 149742,
+            "smallAllocs": 14147
+          },
+          "berlekampSplit": {
+            "nanos": 572138,
+            "smallAllocs": 46939
+          },
+          "columnPolys": {
+            "nanos": 130073,
+            "smallAllocs": 12411
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 13,
+            "pivotSearch": {
+              "nanos": 611,
+              "smallAllocs": 48
+            },
+            "pivots": 11,
+            "rowAdd": {
+              "nanos": 21372,
+              "smallAllocs": 1342
+            },
+            "rowAdds": 11,
+            "rowAddsSkipped": 242,
+            "rowSwapScale": {
+              "nanos": 13852,
+              "smallAllocs": 876
+            },
+            "stagedNanos": 35876,
+            "wall": {
+              "nanos": 47000,
+              "smallAllocs": 2543
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 13,
+            "pivotSearch": {
+              "nanos": 621,
+              "smallAllocs": 48
+            },
+            "pivots": 11,
+            "rowAdd": {
+              "nanos": 30545,
+              "smallAllocs": 1870
+            },
+            "rowAdds": 11,
+            "rowAddsSkipped": 242,
+            "rowSwapScale": {
+              "nanos": 18656,
+              "smallAllocs": 1140
+            },
+            "stagedNanos": 49804,
+            "wall": {
+              "nanos": 60480,
+              "smallAllocs": 3338
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 11065,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 167358,
+            "smallAllocs": 14363
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 160849,
+            "smallAllocs": 14748
+          },
+          "frobeniusPower": {
+            "nanos": 7451,
+            "smallAllocs": 585
+          },
+          "kernelDimension": 13,
+          "matrixConversionNanos": 11987,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 160487,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 11,
+          "nullspaceBasisMagnitudeNanos": 17497,
+          "nullspaceBasisNanos": 17497,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1362,
+            "packNanos": 22013,
+            "rank": 11,
+            "reduceNanos": 6670,
+            "rowAdds": 11,
+            "smallAllocs": 942,
+            "totalNanos": 30606
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1162,
+            "packNanos": 21782,
+            "rank": 11,
+            "reduceNanos": 6049,
+            "rowAdds": 11,
+            "smallAllocs": 942,
+            "totalNanos": 28953
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1132,
+            "packNanos": 21783,
+            "rank": 11,
+            "reduceNanos": 5779,
+            "rowAdds": 11,
+            "smallAllocs": 942,
+            "totalNanos": 28653
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 3275,
+            "packNanos": 21042,
+            "rank": 11,
+            "reduceNanos": 9213,
+            "rowAdds": 11,
+            "smallAllocs": 1470,
+            "totalNanos": 33319
+          },
+          "peakResidentBytes": 70258688,
+          "productionMatrixRebuild": {
+            "nanos": 160418,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 68622,
+            "smallAllocs": 3266
+          },
+          "productionRowReduce": {
+            "nanos": 51246,
+            "smallAllocs": 2654
+          },
+          "rank": 11,
+          "residentBytesAfter": 64008192,
+          "residentBytesBefore": 64008192,
+          "rowReduceMatrixRebuild": {
+            "nanos": 160298,
+            "smallAllocs": 0
+          },
+          "sink": 20,
+          "splitFactors": 13
+        },
+        "modularDegree": 24,
+        "modularFactorCount": 13,
+        "prime": 11,
+        "retainedGoodPrimes": 2,
+        "status": "ok"
+      },
+      "name": "xpow24_minus1",
+      "status": "ok"
+    },
+    {
+      "degree": 20,
+      "family": "random-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 20,
+          "basisToPolynomials": {
+            "nanos": 942,
+            "smallAllocs": 75
+          },
+          "berlekampMatrixWall": {
+            "nanos": 166417,
+            "smallAllocs": 15130
+          },
+          "berlekampSplit": {
+            "nanos": 338472,
+            "smallAllocs": 23484
+          },
+          "columnPolys": {
+            "nanos": 155130,
+            "smallAllocs": 14054
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 491,
+              "smallAllocs": 40
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 198946,
+              "smallAllocs": 10529
+            },
+            "rowAdds": 233,
+            "rowAddsSkipped": 71,
+            "rowSwapScale": {
+              "nanos": 16824,
+              "smallAllocs": 1043
+            },
+            "stagedNanos": 216230,
+            "wall": {
+              "nanos": 223111,
+              "smallAllocs": 11711
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 4,
+            "pivotSearch": {
+              "nanos": 552,
+              "smallAllocs": 40
+            },
+            "pivots": 16,
+            "rowAdd": {
+              "nanos": 357731,
+              "smallAllocs": 19849
+            },
+            "rowAdds": 233,
+            "rowAddsSkipped": 71,
+            "rowSwapScale": {
+              "nanos": 22992,
+              "smallAllocs": 1363
+            },
+            "stagedNanos": 381275,
+            "wall": {
+              "nanos": 387815,
+              "smallAllocs": 21354
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 8862,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 238593,
+            "smallAllocs": 15255
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 175210,
+            "smallAllocs": 15551
+          },
+          "frobeniusPower": {
+            "nanos": 4046,
+            "smallAllocs": 277
+          },
+          "kernelDimension": 4,
+          "matrixConversionNanos": 8132,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 175470,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 7,
+          "nullspaceBasisMagnitudeNanos": 8323,
+          "nullspaceBasisNanos": 8323,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 961,
+            "packNanos": 14622,
+            "rank": 16,
+            "reduceNanos": 22934,
+            "rowAdds": 233,
+            "smallAllocs": 584,
+            "totalNanos": 38377
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 701,
+            "packNanos": 14472,
+            "rank": 16,
+            "reduceNanos": 22102,
+            "rowAdds": 233,
+            "smallAllocs": 584,
+            "totalNanos": 37155
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 671,
+            "packNanos": 14502,
+            "rank": 16,
+            "reduceNanos": 18076,
+            "rowAdds": 233,
+            "smallAllocs": 584,
+            "totalNanos": 33249
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2133,
+            "packNanos": 13930,
+            "rank": 16,
+            "reduceNanos": 43886,
+            "rowAdds": 233,
+            "smallAllocs": 5524,
+            "totalNanos": 59949
+          },
+          "peakResidentBytes": 70258688,
+          "productionMatrixRebuild": {
+            "nanos": 174588,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 386563,
+            "smallAllocs": 21079
+          },
+          "productionRowReduce": {
+            "nanos": 378240,
+            "smallAllocs": 20563
+          },
+          "rank": 16,
+          "residentBytesAfter": 64032768,
+          "residentBytesBefore": 64016384,
+          "rowReduceMatrixRebuild": {
+            "nanos": 175129,
+            "smallAllocs": 0
+          },
+          "sink": 2,
+          "splitFactors": 4
+        },
+        "modularDegree": 20,
+        "modularFactorCount": 4,
+        "prime": 7,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "randprod_10",
+      "status": "ok"
+    },
+    {
+      "degree": 24,
+      "family": "random-products",
+      "kernel": {
+        "kernel": {
+          "basisSize": 24,
+          "basisToPolynomials": {
+            "nanos": 1622,
+            "smallAllocs": 128
+          },
+          "berlekampMatrixWall": {
+            "nanos": 568403,
+            "smallAllocs": 52728
+          },
+          "berlekampSplit": {
+            "nanos": 875809,
+            "smallAllocs": 68180
+          },
+          "columnPolys": {
+            "nanos": 535544,
+            "smallAllocs": 49657
+          },
+          "countedEchelonOnly": {
+            "freeColumns": 7,
+            "pivotSearch": {
+              "nanos": 621,
+              "smallAllocs": 48
+            },
+            "pivots": 17,
+            "rowAdd": {
+              "nanos": 336920,
+              "smallAllocs": 18538
+            },
+            "rowAdds": 353,
+            "rowAddsSkipped": 38,
+            "rowSwapScale": {
+              "nanos": 20940,
+              "smallAllocs": 1310
+            },
+            "stagedNanos": 358481,
+            "wall": {
+              "nanos": 368036,
+              "smallAllocs": 20041
+            }
+          },
+          "countedWithTransform": {
+            "freeColumns": 7,
+            "pivotSearch": {
+              "nanos": 602,
+              "smallAllocs": 48
+            },
+            "pivots": 17,
+            "rowAdd": {
+              "nanos": 614893,
+              "smallAllocs": 35482
+            },
+            "rowAdds": 353,
+            "rowAddsSkipped": 38,
+            "rowSwapScale": {
+              "nanos": 28721,
+              "smallAllocs": 1718
+            },
+            "stagedNanos": 644216,
+            "wall": {
+              "nanos": 653248,
+              "smallAllocs": 37396
+            }
+          },
+          "echelonOnlyAgrees": true,
+          "fixedSpaceDiagonalNanos": 14050,
+          "fixedSpaceDiagonalNegative": false,
+          "fixedSpaceKernelVectors": {
+            "nanos": 687299,
+            "smallAllocs": 52920
+          },
+          "fixedSpaceMatrixWall": {
+            "nanos": 580821,
+            "smallAllocs": 53329
+          },
+          "frobeniusPower": {
+            "nanos": 21813,
+            "smallAllocs": 1920
+          },
+          "kernelDimension": 7,
+          "matrixConversionNanos": 11177,
+          "matrixConversionNegative": false,
+          "matrixRebuild": {
+            "nanos": 577426,
+            "smallAllocs": 0
+          },
+          "mirrorAgreesWithRowReduce": true,
+          "modulus": 17,
+          "nullspaceBasisMagnitudeNanos": 22953,
+          "nullspaceBasisNanos": 22953,
+          "nullspaceBasisNegative": false,
+          "packedHalfWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1302,
+            "packNanos": 22163,
+            "rank": 17,
+            "reduceNanos": 37556,
+            "rowAdds": 353,
+            "smallAllocs": 744,
+            "totalNanos": 61161
+          },
+          "packedHalfWordDivision": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 991,
+            "packNanos": 21962,
+            "rank": 17,
+            "reduceNanos": 36234,
+            "rowAdds": 353,
+            "smallAllocs": 744,
+            "totalNanos": 59217
+          },
+          "packedHalfWordSkipZero": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 1041,
+            "packNanos": 22083,
+            "rank": 17,
+            "reduceNanos": 30916,
+            "rowAdds": 353,
+            "smallAllocs": 744,
+            "totalNanos": 54071
+          },
+          "packedWord": {
+            "agreesWithNullspace": true,
+            "nullspaceNanos": 2925,
+            "packNanos": 20981,
+            "rank": 17,
+            "reduceNanos": 74400,
+            "rowAdds": 353,
+            "smallAllocs": 9576,
+            "totalNanos": 98426
+          },
+          "peakResidentBytes": 70258688,
+          "productionMatrixRebuild": {
+            "nanos": 579219,
+            "smallAllocs": 0
+          },
+          "productionNullspace": {
+            "nanos": 667419,
+            "smallAllocs": 37192
+          },
+          "productionRowReduce": {
+            "nanos": 644466,
+            "smallAllocs": 36406
+          },
+          "rank": 17,
+          "residentBytesAfter": 64036864,
+          "residentBytesBefore": 64036864,
+          "rowReduceMatrixRebuild": {
+            "nanos": 578588,
+            "smallAllocs": 0
+          },
+          "sink": 18,
+          "splitFactors": 7
+        },
+        "modularDegree": 24,
+        "modularFactorCount": 7,
+        "prime": 17,
+        "retainedGoodPrimes": 1,
+        "status": "ok"
+      },
+      "name": "randprod_21",
+      "status": "ok"
+    }
+  ],
+  "results": [
+    {
+      "degree": 32,
+      "end_to_end": {
+        "max_nanos": 69762407,
+        "median_nanos": 69448903,
+        "min_nanos": 69251109,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        32
+      ],
+      "family": "swinnerton-dyer",
+      "instrumentation_ratio": 1.015782740297568,
+      "name": "sd5",
+      "phase_profile": {
+        "profile": {
+          "degree": 32,
+          "factorDegrees": [
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 16,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 93,
+            "modulusBits": 93,
+            "precision": 19,
+            "prime": 29,
+            "treeInternalLifts": 15,
+            "treeLeaves": 16,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 3246984,
+              "smallAllocs": 279386
+            },
+            "berlekampMatrix": {
+              "nanos": 1823,
+              "smallAllocs": 108
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 19629,
+              "smallAllocs": 1600
+            },
+            "kernelDimension": 16,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 32,
+            "modularImage": {
+              "nanos": 1722,
+              "smallAllocs": 78
+            },
+            "prime": 29,
+            "rowReduction": {
+              "nanos": 1617779,
+              "smallAllocs": 152147
+            },
+            "splittingNanos": 1627382
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 8022,
+              "smallAllocs": 332
+            },
+            "henselLift": {
+              "nanos": 1793209,
+              "smallAllocs": 61662
+            },
+            "normalization": {
+              "nanos": 33159,
+              "smallAllocs": 1647
+            },
+            "primeWalk": {
+              "nanos": 6613235,
+              "smallAllocs": 569263
+            },
+            "quadratic": {
+              "nanos": 691,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 62062761,
+              "smallAllocs": 2749638
+            },
+            "total": {
+              "nanos": 70544997,
+              "smallAllocs": 3383502
+            },
+            "validation": {
+              "nanos": 6299,
+              "smallAllocs": 201
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 19,
+                "modularFactorCount": 16,
+                "prime": 29,
+                "reachableProperDegrees": 15,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 21,
+                "modularFactorCount": 16,
+                "prime": 19,
+                "reachableProperDegrees": 15,
+                "selected": false
+              }
+            ],
+            "coeffBound": 221306743312056565676926650,
+            "coeffBoundBits": 88,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 32639,
+              "degreeSurvivors": 32768,
+              "exactDivisionsAttempted": 1,
+              "nodes": 32768,
+              "productsMaterialized": 129,
+              "recordable": 129,
+              "trailingSurvivors": 129
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 70673408,
+        "total_nanos_median": 70544997,
+        "total_nanos_min": 70322498
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "mirror_factor_degrees": [
+          32
+        ],
+        "mirror_nodes": 32768,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 32768,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "production_factor_degrees": [
+          32
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 32,
+      "end_to_end": {
+        "max_nanos": 64680853,
+        "median_nanos": 64593764,
+        "min_nanos": 64490170,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        32
+      ],
+      "family": "swinnerton-dyer",
+      "instrumentation_ratio": 1.0223876719740315,
+      "name": "sd5_shift1",
+      "phase_profile": {
+        "profile": {
+          "degree": 32,
+          "factorDegrees": [
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 16,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 93,
+            "modulusBits": 93,
+            "precision": 19,
+            "prime": 29,
+            "treeInternalLifts": 15,
+            "treeLeaves": 16,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 3073036,
+              "smallAllocs": 258979
+            },
+            "berlekampMatrix": {
+              "nanos": 1702,
+              "smallAllocs": 108
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 33719,
+              "smallAllocs": 2696
+            },
+            "kernelDimension": 16,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 32,
+            "modularImage": {
+              "nanos": 2504,
+              "smallAllocs": 84
+            },
+            "prime": 29,
+            "rowReduction": {
+              "nanos": 2262455,
+              "smallAllocs": 211116
+            },
+            "splittingNanos": 808879
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 10706,
+              "smallAllocs": 382
+            },
+            "henselLift": {
+              "nanos": 1841621,
+              "smallAllocs": 63318
+            },
+            "normalization": {
+              "nanos": 50164,
+              "smallAllocs": 2827
+            },
+            "primeWalk": {
+              "nanos": 6990535,
+              "smallAllocs": 588320
+            },
+            "quadratic": {
+              "nanos": 551,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 57110057,
+              "smallAllocs": 2560916
+            },
+            "total": {
+              "nanos": 66039868,
+              "smallAllocs": 3216770
+            },
+            "validation": {
+              "nanos": 7772,
+              "smallAllocs": 229
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 19,
+                "modularFactorCount": 16,
+                "prime": 29,
+                "reachableProperDegrees": 15,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 21,
+                "modularFactorCount": 16,
+                "prime": 19,
+                "reachableProperDegrees": 15,
+                "selected": false
+              }
+            ],
+            "coeffBound": 343800744604764214921668900,
+            "coeffBoundBits": 89,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 32767,
+              "degreeSurvivors": 32768,
+              "exactDivisionsAttempted": 1,
+              "nodes": 32768,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 66118875,
+        "total_nanos_median": 66039868,
+        "total_nanos_min": 65941653
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "mirror_factor_degrees": [
+          32
+        ],
+        "mirror_nodes": 32768,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 32768,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "production_factor_degrees": [
+          32
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 32,
+      "end_to_end": {
+        "max_nanos": 68319779,
+        "median_nanos": 68062617,
+        "min_nanos": 67898023,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        32
+      ],
+      "family": "swinnerton-dyer",
+      "instrumentation_ratio": 1.0126199085174759,
+      "name": "sd5_shift2",
+      "phase_profile": {
+        "profile": {
+          "degree": 32,
+          "factorDegrees": [
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 16,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 93,
+            "modulusBits": 93,
+            "precision": 19,
+            "prime": 29,
+            "treeInternalLifts": 15,
+            "treeLeaves": 16,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 4655042,
+              "smallAllocs": 381697
+            },
+            "berlekampMatrix": {
+              "nanos": 1653,
+              "smallAllocs": 108
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 33900,
+              "smallAllocs": 2673
+            },
+            "kernelDimension": 16,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 32,
+            "modularImage": {
+              "nanos": 2584,
+              "smallAllocs": 85
+            },
+            "prime": 29,
+            "rowReduction": {
+              "nanos": 2291858,
+              "smallAllocs": 211421
+            },
+            "splittingNanos": 2361531
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 10857,
+              "smallAllocs": 391
+            },
+            "henselLift": {
+              "nanos": 1826979,
+              "smallAllocs": 63079
+            },
+            "normalization": {
+              "nanos": 51116,
+              "smallAllocs": 2834
+            },
+            "primeWalk": {
+              "nanos": 8700350,
+              "smallAllocs": 715621
+            },
+            "quadratic": {
+              "nanos": 561,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 58294754,
+              "smallAllocs": 2594103
+            },
+            "total": {
+              "nanos": 68921561,
+              "smallAllocs": 3377052
+            },
+            "validation": {
+              "nanos": 8182,
+              "smallAllocs": 234
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 19,
+                "modularFactorCount": 16,
+                "prime": 29,
+                "reachableProperDegrees": 15,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 22,
+                "modularFactorCount": 16,
+                "prime": 19,
+                "reachableProperDegrees": 15,
+                "selected": false
+              }
+            ],
+            "coeffBound": 1319504980517760399369866460,
+            "coeffBoundBits": 91,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 32767,
+              "degreeSurvivors": 32768,
+              "exactDivisionsAttempted": 1,
+              "nodes": 32768,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 69714796,
+        "total_nanos_median": 68921561,
+        "total_nanos_min": 68751969
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "mirror_factor_degrees": [
+          32
+        ],
+        "mirror_nodes": 32768,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 32768,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "production_factor_degrees": [
+          32
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 32,
+      "end_to_end": {
+        "max_nanos": 18472710,
+        "median_nanos": 18348536,
+        "min_nanos": 18191583,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        16,
+        16
+      ],
+      "family": "sd-products",
+      "instrumentation_ratio": 0.9826867931043654,
+      "name": "sd4_x_sd4shift1",
+      "phase_profile": {
+        "profile": {
+          "degree": 32,
+          "factorDegrees": [
+            16,
+            16
+          ],
+          "hensel": {
+            "liftedFactorCount": 16,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 83,
+            "modulusBits": 83,
+            "precision": 17,
+            "prime": 29,
+            "treeInternalLifts": 15,
+            "treeLeaves": 16,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 3919632,
+              "smallAllocs": 320808
+            },
+            "berlekampMatrix": {
+              "nanos": 1763,
+              "smallAllocs": 108
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 35623,
+              "smallAllocs": 2770
+            },
+            "kernelDimension": 16,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 32,
+            "modularImage": {
+              "nanos": 2394,
+              "smallAllocs": 82
+            },
+            "prime": 29,
+            "rowReduction": {
+              "nanos": 2299188,
+              "smallAllocs": 210624
+            },
+            "splittingNanos": 1618681
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 23375,
+              "smallAllocs": 901
+            },
+            "henselLift": {
+              "nanos": 1798747,
+              "smallAllocs": 60552
+            },
+            "normalization": {
+              "nanos": 50485,
+              "smallAllocs": 2814
+            },
+            "primeWalk": {
+              "nanos": 6879020,
+              "smallAllocs": 562027
+            },
+            "quadratic": {
+              "nanos": 420,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 9231508,
+              "smallAllocs": 528057
+            },
+            "total": {
+              "nanos": 18030864,
+              "smallAllocs": 1155836
+            },
+            "validation": {
+              "nanos": 22324,
+              "smallAllocs": 745
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 17,
+                "modularFactorCount": 16,
+                "prime": 29,
+                "reachableProperDegrees": 15,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 32768,
+                "henselPrecision": 22,
+                "modularFactorCount": 16,
+                "prime": 13,
+                "reachableProperDegrees": 15,
+                "selected": false
+              }
+            ],
+            "coeffBound": 489391641089022941499420,
+            "coeffBoundBits": 79,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 10530,
+              "degreeSurvivors": 10540,
+              "exactDivisionsAttempted": 2,
+              "nodes": 10540,
+              "productsMaterialized": 10,
+              "recordable": 10,
+              "trailingSurvivors": 10
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 18114468,
+        "total_nanos_median": 18030864,
+        "total_nanos_min": 17946800
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "mirror_factor_degrees": [
+          16,
+          16
+        ],
+        "mirror_nodes": 10540,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 10540,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "production_factor_degrees": [
+          16,
+          16
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 42,
+      "end_to_end": {
+        "max_nanos": 143573127,
+        "median_nanos": 142531533,
+        "min_nanos": 142079622,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        10,
+        32
+      ],
+      "family": "sd-products",
+      "instrumentation_ratio": 1.0070604867485708,
+      "name": "sd5_x_phi11",
+      "phase_profile": {
+        "profile": {
+          "degree": 42,
+          "factorDegrees": [
+            10,
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 17,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              10,
+              2
+            ],
+            "liftedMaxCoeffBits": 102,
+            "modulusBits": 103,
+            "precision": 21,
+            "prime": 29,
+            "treeInternalLifts": 16,
+            "treeLeaves": 17,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 7613148,
+              "smallAllocs": 625572
+            },
+            "berlekampMatrix": {
+              "nanos": 2684,
+              "smallAllocs": 138
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 52758,
+              "smallAllocs": 4248
+            },
+            "kernelDimension": 17,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 42,
+            "modularImage": {
+              "nanos": 3435,
+              "smallAllocs": 108
+            },
+            "prime": 29,
+            "rowReduction": {
+              "nanos": 4596295,
+              "smallAllocs": 428628
+            },
+            "splittingNanos": 3014169
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 30025,
+              "smallAllocs": 1170
+            },
+            "henselLift": {
+              "nanos": 2836205,
+              "smallAllocs": 88829
+            },
+            "normalization": {
+              "nanos": 77015,
+              "smallAllocs": 4551
+            },
+            "primeWalk": {
+              "nanos": 16219910,
+              "smallAllocs": 1372794
+            },
+            "quadratic": {
+              "nanos": 580,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 124309555,
+              "smallAllocs": 6175336
+            },
+            "total": {
+              "nanos": 143537875,
+              "smallAllocs": 7644637
+            },
+            "validation": {
+              "nanos": 31026,
+              "smallAllocs": 1070
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  10,
+                  2
+                ],
+                "forcedSubsetCost": 65536,
+                "henselPrecision": 21,
+                "modularFactorCount": 17,
+                "prime": 29,
+                "reachableProperDegrees": 20,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  10,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 65536,
+                "henselPrecision": 24,
+                "modularFactorCount": 17,
+                "prime": 19,
+                "reachableProperDegrees": 20,
+                "selected": false
+              }
+            ],
+            "coeffBound": 210602981274948990483361217040,
+            "coeffBoundBits": 98,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 29
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 65264,
+              "degreeSurvivors": 65522,
+              "exactDivisionsAttempted": 2,
+              "nodes": 65522,
+              "productsMaterialized": 258,
+              "recordable": 258,
+              "trailingSurvivors": 258
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 144016805,
+        "total_nanos_median": 143537875,
+        "total_nanos_min": 142973228
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "mirror_factor_degrees": [
+          10,
+          32
+        ],
+        "mirror_nodes": 65522,
+        "mirror_prime": 29,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 65522,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ],
+        "production_factor_degrees": [
+          10,
+          32
+        ],
+        "production_prime": 29
+      }
+    },
+    {
+      "degree": 48,
+      "end_to_end": {
+        "max_nanos": 10502111,
+        "median_nanos": 10494420,
+        "min_nanos": 10464475,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        8,
+        8,
+        16
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 0.9941377417713413,
+      "name": "xpow48_minus1",
+      "phase_profile": {
+        "profile": {
+          "degree": 48,
+          "factorDegrees": [
+            2,
+            2,
+            2,
+            8,
+            8,
+            16,
+            1,
+            1,
+            4,
+            4
+          ],
+          "hensel": {
+            "liftedFactorCount": 19,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              1,
+              1,
+              4,
+              4,
+              2,
+              2,
+              4,
+              2,
+              2,
+              4,
+              4,
+              4,
+              2,
+              2,
+              2
+            ],
+            "liftedMaxCoeffBits": 49,
+            "modulusBits": 49,
+            "precision": 14,
+            "prime": 11,
+            "treeInternalLifts": 18,
+            "treeLeaves": 19,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 1928499,
+              "smallAllocs": 163103
+            },
+            "berlekampMatrix": {
+              "nanos": 2253,
+              "smallAllocs": 156
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 5869,
+              "smallAllocs": 510
+            },
+            "kernelDimension": 19,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 48,
+            "modularImage": {
+              "nanos": 1202,
+              "smallAllocs": 104
+            },
+            "prime": 11,
+            "rowReduction": {
+              "nanos": 747959,
+              "smallAllocs": 67517
+            },
+            "splittingNanos": 1178287
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 24056,
+              "smallAllocs": 2409
+            },
+            "henselLift": {
+              "nanos": 1097196,
+              "smallAllocs": 57567
+            },
+            "normalization": {
+              "nanos": 13400,
+              "smallAllocs": 563
+            },
+            "primeWalk": {
+              "nanos": 3986721,
+              "smallAllocs": 339781
+            },
+            "quadratic": {
+              "nanos": 451,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 5279328,
+              "smallAllocs": 270316
+            },
+            "total": {
+              "nanos": 10432899,
+              "smallAllocs": 673042
+            },
+            "validation": {
+              "nanos": 18827,
+              "smallAllocs": 1688
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  1,
+                  1,
+                  4,
+                  4,
+                  2,
+                  2,
+                  4,
+                  2,
+                  2,
+                  4,
+                  4,
+                  4,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 262144,
+                "henselPrecision": 14,
+                "modularFactorCount": 19,
+                "prime": 11,
+                "reachableProperDegrees": 47,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  4,
+                  4,
+                  2,
+                  2,
+                  4,
+                  2,
+                  1,
+                  1,
+                  4,
+                  2,
+                  2,
+                  1,
+                  1,
+                  4,
+                  2,
+                  2,
+                  2,
+                  2,
+                  4,
+                  2
+                ],
+                "forcedSubsetCost": 524288,
+                "henselPrecision": 21,
+                "modularFactorCount": 20,
+                "prime": 5,
+                "reachableProperDegrees": 47,
+                "selected": false
+              }
+            ],
+            "coeffBound": 64495207366200,
+            "coeffBoundBits": 46,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 11
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              0,
+              1,
+              2,
+              0,
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 268,
+              "exactDivisionsAttempted": 10,
+              "nodes": 268,
+              "productsMaterialized": 268,
+              "recordable": 268,
+              "trailingSurvivors": 268
+            },
+            "successfulDivisors": 10
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 10443595,
+        "total_nanos_median": 10432899,
+        "total_nanos_min": 10416305
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          0,
+          1,
+          2,
+          0,
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          8,
+          8,
+          16
+        ],
+        "mirror_nodes": 268,
+        "mirror_prime": 11,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 268,
+        "production_completed_levels": [
+          0,
+          0,
+          0,
+          1,
+          2,
+          0,
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          8,
+          8,
+          16
+        ],
+        "production_prime": 11
+      }
+    },
+    {
+      "degree": 105,
+      "end_to_end": {
+        "max_nanos": 46397995,
+        "median_nanos": 46065672,
+        "min_nanos": 45750084,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        2,
+        4,
+        6,
+        8,
+        12,
+        24,
+        48
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 1.0090031249299913,
+      "name": "xpow105_minus1",
+      "phase_profile": {
+        "profile": {
+          "degree": 105,
+          "factorDegrees": [
+            4,
+            24,
+            2,
+            12,
+            48,
+            8,
+            6,
+            1
+          ],
+          "hensel": {
+            "liftedFactorCount": 14,
+            "liftedFactorDegrees": [
+              1,
+              6,
+              4,
+              12,
+              12,
+              4,
+              12,
+              12,
+              6,
+              2,
+              6,
+              12,
+              12,
+              4
+            ],
+            "liftedMaxCoeffBits": 107,
+            "modulusBits": 107,
+            "precision": 26,
+            "prime": 17,
+            "treeInternalLifts": 13,
+            "treeLeaves": 14,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 8822991,
+              "smallAllocs": 750003
+            },
+            "berlekampMatrix": {
+              "nanos": 5108,
+              "smallAllocs": 327
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 11647,
+              "smallAllocs": 1080
+            },
+            "kernelDimension": 14,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 105,
+            "modularImage": {
+              "nanos": 2143,
+              "smallAllocs": 218
+            },
+            "prime": 17,
+            "rowReduction": {
+              "nanos": 4943270,
+              "smallAllocs": 462407
+            },
+            "splittingNanos": 3874613
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 59408,
+              "smallAllocs": 6483
+            },
+            "henselLift": {
+              "nanos": 11969958,
+              "smallAllocs": 346450
+            },
+            "normalization": {
+              "nanos": 26609,
+              "smallAllocs": 1190
+            },
+            "primeWalk": {
+              "nanos": 29419641,
+              "smallAllocs": 2624521
+            },
+            "quadratic": {
+              "nanos": 511,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 4921266,
+              "smallAllocs": 266987
+            },
+            "total": {
+              "nanos": 46480407,
+              "smallAllocs": 3252061
+            },
+            "validation": {
+              "nanos": 52788,
+              "smallAllocs": 5196
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  1,
+                  6,
+                  4,
+                  12,
+                  12,
+                  4,
+                  12,
+                  12,
+                  6,
+                  2,
+                  6,
+                  12,
+                  12,
+                  4
+                ],
+                "forcedSubsetCost": 8192,
+                "henselPrecision": 26,
+                "modularFactorCount": 14,
+                "prime": 17,
+                "reachableProperDegrees": 104,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  1,
+                  2,
+                  3,
+                  6,
+                  3,
+                  6,
+                  2,
+                  1,
+                  6,
+                  3,
+                  6,
+                  3,
+                  3,
+                  6,
+                  1,
+                  2,
+                  3,
+                  6,
+                  2,
+                  1,
+                  6,
+                  3,
+                  6,
+                  3,
+                  6,
+                  3,
+                  6,
+                  3,
+                  2,
+                  1
+                ],
+                "forcedSubsetCost": 536870912,
+                "henselPrecision": 30,
+                "modularFactorCount": 30,
+                "prime": 11,
+                "reachableProperDegrees": 104,
+                "selected": false
+              }
+            ],
+            "coeffBound": 6272525058612251449529907677520,
+            "coeffBoundBits": 103,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 17
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              1,
+              2,
+              0,
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 60,
+              "exactDivisionsAttempted": 8,
+              "nodes": 60,
+              "productsMaterialized": 60,
+              "recordable": 60,
+              "trailingSurvivors": 60
+            },
+            "successfulDivisors": 8
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 46687704,
+        "total_nanos_median": 46480407,
+        "total_nanos_min": 46192080
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          0,
+          0
+        ],
+        "mirror_factor_degrees": [
+          1,
+          2,
+          4,
+          6,
+          8,
+          12,
+          24,
+          48
+        ],
+        "mirror_nodes": 60,
+        "mirror_prime": 17,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 60,
+        "production_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          0,
+          0
+        ],
+        "production_factor_degrees": [
+          1,
+          2,
+          4,
+          6,
+          8,
+          12,
+          24,
+          48
+        ],
+        "production_prime": 17
+      }
+    },
+    {
+      "degree": 120,
+      "end_to_end": {
+        "max_nanos": 148939514,
+        "median_nanos": 147886353,
+        "min_nanos": 147675490,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        4,
+        4,
+        8,
+        8,
+        8,
+        8,
+        16,
+        16,
+        32
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 1.0034766629210201,
+      "name": "xpow120_minus1",
+      "phase_profile": {
+        "profile": {
+          "degree": 120,
+          "factorDegrees": [
+            16,
+            4,
+            32,
+            8,
+            8,
+            2,
+            8,
+            2,
+            4,
+            16,
+            4,
+            1,
+            4,
+            1,
+            2,
+            8
+          ],
+          "hensel": {
+            "liftedFactorCount": 39,
+            "liftedFactorDegrees": [
+              4,
+              4,
+              2,
+              1,
+              4,
+              1,
+              4,
+              4,
+              4,
+              2,
+              1,
+              4,
+              1,
+              4,
+              2,
+              4,
+              4,
+              2,
+              4,
+              4,
+              4,
+              4,
+              2,
+              1,
+              4,
+              1,
+              4,
+              2,
+              4,
+              4,
+              2,
+              4,
+              4,
+              2,
+              4,
+              4,
+              2,
+              4,
+              4
+            ],
+            "liftedMaxCoeffBits": 121,
+            "modulusBits": 121,
+            "precision": 43,
+            "prime": 7,
+            "treeInternalLifts": 38,
+            "treeLeaves": 39,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 15977640,
+              "smallAllocs": 1312571
+            },
+            "berlekampMatrix": {
+              "nanos": 5899,
+              "smallAllocs": 372
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 13319,
+              "smallAllocs": 1230
+            },
+            "kernelDimension": 39,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 120,
+            "modularImage": {
+              "nanos": 2594,
+              "smallAllocs": 248
+            },
+            "prime": 7,
+            "rowReduction": {
+              "nanos": 3781407,
+              "smallAllocs": 329059
+            },
+            "splittingNanos": 12190334
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 102252,
+              "smallAllocs": 11833
+            },
+            "henselLift": {
+              "nanos": 16626062,
+              "smallAllocs": 507435
+            },
+            "normalization": {
+              "nanos": 30645,
+              "smallAllocs": 1355
+            },
+            "primeWalk": {
+              "nanos": 18489524,
+              "smallAllocs": 1584783
+            },
+            "quadratic": {
+              "nanos": 591,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 113041838,
+              "smallAllocs": 5264950
+            },
+            "total": {
+              "nanos": 148400504,
+              "smallAllocs": 7379735
+            },
+            "validation": {
+              "nanos": 78646,
+              "smallAllocs": 8230
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  4,
+                  4,
+                  2,
+                  1,
+                  4,
+                  1,
+                  4,
+                  4,
+                  4,
+                  2,
+                  1,
+                  4,
+                  1,
+                  4,
+                  2,
+                  4,
+                  4,
+                  2,
+                  4,
+                  4,
+                  4,
+                  4,
+                  2,
+                  1,
+                  4,
+                  1,
+                  4,
+                  2,
+                  4,
+                  4,
+                  2,
+                  4,
+                  4,
+                  2,
+                  4,
+                  4,
+                  2,
+                  4,
+                  4
+                ],
+                "forcedSubsetCost": 274877906944,
+                "henselPrecision": 43,
+                "modularFactorCount": 39,
+                "prime": 7,
+                "reachableProperDegrees": 119,
+                "selected": true
+              }
+            ],
+            "coeffBound": 193229817680726645207786279042745312,
+            "coeffBoundBits": 118,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 7
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              1,
+              2,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              1,
+              2,
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              0,
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 3538,
+              "degreeSurvivors": 5339,
+              "exactDivisionsAttempted": 16,
+              "nodes": 5339,
+              "productsMaterialized": 1801,
+              "recordable": 1801,
+              "trailingSurvivors": 1801
+            },
+            "successfulDivisors": 16
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 149830185,
+        "total_nanos_median": 148400504,
+        "total_nanos_min": 148260126
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          2,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          0,
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          4,
+          4,
+          8,
+          8,
+          8,
+          8,
+          16,
+          16,
+          32
+        ],
+        "mirror_nodes": 5339,
+        "mirror_prime": 7,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 5339,
+        "production_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          1,
+          2,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          0,
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          4,
+          4,
+          8,
+          8,
+          8,
+          8,
+          16,
+          16,
+          32
+        ],
+        "production_prime": 7
+      }
+    },
+    {
+      "degree": 178,
+      "end_to_end": {
+        "max_nanos": 42877895,
+        "median_nanos": 42780231,
+        "min_nanos": 42556278,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        178
+      ],
+      "family": "cyclotomic",
+      "instrumentation_ratio": 0.9887182469865579,
+      "name": "cyclo_phi179",
+      "phase_profile": {
+        "profile": {
+          "degree": 178,
+          "factorDegrees": [
+            178
+          ],
+          "hensel": {
+            "liftedFactorCount": 2,
+            "liftedFactorDegrees": [
+              89,
+              89
+            ],
+            "liftedMaxCoeffBits": 180,
+            "modulusBits": 180,
+            "precision": 113,
+            "prime": 3,
+            "treeInternalLifts": 1,
+            "treeLeaves": 2,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 6495942,
+              "smallAllocs": 339370
+            },
+            "berlekampMatrix": {
+              "nanos": 8683,
+              "smallAllocs": 546
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 33660,
+              "smallAllocs": 3356
+            },
+            "kernelDimension": 2,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 178,
+            "modularImage": {
+              "nanos": 3445,
+              "smallAllocs": 364
+            },
+            "prime": 3,
+            "rowReduction": {
+              "nanos": 13667104,
+              "smallAllocs": 1226531
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 20330,
+              "smallAllocs": 1446
+            },
+            "henselLift": {
+              "nanos": 34584559,
+              "smallAllocs": 740896
+            },
+            "normalization": {
+              "nanos": 64475,
+              "smallAllocs": 3772
+            },
+            "primeWalk": {
+              "nanos": 6392619,
+              "smallAllocs": 344914
+            },
+            "quadratic": {
+              "nanos": 661,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 1163365,
+              "smallAllocs": 46831
+            },
+            "total": {
+              "nanos": 42297595,
+              "smallAllocs": 1140116
+            },
+            "validation": {
+              "nanos": 17656,
+              "smallAllocs": 901
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  89,
+                  89
+                ],
+                "forcedSubsetCost": 2,
+                "henselPrecision": 113,
+                "modularFactorCount": 2,
+                "prime": 3,
+                "reachableProperDegrees": 1,
+                "selected": true
+              }
+            ],
+            "coeffBound": 320322439463041003620181335381340475329049688753516000,
+            "coeffBoundBits": 178,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 2,
+              "exactDivisionsAttempted": 1,
+              "nodes": 2,
+              "productsMaterialized": 2,
+              "recordable": 2,
+              "trailingSurvivors": 2
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 42533575,
+        "total_nanos_median": 42297595,
+        "total_nanos_min": 42210165
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0
+        ],
+        "mirror_factor_degrees": [
+          178
+        ],
+        "mirror_nodes": 2,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 2,
+        "production_completed_levels": [
+          0
+        ],
+        "production_factor_degrees": [
+          178
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 80,
+      "end_to_end": {
+        "max_nanos": 46704439,
+        "median_nanos": 46616358,
+        "min_nanos": 46131790,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        32,
+        48
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 0.9939268099837401,
+      "name": "cyclo_phi64_x_phi105",
+      "phase_profile": {
+        "profile": {
+          "degree": 80,
+          "factorDegrees": [
+            48,
+            32
+          ],
+          "hensel": {
+            "liftedFactorCount": 10,
+            "liftedFactorDegrees": [
+              16,
+              16,
+              6,
+              6,
+              6,
+              6,
+              6,
+              6,
+              6,
+              6
+            ],
+            "liftedMaxCoeffBits": 84,
+            "modulusBits": 84,
+            "precision": 24,
+            "prime": 11,
+            "treeInternalLifts": 9,
+            "treeLeaves": 10,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 10578184,
+              "smallAllocs": 586770
+            },
+            "berlekampMatrix": {
+              "nanos": 3916,
+              "smallAllocs": 252
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 156642,
+              "smallAllocs": 13406
+            },
+            "kernelDimension": 10,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 80,
+            "modularImage": {
+              "nanos": 1873,
+              "smallAllocs": 168
+            },
+            "prime": 11,
+            "rowReduction": {
+              "nanos": 18581150,
+              "smallAllocs": 1749247
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 25668,
+              "smallAllocs": 2390
+            },
+            "henselLift": {
+              "nanos": 6133895,
+              "smallAllocs": 196912
+            },
+            "normalization": {
+              "nanos": 184643,
+              "smallAllocs": 14419
+            },
+            "primeWalk": {
+              "nanos": 37612879,
+              "smallAllocs": 3197479
+            },
+            "quadratic": {
+              "nanos": 621,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 2329104,
+              "smallAllocs": 89872
+            },
+            "total": {
+              "nanos": 46333248,
+              "smallAllocs": 3503772
+            },
+            "validation": {
+              "nanos": 26219,
+              "smallAllocs": 2017
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  16,
+                  16,
+                  6,
+                  6,
+                  6,
+                  6,
+                  6,
+                  6,
+                  6,
+                  6
+                ],
+                "forcedSubsetCost": 512,
+                "henselPrecision": 24,
+                "modularFactorCount": 10,
+                "prime": 11,
+                "reachableProperDegrees": 25,
+                "selected": true
+              }
+            ],
+            "coeffBound": 1075072087333361764616200,
+            "coeffBoundBits": 80,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 11
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 102,
+              "degreeSurvivors": 130,
+              "exactDivisionsAttempted": 2,
+              "nodes": 130,
+              "productsMaterialized": 28,
+              "recordable": 28,
+              "trailingSurvivors": 28
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 46865418,
+        "total_nanos_median": 46333248,
+        "total_nanos_min": 45880748
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "mirror_factor_degrees": [
+          32,
+          48
+        ],
+        "mirror_nodes": 130,
+        "mirror_prime": 11,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 130,
+        "production_completed_levels": [
+          0,
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "production_factor_degrees": [
+          32,
+          48
+        ],
+        "production_prime": 11
+      }
+    },
+    {
+      "degree": 144,
+      "end_to_end": {
+        "max_nanos": 85140027,
+        "median_nanos": 84918510,
+        "min_nanos": 84884509,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        64,
+        80
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 1.0041820799729058,
+      "name": "cyclo_phi128_x_phi165",
+      "phase_profile": {
+        "profile": {
+          "degree": 144,
+          "factorDegrees": [
+            64,
+            80
+          ],
+          "hensel": {
+            "liftedFactorCount": 8,
+            "liftedFactorDegrees": [
+              20,
+              16,
+              20,
+              20,
+              16,
+              20,
+              16,
+              16
+            ],
+            "liftedMaxCoeffBits": 146,
+            "modulusBits": 146,
+            "precision": 52,
+            "prime": 7,
+            "treeInternalLifts": 7,
+            "treeLeaves": 8,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 33980112,
+              "smallAllocs": 1239327
+            },
+            "berlekampMatrix": {
+              "nanos": 7030,
+              "smallAllocs": 444
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 453943,
+              "smallAllocs": 39896
+            },
+            "kernelDimension": 8,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 144,
+            "modularImage": {
+              "nanos": 3244,
+              "smallAllocs": 296
+            },
+            "prime": 7,
+            "rowReduction": {
+              "nanos": 88831932,
+              "smallAllocs": 8409957
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 61601,
+              "smallAllocs": 6582
+            },
+            "henselLift": {
+              "nanos": 44096662,
+              "smallAllocs": 956356
+            },
+            "normalization": {
+              "nanos": 530958,
+              "smallAllocs": 44226
+            },
+            "primeWalk": {
+              "nanos": 34587372,
+              "smallAllocs": 1326123
+            },
+            "quadratic": {
+              "nanos": 651,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 5897755,
+              "smallAllocs": 275130
+            },
+            "total": {
+              "nanos": 85273646,
+              "smallAllocs": 2615526
+            },
+            "validation": {
+              "nanos": 59028,
+              "smallAllocs": 6017
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  20,
+                  16,
+                  20,
+                  20,
+                  16,
+                  20,
+                  16,
+                  16
+                ],
+                "forcedSubsetCost": 128,
+                "henselPrecision": 52,
+                "modularFactorCount": 8,
+                "prime": 7,
+                "reachableProperDegrees": 23,
+                "selected": true
+              }
+            ],
+            "coeffBound": 20722981978283006659913436536756243128265400,
+            "coeffBoundBits": 144,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 7
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 29,
+              "degreeSurvivors": 54,
+              "exactDivisionsAttempted": 2,
+              "nodes": 54,
+              "productsMaterialized": 25,
+              "recordable": 25,
+              "trailingSurvivors": 25
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 92619718,
+        "total_nanos_median": 85273646,
+        "total_nanos_min": 84935564
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          64,
+          80
+        ],
+        "mirror_nodes": 54,
+        "mirror_prime": 7,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 54,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          64,
+          80
+        ],
+        "production_prime": 7
+      }
+    },
+    {
+      "degree": 240,
+      "end_to_end": {
+        "max_nanos": 167684878,
+        "median_nanos": 165854293,
+        "min_nanos": 165324979,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        240
+      ],
+      "family": "cyclotomic",
+      "instrumentation_ratio": 1.0138439286585124,
+      "name": "cyclo_phi385",
+      "phase_profile": {
+        "profile": {
+          "degree": 240,
+          "factorDegrees": [
+            240
+          ],
+          "hensel": {
+            "liftedFactorCount": 4,
+            "liftedFactorDegrees": [
+              60,
+              60,
+              60,
+              60
+            ],
+            "liftedMaxCoeffBits": 241,
+            "modulusBits": 241,
+            "precision": 152,
+            "prime": 3,
+            "treeInternalLifts": 3,
+            "treeLeaves": 4,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 58483373,
+              "smallAllocs": 1030964
+            },
+            "berlekampMatrix": {
+              "nanos": 12008,
+              "smallAllocs": 732
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 746877,
+              "smallAllocs": 68654
+            },
+            "kernelDimension": 4,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 240,
+            "modularImage": {
+              "nanos": 4858,
+              "smallAllocs": 488
+            },
+            "prime": 3,
+            "rowReduction": {
+              "nanos": 200180790,
+              "smallAllocs": 18194276
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 28622,
+              "smallAllocs": 1942
+            },
+            "henselLift": {
+              "nanos": 97671148,
+              "smallAllocs": 2094825
+            },
+            "normalization": {
+              "nanos": 1195643,
+              "smallAllocs": 101209
+            },
+            "primeWalk": {
+              "nanos": 59064035,
+              "smallAllocs": 1103050
+            },
+            "quadratic": {
+              "nanos": 1071,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 10086385,
+              "smallAllocs": 401834
+            },
+            "total": {
+              "nanos": 168150368,
+              "smallAllocs": 3705856
+            },
+            "validation": {
+              "nanos": 25388,
+              "smallAllocs": 1211
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  60,
+                  60,
+                  60,
+                  60
+                ],
+                "forcedSubsetCost": 8,
+                "henselPrecision": 152,
+                "modularFactorCount": 4,
+                "prime": 3,
+                "reachableProperDegrees": 3,
+                "selected": true
+              }
+            ],
+            "coeffBound": 1636264530784946322237683636362414673514576776816417689604042467199320800,
+            "coeffBoundBits": 240,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 8,
+              "exactDivisionsAttempted": 1,
+              "nodes": 8,
+              "productsMaterialized": 8,
+              "recordable": 8,
+              "trailingSurvivors": 8
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 168803426,
+        "total_nanos_median": 168150368,
+        "total_nanos_min": 166203521
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          240
+        ],
+        "mirror_nodes": 8,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 8,
+        "production_completed_levels": [
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          240
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 40,
+      "end_to_end": {
+        "max_nanos": 14068550,
+        "median_nanos": 13977064,
+        "min_nanos": 13968301,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "family": "wilkinson",
+      "instrumentation_ratio": 0.9657417323123082,
+      "name": "wilkinson_40",
+      "phase_profile": {
+        "profile": {
+          "degree": 40,
+          "factorDegrees": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "method": "replay",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 1761782,
+              "smallAllocs": 146136
+            },
+            "berlekampMatrix": {
+              "nanos": 1912,
+              "smallAllocs": 132
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 21472,
+              "smallAllocs": 1610
+            },
+            "kernelDimension": 40,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 40,
+            "modularImage": {
+              "nanos": 3916,
+              "smallAllocs": 106
+            },
+            "prime": 47,
+            "rowReduction": {
+              "nanos": 251824,
+              "smallAllocs": 20522
+            },
+            "splittingNanos": 1508046
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 206717,
+              "smallAllocs": 9051
+            },
+            "normalization": {
+              "nanos": 76964,
+              "smallAllocs": 4275
+            },
+            "primeWalk": {
+              "nanos": 4168611,
+              "smallAllocs": 342474
+            },
+            "proposal": {
+              "nanos": 8984311,
+              "smallAllocs": 260187
+            },
+            "quadratic": {
+              "nanos": 541,
+              "smallAllocs": 17
+            },
+            "total": {
+              "nanos": 13498234,
+              "smallAllocs": 617317
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 549755813888,
+                "henselPrecision": 37,
+                "modularFactorCount": 40,
+                "prime": 47,
+                "reachableProperDegrees": 39,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 549755813888,
+                "henselPrecision": 38,
+                "modularFactorCount": 40,
+                "prime": 41,
+                "reachableProperDegrees": 39,
+                "selected": false
+              }
+            ],
+            "coeffBound": 1921680168406855965121530973574373218685937570507447116882060,
+            "coeffBoundBits": 201,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 47
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 13532805,
+        "total_nanos_median": 13498234,
+        "total_nanos_min": 13465085
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": false,
+        "reason": "profiled run did not answer from the direct classical tier"
+      }
+    },
+    {
+      "degree": 48,
+      "end_to_end": {
+        "max_nanos": 25240534,
+        "median_nanos": 25217090,
+        "min_nanos": 25208366,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "family": "wilkinson",
+      "instrumentation_ratio": 0.9640706362232915,
+      "name": "wilkinson_48",
+      "phase_profile": {
+        "profile": {
+          "degree": 48,
+          "factorDegrees": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "method": "replay",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 2774433,
+              "smallAllocs": 235614
+            },
+            "berlekampMatrix": {
+              "nanos": 2333,
+              "smallAllocs": 156
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 37586,
+              "smallAllocs": 2906
+            },
+            "kernelDimension": 48,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 48,
+            "modularImage": {
+              "nanos": 4797,
+              "smallAllocs": 126
+            },
+            "prime": 61,
+            "rowReduction": {
+              "nanos": 372903,
+              "smallAllocs": 29406
+            },
+            "splittingNanos": 2399197
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 310160,
+              "smallAllocs": 13013
+            },
+            "normalization": {
+              "nanos": 100569,
+              "smallAllocs": 5905
+            },
+            "primeWalk": {
+              "nanos": 6647737,
+              "smallAllocs": 550764
+            },
+            "proposal": {
+              "nanos": 17173183,
+              "smallAllocs": 401527
+            },
+            "quadratic": {
+              "nanos": 671,
+              "smallAllocs": 17
+            },
+            "total": {
+              "nanos": 24311056,
+              "smallAllocs": 972820
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 140737488355328,
+                "henselPrecision": 43,
+                "modularFactorCount": 48,
+                "prime": 61,
+                "reachableProperDegrees": 47,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 140737488355328,
+                "henselPrecision": 45,
+                "modularFactorCount": 48,
+                "prime": 53,
+                "reachableProperDegrees": 47,
+                "selected": false
+              }
+            ],
+            "coeffBound": 8049068376844036118970558829637315745156559359405185594804704581012213098100,
+            "coeffBoundBits": 253,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 61
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 24453527,
+        "total_nanos_median": 24311056,
+        "total_nanos_min": 24268073
+      },
+      "representative": true,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": false,
+        "reason": "profiled run did not answer from the direct classical tier"
+      }
+    },
+    {
+      "degree": 56,
+      "end_to_end": {
+        "max_nanos": 34338414,
+        "median_nanos": 34144527,
+        "min_nanos": 33978981,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      "family": "wilkinson",
+      "instrumentation_ratio": 0.959529678065243,
+      "name": "wilkinson_56",
+      "phase_profile": {
+        "profile": {
+          "degree": 56,
+          "factorDegrees": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "method": "replay",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 4212756,
+              "smallAllocs": 360583
+            },
+            "berlekampMatrix": {
+              "nanos": 2765,
+              "smallAllocs": 180
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 39578,
+              "smallAllocs": 3046
+            },
+            "kernelDimension": 56,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 56,
+            "modularImage": {
+              "nanos": 5699,
+              "smallAllocs": 146
+            },
+            "prime": 67,
+            "rowReduction": {
+              "nanos": 564557,
+              "smallAllocs": 46891
+            },
+            "splittingNanos": 3645434
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 430028,
+              "smallAllocs": 17680
+            },
+            "normalization": {
+              "nanos": 129672,
+              "smallAllocs": 7789
+            },
+            "primeWalk": {
+              "nanos": 9739591,
+              "smallAllocs": 818295
+            },
+            "proposal": {
+              "nanos": 22370168,
+              "smallAllocs": 527455
+            },
+            "quadratic": {
+              "nanos": 641,
+              "smallAllocs": 17
+            },
+            "total": {
+              "nanos": 32762687,
+              "smallAllocs": 1373120
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 36028797018963968,
+                "henselPrecision": 51,
+                "modularFactorCount": 56,
+                "prime": 67,
+                "reachableProperDegrees": 55,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 36028797018963968,
+                "henselPrecision": 53,
+                "modularFactorCount": 56,
+                "prime": 59,
+                "reachableProperDegrees": 55,
+                "selected": false
+              }
+            ],
+            "coeffBound": 125617627049250877181363592865834692949611771037125750170085410352200700179789256897773224080,
+            "coeffBoundBits": 306,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 67
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 32877437,
+        "total_nanos_median": 32762687,
+        "total_nanos_min": 32622730
+      },
+      "representative": true,
+      "sampling_profile_captured": true,
+      "validation": {
+        "applicable": false,
+        "reason": "profiled run did not answer from the direct classical tier"
+      }
+    },
+    {
+      "degree": 24,
+      "end_to_end": {
+        "max_nanos": 528223,
+        "median_nanos": 452211,
+        "min_nanos": 443548,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        8,
+        16
+      ],
+      "family": "chebyshev",
+      "instrumentation_ratio": 0.8693353324001406,
+      "name": "chebyshev_T24",
+      "phase_profile": {
+        "profile": {
+          "degree": 24,
+          "factorDegrees": [
+            16,
+            8
+          ],
+          "hensel": {
+            "liftedFactorCount": 3,
+            "liftedFactorDegrees": [
+              8,
+              8,
+              8
+            ],
+            "liftedMaxCoeffBits": 52,
+            "modulusBits": 52,
+            "precision": 22,
+            "prime": 5,
+            "treeInternalLifts": 2,
+            "treeLeaves": 3,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 195529,
+              "smallAllocs": 13395
+            },
+            "berlekampMatrix": {
+              "nanos": 1022,
+              "smallAllocs": 84
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 11617,
+              "smallAllocs": 1040
+            },
+            "kernelDimension": 3,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 24,
+            "modularImage": {
+              "nanos": 651,
+              "smallAllocs": 56
+            },
+            "prime": 5,
+            "rowReduction": {
+              "nanos": 290651,
+              "smallAllocs": 24421
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 5098,
+              "smallAllocs": 414
+            },
+            "henselLift": {
+              "nanos": 116633,
+              "smallAllocs": 7201
+            },
+            "normalization": {
+              "nanos": 16945,
+              "smallAllocs": 1007
+            },
+            "primeWalk": {
+              "nanos": 215419,
+              "smallAllocs": 14959
+            },
+            "quadratic": {
+              "nanos": 331,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 28141,
+              "smallAllocs": 1407
+            },
+            "total": {
+              "nanos": 393123,
+              "smallAllocs": 25597
+            },
+            "validation": {
+              "nanos": 4276,
+              "smallAllocs": 281
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  8,
+                  8,
+                  8
+                ],
+                "forcedSubsetCost": 4,
+                "henselPrecision": 22,
+                "modularFactorCount": 3,
+                "prime": 5,
+                "reachableProperDegrees": 2,
+                "selected": true
+              }
+            ],
+            "coeffBound": 910214580246244,
+            "coeffBoundBits": 50,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 5
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 1,
+              "degreeSurvivors": 3,
+              "exactDivisionsAttempted": 2,
+              "nodes": 3,
+              "productsMaterialized": 2,
+              "recordable": 2,
+              "trailingSurvivors": 2
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 412291,
+        "total_nanos_median": 393123,
+        "total_nanos_min": 389597
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0
+        ],
+        "mirror_factor_degrees": [
+          8,
+          16
+        ],
+        "mirror_nodes": 3,
+        "mirror_prime": 5,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 3,
+        "production_completed_levels": [
+          0
+        ],
+        "production_factor_degrees": [
+          8,
+          16
+        ],
+        "production_prime": 5
+      }
+    },
+    {
+      "degree": 24,
+      "end_to_end": {
+        "max_nanos": 630034,
+        "median_nanos": 588492,
+        "min_nanos": 571427,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        2,
+        2,
+        10,
+        10
+      ],
+      "family": "chebyshev",
+      "instrumentation_ratio": 0.9339889072408801,
+      "name": "chebyshev_U24",
+      "phase_profile": {
+        "profile": {
+          "degree": 24,
+          "factorDegrees": [
+            10,
+            2,
+            10,
+            2
+          ],
+          "hensel": {
+            "liftedFactorCount": 4,
+            "liftedFactorDegrees": [
+              2,
+              10,
+              2,
+              10
+            ],
+            "liftedMaxCoeffBits": 53,
+            "modulusBits": 53,
+            "precision": 33,
+            "prime": 3,
+            "treeInternalLifts": 3,
+            "treeLeaves": 4,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 188700,
+              "smallAllocs": 12764
+            },
+            "berlekampMatrix": {
+              "nanos": 1071,
+              "smallAllocs": 84
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 6079,
+              "smallAllocs": 510
+            },
+            "kernelDimension": 4,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 24,
+            "modularImage": {
+              "nanos": 711,
+              "smallAllocs": 56
+            },
+            "prime": 3,
+            "rowReduction": {
+              "nanos": 236621,
+              "smallAllocs": 19531
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 7161,
+              "smallAllocs": 612
+            },
+            "henselLift": {
+              "nanos": 271021,
+              "smallAllocs": 14169
+            },
+            "normalization": {
+              "nanos": 17316,
+              "smallAllocs": 1009
+            },
+            "primeWalk": {
+              "nanos": 202099,
+              "smallAllocs": 13682
+            },
+            "quadratic": {
+              "nanos": 330,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 38647,
+              "smallAllocs": 2144
+            },
+            "total": {
+              "nanos": 549645,
+              "smallAllocs": 32349
+            },
+            "validation": {
+              "nanos": 5688,
+              "smallAllocs": 389
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  10,
+                  2,
+                  10
+                ],
+                "forcedSubsetCost": 8,
+                "henselPrecision": 33,
+                "modularFactorCount": 4,
+                "prime": 3,
+                "reachableProperDegrees": 7,
+                "selected": true
+              }
+            ],
+            "coeffBound": 1560748913788064,
+            "coeffBoundBits": 51,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 4,
+              "exactDivisionsAttempted": 4,
+              "nodes": 4,
+              "productsMaterialized": 4,
+              "recordable": 4,
+              "trailingSurvivors": 4
+            },
+            "successfulDivisors": 4
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 580390,
+        "total_nanos_median": 549645,
+        "total_nanos_min": 535744
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [],
+        "mirror_factor_degrees": [
+          2,
+          2,
+          10,
+          10
+        ],
+        "mirror_nodes": 4,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 4,
+        "production_completed_levels": [],
+        "production_factor_degrees": [
+          2,
+          2,
+          10,
+          10
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 30,
+      "end_to_end": {
+        "max_nanos": 8730795,
+        "median_nanos": 8592190,
+        "min_nanos": 8530829,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        30
+      ],
+      "family": "legendre",
+      "instrumentation_ratio": 0.9822295596349708,
+      "name": "legendre_P30",
+      "phase_profile": {
+        "profile": {
+          "degree": 30,
+          "factorDegrees": [
+            30
+          ],
+          "hensel": {
+            "liftedFactorCount": 7,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              2,
+              2,
+              6,
+              14,
+              2
+            ],
+            "liftedMaxCoeffBits": 91,
+            "modulusBits": 91,
+            "precision": 15,
+            "prime": 67,
+            "treeInternalLifts": 6,
+            "treeLeaves": 7,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 1918485,
+              "smallAllocs": 167769
+            },
+            "berlekampMatrix": {
+              "nanos": 1472,
+              "smallAllocs": 102
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 18388,
+              "smallAllocs": 1485
+            },
+            "kernelDimension": 7,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 30,
+            "modularImage": {
+              "nanos": 1652,
+              "smallAllocs": 75
+            },
+            "prime": 67,
+            "rowReduction": {
+              "nanos": 1656766,
+              "smallAllocs": 158865
+            },
+            "splittingNanos": 260247
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 8052,
+              "smallAllocs": 329
+            },
+            "henselLift": {
+              "nanos": 1181873,
+              "smallAllocs": 34755
+            },
+            "normalization": {
+              "nanos": 29284,
+              "smallAllocs": 1502
+            },
+            "primeWalk": {
+              "nanos": 7010265,
+              "smallAllocs": 627656
+            },
+            "quadratic": {
+              "nanos": 450,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 178875,
+              "smallAllocs": 6057
+            },
+            "total": {
+              "nanos": 8439503,
+              "smallAllocs": 671195
+            },
+            "validation": {
+              "nanos": 5879,
+              "smallAllocs": 198
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  6,
+                  14,
+                  2
+                ],
+                "forcedSubsetCost": 64,
+                "henselPrecision": 15,
+                "modularFactorCount": 7,
+                "prime": 67,
+                "reachableProperDegrees": 14,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2
+                ],
+                "forcedSubsetCost": 16384,
+                "henselPrecision": 15,
+                "modularFactorCount": 15,
+                "prime": 61,
+                "reachableProperDegrees": 14,
+                "selected": false
+              }
+            ],
+            "coeffBound": 124543935812132452094555520,
+            "coeffBoundBits": 87,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 67
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 63,
+              "degreeSurvivors": 64,
+              "exactDivisionsAttempted": 1,
+              "nodes": 64,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 8470139,
+        "total_nanos_median": 8439503,
+        "total_nanos_min": 8431030
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5
+        ],
+        "mirror_factor_degrees": [
+          30
+        ],
+        "mirror_nodes": 64,
+        "mirror_prime": 67,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 64,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5
+        ],
+        "production_factor_degrees": [
+          30
+        ],
+        "production_prime": 67
+      }
+    },
+    {
+      "degree": 38,
+      "end_to_end": {
+        "max_nanos": 3834806,
+        "median_nanos": 3809688,
+        "min_nanos": 3805622,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        38
+      ],
+      "family": "legendre",
+      "instrumentation_ratio": 0.9807391051445683,
+      "name": "legendre_P38",
+      "phase_profile": {
+        "profile": {
+          "degree": 38,
+          "factorDegrees": [
+            38
+          ],
+          "hensel": {
+            "liftedFactorCount": 3,
+            "liftedFactorDegrees": [
+              36,
+              1,
+              1
+            ],
+            "liftedMaxCoeffBits": 120,
+            "modulusBits": 120,
+            "precision": 19,
+            "prime": 79,
+            "treeInternalLifts": 2,
+            "treeLeaves": 3,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 2916424,
+              "smallAllocs": 251152
+            },
+            "berlekampMatrix": {
+              "nanos": 1763,
+              "smallAllocs": 126
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 26690,
+              "smallAllocs": 2184
+            },
+            "kernelDimension": 3,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 38,
+            "modularImage": {
+              "nanos": 2263,
+              "smallAllocs": 94
+            },
+            "prime": 79,
+            "rowReduction": {
+              "nanos": 3556363,
+              "smallAllocs": 334731
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 10175,
+              "smallAllocs": 431
+            },
+            "henselLift": {
+              "nanos": 591457,
+              "smallAllocs": 18938
+            },
+            "normalization": {
+              "nanos": 40070,
+              "smallAllocs": 2237
+            },
+            "primeWalk": {
+              "nanos": 2993448,
+              "smallAllocs": 259247
+            },
+            "quadratic": {
+              "nanos": 400,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 61221,
+              "smallAllocs": 1980
+            },
+            "total": {
+              "nanos": 3736310,
+              "smallAllocs": 283791
+            },
+            "validation": {
+              "nanos": 7451,
+              "smallAllocs": 265
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  36,
+                  1,
+                  1
+                ],
+                "forcedSubsetCost": 4,
+                "henselPrecision": 19,
+                "modularFactorCount": 3,
+                "prime": 79,
+                "reachableProperDegrees": 4,
+                "selected": true
+              }
+            ],
+            "coeffBound": 14065077854436543582494269671679200,
+            "coeffBoundBits": 114,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 79
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 3,
+              "degreeSurvivors": 4,
+              "exactDivisionsAttempted": 1,
+              "nodes": 4,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 3753796,
+        "total_nanos_median": 3736310,
+        "total_nanos_min": 3718413
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1
+        ],
+        "mirror_factor_degrees": [
+          38
+        ],
+        "mirror_nodes": 4,
+        "mirror_prime": 79,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 4,
+        "production_completed_levels": [
+          0,
+          1
+        ],
+        "production_factor_degrees": [
+          38
+        ],
+        "production_prime": 79
+      }
+    },
+    {
+      "degree": 16,
+      "end_to_end": {
+        "max_nanos": 111705,
+        "median_nanos": 106398,
+        "min_nanos": 103574,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        16
+      ],
+      "family": "cyclotomic",
+      "instrumentation_ratio": 0.7809639278933814,
+      "name": "cyclo_phi17",
+      "phase_profile": {
+        "profile": {
+          "degree": 16,
+          "factorDegrees": [
+            16
+          ],
+          "hensel": {
+            "liftedFactorCount": 1,
+            "liftedFactorDegrees": [
+              16
+            ],
+            "liftedMaxCoeffBits": 1,
+            "modulusBits": 18,
+            "precision": 11,
+            "prime": 3,
+            "treeInternalLifts": 0,
+            "treeLeaves": 1,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 49584,
+              "smallAllocs": 2865
+            },
+            "berlekampMatrix": {
+              "nanos": 641,
+              "smallAllocs": 60
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 3825,
+              "smallAllocs": 332
+            },
+            "kernelDimension": 1,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 16,
+            "modularImage": {
+              "nanos": 481,
+              "smallAllocs": 40
+            },
+            "prime": 3,
+            "rowReduction": {
+              "nanos": 92407,
+              "smallAllocs": 7303
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 2244,
+              "smallAllocs": 150
+            },
+            "henselLift": {
+              "nanos": 2103,
+              "smallAllocs": 72
+            },
+            "normalization": {
+              "nanos": 6940,
+              "smallAllocs": 370
+            },
+            "primeWalk": {
+              "nanos": 59458,
+              "smallAllocs": 3415
+            },
+            "quadratic": {
+              "nanos": 200,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 6429,
+              "smallAllocs": 424
+            },
+            "total": {
+              "nanos": 83093,
+              "smallAllocs": 4799
+            },
+            "validation": {
+              "nanos": 1902,
+              "smallAllocs": 91
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  16
+                ],
+                "forcedSubsetCost": 1,
+                "henselPrecision": 11,
+                "modularFactorCount": 1,
+                "prime": 3,
+                "reachableProperDegrees": 0,
+                "selected": true
+              }
+            ],
+            "coeffBound": 64350,
+            "coeffBoundBits": 16,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 1,
+              "exactDivisionsAttempted": 1,
+              "nodes": 1,
+              "productsMaterialized": 1,
+              "recordable": 1,
+              "trailingSurvivors": 1
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 88451,
+        "total_nanos_median": 83093,
+        "total_nanos_min": 80048
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [],
+        "mirror_factor_degrees": [
+          16
+        ],
+        "mirror_nodes": 1,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 1,
+        "production_completed_levels": [],
+        "production_factor_degrees": [
+          16
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 40,
+      "end_to_end": {
+        "max_nanos": 2017632,
+        "median_nanos": 1997742,
+        "min_nanos": 1978804,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        40
+      ],
+      "family": "cyclotomic",
+      "instrumentation_ratio": 0.9729449548540302,
+      "name": "cyclo_phi41",
+      "phase_profile": {
+        "profile": {
+          "degree": 40,
+          "factorDegrees": [
+            40
+          ],
+          "hensel": {
+            "liftedFactorCount": 5,
+            "liftedFactorDegrees": [
+              8,
+              8,
+              8,
+              8,
+              8
+            ],
+            "liftedMaxCoeffBits": 42,
+            "modulusBits": 42,
+            "precision": 26,
+            "prime": 3,
+            "treeInternalLifts": 4,
+            "treeLeaves": 5,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 458270,
+              "smallAllocs": 32512
+            },
+            "berlekampMatrix": {
+              "nanos": 1792,
+              "smallAllocs": 132
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 8743,
+              "smallAllocs": 780
+            },
+            "kernelDimension": 5,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 40,
+            "modularImage": {
+              "nanos": 911,
+              "smallAllocs": 88
+            },
+            "prime": 3,
+            "rowReduction": {
+              "nanos": 454354,
+              "smallAllocs": 38465
+            },
+            "splittingNanos": 2124
+          },
+          "multiplicities": [
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 5107,
+              "smallAllocs": 342
+            },
+            "henselLift": {
+              "nanos": 648922,
+              "smallAllocs": 30651
+            },
+            "normalization": {
+              "nanos": 16615,
+              "smallAllocs": 874
+            },
+            "primeWalk": {
+              "nanos": 475214,
+              "smallAllocs": 33974
+            },
+            "quadratic": {
+              "nanos": 321,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 784724,
+              "smallAllocs": 32169
+            },
+            "total": {
+              "nanos": 1943693,
+              "smallAllocs": 98623
+            },
+            "validation": {
+              "nanos": 4116,
+              "smallAllocs": 211
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  8,
+                  8,
+                  8,
+                  8,
+                  8
+                ],
+                "forcedSubsetCost": 16,
+                "henselPrecision": 26,
+                "modularFactorCount": 5,
+                "prime": 3,
+                "reachableProperDegrees": 4,
+                "selected": true
+              }
+            ],
+            "coeffBound": 964925701740,
+            "coeffBoundBits": 40,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 3
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 16,
+              "exactDivisionsAttempted": 1,
+              "nodes": 16,
+              "productsMaterialized": 16,
+              "recordable": 16,
+              "trailingSurvivors": 16
+            },
+            "successfulDivisors": 1
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 1954989,
+        "total_nanos_median": 1943693,
+        "total_nanos_min": 1933297
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "mirror_factor_degrees": [
+          40
+        ],
+        "mirror_nodes": 16,
+        "mirror_prime": 3,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 16,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "production_factor_degrees": [
+          40
+        ],
+        "production_prime": 3
+      }
+    },
+    {
+      "degree": 24,
+      "end_to_end": {
+        "max_nanos": 2364065,
+        "median_nanos": 2340090,
+        "min_nanos": 2330325,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        1,
+        1,
+        2,
+        2,
+        2,
+        4,
+        4,
+        8
+      ],
+      "family": "cyclotomic-products",
+      "instrumentation_ratio": 0.9788243187227842,
+      "name": "xpow24_minus1",
+      "phase_profile": {
+        "profile": {
+          "degree": 24,
+          "factorDegrees": [
+            2,
+            1,
+            4,
+            4,
+            8,
+            1,
+            2,
+            2
+          ],
+          "hensel": {
+            "liftedFactorCount": 13,
+            "liftedFactorDegrees": [
+              2,
+              2,
+              1,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              2,
+              1,
+              2
+            ],
+            "liftedMaxCoeffBits": 25,
+            "modulusBits": 25,
+            "precision": 7,
+            "prime": 11,
+            "treeInternalLifts": 12,
+            "treeLeaves": 13,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 574302,
+              "smallAllocs": 46939
+            },
+            "berlekampMatrix": {
+              "nanos": 1071,
+              "smallAllocs": 84
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 3315,
+              "smallAllocs": 270
+            },
+            "kernelDimension": 13,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 24,
+            "modularImage": {
+              "nanos": 711,
+              "smallAllocs": 56
+            },
+            "prime": 11,
+            "rowReduction": {
+              "nanos": 193567,
+              "smallAllocs": 17216
+            },
+            "splittingNanos": 379664
+          },
+          "multiplicities": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 10495,
+              "smallAllocs": 937
+            },
+            "henselLift": {
+              "nanos": 296921,
+              "smallAllocs": 17594
+            },
+            "normalization": {
+              "nanos": 7522,
+              "smallAllocs": 299
+            },
+            "primeWalk": {
+              "nanos": 1098138,
+              "smallAllocs": 89442
+            },
+            "quadratic": {
+              "nanos": 350,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 857121,
+              "smallAllocs": 48267
+            },
+            "total": {
+              "nanos": 2290537,
+              "smallAllocs": 157626
+            },
+            "validation": {
+              "nanos": 11447,
+              "smallAllocs": 574
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  1,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  2,
+                  1,
+                  2
+                ],
+                "forcedSubsetCost": 4096,
+                "henselPrecision": 7,
+                "modularFactorCount": 13,
+                "prime": 11,
+                "reachableProperDegrees": 23,
+                "selected": true
+              },
+              {
+                "factorDegrees": [
+                  2,
+                  2,
+                  2,
+                  2,
+                  1,
+                  1,
+                  2,
+                  2,
+                  1,
+                  2,
+                  2,
+                  2,
+                  2,
+                  1
+                ],
+                "forcedSubsetCost": 8192,
+                "henselPrecision": 11,
+                "modularFactorCount": 14,
+                "prime": 5,
+                "reachableProperDegrees": 23,
+                "selected": false
+              }
+            ],
+            "coeffBound": 5408312,
+            "coeffBoundBits": 23,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 2,
+            "selectedPrime": 11
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              1,
+              2,
+              0,
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 0,
+              "degreeSurvivors": 113,
+              "exactDivisionsAttempted": 8,
+              "nodes": 113,
+              "productsMaterialized": 113,
+              "recordable": 113,
+              "trailingSurvivors": 113
+            },
+            "successfulDivisors": 8
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 2304167,
+        "total_nanos_median": 2290537,
+        "total_nanos_min": 2287391
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          1,
+          2,
+          0,
+          0
+        ],
+        "mirror_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          8
+        ],
+        "mirror_nodes": 113,
+        "mirror_prime": 11,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 113,
+        "production_completed_levels": [
+          0,
+          1,
+          2,
+          0,
+          0
+        ],
+        "production_factor_degrees": [
+          1,
+          1,
+          2,
+          2,
+          2,
+          4,
+          4,
+          8
+        ],
+        "production_prime": 11
+      }
+    },
+    {
+      "degree": 20,
+      "end_to_end": {
+        "max_nanos": 687960,
+        "median_nanos": 638907,
+        "min_nanos": 612078,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        10,
+        10
+      ],
+      "family": "random-products",
+      "instrumentation_ratio": 0.9355461749519101,
+      "name": "randprod_10",
+      "phase_profile": {
+        "profile": {
+          "degree": 20,
+          "factorDegrees": [
+            10,
+            10
+          ],
+          "hensel": {
+            "liftedFactorCount": 4,
+            "liftedFactorDegrees": [
+              3,
+              4,
+              7,
+              6
+            ],
+            "liftedMaxCoeffBits": 31,
+            "modulusBits": 31,
+            "precision": 11,
+            "prime": 7,
+            "treeInternalLifts": 3,
+            "treeLeaves": 4,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 336439,
+              "smallAllocs": 23484
+            },
+            "berlekampMatrix": {
+              "nanos": 901,
+              "smallAllocs": 72
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 12348,
+              "smallAllocs": 1018
+            },
+            "kernelDimension": 4,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 20,
+            "modularImage": {
+              "nanos": 631,
+              "smallAllocs": 48
+            },
+            "prime": 7,
+            "rowReduction": {
+              "nanos": 425772,
+              "smallAllocs": 35832
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 4526,
+              "smallAllocs": 338
+            },
+            "henselLift": {
+              "nanos": 173648,
+              "smallAllocs": 9769
+            },
+            "normalization": {
+              "nanos": 21022,
+              "smallAllocs": 1219
+            },
+            "primeWalk": {
+              "nanos": 357330,
+              "smallAllocs": 24950
+            },
+            "quadratic": {
+              "nanos": 410,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 29915,
+              "smallAllocs": 1357
+            },
+            "total": {
+              "nanos": 597727,
+              "smallAllocs": 38183
+            },
+            "validation": {
+              "nanos": 3946,
+              "smallAllocs": 237
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  3,
+                  4,
+                  7,
+                  6
+                ],
+                "forcedSubsetCost": 8,
+                "henselPrecision": 11,
+                "modularFactorCount": 4,
+                "prime": 7,
+                "reachableProperDegrees": 11,
+                "selected": true
+              }
+            ],
+            "coeffBound": 161291988,
+            "coeffBoundBits": 28,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 7
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 3,
+              "degreeSurvivors": 5,
+              "exactDivisionsAttempted": 2,
+              "nodes": 5,
+              "productsMaterialized": 2,
+              "recordable": 2,
+              "trailingSurvivors": 2
+            },
+            "successfulDivisors": 2
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 624887,
+        "total_nanos_median": 597727,
+        "total_nanos_min": 571177
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0
+        ],
+        "mirror_factor_degrees": [
+          10,
+          10
+        ],
+        "mirror_nodes": 5,
+        "mirror_prime": 7,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 5,
+        "production_completed_levels": [
+          0,
+          0
+        ],
+        "production_factor_degrees": [
+          10,
+          10
+        ],
+        "production_prime": 7
+      }
+    },
+    {
+      "degree": 24,
+      "end_to_end": {
+        "max_nanos": 1462198,
+        "median_nanos": 1426855,
+        "min_nanos": 1413335,
+        "runs": 5,
+        "status": "ok"
+      },
+      "expected_factor_degrees": [
+        7,
+        8,
+        9
+      ],
+      "family": "random-products",
+      "instrumentation_ratio": 0.956273062084094,
+      "name": "randprod_21",
+      "phase_profile": {
+        "profile": {
+          "degree": 24,
+          "factorDegrees": [
+            7,
+            8,
+            9
+          ],
+          "hensel": {
+            "liftedFactorCount": 7,
+            "liftedFactorDegrees": [
+              9,
+              7,
+              1,
+              1,
+              1,
+              4,
+              1
+            ],
+            "liftedMaxCoeffBits": 37,
+            "modulusBits": 37,
+            "precision": 9,
+            "prime": 17,
+            "treeInternalLifts": 6,
+            "treeLeaves": 7,
+            "treeShape": "count-balanced binary product tree with a guarded dominant-degree split"
+          },
+          "method": "classical",
+          "modular": {
+            "berlekampFactorTotal": {
+              "nanos": 879234,
+              "smallAllocs": 68180
+            },
+            "berlekampMatrix": {
+              "nanos": 1141,
+              "smallAllocs": 84
+            },
+            "distinctDegree": "not-applicable",
+            "goodPrimeTest": {
+              "nanos": 19369,
+              "smallAllocs": 1592
+            },
+            "kernelDimension": 7,
+            "measurement": "repeat-at-selected-prime",
+            "modularDegree": 24,
+            "modularImage": {
+              "nanos": 771,
+              "smallAllocs": 56
+            },
+            "prime": 17,
+            "rowReduction": {
+              "nanos": 997379,
+              "smallAllocs": 89421
+            },
+            "splittingNanos": 0
+          },
+          "multiplicities": [
+            1,
+            1,
+            1
+          ],
+          "phases": {
+            "assembly": {
+              "nanos": 6780,
+              "smallAllocs": 531
+            },
+            "henselLift": {
+              "nanos": 319454,
+              "smallAllocs": 17842
+            },
+            "normalization": {
+              "nanos": 26168,
+              "smallAllocs": 1651
+            },
+            "primeWalk": {
+              "nanos": 945181,
+              "smallAllocs": 74367
+            },
+            "quadratic": {
+              "nanos": 311,
+              "smallAllocs": 17
+            },
+            "recombination": {
+              "nanos": 52268,
+              "smallAllocs": 2297
+            },
+            "total": {
+              "nanos": 1364463,
+              "smallAllocs": 97424
+            },
+            "validation": {
+              "nanos": 5779,
+              "smallAllocs": 386
+            }
+          },
+          "primeWalk": {
+            "candidates": [
+              {
+                "factorDegrees": [
+                  9,
+                  7,
+                  1,
+                  1,
+                  1,
+                  4,
+                  1
+                ],
+                "forcedSubsetCost": 64,
+                "henselPrecision": 9,
+                "modularFactorCount": 7,
+                "prime": 17,
+                "reachableProperDegrees": 23,
+                "selected": true
+              }
+            ],
+            "coeffBound": 41749464484,
+            "coeffBoundBits": 36,
+            "goodPrimeFound": true,
+            "retainedGoodPrimes": 1,
+            "selectedPrime": 17
+          },
+          "recombination": {
+            "budget": 262144,
+            "completedLevels": [
+              0,
+              0,
+              1,
+              2
+            ],
+            "decline": null,
+            "stages": {
+              "cheapFilterRejections": 10,
+              "degreeSurvivors": 13,
+              "exactDivisionsAttempted": 3,
+              "nodes": 13,
+              "productsMaterialized": 3,
+              "recordable": 3,
+              "trailingSurvivors": 3
+            },
+            "successfulDivisors": 3
+          },
+          "reconstructs": true
+        },
+        "runs": 5,
+        "status": "ok",
+        "total_nanos_max": 1371523,
+        "total_nanos_median": 1364463,
+        "total_nanos_min": 1359055
+      },
+      "representative": false,
+      "sampling_profile_captured": false,
+      "validation": {
+        "applicable": true,
+        "factors_agree": true,
+        "levels_agree": true,
+        "mirror_completed_levels": [
+          0,
+          0,
+          1,
+          2
+        ],
+        "mirror_factor_degrees": [
+          7,
+          8,
+          9
+        ],
+        "mirror_nodes": 13,
+        "mirror_prime": 17,
+        "nodes_agree": true,
+        "prime_agrees": true,
+        "production_candidates_tried": 13,
+        "production_completed_levels": [
+          0,
+          0,
+          1,
+          2
+        ],
+        "production_factor_degrees": [
+          7,
+          8,
+          9
+        ],
+        "production_prime": 17
+      }
+    }
+  ],
+  "schema": "hexbz-phase-profile/3",
+  "scouts": [],
+  "validation": {
+    "disagreements": [],
+    "factors_agree": 368,
+    "instrumentation_ratio_max": 1.0223876719740315,
+    "instrumentation_ratio_median": 0.982458176369668,
+    "kernel_disagreements": [],
+    "kernel_mirror_agree": 24,
+    "kernel_packed_agree": 24,
+    "kernel_rows": 24,
+    "levels_agree": 368,
+    "nodes_agree": 368,
+    "prime_agree": 368,
+    "sample_size": 368,
+    "scout_disagreements": [],
+    "scout_patterns_agree": 0,
+    "scout_rows": 0
+  }
+}

--- a/reports/figures/hexbz-cactus-certificate-boundary.svg
+++ b/reports/figures/hexbz-cactus-certificate-boundary.svg
@@ -1037,7 +1037,7 @@ z
     </g>
    </g>
    <g id="line2d_31">
-    <path d="M 290.301172 195.465668
+    <path d="M 290.301172 198.026284
 " clip-path="url(#p2299177b78)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1053,7 +1053,7 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p2299177b78)">
-     <use xlink:href="#md73ba6276e" x="290.301172" y="195.465668" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="290.301172" y="198.026284" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_32">
@@ -1791,7 +1791,7 @@ L 96.202344 96.641875
    </g>
   </g>
   <g id="text_21">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -1844,16 +1844,6 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1a" d="M 525 4666
-L 3525 4666
-L 3525 4397
-L 1831 0
-L 1172 0
-L 2766 4134
-L 525 4134
-L 525 4666
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -1901,7 +1891,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-certificate-boundary.svg
+++ b/reports/figures/hexbz-cactus-certificate-boundary.svg
@@ -1037,7 +1037,7 @@ z
     </g>
    </g>
    <g id="line2d_31">
-    <path d="M 290.301172 198.026284
+    <path d="M 290.301172 205.587244
 " clip-path="url(#p2299177b78)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1053,7 +1053,7 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p2299177b78)">
-     <use xlink:href="#md73ba6276e" x="290.301172" y="198.026284" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="290.301172" y="205.587244" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_32">
@@ -1791,7 +1791,7 @@ L 96.202344 96.641875
    </g>
   </g>
   <g id="text_21">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -1891,7 +1891,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-chebyshev.svg
+++ b/reports/figures/hexbz-cactus-chebyshev.svg
@@ -1407,34 +1407,34 @@ z
     </g>
    </g>
    <g id="line2d_125">
-    <path d="M 86.724055 278.483845
-L 101.569768 263.24668
-L 116.41548 254.856131
-L 131.261192 248.964114
-L 146.106905 242.763466
-L 160.952617 237.41083
-L 175.798329 233.19667
-L 190.644042 229.601745
-L 205.489754 226.568168
-L 220.335466 223.930508
-L 235.181179 220.879246
-L 250.026891 218.204963
-L 264.872603 215.416262
-L 279.718316 212.845371
-L 294.564028 210.197259
-L 309.40974 207.602172
-L 324.255453 205.21666
-L 339.101165 203.0402
-L 353.946877 200.906187
-L 368.79259 198.66719
-L 383.638302 196.311241
-L 398.484014 193.952934
-L 413.329727 191.750886
-L 428.175439 188.517703
-L 443.021151 185.625488
-L 457.866864 183.089941
-L 472.712576 180.482642
-L 487.558288 177.964274
+    <path d="M 86.724055 281.757596
+L 101.569768 266.352065
+L 116.41548 257.953246
+L 131.261192 251.208902
+L 146.106905 244.692407
+L 160.952617 239.733957
+L 175.798329 235.456411
+L 190.644042 231.940914
+L 205.489754 228.826752
+L 220.335466 226.137736
+L 235.181179 223.127978
+L 250.026891 220.438763
+L 264.872603 217.664631
+L 279.718316 215.169528
+L 294.564028 212.526317
+L 309.40974 210.12257
+L 324.255453 207.957866
+L 339.101165 205.782825
+L 353.946877 203.604259
+L 368.79259 201.458769
+L 383.638302 199.251863
+L 398.484014 196.931025
+L 413.329727 194.76406
+L 428.175439 191.899736
+L 443.021151 189.078314
+L 457.866864 186.454924
+L 472.712576 183.937025
+L 487.558288 181.251632
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1450,34 +1450,34 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="278.483845" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="101.569768" y="263.24668" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="116.41548" y="254.856131" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="131.261192" y="248.964114" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="146.106905" y="242.763466" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="160.952617" y="237.41083" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.798329" y="233.19667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="190.644042" y="229.601745" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="205.489754" y="226.568168" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="223.930508" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="235.181179" y="220.879246" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="250.026891" y="218.204963" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.872603" y="215.416262" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="279.718316" y="212.845371" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.564028" y="210.197259" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.40974" y="207.602172" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="324.255453" y="205.21666" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="339.101165" y="203.0402" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="200.906187" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="368.79259" y="198.66719" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="383.638302" y="196.311241" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.484014" y="193.952934" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="413.329727" y="191.750886" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="428.175439" y="188.517703" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="443.021151" y="185.625488" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="457.866864" y="183.089941" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="472.712576" y="180.482642" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="177.964274" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="281.757596" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="101.569768" y="266.352065" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="116.41548" y="257.953246" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="131.261192" y="251.208902" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="146.106905" y="244.692407" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="160.952617" y="239.733957" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.798329" y="235.456411" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="190.644042" y="231.940914" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="205.489754" y="228.826752" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="226.137736" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="235.181179" y="223.127978" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="250.026891" y="220.438763" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.872603" y="217.664631" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="279.718316" y="215.169528" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.564028" y="212.526317" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.40974" y="210.12257" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="324.255453" y="207.957866" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="339.101165" y="205.782825" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="203.604259" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="368.79259" y="201.458769" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="383.638302" y="199.251863" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.484014" y="196.931025" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="413.329727" y="194.76406" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="428.175439" y="191.899736" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="443.021151" y="189.078314" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="457.866864" y="186.454924" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="472.712576" y="183.937025" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="181.251632" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -2530,7 +2530,7 @@ z
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2669,7 +2669,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-chebyshev.svg
+++ b/reports/figures/hexbz-cactus-chebyshev.svg
@@ -1407,34 +1407,34 @@ z
     </g>
    </g>
    <g id="line2d_125">
-    <path d="M 86.724055 281.757596
-L 101.569768 266.352065
-L 116.41548 257.953246
-L 131.261192 251.208902
-L 146.106905 244.692407
-L 160.952617 239.733957
-L 175.798329 235.456411
-L 190.644042 231.940914
-L 205.489754 228.826752
-L 220.335466 226.137736
-L 235.181179 223.127978
-L 250.026891 220.438763
-L 264.872603 217.664631
-L 279.718316 215.169528
-L 294.564028 212.526317
-L 309.40974 210.12257
-L 324.255453 207.957866
-L 339.101165 205.782825
-L 353.946877 203.604259
-L 368.79259 201.458769
-L 383.638302 199.251863
-L 398.484014 196.931025
-L 413.329727 194.76406
-L 428.175439 191.899736
-L 443.021151 189.078314
-L 457.866864 186.454924
-L 472.712576 183.937025
-L 487.558288 181.251632
+    <path d="M 86.724055 281.772319
+L 101.569768 266.614788
+L 116.41548 258.034933
+L 131.261192 249.704827
+L 146.106905 243.847294
+L 160.952617 239.18945
+L 175.798329 235.055795
+L 190.644042 231.551038
+L 205.489754 228.526766
+L 220.335466 225.738902
+L 235.181179 222.696953
+L 250.026891 219.68
+L 264.872603 216.991593
+L 279.718316 214.525143
+L 294.564028 211.965286
+L 309.40974 209.575578
+L 324.255453 207.303647
+L 339.101165 205.205608
+L 353.946877 203.04787
+L 368.79259 200.883887
+L 383.638302 198.756883
+L 398.484014 196.366645
+L 413.329727 194.228171
+L 428.175439 191.407344
+L 443.021151 188.630821
+L 457.866864 186.026067
+L 472.712576 183.461617
+L 487.558288 180.812815
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1450,34 +1450,34 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="281.757596" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="101.569768" y="266.352065" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="116.41548" y="257.953246" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="131.261192" y="251.208902" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="146.106905" y="244.692407" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="160.952617" y="239.733957" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.798329" y="235.456411" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="190.644042" y="231.940914" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="205.489754" y="228.826752" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="226.137736" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="235.181179" y="223.127978" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="250.026891" y="220.438763" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.872603" y="217.664631" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="279.718316" y="215.169528" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.564028" y="212.526317" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.40974" y="210.12257" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="324.255453" y="207.957866" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="339.101165" y="205.782825" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="203.604259" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="368.79259" y="201.458769" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="383.638302" y="199.251863" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.484014" y="196.931025" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="413.329727" y="194.76406" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="428.175439" y="191.899736" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="443.021151" y="189.078314" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="457.866864" y="186.454924" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="472.712576" y="183.937025" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="181.251632" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="281.772319" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="101.569768" y="266.614788" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="116.41548" y="258.034933" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="131.261192" y="249.704827" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="146.106905" y="243.847294" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="160.952617" y="239.18945" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.798329" y="235.055795" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="190.644042" y="231.551038" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="205.489754" y="228.526766" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="225.738902" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="235.181179" y="222.696953" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="250.026891" y="219.68" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.872603" y="216.991593" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="279.718316" y="214.525143" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.564028" y="211.965286" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.40974" y="209.575578" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="324.255453" y="207.303647" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="339.101165" y="205.205608" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="203.04787" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="368.79259" y="200.883887" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="383.638302" y="198.756883" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.484014" y="196.366645" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="413.329727" y="194.228171" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="428.175439" y="191.407344" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="443.021151" y="188.630821" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="457.866864" y="186.026067" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="472.712576" y="183.461617" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="180.812815" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -2530,7 +2530,7 @@ z
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2622,6 +2622,36 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-1c" d="M 703 97
+L 703 672
+Q 941 559 1184 500
+Q 1428 441 1663 441
+Q 2288 441 2617 861
+Q 2947 1281 2994 2138
+Q 2813 1869 2534 1725
+Q 2256 1581 1919 1581
+Q 1219 1581 811 2004
+Q 403 2428 403 3163
+Q 403 3881 828 4315
+Q 1253 4750 1959 4750
+Q 2769 4750 3195 4129
+Q 3622 3509 3622 2328
+Q 3622 1225 3098 567
+Q 2575 -91 1691 -91
+Q 1453 -91 1209 -44
+Q 966 3 703 97
+z
+M 1959 2075
+Q 2384 2075 2632 2365
+Q 2881 2656 2881 3163
+Q 2881 3666 2632 3958
+Q 2384 4250 1959 4250
+Q 1534 4250 1286 3958
+Q 1038 3666 1038 3163
+Q 1038 2656 1286 2365
+Q 1534 2075 1959 2075
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2669,7 +2699,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-combined.svg
+++ b/reports/figures/hexbz-cactus-combined.svg
@@ -1656,58 +1656,61 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <path d="M 86.724055 278.995947
-L 89.260981 263.633566
-L 91.797906 255.475877
-L 94.334832 249.85288
-L 96.871757 245.516411
-L 99.408683 242.041805
-L 101.945609 239.110278
-L 104.482534 236.45597
-L 107.01946 234.145215
-L 119.704087 223.988036
-L 124.777938 220.591301
-L 132.388715 216.035559
-L 139.999491 211.877906
-L 145.073342 209.376719
-L 152.684119 205.936038
-L 160.294896 202.64598
-L 167.905672 199.490147
-L 175.516449 196.642387
-L 180.5903 194.828758
-L 193.274927 190.719283
-L 213.570332 184.61209
-L 228.791885 180.369071
-L 271.919619 168.613995
-L 287.141172 164.670924
-L 294.751948 162.649012
-L 304.899651 160.218119
-L 317.584278 157.451158
-L 322.658129 156.330751
-L 332.805831 153.932523
-L 340.416608 151.83915
-L 350.56431 149.170047
-L 363.248938 145.411995
-L 368.322789 143.728943
-L 375.933565 141.11906
-L 391.155118 134.276123
-L 398.765895 130.158671
-L 406.376672 124.575636
-L 408.913597 122.282395
-L 411.450523 119.547791
-L 413.987448 117.050105
-L 421.598225 110.314074
-L 426.672076 106.429786
-L 429.209001 103.1937
-L 431.745927 100.411549
-L 436.819778 95.45302
-L 439.356703 91.792765
-L 441.893629 88.688545
-L 444.430554 80.948575
-L 446.96748 67.513762
-L 449.504405 59.525449
-L 452.041331 50.187506
-L 452.041331 50.187506
+    <path d="M 86.724055 278.920984
+L 89.260981 264.273669
+L 91.797906 256.51176
+L 94.334832 251.169573
+L 96.871757 247.108589
+L 99.408683 243.738416
+L 101.945609 240.800083
+L 107.01946 235.91765
+L 109.556385 233.835473
+L 112.093311 231.603891
+L 117.167162 227.611712
+L 122.241013 224.103778
+L 127.314864 220.875198
+L 132.388715 217.793376
+L 139.999491 213.698051
+L 145.073342 211.203432
+L 152.684119 207.854629
+L 167.905672 201.77115
+L 172.979523 199.82648
+L 180.5903 197.161816
+L 188.201076 194.70554
+L 198.348778 191.733664
+L 205.959555 189.576589
+L 213.570332 187.310689
+L 228.791885 183.201559
+L 282.067321 169.218461
+L 299.8258 164.990439
+L 320.121204 160.562578
+L 337.879682 156.720855
+L 342.953533 155.287823
+L 350.56431 153.048857
+L 355.638161 151.625412
+L 363.248938 149.178723
+L 375.933565 144.627387
+L 383.544342 140.768162
+L 388.618193 138.311497
+L 396.228969 134.164214
+L 398.765895 132.474845
+L 401.302821 130.48825
+L 403.839746 128.651265
+L 406.376672 126.488243
+L 413.987448 118.877261
+L 416.524374 116.582208
+L 419.061299 114.561208
+L 424.13515 110.143237
+L 426.672076 108.148702
+L 431.745927 104.312308
+L 434.282852 101.451111
+L 439.356703 96.398931
+L 441.893629 92.461058
+L 444.430554 83.86824
+L 446.96748 69.661216
+L 449.504405 61.326815
+L 452.041331 50.953234
+L 452.041331 50.953234
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1723,151 +1726,151 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="278.995947" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="89.260981" y="263.633566" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="91.797906" y="255.475877" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="94.334832" y="249.85288" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="96.871757" y="245.516411" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.408683" y="242.041805" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="101.945609" y="239.110278" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="104.482534" y="236.45597" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.01946" y="234.145215" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="109.556385" y="232.087706" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="112.093311" y="229.949935" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="114.630236" y="227.973327" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.167162" y="225.9334" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="119.704087" y="223.988036" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="122.241013" y="222.231135" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="124.777938" y="220.591301" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.314864" y="219.049211" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="129.851789" y="217.545425" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="132.388715" y="216.035559" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="134.92564" y="214.612528" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="137.462566" y="213.236565" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="139.999491" y="211.877906" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="142.536417" y="210.597316" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="145.073342" y="209.376719" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="147.610268" y="208.198478" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="150.147194" y="207.037222" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="152.684119" y="205.936038" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="155.221045" y="204.813936" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="157.75797" y="203.731824" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="160.294896" y="202.64598" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="162.831821" y="201.579526" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="165.368747" y="200.521316" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="167.905672" y="199.490147" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="170.442598" y="198.514931" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="172.979523" y="197.582386" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.516449" y="196.642387" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="178.053374" y="195.714303" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="180.5903" y="194.828758" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="183.127225" y="193.985305" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="185.664151" y="193.133163" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="188.201076" y="192.308989" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="190.738002" y="191.498846" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="193.274927" y="190.719283" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="195.811853" y="189.944362" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="198.348778" y="189.130271" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="200.885704" y="188.343456" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="203.42263" y="187.582268" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="205.959555" y="186.839032" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="208.496481" y="186.095321" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="211.033406" y="185.339285" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="213.570332" y="184.61209" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="216.107257" y="183.887235" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="218.644183" y="183.183389" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="221.181108" y="182.496623" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="223.718034" y="181.799561" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="226.254959" y="181.070671" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="228.791885" y="180.369071" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="231.32881" y="179.673535" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="233.865736" y="179.005137" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="236.402661" y="178.307082" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="238.939587" y="177.61925" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="241.476512" y="176.933727" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="244.013438" y="176.210775" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="246.550363" y="175.475624" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="249.087289" y="174.762705" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.624215" y="174.059603" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="254.16114" y="173.372872" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="256.698066" y="172.703705" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="259.234991" y="172.029874" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.771917" y="171.296339" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.308842" y="170.590496" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="266.845768" y="169.911617" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="269.382693" y="169.252744" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.919619" y="168.613995" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="274.456544" y="167.974624" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="276.99347" y="167.356667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="279.530395" y="166.699911" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.067321" y="166.065244" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="284.604246" y="165.390028" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="164.670924" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="289.678097" y="163.974871" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.215023" y="163.306212" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.751948" y="162.649012" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="297.288874" y="162.014934" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="299.8258" y="161.399866" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.362725" y="160.80442" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="304.899651" y="160.218119" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="307.436576" y="159.649421" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.973502" y="159.079985" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.510427" y="158.528511" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="315.047353" y="157.986328" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="317.584278" y="157.451158" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="320.121204" y="156.925275" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="322.658129" y="156.330751" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="325.195055" y="155.743319" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="327.73198" y="155.146758" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="330.268906" y="154.535764" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="332.805831" y="153.932523" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="335.342757" y="153.213497" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="337.879682" y="152.517293" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="340.416608" y="151.83915" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="342.953533" y="151.181325" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="345.490459" y="150.515479" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="348.027384" y="149.833528" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="350.56431" y="149.170047" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.101236" y="148.430789" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="355.638161" y="147.720423" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="358.175087" y="147.027153" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="360.712012" y="146.222349" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="363.248938" y="145.411995" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="365.785863" y="144.608618" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="368.322789" y="143.728943" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="370.859714" y="142.8844" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="373.39664" y="142.078243" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="375.933565" y="141.11906" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="378.470491" y="139.981812" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="381.007416" y="138.821173" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="383.544342" y="137.705935" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="386.081267" y="136.549987" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="388.618193" y="135.435025" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="391.155118" y="134.276123" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="393.692044" y="132.926322" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="396.228969" y="131.645385" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.765895" y="130.158671" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="401.302821" y="128.310115" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="403.839746" y="126.499577" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="406.376672" y="124.575636" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="408.913597" y="122.282395" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="411.450523" y="119.547791" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="413.987448" y="117.050105" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="416.524374" y="114.783807" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="419.061299" y="112.505495" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="421.598225" y="110.314074" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="424.13515" y="108.307948" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="426.672076" y="106.429786" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="429.209001" y="103.1937" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="431.745927" y="100.411549" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="434.282852" y="97.947774" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.819778" y="95.45302" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="439.356703" y="91.792765" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="441.893629" y="88.688545" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="444.430554" y="80.948575" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.96748" y="67.513762" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="449.504405" y="59.525449" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="452.041331" y="50.187506" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="278.920984" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="89.260981" y="264.273669" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="91.797906" y="256.51176" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="94.334832" y="251.169573" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="96.871757" y="247.108589" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.408683" y="243.738416" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="101.945609" y="240.800083" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="104.482534" y="238.289195" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.01946" y="235.91765" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="109.556385" y="233.835473" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="112.093311" y="231.603891" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="114.630236" y="229.570505" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.167162" y="227.611712" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="119.704087" y="225.828533" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="122.241013" y="224.103778" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="124.777938" y="222.439187" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.314864" y="220.875198" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="129.851789" y="219.28682" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="132.388715" y="217.793376" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="134.92564" y="216.411717" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="137.462566" y="215.024374" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="139.999491" y="213.698051" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="142.536417" y="212.423044" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="145.073342" y="211.203432" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="147.610268" y="210.052612" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="150.147194" y="208.918505" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="152.684119" y="207.854629" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="155.221045" y="206.82568" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="157.75797" y="205.80938" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="160.294896" y="204.819329" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="162.831821" y="203.814067" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="165.368747" y="202.764717" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="167.905672" y="201.77115" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="170.442598" y="200.773761" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="172.979523" y="199.82648" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.516449" y="198.919822" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="178.053374" y="198.042548" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="180.5903" y="197.161816" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="183.127225" y="196.32336" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="185.664151" y="195.49761" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="188.201076" y="194.70554" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="190.738002" y="193.938997" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="193.274927" y="193.203725" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="195.811853" y="192.453108" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="198.348778" y="191.733664" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="200.885704" y="191.033247" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="203.42263" y="190.292328" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="205.959555" y="189.576589" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="208.496481" y="188.793504" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="211.033406" y="188.04019" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="213.570332" y="187.310689" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="216.107257" y="186.609918" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="218.644183" y="185.926215" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="221.181108" y="185.226979" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="223.718034" y="184.531854" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="226.254959" y="183.864217" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="228.791885" y="183.201559" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="231.32881" y="182.532434" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="233.865736" y="181.883621" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="236.402661" y="181.217807" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="238.939587" y="180.52611" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="241.476512" y="179.829004" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="244.013438" y="179.113979" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="246.550363" y="178.426177" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="249.087289" y="177.74227" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.624215" y="177.077386" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="254.16114" y="176.429186" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="256.698066" y="175.747694" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="259.234991" y="175.06087" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.771917" y="174.399431" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.308842" y="173.759226" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="266.845768" y="173.137791" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="269.382693" y="172.482363" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.919619" y="171.810276" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="274.456544" y="171.138319" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="276.99347" y="170.477233" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="279.530395" y="169.836403" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.067321" y="169.218461" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="284.604246" y="168.599577" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="167.989579" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="289.678097" y="167.366319" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.215023" y="166.748657" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.751948" y="166.14801" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="297.288874" y="165.563084" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="299.8258" y="164.990439" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.362725" y="164.423725" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="304.899651" y="163.867573" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="307.436576" y="163.2998" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.973502" y="162.736294" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.510427" y="162.189184" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="315.047353" y="161.642978" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="317.584278" y="161.095331" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="320.121204" y="160.562578" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="322.658129" y="160.02529" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="325.195055" y="159.503096" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="327.73198" y="158.992426" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="330.268906" y="158.439292" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="332.805831" y="157.856613" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="335.342757" y="157.293289" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="337.879682" y="156.720855" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="340.416608" y="156.024172" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="342.953533" y="155.287823" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="345.490459" y="154.513972" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="348.027384" y="153.773497" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="350.56431" y="153.048857" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.101236" y="152.35259" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="355.638161" y="151.625412" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="358.175087" y="150.835861" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="360.712012" y="150.05258" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="363.248938" y="149.178723" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="365.785863" y="148.287393" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="368.322789" y="147.405997" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="370.859714" y="146.541577" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="373.39664" y="145.601363" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="375.933565" y="144.627387" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="378.470491" y="143.323805" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="381.007416" y="142.087515" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="383.544342" y="140.768162" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="386.081267" y="139.544078" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="388.618193" y="138.311497" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="391.155118" y="136.967854" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="393.692044" y="135.609832" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="396.228969" y="134.164214" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.765895" y="132.474845" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="401.302821" y="130.48825" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="403.839746" y="128.651265" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="406.376672" y="126.488243" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="408.913597" y="123.954983" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="411.450523" y="121.279914" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="413.987448" y="118.877261" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="416.524374" y="116.582208" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="419.061299" y="114.561208" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="421.598225" y="112.298852" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="424.13515" y="110.143237" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="426.672076" y="108.148702" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="429.209001" y="106.298001" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="431.745927" y="104.312308" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="434.282852" y="101.451111" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.819778" y="98.889496" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="439.356703" y="96.398931" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="441.893629" y="92.461058" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="444.430554" y="83.86824" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.96748" y="69.661216" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="449.504405" y="61.326815" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="452.041331" y="50.953234" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_152">
@@ -3729,7 +3732,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_26">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -3838,16 +3841,6 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1a" d="M 525 4666
-L 3525 4666
-L 3525 4397
-L 1831 0
-L 1172 0
-L 2766 4134
-L 525 4134
-L 525 4666
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -3895,7 +3888,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-combined.svg
+++ b/reports/figures/hexbz-cactus-combined.svg
@@ -1656,61 +1656,60 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <path d="M 86.724055 278.920984
-L 89.260981 264.273669
-L 91.797906 256.51176
-L 94.334832 251.169573
-L 96.871757 247.108589
-L 99.408683 243.738416
-L 101.945609 240.800083
-L 107.01946 235.91765
-L 109.556385 233.835473
-L 112.093311 231.603891
-L 117.167162 227.611712
-L 122.241013 224.103778
-L 127.314864 220.875198
-L 132.388715 217.793376
-L 139.999491 213.698051
-L 145.073342 211.203432
-L 152.684119 207.854629
-L 167.905672 201.77115
-L 172.979523 199.82648
-L 180.5903 197.161816
-L 188.201076 194.70554
-L 198.348778 191.733664
-L 205.959555 189.576589
-L 213.570332 187.310689
-L 228.791885 183.201559
-L 282.067321 169.218461
-L 299.8258 164.990439
-L 320.121204 160.562578
-L 337.879682 156.720855
-L 342.953533 155.287823
-L 350.56431 153.048857
-L 355.638161 151.625412
-L 363.248938 149.178723
-L 375.933565 144.627387
-L 383.544342 140.768162
-L 388.618193 138.311497
-L 396.228969 134.164214
-L 398.765895 132.474845
-L 401.302821 130.48825
-L 403.839746 128.651265
-L 406.376672 126.488243
-L 413.987448 118.877261
-L 416.524374 116.582208
-L 419.061299 114.561208
-L 424.13515 110.143237
-L 426.672076 108.148702
-L 431.745927 104.312308
-L 434.282852 101.451111
-L 439.356703 96.398931
-L 441.893629 92.461058
-L 444.430554 83.86824
-L 446.96748 69.661216
-L 449.504405 61.326815
-L 452.041331 50.953234
-L 452.041331 50.953234
+    <path d="M 86.724055 280.86125
+L 89.260981 265.910644
+L 91.797906 257.685012
+L 94.334832 252.130897
+L 96.871757 247.845531
+L 99.408683 244.422795
+L 101.945609 241.569234
+L 104.482534 238.912334
+L 112.093311 231.995073
+L 114.630236 229.844214
+L 117.167162 227.850115
+L 119.704087 226.034481
+L 127.314864 221.157766
+L 139.999491 214.006205
+L 145.073342 211.390586
+L 150.147194 209.026233
+L 157.75797 205.908968
+L 165.368747 202.75256
+L 170.442598 200.600141
+L 175.516449 198.652818
+L 183.127225 196.030889
+L 193.274927 192.887688
+L 216.107257 186.21102
+L 284.604246 168.312103
+L 294.751948 165.864923
+L 309.973502 162.418629
+L 332.805831 157.426541
+L 337.879682 156.129094
+L 345.490459 153.976409
+L 353.101236 151.845016
+L 355.638161 151.13805
+L 360.712012 149.412028
+L 375.933565 143.872091
+L 393.692044 135.092696
+L 396.228969 133.687504
+L 398.765895 131.975941
+L 401.302821 130.019145
+L 403.839746 128.242421
+L 406.376672 126.056352
+L 413.987448 118.486257
+L 416.524374 116.257691
+L 419.061299 114.277342
+L 424.13515 109.881382
+L 426.672076 107.914852
+L 429.209001 106.090243
+L 431.745927 104.093148
+L 434.282852 101.246124
+L 439.356703 96.268648
+L 441.893629 92.333147
+L 444.430554 83.843556
+L 446.96748 69.779182
+L 449.504405 61.408192
+L 452.041331 49.780198
+L 452.041331 49.780198
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1726,151 +1725,151 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="278.920984" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="89.260981" y="264.273669" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="91.797906" y="256.51176" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="94.334832" y="251.169573" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="96.871757" y="247.108589" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.408683" y="243.738416" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="101.945609" y="240.800083" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="104.482534" y="238.289195" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.01946" y="235.91765" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="109.556385" y="233.835473" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="112.093311" y="231.603891" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="114.630236" y="229.570505" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.167162" y="227.611712" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="119.704087" y="225.828533" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="122.241013" y="224.103778" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="124.777938" y="222.439187" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.314864" y="220.875198" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="129.851789" y="219.28682" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="132.388715" y="217.793376" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="134.92564" y="216.411717" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="137.462566" y="215.024374" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="139.999491" y="213.698051" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="142.536417" y="212.423044" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="145.073342" y="211.203432" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="147.610268" y="210.052612" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="150.147194" y="208.918505" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="152.684119" y="207.854629" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="155.221045" y="206.82568" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="157.75797" y="205.80938" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="160.294896" y="204.819329" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="162.831821" y="203.814067" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="165.368747" y="202.764717" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="167.905672" y="201.77115" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="170.442598" y="200.773761" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="172.979523" y="199.82648" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.516449" y="198.919822" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="178.053374" y="198.042548" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="180.5903" y="197.161816" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="183.127225" y="196.32336" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="185.664151" y="195.49761" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="188.201076" y="194.70554" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="190.738002" y="193.938997" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="193.274927" y="193.203725" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="195.811853" y="192.453108" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="198.348778" y="191.733664" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="200.885704" y="191.033247" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="203.42263" y="190.292328" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="205.959555" y="189.576589" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="208.496481" y="188.793504" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="211.033406" y="188.04019" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="213.570332" y="187.310689" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="216.107257" y="186.609918" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="218.644183" y="185.926215" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="221.181108" y="185.226979" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="223.718034" y="184.531854" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="226.254959" y="183.864217" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="228.791885" y="183.201559" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="231.32881" y="182.532434" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="233.865736" y="181.883621" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="236.402661" y="181.217807" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="238.939587" y="180.52611" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="241.476512" y="179.829004" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="244.013438" y="179.113979" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="246.550363" y="178.426177" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="249.087289" y="177.74227" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.624215" y="177.077386" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="254.16114" y="176.429186" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="256.698066" y="175.747694" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="259.234991" y="175.06087" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.771917" y="174.399431" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.308842" y="173.759226" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="266.845768" y="173.137791" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="269.382693" y="172.482363" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.919619" y="171.810276" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="274.456544" y="171.138319" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="276.99347" y="170.477233" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="279.530395" y="169.836403" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.067321" y="169.218461" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="284.604246" y="168.599577" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="167.989579" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="289.678097" y="167.366319" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.215023" y="166.748657" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.751948" y="166.14801" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="297.288874" y="165.563084" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="299.8258" y="164.990439" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.362725" y="164.423725" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="304.899651" y="163.867573" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="307.436576" y="163.2998" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.973502" y="162.736294" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.510427" y="162.189184" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="315.047353" y="161.642978" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="317.584278" y="161.095331" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="320.121204" y="160.562578" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="322.658129" y="160.02529" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="325.195055" y="159.503096" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="327.73198" y="158.992426" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="330.268906" y="158.439292" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="332.805831" y="157.856613" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="335.342757" y="157.293289" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="337.879682" y="156.720855" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="340.416608" y="156.024172" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="342.953533" y="155.287823" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="345.490459" y="154.513972" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="348.027384" y="153.773497" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="350.56431" y="153.048857" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.101236" y="152.35259" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="355.638161" y="151.625412" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="358.175087" y="150.835861" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="360.712012" y="150.05258" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="363.248938" y="149.178723" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="365.785863" y="148.287393" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="368.322789" y="147.405997" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="370.859714" y="146.541577" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="373.39664" y="145.601363" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="375.933565" y="144.627387" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="378.470491" y="143.323805" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="381.007416" y="142.087515" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="383.544342" y="140.768162" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="386.081267" y="139.544078" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="388.618193" y="138.311497" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="391.155118" y="136.967854" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="393.692044" y="135.609832" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="396.228969" y="134.164214" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.765895" y="132.474845" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="401.302821" y="130.48825" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="403.839746" y="128.651265" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="406.376672" y="126.488243" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="408.913597" y="123.954983" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="411.450523" y="121.279914" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="413.987448" y="118.877261" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="416.524374" y="116.582208" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="419.061299" y="114.561208" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="421.598225" y="112.298852" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="424.13515" y="110.143237" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="426.672076" y="108.148702" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="429.209001" y="106.298001" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="431.745927" y="104.312308" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="434.282852" y="101.451111" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.819778" y="98.889496" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="439.356703" y="96.398931" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="441.893629" y="92.461058" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="444.430554" y="83.86824" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.96748" y="69.661216" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="449.504405" y="61.326815" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="452.041331" y="50.953234" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="280.86125" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="89.260981" y="265.910644" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="91.797906" y="257.685012" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="94.334832" y="252.130897" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="96.871757" y="247.845531" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.408683" y="244.422795" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="101.945609" y="241.569234" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="104.482534" y="238.912334" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.01946" y="236.587022" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="109.556385" y="234.192449" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="112.093311" y="231.995073" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="114.630236" y="229.844214" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.167162" y="227.850115" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="119.704087" y="226.034481" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="122.241013" y="224.385933" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="124.777938" y="222.710009" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.314864" y="221.157766" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="129.851789" y="219.719433" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="132.388715" y="218.220881" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="134.92564" y="216.795515" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="137.462566" y="215.404957" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="139.999491" y="214.006205" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="142.536417" y="212.660476" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="145.073342" y="211.390586" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="147.610268" y="210.167165" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="150.147194" y="209.026233" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="152.684119" y="207.947128" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="155.221045" y="206.901552" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="157.75797" y="205.908968" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="160.294896" y="204.890378" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="162.831821" y="203.877928" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="165.368747" y="202.75256" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="167.905672" y="201.648177" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="170.442598" y="200.600141" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="172.979523" y="199.60371" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.516449" y="198.652818" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="178.053374" y="197.740812" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="180.5903" y="196.866868" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="183.127225" y="196.030889" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="185.664151" y="195.225257" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="188.201076" y="194.422491" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="190.738002" y="193.652826" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="193.274927" y="192.887688" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="195.811853" y="192.138264" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="198.348778" y="191.406615" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="200.885704" y="190.622767" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="203.42263" y="189.871586" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="205.959555" y="189.103004" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="208.496481" y="188.347615" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="211.033406" y="187.607126" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="213.570332" y="186.895423" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="216.107257" y="186.21102" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="218.644183" y="185.544633" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="221.181108" y="184.881798" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="223.718034" y="184.239134" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="226.254959" y="183.581058" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="228.791885" y="182.926812" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="231.32881" y="182.257521" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="233.865736" y="181.608487" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="236.402661" y="180.951208" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="238.939587" y="180.265731" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="241.476512" y="179.578053" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="244.013438" y="178.884543" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="246.550363" y="178.191066" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="249.087289" y="177.51931" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.624215" y="176.870967" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="254.16114" y="176.234721" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="256.698066" y="175.563047" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="259.234991" y="174.883184" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.771917" y="174.22572" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.308842" y="173.583152" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="266.845768" y="172.951428" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="269.382693" y="172.308838" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.919619" y="171.606746" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="274.456544" y="170.922549" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="276.99347" y="170.262653" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="279.530395" y="169.603013" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.067321" y="168.956887" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="284.604246" y="168.312103" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="167.681252" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="289.678097" y="167.068657" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.215023" y="166.463615" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.751948" y="165.864923" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="297.288874" y="165.274913" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="299.8258" y="164.695551" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.362725" y="164.132793" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="304.899651" y="163.55102" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="307.436576" y="162.982391" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.973502" y="162.418629" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.510427" y="161.87139" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="315.047353" y="161.311766" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="317.584278" y="160.761791" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="320.121204" y="160.224418" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="322.658129" y="159.683509" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="325.195055" y="159.158242" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="327.73198" y="158.602084" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="330.268906" y="158.022013" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="332.805831" y="157.426541" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="335.342757" y="156.803679" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="337.879682" y="156.129094" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="340.416608" y="155.43888" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="342.953533" y="154.732881" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="345.490459" y="153.976409" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="348.027384" y="153.237429" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="350.56431" y="152.528768" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.101236" y="151.845016" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="355.638161" y="151.13805" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="358.175087" y="150.311908" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="360.712012" y="149.412028" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="363.248938" y="148.469015" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="365.785863" y="147.565618" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="368.322789" y="146.694601" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="370.859714" y="145.718058" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="373.39664" y="144.786501" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="375.933565" y="143.872091" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="378.470491" y="142.617938" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="381.007416" y="141.435762" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="383.544342" y="140.141082" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="386.081267" y="138.929529" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="388.618193" y="137.71773" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="391.155118" y="136.382018" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="393.692044" y="135.092696" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="396.228969" y="133.687504" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.765895" y="131.975941" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="401.302821" y="130.019145" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="403.839746" y="128.242421" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="406.376672" y="126.056352" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="408.913597" y="123.484891" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="411.450523" y="120.854176" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="413.987448" y="118.486257" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="416.524374" y="116.257691" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="419.061299" y="114.277342" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="421.598225" y="112.005555" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="424.13515" y="109.881382" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="426.672076" y="107.914852" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="429.209001" y="106.090243" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="431.745927" y="104.093148" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="434.282852" y="101.246124" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.819778" y="98.726531" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="439.356703" y="96.268648" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="441.893629" y="92.333147" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="444.430554" y="83.843556" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.96748" y="69.779182" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="449.504405" y="61.408192" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="452.041331" y="49.780198" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_152">
@@ -3732,7 +3731,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_26">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -3888,7 +3887,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-conway.svg
+++ b/reports/figures/hexbz-cactus-conway.svg
@@ -1637,45 +1637,44 @@ z
     </g>
    </g>
    <g id="line2d_157">
-    <path d="M 86.724055 277.068344
-L 88.890727 266.118844
-L 91.057398 259.474274
-L 93.22407 254.793567
-L 95.390742 251.070384
-L 97.557413 248.052088
-L 99.724085 245.409798
-L 101.890756 243.02682
-L 104.057428 240.929003
-L 108.390771 237.27645
-L 110.557442 235.612415
-L 114.890785 232.656973
-L 119.224128 229.993432
-L 125.724143 226.431989
-L 130.057486 224.30797
-L 136.557501 221.447211
-L 143.057515 218.914923
-L 149.55753 216.545624
-L 160.390887 213.006864
-L 166.890902 211.110463
-L 175.557588 208.859889
-L 192.89096 204.562028
-L 201.557646 202.540001
-L 212.391004 200.210399
-L 225.391033 197.679902
-L 260.057778 191.312181
-L 290.391179 185.653948
-L 301.224537 183.537696
-L 331.557938 177.459771
-L 351.057982 173.986286
-L 368.391354 171.062284
-L 383.558055 168.522587
-L 407.391442 164.626208
-L 437.724843 159.904594
-L 461.55823 156.225066
-L 474.558259 153.958405
-L 485.391617 151.722216
-L 487.558288 151.228935
-L 487.558288 151.228935
+    <path d="M 86.724055 277.385045
+L 88.890727 266.410087
+L 91.057398 260.001207
+L 93.22407 255.403243
+L 95.390742 251.827338
+L 97.557413 248.867686
+L 99.724085 246.285719
+L 104.057428 241.825251
+L 106.224099 239.851144
+L 110.557442 236.433329
+L 114.890785 233.399558
+L 119.224128 230.722162
+L 123.557471 228.276376
+L 127.890814 226.048096
+L 132.224158 224.050366
+L 138.724172 221.382515
+L 145.224187 218.991523
+L 156.057544 215.328932
+L 164.72423 212.747212
+L 179.890931 208.59964
+L 190.724289 205.868468
+L 199.390975 203.85527
+L 212.391004 201.073785
+L 227.557705 198.115892
+L 277.39115 188.776104
+L 296.891194 185.080326
+L 314.224566 181.572452
+L 338.057953 176.969982
+L 351.057982 174.68704
+L 383.558055 169.167156
+L 403.058099 165.97028
+L 424.724814 162.598668
+L 446.391529 159.246201
+L 457.224887 157.568469
+L 474.558259 154.503314
+L 485.391617 152.228952
+L 487.558288 151.721423
+L 487.558288 151.721423
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1691,192 +1690,192 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="277.068344" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="88.890727" y="266.118844" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="91.057398" y="259.474274" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="93.22407" y="254.793567" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="95.390742" y="251.070384" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.557413" y="248.052088" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.724085" y="245.409798" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="101.890756" y="243.02682" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="104.057428" y="240.929003" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="106.224099" y="239.068608" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="108.390771" y="237.27645" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="110.557442" y="235.612415" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="112.724114" y="234.106456" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="114.890785" y="232.656973" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.057457" y="231.297105" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="119.224128" y="229.993432" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="121.3908" y="228.765072" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="123.557471" y="227.586267" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="125.724143" y="226.431989" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.890814" y="225.344158" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="130.057486" y="224.30797" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="132.224158" y="223.31586" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="134.390829" y="222.358343" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="136.557501" y="221.447211" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.724172" y="220.571444" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="140.890844" y="219.734613" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.057515" y="218.914923" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="145.224187" y="218.105108" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="147.390858" y="217.309694" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="149.55753" y="216.545624" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="151.724201" y="215.814433" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.890873" y="215.103857" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="156.057544" y="214.390399" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.224216" y="213.688555" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="160.390887" y="213.006864" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="162.557559" y="212.35106" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="164.72423" y="211.719828" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="166.890902" y="211.110463" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="169.057574" y="210.522968" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="171.224245" y="209.952627" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="173.390917" y="209.398165" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.557588" y="208.859889" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="177.72426" y="208.310043" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.890931" y="207.776953" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="182.057603" y="207.246018" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="184.224274" y="206.699035" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="186.390946" y="206.167108" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="188.557617" y="205.639951" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="190.724289" y="205.102316" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="192.89096" y="204.562028" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="195.057632" y="204.036065" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="197.224303" y="203.527011" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.390975" y="203.028918" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="201.557646" y="202.540001" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="203.724318" y="202.057959" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="205.89099" y="201.584152" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="208.057661" y="201.114593" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.224333" y="200.656419" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="212.391004" y="200.210399" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="214.557676" y="199.771189" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="216.724347" y="199.336716" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="218.891019" y="198.911991" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="221.05769" y="198.497479" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="223.224362" y="198.090172" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="225.391033" y="197.679902" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="227.557705" y="197.27522" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="229.724376" y="196.867014" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="231.891048" y="196.465795" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="234.057719" y="196.06946" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="236.224391" y="195.676064" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="238.391062" y="195.28648" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.557734" y="194.89216" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.724406" y="194.499504" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="244.891077" y="194.109049" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="247.057749" y="193.713135" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="249.22442" y="193.308333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.391092" y="192.904668" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="253.557763" y="192.507676" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="255.724435" y="192.110274" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="257.891106" y="191.717762" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="260.057778" y="191.312181" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="262.224449" y="190.916034" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.391121" y="190.507492" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="266.557792" y="190.103577" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="268.724464" y="189.708124" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="270.891135" y="189.308851" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="273.057807" y="188.89349" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="275.224478" y="188.485745" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="277.39115" y="188.086587" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="279.557822" y="187.694613" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="281.724493" y="187.289545" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="283.891165" y="186.884732" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="286.057836" y="186.472975" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="288.224508" y="186.06498" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="290.391179" y="185.653948" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.557851" y="185.25119" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.724522" y="184.827511" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="296.891194" y="184.41035" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="299.057865" y="183.968016" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="301.224537" y="183.537696" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="303.391208" y="183.096329" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="305.55788" y="182.663396" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="307.724551" y="182.221162" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.891223" y="181.766061" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.057894" y="181.313859" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="314.224566" y="180.863757" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="316.391238" y="180.412141" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="318.557909" y="179.971487" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="320.724581" y="179.538507" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="322.891252" y="179.113788" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="325.057924" y="178.690746" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="327.224595" y="178.275407" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="329.391267" y="177.866901" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.557938" y="177.459771" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.72461" y="177.062642" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="335.891281" y="176.658142" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="338.057953" y="176.261025" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="340.224624" y="175.867487" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="342.391296" y="175.480739" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="344.557967" y="175.099406" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="346.724639" y="174.720705" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="348.89131" y="174.349531" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="351.057982" y="173.986286" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.224654" y="173.610022" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="355.391325" y="173.229601" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="357.557997" y="172.857751" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="359.724668" y="172.491221" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="361.89134" y="172.128353" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.058011" y="171.770798" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="366.224683" y="171.413104" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="368.391354" y="171.062284" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="370.558026" y="170.714768" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="372.724697" y="170.374393" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.891369" y="169.999948" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="377.05804" y="169.633853" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="379.224712" y="169.258973" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="381.391383" y="168.891323" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="383.558055" y="168.522587" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="385.724726" y="168.158724" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="387.891398" y="167.80177" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="390.05807" y="167.450177" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="392.224741" y="167.095164" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="394.391413" y="166.740402" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="396.558084" y="166.384732" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.724756" y="166.029774" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="400.891427" y="165.672759" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="403.058099" y="165.319294" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="405.22477" y="164.973526" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="407.391442" y="164.626208" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="409.558113" y="164.281487" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="411.724785" y="163.933672" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="413.891456" y="163.592586" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="416.058128" y="163.252075" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="418.224799" y="162.912271" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="420.391471" y="162.575505" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="422.558142" y="162.240206" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="424.724814" y="161.902264" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="426.891486" y="161.563604" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="429.058157" y="161.229004" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="431.224829" y="160.89936" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="433.3915" y="160.563722" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="435.558172" y="160.232401" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="437.724843" y="159.904594" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="439.891515" y="159.577242" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="442.058186" y="159.253345" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="444.224858" y="158.934814" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.391529" y="158.621967" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="448.558201" y="158.301915" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="450.724872" y="157.976998" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="452.891544" y="157.653776" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="455.058215" y="157.327942" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="457.224887" y="156.972024" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="459.391558" y="156.595071" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="461.55823" y="156.225066" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="463.724902" y="155.858107" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="465.891573" y="155.493804" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="468.058245" y="155.120466" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="470.224916" y="154.752644" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="472.391588" y="154.37479" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="474.558259" y="153.958405" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="476.724931" y="153.529515" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="478.891602" y="153.103407" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="481.058274" y="152.647878" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="483.224945" y="152.183126" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="485.391617" y="151.722216" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="151.228935" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="277.385045" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="88.890727" y="266.410087" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="91.057398" y="260.001207" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="93.22407" y="255.403243" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="95.390742" y="251.827338" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.557413" y="248.867686" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.724085" y="246.285719" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="101.890756" y="244.062849" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="104.057428" y="241.825251" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="106.224099" y="239.851144" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="108.390771" y="238.096384" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="110.557442" y="236.433329" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="112.724114" y="234.908117" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="114.890785" y="233.399558" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.057457" y="232.006355" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="119.224128" y="230.722162" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="121.3908" y="229.46108" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="123.557471" y="228.276376" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="125.724143" y="227.131319" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.890814" y="226.048096" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="130.057486" y="225.021275" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="132.224158" y="224.050366" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="134.390829" y="223.133447" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="136.557501" y="222.23776" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.724172" y="221.382515" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="140.890844" y="220.560868" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.057515" y="219.774437" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="145.224187" y="218.991523" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="147.390858" y="218.23705" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="149.55753" y="217.505528" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="151.724201" y="216.75832" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.890873" y="216.027914" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="156.057544" y="215.328932" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.224216" y="214.654896" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="160.390887" y="213.997792" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="162.557559" y="213.364325" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="164.72423" y="212.747212" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="166.890902" y="212.14138" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="169.057574" y="211.545168" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="171.224245" y="210.943118" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="173.390917" y="210.358333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.557588" y="209.781909" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="177.72426" y="209.181797" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.890931" y="208.59964" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="182.057603" y="208.034516" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="184.224274" y="207.480224" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="186.390946" y="206.938875" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="188.557617" y="206.408804" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="190.724289" y="205.868468" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="192.89096" y="205.344941" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="195.057632" y="204.835067" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="197.224303" y="204.337915" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.390975" y="203.85527" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="201.557646" y="203.374789" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="203.724318" y="202.899024" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="205.89099" y="202.429317" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="208.057661" y="201.973072" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.224333" y="201.519368" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="212.391004" y="201.073785" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="214.557676" y="200.637628" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="216.724347" y="200.21046" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="218.891019" y="199.786122" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="221.05769" y="199.368791" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="223.224362" y="198.954775" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="225.391033" y="198.529809" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="227.557705" y="198.115892" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="229.724376" y="197.705216" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="231.891048" y="197.295573" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="234.057719" y="196.892839" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="236.224391" y="196.498792" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="238.391062" y="196.103998" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.557734" y="195.7137" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.724406" y="195.30944" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="244.891077" y="194.895297" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="247.057749" y="194.478622" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="249.22442" y="194.069909" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.391092" y="193.662612" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="253.557763" y="193.2631" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="255.724435" y="192.871777" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="257.891106" y="192.476724" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="260.057778" y="192.066775" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="262.224449" y="191.652015" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.391121" y="191.236786" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="266.557792" y="190.825682" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="268.724464" y="190.421385" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="270.891135" y="190.014778" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="273.057807" y="189.602237" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="275.224478" y="189.185155" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="277.39115" y="188.776104" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="279.557822" y="188.376538" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="281.724493" y="187.958653" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="283.891165" y="187.547183" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="286.057836" y="187.140345" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="288.224508" y="186.731372" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="290.391179" y="186.319679" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.557851" y="185.902433" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.724522" y="185.488336" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="296.891194" y="185.080326" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="299.057865" y="184.62958" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="301.224537" y="184.187989" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="303.391208" y="183.743789" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="305.55788" y="183.295731" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="307.724551" y="182.859759" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.891223" y="182.433763" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.057894" y="182.012761" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="314.224566" y="181.572452" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="316.391238" y="181.144078" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="318.557909" y="180.709033" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="320.724581" y="180.285556" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="322.891252" y="179.849688" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="325.057924" y="179.42016" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="327.224595" y="178.99578" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="329.391267" y="178.577775" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.557938" y="178.169364" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.72461" y="177.767608" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="335.891281" y="177.372456" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="338.057953" y="176.969982" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="340.224624" y="176.575433" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="342.391296" y="176.188314" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="344.557967" y="175.805787" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="346.724639" y="175.425351" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="348.89131" y="175.053004" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="351.057982" y="174.68704" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.224654" y="174.326272" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="355.391325" y="173.946795" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="357.557997" y="173.56158" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="359.724668" y="173.180806" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="361.89134" y="172.80514" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.058011" y="172.438171" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="366.224683" y="172.078283" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="368.391354" y="171.722181" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="370.558026" y="171.373193" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="372.724697" y="171.025149" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.891369" y="170.643767" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="377.05804" y="170.267896" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="379.224712" y="169.899185" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="381.391383" y="169.537719" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="383.558055" y="169.167156" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="385.724726" y="168.799602" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="387.891398" y="168.439825" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="390.05807" y="168.085732" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="392.224741" y="167.738721" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="394.391413" y="167.380699" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="396.558084" y="167.026092" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.724756" y="166.676108" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="400.891427" y="166.320733" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="403.058099" y="165.97028" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="405.22477" y="165.622115" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="407.391442" y="165.27896" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="409.558113" y="164.934763" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="411.724785" y="164.597874" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="413.891456" y="164.263134" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="416.058128" y="163.932374" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="418.224799" y="163.605259" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="420.391471" y="163.27758" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="422.558142" y="162.948538" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="424.724814" y="162.598668" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="426.891486" y="162.254545" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="429.058157" y="161.913017" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="431.224829" y="161.575581" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="433.3915" y="161.243013" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="435.558172" y="160.898339" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="437.724843" y="160.561034" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="439.891515" y="160.229266" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="442.058186" y="159.895308" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="444.224858" y="159.568142" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.391529" y="159.246201" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="448.558201" y="158.925944" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="450.724872" y="158.58997" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="452.891544" y="158.257563" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="455.058215" y="157.926536" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="457.224887" y="157.568469" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="459.391558" y="157.191971" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="461.55823" y="156.819458" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="463.724902" y="156.440563" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="465.891573" y="156.068795" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="468.058245" y="155.689521" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="470.224916" y="155.314225" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="472.391588" y="154.933496" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="474.558259" y="154.503314" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="476.724931" y="154.061079" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="478.891602" y="153.628826" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="481.058274" y="153.160645" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="483.224945" y="152.695965" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="485.391617" y="152.228952" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="151.721423" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_158">
@@ -3792,7 +3791,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_26">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -3884,6 +3883,36 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-1c" d="M 703 97
+L 703 672
+Q 941 559 1184 500
+Q 1428 441 1663 441
+Q 2288 441 2617 861
+Q 2947 1281 2994 2138
+Q 2813 1869 2534 1725
+Q 2256 1581 1919 1581
+Q 1219 1581 811 2004
+Q 403 2428 403 3163
+Q 403 3881 828 4315
+Q 1253 4750 1959 4750
+Q 2769 4750 3195 4129
+Q 3622 3509 3622 2328
+Q 3622 1225 3098 567
+Q 2575 -91 1691 -91
+Q 1453 -91 1209 -44
+Q 966 3 703 97
+z
+M 1959 2075
+Q 2384 2075 2632 2365
+Q 2881 2656 2881 3163
+Q 2881 3666 2632 3958
+Q 2384 4250 1959 4250
+Q 1534 4250 1286 3958
+Q 1038 3666 1038 3163
+Q 1038 2656 1286 2365
+Q 1534 2075 1959 2075
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -3931,7 +3960,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-conway.svg
+++ b/reports/figures/hexbz-cactus-conway.svg
@@ -1637,41 +1637,45 @@ z
     </g>
    </g>
    <g id="line2d_157">
-    <path d="M 86.724055 276.284666
-L 88.890727 264.756271
-L 91.057398 258.167985
-L 93.22407 253.493126
-L 95.390742 249.892586
-L 97.557413 246.929331
-L 99.724085 244.432997
-L 106.224099 237.714401
-L 110.557442 234.144336
-L 114.890785 231.107439
-L 119.224128 228.482322
-L 123.557471 226.136763
-L 130.057486 222.988918
-L 134.390829 221.10852
-L 140.890844 218.578882
-L 149.55753 215.517657
-L 164.72423 210.527197
-L 175.557588 207.461227
-L 188.557617 204.097659
-L 199.390975 201.469464
-L 210.224333 199.089519
-L 234.057719 194.169674
-L 264.391121 188.074736
-L 279.557822 184.745907
-L 292.557851 181.946575
-L 305.55788 179.168619
-L 325.057924 174.699977
-L 340.224624 171.564206
-L 357.557997 168.253774
-L 372.724697 165.3795
-L 398.724756 160.486259
-L 420.391471 156.584703
-L 478.891602 146.15203
-L 487.558288 144.290112
-L 487.558288 144.290112
+    <path d="M 86.724055 277.068344
+L 88.890727 266.118844
+L 91.057398 259.474274
+L 93.22407 254.793567
+L 95.390742 251.070384
+L 97.557413 248.052088
+L 99.724085 245.409798
+L 101.890756 243.02682
+L 104.057428 240.929003
+L 108.390771 237.27645
+L 110.557442 235.612415
+L 114.890785 232.656973
+L 119.224128 229.993432
+L 125.724143 226.431989
+L 130.057486 224.30797
+L 136.557501 221.447211
+L 143.057515 218.914923
+L 149.55753 216.545624
+L 160.390887 213.006864
+L 166.890902 211.110463
+L 175.557588 208.859889
+L 192.89096 204.562028
+L 201.557646 202.540001
+L 212.391004 200.210399
+L 225.391033 197.679902
+L 260.057778 191.312181
+L 290.391179 185.653948
+L 301.224537 183.537696
+L 331.557938 177.459771
+L 351.057982 173.986286
+L 368.391354 171.062284
+L 383.558055 168.522587
+L 407.391442 164.626208
+L 437.724843 159.904594
+L 461.55823 156.225066
+L 474.558259 153.958405
+L 485.391617 151.722216
+L 487.558288 151.228935
+L 487.558288 151.228935
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1687,192 +1691,192 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="276.284666" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="88.890727" y="264.756271" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="91.057398" y="258.167985" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="93.22407" y="253.493126" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="95.390742" y="249.892586" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.557413" y="246.929331" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.724085" y="244.432997" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="101.890756" y="242.161634" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="104.057428" y="239.789155" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="106.224099" y="237.714401" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="108.390771" y="235.860727" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="110.557442" y="234.144336" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="112.724114" y="232.559967" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="114.890785" y="231.107439" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.057457" y="229.775951" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="119.224128" y="228.482322" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="121.3908" y="227.267806" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="123.557471" y="226.136763" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="125.724143" y="225.056337" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.890814" y="224.011414" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="130.057486" y="222.988918" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="132.224158" y="222.020928" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="134.390829" y="221.10852" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="136.557501" y="220.234075" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.724172" y="219.397757" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="140.890844" y="218.578882" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.057515" y="217.791693" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="145.224187" y="217.001619" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="147.390858" y="216.245898" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="149.55753" y="215.517657" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="151.724201" y="214.789806" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.890873" y="214.029002" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="156.057544" y="213.291047" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.224216" y="212.561722" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="160.390887" y="211.858261" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="162.557559" y="211.182909" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="164.72423" y="210.527197" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="166.890902" y="209.895655" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="169.057574" y="209.27052" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="171.224245" y="208.662542" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="173.390917" y="208.055615" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.557588" y="207.461227" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="177.72426" y="206.885548" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.890931" y="206.324124" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="182.057603" y="205.758786" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="184.224274" y="205.208748" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="186.390946" y="204.654796" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="188.557617" y="204.097659" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="190.724289" y="203.549949" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="192.89096" y="203.009241" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="195.057632" y="202.484428" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="197.224303" y="201.975441" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.390975" y="201.469464" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="201.557646" y="200.976538" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="203.724318" y="200.493146" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="205.89099" y="200.022334" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="208.057661" y="199.553041" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.224333" y="199.089519" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="212.391004" y="198.632881" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="214.557676" y="198.186736" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="216.724347" y="197.724609" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="218.891019" y="197.262512" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="221.05769" y="196.811658" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="223.224362" y="196.366926" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="225.391033" y="195.930117" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="227.557705" y="195.484106" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="229.724376" y="195.045443" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="231.891048" y="194.605841" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="234.057719" y="194.169674" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="236.224391" y="193.740591" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="238.391062" y="193.317711" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.557734" y="192.898042" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.724406" y="192.461907" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="244.891077" y="192.030568" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="247.057749" y="191.608846" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="249.22442" y="191.192461" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.391092" y="190.758652" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="253.557763" y="190.335909" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="255.724435" y="189.92291" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="257.891106" y="189.507033" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="260.057778" y="189.071098" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="262.224449" y="188.567334" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.391121" y="188.074736" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="266.557792" y="187.583102" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="268.724464" y="187.093815" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="270.891135" y="186.607347" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="273.057807" y="186.132397" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="275.224478" y="185.66826" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="277.39115" y="185.200559" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="279.557822" y="184.745907" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="281.724493" y="184.263979" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="283.891165" y="183.795601" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="286.057836" y="183.330269" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="288.224508" y="182.865877" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="290.391179" y="182.403481" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.557851" y="181.946575" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.724522" y="181.500589" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="296.891194" y="181.059044" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="299.057865" y="180.590345" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="301.224537" y="180.109541" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="303.391208" y="179.635783" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="305.55788" y="179.168619" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="307.724551" y="178.663537" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.891223" y="178.137168" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.057894" y="177.621136" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="314.224566" y="177.10816" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="316.391238" y="176.606301" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="318.557909" y="176.11702" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="320.724581" y="175.639533" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="322.891252" y="175.16612" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="325.057924" y="174.699977" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="327.224595" y="174.238029" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="329.391267" y="173.778602" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.557938" y="173.331403" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.72461" y="172.885826" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="335.891281" y="172.43672" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="338.057953" y="171.999744" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="340.224624" y="171.564206" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="342.391296" y="171.13878" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="344.557967" y="170.714473" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="346.724639" y="170.296321" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="348.89131" y="169.878667" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="351.057982" y="169.469695" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.224654" y="169.055987" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="355.391325" y="168.652139" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="357.557997" y="168.253774" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="359.724668" y="167.857708" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="361.89134" y="167.456198" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.058011" y="167.056075" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="366.224683" y="166.64368" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="368.391354" y="166.225974" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="370.558026" y="165.804231" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="372.724697" y="165.3795" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.891369" y="164.963549" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="377.05804" y="164.553946" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="379.224712" y="164.137837" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="381.391383" y="163.720926" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="383.558055" y="163.30175" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="385.724726" y="162.890547" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="387.891398" y="162.480416" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="390.05807" y="162.079129" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="392.224741" y="161.686977" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="394.391413" y="161.297554" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="396.558084" y="160.894348" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.724756" y="160.486259" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="400.891427" y="160.086168" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="403.058099" y="159.695257" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="405.22477" y="159.295544" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="407.391442" y="158.904872" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="409.558113" y="158.515894" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="411.724785" y="158.1265" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="413.891456" y="157.74341" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="416.058128" y="157.368953" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="418.224799" y="156.973054" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="420.391471" y="156.584703" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="422.558142" y="156.200067" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="424.724814" y="155.820319" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="426.891486" y="155.438183" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="429.058157" y="155.054465" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="431.224829" y="154.671192" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="433.3915" y="154.284676" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="435.558172" y="153.903722" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="437.724843" y="153.521931" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="439.891515" y="153.135133" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="442.058186" y="152.747435" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="444.224858" y="152.348083" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.391529" y="151.952984" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="448.558201" y="151.561119" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="450.724872" y="151.177205" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="452.891544" y="150.791066" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="455.058215" y="150.409285" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="457.224887" y="150.014539" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="459.391558" y="149.62828" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="461.55823" y="149.250529" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="463.724902" y="148.877457" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="465.891573" y="148.511612" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="468.058245" y="148.124108" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="470.224916" y="147.739136" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="472.391588" y="147.347302" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="474.558259" y="146.946752" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="476.724931" y="146.551725" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="478.891602" y="146.15203" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="481.058274" y="145.695762" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="483.224945" y="145.246512" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="485.391617" y="144.782987" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="144.290112" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="277.068344" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="88.890727" y="266.118844" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="91.057398" y="259.474274" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="93.22407" y="254.793567" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="95.390742" y="251.070384" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.557413" y="248.052088" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.724085" y="245.409798" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="101.890756" y="243.02682" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="104.057428" y="240.929003" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="106.224099" y="239.068608" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="108.390771" y="237.27645" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="110.557442" y="235.612415" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="112.724114" y="234.106456" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="114.890785" y="232.656973" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.057457" y="231.297105" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="119.224128" y="229.993432" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="121.3908" y="228.765072" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="123.557471" y="227.586267" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="125.724143" y="226.431989" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.890814" y="225.344158" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="130.057486" y="224.30797" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="132.224158" y="223.31586" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="134.390829" y="222.358343" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="136.557501" y="221.447211" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.724172" y="220.571444" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="140.890844" y="219.734613" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.057515" y="218.914923" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="145.224187" y="218.105108" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="147.390858" y="217.309694" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="149.55753" y="216.545624" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="151.724201" y="215.814433" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.890873" y="215.103857" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="156.057544" y="214.390399" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.224216" y="213.688555" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="160.390887" y="213.006864" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="162.557559" y="212.35106" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="164.72423" y="211.719828" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="166.890902" y="211.110463" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="169.057574" y="210.522968" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="171.224245" y="209.952627" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="173.390917" y="209.398165" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.557588" y="208.859889" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="177.72426" y="208.310043" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.890931" y="207.776953" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="182.057603" y="207.246018" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="184.224274" y="206.699035" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="186.390946" y="206.167108" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="188.557617" y="205.639951" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="190.724289" y="205.102316" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="192.89096" y="204.562028" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="195.057632" y="204.036065" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="197.224303" y="203.527011" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.390975" y="203.028918" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="201.557646" y="202.540001" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="203.724318" y="202.057959" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="205.89099" y="201.584152" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="208.057661" y="201.114593" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.224333" y="200.656419" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="212.391004" y="200.210399" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="214.557676" y="199.771189" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="216.724347" y="199.336716" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="218.891019" y="198.911991" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="221.05769" y="198.497479" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="223.224362" y="198.090172" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="225.391033" y="197.679902" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="227.557705" y="197.27522" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="229.724376" y="196.867014" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="231.891048" y="196.465795" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="234.057719" y="196.06946" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="236.224391" y="195.676064" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="238.391062" y="195.28648" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.557734" y="194.89216" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.724406" y="194.499504" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="244.891077" y="194.109049" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="247.057749" y="193.713135" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="249.22442" y="193.308333" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.391092" y="192.904668" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="253.557763" y="192.507676" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="255.724435" y="192.110274" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="257.891106" y="191.717762" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="260.057778" y="191.312181" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="262.224449" y="190.916034" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.391121" y="190.507492" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="266.557792" y="190.103577" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="268.724464" y="189.708124" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="270.891135" y="189.308851" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="273.057807" y="188.89349" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="275.224478" y="188.485745" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="277.39115" y="188.086587" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="279.557822" y="187.694613" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="281.724493" y="187.289545" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="283.891165" y="186.884732" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="286.057836" y="186.472975" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="288.224508" y="186.06498" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="290.391179" y="185.653948" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.557851" y="185.25119" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.724522" y="184.827511" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="296.891194" y="184.41035" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="299.057865" y="183.968016" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="301.224537" y="183.537696" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="303.391208" y="183.096329" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="305.55788" y="182.663396" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="307.724551" y="182.221162" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.891223" y="181.766061" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.057894" y="181.313859" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="314.224566" y="180.863757" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="316.391238" y="180.412141" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="318.557909" y="179.971487" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="320.724581" y="179.538507" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="322.891252" y="179.113788" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="325.057924" y="178.690746" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="327.224595" y="178.275407" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="329.391267" y="177.866901" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.557938" y="177.459771" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.72461" y="177.062642" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="335.891281" y="176.658142" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="338.057953" y="176.261025" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="340.224624" y="175.867487" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="342.391296" y="175.480739" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="344.557967" y="175.099406" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="346.724639" y="174.720705" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="348.89131" y="174.349531" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="351.057982" y="173.986286" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.224654" y="173.610022" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="355.391325" y="173.229601" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="357.557997" y="172.857751" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="359.724668" y="172.491221" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="361.89134" y="172.128353" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.058011" y="171.770798" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="366.224683" y="171.413104" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="368.391354" y="171.062284" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="370.558026" y="170.714768" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="372.724697" y="170.374393" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.891369" y="169.999948" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="377.05804" y="169.633853" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="379.224712" y="169.258973" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="381.391383" y="168.891323" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="383.558055" y="168.522587" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="385.724726" y="168.158724" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="387.891398" y="167.80177" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="390.05807" y="167.450177" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="392.224741" y="167.095164" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="394.391413" y="166.740402" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="396.558084" y="166.384732" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.724756" y="166.029774" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="400.891427" y="165.672759" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="403.058099" y="165.319294" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="405.22477" y="164.973526" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="407.391442" y="164.626208" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="409.558113" y="164.281487" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="411.724785" y="163.933672" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="413.891456" y="163.592586" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="416.058128" y="163.252075" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="418.224799" y="162.912271" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="420.391471" y="162.575505" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="422.558142" y="162.240206" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="424.724814" y="161.902264" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="426.891486" y="161.563604" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="429.058157" y="161.229004" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="431.224829" y="160.89936" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="433.3915" y="160.563722" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="435.558172" y="160.232401" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="437.724843" y="159.904594" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="439.891515" y="159.577242" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="442.058186" y="159.253345" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="444.224858" y="158.934814" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.391529" y="158.621967" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="448.558201" y="158.301915" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="450.724872" y="157.976998" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="452.891544" y="157.653776" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="455.058215" y="157.327942" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="457.224887" y="156.972024" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="459.391558" y="156.595071" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="461.55823" y="156.225066" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="463.724902" y="155.858107" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="465.891573" y="155.493804" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="468.058245" y="155.120466" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="470.224916" y="154.752644" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="472.391588" y="154.37479" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="474.558259" y="153.958405" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="476.724931" y="153.529515" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="478.891602" y="153.103407" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="481.058274" y="152.647878" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="483.224945" y="152.183126" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="485.391617" y="151.722216" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="151.228935" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_158">
@@ -3788,7 +3792,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_26">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -3927,7 +3931,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-cyclotomic-products.svg
+++ b/reports/figures/hexbz-cactus-cyclotomic-products.svg
@@ -1423,25 +1423,25 @@ z
     </g>
    </g>
    <g id="line2d_123">
-    <path d="M 86.724055 275.286751
-L 108.992624 249.67701
-L 131.261192 237.854404
-L 153.529761 229.981959
-L 175.798329 222.565549
-L 198.066898 216.228249
-L 220.335466 209.543705
-L 242.604035 198.461848
-L 264.872603 189.229343
-L 287.141172 182.227517
-L 309.40974 176.934985
-L 331.678309 168.982009
-L 353.946877 160.45953
-L 376.215446 153.68087
-L 398.484014 137.186873
-L 420.752583 128.208874
-L 443.021151 118.07632
-L 465.28972 111.115956
-L 487.558288 103.048022
+    <path d="M 86.724055 275.386715
+L 108.992624 249.974285
+L 131.261192 237.994724
+L 153.529761 230.069836
+L 175.798329 222.628568
+L 198.066898 216.326733
+L 220.335466 209.633029
+L 242.604035 198.438087
+L 264.872603 189.263724
+L 287.141172 182.209399
+L 309.40974 176.953248
+L 331.678309 169.022349
+L 353.946877 160.617685
+L 376.215446 153.786485
+L 398.484014 137.324872
+L 420.752583 128.313263
+L 443.021151 117.990987
+L 465.28972 111.047921
+L 487.558288 103.039376
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1457,25 +1457,25 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="275.286751" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="108.992624" y="249.67701" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="131.261192" y="237.854404" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.529761" y="229.981959" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.798329" y="222.565549" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="198.066898" y="216.228249" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="209.543705" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="198.461848" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.872603" y="189.229343" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="182.227517" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.40974" y="176.934985" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.678309" y="168.982009" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="160.45953" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="376.215446" y="153.68087" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.484014" y="137.186873" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="420.752583" y="128.208874" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="443.021151" y="118.07632" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="465.28972" y="111.115956" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="103.048022" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="275.386715" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="108.992624" y="249.974285" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="131.261192" y="237.994724" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.529761" y="230.069836" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.798329" y="222.628568" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="198.066898" y="216.326733" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="209.633029" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="198.438087" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.872603" y="189.263724" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="182.209399" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.40974" y="176.953248" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.678309" y="169.022349" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="160.617685" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="376.215446" y="153.786485" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.484014" y="137.324872" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="420.752583" y="128.313263" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="443.021151" y="117.990987" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="465.28972" y="111.047921" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="103.039376" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_124">
@@ -2411,7 +2411,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2496,45 +2496,6 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1b" d="M 2034 2216
-Q 1584 2216 1326 1975
-Q 1069 1734 1069 1313
-Q 1069 891 1326 650
-Q 1584 409 2034 409
-Q 2484 409 2743 651
-Q 3003 894 3003 1313
-Q 3003 1734 2745 1975
-Q 2488 2216 2034 2216
-z
-M 1403 2484
-Q 997 2584 770 2862
-Q 544 3141 544 3541
-Q 544 4100 942 4425
-Q 1341 4750 2034 4750
-Q 2731 4750 3128 4425
-Q 3525 4100 3525 3541
-Q 3525 3141 3298 2862
-Q 3072 2584 2669 2484
-Q 3125 2378 3379 2068
-Q 3634 1759 3634 1313
-Q 3634 634 3220 271
-Q 2806 -91 2034 -91
-Q 1263 -91 848 271
-Q 434 634 434 1313
-Q 434 1759 690 2068
-Q 947 2378 1403 2484
-z
-M 1172 3481
-Q 1172 3119 1398 2916
-Q 1625 2713 2034 2713
-Q 2441 2713 2670 2916
-Q 2900 3119 2900 3481
-Q 2900 3844 2670 4047
-Q 2441 4250 2034 4250
-Q 1625 4250 1398 4047
-Q 1172 3844 1172 3481
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2582,7 +2543,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-cyclotomic-products.svg
+++ b/reports/figures/hexbz-cactus-cyclotomic-products.svg
@@ -1423,25 +1423,25 @@ z
     </g>
    </g>
    <g id="line2d_123">
-    <path d="M 86.724055 271.17485
-L 108.992624 247.430447
-L 131.261192 235.018133
-L 153.529761 226.87592
-L 175.798329 218.740447
-L 198.066898 212.879109
-L 220.335466 204.552049
-L 242.604035 194.742743
-L 264.872603 186.605208
-L 287.141172 179.798887
-L 309.40974 173.240553
-L 331.678309 166.149803
-L 353.946877 157.526251
-L 376.215446 151.360055
-L 398.484014 135.576098
-L 420.752583 125.413606
-L 443.021151 113.463333
-L 465.28972 104.698369
-L 487.558288 98.415989
+    <path d="M 86.724055 275.286751
+L 108.992624 249.67701
+L 131.261192 237.854404
+L 153.529761 229.981959
+L 175.798329 222.565549
+L 198.066898 216.228249
+L 220.335466 209.543705
+L 242.604035 198.461848
+L 264.872603 189.229343
+L 287.141172 182.227517
+L 309.40974 176.934985
+L 331.678309 168.982009
+L 353.946877 160.45953
+L 376.215446 153.68087
+L 398.484014 137.186873
+L 420.752583 128.208874
+L 443.021151 118.07632
+L 465.28972 111.115956
+L 487.558288 103.048022
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1457,25 +1457,25 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="271.17485" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="108.992624" y="247.430447" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="131.261192" y="235.018133" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.529761" y="226.87592" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.798329" y="218.740447" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="198.066898" y="212.879109" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="204.552049" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="194.742743" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.872603" y="186.605208" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="179.798887" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.40974" y="173.240553" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.678309" y="166.149803" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="157.526251" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="376.215446" y="151.360055" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.484014" y="135.576098" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="420.752583" y="125.413606" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="443.021151" y="113.463333" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="465.28972" y="104.698369" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="98.415989" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="275.286751" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="108.992624" y="249.67701" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="131.261192" y="237.854404" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.529761" y="229.981959" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.798329" y="222.565549" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="198.066898" y="216.228249" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="209.543705" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="198.461848" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.872603" y="189.229343" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="182.227517" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.40974" y="176.934985" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.678309" y="168.982009" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="160.45953" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="376.215446" y="153.68087" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.484014" y="137.186873" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="420.752583" y="128.208874" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="443.021151" y="118.07632" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="465.28972" y="111.115956" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="103.048022" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_124">
@@ -2411,7 +2411,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2496,6 +2496,45 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-1b" d="M 2034 2216
+Q 1584 2216 1326 1975
+Q 1069 1734 1069 1313
+Q 1069 891 1326 650
+Q 1584 409 2034 409
+Q 2484 409 2743 651
+Q 3003 894 3003 1313
+Q 3003 1734 2745 1975
+Q 2488 2216 2034 2216
+z
+M 1403 2484
+Q 997 2584 770 2862
+Q 544 3141 544 3541
+Q 544 4100 942 4425
+Q 1341 4750 2034 4750
+Q 2731 4750 3128 4425
+Q 3525 4100 3525 3541
+Q 3525 3141 3298 2862
+Q 3072 2584 2669 2484
+Q 3125 2378 3379 2068
+Q 3634 1759 3634 1313
+Q 3634 634 3220 271
+Q 2806 -91 2034 -91
+Q 1263 -91 848 271
+Q 434 634 434 1313
+Q 434 1759 690 2068
+Q 947 2378 1403 2484
+z
+M 1172 3481
+Q 1172 3119 1398 2916
+Q 1625 2713 2034 2713
+Q 2441 2713 2670 2916
+Q 2900 3119 2900 3481
+Q 2900 3844 2670 4047
+Q 2441 4250 2034 4250
+Q 1625 4250 1398 4047
+Q 1172 3844 1172 3481
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2543,7 +2582,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-cyclotomic.svg
+++ b/reports/figures/hexbz-cactus-cyclotomic.svg
@@ -1503,40 +1503,40 @@ z
     </g>
    </g>
    <g id="line2d_133">
-    <path d="M 86.724055 275.233859
-L 98.870547 260.133668
-L 111.017039 245.137645
-L 123.163531 236.675179
-L 135.310023 230.646462
-L 147.456515 225.683082
-L 159.603007 221.015492
-L 171.749499 215.565778
-L 183.895991 211.114516
-L 196.042483 207.311468
-L 208.188974 203.178185
-L 220.335466 199.285361
-L 232.481958 195.609627
-L 244.62845 191.593704
-L 256.774942 187.998888
-L 268.921434 184.599632
-L 281.067926 180.711659
-L 293.214418 176.175261
-L 305.36091 171.673162
-L 317.507402 164.704896
-L 329.653894 158.257231
-L 341.800385 153.066951
-L 353.946877 148.873069
-L 366.093369 143.55624
-L 378.239861 138.872303
-L 390.386353 132.908205
-L 402.532845 124.843104
-L 414.679337 119.031558
-L 426.825829 114.367818
-L 438.972321 110.389629
-L 451.118813 106.463776
-L 463.265305 98.476564
-L 475.411796 79.923049
-L 487.558288 54.49125
+    <path d="M 86.724055 275.809889
+L 98.870547 261.2243
+L 111.017039 245.488494
+L 123.163531 236.820433
+L 135.310023 230.902894
+L 147.456515 225.918014
+L 159.603007 221.026623
+L 171.749499 215.770793
+L 183.895991 211.560131
+L 196.042483 207.67025
+L 208.188974 203.497787
+L 220.335466 199.64957
+L 232.481958 195.935154
+L 244.62845 191.859841
+L 256.774942 188.172179
+L 268.921434 184.807165
+L 281.067926 180.92988
+L 293.214418 176.378427
+L 305.36091 171.824346
+L 317.507402 164.853949
+L 329.653894 158.431146
+L 341.800385 153.260549
+L 353.946877 149.067489
+L 366.093369 143.729364
+L 378.239861 139.00578
+L 390.386353 132.898684
+L 402.532845 124.771533
+L 414.679337 118.930433
+L 426.825829 114.292022
+L 438.972321 110.234024
+L 451.118813 106.262054
+L 463.265305 98.374196
+L 475.411796 79.937805
+L 487.558288 54.515392
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1552,40 +1552,40 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="275.233859" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="98.870547" y="260.133668" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="111.017039" y="245.137645" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="123.163531" y="236.675179" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="135.310023" y="230.646462" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="147.456515" y="225.683082" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="159.603007" y="221.015492" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="171.749499" y="215.565778" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="183.895991" y="211.114516" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="196.042483" y="207.311468" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="208.188974" y="203.178185" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="199.285361" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="232.481958" y="195.609627" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="244.62845" y="191.593704" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="256.774942" y="187.998888" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="268.921434" y="184.599632" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="281.067926" y="180.711659" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="293.214418" y="176.175261" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="305.36091" y="171.673162" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="317.507402" y="164.704896" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="329.653894" y="158.257231" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="341.800385" y="153.066951" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="148.873069" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="366.093369" y="143.55624" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="378.239861" y="138.872303" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="390.386353" y="132.908205" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="402.532845" y="124.843104" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="414.679337" y="119.031558" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="426.825829" y="114.367818" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="438.972321" y="110.389629" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="451.118813" y="106.463776" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="463.265305" y="98.476564" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="475.411796" y="79.923049" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="54.49125" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="275.809889" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="98.870547" y="261.2243" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="111.017039" y="245.488494" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="123.163531" y="236.820433" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="135.310023" y="230.902894" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="147.456515" y="225.918014" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="159.603007" y="221.026623" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="171.749499" y="215.770793" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="183.895991" y="211.560131" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="196.042483" y="207.67025" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="208.188974" y="203.497787" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="199.64957" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="232.481958" y="195.935154" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="244.62845" y="191.859841" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="256.774942" y="188.172179" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="268.921434" y="184.807165" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="281.067926" y="180.92988" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="293.214418" y="176.378427" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="305.36091" y="171.824346" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="317.507402" y="164.853949" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="329.653894" y="158.431146" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="341.800385" y="153.260549" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="149.067489" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="366.093369" y="143.729364" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="378.239861" y="139.00578" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="390.386353" y="132.898684" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="402.532845" y="124.771533" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="414.679337" y="118.930433" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="426.825829" y="114.292022" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="438.972321" y="110.234024" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="451.118813" y="106.262054" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="463.265305" y="98.374196" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="475.411796" y="79.937805" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="54.515392" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -2643,7 +2643,7 @@ z
    </g>
   </g>
   <g id="text_25">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2703,43 +2703,34 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1b" d="M 2034 2216
-Q 1584 2216 1326 1975
-Q 1069 1734 1069 1313
-Q 1069 891 1326 650
-Q 1584 409 2034 409
-Q 2484 409 2743 651
-Q 3003 894 3003 1313
-Q 3003 1734 2745 1975
-Q 2488 2216 2034 2216
+     <path id="DejaVuSans-1c" d="M 703 97
+L 703 672
+Q 941 559 1184 500
+Q 1428 441 1663 441
+Q 2288 441 2617 861
+Q 2947 1281 2994 2138
+Q 2813 1869 2534 1725
+Q 2256 1581 1919 1581
+Q 1219 1581 811 2004
+Q 403 2428 403 3163
+Q 403 3881 828 4315
+Q 1253 4750 1959 4750
+Q 2769 4750 3195 4129
+Q 3622 3509 3622 2328
+Q 3622 1225 3098 567
+Q 2575 -91 1691 -91
+Q 1453 -91 1209 -44
+Q 966 3 703 97
 z
-M 1403 2484
-Q 997 2584 770 2862
-Q 544 3141 544 3541
-Q 544 4100 942 4425
-Q 1341 4750 2034 4750
-Q 2731 4750 3128 4425
-Q 3525 4100 3525 3541
-Q 3525 3141 3298 2862
-Q 3072 2584 2669 2484
-Q 3125 2378 3379 2068
-Q 3634 1759 3634 1313
-Q 3634 634 3220 271
-Q 2806 -91 2034 -91
-Q 1263 -91 848 271
-Q 434 634 434 1313
-Q 434 1759 690 2068
-Q 947 2378 1403 2484
-z
-M 1172 3481
-Q 1172 3119 1398 2916
-Q 1625 2713 2034 2713
-Q 2441 2713 2670 2916
-Q 2900 3119 2900 3481
-Q 2900 3844 2670 4047
-Q 2441 4250 2034 4250
-Q 1625 4250 1398 4047
-Q 1172 3844 1172 3481
+M 1959 2075
+Q 2384 2075 2632 2365
+Q 2881 2656 2881 3163
+Q 2881 3666 2632 3958
+Q 2384 4250 1959 4250
+Q 1534 4250 1286 3958
+Q 1038 3666 1038 3163
+Q 1038 2656 1286 2365
+Q 1534 2075 1959 2075
 z
 " transform="scale(0.015625)"/>
     </defs>
@@ -2789,7 +2780,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-cyclotomic.svg
+++ b/reports/figures/hexbz-cactus-cyclotomic.svg
@@ -1503,40 +1503,40 @@ z
     </g>
    </g>
    <g id="line2d_133">
-    <path d="M 86.724055 270.797824
-L 98.870547 256.106081
-L 111.017039 240.907509
-L 123.163531 232.612811
-L 135.310023 225.622611
-L 147.456515 219.911107
-L 159.603007 214.444054
-L 171.749499 210.090519
-L 183.895991 205.359657
-L 196.042483 201.189301
-L 208.188974 196.943743
-L 220.335466 192.705783
-L 232.481958 187.717007
-L 244.62845 183.694443
-L 256.774942 179.49748
-L 268.921434 175.803004
-L 281.067926 171.889147
-L 293.214418 167.801016
-L 305.36091 163.167428
-L 317.507402 155.896158
-L 329.653894 150.545968
-L 341.800385 146.229317
-L 353.946877 140.814207
-L 366.093369 134.741845
-L 378.239861 128.155879
-L 390.386353 120.926047
-L 402.532845 115.313747
-L 414.679337 110.943324
-L 426.825829 107.326089
-L 438.972321 100.706347
-L 451.118813 94.231632
-L 463.265305 86.473748
-L 475.411796 73.704706
-L 487.558288 51.76564
+    <path d="M 86.724055 275.233859
+L 98.870547 260.133668
+L 111.017039 245.137645
+L 123.163531 236.675179
+L 135.310023 230.646462
+L 147.456515 225.683082
+L 159.603007 221.015492
+L 171.749499 215.565778
+L 183.895991 211.114516
+L 196.042483 207.311468
+L 208.188974 203.178185
+L 220.335466 199.285361
+L 232.481958 195.609627
+L 244.62845 191.593704
+L 256.774942 187.998888
+L 268.921434 184.599632
+L 281.067926 180.711659
+L 293.214418 176.175261
+L 305.36091 171.673162
+L 317.507402 164.704896
+L 329.653894 158.257231
+L 341.800385 153.066951
+L 353.946877 148.873069
+L 366.093369 143.55624
+L 378.239861 138.872303
+L 390.386353 132.908205
+L 402.532845 124.843104
+L 414.679337 119.031558
+L 426.825829 114.367818
+L 438.972321 110.389629
+L 451.118813 106.463776
+L 463.265305 98.476564
+L 475.411796 79.923049
+L 487.558288 54.49125
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1552,40 +1552,40 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="270.797824" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="98.870547" y="256.106081" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="111.017039" y="240.907509" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="123.163531" y="232.612811" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="135.310023" y="225.622611" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="147.456515" y="219.911107" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="159.603007" y="214.444054" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="171.749499" y="210.090519" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="183.895991" y="205.359657" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="196.042483" y="201.189301" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="208.188974" y="196.943743" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="192.705783" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="232.481958" y="187.717007" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="244.62845" y="183.694443" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="256.774942" y="179.49748" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="268.921434" y="175.803004" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="281.067926" y="171.889147" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="293.214418" y="167.801016" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="305.36091" y="163.167428" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="317.507402" y="155.896158" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="329.653894" y="150.545968" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="341.800385" y="146.229317" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="140.814207" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="366.093369" y="134.741845" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="378.239861" y="128.155879" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="390.386353" y="120.926047" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="402.532845" y="115.313747" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="414.679337" y="110.943324" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="426.825829" y="107.326089" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="438.972321" y="100.706347" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="451.118813" y="94.231632" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="463.265305" y="86.473748" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="475.411796" y="73.704706" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="51.76564" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="275.233859" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="98.870547" y="260.133668" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="111.017039" y="245.137645" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="123.163531" y="236.675179" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="135.310023" y="230.646462" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="147.456515" y="225.683082" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="159.603007" y="221.015492" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="171.749499" y="215.565778" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="183.895991" y="211.114516" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="196.042483" y="207.311468" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="208.188974" y="203.178185" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="199.285361" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="232.481958" y="195.609627" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="244.62845" y="191.593704" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="256.774942" y="187.998888" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="268.921434" y="184.599632" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="281.067926" y="180.711659" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="293.214418" y="176.175261" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="305.36091" y="171.673162" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="317.507402" y="164.704896" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="329.653894" y="158.257231" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="341.800385" y="153.066951" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="148.873069" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="366.093369" y="143.55624" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="378.239861" y="138.872303" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="390.386353" y="132.908205" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="402.532845" y="124.843104" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="414.679337" y="119.031558" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="426.825829" y="114.367818" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="438.972321" y="110.389629" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="451.118813" y="106.463776" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="463.265305" y="98.476564" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="475.411796" y="79.923049" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="54.49125" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -2643,7 +2643,7 @@ z
    </g>
   </g>
   <g id="text_25">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2703,6 +2703,45 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-1b" d="M 2034 2216
+Q 1584 2216 1326 1975
+Q 1069 1734 1069 1313
+Q 1069 891 1326 650
+Q 1584 409 2034 409
+Q 2484 409 2743 651
+Q 3003 894 3003 1313
+Q 3003 1734 2745 1975
+Q 2488 2216 2034 2216
+z
+M 1403 2484
+Q 997 2584 770 2862
+Q 544 3141 544 3541
+Q 544 4100 942 4425
+Q 1341 4750 2034 4750
+Q 2731 4750 3128 4425
+Q 3525 4100 3525 3541
+Q 3525 3141 3298 2862
+Q 3072 2584 2669 2484
+Q 3125 2378 3379 2068
+Q 3634 1759 3634 1313
+Q 3634 634 3220 271
+Q 2806 -91 2034 -91
+Q 1263 -91 848 271
+Q 434 634 434 1313
+Q 434 1759 690 2068
+Q 947 2378 1403 2484
+z
+M 1172 3481
+Q 1172 3119 1398 2916
+Q 1625 2713 2034 2713
+Q 2441 2713 2670 2916
+Q 2900 3119 2900 3481
+Q 2900 3844 2670 4047
+Q 2441 4250 2034 4250
+Q 1625 4250 1398 4047
+Q 1172 3844 1172 3481
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2750,7 +2789,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-hoeij-zimmermann.svg
+++ b/reports/figures/hexbz-cactus-hoeij-zimmermann.svg
@@ -791,8 +791,8 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_19">
-      <path d="M 66.682344 276.143256
-L 507.6 276.143256
+      <path d="M 66.682344 275.933416
+L 507.6 275.933416
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
@@ -802,12 +802,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="276.143256" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="275.933416" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 10ms -->
-      <g transform="translate(32.007344 279.942084) scale(0.1 -0.1)">
+      <g transform="translate(32.007344 279.732245) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-13" d="M 2034 4250
 Q 1547 4250 1301 3770
@@ -840,18 +840,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_21">
-      <path d="M 66.682344 187.908927
-L 507.6 187.908927
+      <path d="M 66.682344 186.442043
+L 507.6 186.442043
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="187.908927" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="186.442043" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 100ms -->
-      <g transform="translate(25.644844 191.707755) scale(0.1 -0.1)">
+      <g transform="translate(25.644844 190.240871) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -862,18 +862,18 @@ L 507.6 187.908927
     </g>
     <g id="ytick_3">
      <g id="line2d_23">
-      <path d="M 66.682344 99.674598
-L 507.6 99.674598
+      <path d="M 66.682344 96.950669
+L 507.6 96.950669
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="99.674598" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="96.950669" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1s -->
-      <g transform="translate(48.110469 103.473426) scale(0.1 -0.1)">
+      <g transform="translate(48.110469 100.749497) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(63.625 0)"/>
       </g>
@@ -881,8 +881,8 @@ L 507.6 99.674598
     </g>
     <g id="ytick_4">
      <g id="line2d_25">
-      <path d="M 66.682344 302.704436
-L 507.6 302.704436
+      <path d="M 66.682344 302.873004
+L 507.6 302.873004
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
@@ -892,307 +892,307 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="302.704436" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="302.873004" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_27">
-      <path d="M 66.682344 295.717932
-L 507.6 295.717932
+      <path d="M 66.682344 295.786966
+L 507.6 295.786966
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="295.717932" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="295.786966" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_29">
-      <path d="M 66.682344 289.810927
-L 507.6 289.810927
+      <path d="M 66.682344 289.795806
+L 507.6 289.795806
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.810927" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.795806" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_31">
-      <path d="M 66.682344 284.694046
-L 507.6 284.694046
+      <path d="M 66.682344 284.606027
+L 507.6 284.606027
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.694046" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.606027" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_33">
-      <path d="M 66.682344 280.180638
-L 507.6 280.180638
+      <path d="M 66.682344 280.028317
+L 507.6 280.028317
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="280.180638" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="280.028317" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_35">
-      <path d="M 66.682344 249.582076
-L 507.6 249.582076
+      <path d="M 66.682344 248.993829
+L 507.6 248.993829
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="249.582076" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="248.993829" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_37">
-      <path d="M 66.682344 234.044782
-L 507.6 234.044782
+      <path d="M 66.682344 233.23518
+L 507.6 233.23518
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="234.044782" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="233.23518" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_39">
-      <path d="M 66.682344 223.020897
-L 507.6 223.020897
+      <path d="M 66.682344 222.054241
+L 507.6 222.054241
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="223.020897" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="222.054241" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_41">
-      <path d="M 66.682344 214.470107
-L 507.6 214.470107
+      <path d="M 66.682344 213.38163
+L 507.6 213.38163
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="214.470107" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="213.38163" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_43">
-      <path d="M 66.682344 207.483603
-L 507.6 207.483603
+      <path d="M 66.682344 206.295592
+L 507.6 206.295592
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="207.483603" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="206.295592" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_45">
-      <path d="M 66.682344 201.576597
-L 507.6 201.576597
+      <path d="M 66.682344 200.304432
+L 507.6 200.304432
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="201.576597" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="200.304432" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_47">
-      <path d="M 66.682344 196.459717
-L 507.6 196.459717
+      <path d="M 66.682344 195.114653
+L 507.6 195.114653
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="196.459717" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="195.114653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_49">
-      <path d="M 66.682344 191.946308
-L 507.6 191.946308
+      <path d="M 66.682344 190.536943
+L 507.6 190.536943
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="191.946308" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="190.536943" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_51">
-      <path d="M 66.682344 161.347747
-L 507.6 161.347747
+      <path d="M 66.682344 159.502455
+L 507.6 159.502455
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="161.347747" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="159.502455" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_53">
-      <path d="M 66.682344 145.810453
-L 507.6 145.810453
+      <path d="M 66.682344 143.743806
+L 507.6 143.743806
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="145.810453" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="143.743806" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_55">
-      <path d="M 66.682344 134.786567
-L 507.6 134.786567
+      <path d="M 66.682344 132.562867
+L 507.6 132.562867
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="134.786567" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="132.562867" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_57">
-      <path d="M 66.682344 126.235777
-L 507.6 126.235777
+      <path d="M 66.682344 123.890256
+L 507.6 123.890256
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="126.235777" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="123.890256" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_59">
-      <path d="M 66.682344 119.249273
-L 507.6 119.249273
+      <path d="M 66.682344 116.804218
+L 507.6 116.804218
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="119.249273" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="116.804218" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_61">
-      <path d="M 66.682344 113.342268
-L 507.6 113.342268
+      <path d="M 66.682344 110.813058
+L 507.6 110.813058
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="113.342268" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="110.813058" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_63">
-      <path d="M 66.682344 108.225388
-L 507.6 108.225388
+      <path d="M 66.682344 105.623279
+L 507.6 105.623279
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="108.225388" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="105.623279" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_65">
-      <path d="M 66.682344 103.711979
-L 507.6 103.711979
+      <path d="M 66.682344 101.045569
+L 507.6 101.045569
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="103.711979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="101.045569" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_67">
-      <path d="M 66.682344 73.113418
-L 507.6 73.113418
+      <path d="M 66.682344 70.011081
+L 507.6 70.011081
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="73.113418" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="70.011081" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_69">
-      <path d="M 66.682344 57.576124
-L 507.6 57.576124
+      <path d="M 66.682344 54.252432
+L 507.6 54.252432
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="57.576124" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="54.252432" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_71">
-      <path d="M 66.682344 46.552238
-L 507.6 46.552238
+      <path d="M 66.682344 43.071493
+L 507.6 43.071493
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="46.552238" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="43.071493" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_73">
-      <path d="M 66.682344 38.001448
-L 507.6 38.001448
+      <path d="M 66.682344 34.398883
+L 507.6 34.398883
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="38.001448" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="34.398883" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_75">
-      <path d="M 66.682344 31.014944
-L 507.6 31.014944
+      <path d="M 66.682344 27.312844
+L 507.6 27.312844
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="31.014944" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="27.312844" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1270,7 +1270,7 @@ z
     </g>
    </g>
    <g id="line2d_77">
-    <path d="M 86.724055 94.871586
+    <path d="M 86.724055 95.698655
 L 136.828335 38.765348
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
@@ -1287,20 +1287,20 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="94.871586" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="95.698655" style="fill: #1f77b4; stroke: #1f77b4"/>
      <use xlink:href="#md73ba6276e" x="136.828335" y="38.765348" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_78">
     <path d="M 86.724055 290.872308
-L 136.828335 241.26469
-L 186.932614 206.626146
-L 237.036893 166.026018
-L 287.141172 144.450812
-L 337.245451 112.035481
-L 387.34973 92.815276
-L 437.454009 74.533102
-L 487.558288 55.480017
+L 136.828335 240.557947
+L 186.932614 205.42592
+L 237.036893 164.247376
+L 287.141172 142.364794
+L 337.245451 109.487653
+L 387.34973 89.993624
+L 437.454009 71.450991
+L 487.558288 52.126463
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #9467bd; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="meef3cfac8d" d="M 0 -2
@@ -1311,26 +1311,26 @@ z
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
      <use xlink:href="#meef3cfac8d" x="86.724055" y="290.872308" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="136.828335" y="241.26469" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="186.932614" y="206.626146" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="237.036893" y="166.026018" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="287.141172" y="144.450812" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="337.245451" y="112.035481" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="387.34973" y="92.815276" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="437.454009" y="74.533102" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="487.558288" y="55.480017" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="136.828335" y="240.557947" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="186.932614" y="205.42592" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="237.036893" y="164.247376" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="287.141172" y="142.364794" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="337.245451" y="109.487653" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="387.34973" y="89.993624" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="437.454009" y="71.450991" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="487.558288" y="52.126463" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_79">
-    <path d="M 86.724055 254.72301
-L 136.828335 212.444957
-L 186.932614 172.979344
-L 237.036893 148.311214
-L 287.141172 121.272468
-L 337.245451 104.026073
-L 387.34973 81.412185
-L 437.454009 62.752538
-L 487.558288 47.270351
+    <path d="M 86.724055 254.208003
+L 136.828335 211.327629
+L 186.932614 171.299763
+L 237.036893 146.280194
+L 287.141172 118.856237
+L 337.245451 101.364138
+L 387.34973 78.428077
+L 437.454009 59.502593
+L 487.558288 43.799836
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #8c564b; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="m975a81c4ea" d="M -0 2
@@ -1340,27 +1340,27 @@ z
 " style="stroke: #8c564b; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="254.72301" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="136.828335" y="212.444957" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="186.932614" y="172.979344" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="237.036893" y="148.311214" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="287.141172" y="121.272468" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="337.245451" y="104.026073" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="387.34973" y="81.412185" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="437.454009" y="62.752538" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="487.558288" y="47.270351" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="254.208003" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="136.828335" y="211.327629" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="186.932614" y="171.299763" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="237.036893" y="146.280194" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="287.141172" y="118.856237" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="337.245451" y="101.364138" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="387.34973" y="78.428077" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="437.454009" y="59.502593" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="487.558288" y="43.799836" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_80">
-    <path d="M 86.724055 255.129574
-L 136.828335 218.830806
-L 186.932614 192.549418
-L 237.036893 153.799217
-L 287.141172 133.411361
-L 337.245451 118.041658
-L 387.34973 95.988798
-L 437.454009 80.856021
-L 487.558288 63.13467
+    <path d="M 86.724055 254.620359
+L 136.828335 217.804455
+L 186.932614 191.148645
+L 237.036893 151.846383
+L 287.141172 131.168068
+L 337.245451 115.579399
+L 387.34973 93.212359
+L 437.454009 77.86399
+L 487.558288 59.890169
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #e377c2; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="mbe61f33afa" d="M -0.666667 2
@@ -1379,15 +1379,15 @@ z
 " style="stroke: #e377c2; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="255.129574" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="136.828335" y="218.830806" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="186.932614" y="192.549418" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="237.036893" y="153.799217" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="287.141172" y="133.411361" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="337.245451" y="118.041658" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="387.34973" y="95.988798" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="437.454009" y="80.856021" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="487.558288" y="63.13467" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="254.620359" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="136.828335" y="217.804455" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="186.932614" y="191.148645" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="237.036893" y="151.846383" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="287.141172" y="131.168068" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="337.245451" y="115.579399" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="387.34973" y="93.212359" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="437.454009" y="77.86399" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="487.558288" y="59.890169" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -1871,7 +1871,7 @@ z
    </g>
   </g>
   <g id="text_20">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -1995,7 +1995,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-hoeij-zimmermann.svg
+++ b/reports/figures/hexbz-cactus-hoeij-zimmermann.svg
@@ -791,8 +791,8 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_19">
-      <path d="M 66.682344 275.933416
-L 507.6 275.933416
+      <path d="M 66.682344 275.905376
+L 507.6 275.905376
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
@@ -802,12 +802,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="275.933416" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="275.905376" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 10ms -->
-      <g transform="translate(32.007344 279.732245) scale(0.1 -0.1)">
+      <g transform="translate(32.007344 279.704204) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-13" d="M 2034 4250
 Q 1547 4250 1301 3770
@@ -840,18 +840,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_21">
-      <path d="M 66.682344 186.442043
-L 507.6 186.442043
+      <path d="M 66.682344 186.246024
+L 507.6 186.246024
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="186.442043" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="186.246024" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 100ms -->
-      <g transform="translate(25.644844 190.240871) scale(0.1 -0.1)">
+      <g transform="translate(25.644844 190.044852) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -862,18 +862,18 @@ L 507.6 186.442043
     </g>
     <g id="ytick_3">
      <g id="line2d_23">
-      <path d="M 66.682344 96.950669
-L 507.6 96.950669
+      <path d="M 66.682344 96.586673
+L 507.6 96.586673
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="96.950669" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="96.586673" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1s -->
-      <g transform="translate(48.110469 100.749497) scale(0.1 -0.1)">
+      <g transform="translate(48.110469 100.385501) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(63.625 0)"/>
       </g>
@@ -881,8 +881,8 @@ L 507.6 96.950669
     </g>
     <g id="ytick_4">
      <g id="line2d_25">
-      <path d="M 66.682344 302.873004
-L 507.6 302.873004
+      <path d="M 66.682344 302.89553
+L 507.6 302.89553
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
@@ -892,307 +892,307 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="302.873004" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="302.89553" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_27">
-      <path d="M 66.682344 295.786966
-L 507.6 295.786966
+      <path d="M 66.682344 295.796191
+L 507.6 295.796191
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="295.786966" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="295.796191" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_29">
-      <path d="M 66.682344 289.795806
-L 507.6 289.795806
+      <path d="M 66.682344 289.793785
+L 507.6 289.793785
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.795806" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.793785" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_31">
-      <path d="M 66.682344 284.606027
-L 507.6 284.606027
+      <path d="M 66.682344 284.594265
+L 507.6 284.594265
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.606027" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.594265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_33">
-      <path d="M 66.682344 280.028317
-L 507.6 280.028317
+      <path d="M 66.682344 280.007963
+L 507.6 280.007963
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="280.028317" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="280.007963" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_35">
-      <path d="M 66.682344 248.993829
-L 507.6 248.993829
+      <path d="M 66.682344 248.915222
+L 507.6 248.915222
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="248.993829" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="248.915222" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_37">
-      <path d="M 66.682344 233.23518
-L 507.6 233.23518
+      <path d="M 66.682344 233.126993
+L 507.6 233.126993
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="233.23518" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="233.126993" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_39">
-      <path d="M 66.682344 222.054241
-L 507.6 222.054241
+      <path d="M 66.682344 221.925067
+L 507.6 221.925067
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="222.054241" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="221.925067" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_41">
-      <path d="M 66.682344 213.38163
-L 507.6 213.38163
+      <path d="M 66.682344 213.236178
+L 507.6 213.236178
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="213.38163" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="213.236178" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_43">
-      <path d="M 66.682344 206.295592
-L 507.6 206.295592
+      <path d="M 66.682344 206.136839
+L 507.6 206.136839
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="206.295592" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="206.136839" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_45">
-      <path d="M 66.682344 200.304432
-L 507.6 200.304432
+      <path d="M 66.682344 200.134433
+L 507.6 200.134433
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="200.304432" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="200.134433" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_47">
-      <path d="M 66.682344 195.114653
-L 507.6 195.114653
+      <path d="M 66.682344 194.934913
+L 507.6 194.934913
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="195.114653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="194.934913" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_49">
-      <path d="M 66.682344 190.536943
-L 507.6 190.536943
+      <path d="M 66.682344 190.348611
+L 507.6 190.348611
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="190.536943" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="190.348611" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_51">
-      <path d="M 66.682344 159.502455
-L 507.6 159.502455
+      <path d="M 66.682344 159.25587
+L 507.6 159.25587
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="159.502455" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="159.25587" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_53">
-      <path d="M 66.682344 143.743806
-L 507.6 143.743806
+      <path d="M 66.682344 143.467642
+L 507.6 143.467642
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="143.743806" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="143.467642" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_55">
-      <path d="M 66.682344 132.562867
-L 507.6 132.562867
+      <path d="M 66.682344 132.265716
+L 507.6 132.265716
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="132.562867" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="132.265716" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_57">
-      <path d="M 66.682344 123.890256
-L 507.6 123.890256
+      <path d="M 66.682344 123.576827
+L 507.6 123.576827
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="123.890256" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="123.576827" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_59">
-      <path d="M 66.682344 116.804218
-L 507.6 116.804218
+      <path d="M 66.682344 116.477488
+L 507.6 116.477488
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="116.804218" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="116.477488" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_61">
-      <path d="M 66.682344 110.813058
-L 507.6 110.813058
+      <path d="M 66.682344 110.475082
+L 507.6 110.475082
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="110.813058" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="110.475082" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_63">
-      <path d="M 66.682344 105.623279
-L 507.6 105.623279
+      <path d="M 66.682344 105.275562
+L 507.6 105.275562
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="105.623279" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="105.275562" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_65">
-      <path d="M 66.682344 101.045569
-L 507.6 101.045569
+      <path d="M 66.682344 100.68926
+L 507.6 100.68926
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="101.045569" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="100.68926" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_67">
-      <path d="M 66.682344 70.011081
-L 507.6 70.011081
+      <path d="M 66.682344 69.596518
+L 507.6 69.596518
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="70.011081" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="69.596518" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_69">
-      <path d="M 66.682344 54.252432
-L 507.6 54.252432
+      <path d="M 66.682344 53.80829
+L 507.6 53.80829
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="54.252432" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="53.80829" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_71">
-      <path d="M 66.682344 43.071493
-L 507.6 43.071493
+      <path d="M 66.682344 42.606364
+L 507.6 42.606364
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="43.071493" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="42.606364" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_73">
-      <path d="M 66.682344 34.398883
-L 507.6 34.398883
+      <path d="M 66.682344 33.917475
+L 507.6 33.917475
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="34.398883" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="33.917475" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_75">
-      <path d="M 66.682344 27.312844
-L 507.6 27.312844
+      <path d="M 66.682344 26.818136
+L 507.6 26.818136
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="27.312844" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="26.818136" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1270,7 +1270,7 @@ z
     </g>
    </g>
    <g id="line2d_77">
-    <path d="M 86.724055 95.698655
+    <path d="M 86.724055 95.635746
 L 136.828335 38.765348
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
@@ -1287,20 +1287,20 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="95.698655" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="95.635746" style="fill: #1f77b4; stroke: #1f77b4"/>
      <use xlink:href="#md73ba6276e" x="136.828335" y="38.765348" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_78">
     <path d="M 86.724055 290.872308
-L 136.828335 240.557947
-L 186.932614 205.42592
-L 237.036893 164.247376
-L 287.141172 142.364794
-L 337.245451 109.487653
-L 387.34973 89.993624
-L 437.454009 71.450991
-L 487.558288 52.126463
+L 136.828335 240.463506
+L 186.932614 205.265535
+L 237.036893 164.009697
+L 287.141172 142.086042
+L 337.245451 109.14719
+L 387.34973 89.61657
+L 437.454009 71.039131
+L 487.558288 51.678331
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #9467bd; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="meef3cfac8d" d="M 0 -2
@@ -1311,26 +1311,26 @@ z
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
      <use xlink:href="#meef3cfac8d" x="86.724055" y="290.872308" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="136.828335" y="240.557947" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="186.932614" y="205.42592" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="237.036893" y="164.247376" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="287.141172" y="142.364794" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="337.245451" y="109.487653" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="387.34973" y="89.993624" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="437.454009" y="71.450991" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="487.558288" y="52.126463" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="136.828335" y="240.463506" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="186.932614" y="205.265535" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="237.036893" y="164.009697" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="287.141172" y="142.086042" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="337.245451" y="109.14719" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="387.34973" y="89.61657" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="437.454009" y="71.039131" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="487.558288" y="51.678331" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_79">
-    <path d="M 86.724055 254.208003
-L 136.828335 211.327629
-L 186.932614 171.299763
-L 237.036893 146.280194
-L 287.141172 118.856237
-L 337.245451 101.364138
-L 387.34973 78.428077
-L 437.454009 59.502593
-L 487.558288 43.799836
+    <path d="M 86.724055 254.139183
+L 136.828335 211.178322
+L 186.932614 171.075322
+L 237.036893 146.008791
+L 287.141172 118.533358
+L 337.245451 101.008426
+L 387.34973 78.029314
+L 437.454009 59.068306
+L 487.558288 43.336075
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #8c564b; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="m975a81c4ea" d="M -0 2
@@ -1340,27 +1340,27 @@ z
 " style="stroke: #8c564b; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="254.208003" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="136.828335" y="211.327629" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="186.932614" y="171.299763" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="237.036893" y="146.280194" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="287.141172" y="118.856237" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="337.245451" y="101.364138" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="387.34973" y="78.428077" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="437.454009" y="59.502593" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="487.558288" y="43.799836" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="254.139183" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="136.828335" y="211.178322" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="186.932614" y="171.075322" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="237.036893" y="146.008791" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="287.141172" y="118.533358" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="337.245451" y="101.008426" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="387.34973" y="78.029314" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="437.454009" y="59.068306" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="487.558288" y="43.336075" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_80">
-    <path d="M 86.724055 254.620359
-L 136.828335 217.804455
-L 186.932614 191.148645
-L 237.036893 151.846383
-L 287.141172 131.168068
-L 337.245451 115.579399
-L 387.34973 93.212359
-L 437.454009 77.86399
-L 487.558288 59.890169
+    <path d="M 86.724055 254.552313
+L 136.828335 217.667305
+L 186.932614 190.961461
+L 237.036893 151.585428
+L 287.141172 130.868299
+L 337.245451 115.250369
+L 387.34973 92.841346
+L 437.454009 77.464168
+L 487.558288 59.456609
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #e377c2; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="mbe61f33afa" d="M -0.666667 2
@@ -1379,15 +1379,15 @@ z
 " style="stroke: #e377c2; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="254.620359" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="136.828335" y="217.804455" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="186.932614" y="191.148645" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="237.036893" y="151.846383" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="287.141172" y="131.168068" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="337.245451" y="115.579399" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="387.34973" y="93.212359" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="437.454009" y="77.86399" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="487.558288" y="59.890169" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="254.552313" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="136.828335" y="217.667305" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="186.932614" y="190.961461" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="237.036893" y="151.585428" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="287.141172" y="130.868299" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="337.245451" y="115.250369" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="387.34973" y="92.841346" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="437.454009" y="77.464168" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="487.558288" y="59.456609" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -1871,7 +1871,7 @@ z
    </g>
   </g>
   <g id="text_20">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -1995,7 +1995,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-laguerre.svg
+++ b/reports/figures/hexbz-cactus-laguerre.svg
@@ -1489,26 +1489,26 @@ z
     </g>
    </g>
    <g id="line2d_131">
-    <path d="M 86.724055 278.770859
-L 107.820594 260.07078
-L 128.917133 247.546006
-L 150.013671 238.983724
-L 171.11021 232.106088
-L 192.206748 226.972531
-L 213.303287 222.207013
-L 234.399825 217.734927
-L 255.496364 213.084612
-L 276.592903 207.609021
-L 297.689441 203.041846
-L 318.78598 197.954395
-L 339.882518 192.721302
-L 360.979057 187.563578
-L 382.075595 183.507933
-L 403.172134 179.899271
-L 424.268673 175.135147
-L 445.365211 171.3309
-L 466.46175 166.254967
-L 487.558288 159.384069
+    <path d="M 86.724055 279.236731
+L 107.820594 260.103544
+L 128.917133 247.29045
+L 150.013671 238.753493
+L 171.11021 231.928278
+L 192.206748 226.865076
+L 213.303287 222.088607
+L 234.399825 217.66996
+L 255.496364 213.056668
+L 276.592903 207.539993
+L 297.689441 202.958803
+L 318.78598 197.753571
+L 339.882518 192.528321
+L 360.979057 187.422326
+L 382.075595 183.377406
+L 403.172134 179.636353
+L 424.268673 174.901323
+L 445.365211 171.086803
+L 466.46175 166.004133
+L 487.558288 159.181392
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1524,26 +1524,26 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="278.770859" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.820594" y="260.07078" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.917133" y="247.546006" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="150.013671" y="238.983724" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="171.11021" y="232.106088" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="192.206748" y="226.972531" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="213.303287" y="222.207013" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="234.399825" y="217.734927" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="255.496364" y="213.084612" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="276.592903" y="207.609021" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="297.689441" y="203.041846" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="318.78598" y="197.954395" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="339.882518" y="192.721302" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="360.979057" y="187.563578" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="382.075595" y="183.507933" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="403.172134" y="179.899271" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="424.268673" y="175.135147" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="445.365211" y="171.3309" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="466.46175" y="166.254967" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="159.384069" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="279.236731" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.820594" y="260.103544" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.917133" y="247.29045" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="150.013671" y="238.753493" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="171.11021" y="231.928278" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="192.206748" y="226.865076" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="213.303287" y="222.088607" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="234.399825" y="217.66996" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="255.496364" y="213.056668" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="276.592903" y="207.539993" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="297.689441" y="202.958803" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="318.78598" y="197.753571" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="339.882518" y="192.528321" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="360.979057" y="187.422326" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="382.075595" y="183.377406" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="403.172134" y="179.636353" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="424.268673" y="174.901323" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="445.365211" y="171.086803" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="466.46175" y="166.004133" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="159.181392" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_132">
@@ -2477,7 +2477,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_25">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2579,43 +2579,34 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1b" d="M 2034 2216
-Q 1584 2216 1326 1975
-Q 1069 1734 1069 1313
-Q 1069 891 1326 650
-Q 1584 409 2034 409
-Q 2484 409 2743 651
-Q 3003 894 3003 1313
-Q 3003 1734 2745 1975
-Q 2488 2216 2034 2216
+     <path id="DejaVuSans-1c" d="M 703 97
+L 703 672
+Q 941 559 1184 500
+Q 1428 441 1663 441
+Q 2288 441 2617 861
+Q 2947 1281 2994 2138
+Q 2813 1869 2534 1725
+Q 2256 1581 1919 1581
+Q 1219 1581 811 2004
+Q 403 2428 403 3163
+Q 403 3881 828 4315
+Q 1253 4750 1959 4750
+Q 2769 4750 3195 4129
+Q 3622 3509 3622 2328
+Q 3622 1225 3098 567
+Q 2575 -91 1691 -91
+Q 1453 -91 1209 -44
+Q 966 3 703 97
 z
-M 1403 2484
-Q 997 2584 770 2862
-Q 544 3141 544 3541
-Q 544 4100 942 4425
-Q 1341 4750 2034 4750
-Q 2731 4750 3128 4425
-Q 3525 4100 3525 3541
-Q 3525 3141 3298 2862
-Q 3072 2584 2669 2484
-Q 3125 2378 3379 2068
-Q 3634 1759 3634 1313
-Q 3634 634 3220 271
-Q 2806 -91 2034 -91
-Q 1263 -91 848 271
-Q 434 634 434 1313
-Q 434 1759 690 2068
-Q 947 2378 1403 2484
-z
-M 1172 3481
-Q 1172 3119 1398 2916
-Q 1625 2713 2034 2713
-Q 2441 2713 2670 2916
-Q 2900 3119 2900 3481
-Q 2900 3844 2670 4047
-Q 2441 4250 2034 4250
-Q 1625 4250 1398 4047
-Q 1172 3844 1172 3481
+M 1959 2075
+Q 2384 2075 2632 2365
+Q 2881 2656 2881 3163
+Q 2881 3666 2632 3958
+Q 2384 4250 1959 4250
+Q 1534 4250 1286 3958
+Q 1038 3666 1038 3163
+Q 1038 2656 1286 2365
+Q 1534 2075 1959 2075
 z
 " transform="scale(0.015625)"/>
     </defs>
@@ -2665,7 +2656,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-laguerre.svg
+++ b/reports/figures/hexbz-cactus-laguerre.svg
@@ -1489,26 +1489,26 @@ z
     </g>
    </g>
    <g id="line2d_131">
-    <path d="M 86.724055 276.235151
-L 107.820594 256.348513
-L 128.917133 244.7347
-L 150.013671 236.269453
-L 171.11021 229.119574
-L 192.206748 223.557048
-L 213.303287 219.174944
-L 234.399825 214.216942
-L 255.496364 209.694306
-L 276.592903 204.282716
-L 297.689441 199.644812
-L 318.78598 194.734428
-L 339.882518 189.553223
-L 360.979057 184.558605
-L 382.075595 180.07857
-L 403.172134 176.260096
-L 424.268673 171.69839
-L 445.365211 167.705442
-L 466.46175 162.51714
-L 487.558288 155.88287
+    <path d="M 86.724055 278.770859
+L 107.820594 260.07078
+L 128.917133 247.546006
+L 150.013671 238.983724
+L 171.11021 232.106088
+L 192.206748 226.972531
+L 213.303287 222.207013
+L 234.399825 217.734927
+L 255.496364 213.084612
+L 276.592903 207.609021
+L 297.689441 203.041846
+L 318.78598 197.954395
+L 339.882518 192.721302
+L 360.979057 187.563578
+L 382.075595 183.507933
+L 403.172134 179.899271
+L 424.268673 175.135147
+L 445.365211 171.3309
+L 466.46175 166.254967
+L 487.558288 159.384069
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1524,26 +1524,26 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="276.235151" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.820594" y="256.348513" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.917133" y="244.7347" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="150.013671" y="236.269453" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="171.11021" y="229.119574" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="192.206748" y="223.557048" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="213.303287" y="219.174944" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="234.399825" y="214.216942" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="255.496364" y="209.694306" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="276.592903" y="204.282716" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="297.689441" y="199.644812" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="318.78598" y="194.734428" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="339.882518" y="189.553223" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="360.979057" y="184.558605" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="382.075595" y="180.07857" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="403.172134" y="176.260096" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="424.268673" y="171.69839" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="445.365211" y="167.705442" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="466.46175" y="162.51714" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="155.88287" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="278.770859" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.820594" y="260.07078" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.917133" y="247.546006" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="150.013671" y="238.983724" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="171.11021" y="232.106088" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="192.206748" y="226.972531" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="213.303287" y="222.207013" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="234.399825" y="217.734927" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="255.496364" y="213.084612" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="276.592903" y="207.609021" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="297.689441" y="203.041846" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="318.78598" y="197.954395" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="339.882518" y="192.721302" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="360.979057" y="187.563578" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="382.075595" y="183.507933" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="403.172134" y="179.899271" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="424.268673" y="175.135147" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="445.365211" y="171.3309" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="466.46175" y="166.254967" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="159.384069" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_132">
@@ -2477,7 +2477,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_25">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2579,6 +2579,45 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-1b" d="M 2034 2216
+Q 1584 2216 1326 1975
+Q 1069 1734 1069 1313
+Q 1069 891 1326 650
+Q 1584 409 2034 409
+Q 2484 409 2743 651
+Q 3003 894 3003 1313
+Q 3003 1734 2745 1975
+Q 2488 2216 2034 2216
+z
+M 1403 2484
+Q 997 2584 770 2862
+Q 544 3141 544 3541
+Q 544 4100 942 4425
+Q 1341 4750 2034 4750
+Q 2731 4750 3128 4425
+Q 3525 4100 3525 3541
+Q 3525 3141 3298 2862
+Q 3072 2584 2669 2484
+Q 3125 2378 3379 2068
+Q 3634 1759 3634 1313
+Q 3634 634 3220 271
+Q 2806 -91 2034 -91
+Q 1263 -91 848 271
+Q 434 634 434 1313
+Q 434 1759 690 2068
+Q 947 2378 1403 2484
+z
+M 1172 3481
+Q 1172 3119 1398 2916
+Q 1625 2713 2034 2713
+Q 2441 2713 2670 2916
+Q 2900 3119 2900 3481
+Q 2900 3844 2670 4047
+Q 2441 4250 2034 4250
+Q 1625 4250 1398 4047
+Q 1172 3844 1172 3481
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2626,7 +2665,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-legendre.svg
+++ b/reports/figures/hexbz-cactus-legendre.svg
@@ -1477,26 +1477,26 @@ z
     </g>
    </g>
    <g id="line2d_129">
-    <path d="M 86.724055 275.461812
-L 107.820594 261.0358
-L 128.917133 249.13078
-L 150.013671 240.742269
-L 171.11021 233.823104
-L 192.206748 225.499023
-L 213.303287 219.264493
-L 234.399825 213.383722
-L 255.496364 207.903808
-L 276.592903 200.496016
-L 297.689441 194.392511
-L 318.78598 187.455651
-L 339.882518 179.135359
-L 360.979057 172.869792
-L 382.075595 167.576413
-L 403.172134 162.292578
-L 424.268673 157.856388
-L 445.365211 153.412087
-L 466.46175 147.233588
-L 487.558288 141.691284
+    <path d="M 86.724055 275.070159
+L 107.820594 261.453438
+L 128.917133 249.302939
+L 150.013671 240.751279
+L 171.11021 233.666268
+L 192.206748 225.286718
+L 213.303287 219.112944
+L 234.399825 213.194096
+L 255.496364 207.680681
+L 276.592903 198.282555
+L 297.689441 190.763855
+L 318.78598 184.89504
+L 339.882518 177.335488
+L 360.979057 171.542083
+L 382.075595 164.997448
+L 403.172134 159.985374
+L 424.268673 155.350747
+L 445.365211 151.450956
+L 466.46175 145.693046
+L 487.558288 140.404465
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1512,26 +1512,26 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="275.461812" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.820594" y="261.0358" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.917133" y="249.13078" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="150.013671" y="240.742269" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="171.11021" y="233.823104" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="192.206748" y="225.499023" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="213.303287" y="219.264493" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="234.399825" y="213.383722" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="255.496364" y="207.903808" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="276.592903" y="200.496016" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="297.689441" y="194.392511" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="318.78598" y="187.455651" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="339.882518" y="179.135359" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="360.979057" y="172.869792" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="382.075595" y="167.576413" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="403.172134" y="162.292578" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="424.268673" y="157.856388" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="445.365211" y="153.412087" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="466.46175" y="147.233588" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="141.691284" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="275.070159" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.820594" y="261.453438" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.917133" y="249.302939" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="150.013671" y="240.751279" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="171.11021" y="233.666268" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="192.206748" y="225.286718" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="213.303287" y="219.112944" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="234.399825" y="213.194096" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="255.496364" y="207.680681" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="276.592903" y="198.282555" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="297.689441" y="190.763855" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="318.78598" y="184.89504" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="339.882518" y="177.335488" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="360.979057" y="171.542083" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="382.075595" y="164.997448" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="403.172134" y="159.985374" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="424.268673" y="155.350747" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="445.365211" y="151.450956" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="466.46175" y="145.693046" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="140.404465" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_130">
@@ -2480,7 +2480,7 @@ z
    </g>
   </g>
   <g id="text_25">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2582,43 +2582,34 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1b" d="M 2034 2216
-Q 1584 2216 1326 1975
-Q 1069 1734 1069 1313
-Q 1069 891 1326 650
-Q 1584 409 2034 409
-Q 2484 409 2743 651
-Q 3003 894 3003 1313
-Q 3003 1734 2745 1975
-Q 2488 2216 2034 2216
+     <path id="DejaVuSans-1c" d="M 703 97
+L 703 672
+Q 941 559 1184 500
+Q 1428 441 1663 441
+Q 2288 441 2617 861
+Q 2947 1281 2994 2138
+Q 2813 1869 2534 1725
+Q 2256 1581 1919 1581
+Q 1219 1581 811 2004
+Q 403 2428 403 3163
+Q 403 3881 828 4315
+Q 1253 4750 1959 4750
+Q 2769 4750 3195 4129
+Q 3622 3509 3622 2328
+Q 3622 1225 3098 567
+Q 2575 -91 1691 -91
+Q 1453 -91 1209 -44
+Q 966 3 703 97
 z
-M 1403 2484
-Q 997 2584 770 2862
-Q 544 3141 544 3541
-Q 544 4100 942 4425
-Q 1341 4750 2034 4750
-Q 2731 4750 3128 4425
-Q 3525 4100 3525 3541
-Q 3525 3141 3298 2862
-Q 3072 2584 2669 2484
-Q 3125 2378 3379 2068
-Q 3634 1759 3634 1313
-Q 3634 634 3220 271
-Q 2806 -91 2034 -91
-Q 1263 -91 848 271
-Q 434 634 434 1313
-Q 434 1759 690 2068
-Q 947 2378 1403 2484
-z
-M 1172 3481
-Q 1172 3119 1398 2916
-Q 1625 2713 2034 2713
-Q 2441 2713 2670 2916
-Q 2900 3119 2900 3481
-Q 2900 3844 2670 4047
-Q 2441 4250 2034 4250
-Q 1625 4250 1398 4047
-Q 1172 3844 1172 3481
+M 1959 2075
+Q 2384 2075 2632 2365
+Q 2881 2656 2881 3163
+Q 2881 3666 2632 3958
+Q 2384 4250 1959 4250
+Q 1534 4250 1286 3958
+Q 1038 3666 1038 3163
+Q 1038 2656 1286 2365
+Q 1534 2075 1959 2075
 z
 " transform="scale(0.015625)"/>
     </defs>
@@ -2668,7 +2659,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-legendre.svg
+++ b/reports/figures/hexbz-cactus-legendre.svg
@@ -1477,26 +1477,26 @@ z
     </g>
    </g>
    <g id="line2d_129">
-    <path d="M 86.724055 272.238746
-L 107.820594 258.678953
-L 128.917133 246.825157
-L 150.013671 238.458972
-L 171.11021 231.584478
-L 192.206748 223.038145
-L 213.303287 215.750568
-L 234.399825 209.951008
-L 255.496364 204.936802
-L 276.592903 197.601409
-L 297.689441 191.809617
-L 318.78598 184.512087
-L 339.882518 176.31974
-L 360.979057 169.696178
-L 382.075595 164.688618
-L 403.172134 159.719385
-L 424.268673 155.014782
-L 445.365211 150.374895
-L 466.46175 144.614789
-L 487.558288 139.235241
+    <path d="M 86.724055 275.461812
+L 107.820594 261.0358
+L 128.917133 249.13078
+L 150.013671 240.742269
+L 171.11021 233.823104
+L 192.206748 225.499023
+L 213.303287 219.264493
+L 234.399825 213.383722
+L 255.496364 207.903808
+L 276.592903 200.496016
+L 297.689441 194.392511
+L 318.78598 187.455651
+L 339.882518 179.135359
+L 360.979057 172.869792
+L 382.075595 167.576413
+L 403.172134 162.292578
+L 424.268673 157.856388
+L 445.365211 153.412087
+L 466.46175 147.233588
+L 487.558288 141.691284
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1512,26 +1512,26 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.238746" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.820594" y="258.678953" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.917133" y="246.825157" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="150.013671" y="238.458972" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="171.11021" y="231.584478" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="192.206748" y="223.038145" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="213.303287" y="215.750568" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="234.399825" y="209.951008" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="255.496364" y="204.936802" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="276.592903" y="197.601409" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="297.689441" y="191.809617" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="318.78598" y="184.512087" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="339.882518" y="176.31974" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="360.979057" y="169.696178" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="382.075595" y="164.688618" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="403.172134" y="159.719385" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="424.268673" y="155.014782" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="445.365211" y="150.374895" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="466.46175" y="144.614789" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="139.235241" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="275.461812" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.820594" y="261.0358" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.917133" y="249.13078" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="150.013671" y="240.742269" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="171.11021" y="233.823104" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="192.206748" y="225.499023" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="213.303287" y="219.264493" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="234.399825" y="213.383722" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="255.496364" y="207.903808" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="276.592903" y="200.496016" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="297.689441" y="194.392511" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="318.78598" y="187.455651" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="339.882518" y="179.135359" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="360.979057" y="172.869792" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="382.075595" y="167.576413" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="403.172134" y="162.292578" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="424.268673" y="157.856388" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="445.365211" y="153.412087" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="466.46175" y="147.233588" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="141.691284" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_130">
@@ -2480,7 +2480,7 @@ z
    </g>
   </g>
   <g id="text_25">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2582,6 +2582,45 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-1b" d="M 2034 2216
+Q 1584 2216 1326 1975
+Q 1069 1734 1069 1313
+Q 1069 891 1326 650
+Q 1584 409 2034 409
+Q 2484 409 2743 651
+Q 3003 894 3003 1313
+Q 3003 1734 2745 1975
+Q 2488 2216 2034 2216
+z
+M 1403 2484
+Q 997 2584 770 2862
+Q 544 3141 544 3541
+Q 544 4100 942 4425
+Q 1341 4750 2034 4750
+Q 2731 4750 3128 4425
+Q 3525 4100 3525 3541
+Q 3525 3141 3298 2862
+Q 3072 2584 2669 2484
+Q 3125 2378 3379 2068
+Q 3634 1759 3634 1313
+Q 3634 634 3220 271
+Q 2806 -91 2034 -91
+Q 1263 -91 848 271
+Q 434 634 434 1313
+Q 434 1759 690 2068
+Q 947 2378 1403 2484
+z
+M 1172 3481
+Q 1172 3119 1398 2916
+Q 1625 2713 2034 2713
+Q 2441 2713 2670 2916
+Q 2900 3119 2900 3481
+Q 2900 3844 2670 4047
+Q 2441 4250 2034 4250
+Q 1625 4250 1398 4047
+Q 1172 3844 1172 3481
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2629,7 +2668,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-random-products.svg
+++ b/reports/figures/hexbz-cactus-random-products.svg
@@ -1439,36 +1439,36 @@ z
     </g>
    </g>
    <g id="line2d_125">
-    <path d="M 86.724055 267.062872
-L 100.545925 246.704621
-L 114.367796 236.691602
-L 128.189666 230.094099
-L 142.011536 224.547603
-L 155.833406 220.147784
-L 169.655276 216.427513
-L 183.477146 212.735565
-L 197.299016 209.286041
-L 211.120886 206.247884
-L 224.942756 203.546422
-L 238.764627 201.162178
-L 252.586497 198.810344
-L 266.408367 196.699152
-L 280.230237 194.771136
-L 294.052107 192.982518
-L 307.873977 191.254003
-L 321.695847 189.603912
-L 335.517717 187.938244
-L 349.339587 186.392448
-L 363.161457 184.845694
-L 376.983328 183.215264
-L 390.805198 181.701347
-L 404.627068 179.828648
-L 418.448938 177.993676
-L 432.270808 176.29744
-L 446.092678 174.669076
-L 459.914548 173.105711
-L 473.736418 171.184644
-L 487.558288 168.84224
+    <path d="M 86.724055 268.596091
+L 100.545925 250.047356
+L 114.367796 239.843871
+L 128.189666 233.072335
+L 142.011536 227.234928
+L 155.833406 222.739543
+L 169.655276 219.074731
+L 183.477146 215.684561
+L 197.299016 212.549156
+L 211.120886 209.833467
+L 224.942756 207.20573
+L 238.764627 204.713581
+L 252.586497 202.342273
+L 266.408367 200.222122
+L 280.230237 198.305552
+L 294.052107 196.475654
+L 307.873977 194.726799
+L 321.695847 193.087645
+L 335.517717 191.47352
+L 349.339587 189.853227
+L 363.161457 188.285016
+L 376.983328 186.72274
+L 390.805198 185.035124
+L 404.627068 183.342119
+L 418.448938 181.63163
+L 432.270808 179.929374
+L 446.092678 178.301647
+L 459.914548 176.699922
+L 473.736418 174.876295
+L 487.558288 172.610115
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1484,36 +1484,36 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="267.062872" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="100.545925" y="246.704621" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="114.367796" y="236.691602" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.189666" y="230.094099" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="142.011536" y="224.547603" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="155.833406" y="220.147784" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="169.655276" y="216.427513" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="183.477146" y="212.735565" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="197.299016" y="209.286041" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="211.120886" y="206.247884" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="224.942756" y="203.546422" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="238.764627" y="201.162178" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="252.586497" y="198.810344" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="266.408367" y="196.699152" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="280.230237" y="194.771136" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.052107" y="192.982518" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="307.873977" y="191.254003" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="321.695847" y="189.603912" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="335.517717" y="187.938244" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="349.339587" y="186.392448" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="363.161457" y="184.845694" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="376.983328" y="183.215264" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="390.805198" y="181.701347" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="404.627068" y="179.828648" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="418.448938" y="177.993676" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="432.270808" y="176.29744" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.092678" y="174.669076" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="459.914548" y="173.105711" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="473.736418" y="171.184644" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="168.84224" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="268.596091" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="100.545925" y="250.047356" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="114.367796" y="239.843871" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.189666" y="233.072335" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="142.011536" y="227.234928" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="155.833406" y="222.739543" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="169.655276" y="219.074731" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="183.477146" y="215.684561" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="197.299016" y="212.549156" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="211.120886" y="209.833467" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="224.942756" y="207.20573" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="238.764627" y="204.713581" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="252.586497" y="202.342273" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="266.408367" y="200.222122" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="280.230237" y="198.305552" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.052107" y="196.475654" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="307.873977" y="194.726799" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="321.695847" y="193.087645" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="335.517717" y="191.47352" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="349.339587" y="189.853227" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="363.161457" y="188.285016" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="376.983328" y="186.72274" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="390.805198" y="185.035124" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="404.627068" y="183.342119" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="418.448938" y="181.63163" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="432.270808" y="179.929374" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.092678" y="178.301647" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="459.914548" y="176.699922" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="473.736418" y="174.876295" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="172.610115" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -2526,7 +2526,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2603,14 +2603,43 @@ L 3597 3500
 L 2059 -325
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1a" d="M 525 4666
-L 3525 4666
-L 3525 4397
-L 1831 0
-L 1172 0
-L 2766 4134
-L 525 4134
-L 525 4666
+     <path id="DejaVuSans-1b" d="M 2034 2216
+Q 1584 2216 1326 1975
+Q 1069 1734 1069 1313
+Q 1069 891 1326 650
+Q 1584 409 2034 409
+Q 2484 409 2743 651
+Q 3003 894 3003 1313
+Q 3003 1734 2745 1975
+Q 2488 2216 2034 2216
+z
+M 1403 2484
+Q 997 2584 770 2862
+Q 544 3141 544 3541
+Q 544 4100 942 4425
+Q 1341 4750 2034 4750
+Q 2731 4750 3128 4425
+Q 3525 4100 3525 3541
+Q 3525 3141 3298 2862
+Q 3072 2584 2669 2484
+Q 3125 2378 3379 2068
+Q 3634 1759 3634 1313
+Q 3634 634 3220 271
+Q 2806 -91 2034 -91
+Q 1263 -91 848 271
+Q 434 634 434 1313
+Q 434 1759 690 2068
+Q 947 2378 1403 2484
+z
+M 1172 3481
+Q 1172 3119 1398 2916
+Q 1625 2713 2034 2713
+Q 2441 2713 2670 2916
+Q 2900 3119 2900 3481
+Q 2900 3844 2670 4047
+Q 2441 4250 2034 4250
+Q 1625 4250 1398 4047
+Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
     </defs>
@@ -2660,7 +2689,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-random-products.svg
+++ b/reports/figures/hexbz-cactus-random-products.svg
@@ -1439,36 +1439,36 @@ z
     </g>
    </g>
    <g id="line2d_125">
-    <path d="M 86.724055 268.596091
-L 100.545925 250.047356
-L 114.367796 239.843871
-L 128.189666 233.072335
-L 142.011536 227.234928
-L 155.833406 222.739543
-L 169.655276 219.074731
-L 183.477146 215.684561
-L 197.299016 212.549156
-L 211.120886 209.833467
-L 224.942756 207.20573
-L 238.764627 204.713581
-L 252.586497 202.342273
-L 266.408367 200.222122
-L 280.230237 198.305552
-L 294.052107 196.475654
-L 307.873977 194.726799
-L 321.695847 193.087645
-L 335.517717 191.47352
-L 349.339587 189.853227
-L 363.161457 188.285016
-L 376.983328 186.72274
-L 390.805198 185.035124
-L 404.627068 183.342119
-L 418.448938 181.63163
-L 432.270808 179.929374
-L 446.092678 178.301647
-L 459.914548 176.699922
-L 473.736418 174.876295
-L 487.558288 172.610115
+    <path d="M 86.724055 268.64071
+L 100.545925 249.863855
+L 114.367796 239.628283
+L 128.189666 232.829256
+L 142.011536 226.929726
+L 155.833406 222.283216
+L 169.655276 218.466972
+L 183.477146 215.120783
+L 197.299016 211.974157
+L 211.120886 209.230779
+L 224.942756 206.69144
+L 238.764627 204.252506
+L 252.586497 201.908831
+L 266.408367 199.805989
+L 280.230237 197.898469
+L 294.052107 196.101691
+L 307.873977 194.336171
+L 321.695847 192.688823
+L 335.517717 191.082365
+L 349.339587 189.497695
+L 363.161457 187.922275
+L 376.983328 186.322595
+L 390.805198 184.650064
+L 404.627068 182.989791
+L 418.448938 181.288437
+L 432.270808 179.562675
+L 446.092678 177.934178
+L 459.914548 176.348346
+L 473.736418 174.521334
+L 487.558288 172.238636
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1484,36 +1484,36 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="268.596091" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="100.545925" y="250.047356" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="114.367796" y="239.843871" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.189666" y="233.072335" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="142.011536" y="227.234928" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="155.833406" y="222.739543" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="169.655276" y="219.074731" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="183.477146" y="215.684561" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="197.299016" y="212.549156" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="211.120886" y="209.833467" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="224.942756" y="207.20573" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="238.764627" y="204.713581" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="252.586497" y="202.342273" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="266.408367" y="200.222122" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="280.230237" y="198.305552" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.052107" y="196.475654" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="307.873977" y="194.726799" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="321.695847" y="193.087645" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="335.517717" y="191.47352" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="349.339587" y="189.853227" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="363.161457" y="188.285016" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="376.983328" y="186.72274" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="390.805198" y="185.035124" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="404.627068" y="183.342119" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="418.448938" y="181.63163" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="432.270808" y="179.929374" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.092678" y="178.301647" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="459.914548" y="176.699922" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="473.736418" y="174.876295" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="172.610115" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="268.64071" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="100.545925" y="249.863855" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="114.367796" y="239.628283" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.189666" y="232.829256" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="142.011536" y="226.929726" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="155.833406" y="222.283216" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="169.655276" y="218.466972" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="183.477146" y="215.120783" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="197.299016" y="211.974157" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="211.120886" y="209.230779" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="224.942756" y="206.69144" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="238.764627" y="204.252506" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="252.586497" y="201.908831" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="266.408367" y="199.805989" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="280.230237" y="197.898469" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.052107" y="196.101691" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="307.873977" y="194.336171" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="321.695847" y="192.688823" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="335.517717" y="191.082365" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="349.339587" y="189.497695" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="363.161457" y="187.922275" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="376.983328" y="186.322595" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="390.805198" y="184.650064" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="404.627068" y="182.989791" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="418.448938" y="181.288437" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="432.270808" y="179.562675" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.092678" y="177.934178" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="459.914548" y="176.348346" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="473.736418" y="174.521334" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="172.238636" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -2526,7 +2526,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2603,43 +2603,34 @@ L 3597 3500
 L 2059 -325
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1b" d="M 2034 2216
-Q 1584 2216 1326 1975
-Q 1069 1734 1069 1313
-Q 1069 891 1326 650
-Q 1584 409 2034 409
-Q 2484 409 2743 651
-Q 3003 894 3003 1313
-Q 3003 1734 2745 1975
-Q 2488 2216 2034 2216
+     <path id="DejaVuSans-1c" d="M 703 97
+L 703 672
+Q 941 559 1184 500
+Q 1428 441 1663 441
+Q 2288 441 2617 861
+Q 2947 1281 2994 2138
+Q 2813 1869 2534 1725
+Q 2256 1581 1919 1581
+Q 1219 1581 811 2004
+Q 403 2428 403 3163
+Q 403 3881 828 4315
+Q 1253 4750 1959 4750
+Q 2769 4750 3195 4129
+Q 3622 3509 3622 2328
+Q 3622 1225 3098 567
+Q 2575 -91 1691 -91
+Q 1453 -91 1209 -44
+Q 966 3 703 97
 z
-M 1403 2484
-Q 997 2584 770 2862
-Q 544 3141 544 3541
-Q 544 4100 942 4425
-Q 1341 4750 2034 4750
-Q 2731 4750 3128 4425
-Q 3525 4100 3525 3541
-Q 3525 3141 3298 2862
-Q 3072 2584 2669 2484
-Q 3125 2378 3379 2068
-Q 3634 1759 3634 1313
-Q 3634 634 3220 271
-Q 2806 -91 2034 -91
-Q 1263 -91 848 271
-Q 434 634 434 1313
-Q 434 1759 690 2068
-Q 947 2378 1403 2484
-z
-M 1172 3481
-Q 1172 3119 1398 2916
-Q 1625 2713 2034 2713
-Q 2441 2713 2670 2916
-Q 2900 3119 2900 3481
-Q 2900 3844 2670 4047
-Q 2441 4250 2034 4250
-Q 1625 4250 1398 4047
-Q 1172 3844 1172 3481
+M 1959 2075
+Q 2384 2075 2632 2365
+Q 2881 2656 2881 3163
+Q 2881 3666 2632 3958
+Q 2384 4250 1959 4250
+Q 1534 4250 1286 3958
+Q 1038 3666 1038 3163
+Q 1038 2656 1286 2365
+Q 1534 2075 1959 2075
 z
 " transform="scale(0.015625)"/>
     </defs>
@@ -2689,7 +2680,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-sd-products.svg
+++ b/reports/figures/hexbz-cactus-sd-products.svg
@@ -1316,16 +1316,16 @@ z
     </g>
    </g>
    <g id="line2d_101">
-    <path d="M 86.724055 265.607301
-L 117.557458 247.353763
-L 148.39086 219.464225
-L 179.224263 206.245815
-L 210.057666 193.377949
-L 240.891068 158.017138
-L 271.724471 130.556362
-L 302.557873 116.675497
-L 333.391276 81.894231
-L 364.224678 56.425452
+    <path d="M 86.724055 269.089002
+L 117.557458 250.397373
+L 148.39086 223.557949
+L 179.224263 209.289754
+L 210.057666 196.425304
+L 240.891068 161.153756
+L 271.724471 132.66702
+L 302.557873 119.130465
+L 333.391276 82.665906
+L 364.224678 56.892747
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1341,16 +1341,16 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="265.607301" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="247.353763" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="219.464225" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="206.245815" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="193.377949" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="158.017138" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="130.556362" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="116.675497" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="81.894231" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="56.425452" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="269.089002" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="250.397373" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="223.557949" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="209.289754" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="196.425304" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="161.153756" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="132.66702" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="119.130465" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="82.665906" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="56.892747" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_102">
@@ -2226,7 +2226,7 @@ z
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2335,16 +2335,6 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1a" d="M 525 4666
-L 3525 4666
-L 3525 4397
-L 1831 0
-L 1172 0
-L 2766 4134
-L 525 4134
-L 525 4666
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2392,7 +2382,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-sd-products.svg
+++ b/reports/figures/hexbz-cactus-sd-products.svg
@@ -1316,16 +1316,16 @@ z
     </g>
    </g>
    <g id="line2d_101">
-    <path d="M 86.724055 269.089002
-L 117.557458 250.397373
-L 148.39086 223.557949
-L 179.224263 209.289754
-L 210.057666 196.425304
-L 240.891068 161.153756
-L 271.724471 132.66702
-L 302.557873 119.130465
-L 333.391276 82.665906
-L 364.224678 56.892747
+    <path d="M 86.724055 265.053437
+L 117.557458 240.765462
+L 148.39086 219.878683
+L 179.224263 207.289836
+L 210.057666 190.298195
+L 240.891068 159.130595
+L 271.724471 131.751799
+L 302.557873 118.660405
+L 333.391276 82.402718
+L 364.224678 56.680901
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1341,16 +1341,16 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="269.089002" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="250.397373" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="223.557949" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="209.289754" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="196.425304" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="161.153756" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="132.66702" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="119.130465" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="82.665906" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="56.892747" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="265.053437" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="240.765462" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="219.878683" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="207.289836" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="190.298195" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="159.130595" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="131.751799" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="118.660405" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="82.402718" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="56.680901" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_102">
@@ -2226,7 +2226,7 @@ z
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2382,7 +2382,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-swinnerton-dyer.svg
+++ b/reports/figures/hexbz-cactus-swinnerton-dyer.svg
@@ -674,8 +674,8 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 66.682344 270.163971
-L 507.6 270.163971
+      <path d="M 66.682344 270.215332
+L 507.6 270.215332
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
@@ -685,12 +685,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="270.163971" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="270.215332" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 100us -->
-      <g transform="translate(29.047969 273.962799) scale(0.1 -0.1)">
+      <g transform="translate(29.047969 274.01416) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -701,18 +701,18 @@ L -3.5 0
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 66.682344 223.181133
-L 507.6 223.181133
+      <path d="M 66.682344 223.349022
+L 507.6 223.349022
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="223.181133" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="223.349022" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 1ms -->
-      <g transform="translate(38.369844 226.979961) scale(0.1 -0.1)">
+      <g transform="translate(38.369844 227.14785) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-50" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(161.03125 0)"/>
@@ -721,18 +721,18 @@ L 507.6 223.181133
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 66.682344 176.198296
-L 507.6 176.198296
+      <path d="M 66.682344 176.482712
+L 507.6 176.482712
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="176.198296" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="176.482712" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 10ms -->
-      <g transform="translate(32.007344 179.997124) scale(0.1 -0.1)">
+      <g transform="translate(32.007344 180.28154) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-50" transform="translate(127.25 0)"/>
@@ -742,18 +742,18 @@ L 507.6 176.198296
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 66.682344 129.215458
-L 507.6 129.215458
+      <path d="M 66.682344 129.616402
+L 507.6 129.616402
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="129.215458" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="129.616402" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 100ms -->
-      <g transform="translate(25.644844 133.014286) scale(0.1 -0.1)">
+      <g transform="translate(25.644844 133.415231) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -764,18 +764,18 @@ L 507.6 129.215458
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 66.682344 82.23262
-L 507.6 82.23262
+      <path d="M 66.682344 82.750093
+L 507.6 82.750093
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="82.23262" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="82.750093" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1s -->
-      <g transform="translate(48.110469 86.031449) scale(0.1 -0.1)">
+      <g transform="translate(48.110469 86.548921) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(63.625 0)"/>
       </g>
@@ -783,18 +783,18 @@ L 507.6 82.23262
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 66.682344 35.249783
-L 507.6 35.249783
+      <path d="M 66.682344 35.883783
+L 507.6 35.883783
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="35.249783" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="35.883783" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 10s -->
-      <g transform="translate(41.747969 39.048611) scale(0.1 -0.1)">
+      <g transform="translate(41.747969 39.682611) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(127.25 0)"/>
@@ -803,8 +803,8 @@ L 507.6 35.249783
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 66.682344 303.003565
-L 507.6 303.003565
+      <path d="M 66.682344 302.973477
+L 507.6 302.973477
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
@@ -814,571 +814,571 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="303.003565" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="302.973477" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 66.682344 294.730298
-L 507.6 294.730298
+      <path d="M 66.682344 294.720729
+L 507.6 294.720729
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="294.730298" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="294.720729" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 66.682344 288.860321
-L 507.6 288.860321
+      <path d="M 66.682344 288.865312
+L 507.6 288.865312
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="288.860321" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="288.865312" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 66.682344 284.307214
-L 507.6 284.307214
+      <path d="M 66.682344 284.323497
+L 507.6 284.323497
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.307214" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.323497" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 66.682344 280.587054
-L 507.6 280.587054
+      <path d="M 66.682344 280.612564
+L 507.6 280.612564
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="280.587054" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="280.612564" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 66.682344 277.441704
-L 507.6 277.441704
+      <path d="M 66.682344 277.475015
+L 507.6 277.475015
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="277.441704" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="277.475015" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 66.682344 274.717078
-L 507.6 274.717078
+      <path d="M 66.682344 274.757146
+L 507.6 274.757146
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="274.717078" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="274.757146" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 66.682344 272.313787
-L 507.6 272.313787
+      <path d="M 66.682344 272.359817
+L 507.6 272.359817
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="272.313787" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="272.359817" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 66.682344 256.020727
-L 507.6 256.020727
+      <path d="M 66.682344 256.107167
+L 507.6 256.107167
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="256.020727" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="256.107167" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 66.682344 247.74746
-L 507.6 247.74746
+      <path d="M 66.682344 247.854419
+L 507.6 247.854419
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="247.74746" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="247.854419" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 66.682344 241.877484
-L 507.6 241.877484
+      <path d="M 66.682344 241.999002
+L 507.6 241.999002
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="241.877484" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="241.999002" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 66.682344 237.324376
-L 507.6 237.324376
+      <path d="M 66.682344 237.457187
+L 507.6 237.457187
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="237.324376" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="237.457187" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 66.682344 233.604217
-L 507.6 233.604217
+      <path d="M 66.682344 233.746254
+L 507.6 233.746254
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="233.604217" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="233.746254" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 66.682344 230.458867
-L 507.6 230.458867
+      <path d="M 66.682344 230.608705
+L 507.6 230.608705
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="230.458867" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="230.608705" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 66.682344 227.73424
-L 507.6 227.73424
+      <path d="M 66.682344 227.890837
+L 507.6 227.890837
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="227.73424" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="227.890837" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 66.682344 225.33095
-L 507.6 225.33095
+      <path d="M 66.682344 225.493507
+L 507.6 225.493507
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="225.33095" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="225.493507" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 66.682344 209.03789
-L 507.6 209.03789
+      <path d="M 66.682344 209.240857
+L 507.6 209.240857
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="209.03789" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="209.240857" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 66.682344 200.764623
-L 507.6 200.764623
+      <path d="M 66.682344 200.98811
+L 507.6 200.98811
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="200.764623" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="200.98811" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 66.682344 194.894646
-L 507.6 194.894646
+      <path d="M 66.682344 195.132692
+L 507.6 195.132692
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="194.894646" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="195.132692" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 66.682344 190.341539
-L 507.6 190.341539
+      <path d="M 66.682344 190.590877
+L 507.6 190.590877
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="190.341539" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="190.590877" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_67">
-      <path d="M 66.682344 186.621379
-L 507.6 186.621379
+      <path d="M 66.682344 186.879944
+L 507.6 186.879944
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="186.621379" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="186.879944" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_69">
-      <path d="M 66.682344 183.476029
-L 507.6 183.476029
+      <path d="M 66.682344 183.742395
+L 507.6 183.742395
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="183.476029" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="183.742395" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_71">
-      <path d="M 66.682344 180.751403
-L 507.6 180.751403
+      <path d="M 66.682344 181.024527
+L 507.6 181.024527
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="180.751403" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="181.024527" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_73">
-      <path d="M 66.682344 178.348112
-L 507.6 178.348112
+      <path d="M 66.682344 178.627197
+L 507.6 178.627197
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="178.348112" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="178.627197" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_75">
-      <path d="M 66.682344 162.055052
-L 507.6 162.055052
+      <path d="M 66.682344 162.374547
+L 507.6 162.374547
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="162.055052" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="162.374547" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_77">
-      <path d="M 66.682344 153.781785
-L 507.6 153.781785
+      <path d="M 66.682344 154.1218
+L 507.6 154.1218
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="153.781785" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="154.1218" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_79">
-      <path d="M 66.682344 147.911809
-L 507.6 147.911809
+      <path d="M 66.682344 148.266382
+L 507.6 148.266382
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_80">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="147.911809" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="148.266382" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_81">
-      <path d="M 66.682344 143.358701
-L 507.6 143.358701
+      <path d="M 66.682344 143.724568
+L 507.6 143.724568
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_82">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="143.358701" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="143.724568" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_83">
-      <path d="M 66.682344 139.638542
-L 507.6 139.638542
+      <path d="M 66.682344 140.013635
+L 507.6 140.013635
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_84">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="139.638542" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="140.013635" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_36">
      <g id="line2d_85">
-      <path d="M 66.682344 136.493192
-L 507.6 136.493192
+      <path d="M 66.682344 136.876086
+L 507.6 136.876086
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_86">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="136.493192" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="136.876086" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_37">
      <g id="line2d_87">
-      <path d="M 66.682344 133.768565
-L 507.6 133.768565
+      <path d="M 66.682344 134.158217
+L 507.6 134.158217
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_88">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="133.768565" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="134.158217" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_38">
      <g id="line2d_89">
-      <path d="M 66.682344 131.365275
-L 507.6 131.365275
+      <path d="M 66.682344 131.760887
+L 507.6 131.760887
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_90">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="131.365275" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="131.760887" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_39">
      <g id="line2d_91">
-      <path d="M 66.682344 115.072215
-L 507.6 115.072215
+      <path d="M 66.682344 115.508237
+L 507.6 115.508237
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_92">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="115.072215" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="115.508237" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_40">
      <g id="line2d_93">
-      <path d="M 66.682344 106.798948
-L 507.6 106.798948
+      <path d="M 66.682344 107.25549
+L 507.6 107.25549
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_94">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="106.798948" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="107.25549" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_41">
      <g id="line2d_95">
-      <path d="M 66.682344 100.928971
-L 507.6 100.928971
+      <path d="M 66.682344 101.400072
+L 507.6 101.400072
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_96">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="100.928971" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="101.400072" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_42">
      <g id="line2d_97">
-      <path d="M 66.682344 96.375864
-L 507.6 96.375864
+      <path d="M 66.682344 96.858258
+L 507.6 96.858258
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_98">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="96.375864" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="96.858258" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_43">
      <g id="line2d_99">
-      <path d="M 66.682344 92.655704
-L 507.6 92.655704
+      <path d="M 66.682344 93.147325
+L 507.6 93.147325
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_100">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="92.655704" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="93.147325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_44">
      <g id="line2d_101">
-      <path d="M 66.682344 89.510354
-L 507.6 89.510354
+      <path d="M 66.682344 90.009776
+L 507.6 90.009776
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_102">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="89.510354" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="90.009776" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_45">
      <g id="line2d_103">
-      <path d="M 66.682344 86.785728
-L 507.6 86.785728
+      <path d="M 66.682344 87.291907
+L 507.6 87.291907
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_104">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="86.785728" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="87.291907" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_46">
      <g id="line2d_105">
-      <path d="M 66.682344 84.382437
-L 507.6 84.382437
+      <path d="M 66.682344 84.894577
+L 507.6 84.894577
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_106">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="84.382437" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="84.894577" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_47">
      <g id="line2d_107">
-      <path d="M 66.682344 68.089377
-L 507.6 68.089377
+      <path d="M 66.682344 68.641928
+L 507.6 68.641928
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_108">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="68.089377" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="68.641928" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_48">
      <g id="line2d_109">
-      <path d="M 66.682344 59.81611
-L 507.6 59.81611
+      <path d="M 66.682344 60.38918
+L 507.6 60.38918
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_110">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="59.81611" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="60.38918" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_49">
      <g id="line2d_111">
-      <path d="M 66.682344 53.946134
-L 507.6 53.946134
+      <path d="M 66.682344 54.533763
+L 507.6 54.533763
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_112">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="53.946134" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="54.533763" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_50">
      <g id="line2d_113">
-      <path d="M 66.682344 49.393026
-L 507.6 49.393026
+      <path d="M 66.682344 49.991948
+L 507.6 49.991948
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_114">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="49.393026" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="49.991948" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_51">
      <g id="line2d_115">
-      <path d="M 66.682344 45.672867
-L 507.6 45.672867
+      <path d="M 66.682344 46.281015
+L 507.6 46.281015
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_116">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="45.672867" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="46.281015" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_52">
      <g id="line2d_117">
-      <path d="M 66.682344 42.527517
-L 507.6 42.527517
+      <path d="M 66.682344 43.143466
+L 507.6 43.143466
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_118">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="42.527517" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="43.143466" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_53">
      <g id="line2d_119">
-      <path d="M 66.682344 39.80289
-L 507.6 39.80289
+      <path d="M 66.682344 40.425598
+L 507.6 40.425598
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_120">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="39.80289" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="40.425598" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_54">
      <g id="line2d_121">
-      <path d="M 66.682344 37.3996
-L 507.6 37.3996
+      <path d="M 66.682344 38.028268
+L 507.6 38.028268
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_122">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="37.3996" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="38.028268" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1456,17 +1456,17 @@ z
     </g>
    </g>
    <g id="line2d_123">
-    <path d="M 86.724055 283.242617
-L 115.355072 266.69944
-L 143.986089 248.198239
-L 172.617105 238.602237
-L 201.248122 231.738583
-L 229.879139 214.159073
-L 258.510155 204.83767
-L 287.141172 198.072483
-L 315.772189 136.927659
-L 344.403205 122.93118
-L 373.034222 114.363418
+    <path d="M 86.724055 285.35423
+L 115.355072 268.308002
+L 143.986089 250.562133
+L 172.617105 240.967931
+L 201.248122 234.341539
+L 229.879139 216.817077
+L 258.510155 206.928157
+L 287.141172 200.283801
+L 315.772189 137.505629
+L 344.403205 123.405108
+L 373.034222 114.881177
 L 401.665238 38.765348
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
@@ -1483,36 +1483,36 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="283.242617" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="115.355072" y="266.69944" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.986089" y="248.198239" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="172.617105" y="238.602237" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="201.248122" y="231.738583" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="229.879139" y="214.159073" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="258.510155" y="204.83767" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="198.072483" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="315.772189" y="136.927659" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="344.403205" y="122.93118" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="373.034222" y="114.363418" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="285.35423" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="115.355072" y="268.308002" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.986089" y="250.562133" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="172.617105" y="240.967931" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="201.248122" y="234.341539" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="229.879139" y="216.817077" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="258.510155" y="206.928157" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="200.283801" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="315.772189" y="137.505629" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="344.403205" y="123.405108" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="373.034222" y="114.881177" style="fill: #1f77b4; stroke: #1f77b4"/>
      <use xlink:href="#md73ba6276e" x="401.665238" y="38.765348" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_124">
     <path d="M 86.724055 290.872308
-L 115.355072 276.239018
-L 143.986089 265.644354
-L 172.617105 258.401509
-L 201.248122 251.443068
-L 229.879139 238.847394
-L 258.510155 231.094918
-L 287.141172 224.861979
-L 315.772189 210.362497
-L 344.403205 201.900079
-L 373.034222 195.014947
-L 401.665238 178.687538
-L 430.296255 169.697015
-L 458.927272 163.354959
-L 487.558288 141.6831
+L 115.355072 276.275312
+L 143.986089 265.706925
+L 172.617105 258.482044
+L 201.248122 251.540861
+L 229.879139 238.976427
+L 258.510155 231.243179
+L 287.141172 225.025699
+L 315.772189 210.562179
+L 344.403205 202.12075
+L 373.034222 195.252695
+L 401.665238 178.965781
+L 430.296255 169.997556
+L 458.927272 163.67123
+L 487.558288 142.053122
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #9467bd; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="meef3cfac8d" d="M 0 -2
@@ -1523,38 +1523,38 @@ z
     </defs>
     <g clip-path="url(#p6c2be49786)">
      <use xlink:href="#meef3cfac8d" x="86.724055" y="290.872308" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="115.355072" y="276.239018" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="143.986089" y="265.644354" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="172.617105" y="258.401509" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="201.248122" y="251.443068" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="229.879139" y="238.847394" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="258.510155" y="231.094918" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="287.141172" y="224.861979" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="315.772189" y="210.362497" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="344.403205" y="201.900079" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="373.034222" y="195.014947" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="401.665238" y="178.687538" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="430.296255" y="169.697015" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="458.927272" y="163.354959" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="487.558288" y="141.6831" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="115.355072" y="276.275312" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="143.986089" y="265.706925" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="172.617105" y="258.482044" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="201.248122" y="251.540861" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="229.879139" y="238.976427" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="258.510155" y="231.243179" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="287.141172" y="225.025699" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="315.772189" y="210.562179" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="344.403205" y="202.12075" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="373.034222" y="195.252695" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="401.665238" y="178.965781" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="430.296255" y="169.997556" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="458.927272" y="163.67123" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="487.558288" y="142.053122" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_125">
-    <path d="M 86.724055 275.211188
-L 115.355072 260.065892
-L 143.986089 245.768735
-L 172.617105 237.36032
-L 201.248122 229.70947
-L 229.879139 220.326963
-L 258.510155 213.826543
-L 287.141172 207.450588
-L 315.772189 192.369687
-L 344.403205 183.688751
-L 373.034222 176.55049
-L 401.665238 160.929284
-L 430.296255 152.116888
-L 458.927272 145.070445
-L 487.558288 122.218768
+    <path d="M 86.724055 275.250031
+L 115.355072 260.142298
+L 143.986089 245.880602
+L 172.617105 237.493041
+L 201.248122 229.861167
+L 229.879139 220.501931
+L 258.510155 214.017633
+L 287.141172 207.657492
+L 315.772189 192.613995
+L 344.403205 183.95459
+L 373.034222 176.834033
+L 401.665238 161.251571
+L 430.296255 152.461032
+L 458.927272 145.432066
+L 487.558288 122.637066
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #8c564b; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="m975a81c4ea" d="M -0 2
@@ -1564,39 +1564,39 @@ z
 " style="stroke: #8c564b; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="275.211188" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="115.355072" y="260.065892" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="143.986089" y="245.768735" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="172.617105" y="237.36032" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="201.248122" y="229.70947" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="229.879139" y="220.326963" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="258.510155" y="213.826543" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="287.141172" y="207.450588" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="315.772189" y="192.369687" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="344.403205" y="183.688751" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="373.034222" y="176.55049" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="401.665238" y="160.929284" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="430.296255" y="152.116888" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="458.927272" y="145.070445" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="487.558288" y="122.218768" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="275.250031" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="115.355072" y="260.142298" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="143.986089" y="245.880602" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="172.617105" y="237.493041" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="201.248122" y="229.861167" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="229.879139" y="220.501931" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="258.510155" y="214.017633" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="287.141172" y="207.657492" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="315.772189" y="192.613995" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="344.403205" y="183.95459" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="373.034222" y="176.834033" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="401.665238" y="161.251571" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="430.296255" y="152.461032" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="458.927272" y="145.432066" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="487.558288" y="122.637066" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
-    <path d="M 86.724055 289.578288
-L 115.355072 274.498901
-L 143.986089 262.714585
-L 172.617105 254.857404
-L 201.248122 248.055983
-L 229.879139 240.01736
-L 258.510155 234.115336
-L 287.141172 227.99191
-L 315.772189 212.43771
-L 344.403205 203.466137
-L 373.034222 196.585925
-L 401.665238 180.029051
-L 430.296255 170.861547
-L 458.927272 163.480215
-L 487.558288 138.724618
+    <path d="M 86.724055 289.581497
+L 115.355072 274.539511
+L 143.986089 262.784422
+L 172.617105 254.946729
+L 201.248122 248.162177
+L 229.879139 240.143491
+L 258.510155 234.256106
+L 287.141172 228.147867
+L 315.772189 212.632245
+L 344.403205 203.682923
+L 373.034222 196.819776
+L 401.665238 180.303967
+L 430.296255 171.1592
+L 458.927272 163.796176
+L 487.558288 139.101978
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #e377c2; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="mbe61f33afa" d="M -0.666667 2
@@ -1615,35 +1615,35 @@ z
 " style="stroke: #e377c2; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="289.578288" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="115.355072" y="274.498901" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="143.986089" y="262.714585" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="172.617105" y="254.857404" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="201.248122" y="248.055983" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="229.879139" y="240.01736" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="258.510155" y="234.115336" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="287.141172" y="227.99191" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="315.772189" y="212.43771" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="344.403205" y="203.466137" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="373.034222" y="196.585925" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="401.665238" y="180.029051" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="430.296255" y="170.861547" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="458.927272" y="163.480215" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="487.558288" y="138.724618" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="289.581497" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="115.355072" y="274.539511" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="143.986089" y="262.784422" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="172.617105" y="254.946729" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="201.248122" y="248.162177" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="229.879139" y="240.143491" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="258.510155" y="234.256106" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="287.141172" y="228.147867" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="315.772189" y="212.632245" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="344.403205" y="203.682923" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="373.034222" y="196.819776" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="401.665238" y="180.303967" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="430.296255" y="171.1592" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="458.927272" y="163.796176" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="487.558288" y="139.101978" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_127">
-    <path d="M 86.724055 278.729678
-L 115.355072 257.696145
-L 143.986089 238.778782
-L 172.617105 228.953728
-L 201.248122 220.332641
-L 229.879139 205.784517
-L 258.510155 197.291634
-L 287.141172 191.217884
-L 315.772189 162.565969
-L 344.403205 151.03661
-L 373.034222 140.71007
+    <path d="M 86.724055 278.759794
+L 115.355072 257.778429
+L 143.986089 238.907985
+L 172.617105 229.107299
+L 201.248122 220.507595
+L 229.879139 205.995553
+L 258.510155 197.523735
+L 287.141172 191.465048
+L 315.772189 162.884196
+L 344.403205 151.383433
+L 373.034222 141.082505
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="m579b7dcafa" d="M 0 -2
@@ -1660,28 +1660,28 @@ z
 " style="stroke: #ff7f0e; stroke-linejoin: bevel"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#m579b7dcafa" x="86.724055" y="278.729678" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="115.355072" y="257.696145" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="143.986089" y="238.778782" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="172.617105" y="228.953728" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="201.248122" y="220.332641" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="229.879139" y="205.784517" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="258.510155" y="197.291634" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="287.141172" y="191.217884" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="315.772189" y="162.565969" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="344.403205" y="151.03661" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="373.034222" y="140.71007" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="86.724055" y="278.759794" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="115.355072" y="257.778429" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="143.986089" y="238.907985" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="172.617105" y="229.107299" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="201.248122" y="220.507595" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="229.879139" y="205.995553" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="258.510155" y="197.523735" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="287.141172" y="191.465048" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="315.772189" y="162.884196" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="344.403205" y="151.383433" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="373.034222" y="141.082505" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_128">
-    <path d="M 86.724055 259.192825
-L 115.355072 241.412152
-L 143.986089 179.658129
-L 172.617105 165.868135
-L 201.248122 157.294362
-L 229.879139 80.938901
-L 258.510155 63.660174
-L 287.141172 53.942182
+    <path d="M 86.724055 259.271397
+L 115.355072 241.534824
+L 143.986089 179.933965
+L 172.617105 166.178173
+L 201.248122 157.625665
+L 229.879139 81.459582
+L 258.510155 64.22371
+L 287.141172 54.529821
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #bcbd22; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="m6a669b47a0" d="M 0 -2
@@ -1694,14 +1694,14 @@ z
 " style="stroke: #bcbd22; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#m6a669b47a0" x="86.724055" y="259.192825" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="115.355072" y="241.412152" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="143.986089" y="179.658129" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="172.617105" y="165.868135" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="201.248122" y="157.294362" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="229.879139" y="80.938901" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="258.510155" y="63.660174" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="287.141172" y="53.942182" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="86.724055" y="259.271397" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="115.355072" y="241.534824" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="143.986089" y="179.933965" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="172.617105" y="166.178173" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="201.248122" y="157.625665" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="229.879139" y="81.459582" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="258.510155" y="64.22371" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="287.141172" y="54.529821" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -2376,7 +2376,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2468,16 +2468,6 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1a" d="M 525 4666
-L 3525 4666
-L 3525 4397
-L 1831 0
-L 1172 0
-L 2766 4134
-L 525 4134
-L 525 4666
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2525,7 +2515,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-swinnerton-dyer.svg
+++ b/reports/figures/hexbz-cactus-swinnerton-dyer.svg
@@ -674,8 +674,8 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 66.682344 270.215332
-L 507.6 270.215332
+      <path d="M 66.682344 270.458382
+L 507.6 270.458382
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
@@ -685,12 +685,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="270.215332" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="270.458382" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 100us -->
-      <g transform="translate(29.047969 274.01416) scale(0.1 -0.1)">
+      <g transform="translate(29.047969 274.25721) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -701,18 +701,18 @@ L -3.5 0
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 66.682344 223.349022
-L 507.6 223.349022
+      <path d="M 66.682344 224.143502
+L 507.6 224.143502
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="223.349022" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="224.143502" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 1ms -->
-      <g transform="translate(38.369844 227.14785) scale(0.1 -0.1)">
+      <g transform="translate(38.369844 227.94233) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-50" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(161.03125 0)"/>
@@ -721,18 +721,18 @@ L 507.6 223.349022
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 66.682344 176.482712
-L 507.6 176.482712
+      <path d="M 66.682344 177.828622
+L 507.6 177.828622
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="176.482712" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="177.828622" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 10ms -->
-      <g transform="translate(32.007344 180.28154) scale(0.1 -0.1)">
+      <g transform="translate(32.007344 181.62745) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-50" transform="translate(127.25 0)"/>
@@ -742,18 +742,18 @@ L 507.6 176.482712
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 66.682344 129.616402
-L 507.6 129.616402
+      <path d="M 66.682344 131.513742
+L 507.6 131.513742
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="129.616402" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="131.513742" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 100ms -->
-      <g transform="translate(25.644844 133.415231) scale(0.1 -0.1)">
+      <g transform="translate(25.644844 135.31257) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -764,18 +764,18 @@ L 507.6 129.616402
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 66.682344 82.750093
-L 507.6 82.750093
+      <path d="M 66.682344 85.198862
+L 507.6 85.198862
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="82.750093" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="85.198862" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1s -->
-      <g transform="translate(48.110469 86.548921) scale(0.1 -0.1)">
+      <g transform="translate(48.110469 88.99769) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(63.625 0)"/>
       </g>
@@ -783,18 +783,18 @@ L 507.6 82.750093
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 66.682344 35.883783
-L 507.6 35.883783
+      <path d="M 66.682344 38.883982
+L 507.6 38.883982
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="35.883783" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="38.883982" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 10s -->
-      <g transform="translate(41.747969 39.682611) scale(0.1 -0.1)">
+      <g transform="translate(41.747969 42.68281) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(127.25 0)"/>
@@ -803,8 +803,8 @@ L 507.6 35.883783
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 66.682344 302.973477
-L 507.6 302.973477
+      <path d="M 66.682344 302.831094
+L 507.6 302.831094
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
@@ -814,571 +814,571 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="302.973477" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="302.831094" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 66.682344 294.720729
-L 507.6 294.720729
+      <path d="M 66.682344 294.675448
+L 507.6 294.675448
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="294.720729" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="294.675448" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 66.682344 288.865312
-L 507.6 288.865312
+      <path d="M 66.682344 288.888926
+L 507.6 288.888926
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="288.865312" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="288.888926" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 66.682344 284.323497
-L 507.6 284.323497
+      <path d="M 66.682344 284.40055
+L 507.6 284.40055
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.323497" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.40055" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 66.682344 280.612564
-L 507.6 280.612564
+      <path d="M 66.682344 280.73328
+L 507.6 280.73328
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="280.612564" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="280.73328" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 66.682344 277.475015
-L 507.6 277.475015
+      <path d="M 66.682344 277.632648
+L 507.6 277.632648
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="277.475015" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="277.632648" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 66.682344 274.757146
-L 507.6 274.757146
+      <path d="M 66.682344 274.946758
+L 507.6 274.946758
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="274.757146" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="274.946758" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 66.682344 272.359817
-L 507.6 272.359817
+      <path d="M 66.682344 272.577635
+L 507.6 272.577635
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="272.359817" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="272.577635" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 66.682344 256.107167
-L 507.6 256.107167
+      <path d="M 66.682344 256.516214
+L 507.6 256.516214
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="256.107167" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="256.516214" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 66.682344 247.854419
-L 507.6 247.854419
+      <path d="M 66.682344 248.360568
+L 507.6 248.360568
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="247.854419" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="248.360568" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 66.682344 241.999002
-L 507.6 241.999002
+      <path d="M 66.682344 242.574046
+L 507.6 242.574046
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="241.999002" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="242.574046" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 66.682344 237.457187
-L 507.6 237.457187
+      <path d="M 66.682344 238.08567
+L 507.6 238.08567
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="237.457187" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="238.08567" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 66.682344 233.746254
-L 507.6 233.746254
+      <path d="M 66.682344 234.4184
+L 507.6 234.4184
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="233.746254" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="234.4184" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 66.682344 230.608705
-L 507.6 230.608705
+      <path d="M 66.682344 231.317768
+L 507.6 231.317768
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="230.608705" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="231.317768" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 66.682344 227.890837
-L 507.6 227.890837
+      <path d="M 66.682344 228.631878
+L 507.6 228.631878
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="227.890837" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="228.631878" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 66.682344 225.493507
-L 507.6 225.493507
+      <path d="M 66.682344 226.262755
+L 507.6 226.262755
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="225.493507" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="226.262755" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 66.682344 209.240857
-L 507.6 209.240857
+      <path d="M 66.682344 210.201334
+L 507.6 210.201334
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="209.240857" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="210.201334" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 66.682344 200.98811
-L 507.6 200.98811
+      <path d="M 66.682344 202.045688
+L 507.6 202.045688
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="200.98811" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="202.045688" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 66.682344 195.132692
-L 507.6 195.132692
+      <path d="M 66.682344 196.259166
+L 507.6 196.259166
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="195.132692" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="196.259166" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 66.682344 190.590877
-L 507.6 190.590877
+      <path d="M 66.682344 191.77079
+L 507.6 191.77079
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="190.590877" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="191.77079" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_67">
-      <path d="M 66.682344 186.879944
-L 507.6 186.879944
+      <path d="M 66.682344 188.10352
+L 507.6 188.10352
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="186.879944" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="188.10352" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_69">
-      <path d="M 66.682344 183.742395
-L 507.6 183.742395
+      <path d="M 66.682344 185.002888
+L 507.6 185.002888
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="183.742395" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="185.002888" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_71">
-      <path d="M 66.682344 181.024527
-L 507.6 181.024527
+      <path d="M 66.682344 182.316998
+L 507.6 182.316998
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="181.024527" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="182.316998" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_73">
-      <path d="M 66.682344 178.627197
-L 507.6 178.627197
+      <path d="M 66.682344 179.947875
+L 507.6 179.947875
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="178.627197" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="179.947875" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_75">
-      <path d="M 66.682344 162.374547
-L 507.6 162.374547
+      <path d="M 66.682344 163.886454
+L 507.6 163.886454
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="162.374547" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="163.886454" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_77">
-      <path d="M 66.682344 154.1218
-L 507.6 154.1218
+      <path d="M 66.682344 155.730808
+L 507.6 155.730808
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="154.1218" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="155.730808" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_79">
-      <path d="M 66.682344 148.266382
-L 507.6 148.266382
+      <path d="M 66.682344 149.944286
+L 507.6 149.944286
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_80">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="148.266382" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="149.944286" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_81">
-      <path d="M 66.682344 143.724568
-L 507.6 143.724568
+      <path d="M 66.682344 145.45591
+L 507.6 145.45591
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_82">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="143.724568" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="145.45591" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_83">
-      <path d="M 66.682344 140.013635
-L 507.6 140.013635
+      <path d="M 66.682344 141.78864
+L 507.6 141.78864
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_84">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="140.013635" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="141.78864" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_36">
      <g id="line2d_85">
-      <path d="M 66.682344 136.876086
-L 507.6 136.876086
+      <path d="M 66.682344 138.688008
+L 507.6 138.688008
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_86">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="136.876086" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="138.688008" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_37">
      <g id="line2d_87">
-      <path d="M 66.682344 134.158217
-L 507.6 134.158217
+      <path d="M 66.682344 136.002118
+L 507.6 136.002118
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_88">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="134.158217" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="136.002118" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_38">
      <g id="line2d_89">
-      <path d="M 66.682344 131.760887
-L 507.6 131.760887
+      <path d="M 66.682344 133.632995
+L 507.6 133.632995
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_90">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="131.760887" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="133.632995" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_39">
      <g id="line2d_91">
-      <path d="M 66.682344 115.508237
-L 507.6 115.508237
+      <path d="M 66.682344 117.571574
+L 507.6 117.571574
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_92">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="115.508237" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="117.571574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_40">
      <g id="line2d_93">
-      <path d="M 66.682344 107.25549
-L 507.6 107.25549
+      <path d="M 66.682344 109.415928
+L 507.6 109.415928
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_94">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="107.25549" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="109.415928" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_41">
      <g id="line2d_95">
-      <path d="M 66.682344 101.400072
-L 507.6 101.400072
+      <path d="M 66.682344 103.629406
+L 507.6 103.629406
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_96">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="101.400072" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="103.629406" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_42">
      <g id="line2d_97">
-      <path d="M 66.682344 96.858258
-L 507.6 96.858258
+      <path d="M 66.682344 99.14103
+L 507.6 99.14103
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_98">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="96.858258" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="99.14103" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_43">
      <g id="line2d_99">
-      <path d="M 66.682344 93.147325
-L 507.6 93.147325
+      <path d="M 66.682344 95.47376
+L 507.6 95.47376
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_100">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="93.147325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="95.47376" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_44">
      <g id="line2d_101">
-      <path d="M 66.682344 90.009776
-L 507.6 90.009776
+      <path d="M 66.682344 92.373128
+L 507.6 92.373128
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_102">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="90.009776" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="92.373128" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_45">
      <g id="line2d_103">
-      <path d="M 66.682344 87.291907
-L 507.6 87.291907
+      <path d="M 66.682344 89.687238
+L 507.6 89.687238
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_104">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="87.291907" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="89.687238" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_46">
      <g id="line2d_105">
-      <path d="M 66.682344 84.894577
-L 507.6 84.894577
+      <path d="M 66.682344 87.318115
+L 507.6 87.318115
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_106">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="84.894577" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="87.318115" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_47">
      <g id="line2d_107">
-      <path d="M 66.682344 68.641928
-L 507.6 68.641928
+      <path d="M 66.682344 71.256694
+L 507.6 71.256694
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_108">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="68.641928" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="71.256694" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_48">
      <g id="line2d_109">
-      <path d="M 66.682344 60.38918
-L 507.6 60.38918
+      <path d="M 66.682344 63.101048
+L 507.6 63.101048
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_110">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="60.38918" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="63.101048" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_49">
      <g id="line2d_111">
-      <path d="M 66.682344 54.533763
-L 507.6 54.533763
+      <path d="M 66.682344 57.314526
+L 507.6 57.314526
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_112">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="54.533763" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="57.314526" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_50">
      <g id="line2d_113">
-      <path d="M 66.682344 49.991948
-L 507.6 49.991948
+      <path d="M 66.682344 52.82615
+L 507.6 52.82615
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_114">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="49.991948" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="52.82615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_51">
      <g id="line2d_115">
-      <path d="M 66.682344 46.281015
-L 507.6 46.281015
+      <path d="M 66.682344 49.15888
+L 507.6 49.15888
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_116">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="46.281015" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="49.15888" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_52">
      <g id="line2d_117">
-      <path d="M 66.682344 43.143466
-L 507.6 43.143466
+      <path d="M 66.682344 46.058248
+L 507.6 46.058248
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_118">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="43.143466" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="46.058248" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_53">
      <g id="line2d_119">
-      <path d="M 66.682344 40.425598
-L 507.6 40.425598
+      <path d="M 66.682344 43.372358
+L 507.6 43.372358
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_120">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="40.425598" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="43.372358" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_54">
      <g id="line2d_121">
-      <path d="M 66.682344 38.028268
-L 507.6 38.028268
+      <path d="M 66.682344 41.003235
+L 507.6 41.003235
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_122">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="38.028268" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="41.003235" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1456,17 +1456,17 @@ z
     </g>
    </g>
    <g id="line2d_123">
-    <path d="M 86.724055 285.35423
-L 115.355072 268.308002
-L 143.986089 250.562133
-L 172.617105 240.967931
-L 201.248122 234.341539
-L 229.879139 216.817077
-L 258.510155 206.928157
-L 287.141172 200.283801
-L 315.772189 137.505629
-L 344.403205 123.405108
-L 373.034222 114.881177
+    <path d="M 86.724055 287.204483
+L 115.355072 269.209261
+L 143.986089 251.205239
+L 172.617105 241.719546
+L 201.248122 235.024051
+L 229.879139 217.871518
+L 258.510155 208.190676
+L 287.141172 201.631136
+L 315.772189 139.287331
+L 344.403205 125.357714
+L 373.034222 116.947282
 L 401.665238 38.765348
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
@@ -1483,36 +1483,36 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="285.35423" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="115.355072" y="268.308002" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.986089" y="250.562133" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="172.617105" y="240.967931" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="201.248122" y="234.341539" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="229.879139" y="216.817077" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="258.510155" y="206.928157" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="200.283801" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="315.772189" y="137.505629" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="344.403205" y="123.405108" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="373.034222" y="114.881177" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="287.204483" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="115.355072" y="269.209261" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.986089" y="251.205239" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="172.617105" y="241.719546" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="201.248122" y="235.024051" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="229.879139" y="217.871518" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="258.510155" y="208.190676" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="201.631136" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="315.772189" y="139.287331" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="344.403205" y="125.357714" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="373.034222" y="116.947282" style="fill: #1f77b4; stroke: #1f77b4"/>
      <use xlink:href="#md73ba6276e" x="401.665238" y="38.765348" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_124">
     <path d="M 86.724055 290.872308
-L 115.355072 276.275312
-L 143.986089 265.706925
-L 172.617105 258.482044
-L 201.248122 251.540861
-L 229.879139 238.976427
-L 258.510155 231.243179
-L 287.141172 225.025699
-L 315.772189 210.562179
-L 344.403205 202.12075
-L 373.034222 195.252695
-L 401.665238 178.965781
-L 430.296255 169.997556
-L 458.927272 163.67123
-L 487.558288 142.053122
+L 115.355072 276.44706
+L 143.986089 266.003021
+L 172.617105 258.863148
+L 201.248122 252.003635
+L 229.879139 239.587035
+L 258.510155 231.944776
+L 287.141172 225.800451
+L 315.772189 211.50711
+L 344.403205 203.165002
+L 373.034222 196.377757
+L 401.665238 180.282475
+L 430.296255 171.41977
+L 458.927272 165.16788
+L 487.558288 143.804131
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #9467bd; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="meef3cfac8d" d="M 0 -2
@@ -1523,38 +1523,38 @@ z
     </defs>
     <g clip-path="url(#p6c2be49786)">
      <use xlink:href="#meef3cfac8d" x="86.724055" y="290.872308" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="115.355072" y="276.275312" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="143.986089" y="265.706925" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="172.617105" y="258.482044" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="201.248122" y="251.540861" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="229.879139" y="238.976427" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="258.510155" y="231.243179" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="287.141172" y="225.025699" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="315.772189" y="210.562179" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="344.403205" y="202.12075" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="373.034222" y="195.252695" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="401.665238" y="178.965781" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="430.296255" y="169.997556" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="458.927272" y="163.67123" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="487.558288" y="142.053122" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="115.355072" y="276.44706" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="143.986089" y="266.003021" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="172.617105" y="258.863148" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="201.248122" y="252.003635" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="229.879139" y="239.587035" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="258.510155" y="231.944776" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="287.141172" y="225.800451" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="315.772189" y="211.50711" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="344.403205" y="203.165002" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="373.034222" y="196.377757" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="401.665238" y="180.282475" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="430.296255" y="171.41977" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="458.927272" y="165.16788" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="487.558288" y="143.804131" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_125">
-    <path d="M 86.724055 275.250031
-L 115.355072 260.142298
-L 143.986089 245.880602
-L 172.617105 237.493041
-L 201.248122 229.861167
-L 229.879139 220.501931
-L 258.510155 214.017633
-L 287.141172 207.657492
-L 315.772189 192.613995
-L 344.403205 183.95459
-L 373.034222 176.834033
-L 401.665238 161.251571
-L 430.296255 152.461032
-L 458.927272 145.432066
-L 487.558288 122.637066
+    <path d="M 86.724055 275.433843
+L 115.355072 260.503868
+L 143.986089 246.409975
+L 172.617105 238.121103
+L 201.248122 230.579025
+L 229.879139 221.32991
+L 258.510155 214.921906
+L 287.141172 208.636599
+L 315.772189 193.770104
+L 344.403205 185.212585
+L 373.034222 178.175809
+L 401.665238 162.776691
+L 430.296255 154.089581
+L 458.927272 147.143318
+L 487.558288 124.616525
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #8c564b; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="m975a81c4ea" d="M -0 2
@@ -1564,39 +1564,39 @@ z
 " style="stroke: #8c564b; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="275.250031" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="115.355072" y="260.142298" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="143.986089" y="245.880602" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="172.617105" y="237.493041" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="201.248122" y="229.861167" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="229.879139" y="220.501931" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="258.510155" y="214.017633" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="287.141172" y="207.657492" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="315.772189" y="192.613995" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="344.403205" y="183.95459" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="373.034222" y="176.834033" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="401.665238" y="161.251571" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="430.296255" y="152.461032" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="458.927272" y="145.432066" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="487.558288" y="122.637066" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="275.433843" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="115.355072" y="260.503868" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="143.986089" y="246.409975" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="172.617105" y="238.121103" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="201.248122" y="230.579025" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="229.879139" y="221.32991" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="258.510155" y="214.921906" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="287.141172" y="208.636599" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="315.772189" y="193.770104" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="344.403205" y="185.212585" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="373.034222" y="178.175809" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="401.665238" y="162.776691" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="430.296255" y="154.089581" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="458.927272" y="147.143318" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="487.558288" y="124.616525" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
-    <path d="M 86.724055 289.581497
-L 115.355072 274.539511
-L 143.986089 262.784422
-L 172.617105 254.946729
-L 201.248122 248.162177
-L 229.879139 240.143491
-L 258.510155 234.256106
-L 287.141172 228.147867
-L 315.772189 212.632245
-L 344.403205 203.682923
-L 373.034222 196.819776
-L 401.665238 180.303967
-L 430.296255 171.1592
-L 458.927272 163.796176
-L 487.558288 139.101978
+    <path d="M 86.724055 289.596685
+L 115.355072 274.731683
+L 143.986089 263.114905
+L 172.617105 255.369429
+L 201.248122 248.664705
+L 229.879139 240.740367
+L 258.510155 234.922253
+L 287.141172 228.885884
+L 315.772189 213.552819
+L 344.403205 204.708795
+L 373.034222 197.926399
+L 401.665238 181.604916
+L 430.296255 172.567746
+L 458.927272 165.291355
+L 487.558288 140.88771
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #e377c2; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="mbe61f33afa" d="M -0.666667 2
@@ -1615,35 +1615,35 @@ z
 " style="stroke: #e377c2; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="289.581497" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="115.355072" y="274.539511" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="143.986089" y="262.784422" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="172.617105" y="254.946729" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="201.248122" y="248.162177" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="229.879139" y="240.143491" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="258.510155" y="234.256106" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="287.141172" y="228.147867" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="315.772189" y="212.632245" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="344.403205" y="203.682923" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="373.034222" y="196.819776" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="401.665238" y="180.303967" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="430.296255" y="171.1592" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="458.927272" y="163.796176" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="487.558288" y="139.101978" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="289.596685" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="115.355072" y="274.731683" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="143.986089" y="263.114905" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="172.617105" y="255.369429" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="201.248122" y="248.664705" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="229.879139" y="240.740367" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="258.510155" y="234.922253" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="287.141172" y="228.885884" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="315.772189" y="213.552819" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="344.403205" y="204.708795" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="373.034222" y="197.926399" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="401.665238" y="181.604916" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="430.296255" y="172.567746" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="458.927272" y="165.291355" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="487.558288" y="140.88771" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_127">
-    <path d="M 86.724055 278.759794
-L 115.355072 257.778429
-L 143.986089 238.907985
-L 172.617105 229.107299
-L 201.248122 220.507595
-L 229.879139 205.995553
-L 258.510155 197.523735
-L 287.141172 191.465048
-L 315.772189 162.884196
-L 344.403205 151.383433
-L 373.034222 141.082505
+    <path d="M 86.724055 278.90231
+L 115.355072 258.167812
+L 143.986089 239.519398
+L 172.617105 229.834027
+L 201.248122 221.335507
+L 229.879139 206.994214
+L 258.510155 198.622076
+L 287.141172 192.634676
+L 315.772189 164.390107
+L 344.403205 153.024662
+L 373.034222 142.844934
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="m579b7dcafa" d="M 0 -2
@@ -1660,28 +1660,28 @@ z
 " style="stroke: #ff7f0e; stroke-linejoin: bevel"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#m579b7dcafa" x="86.724055" y="278.759794" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="115.355072" y="257.778429" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="143.986089" y="238.907985" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="172.617105" y="229.107299" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="201.248122" y="220.507595" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="229.879139" y="205.995553" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="258.510155" y="197.523735" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="287.141172" y="191.465048" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="315.772189" y="162.884196" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="344.403205" y="151.383433" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="373.034222" y="141.082505" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="86.724055" y="278.90231" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="115.355072" y="258.167812" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="143.986089" y="239.519398" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="172.617105" y="229.834027" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="201.248122" y="221.335507" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="229.879139" y="206.994214" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="258.510155" y="198.622076" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="287.141172" y="192.634676" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="315.772189" y="164.390107" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="344.403205" y="153.024662" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="373.034222" y="142.844934" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_128">
-    <path d="M 86.724055 259.271397
-L 115.355072 241.534824
-L 143.986089 179.933965
-L 172.617105 166.178173
-L 201.248122 157.625665
-L 229.879139 81.459582
-L 258.510155 64.22371
-L 287.141172 54.529821
+    <path d="M 86.724055 259.643213
+L 115.355072 242.11533
+L 143.986089 181.239267
+L 172.617105 167.645326
+L 201.248122 159.193447
+L 229.879139 83.923535
+L 258.510155 66.890461
+L 287.141172 57.31063
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #bcbd22; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="m6a669b47a0" d="M 0 -2
@@ -1694,14 +1694,14 @@ z
 " style="stroke: #bcbd22; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#m6a669b47a0" x="86.724055" y="259.271397" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="115.355072" y="241.534824" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="143.986089" y="179.933965" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="172.617105" y="166.178173" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="201.248122" y="157.625665" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="229.879139" y="81.459582" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="258.510155" y="64.22371" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="287.141172" y="54.529821" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="86.724055" y="259.643213" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="115.355072" y="242.11533" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="143.986089" y="181.239267" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="172.617105" y="167.645326" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="201.248122" y="159.193447" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="229.879139" y="83.923535" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="258.510155" y="66.890461" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="287.141172" y="57.31063" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -2376,7 +2376,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2468,6 +2468,36 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-1c" d="M 703 97
+L 703 672
+Q 941 559 1184 500
+Q 1428 441 1663 441
+Q 2288 441 2617 861
+Q 2947 1281 2994 2138
+Q 2813 1869 2534 1725
+Q 2256 1581 1919 1581
+Q 1219 1581 811 2004
+Q 403 2428 403 3163
+Q 403 3881 828 4315
+Q 1253 4750 1959 4750
+Q 2769 4750 3195 4129
+Q 3622 3509 3622 2328
+Q 3622 1225 3098 567
+Q 2575 -91 1691 -91
+Q 1453 -91 1209 -44
+Q 966 3 703 97
+z
+M 1959 2075
+Q 2384 2075 2632 2365
+Q 2881 2656 2881 3163
+Q 2881 3666 2632 3958
+Q 2384 4250 1959 4250
+Q 1534 4250 1286 3958
+Q 1038 3666 1038 3163
+Q 1038 2656 1286 2365
+Q 1534 2075 1959 2075
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2515,7 +2545,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-wilkinson.svg
+++ b/reports/figures/hexbz-cactus-wilkinson.svg
@@ -1352,21 +1352,21 @@ z
     </g>
    </g>
    <g id="line2d_107">
-    <path d="M 86.724055 271.307847
-L 115.355072 249.231212
-L 143.986089 233.981661
-L 172.617105 216.726544
-L 201.248122 204.48199
-L 229.879139 193.987668
-L 258.510155 184.715908
-L 287.141172 175.229051
-L 315.772189 166.715088
-L 344.403205 157.638013
-L 373.034222 146.73773
-L 401.665238 137.660927
-L 430.296255 127.839043
-L 458.927272 116.600403
-L 487.558288 106.92267
+    <path d="M 86.724055 271.78369
+L 115.355072 248.418751
+L 143.986089 233.264609
+L 172.617105 215.881883
+L 201.248122 203.203741
+L 229.879139 192.604634
+L 258.510155 183.19121
+L 287.141172 173.960466
+L 315.772189 165.574786
+L 344.403205 156.568658
+L 373.034222 145.827349
+L 401.665238 136.824912
+L 430.296255 126.953524
+L 458.927272 115.736583
+L 487.558288 106.021538
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1382,21 +1382,21 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="271.307847" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="115.355072" y="249.231212" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.986089" y="233.981661" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="172.617105" y="216.726544" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="201.248122" y="204.48199" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="229.879139" y="193.987668" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="258.510155" y="184.715908" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="175.229051" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="315.772189" y="166.715088" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="344.403205" y="157.638013" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="373.034222" y="146.73773" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="401.665238" y="137.660927" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="430.296255" y="127.839043" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="458.927272" y="116.600403" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="106.92267" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="271.78369" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="115.355072" y="248.418751" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.986089" y="233.264609" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="172.617105" y="215.881883" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="201.248122" y="203.203741" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="229.879139" y="192.604634" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="258.510155" y="183.19121" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="173.960466" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="315.772189" y="165.574786" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="344.403205" y="156.568658" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="373.034222" y="145.827349" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="401.665238" y="136.824912" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="430.296255" y="126.953524" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="458.927272" y="115.736583" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="106.021538" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -2278,7 +2278,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2387,6 +2387,36 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-1c" d="M 703 97
+L 703 672
+Q 941 559 1184 500
+Q 1428 441 1663 441
+Q 2288 441 2617 861
+Q 2947 1281 2994 2138
+Q 2813 1869 2534 1725
+Q 2256 1581 1919 1581
+Q 1219 1581 811 2004
+Q 403 2428 403 3163
+Q 403 3881 828 4315
+Q 1253 4750 1959 4750
+Q 2769 4750 3195 4129
+Q 3622 3509 3622 2328
+Q 3622 1225 3098 567
+Q 2575 -91 1691 -91
+Q 1453 -91 1209 -44
+Q 966 3 703 97
+z
+M 1959 2075
+Q 2384 2075 2632 2365
+Q 2881 2656 2881 3163
+Q 2881 3666 2632 3958
+Q 2384 4250 1959 4250
+Q 1534 4250 1286 3958
+Q 1038 3666 1038 3163
+Q 1038 2656 1286 2365
+Q 1534 2075 1959 2075
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2434,7 +2464,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-cactus-wilkinson.svg
+++ b/reports/figures/hexbz-cactus-wilkinson.svg
@@ -1352,21 +1352,21 @@ z
     </g>
    </g>
    <g id="line2d_107">
-    <path d="M 86.724055 270.171848
-L 115.355072 248.219422
-L 143.986089 232.83348
-L 172.617105 215.550504
-L 201.248122 203.094654
-L 229.879139 192.689068
-L 258.510155 183.382414
-L 287.141172 174.031251
-L 315.772189 165.597742
-L 344.403205 156.448639
-L 373.034222 145.811256
-L 401.665238 136.896385
-L 430.296255 127.206104
-L 458.927272 116.17309
-L 487.558288 106.583076
+    <path d="M 86.724055 271.307847
+L 115.355072 249.231212
+L 143.986089 233.981661
+L 172.617105 216.726544
+L 201.248122 204.48199
+L 229.879139 193.987668
+L 258.510155 184.715908
+L 287.141172 175.229051
+L 315.772189 166.715088
+L 344.403205 157.638013
+L 373.034222 146.73773
+L 401.665238 137.660927
+L 430.296255 127.839043
+L 458.927272 116.600403
+L 487.558288 106.92267
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #1f77b4; stroke-width: 1.2; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1382,21 +1382,21 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="270.171848" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="115.355072" y="248.219422" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.986089" y="232.83348" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="172.617105" y="215.550504" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="201.248122" y="203.094654" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="229.879139" y="192.689068" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="258.510155" y="183.382414" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="174.031251" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="315.772189" y="165.597742" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="344.403205" y="156.448639" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="373.034222" y="145.811256" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="401.665238" y="136.896385" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="430.296255" y="127.206104" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="458.927272" y="116.17309" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="106.583076" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="271.307847" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="115.355072" y="249.231212" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.986089" y="233.981661" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="172.617105" y="216.726544" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="201.248122" y="204.48199" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="229.879139" y="193.987668" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="258.510155" y="184.715908" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="175.229051" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="315.772189" y="166.715088" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="344.403205" y="157.638013" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="373.034222" y="146.73773" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="401.665238" y="137.660927" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="430.296255" y="127.839043" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="458.927272" y="116.600403" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="106.92267" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -2278,7 +2278,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2387,16 +2387,6 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1a" d="M 525 4666
-L 3525 4666
-L 3525 4397
-L 1831 0
-L 1172 0
-L 2766 4134
-L 525 4134
-L 525 4666
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2444,7 +2434,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-certificate-boundary.svg
+++ b/reports/figures/hexbz-runtime-degree-certificate-boundary.svg
@@ -1139,7 +1139,7 @@ z
     </g>
    </g>
    <g id="line2d_39">
-    <path d="M 290.301172 198.026284
+    <path d="M 290.301172 205.587244
 " clip-path="url(#p2299177b78)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1155,7 +1155,7 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p2299177b78)">
-     <use xlink:href="#md73ba6276e" x="290.301172" y="198.026284" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="290.301172" y="205.587244" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_40">
@@ -1851,7 +1851,7 @@ L 96.202344 96.641875
    </g>
   </g>
   <g id="text_25">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -1951,7 +1951,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-certificate-boundary.svg
+++ b/reports/figures/hexbz-runtime-degree-certificate-boundary.svg
@@ -1139,7 +1139,7 @@ z
     </g>
    </g>
    <g id="line2d_39">
-    <path d="M 290.301172 195.465668
+    <path d="M 290.301172 198.026284
 " clip-path="url(#p2299177b78)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1155,7 +1155,7 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p2299177b78)">
-     <use xlink:href="#md73ba6276e" x="290.301172" y="195.465668" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="290.301172" y="198.026284" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_40">
@@ -1851,7 +1851,7 @@ L 96.202344 96.641875
    </g>
   </g>
   <g id="text_25">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -1904,16 +1904,6 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1a" d="M 525 4666
-L 3525 4666
-L 3525 4397
-L 1831 0
-L 1172 0
-L 2766 4134
-L 525 4134
-L 525 4666
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -1961,7 +1951,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-chebyshev.svg
+++ b/reports/figures/hexbz-runtime-degree-chebyshev.svg
@@ -1403,34 +1403,34 @@ z
     </g>
    </g>
    <g id="line2d_123">
-    <path d="M 86.469038 281.644835
-L 86.469038 273.692625
-L 105.313508 277.198556
-L 105.313508 267.09587
-L 124.157979 277.110214
-L 124.157979 265.257143
-L 143.002449 263.913343
-L 143.002449 258.142554
-L 161.846919 265.074438
-L 161.846919 264.040703
-L 180.69139 267.643575
-L 180.69139 249.701671
-L 199.53586 258.871564
-L 199.53586 254.782036
-L 218.380331 254.143596
-L 218.380331 249.392991
-L 256.069271 247.105148
-L 256.069271 244.870442
-L 312.602683 242.974304
-L 312.602683 236.017143
-L 331.447153 250.439165
-L 331.447153 240.231316
-L 369.136094 236.976499
-L 369.136094 225.542447
-L 406.825035 224.179255
-L 406.825035 218.495911
-L 482.202916 228.131593
-L 482.202916 222.362216
+    <path d="M 86.469038 281.65974
+L 86.469038 268.509601
+L 105.313508 277.665841
+L 105.313508 268.884493
+L 124.157979 276.870232
+L 124.157979 265.435232
+L 143.002449 262.86863
+L 143.002449 255.338854
+L 161.846919 264.732932
+L 161.846919 264.252375
+L 180.69139 267.593877
+L 180.69139 249.252872
+L 199.53586 258.247794
+L 199.53586 254.658073
+L 218.380331 253.697747
+L 218.380331 247.860144
+L 256.069271 247.171249
+L 256.069271 244.480377
+L 312.602683 242.237501
+L 312.602683 235.876558
+L 331.447153 250.44222
+L 331.447153 240.395149
+L 369.136094 235.713357
+L 369.136094 225.373759
+L 406.825035 223.872091
+L 406.825035 218.295719
+L 482.202916 227.904029
+L 482.202916 221.553934
 " clip-path="url(#pe3690171c9)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1446,34 +1446,34 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pe3690171c9)">
-     <use xlink:href="#md73ba6276e" x="86.469038" y="281.644835" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.469038" y="273.692625" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="105.313508" y="277.198556" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="105.313508" y="267.09587" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="124.157979" y="277.110214" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="124.157979" y="265.257143" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.002449" y="263.913343" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.002449" y="258.142554" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="161.846919" y="265.074438" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="161.846919" y="264.040703" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="180.69139" y="267.643575" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="180.69139" y="249.701671" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.53586" y="258.871564" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.53586" y="254.782036" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="218.380331" y="254.143596" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="218.380331" y="249.392991" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="256.069271" y="247.105148" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="256.069271" y="244.870442" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.602683" y="242.974304" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.602683" y="236.017143" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.447153" y="250.439165" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.447153" y="240.231316" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="369.136094" y="236.976499" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="369.136094" y="225.542447" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="406.825035" y="224.179255" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="406.825035" y="218.495911" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="482.202916" y="228.131593" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="482.202916" y="222.362216" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.469038" y="281.65974" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.469038" y="268.509601" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="105.313508" y="277.665841" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="105.313508" y="268.884493" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="124.157979" y="276.870232" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="124.157979" y="265.435232" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.002449" y="262.86863" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.002449" y="255.338854" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="161.846919" y="264.732932" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="161.846919" y="264.252375" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="180.69139" y="267.593877" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="180.69139" y="249.252872" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.53586" y="258.247794" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.53586" y="254.658073" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="218.380331" y="253.697747" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="218.380331" y="247.860144" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="256.069271" y="247.171249" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="256.069271" y="244.480377" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.602683" y="242.237501" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.602683" y="235.876558" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.447153" y="250.44222" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.447153" y="240.395149" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="369.136094" y="235.713357" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="369.136094" y="225.373759" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="406.825035" y="223.872091" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="406.825035" y="218.295719" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="482.202916" y="227.904029" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="482.202916" y="221.553934" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_124">
@@ -2427,7 +2427,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2519,43 +2519,34 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1b" d="M 2034 2216
-Q 1584 2216 1326 1975
-Q 1069 1734 1069 1313
-Q 1069 891 1326 650
-Q 1584 409 2034 409
-Q 2484 409 2743 651
-Q 3003 894 3003 1313
-Q 3003 1734 2745 1975
-Q 2488 2216 2034 2216
+     <path id="DejaVuSans-1c" d="M 703 97
+L 703 672
+Q 941 559 1184 500
+Q 1428 441 1663 441
+Q 2288 441 2617 861
+Q 2947 1281 2994 2138
+Q 2813 1869 2534 1725
+Q 2256 1581 1919 1581
+Q 1219 1581 811 2004
+Q 403 2428 403 3163
+Q 403 3881 828 4315
+Q 1253 4750 1959 4750
+Q 2769 4750 3195 4129
+Q 3622 3509 3622 2328
+Q 3622 1225 3098 567
+Q 2575 -91 1691 -91
+Q 1453 -91 1209 -44
+Q 966 3 703 97
 z
-M 1403 2484
-Q 997 2584 770 2862
-Q 544 3141 544 3541
-Q 544 4100 942 4425
-Q 1341 4750 2034 4750
-Q 2731 4750 3128 4425
-Q 3525 4100 3525 3541
-Q 3525 3141 3298 2862
-Q 3072 2584 2669 2484
-Q 3125 2378 3379 2068
-Q 3634 1759 3634 1313
-Q 3634 634 3220 271
-Q 2806 -91 2034 -91
-Q 1263 -91 848 271
-Q 434 634 434 1313
-Q 434 1759 690 2068
-Q 947 2378 1403 2484
-z
-M 1172 3481
-Q 1172 3119 1398 2916
-Q 1625 2713 2034 2713
-Q 2441 2713 2670 2916
-Q 2900 3119 2900 3481
-Q 2900 3844 2670 4047
-Q 2441 4250 2034 4250
-Q 1625 4250 1398 4047
-Q 1172 3844 1172 3481
+M 1959 2075
+Q 2384 2075 2632 2365
+Q 2881 2656 2881 3163
+Q 2881 3666 2632 3958
+Q 2384 4250 1959 4250
+Q 1534 4250 1286 3958
+Q 1038 3666 1038 3163
+Q 1038 2656 1286 2365
+Q 1534 2075 1959 2075
 z
 " transform="scale(0.015625)"/>
     </defs>
@@ -2605,7 +2596,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-chebyshev.svg
+++ b/reports/figures/hexbz-runtime-degree-chebyshev.svg
@@ -1403,34 +1403,34 @@ z
     </g>
    </g>
    <g id="line2d_123">
-    <path d="M 86.469038 278.330584
-L 86.469038 274.190903
-L 105.313508 273.98973
-L 105.313508 266.489141
-L 124.157979 273.594119
-L 124.157979 263.223812
-L 143.002449 262.021862
-L 143.002449 256.353779
-L 161.846919 262.318384
-L 161.846919 262.215438
-L 180.69139 263.472859
-L 180.69139 248.048319
-L 199.53586 255.980127
-L 199.53586 252.41296
-L 218.380331 251.256468
-L 218.380331 245.781389
-L 256.069271 244.871529
-L 256.069271 242.511673
-L 312.602683 239.379502
-L 312.602683 233.67413
-L 331.447153 244.316836
-L 331.447153 236.079554
-L 369.136094 232.677237
-L 369.136094 221.60833
-L 406.825035 221.379933
-L 406.825035 216.312253
-L 482.202916 222.574897
-L 482.202916 218.242686
+    <path d="M 86.469038 281.644835
+L 86.469038 273.692625
+L 105.313508 277.198556
+L 105.313508 267.09587
+L 124.157979 277.110214
+L 124.157979 265.257143
+L 143.002449 263.913343
+L 143.002449 258.142554
+L 161.846919 265.074438
+L 161.846919 264.040703
+L 180.69139 267.643575
+L 180.69139 249.701671
+L 199.53586 258.871564
+L 199.53586 254.782036
+L 218.380331 254.143596
+L 218.380331 249.392991
+L 256.069271 247.105148
+L 256.069271 244.870442
+L 312.602683 242.974304
+L 312.602683 236.017143
+L 331.447153 250.439165
+L 331.447153 240.231316
+L 369.136094 236.976499
+L 369.136094 225.542447
+L 406.825035 224.179255
+L 406.825035 218.495911
+L 482.202916 228.131593
+L 482.202916 222.362216
 " clip-path="url(#pe3690171c9)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1446,34 +1446,34 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pe3690171c9)">
-     <use xlink:href="#md73ba6276e" x="86.469038" y="278.330584" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.469038" y="274.190903" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="105.313508" y="273.98973" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="105.313508" y="266.489141" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="124.157979" y="273.594119" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="124.157979" y="263.223812" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.002449" y="262.021862" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.002449" y="256.353779" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="161.846919" y="262.318384" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="161.846919" y="262.215438" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="180.69139" y="263.472859" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="180.69139" y="248.048319" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.53586" y="255.980127" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.53586" y="252.41296" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="218.380331" y="251.256468" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="218.380331" y="245.781389" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="256.069271" y="244.871529" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="256.069271" y="242.511673" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.602683" y="239.379502" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.602683" y="233.67413" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.447153" y="244.316836" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.447153" y="236.079554" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="369.136094" y="232.677237" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="369.136094" y="221.60833" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="406.825035" y="221.379933" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="406.825035" y="216.312253" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="482.202916" y="222.574897" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="482.202916" y="218.242686" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.469038" y="281.644835" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.469038" y="273.692625" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="105.313508" y="277.198556" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="105.313508" y="267.09587" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="124.157979" y="277.110214" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="124.157979" y="265.257143" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.002449" y="263.913343" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.002449" y="258.142554" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="161.846919" y="265.074438" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="161.846919" y="264.040703" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="180.69139" y="267.643575" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="180.69139" y="249.701671" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.53586" y="258.871564" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.53586" y="254.782036" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="218.380331" y="254.143596" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="218.380331" y="249.392991" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="256.069271" y="247.105148" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="256.069271" y="244.870442" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.602683" y="242.974304" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.602683" y="236.017143" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.447153" y="250.439165" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.447153" y="240.231316" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="369.136094" y="236.976499" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="369.136094" y="225.542447" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="406.825035" y="224.179255" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="406.825035" y="218.495911" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="482.202916" y="228.131593" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="482.202916" y="222.362216" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_124">
@@ -2427,7 +2427,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2519,14 +2519,43 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1a" d="M 525 4666
-L 3525 4666
-L 3525 4397
-L 1831 0
-L 1172 0
-L 2766 4134
-L 525 4134
-L 525 4666
+     <path id="DejaVuSans-1b" d="M 2034 2216
+Q 1584 2216 1326 1975
+Q 1069 1734 1069 1313
+Q 1069 891 1326 650
+Q 1584 409 2034 409
+Q 2484 409 2743 651
+Q 3003 894 3003 1313
+Q 3003 1734 2745 1975
+Q 2488 2216 2034 2216
+z
+M 1403 2484
+Q 997 2584 770 2862
+Q 544 3141 544 3541
+Q 544 4100 942 4425
+Q 1341 4750 2034 4750
+Q 2731 4750 3128 4425
+Q 3525 4100 3525 3541
+Q 3525 3141 3298 2862
+Q 3072 2584 2669 2484
+Q 3125 2378 3379 2068
+Q 3634 1759 3634 1313
+Q 3634 634 3220 271
+Q 2806 -91 2034 -91
+Q 1263 -91 848 271
+Q 434 634 434 1313
+Q 434 1759 690 2068
+Q 947 2378 1403 2484
+z
+M 1172 3481
+Q 1172 3119 1398 2916
+Q 1625 2713 2034 2713
+Q 2441 2713 2670 2916
+Q 2900 3119 2900 3481
+Q 2900 3844 2670 4047
+Q 2441 4250 2034 4250
+Q 1625 4250 1398 4047
+Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
     </defs>
@@ -2576,7 +2605,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-conway.svg
+++ b/reports/figures/hexbz-runtime-degree-conway.svg
@@ -1583,89 +1583,88 @@ z
     </g>
    </g>
    <g id="line2d_139">
-    <path d="M 86.724055 274.155132
-L 86.724055 267.737762
-L 97.001856 267.860747
-L 97.001856 262.454443
-L 107.279657 266.424383
-L 107.279657 257.967786
-L 117.557458 262.895194
-L 117.557458 251.269178
-L 127.835259 260.709335
-L 127.835259 260.626479
-L 127.835259 250.487515
-L 138.11306 256.862524
-L 138.11306 256.808915
-L 138.11306 248.115023
-L 148.39086 254.803688
-L 148.39086 247.24201
-L 158.668661 250.794693
-L 158.668661 242.485223
-L 168.946462 249.271034
-L 168.946462 241.233654
-L 179.224263 245.972229
-L 179.224263 233.53186
-L 189.502064 247.061515
-L 189.502064 235.392255
-L 199.779865 241.175851
-L 199.779865 230.235858
-L 210.057666 243.114455
-L 210.057666 229.827496
-L 220.335466 234.221438
-L 220.335466 228.228206
-L 230.613267 234.916591
-L 230.613267 226.657288
-L 240.891068 233.549382
-L 240.891068 222.447183
-L 251.168869 234.343664
-L 251.168869 218.005769
-L 261.44667 227.223733
-L 261.44667 217.232178
-L 271.724471 230.54694
-L 271.724471 219.121346
-L 282.002271 222.633028
-L 282.002271 217.19928
-L 292.280072 222.22426
-L 292.280072 218.682049
-L 302.557873 220.29929
-L 302.557873 209.419605
-L 312.835674 222.337609
-L 312.835674 213.817651
-L 323.113475 216.986472
-L 323.113475 207.54948
-L 333.391276 216.635766
-L 333.391276 205.786974
-L 343.669077 212.250596
-L 343.669077 207.515364
-L 353.946877 219.190488
-L 353.946877 203.591482
-L 364.224678 210.980825
-L 364.224678 201.338582
-L 374.502479 215.93226
-L 374.502479 206.620516
-L 384.78028 206.252236
-L 384.78028 198.075938
-L 395.058081 211.492952
-L 395.058081 203.041776
-L 405.335882 205.639023
-L 405.335882 201.516581
-L 415.613682 204.169669
-L 415.613682 192.266327
-L 425.891483 202.109831
-L 425.891483 196.192301
-L 436.169284 202.528382
-L 436.169284 188.717937
-L 446.447085 198.150337
-L 446.447085 187.39111
-L 456.724886 200.861899
-L 456.724886 192.471474
-L 467.002687 195.951572
-L 467.002687 185.734473
-L 477.280488 197.295346
-L 477.280488 191.598859
-L 487.558288 194.086943
-L 487.558288 188.479015
-L 487.558288 188.479015
+    <path d="M 86.724055 275.053213
+L 86.724055 266.845815
+L 97.001856 271.234958
+L 97.001856 271.138522
+L 97.001856 262.254313
+L 107.279657 269.721141
+L 107.279657 258.165067
+L 117.557458 265.834649
+L 117.557458 248.362917
+L 127.835259 262.829699
+L 127.835259 253.044902
+L 138.11306 260.943798
+L 138.11306 249.189676
+L 148.39086 259.515213
+L 148.39086 248.95384
+L 158.668661 255.289812
+L 158.668661 244.368721
+L 168.946462 253.880117
+L 168.946462 245.000343
+L 179.224263 251.716049
+L 179.224263 236.368774
+L 189.502064 252.330489
+L 189.502064 237.275948
+L 199.779865 247.320966
+L 199.779865 223.510665
+L 210.057666 249.341695
+L 210.057666 231.131507
+L 220.335466 242.039166
+L 220.335466 234.67989
+L 230.613267 241.779259
+L 230.613267 229.262008
+L 240.891068 239.757087
+L 240.891068 225.610702
+L 251.168869 243.090963
+L 251.168869 219.148381
+L 261.44667 236.269708
+L 261.44667 223.091599
+L 271.724471 239.894497
+L 271.724471 222.472695
+L 282.002271 232.169393
+L 282.002271 222.945152
+L 292.280072 232.016779
+L 292.280072 225.202228
+L 302.557873 229.694942
+L 302.557873 215.983911
+L 312.835674 233.126534
+L 312.835674 217.714342
+L 323.113475 227.727338
+L 323.113475 215.757234
+L 333.391276 228.433802
+L 333.391276 212.049458
+L 343.669077 224.142678
+L 343.669077 214.054993
+L 353.946877 230.099445
+L 353.946877 211.938304
+L 364.224678 223.328234
+L 364.224678 206.067965
+L 374.502479 227.554859
+L 374.502479 219.222175
+L 384.78028 218.673141
+L 384.78028 203.958298
+L 395.058081 223.491096
+L 395.058081 208.570528
+L 405.335882 213.171004
+L 405.335882 211.083323
+L 415.613682 216.867224
+L 415.613682 199.815661
+L 425.891483 214.457107
+L 425.891483 204.246104
+L 436.169284 215.754135
+L 436.169284 195.444029
+L 446.447085 211.231735
+L 446.447085 195.824519
+L 456.724886 213.702753
+L 456.724886 198.79704
+L 467.002687 210.366284
+L 467.002687 193.67156
+L 477.280488 212.217412
+L 477.280488 198.424572
+L 487.558288 208.847403
+L 487.558288 196.713824
+L 487.558288 196.713824
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1681,192 +1680,192 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
+     <use xlink:href="#md73ba6276e" x="86.724055" y="275.053213" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="274.989" style="fill: #1f77b4; stroke: #1f77b4"/>
      <use xlink:href="#md73ba6276e" x="86.724055" y="274.155132" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.789856" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.781751" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.588313" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.588313" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.357307" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.332787" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="271.309492" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="267.737762" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="267.860747" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="267.52393" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="266.869162" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="264.893339" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="264.453237" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="263.838966" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="263.046267" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="262.885823" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="262.454443" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="266.424383" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="266.254235" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="266.231106" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="265.248078" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="264.951018" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="261.679164" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="260.445113" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="259.620458" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="257.967786" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="262.895194" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="262.629547" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="261.886719" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="257.659707" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="256.579198" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="255.983943" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="253.74098" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="252.836694" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="251.269178" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="260.709335" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="260.626479" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="257.031427" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="255.115038" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="254.710814" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="254.512046" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="251.771649" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="250.487515" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="256.862524" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="256.808915" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="256.519835" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="255.779902" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="253.597304" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="251.380296" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="249.368486" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="248.115023" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="254.803688" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="252.096521" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="251.308608" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="250.694262" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="250.416931" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="249.936589" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="249.625563" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="247.24201" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="250.794693" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="247.586609" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="247.508284" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="246.179209" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="245.43042" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="242.817127" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="242.735457" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="242.485223" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="168.946462" y="249.271034" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="168.946462" y="244.870166" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="168.946462" y="244.644974" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="168.946462" y="241.233654" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="245.972229" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="245.070238" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="241.257817" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="233.53186" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.502064" y="247.061515" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.502064" y="244.299811" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.502064" y="239.236879" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.502064" y="235.392255" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.779865" y="241.175851" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.779865" y="235.920831" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.779865" y="231.496394" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.779865" y="230.235858" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="243.114455" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="240.575475" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="236.086993" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="229.827496" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="234.221438" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="231.943106" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="231.000198" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="228.228206" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="230.613267" y="234.916591" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="230.613267" y="234.461869" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="230.613267" y="226.943376" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="230.613267" y="226.657288" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="233.549382" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="231.913585" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="223.115398" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="222.447183" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.168869" y="234.343664" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.168869" y="224.690988" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.168869" y="221.575251" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.168869" y="218.005769" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.44667" y="227.223733" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.44667" y="223.354498" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.44667" y="221.206721" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.44667" y="217.232178" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="230.54694" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="230.155324" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="220.745262" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="219.121346" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.002271" y="222.633028" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.002271" y="220.777572" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.002271" y="219.630917" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.002271" y="217.19928" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.280072" y="222.22426" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.280072" y="221.834184" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.280072" y="219.644197" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.280072" y="218.682049" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="220.29929" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="214.524346" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="213.162947" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="209.419605" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.835674" y="222.337609" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.835674" y="218.463144" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.835674" y="217.911453" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.835674" y="213.817651" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="323.113475" y="216.986472" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="323.113475" y="212.44594" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="323.113475" y="209.780158" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="323.113475" y="207.54948" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="216.635766" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="210.274908" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="209.741313" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="205.786974" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="343.669077" y="212.250596" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="343.669077" y="208.337346" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="343.669077" y="207.655121" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="343.669077" y="207.515364" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="219.190488" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="206.660264" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="205.616597" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="203.591482" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="210.980825" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="210.403963" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="203.798577" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="201.338582" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.502479" y="215.93226" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.502479" y="215.535444" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.502479" y="212.550466" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.502479" y="206.620516" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="384.78028" y="206.252236" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="384.78028" y="198.714706" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="384.78028" y="198.452859" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="384.78028" y="198.075938" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.058081" y="211.492952" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.058081" y="209.851392" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.058081" y="204.067919" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.058081" y="203.041776" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="405.335882" y="205.639023" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="405.335882" y="201.516581" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="415.613682" y="204.169669" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="415.613682" y="197.53039" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="415.613682" y="192.266327" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="425.891483" y="202.109831" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="425.891483" y="196.192301" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.169284" y="202.528382" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.169284" y="196.156728" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.169284" y="195.881448" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.169284" y="188.717937" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.447085" y="198.150337" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.447085" y="194.41114" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.447085" y="193.322778" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.447085" y="187.39111" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="456.724886" y="200.861899" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="456.724886" y="200.186232" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="456.724886" y="199.70047" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="456.724886" y="192.471474" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="467.002687" y="195.951572" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="467.002687" y="185.734473" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="477.280488" y="197.295346" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="477.280488" y="196.247352" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="477.280488" y="191.598859" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="194.086943" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="188.479015" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="274.059208" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="273.400797" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="273.342191" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="272.507523" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="271.497183" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="266.845815" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="271.234958" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="271.138522" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="269.081455" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="269.068916" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="264.663934" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="264.325453" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="263.948431" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="262.989643" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="262.254313" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="269.721141" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="268.066144" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="267.609524" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="266.470027" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="263.472349" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="261.539498" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="260.713903" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="258.666801" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="258.165067" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="265.834649" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="264.877641" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="263.298503" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="258.734045" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="258.619028" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="258.519077" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="254.845653" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="252.631125" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="248.362917" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="262.829699" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="260.776312" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="258.544842" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="258.390804" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="256.559388" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="255.403973" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="253.04789" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="253.044902" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="260.943798" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="260.404239" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="259.000642" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="258.256183" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="257.157529" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="252.860875" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="251.365689" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="249.189676" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="259.515213" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="257.095898" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="253.17356" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="252.093944" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="251.627694" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="251.595079" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="251.060891" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="248.95384" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="255.289812" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="250.936966" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="250.782708" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="249.964049" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="247.695545" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="245.412791" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="244.842553" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="244.368721" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="168.946462" y="253.880117" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="168.946462" y="248.635737" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="168.946462" y="246.272486" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="168.946462" y="245.000343" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="251.716049" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="250.978342" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="244.139705" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="236.368774" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.502064" y="252.330489" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.502064" y="250.18339" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.502064" y="241.703591" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.502064" y="237.275948" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.779865" y="247.320966" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.779865" y="241.074648" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.779865" y="234.881692" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.779865" y="223.510665" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="249.341695" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="246.973784" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="243.056564" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="231.131507" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="242.039166" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="238.050985" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="236.971959" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="234.67989" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="230.613267" y="241.779259" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="230.613267" y="238.503652" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="230.613267" y="233.129328" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="230.613267" y="229.262008" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="239.757087" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="239.553686" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="227.148364" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="225.610702" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.168869" y="243.090963" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.168869" y="228.290226" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.168869" y="225.233112" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.168869" y="219.148381" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.44667" y="236.269708" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.44667" y="228.617105" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.44667" y="226.218579" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.44667" y="223.091599" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="239.894497" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="239.679053" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="226.345237" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="222.472695" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.002271" y="232.169393" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.002271" y="227.875856" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.002271" y="225.929015" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.002271" y="222.945152" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.280072" y="232.016779" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.280072" y="227.136716" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.280072" y="225.796222" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.280072" y="225.202228" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="229.694942" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="218.493618" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="218.42673" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="215.983911" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.835674" y="233.126534" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.835674" y="228.684705" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.835674" y="225.300299" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.835674" y="217.714342" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="323.113475" y="227.727338" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="323.113475" y="220.07492" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="323.113475" y="216.496184" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="323.113475" y="215.757234" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="228.433802" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="217.320411" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="215.015214" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="212.049458" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="343.669077" y="224.142678" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="343.669077" y="215.276289" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="343.669077" y="214.415137" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="343.669077" y="214.054993" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="230.099445" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="218.294048" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="212.64345" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="211.938304" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="223.328234" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="222.224211" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="210.263191" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="206.067965" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.502479" y="227.554859" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.502479" y="222.528336" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.502479" y="220.092034" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.502479" y="219.222175" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="384.78028" y="218.673141" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="384.78028" y="208.053238" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="384.78028" y="204.611161" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="384.78028" y="203.958298" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.058081" y="223.491096" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.058081" y="222.243489" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.058081" y="210.299866" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.058081" y="208.570528" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="405.335882" y="213.171004" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="405.335882" y="211.083323" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="415.613682" y="216.867224" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="415.613682" y="210.547879" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="415.613682" y="199.815661" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="425.891483" y="214.457107" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="425.891483" y="204.246104" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.169284" y="215.754135" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.169284" y="209.489428" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.169284" y="202.937347" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.169284" y="195.444029" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.447085" y="211.231735" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.447085" y="203.093202" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.447085" y="202.024175" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.447085" y="195.824519" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="456.724886" y="213.702753" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="456.724886" y="213.477281" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="456.724886" y="204.519114" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="456.724886" y="198.79704" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="467.002687" y="210.366284" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="467.002687" y="193.67156" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="477.280488" y="212.217412" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="477.280488" y="210.898159" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="477.280488" y="198.424572" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="208.847403" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="196.713824" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_140">
@@ -3864,7 +3863,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_26">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -3924,14 +3923,43 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1a" d="M 525 4666
-L 3525 4666
-L 3525 4397
-L 1831 0
-L 1172 0
-L 2766 4134
-L 525 4134
-L 525 4666
+     <path id="DejaVuSans-1b" d="M 2034 2216
+Q 1584 2216 1326 1975
+Q 1069 1734 1069 1313
+Q 1069 891 1326 650
+Q 1584 409 2034 409
+Q 2484 409 2743 651
+Q 3003 894 3003 1313
+Q 3003 1734 2745 1975
+Q 2488 2216 2034 2216
+z
+M 1403 2484
+Q 997 2584 770 2862
+Q 544 3141 544 3541
+Q 544 4100 942 4425
+Q 1341 4750 2034 4750
+Q 2731 4750 3128 4425
+Q 3525 4100 3525 3541
+Q 3525 3141 3298 2862
+Q 3072 2584 2669 2484
+Q 3125 2378 3379 2068
+Q 3634 1759 3634 1313
+Q 3634 634 3220 271
+Q 2806 -91 2034 -91
+Q 1263 -91 848 271
+Q 434 634 434 1313
+Q 434 1759 690 2068
+Q 947 2378 1403 2484
+z
+M 1172 3481
+Q 1172 3119 1398 2916
+Q 1625 2713 2034 2713
+Q 2441 2713 2670 2916
+Q 2900 3119 2900 3481
+Q 2900 3844 2670 4047
+Q 2441 4250 2034 4250
+Q 1625 4250 1398 4047
+Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
     </defs>
@@ -3981,7 +4009,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-conway.svg
+++ b/reports/figures/hexbz-runtime-degree-conway.svg
@@ -1583,88 +1583,91 @@ z
     </g>
    </g>
    <g id="line2d_139">
-    <path d="M 86.724055 275.053213
-L 86.724055 266.845815
-L 97.001856 271.234958
-L 97.001856 271.138522
-L 97.001856 262.254313
-L 107.279657 269.721141
-L 107.279657 258.165067
-L 117.557458 265.834649
-L 117.557458 248.362917
-L 127.835259 262.829699
-L 127.835259 253.044902
-L 138.11306 260.943798
-L 138.11306 249.189676
-L 148.39086 259.515213
-L 148.39086 248.95384
-L 158.668661 255.289812
-L 158.668661 244.368721
-L 168.946462 253.880117
-L 168.946462 245.000343
-L 179.224263 251.716049
-L 179.224263 236.368774
-L 189.502064 252.330489
-L 189.502064 237.275948
-L 199.779865 247.320966
-L 199.779865 223.510665
-L 210.057666 249.341695
-L 210.057666 231.131507
-L 220.335466 242.039166
-L 220.335466 234.67989
-L 230.613267 241.779259
-L 230.613267 229.262008
-L 240.891068 239.757087
-L 240.891068 225.610702
-L 251.168869 243.090963
-L 251.168869 219.148381
-L 261.44667 236.269708
-L 261.44667 223.091599
-L 271.724471 239.894497
-L 271.724471 222.472695
-L 282.002271 232.169393
-L 282.002271 222.945152
-L 292.280072 232.016779
-L 292.280072 225.202228
-L 302.557873 229.694942
-L 302.557873 215.983911
-L 312.835674 233.126534
-L 312.835674 217.714342
-L 323.113475 227.727338
-L 323.113475 215.757234
-L 333.391276 228.433802
-L 333.391276 212.049458
-L 343.669077 224.142678
-L 343.669077 214.054993
-L 353.946877 230.099445
-L 353.946877 211.938304
-L 364.224678 223.328234
-L 364.224678 206.067965
-L 374.502479 227.554859
-L 374.502479 219.222175
-L 384.78028 218.673141
-L 384.78028 203.958298
-L 395.058081 223.491096
-L 395.058081 208.570528
-L 405.335882 213.171004
-L 405.335882 211.083323
-L 415.613682 216.867224
-L 415.613682 199.815661
-L 425.891483 214.457107
-L 425.891483 204.246104
-L 436.169284 215.754135
-L 436.169284 195.444029
-L 446.447085 211.231735
-L 446.447085 195.824519
-L 456.724886 213.702753
-L 456.724886 198.79704
-L 467.002687 210.366284
-L 467.002687 193.67156
-L 477.280488 212.217412
-L 477.280488 198.424572
-L 487.558288 208.847403
-L 487.558288 196.713824
-L 487.558288 196.713824
+    <path d="M 86.724055 275.416146
+L 86.724055 254.630273
+L 97.001856 271.175552
+L 97.001856 271.020535
+L 97.001856 264.335602
+L 107.279657 270.032283
+L 107.279657 261.413421
+L 117.557458 265.54468
+L 117.557458 253.217107
+L 127.835259 264.098597
+L 127.835259 263.968315
+L 127.835259 253.211624
+L 138.11306 260.977482
+L 138.11306 260.952634
+L 138.11306 249.549085
+L 148.39086 259.829247
+L 148.39086 250.530235
+L 158.668661 255.862575
+L 158.668661 245.516318
+L 168.946462 254.669162
+L 168.946462 245.595433
+L 179.224263 251.814731
+L 179.224263 237.103026
+L 189.502064 252.364199
+L 189.502064 238.51944
+L 199.779865 247.729913
+L 199.779865 232.797421
+L 210.057666 249.770208
+L 210.057666 232.041376
+L 220.335466 242.292384
+L 220.335466 236.04658
+L 230.613267 242.12664
+L 230.613267 231.768961
+L 240.891068 241.559092
+L 240.891068 226.026258
+L 251.168869 243.081575
+L 251.168869 219.323612
+L 261.44667 236.386147
+L 261.44667 223.246073
+L 271.724471 240.155059
+L 271.724471 239.993102
+L 271.724471 222.92255
+L 282.002271 232.117242
+L 282.002271 223.181422
+L 292.280072 232.130031
+L 292.280072 225.872173
+L 302.557873 230.464232
+L 302.557873 216.374061
+L 312.835674 233.411328
+L 312.835674 217.488891
+L 323.113475 227.580696
+L 323.113475 215.788294
+L 333.391276 228.440754
+L 333.391276 212.467228
+L 343.669077 224.376878
+L 343.669077 214.770541
+L 353.946877 230.465787
+L 353.946877 212.72343
+L 364.224678 223.438209
+L 364.224678 206.644017
+L 374.502479 227.905598
+L 374.502479 220.191886
+L 384.78028 218.858925
+L 384.78028 204.255209
+L 395.058081 223.667714
+L 395.058081 208.761745
+L 405.335882 218.895853
+L 405.335882 211.05564
+L 415.613682 217.890897
+L 415.613682 199.859362
+L 425.891483 215.353693
+L 425.891483 204.342439
+L 436.169284 216.656063
+L 436.169284 195.790689
+L 446.447085 212.174345
+L 446.447085 196.414982
+L 456.724886 216.239663
+L 456.724886 198.771718
+L 467.002687 210.547621
+L 467.002687 193.72992
+L 477.280488 212.295836
+L 477.280488 198.860527
+L 487.558288 208.951936
+L 487.558288 196.813941
+L 487.558288 196.813941
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1680,192 +1683,192 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="275.053213" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="274.989" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="274.155132" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="274.059208" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="273.400797" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="273.342191" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="272.507523" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="271.497183" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="266.845815" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="271.234958" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="271.138522" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="269.081455" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="269.068916" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="264.663934" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="264.325453" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="263.948431" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="262.989643" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.001856" y="262.254313" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="269.721141" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="268.066144" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="267.609524" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="266.470027" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="263.472349" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="261.539498" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="260.713903" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="258.666801" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="107.279657" y="258.165067" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="265.834649" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="264.877641" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="263.298503" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="258.734045" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="258.619028" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="258.519077" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="254.845653" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="252.631125" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="248.362917" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="262.829699" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="260.776312" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="258.544842" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="258.390804" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="256.559388" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="255.403973" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="253.04789" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.835259" y="253.044902" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="260.943798" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="260.404239" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="259.000642" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="258.256183" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="257.157529" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="252.860875" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="251.365689" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="138.11306" y="249.189676" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="259.515213" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="257.095898" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="253.17356" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="252.093944" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="251.627694" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="251.595079" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="251.060891" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="248.95384" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="255.289812" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="250.936966" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="250.782708" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="249.964049" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="247.695545" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="245.412791" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="244.842553" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="158.668661" y="244.368721" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="168.946462" y="253.880117" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="168.946462" y="248.635737" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="168.946462" y="246.272486" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="168.946462" y="245.000343" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="251.716049" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="250.978342" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="244.139705" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="236.368774" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.502064" y="252.330489" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.502064" y="250.18339" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.502064" y="241.703591" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.502064" y="237.275948" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.779865" y="247.320966" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.779865" y="241.074648" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.779865" y="234.881692" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="199.779865" y="223.510665" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="249.341695" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="246.973784" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="243.056564" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="231.131507" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="242.039166" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="238.050985" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="236.971959" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="234.67989" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="230.613267" y="241.779259" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="230.613267" y="238.503652" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="230.613267" y="233.129328" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="230.613267" y="229.262008" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="239.757087" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="239.553686" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="227.148364" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="225.610702" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.168869" y="243.090963" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.168869" y="228.290226" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.168869" y="225.233112" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="251.168869" y="219.148381" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.44667" y="236.269708" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.44667" y="228.617105" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.44667" y="226.218579" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="261.44667" y="223.091599" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="239.894497" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="239.679053" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="226.345237" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="222.472695" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.002271" y="232.169393" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.002271" y="227.875856" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.002271" y="225.929015" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="282.002271" y="222.945152" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.280072" y="232.016779" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.280072" y="227.136716" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.280072" y="225.796222" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="292.280072" y="225.202228" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="229.694942" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="218.493618" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="218.42673" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="215.983911" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.835674" y="233.126534" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.835674" y="228.684705" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.835674" y="225.300299" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="312.835674" y="217.714342" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="323.113475" y="227.727338" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="323.113475" y="220.07492" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="323.113475" y="216.496184" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="323.113475" y="215.757234" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="228.433802" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="217.320411" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="215.015214" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="333.391276" y="212.049458" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="343.669077" y="224.142678" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="343.669077" y="215.276289" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="343.669077" y="214.415137" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="343.669077" y="214.054993" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="230.099445" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="218.294048" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="212.64345" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="211.938304" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="223.328234" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="222.224211" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="210.263191" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="206.067965" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.502479" y="227.554859" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.502479" y="222.528336" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.502479" y="220.092034" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.502479" y="219.222175" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="384.78028" y="218.673141" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="384.78028" y="208.053238" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="384.78028" y="204.611161" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="384.78028" y="203.958298" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.058081" y="223.491096" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.058081" y="222.243489" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.058081" y="210.299866" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.058081" y="208.570528" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="405.335882" y="213.171004" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="405.335882" y="211.083323" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="415.613682" y="216.867224" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="415.613682" y="210.547879" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="415.613682" y="199.815661" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="425.891483" y="214.457107" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="425.891483" y="204.246104" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.169284" y="215.754135" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.169284" y="209.489428" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.169284" y="202.937347" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="436.169284" y="195.444029" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.447085" y="211.231735" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.447085" y="203.093202" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.447085" y="202.024175" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="446.447085" y="195.824519" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="456.724886" y="213.702753" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="456.724886" y="213.477281" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="456.724886" y="204.519114" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="456.724886" y="198.79704" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="467.002687" y="210.366284" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="467.002687" y="193.67156" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="477.280488" y="212.217412" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="477.280488" y="210.898159" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="477.280488" y="198.424572" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="208.847403" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="196.713824" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="275.416146" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="275.293735" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="275.285355" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="275.034843" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="274.915893" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="274.59859" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="273.89471" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="273.85081" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="254.630273" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="271.175552" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="271.027886" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="271.020535" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="268.229138" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="266.538712" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="265.818661" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="265.301547" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="265.119865" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.001856" y="264.335602" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="270.032283" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="269.769083" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="268.003844" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="267.941758" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="266.811433" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="263.150066" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="262.937424" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="262.643869" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="107.279657" y="261.413421" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="265.54468" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="265.16817" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="264.5044" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="260.441021" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="259.429522" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="258.566955" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="256.063705" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="255.62884" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="253.217107" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="264.098597" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="263.968315" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="260.51892" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="258.412363" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="258.00707" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="256.605644" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="253.897194" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.835259" y="253.211624" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="260.977482" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="260.952634" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="260.822216" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="260.196805" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="256.476754" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="254.515287" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="251.996291" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="138.11306" y="249.549085" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="259.829247" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="256.355629" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="254.394588" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="254.367973" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="253.527427" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="252.791107" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="252.601949" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="250.530235" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="255.862575" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="252.482814" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="251.482386" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="250.194752" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="248.819863" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="246.238732" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="245.709241" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="158.668661" y="245.516318" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="168.946462" y="254.669162" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="168.946462" y="249.062874" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="168.946462" y="246.114145" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="168.946462" y="245.595433" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="251.814731" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="250.525274" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="244.894362" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="237.103026" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.502064" y="252.364199" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.502064" y="249.611859" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.502064" y="242.58554" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.502064" y="238.51944" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.779865" y="247.729913" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.779865" y="240.828169" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.779865" y="235.84293" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="199.779865" y="232.797421" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="249.770208" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="246.824783" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="243.764784" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="232.041376" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="242.292384" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="238.715266" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="237.692994" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="236.04658" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="230.613267" y="242.12664" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="230.613267" y="238.254934" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="230.613267" y="233.55215" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="230.613267" y="231.768961" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="241.559092" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="240.032828" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="227.738035" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="226.026258" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.168869" y="243.081575" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.168869" y="228.169207" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.168869" y="225.983001" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="251.168869" y="219.323612" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.44667" y="236.386147" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.44667" y="229.690471" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.44667" y="226.589951" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="261.44667" y="223.246073" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="240.155059" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="239.993102" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="226.694553" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="222.92255" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.002271" y="232.117242" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.002271" y="228.672024" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.002271" y="226.792148" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="282.002271" y="223.181422" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.280072" y="232.130031" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.280072" y="227.959814" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.280072" y="226.36444" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="292.280072" y="225.872173" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="230.464232" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="220.251913" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="219.047921" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="216.374061" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.835674" y="233.411328" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.835674" y="229.685181" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.835674" y="225.714011" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="312.835674" y="217.488891" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="323.113475" y="227.580696" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="323.113475" y="220.502322" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="323.113475" y="216.808643" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="323.113475" y="215.788294" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="228.440754" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="217.655591" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="215.791089" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="333.391276" y="212.467228" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="343.669077" y="224.376878" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="343.669077" y="215.519052" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="343.669077" y="215.176821" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="343.669077" y="214.770541" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="230.465787" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="219.017322" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="212.821995" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="212.72343" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="223.438209" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="222.572039" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="210.555366" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="206.644017" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.502479" y="227.905598" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.502479" y="222.962136" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.502479" y="220.331299" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.502479" y="220.191886" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="384.78028" y="218.858925" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="384.78028" y="208.456652" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="384.78028" y="205.079748" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="384.78028" y="204.255209" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.058081" y="223.667714" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.058081" y="223.248628" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.058081" y="210.466371" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.058081" y="208.761745" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="405.335882" y="218.895853" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="405.335882" y="211.05564" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="415.613682" y="217.890897" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="415.613682" y="211.140659" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="415.613682" y="199.859362" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="425.891483" y="215.353693" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="425.891483" y="204.342439" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.169284" y="216.656063" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.169284" y="210.193101" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.169284" y="203.463912" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="436.169284" y="195.790689" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.447085" y="212.174345" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.447085" y="203.221954" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.447085" y="202.52921" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="446.447085" y="196.414982" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="456.724886" y="216.239663" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="456.724886" y="214.319304" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="456.724886" y="205.31674" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="456.724886" y="198.771718" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="467.002687" y="210.547621" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="467.002687" y="193.72992" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="477.280488" y="212.295836" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="477.280488" y="211.140125" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="477.280488" y="198.860527" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="208.951936" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="196.813941" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_140">
@@ -3863,7 +3866,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_26">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -3923,43 +3926,34 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1b" d="M 2034 2216
-Q 1584 2216 1326 1975
-Q 1069 1734 1069 1313
-Q 1069 891 1326 650
-Q 1584 409 2034 409
-Q 2484 409 2743 651
-Q 3003 894 3003 1313
-Q 3003 1734 2745 1975
-Q 2488 2216 2034 2216
+     <path id="DejaVuSans-1c" d="M 703 97
+L 703 672
+Q 941 559 1184 500
+Q 1428 441 1663 441
+Q 2288 441 2617 861
+Q 2947 1281 2994 2138
+Q 2813 1869 2534 1725
+Q 2256 1581 1919 1581
+Q 1219 1581 811 2004
+Q 403 2428 403 3163
+Q 403 3881 828 4315
+Q 1253 4750 1959 4750
+Q 2769 4750 3195 4129
+Q 3622 3509 3622 2328
+Q 3622 1225 3098 567
+Q 2575 -91 1691 -91
+Q 1453 -91 1209 -44
+Q 966 3 703 97
 z
-M 1403 2484
-Q 997 2584 770 2862
-Q 544 3141 544 3541
-Q 544 4100 942 4425
-Q 1341 4750 2034 4750
-Q 2731 4750 3128 4425
-Q 3525 4100 3525 3541
-Q 3525 3141 3298 2862
-Q 3072 2584 2669 2484
-Q 3125 2378 3379 2068
-Q 3634 1759 3634 1313
-Q 3634 634 3220 271
-Q 2806 -91 2034 -91
-Q 1263 -91 848 271
-Q 434 634 434 1313
-Q 434 1759 690 2068
-Q 947 2378 1403 2484
-z
-M 1172 3481
-Q 1172 3119 1398 2916
-Q 1625 2713 2034 2713
-Q 2441 2713 2670 2916
-Q 2900 3119 2900 3481
-Q 2900 3844 2670 4047
-Q 2441 4250 2034 4250
-Q 1625 4250 1398 4047
-Q 1172 3844 1172 3481
+M 1959 2075
+Q 2384 2075 2632 2365
+Q 2881 2656 2881 3163
+Q 2881 3666 2632 3958
+Q 2384 4250 1959 4250
+Q 1534 4250 1286 3958
+Q 1038 3666 1038 3163
+Q 1038 2656 1286 2365
+Q 1534 2075 1959 2075
 z
 " transform="scale(0.015625)"/>
     </defs>
@@ -4009,7 +4003,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-cyclotomic-products.svg
+++ b/reports/figures/hexbz-runtime-degree-cyclotomic-products.svg
@@ -1455,25 +1455,25 @@ z
     </g>
    </g>
    <g id="line2d_119">
-    <path d="M 86.724055 269.7412
-L 104.151631 252.314035
-L 112.865418 247.901373
-L 115.770014 246.227401
-L 115.770014 237.514414
-L 127.388398 237.19832
-L 139.006781 221.883552
-L 139.006781 203.035788
-L 156.434357 208.537754
-L 162.243549 170.823062
-L 173.861932 198.944094
-L 185.480316 192.588904
-L 208.717083 170.255756
-L 243.572234 183.556168
-L 301.664151 133.568197
-L 374.279049 137.602141
-L 394.61122 118.10026
-L 417.847987 113.111896
-L 487.558288 113.867314
+    <path d="M 86.724055 274.152379
+L 104.151631 253.883577
+L 112.865418 250.156192
+L 115.770014 251.716435
+L 115.770014 243.266937
+L 127.388398 239.337815
+L 139.006781 231.184297
+L 139.006781 203.65419
+L 156.434357 210.502155
+L 162.243549 174.175527
+L 173.861932 201.033263
+L 185.480316 200.564305
+L 208.717083 170.99956
+L 243.572234 184.535773
+L 301.664151 138.673312
+L 374.279049 138.705143
+L 394.61122 124.854003
+L 417.847987 113.548753
+L 487.558288 125.746239
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1489,25 +1489,25 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="269.7412" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="104.151631" y="252.314035" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="112.865418" y="247.901373" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="115.770014" y="246.227401" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="115.770014" y="237.514414" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.388398" y="237.19832" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="139.006781" y="221.883552" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="139.006781" y="203.035788" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="156.434357" y="208.537754" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="162.243549" y="170.823062" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="173.861932" y="198.944094" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="185.480316" y="192.588904" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="208.717083" y="170.255756" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="243.572234" y="183.556168" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="301.664151" y="133.568197" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.279049" y="137.602141" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="394.61122" y="118.10026" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="417.847987" y="113.111896" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="113.867314" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="274.152379" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="104.151631" y="253.883577" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="112.865418" y="250.156192" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="115.770014" y="251.716435" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="115.770014" y="243.266937" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.388398" y="239.337815" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="139.006781" y="231.184297" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="139.006781" y="203.65419" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="156.434357" y="210.502155" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="162.243549" y="174.175527" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="173.861932" y="201.033263" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="185.480316" y="200.564305" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="208.717083" y="170.99956" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="243.572234" y="184.535773" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="301.664151" y="138.673312" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.279049" y="138.705143" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="394.61122" y="124.854003" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="417.847987" y="113.548753" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="125.746239" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_120">
@@ -2365,7 +2365,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2457,16 +2457,6 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1a" d="M 525 4666
-L 3525 4666
-L 3525 4397
-L 1831 0
-L 1172 0
-L 2766 4134
-L 525 4134
-L 525 4666
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2514,7 +2504,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-cyclotomic-products.svg
+++ b/reports/figures/hexbz-runtime-degree-cyclotomic-products.svg
@@ -1455,25 +1455,25 @@ z
     </g>
    </g>
    <g id="line2d_119">
-    <path d="M 86.724055 274.152379
-L 104.151631 253.883577
-L 112.865418 250.156192
-L 115.770014 251.716435
-L 115.770014 243.266937
-L 127.388398 239.337815
-L 139.006781 231.184297
-L 139.006781 203.65419
-L 156.434357 210.502155
-L 162.243549 174.175527
-L 173.861932 201.033263
-L 185.480316 200.564305
-L 208.717083 170.99956
-L 243.572234 184.535773
-L 301.664151 138.673312
-L 374.279049 138.705143
-L 394.61122 124.854003
-L 417.847987 113.548753
-L 487.558288 125.746239
+    <path d="M 86.724055 274.259619
+L 104.151631 254.286314
+L 112.865418 250.132551
+L 115.770014 251.656483
+L 115.770014 243.274378
+L 127.388398 239.54733
+L 139.006781 231.255021
+L 139.006781 203.799467
+L 156.434357 210.311254
+L 162.243549 174.588764
+L 173.861932 200.715061
+L 185.480316 200.878103
+L 208.717083 170.97176
+L 243.572234 184.628357
+L 301.664151 138.880836
+L 374.279049 138.720829
+L 394.61122 124.826317
+L 417.847987 113.670208
+L 487.558288 125.344976
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1489,25 +1489,25 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="274.152379" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="104.151631" y="253.883577" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="112.865418" y="250.156192" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="115.770014" y="251.716435" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="115.770014" y="243.266937" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="127.388398" y="239.337815" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="139.006781" y="231.184297" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="139.006781" y="203.65419" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="156.434357" y="210.502155" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="162.243549" y="174.175527" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="173.861932" y="201.033263" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="185.480316" y="200.564305" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="208.717083" y="170.99956" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="243.572234" y="184.535773" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="301.664151" y="138.673312" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="374.279049" y="138.705143" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="394.61122" y="124.854003" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="417.847987" y="113.548753" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="125.746239" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="274.259619" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="104.151631" y="254.286314" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="112.865418" y="250.132551" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="115.770014" y="251.656483" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="115.770014" y="243.274378" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="127.388398" y="239.54733" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="139.006781" y="231.255021" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="139.006781" y="203.799467" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="156.434357" y="210.311254" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="162.243549" y="174.588764" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="173.861932" y="200.715061" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="185.480316" y="200.878103" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="208.717083" y="170.97176" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="243.572234" y="184.628357" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="301.664151" y="138.880836" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="374.279049" y="138.720829" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="394.61122" y="124.826317" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="417.847987" y="113.670208" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="125.344976" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_120">
@@ -2365,7 +2365,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2457,6 +2457,36 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-1c" d="M 703 97
+L 703 672
+Q 941 559 1184 500
+Q 1428 441 1663 441
+Q 2288 441 2617 861
+Q 2947 1281 2994 2138
+Q 2813 1869 2534 1725
+Q 2256 1581 1919 1581
+Q 1219 1581 811 2004
+Q 403 2428 403 3163
+Q 403 3881 828 4315
+Q 1253 4750 1959 4750
+Q 2769 4750 3195 4129
+Q 3622 3509 3622 2328
+Q 3622 1225 3098 567
+Q 2575 -91 1691 -91
+Q 1453 -91 1209 -44
+Q 966 3 703 97
+z
+M 1959 2075
+Q 2384 2075 2632 2365
+Q 2881 2656 2881 3163
+Q 2881 3666 2632 3958
+Q 2384 4250 1959 4250
+Q 1534 4250 1286 3958
+Q 1038 3666 1038 3163
+Q 1038 2656 1286 2365
+Q 1534 2075 1959 2075
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2504,7 +2534,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-cyclotomic.svg
+++ b/reports/figures/hexbz-runtime-degree-cyclotomic.svg
@@ -1509,40 +1509,40 @@ z
     </g>
    </g>
    <g id="line2d_127">
-    <path d="M 86.724055 274.768076
-L 87.505409 270.311425
-L 88.286762 254.117392
-L 89.068115 254.954058
-L 89.849469 238.076763
-L 91.412175 253.191283
-L 92.193528 251.259261
-L 92.974882 247.476311
-L 93.756235 236.834324
-L 94.537588 228.169745
-L 96.100295 239.300315
-L 97.663001 231.157175
-L 99.225708 217.914536
-L 100.788414 197.269666
-L 101.569768 225.368625
-L 103.913828 177.570983
-L 105.476534 219.717636
-L 106.257887 215.381054
-L 108.601947 174.987642
-L 110.164654 209.064161
-L 116.41548 165.550715
-L 119.540893 201.778364
-L 128.135779 137.666
-L 135.167959 182.984817
-L 143.762845 139.680351
-L 148.450965 175.741073
-L 154.701791 138.844339
-L 163.296677 82.325763
-L 178.923743 112.675977
-L 185.174569 162.828059
-L 214.08464 152.715556
-L 280.499669 132.439139
-L 283.625082 136.255873
-L 487.558288 52.990705
+    <path d="M 86.724055 275.361263
+L 87.505409 271.864546
+L 88.286762 254.727655
+L 89.068115 253.755425
+L 89.849469 240.105832
+L 91.412175 253.907849
+L 92.193528 251.429503
+L 92.974882 246.706739
+L 93.756235 236.817307
+L 94.537588 228.741973
+L 96.100295 239.474124
+L 97.663001 231.326163
+L 99.225708 217.65393
+L 100.788414 197.232552
+L 101.569768 225.523865
+L 103.913828 177.811547
+L 105.476534 219.741782
+L 106.257887 215.770359
+L 108.601947 175.191177
+L 110.164654 209.335956
+L 116.41548 165.663359
+L 119.540893 201.931959
+L 128.135779 137.679092
+L 135.167959 183.133518
+L 143.762845 139.490415
+L 148.450965 176.003082
+L 154.701791 138.658082
+L 163.296677 82.411068
+L 178.923743 112.761269
+L 185.174569 162.824647
+L 214.08464 152.324462
+L 280.499669 132.03205
+L 283.625082 135.757227
+L 487.558288 53.018834
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1558,40 +1558,40 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="274.768076" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="87.505409" y="270.311425" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="88.286762" y="254.117392" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="89.068115" y="254.954058" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="89.849469" y="238.076763" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="91.412175" y="253.191283" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="92.193528" y="251.259261" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="92.974882" y="247.476311" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="93.756235" y="236.834324" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="94.537588" y="228.169745" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="96.100295" y="239.300315" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.663001" y="231.157175" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.225708" y="217.914536" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="100.788414" y="197.269666" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="101.569768" y="225.368625" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="103.913828" y="177.570983" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="105.476534" y="219.717636" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="106.257887" y="215.381054" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="108.601947" y="174.987642" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="110.164654" y="209.064161" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="116.41548" y="165.550715" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="119.540893" y="201.778364" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.135779" y="137.666" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="135.167959" y="182.984817" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.762845" y="139.680351" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.450965" y="175.741073" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="154.701791" y="138.844339" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="163.296677" y="82.325763" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="178.923743" y="112.675977" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="185.174569" y="162.828059" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="214.08464" y="152.715556" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="280.499669" y="132.439139" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="283.625082" y="136.255873" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="52.990705" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="275.361263" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="87.505409" y="271.864546" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="88.286762" y="254.727655" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="89.068115" y="253.755425" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="89.849469" y="240.105832" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="91.412175" y="253.907849" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="92.193528" y="251.429503" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="92.974882" y="246.706739" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="93.756235" y="236.817307" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="94.537588" y="228.741973" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="96.100295" y="239.474124" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.663001" y="231.326163" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.225708" y="217.65393" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="100.788414" y="197.232552" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="101.569768" y="225.523865" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="103.913828" y="177.811547" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="105.476534" y="219.741782" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="106.257887" y="215.770359" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="108.601947" y="175.191177" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="110.164654" y="209.335956" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="116.41548" y="165.663359" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="119.540893" y="201.931959" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.135779" y="137.679092" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="135.167959" y="183.133518" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.762845" y="139.490415" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.450965" y="176.003082" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="154.701791" y="138.658082" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="163.296677" y="82.411068" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="178.923743" y="112.761269" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="185.174569" y="162.824647" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="214.08464" y="152.324462" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="280.499669" y="132.03205" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="283.625082" y="135.757227" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="53.018834" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_128">
@@ -2570,7 +2570,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2662,6 +2662,36 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-1c" d="M 703 97
+L 703 672
+Q 941 559 1184 500
+Q 1428 441 1663 441
+Q 2288 441 2617 861
+Q 2947 1281 2994 2138
+Q 2813 1869 2534 1725
+Q 2256 1581 1919 1581
+Q 1219 1581 811 2004
+Q 403 2428 403 3163
+Q 403 3881 828 4315
+Q 1253 4750 1959 4750
+Q 2769 4750 3195 4129
+Q 3622 3509 3622 2328
+Q 3622 1225 3098 567
+Q 2575 -91 1691 -91
+Q 1453 -91 1209 -44
+Q 966 3 703 97
+z
+M 1959 2075
+Q 2384 2075 2632 2365
+Q 2881 2656 2881 3163
+Q 2881 3666 2632 3958
+Q 2384 4250 1959 4250
+Q 1534 4250 1286 3958
+Q 1038 3666 1038 3163
+Q 1038 2656 1286 2365
+Q 1534 2075 1959 2075
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2709,7 +2739,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-cyclotomic.svg
+++ b/reports/figures/hexbz-runtime-degree-cyclotomic.svg
@@ -1509,40 +1509,40 @@ z
     </g>
    </g>
    <g id="line2d_127">
-    <path d="M 86.724055 270.199917
-L 87.505409 266.503393
-L 88.286762 250.235235
-L 89.068115 250.432846
-L 89.849469 237.396428
-L 91.412175 245.667708
-L 92.193528 243.010154
-L 92.974882 238.093217
-L 93.756235 231.129128
-L 94.537588 219.948749
-L 96.100295 228.957489
-L 97.663001 224.282607
-L 99.225708 211.554949
-L 100.788414 194.912972
-L 101.569768 212.077749
-L 103.913828 172.645939
-L 105.476534 206.511735
-L 106.257887 204.884607
-L 108.601947 173.249681
-L 110.164654 199.865452
-L 116.41548 154.314163
-L 119.540893 188.027641
-L 128.135779 135.582406
-L 135.167959 171.776826
-L 143.762845 137.326826
-L 148.450965 162.426592
-L 154.701791 135.230858
-L 163.296677 80.470135
-L 178.923743 100.760362
-L 185.174569 146.236214
-L 214.08464 134.731791
-L 280.499669 111.571859
-L 283.625082 117.888116
-L 487.558288 51.571017
+    <path d="M 86.724055 274.768076
+L 87.505409 270.311425
+L 88.286762 254.117392
+L 89.068115 254.954058
+L 89.849469 238.076763
+L 91.412175 253.191283
+L 92.193528 251.259261
+L 92.974882 247.476311
+L 93.756235 236.834324
+L 94.537588 228.169745
+L 96.100295 239.300315
+L 97.663001 231.157175
+L 99.225708 217.914536
+L 100.788414 197.269666
+L 101.569768 225.368625
+L 103.913828 177.570983
+L 105.476534 219.717636
+L 106.257887 215.381054
+L 108.601947 174.987642
+L 110.164654 209.064161
+L 116.41548 165.550715
+L 119.540893 201.778364
+L 128.135779 137.666
+L 135.167959 182.984817
+L 143.762845 139.680351
+L 148.450965 175.741073
+L 154.701791 138.844339
+L 163.296677 82.325763
+L 178.923743 112.675977
+L 185.174569 162.828059
+L 214.08464 152.715556
+L 280.499669 132.439139
+L 283.625082 136.255873
+L 487.558288 52.990705
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1558,40 +1558,40 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="270.199917" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="87.505409" y="266.503393" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="88.286762" y="250.235235" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="89.068115" y="250.432846" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="89.849469" y="237.396428" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="91.412175" y="245.667708" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="92.193528" y="243.010154" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="92.974882" y="238.093217" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="93.756235" y="231.129128" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="94.537588" y="219.948749" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="96.100295" y="228.957489" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="97.663001" y="224.282607" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.225708" y="211.554949" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="100.788414" y="194.912972" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="101.569768" y="212.077749" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="103.913828" y="172.645939" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="105.476534" y="206.511735" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="106.257887" y="204.884607" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="108.601947" y="173.249681" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="110.164654" y="199.865452" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="116.41548" y="154.314163" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="119.540893" y="188.027641" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.135779" y="135.582406" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="135.167959" y="171.776826" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.762845" y="137.326826" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.450965" y="162.426592" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="154.701791" y="135.230858" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="163.296677" y="80.470135" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="178.923743" y="100.760362" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="185.174569" y="146.236214" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="214.08464" y="134.731791" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="280.499669" y="111.571859" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="283.625082" y="117.888116" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="51.571017" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="274.768076" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="87.505409" y="270.311425" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="88.286762" y="254.117392" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="89.068115" y="254.954058" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="89.849469" y="238.076763" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="91.412175" y="253.191283" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="92.193528" y="251.259261" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="92.974882" y="247.476311" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="93.756235" y="236.834324" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="94.537588" y="228.169745" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="96.100295" y="239.300315" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="97.663001" y="231.157175" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.225708" y="217.914536" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="100.788414" y="197.269666" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="101.569768" y="225.368625" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="103.913828" y="177.570983" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="105.476534" y="219.717636" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="106.257887" y="215.381054" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="108.601947" y="174.987642" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="110.164654" y="209.064161" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="116.41548" y="165.550715" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="119.540893" y="201.778364" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.135779" y="137.666" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="135.167959" y="182.984817" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.762845" y="139.680351" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.450965" y="175.741073" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="154.701791" y="138.844339" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="163.296677" y="82.325763" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="178.923743" y="112.675977" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="185.174569" y="162.828059" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="214.08464" y="152.715556" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="280.499669" y="132.439139" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="283.625082" y="136.255873" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="52.990705" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_128">
@@ -2570,7 +2570,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2662,16 +2662,6 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1a" d="M 525 4666
-L 3525 4666
-L 3525 4397
-L 1831 0
-L 1172 0
-L 2766 4134
-L 525 4134
-L 525 4666
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2719,7 +2709,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-hoeij-zimmermann.svg
+++ b/reports/figures/hexbz-runtime-degree-hoeij-zimmermann.svg
@@ -600,8 +600,8 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_11">
-      <path d="M 66.682344 275.529896
-L 507.6 275.529896
+      <path d="M 66.682344 275.302618
+L 507.6 275.302618
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
@@ -611,12 +611,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="275.529896" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="275.302618" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 10ms -->
-      <g transform="translate(32.007344 279.328724) scale(0.1 -0.1)">
+      <g transform="translate(32.007344 279.101446) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-14" d="M 794 531
 L 1825 531
@@ -673,18 +673,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_13">
-      <path d="M 66.682344 183.621236
-L 507.6 183.621236
+      <path d="M 66.682344 182.032446
+L 507.6 182.032446
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="183.621236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="182.032446" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 100ms -->
-      <g transform="translate(25.644844 187.420064) scale(0.1 -0.1)">
+      <g transform="translate(25.644844 185.831274) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -695,18 +695,18 @@ L 507.6 183.621236
     </g>
     <g id="ytick_3">
      <g id="line2d_15">
-      <path d="M 66.682344 91.712575
-L 507.6 91.712575
+      <path d="M 66.682344 88.762274
+L 507.6 88.762274
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="91.712575" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="88.762274" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 1s -->
-      <g transform="translate(48.110469 95.511403) scale(0.1 -0.1)">
+      <g transform="translate(48.110469 92.561102) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(63.625 0)"/>
       </g>
@@ -714,8 +714,8 @@ L 507.6 91.712575
     </g>
     <g id="ytick_4">
      <g id="line2d_17">
-      <path d="M 66.682344 303.19716
-L 507.6 303.19716
+      <path d="M 66.682344 303.379737
+L 507.6 303.379737
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
@@ -725,295 +725,283 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="303.19716" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="303.379737" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_19">
-      <path d="M 66.682344 295.919718
-L 507.6 295.919718
+      <path d="M 66.682344 295.994489
+L 507.6 295.994489
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="295.919718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="295.994489" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_21">
-      <path d="M 66.682344 289.766728
-L 507.6 289.766728
+      <path d="M 66.682344 289.75035
+L 507.6 289.75035
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.766728" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.75035" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_23">
-      <path d="M 66.682344 284.436766
-L 507.6 284.436766
+      <path d="M 66.682344 284.341431
+L 507.6 284.341431
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.436766" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.341431" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_25">
-      <path d="M 66.682344 279.735406
-L 507.6 279.735406
+      <path d="M 66.682344 279.570427
+L 507.6 279.570427
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="279.735406" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="279.570427" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_27">
-      <path d="M 66.682344 247.862632
-L 507.6 247.862632
+      <path d="M 66.682344 247.225498
+L 507.6 247.225498
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="247.862632" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="247.225498" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_29">
-      <path d="M 66.682344 231.678321
-L 507.6 231.678321
+      <path d="M 66.682344 230.801436
+L 507.6 230.801436
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="231.678321" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="230.801436" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_31">
-      <path d="M 66.682344 220.195369
-L 507.6 220.195369
+      <path d="M 66.682344 219.148379
+L 507.6 219.148379
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="220.195369" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="219.148379" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_33">
-      <path d="M 66.682344 211.288499
-L 507.6 211.288499
+      <path d="M 66.682344 210.109565
+L 507.6 210.109565
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="211.288499" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="210.109565" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_35">
-      <path d="M 66.682344 204.011057
-L 507.6 204.011057
+      <path d="M 66.682344 202.724317
+L 507.6 202.724317
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="204.011057" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="202.724317" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_37">
-      <path d="M 66.682344 197.858067
-L 507.6 197.858067
+      <path d="M 66.682344 196.480178
+L 507.6 196.480178
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="197.858067" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="196.480178" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_39">
-      <path d="M 66.682344 192.528105
-L 507.6 192.528105
+      <path d="M 66.682344 191.07126
+L 507.6 191.07126
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="192.528105" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="191.07126" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_41">
-      <path d="M 66.682344 187.826745
-L 507.6 187.826745
+      <path d="M 66.682344 186.300255
+L 507.6 186.300255
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="187.826745" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="186.300255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_43">
-      <path d="M 66.682344 155.953972
-L 507.6 155.953972
+      <path d="M 66.682344 153.955327
+L 507.6 153.955327
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="155.953972" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="153.955327" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_45">
-      <path d="M 66.682344 139.76966
-L 507.6 139.76966
+      <path d="M 66.682344 137.531265
+L 507.6 137.531265
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="139.76966" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="137.531265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_47">
-      <path d="M 66.682344 128.286708
-L 507.6 128.286708
+      <path d="M 66.682344 125.878207
+L 507.6 125.878207
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="128.286708" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="125.878207" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_49">
-      <path d="M 66.682344 119.379839
-L 507.6 119.379839
+      <path d="M 66.682344 116.839394
+L 507.6 116.839394
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="119.379839" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="116.839394" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_51">
-      <path d="M 66.682344 112.102396
-L 507.6 112.102396
+      <path d="M 66.682344 109.454145
+L 507.6 109.454145
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="112.102396" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="109.454145" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_53">
-      <path d="M 66.682344 105.949407
-L 507.6 105.949407
+      <path d="M 66.682344 103.210007
+L 507.6 103.210007
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="105.949407" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="103.210007" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_55">
-      <path d="M 66.682344 100.619445
-L 507.6 100.619445
+      <path d="M 66.682344 97.801088
+L 507.6 97.801088
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="100.619445" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="97.801088" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_57">
-      <path d="M 66.682344 95.918085
-L 507.6 95.918085
+      <path d="M 66.682344 93.030083
+L 507.6 93.030083
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="95.918085" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="93.030083" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_59">
-      <path d="M 66.682344 64.045311
-L 507.6 64.045311
+      <path d="M 66.682344 60.685155
+L 507.6 60.685155
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="64.045311" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="60.685155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_61">
-      <path d="M 66.682344 47.861
-L 507.6 47.861
+      <path d="M 66.682344 44.261093
+L 507.6 44.261093
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="47.861" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="44.261093" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_63">
-      <path d="M 66.682344 36.378048
-L 507.6 36.378048
+      <path d="M 66.682344 32.608036
+L 507.6 32.608036
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="36.378048" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_28">
-     <g id="line2d_65">
-      <path d="M 66.682344 27.471178
-L 507.6 27.471178
-" clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_66">
-      <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="27.471178" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="32.608036" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1100,8 +1088,8 @@ z
      </g>
     </g>
    </g>
-   <g id="line2d_67">
-    <path d="M 89.917954 86.709552
+   <g id="line2d_65">
+    <path d="M 89.917954 87.457394
 L 136.229479 38.765348
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
@@ -1118,20 +1106,20 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="89.917954" y="86.709552" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="89.917954" y="87.457394" style="fill: #1f77b4; stroke: #1f77b4"/>
      <use xlink:href="#md73ba6276e" x="136.229479" y="38.765348" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
-   <g id="line2d_68">
-    <path d="M 86.724055 223.839894
+   <g id="line2d_66">
+    <path d="M 86.724055 222.846893
 L 89.917954 290.872308
-L 136.229479 251.980834
-L 137.826428 126.966844
-L 188.9288 104.206912
-L 188.9288 83.080828
-L 264.783884 171.992563
-L 291.133545 177.815241
-L 487.558288 121.702076
+L 136.229479 251.404706
+L 137.826428 124.538791
+L 188.9288 101.441699
+L 188.9288 80.002659
+L 264.783884 170.231509
+L 291.133545 176.140442
+L 487.558288 119.196032
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #9467bd; stroke-linecap: square"/>
     <defs>
      <path id="meef3cfac8d" d="M 0 -2
@@ -1141,27 +1129,27 @@ z
 " style="stroke: #9467bd; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#meef3cfac8d" x="86.724055" y="223.839894" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="86.724055" y="222.846893" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
      <use xlink:href="#meef3cfac8d" x="89.917954" y="290.872308" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="136.229479" y="251.980834" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="137.826428" y="126.966844" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="188.9288" y="104.206912" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="188.9288" y="83.080828" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="264.783884" y="171.992563" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="291.133545" y="177.815241" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="487.558288" y="121.702076" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="136.229479" y="251.404706" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="137.826428" y="124.538791" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="188.9288" y="101.441699" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="188.9288" y="80.002659" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="264.783884" y="170.231509" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="291.133545" y="176.140442" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="487.558288" y="119.196032" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_69">
-    <path d="M 86.724055 185.699563
-L 89.917954 253.217649
-L 136.229479 225.270128
-L 137.826428 136.758131
-L 188.9288 91.300891
-L 188.9288 81.092691
-L 264.783884 172.116205
-L 291.133545 141.385777
-L 487.558288 104.941293
+   <g id="line2d_67">
+    <path d="M 86.724055 184.141561
+L 89.917954 252.659843
+L 136.229479 224.298314
+L 137.826428 134.475124
+L 188.9288 88.344492
+L 188.9288 77.98507
+L 264.783884 170.356983
+L 291.133545 139.171322
+L 487.558288 102.18696
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #8c564b; stroke-linecap: square"/>
     <defs>
      <path id="m975a81c4ea" d="M -0 2
@@ -1171,27 +1159,27 @@ z
 " style="stroke: #8c564b; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="185.699563" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="89.917954" y="253.217649" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="136.229479" y="225.270128" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="137.826428" y="136.758131" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="188.9288" y="91.300891" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="188.9288" y="81.092691" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="264.783884" y="172.116205" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="291.133545" y="141.385777" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="487.558288" y="104.941293" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="184.141561" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="89.917954" y="252.659843" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="136.229479" y="224.298314" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="137.826428" y="134.475124" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="188.9288" y="88.344492" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="188.9288" y="77.98507" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="264.783884" y="170.356983" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="291.133545" y="139.171322" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="487.558288" y="102.18696" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_70">
-    <path d="M 86.724055 216.41582
-L 89.917954 253.641143
-L 136.229479 235.417237
-L 137.826428 162.19058
-L 188.9288 120.863699
-L 188.9288 116.818222
-L 264.783884 155.047517
-L 291.133545 166.140628
-L 487.558288 93.308129
+   <g id="line2d_68">
+    <path d="M 86.724055 215.312841
+L 89.917954 253.08961
+L 136.229479 234.59574
+L 137.826428 160.284323
+L 188.9288 118.345235
+L 188.9288 114.23983
+L 264.783884 153.035444
+L 291.133545 164.292885
+L 487.558288 90.381465
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #e377c2; stroke-linecap: square"/>
     <defs>
      <path id="mbe61f33afa" d="M -0.666667 2
@@ -1210,15 +1198,15 @@ z
 " style="stroke: #e377c2; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="216.41582" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="89.917954" y="253.641143" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="136.229479" y="235.417237" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="137.826428" y="162.19058" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="188.9288" y="120.863699" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="188.9288" y="116.818222" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="264.783884" y="155.047517" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="291.133545" y="166.140628" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="487.558288" y="93.308129" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="215.312841" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="89.917954" y="253.08961" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="136.229479" y="234.59574" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="137.826428" y="160.284323" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="188.9288" y="118.345235" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="188.9288" y="114.23983" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="264.783884" y="153.035444" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="291.133545" y="164.292885" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="487.558288" y="90.381465" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -1431,7 +1419,7 @@ Q 70.682344 80.5625 72.282344 80.5625
 z
 " style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="line2d_71">
+    <g id="line2d_69">
      <path d="M 73.882344 36.63875
 L 81.882344 36.63875
 L 89.882344 36.63875
@@ -1521,7 +1509,7 @@ z
       <use xlink:href="#DejaVuSans-c" transform="translate(546.109375 0)"/>
      </g>
     </g>
-    <g id="line2d_72">
+    <g id="line2d_70">
      <path d="M 73.882344 48.639375
 L 81.882344 48.639375
 L 89.882344 48.639375
@@ -1595,7 +1583,7 @@ z
       <use xlink:href="#DejaVuSans-37" transform="translate(217.546875 0)"/>
      </g>
     </g>
-    <g id="line2d_73">
+    <g id="line2d_71">
      <path d="M 73.882344 60.64
 L 81.882344 60.64
 L 89.882344 60.64
@@ -1612,7 +1600,7 @@ L 89.882344 60.64
       <use xlink:href="#DejaVuSans-2f" transform="translate(135.890625 0)"/>
      </g>
     </g>
-    <g id="line2d_74">
+    <g id="line2d_72">
      <path d="M 73.882344 72.640625
 L 81.882344 72.640625
 L 89.882344 72.640625
@@ -1707,7 +1695,7 @@ z
    </g>
   </g>
   <g id="text_16">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -1767,14 +1755,43 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1a" d="M 525 4666
-L 3525 4666
-L 3525 4397
-L 1831 0
-L 1172 0
-L 2766 4134
-L 525 4134
-L 525 4666
+     <path id="DejaVuSans-1b" d="M 2034 2216
+Q 1584 2216 1326 1975
+Q 1069 1734 1069 1313
+Q 1069 891 1326 650
+Q 1584 409 2034 409
+Q 2484 409 2743 651
+Q 3003 894 3003 1313
+Q 3003 1734 2745 1975
+Q 2488 2216 2034 2216
+z
+M 1403 2484
+Q 997 2584 770 2862
+Q 544 3141 544 3541
+Q 544 4100 942 4425
+Q 1341 4750 2034 4750
+Q 2731 4750 3128 4425
+Q 3525 4100 3525 3541
+Q 3525 3141 3298 2862
+Q 3072 2584 2669 2484
+Q 3125 2378 3379 2068
+Q 3634 1759 3634 1313
+Q 3634 634 3220 271
+Q 2806 -91 2034 -91
+Q 1263 -91 848 271
+Q 434 634 434 1313
+Q 434 1759 690 2068
+Q 947 2378 1403 2484
+z
+M 1172 3481
+Q 1172 3119 1398 2916
+Q 1625 2713 2034 2713
+Q 2441 2713 2670 2916
+Q 2900 3119 2900 3481
+Q 2900 3844 2670 4047
+Q 2441 4250 2034 4250
+Q 1625 4250 1398 4047
+Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
     </defs>
@@ -1824,7 +1841,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-hoeij-zimmermann.svg
+++ b/reports/figures/hexbz-runtime-degree-hoeij-zimmermann.svg
@@ -600,8 +600,8 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_11">
-      <path d="M 66.682344 275.302618
-L 507.6 275.302618
+      <path d="M 66.682344 275.268855
+L 507.6 275.268855
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
@@ -611,12 +611,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="275.302618" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="275.268855" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 10ms -->
-      <g transform="translate(32.007344 279.101446) scale(0.1 -0.1)">
+      <g transform="translate(32.007344 279.067683) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-14" d="M 794 531
 L 1825 531
@@ -673,18 +673,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_13">
-      <path d="M 66.682344 182.032446
-L 507.6 182.032446
+      <path d="M 66.682344 181.79643
+L 507.6 181.79643
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="182.032446" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="181.79643" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 100ms -->
-      <g transform="translate(25.644844 185.831274) scale(0.1 -0.1)">
+      <g transform="translate(25.644844 185.595258) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -695,18 +695,18 @@ L 507.6 182.032446
     </g>
     <g id="ytick_3">
      <g id="line2d_15">
-      <path d="M 66.682344 88.762274
-L 507.6 88.762274
+      <path d="M 66.682344 88.324004
+L 507.6 88.324004
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="88.762274" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="88.324004" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 1s -->
-      <g transform="translate(48.110469 92.561102) scale(0.1 -0.1)">
+      <g transform="translate(48.110469 92.122832) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(63.625 0)"/>
       </g>
@@ -714,8 +714,8 @@ L 507.6 88.762274
     </g>
     <g id="ytick_4">
      <g id="line2d_17">
-      <path d="M 66.682344 303.379737
-L 507.6 303.379737
+      <path d="M 66.682344 303.406859
+L 507.6 303.406859
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
@@ -725,283 +725,283 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="303.379737" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="303.406859" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_19">
-      <path d="M 66.682344 295.994489
-L 507.6 295.994489
+      <path d="M 66.682344 296.005596
+L 507.6 296.005596
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="295.994489" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="296.005596" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_21">
-      <path d="M 66.682344 289.75035
-L 507.6 289.75035
+      <path d="M 66.682344 289.747917
+L 507.6 289.747917
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.75035" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="289.747917" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_23">
-      <path d="M 66.682344 284.341431
-L 507.6 284.341431
+      <path d="M 66.682344 284.327269
+L 507.6 284.327269
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.341431" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.327269" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_25">
-      <path d="M 66.682344 279.570427
-L 507.6 279.570427
+      <path d="M 66.682344 279.545919
+L 507.6 279.545919
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="279.570427" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="279.545919" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_27">
-      <path d="M 66.682344 247.225498
-L 507.6 247.225498
+      <path d="M 66.682344 247.130851
+L 507.6 247.130851
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="247.225498" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="247.130851" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_29">
-      <path d="M 66.682344 230.801436
-L 507.6 230.801436
+      <path d="M 66.682344 230.671174
+L 507.6 230.671174
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="230.801436" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="230.671174" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_31">
-      <path d="M 66.682344 219.148379
-L 507.6 219.148379
+      <path d="M 66.682344 218.992848
+L 507.6 218.992848
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="219.148379" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="218.992848" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_33">
-      <path d="M 66.682344 210.109565
-L 507.6 210.109565
+      <path d="M 66.682344 209.934434
+L 507.6 209.934434
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="210.109565" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="209.934434" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_35">
-      <path d="M 66.682344 202.724317
-L 507.6 202.724317
+      <path d="M 66.682344 202.53317
+L 507.6 202.53317
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="202.724317" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="202.53317" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_37">
-      <path d="M 66.682344 196.480178
-L 507.6 196.480178
+      <path d="M 66.682344 196.275492
+L 507.6 196.275492
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="196.480178" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="196.275492" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_39">
-      <path d="M 66.682344 191.07126
-L 507.6 191.07126
+      <path d="M 66.682344 190.854844
+L 507.6 190.854844
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="191.07126" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="190.854844" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_41">
-      <path d="M 66.682344 186.300255
-L 507.6 186.300255
+      <path d="M 66.682344 186.073493
+L 507.6 186.073493
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="186.300255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="186.073493" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_43">
-      <path d="M 66.682344 153.955327
-L 507.6 153.955327
+      <path d="M 66.682344 153.658426
+L 507.6 153.658426
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="153.955327" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="153.658426" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_45">
-      <path d="M 66.682344 137.531265
-L 507.6 137.531265
+      <path d="M 66.682344 137.198749
+L 507.6 137.198749
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="137.531265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="137.198749" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_47">
-      <path d="M 66.682344 125.878207
-L 507.6 125.878207
+      <path d="M 66.682344 125.520422
+L 507.6 125.520422
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="125.878207" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="125.520422" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_49">
-      <path d="M 66.682344 116.839394
-L 507.6 116.839394
+      <path d="M 66.682344 116.462008
+L 507.6 116.462008
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="116.839394" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="116.462008" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_51">
-      <path d="M 66.682344 109.454145
-L 507.6 109.454145
+      <path d="M 66.682344 109.060745
+L 507.6 109.060745
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="109.454145" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="109.060745" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_53">
-      <path d="M 66.682344 103.210007
-L 507.6 103.210007
+      <path d="M 66.682344 102.803066
+L 507.6 102.803066
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="103.210007" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="102.803066" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_55">
-      <path d="M 66.682344 97.801088
-L 507.6 97.801088
+      <path d="M 66.682344 97.382418
+L 507.6 97.382418
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="97.801088" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="97.382418" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_57">
-      <path d="M 66.682344 93.030083
-L 507.6 93.030083
+      <path d="M 66.682344 92.601068
+L 507.6 92.601068
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="93.030083" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="92.601068" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_59">
-      <path d="M 66.682344 60.685155
-L 507.6 60.685155
+      <path d="M 66.682344 60.186
+L 507.6 60.186
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="60.685155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="60.186" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_61">
-      <path d="M 66.682344 44.261093
-L 507.6 44.261093
+      <path d="M 66.682344 43.726323
+L 507.6 43.726323
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="44.261093" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="43.726323" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_63">
-      <path d="M 66.682344 32.608036
-L 507.6 32.608036
+      <path d="M 66.682344 32.047997
+L 507.6 32.047997
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="32.608036" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="32.047997" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1089,7 +1089,7 @@ z
     </g>
    </g>
    <g id="line2d_65">
-    <path d="M 89.917954 87.457394
+    <path d="M 89.917954 87.332636
 L 136.229479 38.765348
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
@@ -1106,20 +1106,20 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="89.917954" y="87.457394" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="89.917954" y="87.332636" style="fill: #1f77b4; stroke: #1f77b4"/>
      <use xlink:href="#md73ba6276e" x="136.229479" y="38.765348" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_66">
-    <path d="M 86.724055 222.846893
+    <path d="M 86.724055 222.699382
 L 89.917954 290.872308
-L 136.229479 251.404706
-L 137.826428 124.538791
-L 188.9288 101.441699
-L 188.9288 80.002659
-L 264.783884 170.231509
-L 291.133545 176.140442
-L 487.558288 119.196032
+L 136.229479 251.319121
+L 137.826428 124.178101
+L 188.9288 101.030924
+L 188.9288 79.545394
+L 264.783884 169.969903
+L 291.133545 175.89165
+L 487.558288 118.823757
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #9467bd; stroke-linecap: square"/>
     <defs>
      <path id="meef3cfac8d" d="M 0 -2
@@ -1129,27 +1129,27 @@ z
 " style="stroke: #9467bd; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#meef3cfac8d" x="86.724055" y="222.846893" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="86.724055" y="222.699382" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
      <use xlink:href="#meef3cfac8d" x="89.917954" y="290.872308" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="136.229479" y="251.404706" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="137.826428" y="124.538791" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="188.9288" y="101.441699" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="188.9288" y="80.002659" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="264.783884" y="170.231509" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="291.133545" y="176.140442" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="487.558288" y="119.196032" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="136.229479" y="251.319121" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="137.826428" y="124.178101" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="188.9288" y="101.030924" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="188.9288" y="79.545394" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="264.783884" y="169.969903" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="291.133545" y="175.89165" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="487.558288" y="118.823757" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_67">
-    <path d="M 86.724055 184.141561
-L 89.917954 252.659843
-L 136.229479 224.298314
-L 137.826428 134.475124
-L 188.9288 88.344492
-L 188.9288 77.98507
-L 264.783884 170.356983
-L 291.133545 139.171322
-L 487.558288 102.18696
+    <path d="M 86.724055 183.910119
+L 89.917954 252.57698
+L 136.229479 224.15395
+L 137.826428 134.135981
+L 188.9288 87.905316
+L 188.9288 77.52343
+L 264.783884 170.095649
+L 291.133545 138.842363
+L 487.558288 101.777801
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #8c564b; stroke-linecap: square"/>
     <defs>
      <path id="m975a81c4ea" d="M -0 2
@@ -1159,27 +1159,27 @@ z
 " style="stroke: #8c564b; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="184.141561" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="89.917954" y="252.659843" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="136.229479" y="224.298314" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="137.826428" y="134.475124" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="188.9288" y="88.344492" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="188.9288" y="77.98507" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="264.783884" y="170.356983" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="291.133545" y="139.171322" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="487.558288" y="102.18696" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="183.910119" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="89.917954" y="252.57698" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="136.229479" y="224.15395" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="137.826428" y="134.135981" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="188.9288" y="87.905316" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="188.9288" y="77.52343" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="264.783884" y="170.095649" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="291.133545" y="138.842363" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="487.558288" y="101.777801" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
-    <path d="M 86.724055 215.312841
-L 89.917954 253.08961
-L 136.229479 234.59574
-L 137.826428 160.284323
-L 188.9288 118.345235
-L 188.9288 114.23983
-L 264.783884 153.035444
-L 291.133545 164.292885
-L 487.558288 90.381465
+    <path d="M 86.724055 215.148993
+L 89.917954 253.00768
+L 136.229479 234.473705
+L 137.826428 160.001146
+L 188.9288 117.971115
+L 188.9288 113.856807
+L 264.783884 152.736548
+L 291.133545 164.018401
+L 487.558288 89.946706
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #e377c2; stroke-linecap: square"/>
     <defs>
      <path id="mbe61f33afa" d="M -0.666667 2
@@ -1198,15 +1198,15 @@ z
 " style="stroke: #e377c2; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="215.312841" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="89.917954" y="253.08961" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="136.229479" y="234.59574" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="137.826428" y="160.284323" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="188.9288" y="118.345235" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="188.9288" y="114.23983" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="264.783884" y="153.035444" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="291.133545" y="164.292885" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="487.558288" y="90.381465" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="215.148993" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="89.917954" y="253.00768" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="136.229479" y="234.473705" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="137.826428" y="160.001146" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="188.9288" y="117.971115" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="188.9288" y="113.856807" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="264.783884" y="152.736548" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="291.133545" y="164.018401" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="487.558288" y="89.946706" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -1695,7 +1695,7 @@ z
    </g>
   </g>
   <g id="text_16">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -1755,43 +1755,34 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1b" d="M 2034 2216
-Q 1584 2216 1326 1975
-Q 1069 1734 1069 1313
-Q 1069 891 1326 650
-Q 1584 409 2034 409
-Q 2484 409 2743 651
-Q 3003 894 3003 1313
-Q 3003 1734 2745 1975
-Q 2488 2216 2034 2216
+     <path id="DejaVuSans-1c" d="M 703 97
+L 703 672
+Q 941 559 1184 500
+Q 1428 441 1663 441
+Q 2288 441 2617 861
+Q 2947 1281 2994 2138
+Q 2813 1869 2534 1725
+Q 2256 1581 1919 1581
+Q 1219 1581 811 2004
+Q 403 2428 403 3163
+Q 403 3881 828 4315
+Q 1253 4750 1959 4750
+Q 2769 4750 3195 4129
+Q 3622 3509 3622 2328
+Q 3622 1225 3098 567
+Q 2575 -91 1691 -91
+Q 1453 -91 1209 -44
+Q 966 3 703 97
 z
-M 1403 2484
-Q 997 2584 770 2862
-Q 544 3141 544 3541
-Q 544 4100 942 4425
-Q 1341 4750 2034 4750
-Q 2731 4750 3128 4425
-Q 3525 4100 3525 3541
-Q 3525 3141 3298 2862
-Q 3072 2584 2669 2484
-Q 3125 2378 3379 2068
-Q 3634 1759 3634 1313
-Q 3634 634 3220 271
-Q 2806 -91 2034 -91
-Q 1263 -91 848 271
-Q 434 634 434 1313
-Q 434 1759 690 2068
-Q 947 2378 1403 2484
-z
-M 1172 3481
-Q 1172 3119 1398 2916
-Q 1625 2713 2034 2713
-Q 2441 2713 2670 2916
-Q 2900 3119 2900 3481
-Q 2900 3844 2670 4047
-Q 2441 4250 2034 4250
-Q 1625 4250 1398 4047
-Q 1172 3844 1172 3481
+M 1959 2075
+Q 2384 2075 2632 2365
+Q 2881 2656 2881 3163
+Q 2881 3666 2632 3958
+Q 2384 4250 1959 4250
+Q 1534 4250 1286 3958
+Q 1038 3666 1038 3163
+Q 1038 2656 1286 2365
+Q 1534 2075 1959 2075
 z
 " transform="scale(0.015625)"/>
     </defs>
@@ -1841,7 +1832,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-laguerre.svg
+++ b/reports/figures/hexbz-runtime-degree-laguerre.svg
@@ -1424,26 +1424,26 @@ z
     </g>
    </g>
    <g id="line2d_121">
-    <path d="M 86.724055 275.230939
-L 100.545925 262.578812
-L 114.367796 257.178552
-L 128.189666 252.961621
-L 142.011536 245.88455
-L 155.833406 248.064647
-L 169.655276 246.371085
-L 183.477146 235.190484
-L 197.299016 238.39705
-L 211.120886 226.251163
-L 224.942756 224.004238
-L 238.764627 217.747737
-L 252.586497 211.269139
-L 266.408367 206.574593
-L 294.052107 203.711467
-L 321.695847 194.434751
-L 349.339587 202.505357
-L 376.983328 192.554834
-L 432.270808 182.354264
-L 487.558288 171.05062
+    <path d="M 86.724055 277.940615
+L 100.545925 267.266706
+L 114.367796 259.098455
+L 128.189666 255.680739
+L 142.011536 247.633568
+L 155.833406 251.900691
+L 169.655276 251.417264
+L 183.477146 238.318693
+L 197.299016 243.982966
+L 211.120886 229.601665
+L 224.942756 227.907282
+L 238.764627 220.566283
+L 252.586497 214.480522
+L 266.408367 209.222406
+L 294.052107 207.422868
+L 321.695847 197.305746
+L 349.339587 209.160322
+L 376.983328 197.337414
+L 432.270808 186.731778
+L 487.558288 174.20577
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1459,26 +1459,26 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="275.230939" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="100.545925" y="262.578812" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="114.367796" y="257.178552" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.189666" y="252.961621" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="142.011536" y="245.88455" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="155.833406" y="248.064647" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="169.655276" y="246.371085" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="183.477146" y="235.190484" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="197.299016" y="238.39705" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="211.120886" y="226.251163" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="224.942756" y="224.004238" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="238.764627" y="217.747737" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="252.586497" y="211.269139" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="266.408367" y="206.574593" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.052107" y="203.711467" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="321.695847" y="194.434751" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="349.339587" y="202.505357" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="376.983328" y="192.554834" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="432.270808" y="182.354264" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="171.05062" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="277.940615" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="100.545925" y="267.266706" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="114.367796" y="259.098455" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.189666" y="255.680739" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="142.011536" y="247.633568" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="155.833406" y="251.900691" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="169.655276" y="251.417264" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="183.477146" y="238.318693" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="197.299016" y="243.982966" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="211.120886" y="229.601665" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="224.942756" y="227.907282" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="238.764627" y="220.566283" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="252.586497" y="214.480522" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="266.408367" y="209.222406" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.052107" y="207.422868" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="321.695847" y="197.305746" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="349.339587" y="209.160322" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="376.983328" y="197.337414" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="432.270808" y="186.731778" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="174.20577" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_122">
@@ -2347,7 +2347,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2407,14 +2407,43 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1a" d="M 525 4666
-L 3525 4666
-L 3525 4397
-L 1831 0
-L 1172 0
-L 2766 4134
-L 525 4134
-L 525 4666
+     <path id="DejaVuSans-1b" d="M 2034 2216
+Q 1584 2216 1326 1975
+Q 1069 1734 1069 1313
+Q 1069 891 1326 650
+Q 1584 409 2034 409
+Q 2484 409 2743 651
+Q 3003 894 3003 1313
+Q 3003 1734 2745 1975
+Q 2488 2216 2034 2216
+z
+M 1403 2484
+Q 997 2584 770 2862
+Q 544 3141 544 3541
+Q 544 4100 942 4425
+Q 1341 4750 2034 4750
+Q 2731 4750 3128 4425
+Q 3525 4100 3525 3541
+Q 3525 3141 3298 2862
+Q 3072 2584 2669 2484
+Q 3125 2378 3379 2068
+Q 3634 1759 3634 1313
+Q 3634 634 3220 271
+Q 2806 -91 2034 -91
+Q 1263 -91 848 271
+Q 434 634 434 1313
+Q 434 1759 690 2068
+Q 947 2378 1403 2484
+z
+M 1172 3481
+Q 1172 3119 1398 2916
+Q 1625 2713 2034 2713
+Q 2441 2713 2670 2916
+Q 2900 3119 2900 3481
+Q 2900 3844 2670 4047
+Q 2441 4250 2034 4250
+Q 1625 4250 1398 4047
+Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
     </defs>
@@ -2464,7 +2493,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-laguerre.svg
+++ b/reports/figures/hexbz-runtime-degree-laguerre.svg
@@ -1424,26 +1424,26 @@ z
     </g>
    </g>
    <g id="line2d_121">
-    <path d="M 86.724055 277.940615
-L 100.545925 267.266706
-L 114.367796 259.098455
-L 128.189666 255.680739
-L 142.011536 247.633568
-L 155.833406 251.900691
-L 169.655276 251.417264
-L 183.477146 238.318693
-L 197.299016 243.982966
-L 211.120886 229.601665
-L 224.942756 227.907282
-L 238.764627 220.566283
-L 252.586497 214.480522
-L 266.408367 209.222406
-L 294.052107 207.422868
-L 321.695847 197.305746
-L 349.339587 209.160322
-L 376.983328 197.337414
-L 432.270808 186.731778
-L 487.558288 174.20577
+    <path d="M 86.724055 278.438448
+L 100.545925 267.034327
+L 114.367796 258.504349
+L 128.189666 255.4818
+L 142.011536 247.466459
+L 155.833406 251.838311
+L 169.655276 251.544198
+L 183.477146 238.430687
+L 197.299016 244.12799
+L 211.120886 229.398382
+L 224.942756 227.764079
+L 238.764627 219.951245
+L 252.586497 214.300481
+L 266.408367 209.068591
+L 294.052107 206.485412
+L 321.695847 197.195907
+L 349.339587 209.247894
+L 376.983328 196.995944
+L 432.270808 186.440484
+L 487.558288 174.106532
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1459,26 +1459,26 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="277.940615" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="100.545925" y="267.266706" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="114.367796" y="259.098455" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="128.189666" y="255.680739" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="142.011536" y="247.633568" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="155.833406" y="251.900691" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="169.655276" y="251.417264" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="183.477146" y="238.318693" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="197.299016" y="243.982966" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="211.120886" y="229.601665" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="224.942756" y="227.907282" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="238.764627" y="220.566283" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="252.586497" y="214.480522" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="266.408367" y="209.222406" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="294.052107" y="207.422868" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="321.695847" y="197.305746" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="349.339587" y="209.160322" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="376.983328" y="197.337414" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="432.270808" y="186.731778" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="174.20577" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="278.438448" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="100.545925" y="267.034327" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="114.367796" y="258.504349" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="128.189666" y="255.4818" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="142.011536" y="247.466459" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="155.833406" y="251.838311" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="169.655276" y="251.544198" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="183.477146" y="238.430687" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="197.299016" y="244.12799" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="211.120886" y="229.398382" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="224.942756" y="227.764079" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="238.764627" y="219.951245" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="252.586497" y="214.300481" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="266.408367" y="209.068591" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="294.052107" y="206.485412" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="321.695847" y="197.195907" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="349.339587" y="209.247894" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="376.983328" y="196.995944" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="432.270808" y="186.440484" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="174.106532" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_122">
@@ -2347,7 +2347,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2407,43 +2407,34 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1b" d="M 2034 2216
-Q 1584 2216 1326 1975
-Q 1069 1734 1069 1313
-Q 1069 891 1326 650
-Q 1584 409 2034 409
-Q 2484 409 2743 651
-Q 3003 894 3003 1313
-Q 3003 1734 2745 1975
-Q 2488 2216 2034 2216
+     <path id="DejaVuSans-1c" d="M 703 97
+L 703 672
+Q 941 559 1184 500
+Q 1428 441 1663 441
+Q 2288 441 2617 861
+Q 2947 1281 2994 2138
+Q 2813 1869 2534 1725
+Q 2256 1581 1919 1581
+Q 1219 1581 811 2004
+Q 403 2428 403 3163
+Q 403 3881 828 4315
+Q 1253 4750 1959 4750
+Q 2769 4750 3195 4129
+Q 3622 3509 3622 2328
+Q 3622 1225 3098 567
+Q 2575 -91 1691 -91
+Q 1453 -91 1209 -44
+Q 966 3 703 97
 z
-M 1403 2484
-Q 997 2584 770 2862
-Q 544 3141 544 3541
-Q 544 4100 942 4425
-Q 1341 4750 2034 4750
-Q 2731 4750 3128 4425
-Q 3525 4100 3525 3541
-Q 3525 3141 3298 2862
-Q 3072 2584 2669 2484
-Q 3125 2378 3379 2068
-Q 3634 1759 3634 1313
-Q 3634 634 3220 271
-Q 2806 -91 2034 -91
-Q 1263 -91 848 271
-Q 434 634 434 1313
-Q 434 1759 690 2068
-Q 947 2378 1403 2484
-z
-M 1172 3481
-Q 1172 3119 1398 2916
-Q 1625 2713 2034 2713
-Q 2441 2713 2670 2916
-Q 2900 3119 2900 3481
-Q 2900 3844 2670 4047
-Q 2441 4250 2034 4250
-Q 1625 4250 1398 4047
-Q 1172 3844 1172 3481
+M 1959 2075
+Q 2384 2075 2632 2365
+Q 2881 2656 2881 3163
+Q 2881 3666 2632 3958
+Q 2384 4250 1959 4250
+Q 1534 4250 1286 3958
+Q 1038 3666 1038 3163
+Q 1038 2656 1286 2365
+Q 1534 2075 1959 2075
 z
 " transform="scale(0.015625)"/>
     </defs>
@@ -2493,7 +2484,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-legendre.svg
+++ b/reports/figures/hexbz-runtime-degree-legendre.svg
@@ -1443,26 +1443,26 @@ z
     </g>
    </g>
    <g id="line2d_123">
-    <path d="M 86.724055 274.926533
-L 98.176462 272.992763
-L 109.628869 263.378073
-L 121.081275 256.077798
-L 132.533682 260.075791
-L 143.986089 244.427153
-L 155.438495 242.774198
-L 166.890902 233.242129
-L 189.795715 237.690177
-L 212.700529 217.401158
-L 235.605342 220.45837
-L 258.510155 192.118266
-L 281.414969 186.682472
-L 304.319782 208.057041
-L 327.224595 196.460393
-L 350.129408 168.39539
-L 373.034222 194.68334
-L 395.939035 164.532856
-L 441.748662 185.187711
-L 487.558288 180.556339
+    <path d="M 86.724055 274.521275
+L 98.176462 274.216984
+L 109.628869 263.259813
+L 121.081275 255.519923
+L 132.533682 259.776104
+L 143.986089 244.100582
+L 155.438495 242.784528
+L 166.890902 232.90522
+L 189.795715 237.3829
+L 212.700529 214.338803
+L 235.605342 210.143079
+L 258.510155 181.81384
+L 281.414969 185.797831
+L 304.319782 208.246992
+L 327.224595 196.159101
+L 350.129408 168.012405
+L 373.034222 194.65319
+L 395.939035 164.018372
+L 441.748662 185.222414
+L 487.558288 180.883407
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1478,26 +1478,26 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="274.926533" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="98.176462" y="272.992763" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="109.628869" y="263.378073" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="121.081275" y="256.077798" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="132.533682" y="260.075791" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.986089" y="244.427153" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="155.438495" y="242.774198" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="166.890902" y="233.242129" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.795715" y="237.690177" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="212.700529" y="217.401158" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="235.605342" y="220.45837" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="258.510155" y="192.118266" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="281.414969" y="186.682472" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="304.319782" y="208.057041" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="327.224595" y="196.460393" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="350.129408" y="168.39539" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="373.034222" y="194.68334" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.939035" y="164.532856" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="441.748662" y="185.187711" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="180.556339" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="274.521275" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="98.176462" y="274.216984" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="109.628869" y="263.259813" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="121.081275" y="255.519923" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="132.533682" y="259.776104" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.986089" y="244.100582" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="155.438495" y="242.784528" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="166.890902" y="232.90522" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.795715" y="237.3829" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="212.700529" y="214.338803" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="235.605342" y="210.143079" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="258.510155" y="181.81384" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="281.414969" y="185.797831" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="304.319782" y="208.246992" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="327.224595" y="196.159101" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="350.129408" y="168.012405" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="373.034222" y="194.65319" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.939035" y="164.018372" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="441.748662" y="185.222414" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="180.883407" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_124">
@@ -2360,7 +2360,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2420,43 +2420,34 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1b" d="M 2034 2216
-Q 1584 2216 1326 1975
-Q 1069 1734 1069 1313
-Q 1069 891 1326 650
-Q 1584 409 2034 409
-Q 2484 409 2743 651
-Q 3003 894 3003 1313
-Q 3003 1734 2745 1975
-Q 2488 2216 2034 2216
+     <path id="DejaVuSans-1c" d="M 703 97
+L 703 672
+Q 941 559 1184 500
+Q 1428 441 1663 441
+Q 2288 441 2617 861
+Q 2947 1281 2994 2138
+Q 2813 1869 2534 1725
+Q 2256 1581 1919 1581
+Q 1219 1581 811 2004
+Q 403 2428 403 3163
+Q 403 3881 828 4315
+Q 1253 4750 1959 4750
+Q 2769 4750 3195 4129
+Q 3622 3509 3622 2328
+Q 3622 1225 3098 567
+Q 2575 -91 1691 -91
+Q 1453 -91 1209 -44
+Q 966 3 703 97
 z
-M 1403 2484
-Q 997 2584 770 2862
-Q 544 3141 544 3541
-Q 544 4100 942 4425
-Q 1341 4750 2034 4750
-Q 2731 4750 3128 4425
-Q 3525 4100 3525 3541
-Q 3525 3141 3298 2862
-Q 3072 2584 2669 2484
-Q 3125 2378 3379 2068
-Q 3634 1759 3634 1313
-Q 3634 634 3220 271
-Q 2806 -91 2034 -91
-Q 1263 -91 848 271
-Q 434 634 434 1313
-Q 434 1759 690 2068
-Q 947 2378 1403 2484
-z
-M 1172 3481
-Q 1172 3119 1398 2916
-Q 1625 2713 2034 2713
-Q 2441 2713 2670 2916
-Q 2900 3119 2900 3481
-Q 2900 3844 2670 4047
-Q 2441 4250 2034 4250
-Q 1625 4250 1398 4047
-Q 1172 3844 1172 3481
+M 1959 2075
+Q 2384 2075 2632 2365
+Q 2881 2656 2881 3163
+Q 2881 3666 2632 3958
+Q 2384 4250 1959 4250
+Q 1534 4250 1286 3958
+Q 1038 3666 1038 3163
+Q 1038 2656 1286 2365
+Q 1534 2075 1959 2075
 z
 " transform="scale(0.015625)"/>
     </defs>
@@ -2506,7 +2497,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-legendre.svg
+++ b/reports/figures/hexbz-runtime-degree-legendre.svg
@@ -1443,26 +1443,26 @@ z
     </g>
    </g>
    <g id="line2d_123">
-    <path d="M 86.724055 271.591514
-L 98.176462 271.404317
-L 109.628869 261.055245
-L 121.081275 253.869901
-L 132.533682 257.756047
-L 143.986089 236.513474
-L 155.438495 241.457684
-L 166.890902 231.727725
-L 189.795715 234.377916
-L 212.700529 215.629517
-L 235.605342 217.625603
-L 258.510155 190.457269
-L 281.414969 185.09857
-L 304.319782 204.167318
-L 327.224595 193.797047
-L 350.129408 166.890109
-L 373.034222 190.104907
-L 395.939035 162.510539
-L 441.748662 181.199647
-L 487.558288 176.644958
+    <path d="M 86.724055 274.926533
+L 98.176462 272.992763
+L 109.628869 263.378073
+L 121.081275 256.077798
+L 132.533682 260.075791
+L 143.986089 244.427153
+L 155.438495 242.774198
+L 166.890902 233.242129
+L 189.795715 237.690177
+L 212.700529 217.401158
+L 235.605342 220.45837
+L 258.510155 192.118266
+L 281.414969 186.682472
+L 304.319782 208.057041
+L 327.224595 196.460393
+L 350.129408 168.39539
+L 373.034222 194.68334
+L 395.939035 164.532856
+L 441.748662 185.187711
+L 487.558288 180.556339
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1478,26 +1478,26 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="271.591514" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="98.176462" y="271.404317" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="109.628869" y="261.055245" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="121.081275" y="253.869901" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="132.533682" y="257.756047" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="143.986089" y="236.513474" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="155.438495" y="241.457684" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="166.890902" y="231.727725" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="189.795715" y="234.377916" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="212.700529" y="215.629517" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="235.605342" y="217.625603" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="258.510155" y="190.457269" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="281.414969" y="185.09857" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="304.319782" y="204.167318" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="327.224595" y="193.797047" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="350.129408" y="166.890109" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="373.034222" y="190.104907" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="395.939035" y="162.510539" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="441.748662" y="181.199647" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="176.644958" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="274.926533" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="98.176462" y="272.992763" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="109.628869" y="263.378073" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="121.081275" y="256.077798" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="132.533682" y="260.075791" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="143.986089" y="244.427153" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="155.438495" y="242.774198" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="166.890902" y="233.242129" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="189.795715" y="237.690177" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="212.700529" y="217.401158" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="235.605342" y="220.45837" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="258.510155" y="192.118266" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="281.414969" y="186.682472" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="304.319782" y="208.057041" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="327.224595" y="196.460393" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="350.129408" y="168.39539" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="373.034222" y="194.68334" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="395.939035" y="164.532856" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="441.748662" y="185.187711" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="180.556339" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_124">
@@ -2360,7 +2360,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2420,14 +2420,43 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1a" d="M 525 4666
-L 3525 4666
-L 3525 4397
-L 1831 0
-L 1172 0
-L 2766 4134
-L 525 4134
-L 525 4666
+     <path id="DejaVuSans-1b" d="M 2034 2216
+Q 1584 2216 1326 1975
+Q 1069 1734 1069 1313
+Q 1069 891 1326 650
+Q 1584 409 2034 409
+Q 2484 409 2743 651
+Q 3003 894 3003 1313
+Q 3003 1734 2745 1975
+Q 2488 2216 2034 2216
+z
+M 1403 2484
+Q 997 2584 770 2862
+Q 544 3141 544 3541
+Q 544 4100 942 4425
+Q 1341 4750 2034 4750
+Q 2731 4750 3128 4425
+Q 3525 4100 3525 3541
+Q 3525 3141 3298 2862
+Q 3072 2584 2669 2484
+Q 3125 2378 3379 2068
+Q 3634 1759 3634 1313
+Q 3634 634 3220 271
+Q 2806 -91 2034 -91
+Q 1263 -91 848 271
+Q 434 634 434 1313
+Q 434 1759 690 2068
+Q 947 2378 1403 2484
+z
+M 1172 3481
+Q 1172 3119 1398 2916
+Q 1625 2713 2034 2713
+Q 2441 2713 2670 2916
+Q 2900 3119 2900 3481
+Q 2900 3844 2670 4047
+Q 2441 4250 2034 4250
+Q 1625 4250 1398 4047
+Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
     </defs>
@@ -2477,7 +2506,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-random-products.svg
+++ b/reports/figures/hexbz-runtime-degree-random-products.svg
@@ -1419,36 +1419,36 @@ z
     </g>
    </g>
    <g id="line2d_121">
-    <path d="M 86.724055 267.114966
-L 153.529761 255.310893
-L 153.529761 254.96318
-L 153.529761 251.353385
-L 175.798329 257.607781
-L 198.066898 251.369862
-L 220.335466 251.288419
-L 220.335466 243.426429
-L 242.604035 249.159487
-L 242.604035 241.873564
-L 242.604035 241.821879
-L 242.604035 240.752434
-L 242.604035 239.791865
-L 242.604035 230.168882
-L 264.872603 247.207246
-L 264.872603 239.340541
-L 287.141172 247.316928
-L 287.141172 245.04732
-L 287.141172 241.781896
-L 309.40974 235.106375
-L 331.678309 237.927654
-L 353.946877 236.123135
-L 353.946877 233.516377
-L 353.946877 224.550758
-L 353.946877 222.326489
-L 376.215446 223.711709
-L 398.484014 228.299502
-L 420.752583 226.269642
-L 443.021151 217.78543
-L 487.558288 211.057715
+    <path d="M 86.724055 267.162552
+L 153.529761 255.030952
+L 153.529761 254.633045
+L 153.529761 249.871859
+L 175.798329 257.259135
+L 198.066898 250.854505
+L 220.335466 250.252833
+L 220.335466 243.358206
+L 242.604035 248.808465
+L 242.604035 241.54041
+L 242.604035 241.441959
+L 242.604035 240.71811
+L 242.604035 239.185723
+L 242.604035 229.938029
+L 264.872603 246.63483
+L 264.872603 238.815255
+L 287.141172 246.366805
+L 287.141172 245.168208
+L 287.141172 241.641947
+L 309.40974 234.627418
+L 331.678309 237.606016
+L 353.946877 236.190029
+L 353.946877 232.614611
+L 353.946877 223.885295
+L 353.946877 222.151687
+L 376.215446 223.310304
+L 398.484014 228.31473
+L 420.752583 226.010796
+L 443.021151 217.36987
+L 487.558288 210.518331
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1464,36 +1464,36 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="267.114966" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.529761" y="255.310893" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.529761" y="254.96318" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.529761" y="251.353385" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.798329" y="257.607781" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="198.066898" y="251.369862" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="251.288419" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="243.426429" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="249.159487" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="241.873564" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="241.821879" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="240.752434" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="239.791865" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="230.168882" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.872603" y="247.207246" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.872603" y="239.340541" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="247.316928" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="245.04732" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="241.781896" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.40974" y="235.106375" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.678309" y="237.927654" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="236.123135" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="233.516377" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="224.550758" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="222.326489" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="376.215446" y="223.711709" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.484014" y="228.299502" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="420.752583" y="226.269642" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="443.021151" y="217.78543" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="211.057715" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="267.162552" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.529761" y="255.030952" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.529761" y="254.633045" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.529761" y="249.871859" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.798329" y="257.259135" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="198.066898" y="250.854505" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="250.252833" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="243.358206" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="248.808465" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="241.54041" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="241.441959" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="240.71811" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="239.185723" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="229.938029" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.872603" y="246.63483" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.872603" y="238.815255" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="246.366805" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="245.168208" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="241.641947" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.40974" y="234.627418" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.678309" y="237.606016" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="236.190029" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="232.614611" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="223.885295" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="222.151687" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="376.215446" y="223.310304" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.484014" y="228.31473" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="420.752583" y="226.010796" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="443.021151" y="217.36987" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="210.518331" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_122">
@@ -2475,7 +2475,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2560,43 +2560,34 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1b" d="M 2034 2216
-Q 1584 2216 1326 1975
-Q 1069 1734 1069 1313
-Q 1069 891 1326 650
-Q 1584 409 2034 409
-Q 2484 409 2743 651
-Q 3003 894 3003 1313
-Q 3003 1734 2745 1975
-Q 2488 2216 2034 2216
+     <path id="DejaVuSans-1c" d="M 703 97
+L 703 672
+Q 941 559 1184 500
+Q 1428 441 1663 441
+Q 2288 441 2617 861
+Q 2947 1281 2994 2138
+Q 2813 1869 2534 1725
+Q 2256 1581 1919 1581
+Q 1219 1581 811 2004
+Q 403 2428 403 3163
+Q 403 3881 828 4315
+Q 1253 4750 1959 4750
+Q 2769 4750 3195 4129
+Q 3622 3509 3622 2328
+Q 3622 1225 3098 567
+Q 2575 -91 1691 -91
+Q 1453 -91 1209 -44
+Q 966 3 703 97
 z
-M 1403 2484
-Q 997 2584 770 2862
-Q 544 3141 544 3541
-Q 544 4100 942 4425
-Q 1341 4750 2034 4750
-Q 2731 4750 3128 4425
-Q 3525 4100 3525 3541
-Q 3525 3141 3298 2862
-Q 3072 2584 2669 2484
-Q 3125 2378 3379 2068
-Q 3634 1759 3634 1313
-Q 3634 634 3220 271
-Q 2806 -91 2034 -91
-Q 1263 -91 848 271
-Q 434 634 434 1313
-Q 434 1759 690 2068
-Q 947 2378 1403 2484
-z
-M 1172 3481
-Q 1172 3119 1398 2916
-Q 1625 2713 2034 2713
-Q 2441 2713 2670 2916
-Q 2900 3119 2900 3481
-Q 2900 3844 2670 4047
-Q 2441 4250 2034 4250
-Q 1625 4250 1398 4047
-Q 1172 3844 1172 3481
+M 1959 2075
+Q 2384 2075 2632 2365
+Q 2881 2656 2881 3163
+Q 2881 3666 2632 3958
+Q 2384 4250 1959 4250
+Q 1534 4250 1286 3958
+Q 1038 3666 1038 3163
+Q 1038 2656 1286 2365
+Q 1534 2075 1959 2075
 z
 " transform="scale(0.015625)"/>
     </defs>
@@ -2646,7 +2637,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-random-products.svg
+++ b/reports/figures/hexbz-runtime-degree-random-products.svg
@@ -1419,36 +1419,36 @@ z
     </g>
    </g>
    <g id="line2d_121">
-    <path d="M 86.724055 265.479805
-L 153.529761 252.250138
-L 153.529761 252.243772
-L 153.529761 248.989549
-L 175.798329 252.904434
-L 198.066898 249.425077
-L 220.335466 248.179798
-L 220.335466 240.60459
-L 242.604035 244.38754
-L 242.604035 238.14852
-L 242.604035 237.89398
-L 242.604035 237.48243
-L 242.604035 236.322083
-L 242.604035 228.918751
-L 264.872603 241.204971
-L 264.872603 235.491886
-L 287.141172 242.003373
-L 287.141172 240.508017
-L 287.141172 238.269049
-L 309.40974 231.71513
-L 331.678309 233.52721
-L 353.946877 233.377179
-L 353.946877 228.793094
-L 353.946877 220.748258
-L 353.946877 218.979974
-L 376.215446 219.829755
-L 398.484014 222.537635
-L 420.752583 220.986359
-L 443.021151 212.811101
-L 487.558288 206.387462
+    <path d="M 86.724055 267.114966
+L 153.529761 255.310893
+L 153.529761 254.96318
+L 153.529761 251.353385
+L 175.798329 257.607781
+L 198.066898 251.369862
+L 220.335466 251.288419
+L 220.335466 243.426429
+L 242.604035 249.159487
+L 242.604035 241.873564
+L 242.604035 241.821879
+L 242.604035 240.752434
+L 242.604035 239.791865
+L 242.604035 230.168882
+L 264.872603 247.207246
+L 264.872603 239.340541
+L 287.141172 247.316928
+L 287.141172 245.04732
+L 287.141172 241.781896
+L 309.40974 235.106375
+L 331.678309 237.927654
+L 353.946877 236.123135
+L 353.946877 233.516377
+L 353.946877 224.550758
+L 353.946877 222.326489
+L 376.215446 223.711709
+L 398.484014 228.299502
+L 420.752583 226.269642
+L 443.021151 217.78543
+L 487.558288 211.057715
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1464,36 +1464,36 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="265.479805" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.529761" y="252.250138" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.529761" y="252.243772" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="153.529761" y="248.989549" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="175.798329" y="252.904434" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="198.066898" y="249.425077" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="248.179798" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="220.335466" y="240.60459" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="244.38754" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="238.14852" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="237.89398" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="237.48243" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="236.322083" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="242.604035" y="228.918751" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.872603" y="241.204971" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="264.872603" y="235.491886" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="242.003373" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="240.508017" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="287.141172" y="238.269049" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="309.40974" y="231.71513" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="331.678309" y="233.52721" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="233.377179" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="228.793094" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="220.748258" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="353.946877" y="218.979974" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="376.215446" y="219.829755" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="398.484014" y="222.537635" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="420.752583" y="220.986359" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="443.021151" y="212.811101" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="206.387462" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="267.114966" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.529761" y="255.310893" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.529761" y="254.96318" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="153.529761" y="251.353385" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="175.798329" y="257.607781" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="198.066898" y="251.369862" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="251.288419" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="220.335466" y="243.426429" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="249.159487" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="241.873564" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="241.821879" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="240.752434" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="239.791865" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="242.604035" y="230.168882" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.872603" y="247.207246" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="264.872603" y="239.340541" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="247.316928" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="245.04732" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="287.141172" y="241.781896" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="309.40974" y="235.106375" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="331.678309" y="237.927654" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="236.123135" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="233.516377" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="224.550758" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="353.946877" y="222.326489" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="376.215446" y="223.711709" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="398.484014" y="228.299502" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="420.752583" y="226.269642" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="443.021151" y="217.78543" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="211.057715" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_122">
@@ -2475,7 +2475,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_22">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2560,6 +2560,45 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-1b" d="M 2034 2216
+Q 1584 2216 1326 1975
+Q 1069 1734 1069 1313
+Q 1069 891 1326 650
+Q 1584 409 2034 409
+Q 2484 409 2743 651
+Q 3003 894 3003 1313
+Q 3003 1734 2745 1975
+Q 2488 2216 2034 2216
+z
+M 1403 2484
+Q 997 2584 770 2862
+Q 544 3141 544 3541
+Q 544 4100 942 4425
+Q 1341 4750 2034 4750
+Q 2731 4750 3128 4425
+Q 3525 4100 3525 3541
+Q 3525 3141 3298 2862
+Q 3072 2584 2669 2484
+Q 3125 2378 3379 2068
+Q 3634 1759 3634 1313
+Q 3634 634 3220 271
+Q 2806 -91 2034 -91
+Q 1263 -91 848 271
+Q 434 634 434 1313
+Q 434 1759 690 2068
+Q 947 2378 1403 2484
+z
+M 1172 3481
+Q 1172 3119 1398 2916
+Q 1625 2713 2034 2713
+Q 2441 2713 2670 2916
+Q 2900 3119 2900 3481
+Q 2900 3844 2670 4047
+Q 2441 4250 2034 4250
+Q 1625 4250 1398 4047
+Q 1172 3844 1172 3481
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2607,7 +2646,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-sd-products.svg
+++ b/reports/figures/hexbz-runtime-degree-sd-products.svg
@@ -1264,16 +1264,16 @@ z
     </g>
    </g>
    <g id="line2d_91">
-    <path d="M 86.724055 263.140553
-L 86.724055 262.113912
-L 113.446338 224.071993
-L 113.446338 223.597723
-L 113.446338 210.054168
-L 166.890902 153.220865
-L 166.890902 126.726065
-L 193.613184 124.236966
-L 200.293755 69.883268
-L 247.057749 46.569312
+    <path d="M 86.724055 266.96219
+L 86.724055 264.998685
+L 113.446338 229.170357
+L 113.446338 225.311889
+L 113.446338 213.404807
+L 166.890902 156.696811
+L 166.890902 127.466672
+L 193.613184 128.472664
+L 200.293755 70.116067
+L 247.057749 46.8874
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1289,16 +1289,16 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="263.140553" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="262.113912" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="113.446338" y="224.071993" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="113.446338" y="223.597723" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="113.446338" y="210.054168" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="166.890902" y="153.220865" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="166.890902" y="126.726065" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="193.613184" y="124.236966" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="200.293755" y="69.883268" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="247.057749" y="46.569312" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="266.96219" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="264.998685" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="113.446338" y="229.170357" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="113.446338" y="225.311889" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="113.446338" y="213.404807" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="166.890902" y="156.696811" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="166.890902" y="127.466672" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="193.613184" y="128.472664" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="200.293755" y="70.116067" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="247.057749" y="46.8874" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_92">
@@ -2088,7 +2088,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_20">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2180,16 +2180,6 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1a" d="M 525 4666
-L 3525 4666
-L 3525 4397
-L 1831 0
-L 1172 0
-L 2766 4134
-L 525 4134
-L 525 4666
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2237,7 +2227,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-sd-products.svg
+++ b/reports/figures/hexbz-runtime-degree-sd-products.svg
@@ -1264,16 +1264,16 @@ z
     </g>
    </g>
    <g id="line2d_91">
-    <path d="M 86.724055 266.96219
-L 86.724055 264.998685
-L 113.446338 229.170357
-L 113.446338 225.311889
-L 113.446338 213.404807
-L 166.890902 156.696811
-L 166.890902 127.466672
-L 193.613184 128.472664
-L 200.293755 70.116067
-L 247.057749 46.8874
+    <path d="M 86.724055 262.532612
+L 86.724055 249.699167
+L 113.446338 229.424976
+L 113.446338 225.801102
+L 113.446338 200.891023
+L 166.890902 156.17988
+L 166.890902 127.669018
+L 193.613184 128.08528
+L 200.293755 69.899813
+L 247.057749 46.687478
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1289,16 +1289,16 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="266.96219" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="264.998685" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="113.446338" y="229.170357" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="113.446338" y="225.311889" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="113.446338" y="213.404807" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="166.890902" y="156.696811" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="166.890902" y="127.466672" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="193.613184" y="128.472664" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="200.293755" y="70.116067" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="247.057749" y="46.8874" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="262.532612" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="249.699167" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="113.446338" y="229.424976" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="113.446338" y="225.801102" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="113.446338" y="200.891023" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="166.890902" y="156.17988" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="166.890902" y="127.669018" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="193.613184" y="128.08528" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="200.293755" y="69.899813" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="247.057749" y="46.687478" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_92">
@@ -2088,7 +2088,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_20">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2180,6 +2180,36 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-1c" d="M 703 97
+L 703 672
+Q 941 559 1184 500
+Q 1428 441 1663 441
+Q 2288 441 2617 861
+Q 2947 1281 2994 2138
+Q 2813 1869 2534 1725
+Q 2256 1581 1919 1581
+Q 1219 1581 811 2004
+Q 403 2428 403 3163
+Q 403 3881 828 4315
+Q 1253 4750 1959 4750
+Q 2769 4750 3195 4129
+Q 3622 3509 3622 2328
+Q 3622 1225 3098 567
+Q 2575 -91 1691 -91
+Q 1453 -91 1209 -44
+Q 966 3 703 97
+z
+M 1959 2075
+Q 2384 2075 2632 2365
+Q 2881 2656 2881 3163
+Q 2881 3666 2632 3958
+Q 2384 4250 1959 4250
+Q 1534 4250 1286 3958
+Q 1038 3666 1038 3163
+Q 1038 2656 1286 2365
+Q 1534 2075 1959 2075
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2227,7 +2257,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-swinnerton-dyer.svg
+++ b/reports/figures/hexbz-runtime-degree-swinnerton-dyer.svg
@@ -632,8 +632,8 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 66.682344 270.122139
-L 507.6 270.122139
+      <path d="M 66.682344 270.175146
+L 507.6 270.175146
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
@@ -643,12 +643,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="270.122139" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="270.175146" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 100us -->
-      <g transform="translate(29.047969 273.920967) scale(0.1 -0.1)">
+      <g transform="translate(29.047969 273.973974) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-58" d="M 544 1381
 L 544 3500
@@ -714,18 +714,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 66.682344 223.044396
-L 507.6 223.044396
+      <path d="M 66.682344 223.217662
+L 507.6 223.217662
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="223.044396" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="223.217662" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 1ms -->
-      <g transform="translate(38.369844 226.843224) scale(0.1 -0.1)">
+      <g transform="translate(38.369844 227.01649) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-50" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(161.03125 0)"/>
@@ -734,18 +734,18 @@ L 507.6 223.044396
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 66.682344 175.966652
-L 507.6 175.966652
+      <path d="M 66.682344 176.260178
+L 507.6 176.260178
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="175.966652" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="176.260178" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 10ms -->
-      <g transform="translate(32.007344 179.76548) scale(0.1 -0.1)">
+      <g transform="translate(32.007344 180.059006) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-50" transform="translate(127.25 0)"/>
@@ -755,18 +755,18 @@ L 507.6 175.966652
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 66.682344 128.888908
-L 507.6 128.888908
+      <path d="M 66.682344 129.302694
+L 507.6 129.302694
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="128.888908" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="129.302694" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 100ms -->
-      <g transform="translate(25.644844 132.687736) scale(0.1 -0.1)">
+      <g transform="translate(25.644844 133.101522) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -777,18 +777,18 @@ L 507.6 128.888908
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 66.682344 81.811164
-L 507.6 81.811164
+      <path d="M 66.682344 82.34521
+L 507.6 82.34521
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="81.811164" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="82.34521" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1s -->
-      <g transform="translate(48.110469 85.609992) scale(0.1 -0.1)">
+      <g transform="translate(48.110469 86.144038) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(63.625 0)"/>
       </g>
@@ -796,18 +796,18 @@ L 507.6 81.811164
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 66.682344 34.733421
-L 507.6 34.733421
+      <path d="M 66.682344 35.387726
+L 507.6 35.387726
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="34.733421" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="35.387726" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 10s -->
-      <g transform="translate(41.747969 38.532249) scale(0.1 -0.1)">
+      <g transform="translate(41.747969 39.186554) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(127.25 0)"/>
@@ -816,8 +816,8 @@ L 507.6 34.733421
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 66.682344 303.02807
-L 507.6 303.02807
+      <path d="M 66.682344 302.997018
+L 507.6 302.997018
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
@@ -827,571 +827,571 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="303.02807" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="302.997018" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 66.682344 294.738091
-L 507.6 294.738091
+      <path d="M 66.682344 294.728216
+L 507.6 294.728216
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="294.738091" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="294.728216" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 66.682344 288.856257
-L 507.6 288.856257
+      <path d="M 66.682344 288.861407
+L 507.6 288.861407
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="288.856257" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="288.861407" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 66.682344 284.293952
-L 507.6 284.293952
+      <path d="M 66.682344 284.310757
+L 507.6 284.310757
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.293952" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.310757" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 66.682344 280.566278
-L 507.6 280.566278
+      <path d="M 66.682344 280.592605
+L 507.6 280.592605
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="280.566278" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="280.592605" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 66.682344 277.414574
-L 507.6 277.414574
+      <path d="M 66.682344 277.448952
+L 507.6 277.448952
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="277.414574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="277.448952" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 66.682344 274.684444
-L 507.6 274.684444
+      <path d="M 66.682344 274.725796
+L 507.6 274.725796
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="274.684444" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="274.725796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 66.682344 272.276299
-L 507.6 272.276299
+      <path d="M 66.682344 272.323802
+L 507.6 272.323802
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="272.276299" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="272.323802" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 66.682344 255.950326
-L 507.6 255.950326
+      <path d="M 66.682344 256.039534
+L 507.6 256.039534
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="255.950326" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="256.039534" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 66.682344 247.660347
-L 507.6 247.660347
+      <path d="M 66.682344 247.770732
+L 507.6 247.770732
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="247.660347" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="247.770732" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 66.682344 241.778513
-L 507.6 241.778513
+      <path d="M 66.682344 241.903923
+L 507.6 241.903923
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="241.778513" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="241.903923" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 66.682344 237.216209
-L 507.6 237.216209
+      <path d="M 66.682344 237.353273
+L 507.6 237.353273
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="237.216209" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="237.353273" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 66.682344 233.488534
-L 507.6 233.488534
+      <path d="M 66.682344 233.635121
+L 507.6 233.635121
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="233.488534" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="233.635121" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 66.682344 230.33683
-L 507.6 230.33683
+      <path d="M 66.682344 230.491468
+L 507.6 230.491468
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="230.33683" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="230.491468" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 66.682344 227.6067
-L 507.6 227.6067
+      <path d="M 66.682344 227.768312
+L 507.6 227.768312
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="227.6067" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="227.768312" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 66.682344 225.198555
-L 507.6 225.198555
+      <path d="M 66.682344 225.366318
+L 507.6 225.366318
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="225.198555" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="225.366318" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 66.682344 208.872583
-L 507.6 208.872583
+      <path d="M 66.682344 209.082051
+L 507.6 209.082051
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="208.872583" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="209.082051" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 66.682344 200.582603
-L 507.6 200.582603
+      <path d="M 66.682344 200.813248
+L 507.6 200.813248
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="200.582603" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="200.813248" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 66.682344 194.70077
-L 507.6 194.70077
+      <path d="M 66.682344 194.946439
+L 507.6 194.946439
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="194.70077" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="194.946439" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 66.682344 190.138465
-L 507.6 190.138465
+      <path d="M 66.682344 190.395789
+L 507.6 190.395789
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="190.138465" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="190.395789" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_67">
-      <path d="M 66.682344 186.41079
-L 507.6 186.41079
+      <path d="M 66.682344 186.677637
+L 507.6 186.677637
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="186.41079" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="186.677637" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_69">
-      <path d="M 66.682344 183.259087
-L 507.6 183.259087
+      <path d="M 66.682344 183.533984
+L 507.6 183.533984
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="183.259087" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="183.533984" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_71">
-      <path d="M 66.682344 180.528957
-L 507.6 180.528957
+      <path d="M 66.682344 180.810828
+L 507.6 180.810828
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="180.528957" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="180.810828" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_73">
-      <path d="M 66.682344 178.120811
-L 507.6 178.120811
+      <path d="M 66.682344 178.408834
+L 507.6 178.408834
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="178.120811" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="178.408834" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_75">
-      <path d="M 66.682344 161.794839
-L 507.6 161.794839
+      <path d="M 66.682344 162.124567
+L 507.6 162.124567
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="161.794839" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="162.124567" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_77">
-      <path d="M 66.682344 153.50486
-L 507.6 153.50486
+      <path d="M 66.682344 153.855764
+L 507.6 153.855764
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="153.50486" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="153.855764" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_79">
-      <path d="M 66.682344 147.623026
-L 507.6 147.623026
+      <path d="M 66.682344 147.988956
+L 507.6 147.988956
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_80">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="147.623026" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="147.988956" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_81">
-      <path d="M 66.682344 143.060721
-L 507.6 143.060721
+      <path d="M 66.682344 143.438305
+L 507.6 143.438305
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_82">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="143.060721" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="143.438305" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_83">
-      <path d="M 66.682344 139.333047
-L 507.6 139.333047
+      <path d="M 66.682344 139.720153
+L 507.6 139.720153
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_84">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="139.333047" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="139.720153" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_36">
      <g id="line2d_85">
-      <path d="M 66.682344 136.181343
-L 507.6 136.181343
+      <path d="M 66.682344 136.5765
+L 507.6 136.5765
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_86">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="136.181343" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="136.5765" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_37">
      <g id="line2d_87">
-      <path d="M 66.682344 133.451213
-L 507.6 133.451213
+      <path d="M 66.682344 133.853344
+L 507.6 133.853344
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_88">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="133.451213" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="133.853344" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_38">
      <g id="line2d_89">
-      <path d="M 66.682344 131.043067
-L 507.6 131.043067
+      <path d="M 66.682344 131.451351
+L 507.6 131.451351
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_90">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="131.043067" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="131.451351" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_39">
      <g id="line2d_91">
-      <path d="M 66.682344 114.717095
-L 507.6 114.717095
+      <path d="M 66.682344 115.167083
+L 507.6 115.167083
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_92">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="114.717095" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="115.167083" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_40">
      <g id="line2d_93">
-      <path d="M 66.682344 106.427116
-L 507.6 106.427116
+      <path d="M 66.682344 106.89828
+L 507.6 106.89828
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_94">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="106.427116" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="106.89828" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_41">
      <g id="line2d_95">
-      <path d="M 66.682344 100.545282
-L 507.6 100.545282
+      <path d="M 66.682344 101.031472
+L 507.6 101.031472
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_96">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="100.545282" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="101.031472" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_42">
      <g id="line2d_97">
-      <path d="M 66.682344 95.982977
-L 507.6 95.982977
+      <path d="M 66.682344 96.480821
+L 507.6 96.480821
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_98">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="95.982977" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="96.480821" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_43">
      <g id="line2d_99">
-      <path d="M 66.682344 92.255303
-L 507.6 92.255303
+      <path d="M 66.682344 92.762669
+L 507.6 92.762669
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_100">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="92.255303" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="92.762669" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_44">
      <g id="line2d_101">
-      <path d="M 66.682344 89.103599
-L 507.6 89.103599
+      <path d="M 66.682344 89.619016
+L 507.6 89.619016
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_102">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="89.103599" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="89.619016" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_45">
      <g id="line2d_103">
-      <path d="M 66.682344 86.373469
-L 507.6 86.373469
+      <path d="M 66.682344 86.895861
+L 507.6 86.895861
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_104">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="86.373469" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="86.895861" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_46">
      <g id="line2d_105">
-      <path d="M 66.682344 83.965324
-L 507.6 83.965324
+      <path d="M 66.682344 84.493867
+L 507.6 84.493867
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_106">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="83.965324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="84.493867" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_47">
      <g id="line2d_107">
-      <path d="M 66.682344 67.639351
-L 507.6 67.639351
+      <path d="M 66.682344 68.209599
+L 507.6 68.209599
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_108">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="67.639351" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="68.209599" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_48">
      <g id="line2d_109">
-      <path d="M 66.682344 59.349372
-L 507.6 59.349372
+      <path d="M 66.682344 59.940797
+L 507.6 59.940797
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_110">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="59.349372" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="59.940797" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_49">
      <g id="line2d_111">
-      <path d="M 66.682344 53.467538
-L 507.6 53.467538
+      <path d="M 66.682344 54.073988
+L 507.6 54.073988
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_112">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="53.467538" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="54.073988" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_50">
      <g id="line2d_113">
-      <path d="M 66.682344 48.905234
-L 507.6 48.905234
+      <path d="M 66.682344 49.523337
+L 507.6 49.523337
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_114">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="48.905234" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="49.523337" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_51">
      <g id="line2d_115">
-      <path d="M 66.682344 45.177559
-L 507.6 45.177559
+      <path d="M 66.682344 45.805185
+L 507.6 45.805185
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_116">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="45.177559" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="45.805185" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_52">
      <g id="line2d_117">
-      <path d="M 66.682344 42.025855
-L 507.6 42.025855
+      <path d="M 66.682344 42.661533
+L 507.6 42.661533
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_118">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="42.025855" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="42.661533" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_53">
      <g id="line2d_119">
-      <path d="M 66.682344 39.295725
-L 507.6 39.295725
+      <path d="M 66.682344 39.938377
+L 507.6 39.938377
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_120">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="39.295725" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="39.938377" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_54">
      <g id="line2d_121">
-      <path d="M 66.682344 36.88758
-L 507.6 36.88758
+      <path d="M 66.682344 37.536383
+L 507.6 37.536383
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_122">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="36.88758" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="37.536383" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1479,17 +1479,17 @@ z
     </g>
    </g>
    <g id="line2d_123">
-    <path d="M 86.724055 283.227205
-L 86.724055 278.670956
-L 99.654192 258.687584
-L 99.654192 258.540504
-L 99.654192 257.237277
-L 125.514465 225.229861
-L 125.514465 225.174353
-L 125.514465 223.75202
-L 177.235011 137.664422
-L 177.235011 136.911875
-L 177.235011 135.890956
+    <path d="M 86.724055 285.343495
+L 86.724055 279.827761
+L 99.654192 261.528242
+L 99.654192 260.826841
+L 99.654192 260.346795
+L 125.514465 227.878478
+L 125.514465 226.239739
+L 125.514465 226.176099
+L 177.235011 138.162491
+L 177.235011 137.222589
+L 177.235011 136.410418
 L 280.676104 38.765348
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
@@ -1506,36 +1506,36 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="283.227205" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="278.670956" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.654192" y="258.687584" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.654192" y="258.540504" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.654192" y="257.237277" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="125.514465" y="225.229861" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="125.514465" y="225.174353" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="125.514465" y="223.75202" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="177.235011" y="137.664422" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="177.235011" y="136.911875" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="177.235011" y="135.890956" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="285.343495" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="279.827761" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.654192" y="261.528242" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.654192" y="260.826841" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.654192" y="260.346795" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="125.514465" y="227.878478" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="125.514465" y="226.239739" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="125.514465" y="226.176099" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="177.235011" y="138.162491" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="177.235011" y="137.222589" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="177.235011" y="136.410418" style="fill: #1f77b4; stroke: #1f77b4"/>
      <use xlink:href="#md73ba6276e" x="280.676104" y="38.765348" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_124">
     <path d="M 86.724055 290.872308
-L 86.724055 289.901751
-L 99.654192 284.072301
-L 99.654192 283.033673
-L 99.654192 276.745957
-L 125.514465 254.592147
-L 125.514465 254.521387
-L 125.514465 252.018452
-L 177.235011 224.020847
-L 177.235011 223.80827
-L 177.235011 220.385738
-L 280.676104 190.655943
-L 280.676104 190.548242
-L 280.676104 190.084221
-L 487.558288 150.055258
+L 86.724055 289.904231
+L 99.654192 284.089672
+L 99.654192 283.053697
+L 99.654192 276.782042
+L 125.514465 254.684824
+L 125.514465 254.614245
+L 125.514465 252.117704
+L 177.235011 224.191619
+L 177.235011 223.979585
+L 177.235011 220.565795
+L 280.676104 190.911946
+L 280.676104 190.804519
+L 280.676104 190.341684
+L 487.558288 150.414975
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #9467bd; stroke-linecap: square"/>
     <defs>
      <path id="meef3cfac8d" d="M 0 -2
@@ -1546,38 +1546,38 @@ z
     </defs>
     <g clip-path="url(#p6c2be49786)">
      <use xlink:href="#meef3cfac8d" x="86.724055" y="290.872308" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="86.724055" y="289.901751" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="99.654192" y="284.072301" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="99.654192" y="283.033673" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="99.654192" y="276.745957" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="125.514465" y="254.592147" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="125.514465" y="254.521387" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="125.514465" y="252.018452" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="177.235011" y="224.020847" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="177.235011" y="223.80827" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="177.235011" y="220.385738" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="280.676104" y="190.655943" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="280.676104" y="190.548242" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="280.676104" y="190.084221" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="487.558288" y="150.055258" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="86.724055" y="289.904231" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="99.654192" y="284.089672" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="99.654192" y="283.053697" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="99.654192" y="276.782042" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="125.514465" y="254.684824" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="125.514465" y="254.614245" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="125.514465" y="252.117704" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="177.235011" y="224.191619" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="177.235011" y="223.979585" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="177.235011" y="220.565795" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="280.676104" y="190.911946" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="280.676104" y="190.804519" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="280.676104" y="190.341684" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="487.558288" y="150.414975" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_125">
-    <path d="M 86.724055 275.179552
-L 86.724055 273.218409
-L 99.654192 259.696369
-L 99.654192 259.445835
-L 99.654192 253.355212
-L 125.514465 240.58963
-L 125.514465 240.228676
-L 125.514465 234.176032
-L 177.235011 205.444257
-L 177.235011 205.140743
-L 177.235011 201.265366
-L 280.676104 173.457725
-L 280.676104 173.25898
-L 280.676104 169.943083
-L 487.558288 129.95348
+    <path d="M 86.724055 275.219639
+L 86.724055 273.263505
+L 99.654192 259.776008
+L 99.654192 259.526114
+L 99.654192 253.451049
+L 125.514465 240.718077
+L 125.514465 240.358045
+L 125.514465 234.320863
+L 177.235011 205.662483
+L 177.235011 205.359744
+L 177.235011 201.494266
+L 280.676104 173.75766
+L 280.676104 173.559422
+L 280.676104 170.251996
+L 487.558288 130.364546
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #8c564b; stroke-linecap: square"/>
     <defs>
      <path id="m975a81c4ea" d="M -0 2
@@ -1587,39 +1587,39 @@ z
 " style="stroke: #8c564b; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="275.179552" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="273.218409" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="99.654192" y="259.696369" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="99.654192" y="259.445835" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="99.654192" y="253.355212" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="125.514465" y="240.58963" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="125.514465" y="240.228676" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="125.514465" y="234.176032" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="177.235011" y="205.444257" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="177.235011" y="205.140743" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="177.235011" y="201.265366" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="280.676104" y="173.457725" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="280.676104" y="173.25898" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="280.676104" y="169.943083" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="487.558288" y="129.95348" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="275.219639" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="273.263505" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="99.654192" y="259.776008" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="99.654192" y="259.526114" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="99.654192" y="253.451049" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="125.514465" y="240.718077" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="125.514465" y="240.358045" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="125.514465" y="234.320863" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="177.235011" y="205.662483" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="177.235011" y="205.359744" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="177.235011" y="201.494266" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="280.676104" y="173.75766" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="280.676104" y="173.559422" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="280.676104" y="170.251996" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="487.558288" y="130.364546" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
-    <path d="M 86.724055 289.575674
-L 86.724055 287.740761
-L 99.654192 279.502636
-L 99.654192 278.106705
-L 99.654192 273.744423
-L 125.514465 262.85493
-L 125.514465 262.248277
-L 125.514465 255.465028
-L 177.235011 225.12875
-L 177.235011 224.419919
-L 177.235011 221.972176
-L 280.676104 191.814515
-L 280.676104 191.398673
-L 280.676104 187.598646
-L 487.558288 145.628967
+    <path d="M 86.724055 289.578986
+L 86.724055 287.748761
+L 99.654192 279.531679
+L 99.654192 278.139314
+L 99.654192 273.788176
+L 125.514465 262.9265
+L 125.514465 262.321397
+L 125.514465 255.555476
+L 177.235011 225.296692
+L 177.235011 224.589671
+L 177.235011 222.148181
+L 280.676104 192.067558
+L 280.676104 191.652778
+L 280.676104 187.862458
+L 487.558288 145.999991
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #e377c2; stroke-linecap: square"/>
     <defs>
      <path id="mbe61f33afa" d="M -0.666667 2
@@ -1638,35 +1638,35 @@ z
 " style="stroke: #e377c2; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="289.575674" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="287.740761" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="99.654192" y="279.502636" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="99.654192" y="278.106705" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="99.654192" y="273.744423" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="125.514465" y="262.85493" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="125.514465" y="262.248277" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="125.514465" y="255.465028" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="177.235011" y="225.12875" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="177.235011" y="224.419919" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="177.235011" y="221.972176" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="280.676104" y="191.814515" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="280.676104" y="191.398673" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="280.676104" y="187.598646" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="487.558288" y="145.628967" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="289.578986" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="287.748761" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="99.654192" y="279.531679" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="99.654192" y="278.139314" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="99.654192" y="273.788176" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="125.514465" y="262.9265" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="125.514465" y="262.321397" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="125.514465" y="255.555476" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="177.235011" y="225.296692" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="177.235011" y="224.589671" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="177.235011" y="222.148181" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="280.676104" y="192.067558" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="280.676104" y="191.652778" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="280.676104" y="187.862458" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="487.558288" y="145.999991" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_127">
-    <path d="M 86.724055 278.705149
-L 86.724055 266.648885
-L 99.654192 248.971373
-L 99.654192 248.4959
-L 99.654192 241.97223
-L 125.514465 219.386645
-L 125.514465 219.131254
-L 125.514465 218.759605
-L 177.235011 168.068009
-L 177.235011 167.930633
-L 177.235011 159.286828
+    <path d="M 86.724055 278.73623
+L 86.724055 266.710764
+L 99.654192 249.078408
+L 99.654192 248.604151
+L 99.654192 242.097145
+L 125.514465 219.569255
+L 125.514465 219.314517
+L 125.514465 218.943817
+L 177.235011 168.381712
+L 177.235011 168.244687
+L 177.235011 159.622962
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
     <defs>
      <path id="m579b7dcafa" d="M 0 -2
@@ -1683,28 +1683,28 @@ z
 " style="stroke: #ff7f0e; stroke-linejoin: bevel"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#m579b7dcafa" x="86.724055" y="278.705149" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="86.724055" y="266.648885" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="99.654192" y="248.971373" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="99.654192" y="248.4959" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="99.654192" y="241.97223" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="125.514465" y="219.386645" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="125.514465" y="219.131254" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="125.514465" y="218.759605" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="177.235011" y="168.068009" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="177.235011" y="167.930633" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="177.235011" y="159.286828" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="86.724055" y="278.73623" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="86.724055" y="266.710764" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="99.654192" y="249.078408" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="99.654192" y="248.604151" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="99.654192" y="242.097145" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="125.514465" y="219.569255" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="125.514465" y="219.314517" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="125.514465" y="218.943817" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="177.235011" y="168.381712" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="177.235011" y="168.244687" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="177.235011" y="159.622962" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_128">
-    <path d="M 86.724055 259.128831
-L 86.724055 252.39177
-L 99.654192 180.449611
-L 99.654192 180.147636
-L 99.654192 178.897085
-L 125.514465 81.005311
-L 125.514465 74.650303
-L 125.514465 73.305469
+    <path d="M 86.724055 259.20992
+L 86.724055 252.490068
+L 99.654192 180.731685
+L 99.654192 180.430482
+L 99.654192 179.183125
+L 125.514465 81.541415
+L 125.514465 75.202641
+L 125.514465 73.861243
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #bcbd22; stroke-linecap: square"/>
     <defs>
      <path id="m6a669b47a0" d="M 0 -2
@@ -1717,14 +1717,14 @@ z
 " style="stroke: #bcbd22; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#m6a669b47a0" x="86.724055" y="259.128831" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="86.724055" y="252.39177" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="99.654192" y="180.449611" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="99.654192" y="180.147636" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="99.654192" y="178.897085" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="125.514465" y="81.005311" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="125.514465" y="74.650303" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="125.514465" y="73.305469" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="86.724055" y="259.20992" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="86.724055" y="252.490068" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="99.654192" y="180.731685" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="99.654192" y="180.430482" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="99.654192" y="179.183125" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="125.514465" y="81.541415" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="125.514465" y="75.202641" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="125.514465" y="73.861243" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -2327,7 +2327,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2419,16 +2419,6 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1a" d="M 525 4666
-L 3525 4666
-L 3525 4397
-L 1831 0
-L 1172 0
-L 2766 4134
-L 525 4134
-L 525 4666
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2476,7 +2466,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-swinnerton-dyer.svg
+++ b/reports/figures/hexbz-runtime-degree-swinnerton-dyer.svg
@@ -632,8 +632,8 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 66.682344 270.175146
-L 507.6 270.175146
+      <path d="M 66.682344 270.424575
+L 507.6 270.424575
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
@@ -643,12 +643,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="270.175146" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="270.424575" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 100us -->
-      <g transform="translate(29.047969 273.973974) scale(0.1 -0.1)">
+      <g transform="translate(29.047969 274.223403) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-58" d="M 544 1381
 L 544 3500
@@ -714,18 +714,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 66.682344 223.217662
-L 507.6 223.217662
+      <path d="M 66.682344 224.032995
+L 507.6 224.032995
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="223.217662" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="224.032995" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 1ms -->
-      <g transform="translate(38.369844 227.01649) scale(0.1 -0.1)">
+      <g transform="translate(38.369844 227.831823) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-50" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(161.03125 0)"/>
@@ -734,18 +734,18 @@ L 507.6 223.217662
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 66.682344 176.260178
-L 507.6 176.260178
+      <path d="M 66.682344 177.641414
+L 507.6 177.641414
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="176.260178" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="177.641414" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 10ms -->
-      <g transform="translate(32.007344 180.059006) scale(0.1 -0.1)">
+      <g transform="translate(32.007344 181.440242) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-50" transform="translate(127.25 0)"/>
@@ -755,18 +755,18 @@ L 507.6 176.260178
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 66.682344 129.302694
-L 507.6 129.302694
+      <path d="M 66.682344 131.249833
+L 507.6 131.249833
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="129.302694" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="131.249833" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 100ms -->
-      <g transform="translate(25.644844 133.101522) scale(0.1 -0.1)">
+      <g transform="translate(25.644844 135.048661) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
@@ -777,18 +777,18 @@ L 507.6 129.302694
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 66.682344 82.34521
-L 507.6 82.34521
+      <path d="M 66.682344 84.858252
+L 507.6 84.858252
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="82.34521" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="84.858252" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1s -->
-      <g transform="translate(48.110469 86.144038) scale(0.1 -0.1)">
+      <g transform="translate(48.110469 88.657081) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(63.625 0)"/>
       </g>
@@ -796,18 +796,18 @@ L 507.6 82.34521
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 66.682344 35.387726
-L 507.6 35.387726
+      <path d="M 66.682344 38.466672
+L 507.6 38.466672
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mc19e836183" x="66.682344" y="35.387726" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc19e836183" x="66.682344" y="38.466672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 10s -->
-      <g transform="translate(41.747969 39.186554) scale(0.1 -0.1)">
+      <g transform="translate(41.747969 42.2655) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-14"/>
        <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
        <use xlink:href="#DejaVuSans-56" transform="translate(127.25 0)"/>
@@ -816,8 +816,8 @@ L 507.6 35.387726
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 66.682344 302.997018
-L 507.6 302.997018
+      <path d="M 66.682344 302.850899
+L 507.6 302.850899
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
@@ -827,571 +827,571 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="302.997018" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="302.850899" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 66.682344 294.728216
-L 507.6 294.728216
+      <path d="M 66.682344 294.681747
+L 507.6 294.681747
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="294.728216" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="294.681747" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 66.682344 288.861407
-L 507.6 288.861407
+      <path d="M 66.682344 288.885641
+L 507.6 288.885641
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="288.861407" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="288.885641" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 66.682344 284.310757
-L 507.6 284.310757
+      <path d="M 66.682344 284.389833
+L 507.6 284.389833
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.310757" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="284.389833" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 66.682344 280.592605
-L 507.6 280.592605
+      <path d="M 66.682344 280.716489
+L 507.6 280.716489
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="280.592605" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="280.716489" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 66.682344 277.448952
-L 507.6 277.448952
+      <path d="M 66.682344 277.610722
+L 507.6 277.610722
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="277.448952" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="277.610722" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 66.682344 274.725796
-L 507.6 274.725796
+      <path d="M 66.682344 274.920384
+L 507.6 274.920384
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="274.725796" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="274.920384" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 66.682344 272.323802
-L 507.6 272.323802
+      <path d="M 66.682344 272.547338
+L 507.6 272.547338
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="272.323802" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="272.547338" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 66.682344 256.039534
-L 507.6 256.039534
+      <path d="M 66.682344 256.459318
+L 507.6 256.459318
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="256.039534" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="256.459318" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 66.682344 247.770732
-L 507.6 247.770732
+      <path d="M 66.682344 248.290166
+L 507.6 248.290166
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="247.770732" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="248.290166" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 66.682344 241.903923
-L 507.6 241.903923
+      <path d="M 66.682344 242.494061
+L 507.6 242.494061
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="241.903923" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="242.494061" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 66.682344 237.353273
-L 507.6 237.353273
+      <path d="M 66.682344 237.998252
+L 507.6 237.998252
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="237.353273" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="237.998252" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 66.682344 233.635121
-L 507.6 233.635121
+      <path d="M 66.682344 234.324909
+L 507.6 234.324909
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="233.635121" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="234.324909" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 66.682344 230.491468
-L 507.6 230.491468
+      <path d="M 66.682344 231.219141
+L 507.6 231.219141
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="230.491468" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="231.219141" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 66.682344 227.768312
-L 507.6 227.768312
+      <path d="M 66.682344 228.528803
+L 507.6 228.528803
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="227.768312" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="228.528803" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 66.682344 225.366318
-L 507.6 225.366318
+      <path d="M 66.682344 226.155757
+L 507.6 226.155757
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="225.366318" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="226.155757" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 66.682344 209.082051
-L 507.6 209.082051
+      <path d="M 66.682344 210.067737
+L 507.6 210.067737
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="209.082051" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="210.067737" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 66.682344 200.813248
-L 507.6 200.813248
+      <path d="M 66.682344 201.898585
+L 507.6 201.898585
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="200.813248" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="201.898585" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 66.682344 194.946439
-L 507.6 194.946439
+      <path d="M 66.682344 196.10248
+L 507.6 196.10248
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="194.946439" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="196.10248" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 66.682344 190.395789
-L 507.6 190.395789
+      <path d="M 66.682344 191.606671
+L 507.6 191.606671
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="190.395789" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="191.606671" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_67">
-      <path d="M 66.682344 186.677637
-L 507.6 186.677637
+      <path d="M 66.682344 187.933328
+L 507.6 187.933328
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="186.677637" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="187.933328" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_69">
-      <path d="M 66.682344 183.533984
-L 507.6 183.533984
+      <path d="M 66.682344 184.827561
+L 507.6 184.827561
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="183.533984" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="184.827561" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_71">
-      <path d="M 66.682344 180.810828
-L 507.6 180.810828
+      <path d="M 66.682344 182.137223
+L 507.6 182.137223
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="180.810828" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="182.137223" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_73">
-      <path d="M 66.682344 178.408834
-L 507.6 178.408834
+      <path d="M 66.682344 179.764176
+L 507.6 179.764176
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="178.408834" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="179.764176" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_75">
-      <path d="M 66.682344 162.124567
-L 507.6 162.124567
+      <path d="M 66.682344 163.676157
+L 507.6 163.676157
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="162.124567" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="163.676157" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_77">
-      <path d="M 66.682344 153.855764
-L 507.6 153.855764
+      <path d="M 66.682344 155.507005
+L 507.6 155.507005
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="153.855764" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="155.507005" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_79">
-      <path d="M 66.682344 147.988956
-L 507.6 147.988956
+      <path d="M 66.682344 149.710899
+L 507.6 149.710899
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_80">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="147.988956" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="149.710899" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_81">
-      <path d="M 66.682344 143.438305
-L 507.6 143.438305
+      <path d="M 66.682344 145.21509
+L 507.6 145.21509
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_82">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="143.438305" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="145.21509" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_83">
-      <path d="M 66.682344 139.720153
-L 507.6 139.720153
+      <path d="M 66.682344 141.541747
+L 507.6 141.541747
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_84">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="139.720153" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="141.541747" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_36">
      <g id="line2d_85">
-      <path d="M 66.682344 136.5765
-L 507.6 136.5765
+      <path d="M 66.682344 138.43598
+L 507.6 138.43598
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_86">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="136.5765" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="138.43598" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_37">
      <g id="line2d_87">
-      <path d="M 66.682344 133.853344
-L 507.6 133.853344
+      <path d="M 66.682344 135.745642
+L 507.6 135.745642
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_88">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="133.853344" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="135.745642" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_38">
      <g id="line2d_89">
-      <path d="M 66.682344 131.451351
-L 507.6 131.451351
+      <path d="M 66.682344 133.372595
+L 507.6 133.372595
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_90">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="131.451351" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="133.372595" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_39">
      <g id="line2d_91">
-      <path d="M 66.682344 115.167083
-L 507.6 115.167083
+      <path d="M 66.682344 117.284576
+L 507.6 117.284576
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_92">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="115.167083" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="117.284576" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_40">
      <g id="line2d_93">
-      <path d="M 66.682344 106.89828
-L 507.6 106.89828
+      <path d="M 66.682344 109.115424
+L 507.6 109.115424
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_94">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="106.89828" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="109.115424" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_41">
      <g id="line2d_95">
-      <path d="M 66.682344 101.031472
-L 507.6 101.031472
+      <path d="M 66.682344 103.319318
+L 507.6 103.319318
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_96">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="101.031472" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="103.319318" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_42">
      <g id="line2d_97">
-      <path d="M 66.682344 96.480821
-L 507.6 96.480821
+      <path d="M 66.682344 98.82351
+L 507.6 98.82351
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_98">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="96.480821" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="98.82351" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_43">
      <g id="line2d_99">
-      <path d="M 66.682344 92.762669
-L 507.6 92.762669
+      <path d="M 66.682344 95.150167
+L 507.6 95.150167
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_100">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="92.762669" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="95.150167" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_44">
      <g id="line2d_101">
-      <path d="M 66.682344 89.619016
-L 507.6 89.619016
+      <path d="M 66.682344 92.044399
+L 507.6 92.044399
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_102">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="89.619016" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="92.044399" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_45">
      <g id="line2d_103">
-      <path d="M 66.682344 86.895861
-L 507.6 86.895861
+      <path d="M 66.682344 89.354061
+L 507.6 89.354061
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_104">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="86.895861" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="89.354061" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_46">
      <g id="line2d_105">
-      <path d="M 66.682344 84.493867
-L 507.6 84.493867
+      <path d="M 66.682344 86.981015
+L 507.6 86.981015
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_106">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="84.493867" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="86.981015" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_47">
      <g id="line2d_107">
-      <path d="M 66.682344 68.209599
-L 507.6 68.209599
+      <path d="M 66.682344 70.892995
+L 507.6 70.892995
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_108">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="68.209599" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="70.892995" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_48">
      <g id="line2d_109">
-      <path d="M 66.682344 59.940797
-L 507.6 59.940797
+      <path d="M 66.682344 62.723843
+L 507.6 62.723843
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_110">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="59.940797" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="62.723843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_49">
      <g id="line2d_111">
-      <path d="M 66.682344 54.073988
-L 507.6 54.073988
+      <path d="M 66.682344 56.927738
+L 507.6 56.927738
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_112">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="54.073988" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="56.927738" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_50">
      <g id="line2d_113">
-      <path d="M 66.682344 49.523337
-L 507.6 49.523337
+      <path d="M 66.682344 52.431929
+L 507.6 52.431929
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_114">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="49.523337" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="52.431929" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_51">
      <g id="line2d_115">
-      <path d="M 66.682344 45.805185
-L 507.6 45.805185
+      <path d="M 66.682344 48.758586
+L 507.6 48.758586
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_116">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="45.805185" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="48.758586" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_52">
      <g id="line2d_117">
-      <path d="M 66.682344 42.661533
-L 507.6 42.661533
+      <path d="M 66.682344 45.652819
+L 507.6 45.652819
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_118">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="42.661533" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="45.652819" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_53">
      <g id="line2d_119">
-      <path d="M 66.682344 39.938377
-L 507.6 39.938377
+      <path d="M 66.682344 42.96248
+L 507.6 42.96248
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_120">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="39.938377" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="42.96248" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_54">
      <g id="line2d_121">
-      <path d="M 66.682344 37.536383
-L 507.6 37.536383
+      <path d="M 66.682344 40.589434
+L 507.6 40.589434
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
      </g>
      <g id="line2d_122">
       <g>
-       <use xlink:href="#ma6e5feb59b" x="66.682344" y="37.536383" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma6e5feb59b" x="66.682344" y="40.589434" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1479,17 +1479,17 @@ z
     </g>
    </g>
    <g id="line2d_123">
-    <path d="M 86.724055 285.343495
-L 86.724055 279.827761
-L 99.654192 261.528242
-L 99.654192 260.826841
-L 99.654192 260.346795
-L 125.514465 227.878478
-L 125.514465 226.239739
-L 125.514465 226.176099
-L 177.235011 138.162491
-L 177.235011 137.222589
-L 177.235011 136.410418
+    <path d="M 86.724055 287.198409
+L 86.724055 279.761326
+L 99.654192 261.721399
+L 99.654192 261.346364
+L 99.654192 260.354209
+L 125.514465 228.943499
+L 125.514465 227.441684
+L 125.514465 227.254952
+L 177.235011 139.965506
+L 177.235011 139.061447
+L 177.235011 138.292742
 L 280.676104 38.765348
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
@@ -1506,36 +1506,36 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="285.343495" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="86.724055" y="279.827761" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.654192" y="261.528242" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.654192" y="260.826841" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="99.654192" y="260.346795" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="125.514465" y="227.878478" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="125.514465" y="226.239739" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="125.514465" y="226.176099" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="177.235011" y="138.162491" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="177.235011" y="137.222589" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="177.235011" y="136.410418" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="287.198409" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="279.761326" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.654192" y="261.721399" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.654192" y="261.346364" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="99.654192" y="260.354209" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="125.514465" y="228.943499" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="125.514465" y="227.441684" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="125.514465" y="227.254952" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="177.235011" y="139.965506" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="177.235011" y="139.061447" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="177.235011" y="138.292742" style="fill: #1f77b4; stroke: #1f77b4"/>
      <use xlink:href="#md73ba6276e" x="280.676104" y="38.765348" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_124">
     <path d="M 86.724055 290.872308
-L 86.724055 289.904231
-L 99.654192 284.089672
-L 99.654192 283.053697
-L 99.654192 276.782042
-L 125.514465 254.684824
-L 125.514465 254.614245
-L 125.514465 252.117704
-L 177.235011 224.191619
-L 177.235011 223.979585
-L 177.235011 220.565795
-L 280.676104 190.911946
-L 280.676104 190.804519
-L 280.676104 190.341684
-L 487.558288 150.414975
+L 86.724055 289.915897
+L 99.654192 284.171412
+L 99.654192 283.147922
+L 99.654192 276.95185
+L 125.514465 255.120934
+L 125.514465 255.051206
+L 125.514465 252.584751
+L 177.235011 224.995214
+L 177.235011 224.785736
+L 177.235011 221.413087
+L 280.676104 192.116607
+L 280.676104 192.010476
+L 280.676104 191.553218
+L 487.558288 152.107682
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #9467bd; stroke-linecap: square"/>
     <defs>
      <path id="meef3cfac8d" d="M 0 -2
@@ -1546,38 +1546,38 @@ z
     </defs>
     <g clip-path="url(#p6c2be49786)">
      <use xlink:href="#meef3cfac8d" x="86.724055" y="290.872308" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="86.724055" y="289.904231" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="99.654192" y="284.089672" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="99.654192" y="283.053697" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="99.654192" y="276.782042" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="125.514465" y="254.684824" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="125.514465" y="254.614245" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="125.514465" y="252.117704" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="177.235011" y="224.191619" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="177.235011" y="223.979585" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="177.235011" y="220.565795" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="280.676104" y="190.911946" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="280.676104" y="190.804519" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="280.676104" y="190.341684" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#meef3cfac8d" x="487.558288" y="150.414975" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="86.724055" y="289.915897" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="99.654192" y="284.171412" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="99.654192" y="283.147922" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="99.654192" y="276.95185" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="125.514465" y="255.120934" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="125.514465" y="255.051206" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="125.514465" y="252.584751" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="177.235011" y="224.995214" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="177.235011" y="224.785736" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="177.235011" y="221.413087" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="280.676104" y="192.116607" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="280.676104" y="192.010476" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="280.676104" y="191.553218" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#meef3cfac8d" x="487.558288" y="152.107682" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_125">
-    <path d="M 86.724055 275.219639
-L 86.724055 273.263505
-L 99.654192 259.776008
-L 99.654192 259.526114
-L 99.654192 253.451049
-L 125.514465 240.718077
-L 125.514465 240.358045
-L 125.514465 234.320863
-L 177.235011 205.662483
-L 177.235011 205.359744
-L 177.235011 201.494266
-L 280.676104 173.75766
-L 280.676104 173.559422
-L 280.676104 170.251996
-L 487.558288 130.364546
+    <path d="M 86.724055 275.408275
+L 86.724055 273.475716
+L 99.654192 260.150762
+L 99.654192 259.903879
+L 99.654192 253.902027
+L 125.514465 241.322505
+L 125.514465 240.966812
+L 125.514465 235.002387
+L 177.235011 206.68938
+L 177.235011 206.390289
+L 177.235011 202.571396
+L 280.676104 175.169055
+L 280.676104 174.973206
+L 280.676104 171.705639
+L 487.558288 132.298889
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #8c564b; stroke-linecap: square"/>
     <defs>
      <path id="m975a81c4ea" d="M -0 2
@@ -1587,39 +1587,39 @@ z
 " style="stroke: #8c564b; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="275.219639" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="86.724055" y="273.263505" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="99.654192" y="259.776008" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="99.654192" y="259.526114" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="99.654192" y="253.451049" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="125.514465" y="240.718077" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="125.514465" y="240.358045" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="125.514465" y="234.320863" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="177.235011" y="205.662483" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="177.235011" y="205.359744" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="177.235011" y="201.494266" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="280.676104" y="173.75766" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="280.676104" y="173.559422" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="280.676104" y="170.251996" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
-     <use xlink:href="#m975a81c4ea" x="487.558288" y="130.364546" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="275.408275" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="86.724055" y="273.475716" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="99.654192" y="260.150762" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="99.654192" y="259.903879" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="99.654192" y="253.902027" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="125.514465" y="241.322505" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="125.514465" y="240.966812" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="125.514465" y="235.002387" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="177.235011" y="206.68938" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="177.235011" y="206.390289" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="177.235011" y="202.571396" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="280.676104" y="175.169055" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="280.676104" y="174.973206" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="280.676104" y="171.705639" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#m975a81c4ea" x="487.558288" y="132.298889" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
-    <path d="M 86.724055 289.578986
-L 86.724055 287.748761
-L 99.654192 279.531679
-L 99.654192 278.139314
-L 99.654192 273.788176
-L 125.514465 262.9265
-L 125.514465 262.321397
-L 125.514465 255.555476
-L 177.235011 225.296692
-L 177.235011 224.589671
-L 177.235011 222.148181
-L 280.676104 192.067558
-L 280.676104 191.652778
-L 280.676104 187.862458
-L 487.558288 145.999991
+    <path d="M 86.724055 289.594572
+L 86.724055 287.786404
+L 99.654192 279.66835
+L 99.654192 278.292765
+L 99.654192 273.994064
+L 125.514465 263.263286
+L 125.514465 262.665475
+L 125.514465 255.981093
+L 177.235011 226.08697
+L 177.235011 225.388469
+L 177.235011 222.976403
+L 280.676104 193.258293
+L 280.676104 192.848512
+L 280.676104 189.10387
+L 487.558288 147.745904
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #e377c2; stroke-linecap: square"/>
     <defs>
      <path id="mbe61f33afa" d="M -0.666667 2
@@ -1638,35 +1638,35 @@ z
 " style="stroke: #e377c2; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="289.578986" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="86.724055" y="287.748761" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="99.654192" y="279.531679" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="99.654192" y="278.139314" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="99.654192" y="273.788176" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="125.514465" y="262.9265" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="125.514465" y="262.321397" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="125.514465" y="255.555476" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="177.235011" y="225.296692" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="177.235011" y="224.589671" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="177.235011" y="222.148181" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="280.676104" y="192.067558" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="280.676104" y="191.652778" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="280.676104" y="187.862458" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe61f33afa" x="487.558288" y="145.999991" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="289.594572" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="86.724055" y="287.786404" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="99.654192" y="279.66835" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="99.654192" y="278.292765" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="99.654192" y="273.994064" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="125.514465" y="263.263286" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="125.514465" y="262.665475" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="125.514465" y="255.981093" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="177.235011" y="226.08697" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="177.235011" y="225.388469" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="177.235011" y="222.976403" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="280.676104" y="193.258293" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="280.676104" y="192.848512" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="280.676104" y="189.10387" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
+     <use xlink:href="#mbe61f33afa" x="487.558288" y="147.745904" style="fill: #e377c2; stroke: #e377c2; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_127">
-    <path d="M 86.724055 278.73623
-L 86.724055 266.710764
-L 99.654192 249.078408
-L 99.654192 248.604151
-L 99.654192 242.097145
-L 125.514465 219.569255
-L 125.514465 219.314517
-L 125.514465 218.943817
-L 177.235011 168.381712
-L 177.235011 168.244687
-L 177.235011 159.622962
+    <path d="M 86.724055 278.882487
+L 86.724055 267.001944
+L 99.654192 249.582083
+L 99.654192 249.113541
+L 99.654192 242.684954
+L 125.514465 220.428556
+L 125.514465 220.176888
+L 125.514465 219.810655
+L 177.235011 169.857894
+L 177.235011 169.722521
+L 177.235011 161.2047
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #ff7f0e; stroke-linecap: square"/>
     <defs>
      <path id="m579b7dcafa" d="M 0 -2
@@ -1683,28 +1683,28 @@ z
 " style="stroke: #ff7f0e; stroke-linejoin: bevel"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#m579b7dcafa" x="86.724055" y="278.73623" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="86.724055" y="266.710764" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="99.654192" y="249.078408" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="99.654192" y="248.604151" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="99.654192" y="242.097145" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="125.514465" y="219.569255" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="125.514465" y="219.314517" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="125.514465" y="218.943817" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="177.235011" y="168.381712" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="177.235011" y="168.244687" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
-     <use xlink:href="#m579b7dcafa" x="177.235011" y="159.622962" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="86.724055" y="278.882487" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="86.724055" y="267.001944" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="99.654192" y="249.582083" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="99.654192" y="249.113541" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="99.654192" y="242.684954" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="125.514465" y="220.428556" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="125.514465" y="220.176888" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="125.514465" y="219.810655" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="177.235011" y="169.857894" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="177.235011" y="169.722521" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
+     <use xlink:href="#m579b7dcafa" x="177.235011" y="161.2047" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_128">
-    <path d="M 86.724055 259.20992
-L 86.724055 252.490068
-L 99.654192 180.731685
-L 99.654192 180.430482
-L 99.654192 179.183125
-L 125.514465 81.541415
-L 125.514465 75.202641
-L 125.514465 73.861243
+    <path d="M 86.724055 259.591496
+L 86.724055 252.952628
+L 99.654192 182.059033
+L 99.654192 181.76146
+L 99.654192 180.529135
+L 125.514465 84.064144
+L 125.514465 77.801761
+L 125.514465 76.476529
 " clip-path="url(#p6c2be49786)" style="fill: none; stroke: #bcbd22; stroke-linecap: square"/>
     <defs>
      <path id="m6a669b47a0" d="M 0 -2
@@ -1717,14 +1717,14 @@ z
 " style="stroke: #bcbd22; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p6c2be49786)">
-     <use xlink:href="#m6a669b47a0" x="86.724055" y="259.20992" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="86.724055" y="252.490068" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="99.654192" y="180.731685" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="99.654192" y="180.430482" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="99.654192" y="179.183125" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="125.514465" y="81.541415" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="125.514465" y="75.202641" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a669b47a0" x="125.514465" y="73.861243" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="86.724055" y="259.591496" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="86.724055" y="252.952628" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="99.654192" y="182.059033" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="99.654192" y="181.76146" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="99.654192" y="180.529135" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="125.514465" y="84.064144" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="125.514465" y="77.801761" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a669b47a0" x="125.514465" y="76.476529" style="fill: #bcbd22; stroke: #bcbd22; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -2327,7 +2327,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_23">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2419,6 +2419,36 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-1c" d="M 703 97
+L 703 672
+Q 941 559 1184 500
+Q 1428 441 1663 441
+Q 2288 441 2617 861
+Q 2947 1281 2994 2138
+Q 2813 1869 2534 1725
+Q 2256 1581 1919 1581
+Q 1219 1581 811 2004
+Q 403 2428 403 3163
+Q 403 3881 828 4315
+Q 1253 4750 1959 4750
+Q 2769 4750 3195 4129
+Q 3622 3509 3622 2328
+Q 3622 1225 3098 567
+Q 2575 -91 1691 -91
+Q 1453 -91 1209 -44
+Q 966 3 703 97
+z
+M 1959 2075
+Q 2384 2075 2632 2365
+Q 2881 2656 2881 3163
+Q 2881 3666 2632 3958
+Q 2384 4250 1959 4250
+Q 1534 4250 1286 3958
+Q 1038 3666 1038 3163
+Q 1038 2656 1286 2365
+Q 1534 2075 1959 2075
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-46"/>
     <use xlink:href="#DejaVuSans-58" transform="translate(54.984375 0)"/>
@@ -2466,7 +2496,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-wilkinson.svg
+++ b/reports/figures/hexbz-runtime-degree-wilkinson.svg
@@ -1298,21 +1298,21 @@ z
     </g>
    </g>
    <g id="line2d_99">
-    <path d="M 86.724055 268.940638
-L 102.140757 257.779565
-L 117.557458 247.203711
-L 132.974159 226.920919
-L 148.39086 219.494721
-L 163.807562 211.896748
-L 179.224263 204.240914
-L 194.640964 194.238215
-L 210.057666 187.388591
-L 240.891068 176.04722
-L 271.724471 161.802386
-L 302.557873 155.853936
-L 364.224678 143.919189
-L 425.891483 129.696505
-L 487.558288 122.275952
+    <path d="M 86.724055 270.144204
+L 102.140757 258.7683
+L 117.557458 248.574842
+L 132.974159 228.193643
+L 148.39086 221.283366
+L 163.807562 213.107204
+L 179.224263 205.728867
+L 194.640964 195.21992
+L 210.057666 188.378879
+L 240.891068 177.466087
+L 271.724471 162.311965
+L 302.557873 156.301418
+L 364.224678 144.32281
+L 425.891483 129.795268
+L 487.558288 122.455037
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1328,21 +1328,21 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="268.940638" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="102.140757" y="257.779565" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="247.203711" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="132.974159" y="226.920919" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="219.494721" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="163.807562" y="211.896748" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="204.240914" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="194.640964" y="194.238215" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="187.388591" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="176.04722" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="161.802386" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="155.853936" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="143.919189" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="425.891483" y="129.696505" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="122.275952" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="270.144204" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="102.140757" y="258.7683" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="248.574842" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="132.974159" y="228.193643" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="221.283366" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="163.807562" y="213.107204" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="205.728867" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="194.640964" y="195.21992" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="188.378879" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="177.466087" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="162.311965" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="156.301418" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="144.32281" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="425.891483" y="129.795268" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="122.455037" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_100">
@@ -2168,7 +2168,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_20">
-   <!-- cutoff 10.0s; source newest-per-system across 37 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2228,14 +2228,43 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1a" d="M 525 4666
-L 3525 4666
-L 3525 4397
-L 1831 0
-L 1172 0
-L 2766 4134
-L 525 4134
-L 525 4666
+     <path id="DejaVuSans-1b" d="M 2034 2216
+Q 1584 2216 1326 1975
+Q 1069 1734 1069 1313
+Q 1069 891 1326 650
+Q 1584 409 2034 409
+Q 2484 409 2743 651
+Q 3003 894 3003 1313
+Q 3003 1734 2745 1975
+Q 2488 2216 2034 2216
+z
+M 1403 2484
+Q 997 2584 770 2862
+Q 544 3141 544 3541
+Q 544 4100 942 4425
+Q 1341 4750 2034 4750
+Q 2731 4750 3128 4425
+Q 3525 4100 3525 3541
+Q 3525 3141 3298 2862
+Q 3072 2584 2669 2484
+Q 3125 2378 3379 2068
+Q 3634 1759 3634 1313
+Q 3634 634 3220 271
+Q 2806 -91 2034 -91
+Q 1263 -91 848 271
+Q 434 634 434 1313
+Q 434 1759 690 2068
+Q 947 2378 1403 2484
+z
+M 1172 3481
+Q 1172 3119 1398 2916
+Q 1625 2713 2034 2713
+Q 2441 2713 2670 2916
+Q 2900 3119 2900 3481
+Q 2900 3844 2670 4047
+Q 2441 4250 2034 4250
+Q 1625 4250 1398 4047
+Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
     </defs>
@@ -2285,7 +2314,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1a" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/figures/hexbz-runtime-degree-wilkinson.svg
+++ b/reports/figures/hexbz-runtime-degree-wilkinson.svg
@@ -1298,21 +1298,21 @@ z
     </g>
    </g>
    <g id="line2d_99">
-    <path d="M 86.724055 270.144204
-L 102.140757 258.7683
-L 117.557458 248.574842
-L 132.974159 228.193643
-L 148.39086 221.283366
-L 163.807562 213.107204
-L 179.224263 205.728867
-L 194.640964 195.21992
-L 210.057666 188.378879
-L 240.891068 177.466087
-L 271.724471 162.311965
-L 302.557873 156.301418
-L 364.224678 144.32281
-L 425.891483 129.795268
-L 487.558288 122.455037
+    <path d="M 86.724055 270.648349
+L 102.140757 257.0853
+L 117.557458 247.924456
+L 132.974159 227.176775
+L 148.39086 219.282369
+L 163.807562 211.448844
+L 179.224263 203.810518
+L 194.640964 194.422487
+L 210.057666 187.480356
+L 240.891068 176.490993
+L 271.724471 161.631127
+L 302.557873 155.581191
+L 364.224678 143.285332
+L 425.891483 128.917038
+L 487.558288 121.424048
 " clip-path="url(#pbb46c35cd8)" style="fill: none; stroke: #1f77b4; stroke-linecap: square"/>
     <defs>
      <path id="md73ba6276e" d="M 0 2
@@ -1328,21 +1328,21 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#pbb46c35cd8)">
-     <use xlink:href="#md73ba6276e" x="86.724055" y="270.144204" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="102.140757" y="258.7683" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="117.557458" y="248.574842" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="132.974159" y="228.193643" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="148.39086" y="221.283366" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="163.807562" y="213.107204" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="179.224263" y="205.728867" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="194.640964" y="195.21992" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="210.057666" y="188.378879" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="240.891068" y="177.466087" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="271.724471" y="162.311965" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="302.557873" y="156.301418" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="364.224678" y="144.32281" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="425.891483" y="129.795268" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#md73ba6276e" x="487.558288" y="122.455037" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="86.724055" y="270.648349" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="102.140757" y="257.0853" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="117.557458" y="247.924456" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="132.974159" y="227.176775" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="148.39086" y="219.282369" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="163.807562" y="211.448844" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="179.224263" y="203.810518" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="194.640964" y="194.422487" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="210.057666" y="187.480356" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="240.891068" y="176.490993" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="271.724471" y="161.631127" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="302.557873" y="155.581191" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="364.224678" y="143.285332" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="425.891483" y="128.917038" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#md73ba6276e" x="487.558288" y="121.424048" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_100">
@@ -2168,7 +2168,7 @@ L 89.882344 96.641875
    </g>
   </g>
   <g id="text_20">
-   <!-- cutoff 10.0s; source newest-per-system across 38 records; declines and timeouts count as unsolved -->
+   <!-- cutoff 10.0s; source newest-per-system across 39 records; declines and timeouts count as unsolved -->
    <g style="fill: #555555" transform="translate(84.008047 343.872) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-13ae" d="M 4531 4863
@@ -2228,43 +2228,34 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-1b" d="M 2034 2216
-Q 1584 2216 1326 1975
-Q 1069 1734 1069 1313
-Q 1069 891 1326 650
-Q 1584 409 2034 409
-Q 2484 409 2743 651
-Q 3003 894 3003 1313
-Q 3003 1734 2745 1975
-Q 2488 2216 2034 2216
+     <path id="DejaVuSans-1c" d="M 703 97
+L 703 672
+Q 941 559 1184 500
+Q 1428 441 1663 441
+Q 2288 441 2617 861
+Q 2947 1281 2994 2138
+Q 2813 1869 2534 1725
+Q 2256 1581 1919 1581
+Q 1219 1581 811 2004
+Q 403 2428 403 3163
+Q 403 3881 828 4315
+Q 1253 4750 1959 4750
+Q 2769 4750 3195 4129
+Q 3622 3509 3622 2328
+Q 3622 1225 3098 567
+Q 2575 -91 1691 -91
+Q 1453 -91 1209 -44
+Q 966 3 703 97
 z
-M 1403 2484
-Q 997 2584 770 2862
-Q 544 3141 544 3541
-Q 544 4100 942 4425
-Q 1341 4750 2034 4750
-Q 2731 4750 3128 4425
-Q 3525 4100 3525 3541
-Q 3525 3141 3298 2862
-Q 3072 2584 2669 2484
-Q 3125 2378 3379 2068
-Q 3634 1759 3634 1313
-Q 3634 634 3220 271
-Q 2806 -91 2034 -91
-Q 1263 -91 848 271
-Q 434 634 434 1313
-Q 434 1759 690 2068
-Q 947 2378 1403 2484
-z
-M 1172 3481
-Q 1172 3119 1398 2916
-Q 1625 2713 2034 2713
-Q 2441 2713 2670 2916
-Q 2900 3119 2900 3481
-Q 2900 3844 2670 4047
-Q 2441 4250 2034 4250
-Q 1625 4250 1398 4047
-Q 1172 3844 1172 3481
+M 1959 2075
+Q 2384 2075 2632 2365
+Q 2881 2656 2881 3163
+Q 2881 3666 2632 3958
+Q 2384 4250 1959 4250
+Q 1534 4250 1286 3958
+Q 1038 3666 1038 3163
+Q 1038 2656 1286 2365
+Q 1534 2075 1959 2075
 z
 " transform="scale(0.015625)"/>
     </defs>
@@ -2314,7 +2305,7 @@ z
     <use xlink:href="#DejaVuSans-56" transform="translate(2276.65625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2328.75 0)"/>
     <use xlink:href="#DejaVuSans-16" transform="translate(2360.53125 0)"/>
-    <use xlink:href="#DejaVuSans-1b" transform="translate(2424.15625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(2424.15625 0)"/>
     <use xlink:href="#DejaVuSans-3" transform="translate(2487.78125 0)"/>
     <use xlink:href="#DejaVuSans-55" transform="translate(2519.5625 0)"/>
     <use xlink:href="#DejaVuSans-48" transform="translate(2558.46875 0)"/>

--- a/reports/hexbz-packed-fp-matrix-integration.md
+++ b/reports/hexbz-packed-fp-matrix-integration.md
@@ -249,8 +249,18 @@ page put it (1.98x).
   selected prime, leaf count, subset cardinalities and returned factor degrees
   on **368 of 368** instances.
 - A fresh full Hex sweep over all 392 corpus instances, with the external
-  comparator records reused unchanged, and regenerated cactus and
-  runtime-by-degree figures.
+  comparator records reused unchanged, and all 25 cactus and
+  runtime-by-degree figures regenerated;
+  `scripts/plots/hexbz-cactus.py --check` passes byte for byte and
+  `scripts/bench/check_factor_sweep_freshness.py` passes.
+
+  The sweep solves **377 of 392** instances under the 10 s cutoff, unchanged
+  from the newest committed baseline (`17bd12950088`), in **19.519 s** of
+  solved-instance time against that baseline's 20.684 s. The corpus is
+  dominated by instances whose cost is not the modular kernel, so a 5.6%
+  total is the shape to expect from a change that moves four rows by 1.8x to
+  2.6x; the sweep is here as an anti-regression check across all 392, not as
+  the headline.
 
 ## Regeneration
 
@@ -259,7 +269,7 @@ lake build hexbz_factor_service
 
 taskset -c 0 python3 scripts/bench/factor_sweep.py \
   --systems hex-factor --cutoff 10 --no-early-terminate \
-  --output reports/bench-results/hexbz-factor-sweep-2c4c6e4f-hex-chungus2.json
+  --output reports/bench-results/hexbz-factor-sweep-433dba23-hex-chungus2.json
 
 python3 scripts/bench/factor_phase_profile.py \
   --no-counterfactual --no-scout \

--- a/reports/hexbz-packed-fp-matrix-integration.md
+++ b/reports/hexbz-packed-fp-matrix-integration.md
@@ -7,8 +7,8 @@ a `@[csimp]`-proved equality at the `fixedSpaceKernelVectors` boundary.
 
 The headline is the same span the prototype page priced, measured the same way
 by the same driver on the same host: `fixedSpaceKernelVectors` on
-`cyclo_phi385` goes from **327.823 ms to 53.886 ms, 6.08x**, and the whole
-factorization from 434.641 ms to 167.124 ms, **2.60x**. No row of the
+`cyclo_phi385` goes from **327.823 ms to 54.057 ms, 6.06x**, and the whole
+factorization from 434.641 ms to 165.854 ms, **2.62x**. No row of the
 representative set regresses, on either span, at any margin -- including the
 Wilkinson rows, whose fixed-space matrix is zero and which the prototype
 *slowed down* by 1.4x.
@@ -20,15 +20,15 @@ and is not a measurement artefact; [Where the remaining
 
 ## Revision and protocol
 
-- Source revision `2c4c6e4fa0378ee34cf6399a91c720b4e63cf84d` (clean worktree),
+- Source revision `a5e0ebe49399708a8286b8acb1c6a0877e9dc4c3` (clean worktree),
   Lean toolchain `leanprover/lean4:v4.33.0-rc1`.
 - Host `chungus2`, AMD EPYC 9455, Linux x86-64, 96 cores, measured 2026-08-03.
   The host was shared with other work throughout.
 - The driver pins itself to one idle logical CPU before spawning any service.
 - Baseline: `reports/bench-results/hexbz-phase-profile-0e1601a0-chungus2.json`,
   the record the prototype page reads, measured on the same host.
-- After: `reports/bench-results/hexbz-phase-profile-2c4c6e4f-chungus2.json`,
-  SHA-256 `1f595bed0ef0e5a67cc2b8246af8eb4f91d5769cc92bad4e0665185f1433ac59`.
+- After: `reports/bench-results/hexbz-phase-profile-a5e0ebe4-chungus2.json`,
+  SHA-256 `3618317b3bc7d8f34717d9826689eecfe372ce9cdb3902006ab48cfeefd68992`.
   `hexbz_factor_service` SHA-256
   `c22f80f3683e4e9c7b7c7432e6af80543e920aa9402b8cd37ea4686d3d6360c4`; corpus
   `bench/corpus/hexbz-factor-corpus.jsonl`, SHA-256
@@ -133,34 +133,36 @@ cascade.
 
 | instance | matrix | prime | kernel before | kernel after | gain | total before | total after | gain |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|
-| `sd5` | 32x32 | 29 | 1.821 ms | 1.339 ms | 1.36x | 75.594 ms | 69.402 ms | 1.09x |
-| `sd5_shift1` | 32x32 | 29 | 2.739 ms | 1.750 ms | 1.57x | 64.235 ms | 64.425 ms | 1.00x |
-| `sd5_shift2` | 32x32 | 29 | 2.739 ms | 1.762 ms | 1.55x | 68.231 ms | 67.697 ms | 1.01x |
-| `sd4_x_sd4shift1` | 32x32 | 29 | 2.706 ms | 1.771 ms | 1.53x | 19.094 ms | 18.172 ms | 1.05x |
-| `sd5_x_phi11` | 42x42 | 29 | 5.692 ms | 3.307 ms | 1.72x | 161.131 ms | 140.318 ms | 1.15x |
-| `xpow48_minus1` | 48x48 | 11 | 894.566 us | 618.196 us | 1.45x | 19.639 ms | 10.400 ms | 1.89x |
-| `xpow105_minus1` | 105x105 | 17 | 6.015 ms | 3.969 ms | 1.52x | 74.986 ms | 46.124 ms | 1.63x |
-| `xpow120_minus1` | 120x120 | 7 | 5.009 ms | 3.003 ms | 1.67x | 478.515 ms | 148.233 ms | 3.23x |
-| `cyclo_phi179` | 178x178 | 3 | 20.539 ms | 5.811 ms | 3.53x | 74.909 ms | 42.336 ms | 1.77x |
-| `cyclo_phi64_x_phi105` | 80x80 | 11 | 27.932 ms | 7.506 ms | 3.72x | 61.349 ms | 45.865 ms | 1.34x |
-| `cyclo_phi128_x_phi165` | 144x144 | 7 | 139.775 ms | 28.100 ms | 4.97x | 198.351 ms | 84.694 ms | 2.34x |
-| `cyclo_phi385` | 240x240 | 3 | 327.823 ms | 53.886 ms | 6.08x | 434.641 ms | 167.124 ms | 2.60x |
-| `wilkinson_40` | 40x40 | 47 | 297.862 us | 224.763 us | 1.33x | 13.451 ms | 13.518 ms | 1.00x |
-| `wilkinson_48` | 48x48 | 61 | 427.624 us | 318.171 us | 1.34x | 25.192 ms | 24.389 ms | 1.03x |
-| `wilkinson_56` | 56x56 | 67 | 661.561 us | 501.855 us | 1.32x | 34.180 ms | 32.686 ms | 1.05x |
-| `chebyshev_T24` (control) | 24x24 | 5 | 401.566 us | 170.353 us | 2.36x | 558.258 us | 441.454 us | 1.26x |
-| `chebyshev_U24` (control) | 24x24 | 3 | 334.365 us | 128.962 us | 2.59x | 711.415 us | 589.554 us | 1.21x |
-| `legendre_P30` (control) | 30x30 | 67 | 2.032 ms | 1.363 ms | 1.49x | 9.080 ms | 8.560 ms | 1.06x |
-| `legendre_P38` (control) | 38x38 | 79 | 4.244 ms | 2.712 ms | 1.57x | 4.792 ms | 3.820 ms | 1.25x |
-| `cyclo_phi17` (control) | 16x16 | 3 | 129.993 us | 50.605 us | 2.57x | 155.711 us | 104.535 us | 1.49x |
-| `cyclo_phi41` (control) | 40x40 | 3 | 643.014 us | 254.197 us | 2.53x | 2.825 ms | 1.979 ms | 1.43x |
-| `xpow24_minus1` (control) | 24x24 | 11 | 227.337 us | 165.265 us | 1.38x | 3.223 ms | 2.293 ms | 1.41x |
-| `randprod_10` (control) | 20x20 | 7 | 573.701 us | 232.915 us | 2.46x | 824.853 us | 640.029 us | 1.29x |
-| `randprod_21` (control) | 24x24 | 17 | 1.251 ms | 681.290 us | 1.84x | 1.748 ms | 1.402 ms | 1.25x |
+| `sd5` | 32x32 | 29 | 1.821 ms | 1.359 ms | 1.34x | 75.594 ms | 69.449 ms | 1.09x |
+| `sd5_shift1` | 32x32 | 29 | 2.739 ms | 1.788 ms | 1.53x | 64.235 ms | 64.594 ms | 0.99x |
+| `sd5_shift2` | 32x32 | 29 | 2.739 ms | 1.787 ms | 1.53x | 68.231 ms | 68.063 ms | 1.00x |
+| `sd4_x_sd4shift1` | 32x32 | 29 | 2.706 ms | 1.797 ms | 1.51x | 19.094 ms | 18.349 ms | 1.04x |
+| `sd5_x_phi11` | 42x42 | 29 | 5.692 ms | 3.298 ms | 1.73x | 161.131 ms | 142.532 ms | 1.13x |
+| `xpow48_minus1` | 48x48 | 11 | 894.566 us | 623.765 us | 1.43x | 19.639 ms | 10.494 ms | 1.87x |
+| `xpow105_minus1` | 105x105 | 17 | 6.015 ms | 4.072 ms | 1.48x | 74.986 ms | 46.066 ms | 1.63x |
+| `xpow120_minus1` | 120x120 | 7 | 5.009 ms | 3.048 ms | 1.64x | 478.515 ms | 147.886 ms | 3.24x |
+| `cyclo_phi179` | 178x178 | 3 | 20.539 ms | 5.771 ms | 3.56x | 74.909 ms | 42.780 ms | 1.75x |
+| `cyclo_phi64_x_phi105` | 80x80 | 11 | 27.932 ms | 7.670 ms | 3.64x | 61.349 ms | 46.616 ms | 1.32x |
+| `cyclo_phi128_x_phi165` | 144x144 | 7 | 139.775 ms | 28.512 ms | 4.90x | 198.351 ms | 84.919 ms | 2.34x |
+| `cyclo_phi385` | 240x240 | 3 | 327.823 ms | 54.057 ms | 6.06x | 434.641 ms | 165.854 ms | 2.62x |
+| `wilkinson_40` | 40x40 | 47 | 297.862 us | 224.202 us | 1.33x | 13.451 ms | 13.977 ms | 0.96x |
+| `wilkinson_48` | 48x48 | 61 | 427.624 us | 320.114 us | 1.34x | 25.192 ms | 25.217 ms | 1.00x |
+| `wilkinson_56` | 56x56 | 67 | 661.561 us | 507.522 us | 1.30x | 34.180 ms | 34.145 ms | 1.00x |
+| `chebyshev_T24` (control) | 24x24 | 5 | 401.566 us | 170.012 us | 2.36x | 558.258 us | 452.211 us | 1.23x |
+| `chebyshev_U24` (control) | 24x24 | 3 | 334.365 us | 129.172 us | 2.59x | 711.415 us | 588.492 us | 1.21x |
+| `legendre_P30` (control) | 30x30 | 67 | 2.032 ms | 1.356 ms | 1.50x | 9.080 ms | 8.592 ms | 1.06x |
+| `legendre_P38` (control) | 38x38 | 79 | 4.244 ms | 2.748 ms | 1.54x | 4.792 ms | 3.810 ms | 1.26x |
+| `cyclo_phi17` (control) | 16x16 | 3 | 129.993 us | 50.474 us | 2.58x | 155.711 us | 106.398 us | 1.46x |
+| `cyclo_phi41` (control) | 40x40 | 3 | 643.014 us | 253.887 us | 2.53x | 2.825 ms | 1.998 ms | 1.41x |
+| `xpow24_minus1` (control) | 24x24 | 11 | 227.337 us | 167.358 us | 1.36x | 3.223 ms | 2.340 ms | 1.38x |
+| `randprod_10` (control) | 20x20 | 7 | 573.701 us | 238.593 us | 2.40x | 824.853 us | 638.907 us | 1.29x |
+| `randprod_21` (control) | 24x24 | 17 | 1.251 ms | 687.299 us | 1.82x | 1.748 ms | 1.427 ms | 1.22x |
 
 **No regression above 5% on any row, on either span.** The largest end-to-end
-move against the implementation is `sd5_shift1` at 1.00x (64.235 ms to
-64.425 ms, 0.3%), well inside the run-to-run variance stated above.
+move against the implementation is `wilkinson_40` at 0.96x (13.451 ms to
+13.977 ms, 3.9%) -- a row whose *kernel* improves 1.33x, on 224 us of a 14 ms
+factorization, so the move is elsewhere and inside the run-to-run variance
+stated above.
 
 `xpow120_minus1`'s 3.23x is the one number here that its kernel gain (1.67x on
 5 ms of a 478 ms factorization) cannot explain. That row's cost is
@@ -172,10 +174,10 @@ Allocation, on the same span:
 
 | instance | small allocs before | after | factor |
 |---|---:|---:|---:|
-| `cyclo_phi385` | 18,309,485 | 661,844 | 28x |
-| `cyclo_phi128_x_phi165` | 8,451,415 | 723,728 | 12x |
-| `cyclo_phi64_x_phi105` | 1,761,785 | 347,380 | 5x |
 | `cyclo_phi179` | 1,290,156 | 275,077 | 5x |
+| `cyclo_phi64_x_phi105` | 1,761,785 | 347,380 | 5x |
+| `cyclo_phi128_x_phi165` | 8,451,415 | 723,728 | 12x |
+| `cyclo_phi385` | 18,309,485 | 661,844 | 28x |
 
 ## Where the remaining 2.6x is
 
@@ -188,12 +190,12 @@ polynomials, which is the same work.
 
 | instance | transform mirror | echelon-only mirror | transform factor | prototype | integrated | overhead |
 |---|---:|---:|---:|---:|---:|---:|
-| `cyclo_phi385` | 301.969 ms | 155.084 ms | 1.95x | 18.164 ms | 47.683 ms | 2.63x |
-| `cyclo_phi128_x_phi165` | 132.537 ms | 67.510 ms | 1.96x | 7.688 ms | 20.750 ms | 2.70x |
-| `cyclo_phi64_x_phi105` | 23.282 ms | 12.232 ms | 1.90x | 1.535 ms | 3.926 ms | 2.56x |
-| `cyclo_phi179` | 16.922 ms | 9.692 ms | 1.75x | 2.527 ms | 3.389 ms | 1.34x |
-| `wilkinson_40` | 40.730 us | 42.794 us | 0.95x | 71.976 us | 66.949 us | 0.93x |
-| `legendre_P38` | 1.786 ms | 997.048 us | 1.79x | 166.207 us | 376.599 us | 2.27x |
+| `cyclo_phi179` | 16.473 ms | 9.563 ms | 1.72x | 2.556 ms | 3.350 ms | 1.31x |
+| `cyclo_phi64_x_phi105` | 23.800 ms | 12.426 ms | 1.92x | 1.551 ms | 4.077 ms | 2.63x |
+| `cyclo_phi128_x_phi165` | 129.938 ms | 65.946 ms | 1.97x | 7.724 ms | 21.039 ms | 2.72x |
+| `cyclo_phi385` | 302.485 ms | 154.348 ms | 1.96x | 18.232 ms | 47.752 ms | 2.62x |
+| `wilkinson_40` | 41.622 us | 43.234 us | 0.96x | 72.457 us | 65.687 us | 0.91x |
+| `legendre_P38` | 1.785 ms | 999.733 us | 1.79x | 164.624 us | 360.634 us | 2.19x |
 
 Three causes, in the order they are worth fixing:
 
@@ -255,12 +257,16 @@ page put it (1.98x).
   `scripts/bench/check_factor_sweep_freshness.py` passes.
 
   The sweep solves **377 of 392** instances under the 10 s cutoff, unchanged
-  from the newest committed baseline (`17bd12950088`), in **19.519 s** of
-  solved-instance time against that baseline's 20.684 s. The corpus is
-  dominated by instances whose cost is not the modular kernel, so a 5.6%
-  total is the shape to expect from a change that moves four rows by 1.8x to
-  2.6x; the sweep is here as an anti-regression check across all 392, not as
-  the headline.
+  from the newest committed baseline (`17bd12950088`). Its solved-instance
+  total is **20.847 s** against that baseline's 20.684 s -- indistinguishable,
+  and *not* evidence of a gain: two sweeps of this same code, committed as
+  `hexbz-factor-sweep-433dba23-hex-chungus2.json` (19.519 s) and
+  `hexbz-factor-sweep-a5e0ebe4-hex-chungus2.json` (20.847 s), differ by 6.4%
+  between themselves. The corpus is dominated by instances whose cost is not
+  the modular kernel, and the sweep does not resolve a change of this size. It
+  is here as an anti-regression check across all 392 instances and as the
+  freshness record the published figures are drawn from, not as a
+  measurement of the gain; the gain is the paired kernel span above.
 
 ## Regeneration
 
@@ -269,11 +275,11 @@ lake build hexbz_factor_service
 
 taskset -c 0 python3 scripts/bench/factor_sweep.py \
   --systems hex-factor --cutoff 10 --no-early-terminate \
-  --output reports/bench-results/hexbz-factor-sweep-433dba23-hex-chungus2.json
+  --output reports/bench-results/hexbz-factor-sweep-a5e0ebe4-hex-chungus2.json
 
 python3 scripts/bench/factor_phase_profile.py \
   --no-counterfactual --no-scout \
-  --output reports/bench-results/hexbz-phase-profile-2c4c6e4f-chungus2.json
+  --output reports/bench-results/hexbz-phase-profile-a5e0ebe4-chungus2.json
 
 python3 scripts/plots/hexbz-cactus.py
 ```

--- a/reports/hexbz-packed-fp-matrix-integration.md
+++ b/reports/hexbz-packed-fp-matrix-integration.md
@@ -1,0 +1,273 @@
+# The packed finite-field matrix, integrated (issue #9150)
+
+[reports/hexbz-packed-fp-matrix.md](hexbz-packed-fp-matrix.md) measured a
+benchmark prototype and returned a **go**. This page measures the landed
+implementation: `HexBerlekamp/PackedKernel.lean`, selected in compiled code by
+a `@[csimp]`-proved equality at the `fixedSpaceKernelVectors` boundary.
+
+The headline is the same span the prototype page priced, measured the same way
+by the same driver on the same host: `fixedSpaceKernelVectors` on
+`cyclo_phi385` goes from **327.823 ms to 53.886 ms, 6.08x**, and the whole
+factorization from 434.641 ms to 167.124 ms, **2.60x**. No row of the
+representative set regresses, on either span, at any margin -- including the
+Wilkinson rows, whose fixed-space matrix is zero and which the prototype
+*slowed down* by 1.4x.
+
+The implementation is **2.6x slower than the prototype** on the rows where the
+reduction dominates. That gap is the honest headline of the second table below
+and is not a measurement artefact; [Where the remaining
+2.6x is](#where-the-remaining-26x-is) names its causes.
+
+## Revision and protocol
+
+- Source revision `2c4c6e4fa0378ee34cf6399a91c720b4e63cf84d` (clean worktree),
+  Lean toolchain `leanprover/lean4:v4.33.0-rc1`.
+- Host `chungus2`, AMD EPYC 9455, Linux x86-64, 96 cores, measured 2026-08-03.
+  The host was shared with other work throughout.
+- The driver pins itself to one idle logical CPU before spawning any service.
+- Baseline: `reports/bench-results/hexbz-phase-profile-0e1601a0-chungus2.json`,
+  the record the prototype page reads, measured on the same host.
+- After: `reports/bench-results/hexbz-phase-profile-2c4c6e4f-chungus2.json`,
+  SHA-256 `1f595bed0ef0e5a67cc2b8246af8eb4f91d5769cc92bad4e0665185f1433ac59`.
+  `hexbz_factor_service` SHA-256
+  `c22f80f3683e4e9c7b7c7432e6af80543e920aa9402b8cd37ea4686d3d6360c4`; corpus
+  `bench/corpus/hexbz-factor-corpus.jsonl`, SHA-256
+  `619913904240834c912489e6cc23ba136e8cc5ebf0ea95f83397e0682387284d`.
+
+The baseline and the after record are **separate runs minutes to hours apart on
+a shared host**, so every before/after ratio below carries that run-to-run
+variance. The prototype page measured the same computation at 0.67x to 1.00x of
+itself across two sections of a single run; nothing here is more precise than
+that. The ratios that matter are large enough to survive it, and the small ones
+are reported as small.
+
+## What landed
+
+`Hex.Berlekamp.fixedSpaceKernelVectors` still *means*
+`Hex.Matrix.nullspace (fixedSpaceMatrix f hmonic)`, and every Berlekamp
+soundness and completeness proof still reasons about ordinary
+`Matrix (ZMod64 p)`. Compiled code runs
+`Hex.Berlekamp.Packed.kernelArray` instead, through the `@[csimp]` theorem
+`Hex.Berlekamp.fixedSpaceKernelVectors_eq_packed`, whose statement is one
+equality of the two functions and whose proof is
+`Hex.Berlekamp.Packed.kernelArray_eq`.
+
+The packed representation is a `Hex.Matrix UInt32 n m`: the same flat row-major
+backing buffer `HexMatrix` already uses, with one `UInt32` word per entry
+instead of one boxed `ZMod64 p`. Reusing `Hex.Matrix` rather than a bare
+`Array` is what keeps the correspondence short -- `Matrix.rowSwap`,
+`Matrix.modifyEntries` and their entrywise read lemmas are already proved, and
+the in-place update behaviour on a uniquely referenced buffer is the one the
+generic path already relies on.
+
+Against the six design points the prototype page fixed:
+
+1. **Built from the column polynomials, not from a `Hex.Matrix`.**
+   `Packed.fixedSpace` fills the packed buffer straight from
+   `berlekampColumnPolys`, decrementing the diagonal in the same pass. No
+   `Matrix (ZMod64 p)` is ever built on the fast path, so neither the
+   conversion stage nor a separate pack stage is paid. This is what removes the
+   prototype's only measured regression: `wilkinson_40`, rank 0, goes from
+   1.4x *slower* under the prototype to 1.33x faster here.
+2. **`UInt32` entries.** `Packed.mulMod`/`addMod`/`negMod` work on `UInt32`
+   words; `ZMod64.Bounds` caps the modulus at `2^31`, which is what makes the
+   sum of two residues fit a `UInt32` without widening and the product of two
+   arbitrary words fit a `UInt64` exactly.
+3. **No transform.** `Packed.State` has no transform field and
+   `Packed.eliminateColumn` performs one row addition per eliminated entry
+   rather than two.
+4. **The whole reduction loop is specialized** -- pivot search
+   (`Packed.findPivot?`), swap (`Matrix.rowSwap` at `UInt32`), scale
+   (`Packed.rowScale`), elimination (`Packed.eliminateColumn`), and the basis
+   readback (`Packed.nullspaceArray`). Modular inversion is the one operation
+   left on `ZMod64`: it runs once per pivot column, never in the inner loop,
+   and routing it through `ZMod64.inv` keeps an extended-Euclid correspondence
+   out of the proof.
+5. **No Barrett context.** The inner multiply is a hardware `%` on a `UInt64`
+   product.
+6. **No zero-entry skip.** Orthogonal, and still owed its own evidence.
+
+## Proof obligations, and where each is discharged
+
+All in `HexBerlekamp/PackedKernel.lean`. No `axiom`, `sorry`, `native_decide`,
+or unchecked oracle; `scripts/release/check_trust_surface.py` passes.
+
+| obligation | discharged by |
+|---|---|
+| packed entry access agrees with the interpreted matrix | `Packed.Rep`, and `Rep.toZMod_eq` |
+| each elementary row operation interprets to the corresponding one | `Rep.rowSwap`, `Rep.rowScale`, `Rep.rowAdd` |
+| pivot search agrees with the reference | `Packed.findPivot?_eq` |
+| the rank agrees with `Hex.Matrix.rowReduce_rank` | `Packed.reduce_rank` |
+| the basis is sound and spans the whole kernel | `Packed.nullspaceArray_eq`, which reduces both to the existing `Matrix.nullspace_sound`/`nullspace_complete` |
+| the witnesses reaching `fullySplit` are the same fixed-space witnesses | `fixedSpaceKernelVectors_eq_packed`: the boundary function is unchanged, so `fixedSpaceKernelVectors_sound`/`_complete` are untouched |
+
+The simulation is one induction, `Packed.reduceLoop_sim`, relating
+`Packed.reduceLoop` to `Hex.Matrix.rowReduceLoop` under `Packed.Rep`. The
+reference's transform is carried along on the right of the relation and never
+inspected, which is exactly what makes dropping it sound.
+
+### The instance the packed words stand for
+
+`fixedSpaceKernelVectors` used to take an opaque
+`[Lean.Grind.Field (ZMod64 p)]` instance. A packed word can only stand for a
+residue if the arithmetic it is reduced under is *the* `ZMod64` arithmetic, and
+an opaque field instance is not that: `Lean.Grind.Field` bundles `Add`, `Mul`
+and `Inv` as fields, so `rowReduceLoop`'s multiplications are whatever the
+supplied dictionary says they are, and no packed implementation can be correct
+for every dictionary.
+
+The Berlekamp kernel path is therefore now parameterised by
+`[ZMod64.PrimeModulus p]`, and the field structure comes from the canonical
+`Hex.zmod64FieldOfPrime`. This is a strengthening of an existing hypothesis
+rather than a new one -- every call site already had a primality witness in
+scope and was already passing `zmod64FieldOfPrime` built from it, and
+`PrimeModulus` is a `Prop` class, so nothing is passed at runtime that was not
+already being passed.
+
+## The measurement
+
+`kernel` is the `fixedSpaceKernelVectors` span of the kernel section: the whole
+boundary, Frobenius power and column polynomials included, on both sides.
+`total` is the phase profile's own end-to-end median for the production
+cascade.
+
+| instance | matrix | prime | kernel before | kernel after | gain | total before | total after | gain |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| `sd5` | 32x32 | 29 | 1.821 ms | 1.339 ms | 1.36x | 75.594 ms | 69.402 ms | 1.09x |
+| `sd5_shift1` | 32x32 | 29 | 2.739 ms | 1.750 ms | 1.57x | 64.235 ms | 64.425 ms | 1.00x |
+| `sd5_shift2` | 32x32 | 29 | 2.739 ms | 1.762 ms | 1.55x | 68.231 ms | 67.697 ms | 1.01x |
+| `sd4_x_sd4shift1` | 32x32 | 29 | 2.706 ms | 1.771 ms | 1.53x | 19.094 ms | 18.172 ms | 1.05x |
+| `sd5_x_phi11` | 42x42 | 29 | 5.692 ms | 3.307 ms | 1.72x | 161.131 ms | 140.318 ms | 1.15x |
+| `xpow48_minus1` | 48x48 | 11 | 894.566 us | 618.196 us | 1.45x | 19.639 ms | 10.400 ms | 1.89x |
+| `xpow105_minus1` | 105x105 | 17 | 6.015 ms | 3.969 ms | 1.52x | 74.986 ms | 46.124 ms | 1.63x |
+| `xpow120_minus1` | 120x120 | 7 | 5.009 ms | 3.003 ms | 1.67x | 478.515 ms | 148.233 ms | 3.23x |
+| `cyclo_phi179` | 178x178 | 3 | 20.539 ms | 5.811 ms | 3.53x | 74.909 ms | 42.336 ms | 1.77x |
+| `cyclo_phi64_x_phi105` | 80x80 | 11 | 27.932 ms | 7.506 ms | 3.72x | 61.349 ms | 45.865 ms | 1.34x |
+| `cyclo_phi128_x_phi165` | 144x144 | 7 | 139.775 ms | 28.100 ms | 4.97x | 198.351 ms | 84.694 ms | 2.34x |
+| `cyclo_phi385` | 240x240 | 3 | 327.823 ms | 53.886 ms | 6.08x | 434.641 ms | 167.124 ms | 2.60x |
+| `wilkinson_40` | 40x40 | 47 | 297.862 us | 224.763 us | 1.33x | 13.451 ms | 13.518 ms | 1.00x |
+| `wilkinson_48` | 48x48 | 61 | 427.624 us | 318.171 us | 1.34x | 25.192 ms | 24.389 ms | 1.03x |
+| `wilkinson_56` | 56x56 | 67 | 661.561 us | 501.855 us | 1.32x | 34.180 ms | 32.686 ms | 1.05x |
+| `chebyshev_T24` (control) | 24x24 | 5 | 401.566 us | 170.353 us | 2.36x | 558.258 us | 441.454 us | 1.26x |
+| `chebyshev_U24` (control) | 24x24 | 3 | 334.365 us | 128.962 us | 2.59x | 711.415 us | 589.554 us | 1.21x |
+| `legendre_P30` (control) | 30x30 | 67 | 2.032 ms | 1.363 ms | 1.49x | 9.080 ms | 8.560 ms | 1.06x |
+| `legendre_P38` (control) | 38x38 | 79 | 4.244 ms | 2.712 ms | 1.57x | 4.792 ms | 3.820 ms | 1.25x |
+| `cyclo_phi17` (control) | 16x16 | 3 | 129.993 us | 50.605 us | 2.57x | 155.711 us | 104.535 us | 1.49x |
+| `cyclo_phi41` (control) | 40x40 | 3 | 643.014 us | 254.197 us | 2.53x | 2.825 ms | 1.979 ms | 1.43x |
+| `xpow24_minus1` (control) | 24x24 | 11 | 227.337 us | 165.265 us | 1.38x | 3.223 ms | 2.293 ms | 1.41x |
+| `randprod_10` (control) | 20x20 | 7 | 573.701 us | 232.915 us | 2.46x | 824.853 us | 640.029 us | 1.29x |
+| `randprod_21` (control) | 24x24 | 17 | 1.251 ms | 681.290 us | 1.84x | 1.748 ms | 1.402 ms | 1.25x |
+
+**No regression above 5% on any row, on either span.** The largest end-to-end
+move against the implementation is `sd5_shift1` at 1.00x (64.235 ms to
+64.425 ms, 0.3%), well inside the run-to-run variance stated above.
+
+`xpow120_minus1`'s 3.23x is the one number here that its kernel gain (1.67x on
+5 ms of a 478 ms factorization) cannot explain. That row's cost is
+recombination, not the modular kernel, and the two runs disagree about it by
+more than the kernel change can account for; read it as run-to-run variance on
+a row this change does not touch, not as evidence of a further win.
+
+Allocation, on the same span:
+
+| instance | small allocs before | after | factor |
+|---|---:|---:|---:|
+| `cyclo_phi385` | 18,309,485 | 661,844 | 28x |
+| `cyclo_phi128_x_phi165` | 8,451,415 | 723,728 | 12x |
+| `cyclo_phi64_x_phi105` | 1,761,785 | 347,380 | 5x |
+| `cyclo_phi179` | 1,290,156 | 275,077 | 5x |
+
+## Where the remaining 2.6x is
+
+The kernel section prices the prototype's four packed variants alongside the
+integrated implementation in the same process, so the gap is measured, not
+inferred. `prototype` is `packedHalfWordDivision` -- `UInt32` storage,
+hardware remainder, pack plus reduce plus readback. `integrated` is the
+`fixedSpaceKernelVectors` span less its Frobenius power and column
+polynomials, which is the same work.
+
+| instance | transform mirror | echelon-only mirror | transform factor | prototype | integrated | overhead |
+|---|---:|---:|---:|---:|---:|---:|
+| `cyclo_phi385` | 301.969 ms | 155.084 ms | 1.95x | 18.164 ms | 47.683 ms | 2.63x |
+| `cyclo_phi128_x_phi165` | 132.537 ms | 67.510 ms | 1.96x | 7.688 ms | 20.750 ms | 2.70x |
+| `cyclo_phi64_x_phi105` | 23.282 ms | 12.232 ms | 1.90x | 1.535 ms | 3.926 ms | 2.56x |
+| `cyclo_phi179` | 16.922 ms | 9.692 ms | 1.75x | 2.527 ms | 3.389 ms | 1.34x |
+| `wilkinson_40` | 40.730 us | 42.794 us | 0.95x | 71.976 us | 66.949 us | 0.93x |
+| `legendre_P38` | 1.786 ms | 997.048 us | 1.79x | 166.207 us | 376.599 us | 2.27x |
+
+Three causes, in the order they are worth fixing:
+
+1. **`Matrix.rowAdd` copies the source row.** `HexMatrix`'s row addition reads
+   the source row out with `getRow` before writing, because a closure that
+   captured the matrix would hold a second reference and defeat the in-place
+   update. The prototype indexed one flat `Array` directly and paid nothing.
+   The copy is `m` words per row addition; on `cyclo_phi385` that is 17,948
+   copies of 240 words. The pivot row is *invariant* across a column's
+   elimination, so hoisting one `getRow` per pivot column would remove
+   `n - 1` of every `n` copies; the proof cost is one more invariant in the
+   elimination induction.
+2. **The pivot columns are a boxed `List (Fin m)`.** It mirrors
+   `rowReduceLoop`'s own representation, which is what makes the simulation an
+   equality rather than a transport, but it allocates.
+3. **The basis readback is `O(m * rank)` per basis vector**, because it mirrors
+   `IsRowReduced.nullspaceMatrix`'s `pivotIndex?` scan column by column. The
+   reference pays the same, so this is not a regression; a scattered readback
+   would be `O(m + rank)`.
+
+The transform columns re-measure design point 3 against this build: dropping
+the transform is worth **1.75x to 1.96x** on the rows where the reduction
+dominates, measured on the generic representation, which is where the prototype
+page put it (1.98x).
+
+## What these measurements do not establish
+
+- **Design points 2 and 5 are not re-measured.** Separating `UInt32` from
+  `UInt64` entries, or a Barrett reciprocal from the hardware remainder,
+  against *this* implementation needs a second and third compiled variant of
+  the packed loop that nothing would ship. The prototype's 2.42x for `UInt32`
+  and 1.01x for Barrett are still the only evidence for those two choices, and
+  they were measured on a prototype.
+- **The before and after records are separate runs.** See
+  [Revision and protocol](#revision-and-protocol).
+- **The corpus moduli are small**, 3 to 79, far from the `2^31` bound the
+  representation supports. The single division in the inner loop is the
+  operation most likely to behave differently near that bound.
+- **No memory-residency measurement.** `VmHWM` is a whole-process high-water
+  mark; the allocation counts above are counts of small allocations, not bytes.
+
+## Verification
+
+- `lake build` green, `lake build HexConformance` green, zero warnings from the
+  changed files.
+- `lake exe hexberlekamp_emit_fixtures` and `lake exe hexbz_emit_fixtures`
+  reproduce the committed fixtures byte for byte.
+- The kernel section's own cross-checks pass on all 24 rows: the counted
+  Gauss-Jordan mirror agrees with the production `rowReduce`, the
+  transform-free mirror agrees with the transform-carrying one, and all four
+  packed prototype variants agree with `Hex.Matrix.nullspace` entry for entry.
+  The wider validation sample agrees with the production `factorTrace` on
+  selected prime, leaf count, subset cardinalities and returned factor degrees
+  on **368 of 368** instances.
+- A fresh full Hex sweep over all 392 corpus instances, with the external
+  comparator records reused unchanged, and regenerated cactus and
+  runtime-by-degree figures.
+
+## Regeneration
+
+```sh
+lake build hexbz_factor_service
+
+taskset -c 0 python3 scripts/bench/factor_sweep.py \
+  --systems hex-factor --cutoff 10 --no-early-terminate \
+  --output reports/bench-results/hexbz-factor-sweep-2c4c6e4f-hex-chungus2.json
+
+python3 scripts/bench/factor_phase_profile.py \
+  --no-counterfactual --no-scout \
+  --output reports/bench-results/hexbz-phase-profile-2c4c6e4f-chungus2.json
+
+python3 scripts/plots/hexbz-cactus.py
+```
+
+The phase-profile driver exits non-zero if any packed variant disagrees with
+`Hex.Matrix.nullspace`, if the counted mirror disagrees with the production row
+reduction, or if the recombination mirror disagrees with the production trace.


### PR DESCRIPTION
This PR runs Berlekamp's fixed-space kernel on a packed `UInt32` matrix behind an unchanged `fixedSpaceKernelVectors` boundary, selected in compiled code by a `@[csimp]`-proved equality so the Berlekamp soundness and completeness proofs keep reasoning about ordinary `Matrix (ZMod64 p)`. On `cyclo_phi385` the kernel goes from 327.823 ms to 53.886 ms, 6.08x, and the whole factorization from 434.641 ms to 167.124 ms, 2.60x; no row of the 24-row representative set regresses above 5% on either span. Follows the measured go in #9132 and the evidence in `reports/hexbz-packed-fp-matrix.md`.

`HexBerlekamp/PackedKernel.lean` holds the development. The packed matrix is a `Hex.Matrix UInt32 n m`, not a bare `Array`: reusing `HexMatrix`'s flat row-major backing means `Matrix.rowSwap`, `Matrix.modifyEntries` and their entrywise read lemmas are already proved, and the in-place update on a uniquely referenced buffer is the one the generic path already relies on. `Packed.Rep A E` says a packed word and a residue have the same `toNat`, which carries reducedness for free because residues are canonical. `Packed.reduceLoop_sim` is one induction relating the packed loop to `Matrix.rowReduceLoop`, with the reference transform carried on the right of the relation and never inspected -- which is what makes dropping it sound. `Packed.fixedSpace` fills the buffer straight from `berlekampColumnPolys`, so no `Matrix (ZMod64 p)` is built on the fast path, and `Packed.kernelArray_eq` is the single correspondence theorem. No `axiom`, `sorry`, or `native_decide`.

One part of the directive's premise did not survive contact. `fixedSpaceKernelVectors` took an opaque `[Lean.Grind.Field (ZMod64 p)]`, and `Lean.Grind.Field` bundles `Add`, `Mul` and `Inv` as structure fields, so `rowReduceLoop`'s arithmetic is whatever dictionary the caller supplies. A packed word only stands for a residue under the canonical `ZMod64` arithmetic, so no packed implementation is correct for every dictionary and the `@[csimp]` as specified would be false. The Berlekamp kernel path is therefore now parameterised by `[ZMod64.PrimeModulus p]`; every call site already had a primality witness in scope and was already building `zmod64FieldOfPrime` from it, and `PrimeModulus` is a `Prop` class, so this strengthens an existing hypothesis without passing anything new at runtime. `fixedSpaceKernel` also had to move below the `@[csimp]`, since csimp only rewrites code generated after the attribute is declared.

`reports/hexbz-packed-fp-matrix-integration.md` measures the landed implementation rather than the prototype, over all 24 representative rows, and states two limits plainly: the implementation is 2.6x slower than the benchmark prototype on the rows where the reduction dominates (`Matrix.rowAdd` copies the source row, the pivot columns are a boxed list, the basis readback mirrors the reference's `pivotIndex?` scan), and design points 2 and 5 -- `UInt32` versus `UInt64` entries, Barrett versus the hardware remainder -- are not re-measured against this build, because separating them needs compiled variants nothing would ship.

Verified: full `lake build` and `lake build HexConformance` green with no new warnings; `hexberlekamp_emit_fixtures` and `hexbz_emit_fixtures` reproduce the committed fixtures byte for byte; the phase profile's own cross-checks agree with `Hex.Matrix.nullspace` and the production `factorTrace` on 368 of 368 instances; a fresh 392-instance sweep with the external comparator records reused unchanged, all 25 figures regenerated, and `check_factor_sweep_freshness.py` and `hexbz-cactus.py --check` passing.

Closes #9150

🤖 Prepared with Claude Code