### PR TITLE
doc: point the packed-matrix prototype report at its implementation

### DIFF
--- a/bench/HexBench/BerlekampKernel.lean
+++ b/bench/HexBench/BerlekampKernel.lean
@@ -269,8 +269,11 @@ def mirrorAgrees [BEq R] (M : Matrix R n m) (r : ReduceResult R n m) : Bool :=
 /-! ## Packed prototype
 
 A contiguous row-major buffer of machine words with the modulus's Barrett
-reciprocal alongside it. This is the representation issue #9132 proposes,
-prototyped here to price it before any production specialization is written.
+reciprocal alongside it. This is the representation issue #9132 proposed and
+`Hex.Berlekamp.Packed` now implements, priced here before that implementation
+was written and kept afterwards for two jobs: these variants remain the
+entry-for-entry oracle the production kernel is checked against, and they are
+the floor the implementation's own cost is read against.
 -/
 
 /-- Which packed element storage and modular multiply to price. -/

--- a/reports/hexbz-packed-fp-matrix.md
+++ b/reports/hexbz-packed-fp-matrix.md
@@ -5,6 +5,11 @@ degree-pattern scout, so the modular share of a factorization had to be
 remeasured before any matrix specialization was justified. This page is that
 remeasurement, and it is a **go**.
 
+**The numbers below price a benchmark prototype, not shipped code.** The
+specialization they justified has since landed;
+[reports/hexbz-packed-fp-matrix-integration.md](hexbz-packed-fp-matrix-integration.md)
+measures the implementation, and its factors are the ones to quote.
+
 On `cyclo_phi385` the row reduction and nullspace basis at the selected prime
 are **46.5% of total factor time** and **94.6% of that prime's Berlekamp
 split**; on `cyclo_phi128_x_phi165`, 44.6% and 89.3%; on


### PR DESCRIPTION
This PR adds a forward pointer from the packed-matrix prototype report to the report that measures the landed implementation, and updates the benchmark module's description of what its packed variants are for now that the implementation exists.

`reports/hexbz-packed-fp-matrix.md` prices a benchmark prototype. Its factors were the input to a decision, not a description of shipped code, and the specialization they justified landed in https://github.com/kim-em/hex-dev/pull/9158 "perf: pack the Berlekamp fixed-space matrix into UInt32 words". A reader arriving at the prototype page had nothing telling them that, and its `17.0x` is not the implementation's `6.06x`.

`bench/HexBench/BerlekampKernel.lean` described its packed variants as prototyped "before any production specialization is written". One is written. The variants are still doing two jobs, and the docstring now names them: they remain the entry-for-entry oracle `Hex.Berlekamp.Packed`'s output is checked against on every phase-profile run, and they are the floor the implementation's own cost is read against, which is where the measured 2.62x gap on `cyclo_phi385` comes from.

Documentation only. No Lean declaration changes; `check_factor_sweep_freshness.py` still passes, so no re-measurement is implied.

🤖 Prepared with Claude Code