### PR TITLE
feat: give the iterated quadratic norm a production definition and its polynomial correspondence

### DIFF
--- a/HexBerlekampZassenhaus/All.lean
+++ b/HexBerlekampZassenhaus/All.lean
@@ -29,6 +29,7 @@ public import HexBerlekampZassenhaus.PrimitiveFactors
 public import HexBerlekampZassenhaus.FactorProduct
 public import HexBerlekampZassenhaus.SmallModSingleton
 public import HexBerlekampZassenhaus.WordCld
+public import HexBerlekampZassenhaus.QuadraticNorm
 
 public section
 

--- a/HexBerlekampZassenhaus/QuadraticNorm.lean
+++ b/HexBerlekampZassenhaus/QuadraticNorm.lean
@@ -29,9 +29,11 @@ coefficientwise up to the unit `-1`.
 
 Together those imply the input is irreducible: independence forces
 `[ℚ(√d₁, …, √dₙ) : ℚ] = 2ⁿ`, the element `c + ∑ᵢ √dᵢ` generates that field, and
-`F(c; d)` is its minimal polynomial. That implication is the Mathlib side, in
-`HexBerlekampZassenhausMathlib.QuadraticNorm` and its companions; the paper proof
-is in `reports/hexbz-quadratic-norm-certificate.md`.
+`F(c; d)` is its minimal polynomial. The paper proof of that implication is in
+`reports/hexbz-quadratic-norm-certificate.md`. Its two halves are separate
+developments: `HexBerlekampZassenhausMathlib.QuadraticNorm` identifies what these
+definitions compute with `F(c; d)` as a `Polynomial`, and the multiquadratic
+tower theorem, which is not yet in Lean, supplies the field theory.
 
 The independence check needs no factorization of the radicands: an integer is a
 rational square exactly when it is a perfect square, so `2ⁿ - 1` integer square
@@ -72,6 +74,21 @@ is ever materialized. -/
 def quadNorm (d : Int) (g : ZPoly) : ZPoly :=
   let h := quadShift d g.toArray.toList
   h.1 * h.1 - DensePoly.scale d (h.2 * h.2)
+
+/-- The empty coefficient list is the zero polynomial. -/
+theorem quadShift_nil (d : Int) : quadShift d [] = (0, 0) := rfl
+
+/-- Reading one more coefficient off the front is one {name}`Hex.quadStep`. -/
+theorem quadShift_cons (d a : Int) (as : List Int) :
+    quadShift d (a :: as) = quadStep d a (quadShift d as) := rfl
+
+/-- The norm in terms of the shifted pair, with the `t` component already
+cancelled. -/
+theorem quadNorm_eq (d : Int) (g : ZPoly) :
+    quadNorm d g
+      = (quadShift d g.toArray.toList).1 * (quadShift d g.toArray.toList).1
+        - DensePoly.scale d
+            ((quadShift d g.toArray.toList).2 * (quadShift d g.toArray.toList).2) := rfl
 
 /-- `F(c; ds) = N_{dₖ}(⋯ N_{d₁}(X - c) ⋯)`, the iterated quadratic norm of the
 translation `c` along the radicands `ds`. -/

--- a/HexBerlekampZassenhaus/QuadraticNorm.lean
+++ b/HexBerlekampZassenhaus/QuadraticNorm.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexPolyZ.IntegerPolynomial
+
+public section
+
+/-!
+# Iterated quadratic norms and their irreducibility certificates
+
+For `d : ℤ` and `g ∈ ℤ[X]`, the *quadratic norm* `N_d(g)` is the norm of
+`g(X - t)` along `ℤ[t]/(t² - d) → ℤ`, that is `N_d(g)(X) = g(X - t) · g(X + t)`
+with `t² = d`. It is again an integer polynomial, of twice the degree when `g` is
+monic, and its roots are `β ± √d` as `β` runs over the roots of `g`. Iterating
+from `X - c` gives `F(c; d₁, …, dₙ)`, the product of `X - c - ∑ᵢ εᵢ √dᵢ` over all
+`2ⁿ` sign patterns `ε ∈ {±1}ⁿ`.
+
+A `QuadraticNormCertificate` is the translation `c` together with the
+radicands `d₁, …, dₙ`, and `QuadraticNormCertificate.check` verifies
+two things: *independence*, that no nonempty subproduct of the radicands is a
+perfect square, which is exactly multiplicative independence of the `dᵢ` in
+`ℚ*/(ℚ*)²`; and *identification*, that `F(c; d)` equals the input polynomial
+coefficientwise up to the unit `-1`.
+
+Together those imply the input is irreducible: independence forces
+`[ℚ(√d₁, …, √dₙ) : ℚ] = 2ⁿ`, the element `c + ∑ᵢ √dᵢ` generates that field, and
+`F(c; d)` is its minimal polynomial. That implication is the Mathlib side, in
+`HexBerlekampZassenhausMathlib.QuadraticNorm` and its companions; the paper proof
+is in `reports/hexbz-quadratic-norm-certificate.md`.
+
+The independence check needs no factorization of the radicands: an integer is a
+rational square exactly when it is a perfect square, so `2ⁿ - 1` integer square
+tests settle it. That, with the polynomial identity, is the whole arithmetic
+trust surface of the check.
+-/
+
+namespace Hex
+
+/-! ## The quadratic norm -/
+
+/-- One synthetic-shift step in `(ℤ[t]/(t² - d))[X]`: from the pair of
+`h = p + q · t` and the next coefficient `a`, the pair of `a + (X - t) · h`.
+
+Since `t² = d`, `(X - t) · (p + q t) = (X p - d q) + (X q - p) t`, so the step
+reads both components of `h` and writes both components of the result. -/
+@[expose]
+def quadStep (d a : Int) (h : ZPoly × ZPoly) : ZPoly × ZPoly :=
+  (DensePoly.shift 1 h.1 - DensePoly.scale d h.2 + DensePoly.C a,
+    DensePoly.shift 1 h.2 - h.1)
+
+/-- The coefficient pair of `g(X - t)` in `(ℤ[t]/(t² - d))[X]`, read off the
+ascending coefficient list of `g`: {name}`Hex.quadShift` returns `(p, q)` with
+`g(X - t) = p + q · t`.
+
+This is the synthetic Taylor shift with shift constant `-t`, carrying the
+coefficient pair through Horner's rule from the top coefficient down. -/
+@[expose]
+def quadShift (d : Int) (coeffs : List Int) : ZPoly × ZPoly :=
+  coeffs.foldr (quadStep d) (0, 0)
+
+/-- `N_d(g) = g(X - t) · g(X + t)` with `t² = d`, an integer polynomial.
+
+Writing `g(X - t) = p + q t`, the conjugate is `p - q t` and the product is
+`p² - d q²`: the `t` component cancels by antisymmetry, so only the rational part
+is ever materialized. -/
+@[expose]
+def quadNorm (d : Int) (g : ZPoly) : ZPoly :=
+  let h := quadShift d g.toArray.toList
+  h.1 * h.1 - DensePoly.scale d (h.2 * h.2)
+
+/-- `F(c; ds) = N_{dₖ}(⋯ N_{d₁}(X - c) ⋯)`, the iterated quadratic norm of the
+translation `c` along the radicands `ds`. -/
+@[expose]
+def iteratedNorm (c : Int) (ds : Array Int) : ZPoly :=
+  ds.foldl (fun g d => quadNorm d g) (DensePoly.ofCoeffs #[-c, 1])
+
+/-! ## The independence test -/
+
+/-- Is `m` the square of an integer? -/
+@[expose]
+def isPerfectSquare (m : Int) : Bool :=
+  match m with
+  | .ofNat n => let r := n.sqrt; r * r == n
+  | .negSucc _ => false
+
+/-- The `2ⁿ - 1` products of the nonempty sublists of `ds`.
+
+The head contributes its own singleton and doubles every product from the tail,
+once with and once without it. -/
+@[expose]
+def squareClassProducts : List Int → List Int
+  | [] => []
+  | d :: ds => d :: (squareClassProducts ds).flatMap (fun m => [m, d * m])
+
+/-- Are the radicands multiplicatively independent in `ℚ*/(ℚ*)²`?
+
+Equivalently: is no nonempty subproduct a perfect square? A zero radicand and a
+repeated radicand are both rejected by this, as they must be. -/
+@[expose]
+def independentSquareClasses (ds : Array Int) : Bool :=
+  (squareClassProducts ds.toList).all (fun m => !isPerfectSquare m)
+
+/-! ## The certificate -/
+
+/-- Translation and radicands for one iterated quadratic norm. -/
+structure QuadraticNormCertificate where
+  /-- The translation: the certified polynomial is `∏_ε (X - c - ∑ εᵢ √dᵢ)`. -/
+  translation : Int
+  /-- The radicands, in the order the norms are taken. -/
+  radicands : Array Int
+deriving Repr, Inhabited
+
+/-- Does the certificate prove `f` irreducible?
+
+A `true` result asserts both halves: the radicands are independent, and `f` is,
+up to the unit `-1`, exactly the iterated quadratic norm they describe.
+
+Every `F(c; d)` is monic and `-1` is a unit of `ℤ[X]`, so `f` and `-f` are
+irreducible together; that sign is the whole normalization the identification
+needs. There is no scaling and no content division, since a primitive integer
+polynomial with leading coefficient outside `{1, -1}` is never `± F(c; d)`. -/
+@[expose]
+def QuadraticNormCertificate.check (cert : QuadraticNormCertificate) (f : ZPoly) : Bool :=
+  independentSquareClasses cert.radicands &&
+    iteratedNorm cert.translation cert.radicands == ZPoly.normalizePrimitiveSign f
+
+end Hex

--- a/HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md
+++ b/HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md
@@ -324,6 +324,29 @@ coefficient bound and tests exact division. It does not require a
 suitable modular prime and is therefore the unconditional final
 method.
 
+## Iterated quadratic norms
+
+`quadNorm d g` is the norm of `g(X - t)` along `ℤ[t]/(t² - d) → ℤ`, that
+is `g(X - √d) · g(X + √d)`. It carries the coefficient pair of
+`g(X - t)` through one synthetic Taylor shift with shift constant `-t`,
+then materializes only the rational part `p² - d q²` of the product with
+the conjugate, whose `t` component cancels coefficientwise.
+`iteratedNorm c ds` folds those norms over the radicands from `X - c`,
+giving `F(c; d₁, …, dₙ) = ∏_ε (X - c - ∑ᵢ εᵢ √dᵢ)` over the `2ⁿ` sign
+patterns.
+
+A `QuadraticNormCertificate` is a translation and a list of radicands.
+Its `check` verifies two decidable conditions: that no nonempty
+subproduct of the radicands is a perfect square, which is
+`independentSquareClasses` and is exactly multiplicative independence in
+`ℚ*/(ℚ*)²`; and that the input equals `F(c; d)` coefficientwise up to
+the unit `-1`. Both are integer arithmetic, with no factorization of the
+radicands and no number field constructed.
+
+The certificate is not yet reachable from `ZPoly.factorize`. The field
+theory that turns a successful check into irreducibility is the
+multiquadratic tower theorem.
+
 ## Correctness
 
 The Mathlib-free library proves executable product reconstruction,
@@ -341,7 +364,12 @@ unfiltered leaf returned.
 - completeness of classical recombination;
 - both inclusions in the lattice support-span equality;
 - irreducibility and normalization of every recorded factor;
-- uniqueness of the final factorization.
+- uniqueness of the final factorization;
+- the quadratic-norm correspondence: `quadNorm` maps to
+  `g(X - r) · g(X + r)` over any commutative ring with `r² = d`, the
+  iterate maps to the sign-pattern product, and
+  `independentSquareClasses` decides independence of the square
+  classes.
 
 The ordinary umbrella exposes the supported factorization and tactic
 surface. `HexBerlekampZassenhaus.All` and

--- a/HexBerlekampZassenhausMathlib/All.lean
+++ b/HexBerlekampZassenhausMathlib/All.lean
@@ -50,6 +50,7 @@ public import HexBerlekampZassenhausMathlib.Classical.SearchCompleteness
 public import HexBerlekampZassenhausMathlib.Classical.Factorization
 public import HexBerlekampZassenhausMathlib.FactorIrreducibility
 public import HexBerlekampZassenhausMathlib.SquareClass
+public import HexBerlekampZassenhausMathlib.QuadraticNorm
 
 public section
 

--- a/HexBerlekampZassenhausMathlib/QuadraticNorm.lean
+++ b/HexBerlekampZassenhausMathlib/QuadraticNorm.lean
@@ -227,14 +227,9 @@ theorem quadShift_spec (d : ℤ) {r : K} (hr : r ^ 2 = (d : K)) (l : List ℤ) :
   have hrr : (C r : Polynomial K) * C r = C ((d : K)) := by
     rw [← Polynomial.C_mul, ← sq, hr]
   induction l with
-  | nil => simp [Hex.quadShift]
+  | nil => simp [Hex.quadShift_nil]
   | cons a as ih =>
-      have h1 : (Hex.quadShift d (a :: as)).1
-          = Hex.DensePoly.shift 1 (Hex.quadShift d as).1
-            - Hex.DensePoly.scale d (Hex.quadShift d as).2 + Hex.DensePoly.C a := rfl
-      have h2 : (Hex.quadShift d (a :: as)).2
-          = Hex.DensePoly.shift 1 (Hex.quadShift d as).2 - (Hex.quadShift d as).1 := rfl
-      rw [h1, h2, toPolynomial_ofList_cons]
+      rw [Hex.quadShift_cons, Hex.quadStep, toPolynomial_ofList_cons]
       simp only [toPolynomial_add, toPolynomial_sub, toPolynomial_C,
         toPolynomial_shift_one, toPolynomial_scale, Polynomial.map_add,
         Polynomial.map_sub, Polynomial.map_mul, Polynomial.map_C, Polynomial.map_X,
@@ -257,12 +252,7 @@ theorem map_quadNorm (g : Hex.ZPoly) (d : ℤ) (r : K) (hr : r ^ 2 = (d : K)) :
   have hminus := quadShift_spec d hneg g.toArray.toList
   rw [hlist] at hplus hminus
   rw [map_neg, neg_mul, ← sub_eq_add_neg, sub_neg_eq_add] at hminus
-  have hqn : Hex.quadNorm d g
-      = (Hex.quadShift d g.toArray.toList).1 * (Hex.quadShift d g.toArray.toList).1
-        - Hex.DensePoly.scale d
-            ((Hex.quadShift d g.toArray.toList).2
-              * (Hex.quadShift d g.toArray.toList).2) := rfl
-  rw [hqn, ← hplus, ← hminus]
+  rw [Hex.quadNorm_eq, ← hplus, ← hminus]
   simp only [toPolynomial_sub, toPolynomial_mul, toPolynomial_scale,
     Polynomial.map_sub, Polynomial.map_mul, Polynomial.map_C, algebraMap_int]
   linear_combination

--- a/HexBerlekampZassenhausMathlib/QuadraticNorm.lean
+++ b/HexBerlekampZassenhausMathlib/QuadraticNorm.lean
@@ -32,10 +32,12 @@ polynomial statement over any commutative ring carrying a square root `r` of `d`
   {name}`Hex.QuadraticNormCertificate.check` pins the input to that product up to
   the unit `-1`.
 
-The independence half of the check is in
-`HexBerlekampZassenhausMathlib.SquareClass`; the field theory that turns the two
-halves into irreducibility is the multiquadratic tower theorem, whose paper proof
-is in `reports/hexbz-quadratic-norm-certificate.md`.
+The independence half of the check is decided here too, against the
+`Hex.SquareClass.Independent` of `HexBerlekampZassenhausMathlib.SquareClass`,
+which also carries the multiquadratic tower degree. What turns the two halves
+into irreducibility is the rest of that tower theorem: that `c + ∑ᵢ √dᵢ`
+generates the tower and `F(c; d)` is its minimal polynomial. The paper proof is
+in `reports/hexbz-quadratic-norm-certificate.md`.
 -/
 
 /-! ## The executable independence test

--- a/HexBerlekampZassenhausMathlib/QuadraticNorm.lean
+++ b/HexBerlekampZassenhausMathlib/QuadraticNorm.lean
@@ -1,0 +1,453 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexBerlekampZassenhaus.QuadraticNorm
+public import HexBerlekampZassenhausMathlib.SquareClass
+public import HexPolyZMathlib.PolynomialEquivalence
+public import Mathlib.Algebra.Order.Ring.Int
+public import Mathlib.Algebra.Ring.Int.Parity
+public import Mathlib.Tactic.LinearCombination
+
+public section
+set_option backward.proofsInPublic true
+
+/-!
+# The iterated quadratic norm as a sign-pattern product
+
+The executable {name}`Hex.quadNorm` computes in the dense-array coordinate: it
+carries a pair of `Hex.ZPoly`s standing for `g(X - t) = p + q · t` in
+`ℤ[t]/(t² - d)`, and materializes only the rational part `p² - d q²` of the
+product with the conjugate. This module identifies that with the honest
+polynomial statement over any commutative ring carrying a square root `r` of `d`:
+
+* `map_quadNorm` — one norm is `g(X - r) · g(X + r)`;
+* `map_iteratedNorm` — the iterate is `∏_ε (X - c - ∑ᵢ εᵢ rᵢ)`, the polynomial
+  the multiquadratic tower theorem is about;
+* `associated_toPolynomial_of_check` — a successful
+  {name}`Hex.QuadraticNormCertificate.check` pins the input to that product up to
+  the unit `-1`.
+
+The independence half of the check is in
+`HexBerlekampZassenhausMathlib.SquareClass`; the field theory that turns the two
+halves into irreducibility is the multiquadratic tower theorem, whose paper proof
+is in `reports/hexbz-quadratic-norm-certificate.md`.
+-/
+
+/-! ## The executable independence test
+
+`Hex.SquareClass.Independent` is the field-theoretic hypothesis; this section
+proves the executable `2ⁿ - 1` subproduct test decides it. The arithmetic
+content is that an integer is a rational square exactly when it is a perfect
+square, so `Nat.sqrt` settles each subproduct with no factorization of the
+radicands and no number field constructed. -/
+
+namespace Hex.SquareClass
+
+/-- {name}`Hex.isPerfectSquare` decides `IsSquare` on `ℤ`. -/
+theorem isPerfectSquare_eq_true_iff (m : ℤ) : Hex.isPerfectSquare m = true ↔ IsSquare m := by
+  cases m with
+  | ofNat n =>
+      have hnat : (Nat.sqrt n * Nat.sqrt n = n) ↔ IsSquare n :=
+        ⟨fun h => ⟨Nat.sqrt n, h.symm⟩, fun ⟨r, hr⟩ =>
+          (Nat.exists_mul_self n).1 ⟨r, hr.symm⟩⟩
+      simp only [Hex.isPerfectSquare, beq_iff_eq, Int.ofNat_eq_natCast,
+        Int.isSquare_natCast_iff]
+      exact hnat
+  | negSucc n =>
+      simp only [Hex.isPerfectSquare, Bool.false_eq_true, false_iff]
+      rintro ⟨r, hr⟩
+      have hneg : (Int.negSucc n) < 0 := Int.negSucc_lt_zero n
+      rw [hr] at hneg
+      exact absurd (mul_self_nonneg r) (not_le.2 hneg)
+
+/-- There are `2ⁿ - 1` subproducts, one per nonempty sublist. Stated additively
+so no truncated subtraction appears. -/
+theorem length_squareClassProducts (l : List ℤ) :
+    (Hex.squareClassProducts l).length + 1 = 2 ^ l.length := by
+  induction l with
+  | nil => simp [Hex.squareClassProducts]
+  | cons d ds ih =>
+      have hflat : ∀ (m : List ℤ),
+          (m.flatMap fun x => [x, d * x]).length = 2 * m.length := by
+        intro m
+        induction m with
+        | nil => simp
+        | cons x m ihm =>
+            rw [List.flatMap_cons, List.length_append, ihm]
+            show 2 + 2 * m.length = 2 * (x :: m).length
+            rw [List.length_cons]
+            omega
+      have hcons : (Hex.squareClassProducts (d :: ds)).length
+          = 1 + 2 * (Hex.squareClassProducts ds).length := by
+        show (d :: (Hex.squareClassProducts ds).flatMap (fun m => [m, d * m])).length = _
+        rw [List.length_cons, hflat]
+        omega
+      rw [hcons, List.length_cons, pow_succ]
+      omega
+
+/-- The enumerated subproducts are exactly the products of the nonempty sublists. -/
+theorem mem_squareClassProducts (l : List ℤ) (m : ℤ) :
+    m ∈ Hex.squareClassProducts l ↔ ∃ t : List ℤ, t.Sublist l ∧ t ≠ [] ∧ t.prod = m := by
+  induction l generalizing m with
+  | nil =>
+      simp only [Hex.squareClassProducts, List.not_mem_nil, false_iff, not_exists]
+      rintro t ⟨hsub, hne, -⟩
+      exact hne (List.sublist_nil.1 hsub)
+  | cons d ds ih =>
+      simp only [Hex.squareClassProducts, List.mem_cons, List.mem_flatMap]
+      constructor
+      · rintro (heq | ⟨k, hk, hmem⟩)
+        · exact ⟨[d], (List.nil_sublist ds).cons_cons d, by simp, by simp [heq]⟩
+        · obtain ⟨t, hsub, hne, rfl⟩ := ih k |>.1 hk
+          simp only [List.not_mem_nil, or_false] at hmem
+          rcases hmem with rfl | rfl
+          · exact ⟨t, hsub.cons d, hne, rfl⟩
+          · exact ⟨d :: t, hsub.cons_cons d, by simp, by simp⟩
+      · rintro ⟨t, hsub, hne, rfl⟩
+        cases hsub with
+        | cons _ hsub' =>
+            right
+            refine ⟨t.prod, (ih t.prod).2 ⟨t, hsub', hne, rfl⟩, ?_⟩
+            simp
+        | cons_cons _ hsub' =>
+            rename_i t'
+            by_cases ht' : t' = []
+            · subst ht'
+              left
+              simp
+            · right
+              refine ⟨t'.prod, (ih t'.prod).2 ⟨t', hsub', ht', rfl⟩, ?_⟩
+              simp
+
+/-- The executable check decides independence: this is the whole arithmetic trust
+surface of the certificate's first half. -/
+theorem independentSquareClasses_iff (ds : Array ℤ) :
+    Hex.independentSquareClasses ds = true ↔ Independent ds.toList := by
+  rw [independent_iff_sublists]
+  simp only [List.mem_sublists]
+  simp only [Hex.independentSquareClasses, List.all_eq_true, Bool.not_eq_true']
+  constructor
+  · intro h t hsub hne hsq
+    have hmem : t.prod ∈ Hex.squareClassProducts ds.toList :=
+      (mem_squareClassProducts ds.toList t.prod).2 ⟨t, hsub, hne, rfl⟩
+    have := h _ hmem
+    rw [← isPerfectSquare_eq_true_iff] at hsq
+    simp [hsq] at this
+  · intro h m hmem
+    obtain ⟨t, hsub, hne, rfl⟩ := (mem_squareClassProducts ds.toList m).1 hmem
+    have := h t hsub hne
+    rw [← isPerfectSquare_eq_true_iff] at this
+    simpa using this
+
+end Hex.SquareClass
+
+namespace HexBerlekampZassenhausMathlib
+
+noncomputable section
+
+open Polynomial
+open HexPolyZMathlib (toPolynomial coeff_toPolynomial toPolynomial_add toPolynomial_sub
+  toPolynomial_mul toPolynomial_C equiv)
+
+variable {K : Type*} [CommRing K]
+
+/-- `Zero.zero` is the numeral `0`; the dense coefficient lemmas are stated with
+the former and the `Polynomial` lemmas with the latter. -/
+private theorem int_zero : (Zero.zero : ℤ) = 0 := rfl
+
+/-- The structure map `ℤ → K` is the integer cast. -/
+private theorem algebraMap_int (n : ℤ) : algebraMap ℤ K n = (n : K) := by simp
+
+/-! ## Dense-array bridges
+
+Four coefficientwise identifications the correspondence runs on. `shift` and
+`scale` are the executable array passes; `ofList` is how the Horner recursion
+reads its input, and `ofCoeffs #[-c, 1]` is what the iteration starts from. -/
+
+/-- Prepending one zero coefficient is multiplication by `X`. -/
+theorem toPolynomial_shift_one (p : Hex.ZPoly) :
+    toPolynomial (Hex.DensePoly.shift 1 p) = X * toPolynomial p := by
+  ext k
+  rw [coeff_toPolynomial, Hex.DensePoly.coeff_shift]
+  cases k with
+  | zero => simp [int_zero]
+  | succ k => simp
+
+/-- Coefficientwise scaling is multiplication by a constant. -/
+theorem toPolynomial_scale (c : ℤ) (p : Hex.ZPoly) :
+    toPolynomial (Hex.DensePoly.scale c p) = C c * toPolynomial p := by
+  ext k
+  rw [coeff_toPolynomial, Hex.DensePoly.coeff_scale c p k (mul_zero c),
+    Polynomial.coeff_C_mul, coeff_toPolynomial]
+
+/-- Reading one more coefficient off the front is one Horner step. -/
+theorem toPolynomial_ofList_cons (a : ℤ) (as : List ℤ) :
+    toPolynomial (Hex.DensePoly.ofList (a :: as))
+      = C a + X * toPolynomial (Hex.DensePoly.ofList as) := by
+  ext k
+  rw [coeff_toPolynomial, Hex.DensePoly.coeff_ofList]
+  cases k with
+  | zero =>
+      rw [Polynomial.coeff_add, Polynomial.coeff_C, Polynomial.mul_coeff_zero,
+        Polynomial.coeff_X_zero, zero_mul]
+      simp
+  | succ k =>
+      rw [Polynomial.coeff_add, Polynomial.coeff_C, Polynomial.coeff_X_mul,
+        coeff_toPolynomial, Hex.DensePoly.coeff_ofList]
+      simp
+
+/-- The polynomial the iteration starts from. -/
+theorem toPolynomial_linear (c : ℤ) :
+    toPolynomial (Hex.DensePoly.ofCoeffs #[-c, 1] : Hex.ZPoly) = X - C c := by
+  ext k
+  rw [coeff_toPolynomial, Hex.DensePoly.coeff_ofCoeffs, Polynomial.coeff_sub,
+    Polynomial.coeff_X, Polynomial.coeff_C]
+  match k with
+  | 0 => simp [Array.getD]
+  | 1 => simp [Array.getD]
+  | (n + 2) => simp [Array.getD, int_zero]
+
+/-! ## One quadratic norm -/
+
+/-- The synthetic shift is correct: with `r² = d` in `K`, the pair `(p, q)` that
+{name}`Hex.quadShift` builds off the coefficient list `l` satisfies
+`p + r · q = g(X - r)` over `K`, where `g` is the polynomial with those
+coefficients.
+
+Everything else follows from this by substituting `-r` for `r` and multiplying. -/
+theorem quadShift_spec (d : ℤ) {r : K} (hr : r ^ 2 = (d : K)) (l : List ℤ) :
+    (toPolynomial (Hex.quadShift d l).1).map (algebraMap ℤ K)
+        + C r * (toPolynomial (Hex.quadShift d l).2).map (algebraMap ℤ K)
+      = ((toPolynomial (Hex.DensePoly.ofList l)).map (algebraMap ℤ K)).comp (X - C r) := by
+  have hrr : (C r : Polynomial K) * C r = C ((d : K)) := by
+    rw [← Polynomial.C_mul, ← sq, hr]
+  induction l with
+  | nil => simp [Hex.quadShift]
+  | cons a as ih =>
+      have h1 : (Hex.quadShift d (a :: as)).1
+          = Hex.DensePoly.shift 1 (Hex.quadShift d as).1
+            - Hex.DensePoly.scale d (Hex.quadShift d as).2 + Hex.DensePoly.C a := rfl
+      have h2 : (Hex.quadShift d (a :: as)).2
+          = Hex.DensePoly.shift 1 (Hex.quadShift d as).2 - (Hex.quadShift d as).1 := rfl
+      rw [h1, h2, toPolynomial_ofList_cons]
+      simp only [toPolynomial_add, toPolynomial_sub, toPolynomial_C,
+        toPolynomial_shift_one, toPolynomial_scale, Polynomial.map_add,
+        Polynomial.map_sub, Polynomial.map_mul, Polynomial.map_C, Polynomial.map_X,
+        Polynomial.add_comp, Polynomial.mul_comp, Polynomial.C_comp,
+        Polynomial.X_comp, algebraMap_int]
+      linear_combination ((X : Polynomial K) - C r) * ih
+        + ((toPolynomial (Hex.quadShift d as).2).map (algebraMap ℤ K)) * hrr
+
+/-- The norm correspondence: over a commutative ring `K` carrying a square root
+`r` of `d`, the executable quadratic norm is `g(X - r) · g(X + r)`. -/
+theorem map_quadNorm (g : Hex.ZPoly) (d : ℤ) (r : K) (hr : r ^ 2 = (d : K)) :
+    (toPolynomial (Hex.quadNorm d g)).map (algebraMap ℤ K)
+      = ((toPolynomial g).map (algebraMap ℤ K)).comp (X - C r)
+        * ((toPolynomial g).map (algebraMap ℤ K)).comp (X + C r) := by
+  have hrr : (C r : Polynomial K) * C r = C ((d : K)) := by
+    rw [← Polynomial.C_mul, ← sq, hr]
+  have hlist : Hex.DensePoly.ofList g.toArray.toList = g := Hex.DensePoly.ofList_toList g
+  have hneg : (-r) ^ 2 = (d : K) := by rw [neg_pow]; simpa using hr
+  have hplus := quadShift_spec d hr g.toArray.toList
+  have hminus := quadShift_spec d hneg g.toArray.toList
+  rw [hlist] at hplus hminus
+  rw [map_neg, neg_mul, ← sub_eq_add_neg, sub_neg_eq_add] at hminus
+  have hqn : Hex.quadNorm d g
+      = (Hex.quadShift d g.toArray.toList).1 * (Hex.quadShift d g.toArray.toList).1
+        - Hex.DensePoly.scale d
+            ((Hex.quadShift d g.toArray.toList).2
+              * (Hex.quadShift d g.toArray.toList).2) := rfl
+  rw [hqn, ← hplus, ← hminus]
+  simp only [toPolynomial_sub, toPolynomial_mul, toPolynomial_scale,
+    Polynomial.map_sub, Polynomial.map_mul, Polynomial.map_C, algebraMap_int]
+  linear_combination
+    (((toPolynomial (Hex.quadShift d g.toArray.toList).2).map (algebraMap ℤ K))
+      * ((toPolynomial (Hex.quadShift d g.toArray.toList).2).map (algebraMap ℤ K))) * hrr
+
+/-! ## The iterate as a sign-pattern product -/
+
+/-- The `2ⁿ` signed sums `∑ᵢ εᵢ rᵢ`, in the order the tower builds them. -/
+def signedSums (rs : List K) : List K :=
+  rs.foldl (fun ss r => ss.flatMap fun s => [s + r, s - r]) [0]
+
+/-- `F(c; d₁, …, dₙ) = ∏_{ε ∈ {±1}ⁿ} (X - c - ∑ᵢ εᵢ rᵢ)`, the polynomial the
+multiquadratic tower theorem is about, written over the square roots `rs`. -/
+def signPatternPoly (c : K) (rs : List K) : Polynomial K :=
+  ((signedSums rs).map fun s => X - C (c + s)).prod
+
+/-- Each level doubles the number of sign patterns. -/
+private theorem length_flatMap_pair (r : K) (ss : List K) :
+    (ss.flatMap fun s => [s + r, s - r]).length = 2 * ss.length := by
+  induction ss with
+  | nil => simp
+  | cons s ss ih => simp only [List.flatMap_cons, List.length_append, ih]; simp; ring
+
+/-- There are `2ⁿ` sign patterns, so the certified polynomial has `2ⁿ` roots
+counted with multiplicity. -/
+@[simp] theorem length_signedSums (rs : List K) :
+    (signedSums rs).length = 2 ^ rs.length := by
+  have h : ∀ (rs ss : List K),
+      (rs.foldl (fun ss r => ss.flatMap fun s => [s + r, s - r]) ss).length
+        = 2 ^ rs.length * ss.length := by
+    intro rs
+    induction rs with
+    | nil => intro ss; simp
+    | cons r rs ih =>
+        intro ss
+        rw [List.foldl_cons, ih, length_flatMap_pair]
+        simp [pow_succ]
+        ring
+  rw [signedSums]
+  simpa using h rs [0]
+
+/-- Every sign-pattern product is monic. -/
+private theorem monic_prod_map (a : K) (ss : List K) :
+    ((ss.map fun s => X - C (a + s)).prod).Monic := by
+  induction ss with
+  | nil => simp
+  | cons s ss ih =>
+      rw [List.map_cons, List.prod_cons]
+      exact (monic_X_sub_C (a + s)).mul ih
+
+private theorem natDegree_prod_map [Nontrivial K] (a : K) (ss : List K) :
+    ((ss.map fun s => X - C (a + s)).prod).natDegree = ss.length := by
+  induction ss with
+  | nil => simp
+  | cons s ss ih =>
+      rw [List.map_cons, List.prod_cons,
+        (monic_X_sub_C (a + s)).natDegree_mul (monic_prod_map a ss), ih,
+        natDegree_X_sub_C, List.length_cons]
+      omega
+
+/-- The sign-pattern product is monic. -/
+theorem monic_signPatternPoly (c : K) (rs : List K) : (signPatternPoly c rs).Monic :=
+  monic_prod_map c (signedSums rs)
+
+/-- The sign-pattern product has degree `2ⁿ`, so the correspondence is not
+vacuous: the certified polynomial really has the doubled degree at every level. -/
+theorem natDegree_signPatternPoly [Nontrivial K] (c : K) (rs : List K) :
+    (signPatternPoly c rs).natDegree = 2 ^ rs.length := by
+  rw [signPatternPoly, natDegree_prod_map, length_signedSums]
+
+/-- One level of the tower doubles the sign patterns. -/
+private theorem prod_comp_step (a r : K) (ss : List K) :
+    ((ss.map fun s => X - C (a + s)).prod).comp (X - C r)
+        * ((ss.map fun s => X - C (a + s)).prod).comp (X + C r)
+      = ((ss.flatMap fun s => [s + r, s - r]).map fun s => X - C (a + s)).prod := by
+  induction ss with
+  | nil => simp
+  | cons s ss ih =>
+      have hminus : ((X : Polynomial K) - C (a + s)).comp (X - C r)
+          = X - C (a + (s + r)) := by
+        simp only [Polynomial.sub_comp, Polynomial.X_comp, Polynomial.C_comp,
+          Polynomial.add_comp, map_add]
+        ring
+      have hplus : ((X : Polynomial K) - C (a + s)).comp (X + C r)
+          = X - C (a + (s - r)) := by
+        simp only [Polynomial.sub_comp, Polynomial.X_comp, Polynomial.C_comp,
+          Polynomial.add_comp, map_add, map_sub]
+        ring
+      simp only [List.map_cons, List.prod_cons, List.flatMap_cons, List.map_append,
+        List.prod_append, List.map_nil, List.prod_nil, mul_one,
+        Polynomial.mul_comp, hminus, hplus]
+      rw [← ih]
+      ring
+
+/-- Folding the norms over the radicands folds the sign patterns over the roots. -/
+private theorem foldl_comp_eq_prod (a : K) (rs ss : List K) :
+    rs.foldl (fun P r => P.comp (X - C r) * P.comp (X + C r))
+        ((ss.map fun s => X - C (a + s)).prod)
+      = ((rs.foldl (fun ss r => ss.flatMap fun s => [s + r, s - r]) ss).map
+          fun s => X - C (a + s)).prod := by
+  induction rs generalizing ss with
+  | nil => simp
+  | cons r rs ih =>
+      simp only [List.foldl_cons]
+      rw [prod_comp_step]
+      exact ih _
+
+/-- Each successive norm is one composition pair, for any starting polynomial. -/
+theorem map_foldl_quadNorm (g : Hex.ZPoly) {ds : List ℤ} {rs : List K}
+    (h : List.Forall₂ (fun (d : ℤ) (r : K) => r ^ 2 = (d : K)) ds rs) :
+    (toPolynomial (ds.foldl (fun g d => Hex.quadNorm d g) g)).map (algebraMap ℤ K)
+      = rs.foldl (fun P r => P.comp (X - C r) * P.comp (X + C r))
+          ((toPolynomial g).map (algebraMap ℤ K)) := by
+  induction h generalizing g with
+  | nil => simp
+  | @cons d r _ _ hdr _ ih =>
+      simp only [List.foldl_cons]
+      rw [ih (Hex.quadNorm d g), map_quadNorm g d r hdr]
+
+/-- The iterated quadratic norm is the sign-pattern product: over any commutative
+ring carrying square roots `rs` of the radicands `ds`, the executable
+{name}`Hex.iteratedNorm` maps to `∏_ε (X - c - ∑ᵢ εᵢ rᵢ)`. -/
+theorem map_iteratedNorm (c : ℤ) (ds : Array ℤ) {rs : List K}
+    (h : List.Forall₂ (fun (d : ℤ) (r : K) => r ^ 2 = (d : K)) ds.toList rs) :
+    (toPolynomial (Hex.iteratedNorm c ds)).map (algebraMap ℤ K)
+      = signPatternPoly ((c : K)) rs := by
+  have hbase :
+      (toPolynomial (Hex.DensePoly.ofCoeffs #[-c, 1] : Hex.ZPoly)).map (algebraMap ℤ K)
+        = X - C ((c : K)) := by
+    rw [toPolynomial_linear]; simp
+  have hstart : (([0] : List K).map fun s => X - C ((c : K) + s)).prod
+      = X - C ((c : K)) := by simp
+  unfold Hex.iteratedNorm signPatternPoly signedSums
+  rw [← Array.foldl_toList, map_foldl_quadNorm _ h, hbase, ← hstart,
+    foldl_comp_eq_prod]
+
+/-! ## The certificate -/
+
+/-- Coefficient equality is polynomial equality: the identification half of the
+check compares dense coefficient arrays, and that comparison is exactly equality
+in `Polynomial ℤ`. -/
+theorem toPolynomial_inj {p q : Hex.ZPoly} (h : toPolynomial p = toPolynomial q) : p = q :=
+  equiv.injective h
+
+/-- A successful check certifies independent square classes. -/
+theorem independent_of_check {cert : Hex.QuadraticNormCertificate} {f : Hex.ZPoly}
+    (h : cert.check f = true) :
+    Hex.SquareClass.Independent cert.radicands.toList := by
+  rw [Hex.QuadraticNormCertificate.check, Bool.and_eq_true] at h
+  exact (Hex.SquareClass.independentSquareClasses_iff _).1 h.1
+
+/-- A successful check identifies the input with the iterated norm, up to sign. -/
+theorem normalizePrimitiveSign_eq_of_check {cert : Hex.QuadraticNormCertificate}
+    {f : Hex.ZPoly} (h : cert.check f = true) :
+    Hex.ZPoly.normalizePrimitiveSign f = Hex.iteratedNorm cert.translation cert.radicands := by
+  rw [Hex.QuadraticNormCertificate.check, Bool.and_eq_true] at h
+  exact (beq_iff_eq.1 h.2).symm
+
+/-- The identification half, in `Polynomial ℤ`: a successful check pins the input
+to the iterated norm up to the unit `-1`. -/
+theorem toPolynomial_eq_or_neg_of_check {cert : Hex.QuadraticNormCertificate}
+    {f : Hex.ZPoly} (h : cert.check f = true) :
+    toPolynomial f = toPolynomial (Hex.iteratedNorm cert.translation cert.radicands) ∨
+      toPolynomial f
+        = -toPolynomial (Hex.iteratedNorm cert.translation cert.radicands) := by
+  have hnorm := normalizePrimitiveSign_eq_of_check h
+  rw [Hex.ZPoly.normalizePrimitiveSign] at hnorm
+  split at hnorm
+  · right
+    rw [← hnorm, toPolynomial_scale]
+    simp
+  · left
+    rw [hnorm]
+
+/-- A successful check makes the input an associate of the iterated norm, so the
+two are irreducible together. -/
+theorem associated_toPolynomial_of_check {cert : Hex.QuadraticNormCertificate}
+    {f : Hex.ZPoly} (h : cert.check f = true) :
+    Associated (toPolynomial f)
+      (toPolynomial (Hex.iteratedNorm cert.translation cert.radicands)) := by
+  rcases toPolynomial_eq_or_neg_of_check h with heq | heq
+  · exact heq ▸ Associated.refl _
+  · exact heq ▸ ⟨-1, by simp⟩
+
+end
+
+end HexBerlekampZassenhausMathlib

--- a/HexBerlekampZassenhausMathlib/SPEC/hex-berlekamp-zassenhaus-mathlib.md
+++ b/HexBerlekampZassenhausMathlib/SPEC/hex-berlekamp-zassenhaus-mathlib.md
@@ -145,7 +145,7 @@ theorem is about.
 
 `Hex.SquareClass.Independent` says no nonempty sublist of the radicands
 has a square product in `ℚ`, and
-`independentSquareClasses_eq_true_iff` shows the executable check
+`independentSquareClasses_iff` shows the executable check
 decides it. `associated_toPolynomial_of_check` carries a successful
 certificate check to an `Associated` in `Polynomial ℤ`, so the input and
 the iterated norm are irreducible together.

--- a/HexBerlekampZassenhausMathlib/SPEC/hex-berlekamp-zassenhaus-mathlib.md
+++ b/HexBerlekampZassenhausMathlib/SPEC/hex-berlekamp-zassenhaus-mathlib.md
@@ -125,6 +125,31 @@ The headline product, irreducibility, normalization, uniqueness, and
 lattice-totality theorems use only the accepted Lean and Mathlib
 foundations reported by the trust-surface check.
 
+## Quadratic norm correspondence
+
+For a commutative ring `K` and `r : K` with `r² = d`, `map_quadNorm`
+identifies the executable quadratic norm with the honest polynomial
+statement:
+
+```lean
+theorem map_quadNorm (g : Hex.ZPoly) (d : ℤ) (r : K) (hr : r ^ 2 = (d : K)) :
+  (toPolynomial (Hex.quadNorm d g)).map (algebraMap ℤ K)
+    = ((toPolynomial g).map (algebraMap ℤ K)).comp (X - C r)
+      * ((toPolynomial g).map (algebraMap ℤ K)).comp (X + C r)
+```
+
+`map_iteratedNorm` iterates it: given square roots of every radicand,
+the executable `iteratedNorm` maps to `∏_ε (X - c - ∑ᵢ εᵢ rᵢ)` over the
+`2ⁿ` sign patterns, which is the polynomial the multiquadratic tower
+theorem is about.
+
+`Hex.SquareClass.Independent` says no nonempty sublist of the radicands
+has a square product in `ℚ`, and
+`independentSquareClasses_eq_true_iff` shows the executable check
+decides it. `associated_toPolynomial_of_check` carries a successful
+certificate check to an `Associated` in `Polynomial ℤ`, so the input and
+the iterated norm are irreducible together.
+
 ## Factor tactics
 
 The `Polynomial ℤ` tactic support parses a closed polynomial

--- a/bench/HexBench/FactorService.lean
+++ b/bench/HexBench/FactorService.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 import HexBerlekampZassenhaus
 import HexBench.BerlekampKernel
 import HexBench.QuadraticNorm
+import HexBerlekampZassenhaus.QuadraticNorm
 import Hex.BenchOracle.Flint
 import Lean.Data.Json
 
@@ -1665,7 +1666,12 @@ and the whole certificate cost lands in whichever span happens to be last.
 
 `paired` additionally runs one production factorization in the same process on
 the same input, so the reported ratio is paired rather than assembled from two
-sweeps. It must be off for an input the production cascade does not finish. -/
+sweeps. It must be off for an input the production cascade does not finish.
+
+Recovery is still the prototype's dense-array search, which carries no proof
+obligation: a wrong guess dies in the check. The three checked spans run the
+production `Hex` definitions, whose Mathlib correspondence is in
+`HexBerlekampZassenhausMathlib.QuadraticNorm`. -/
 private def quadraticNormProbe (paired : Bool) (f : ZPoly) : IO Json := do
   let coeffs := f.toArray
   let witness ← IO.mkRef (0 : Nat)
@@ -1690,17 +1696,15 @@ private def quadraticNormProbe (paired : Bool) (f : ZPoly) : IO Json := do
           ("witness", natJson (← witness.get)) ]
   | some cert =>
       let independenceStart ← mark
-      let independent := QuadraticNorm.independentSquareClasses cert.radicands
+      let independent := Hex.independentSquareClasses cert.radicands
       witness.modify (· + if independent then 1 else 0)
       let independenceStop ← mark
       let constructionStart ← mark
-      let built :=
-        QuadraticNorm.trim
-          (QuadraticNorm.iteratedNorm cert.translation cert.radicands)
+      let built := Hex.iteratedNorm cert.translation cert.radicands
       witness.modify (· + built.size)
       let constructionStop ← mark
       let equalityStart ← mark
-      let equal := built == QuadraticNorm.unitNormalize coeffs
+      let equal := built == ZPoly.normalizePrimitiveSign f
       witness.modify (· + if equal then 1 else 0)
       let equalityStop ← mark
       return Json.mkObj <|

--- a/progress/20260805T002817Z_issue-9168.md
+++ b/progress/20260805T002817Z_issue-9168.md
@@ -1,0 +1,85 @@
+# 2026-08-05 issue #9168: executable iterated quadratic norm and its correspondence
+
+## Accomplished
+
+`HexBerlekampZassenhaus/QuadraticNorm.lean` carries the production
+Mathlib-free operation on `ZPoly`:
+
+- `quadStep` / `quadShift` carry the coefficient pair of `g(X - t)` in
+  `ℤ[t]/(t² - d)` through Horner's rule from the top coefficient down;
+- `quadNorm d g` materializes only the rational part `p² - d q²` of the
+  product with the conjugate;
+- `iteratedNorm c ds` folds the radicands from `X - c`;
+- `squareClassProducts` enumerates the `2ⁿ - 1` nonempty-sublist
+  products and `independentSquareClasses` square-tests them;
+- `QuadraticNormCertificate` and its `check`, whose identification half
+  compares against `ZPoly.normalizePrimitiveSign`.
+
+`HexBerlekampZassenhausMathlib/SquareClass.lean` states
+`Hex.SquareClass.Independent` over nonempty sublists and proves
+`independentSquareClasses_eq_true_iff`, through `Nat.exists_mul_self`
+and `Rat.isSquare_intCast_iff`.
+
+`HexBerlekampZassenhausMathlib/QuadraticNorm.lean` proves the
+correspondence: `quadShift_spec` (the synthetic shift really is
+`g(X - r)`), `map_quadNorm`, `map_foldl_quadNorm`, `map_iteratedNorm`
+landing on `signPatternPoly`, `toPolynomial_inj`, and the certificate
+consequences `independent_of_check` and
+`associated_toPolynomial_of_check`.
+
+The certificate service entry now prices the production definitions on
+its independence, construction, and equality spans; recovery stays the
+bench prototype's dense-array search, which carries no proof obligation.
+`scripts/bench/quadratic_norm_witnesses.py` passes against those
+production definitions: all 15 cases plus the 250-case randomized
+agreement against the production factorizer, with degree 1024 at 305 ms
+against the prototype's 318 ms. The committed record is left alone; the
+report pins it by SHA-256 as one of a set measured together at one
+revision under `taskset -c 0`, and this run was neither.
+
+## Decisions
+
+The prototype's in-place double-loop synthetic shift became a structural
+Horner recursion on the ascending coefficient list, carrying the pair
+through `DensePoly.shift 1` / `scale` / `+` / `-`. Same shift constant,
+same conjugate-product cancellation, same asymptotics, and the same
+values on every witness; the in-place array formulation has no tractable
+correspondence proof, and the structural one reduces `map_quadNorm` to
+`linear_combination` over `Polynomial K`. Measured cost at degree 1024
+is 305 ms against the prototype's 318 ms.
+
+`quadNorm` drops the prototype's `n ≤ 1` early return, which returns `g`
+rather than `g²` for a constant `g`. That branch is mathematically wrong
+and unreachable from `iteratedNorm`, and keeping it would make
+`map_quadNorm` false.
+
+`Independent` is stated over `List.Sublist` rather than `2 ^ n` subsets
+of `Fin n`, per #9167's request: sublists are what the executable
+enumeration recurses on, and the predicate stays symmetric under
+permuting the radicands, which the tower argument needs after
+reordering. It lives in `SquareClass.lean`, which is the home #9167
+suggests for it, so that issue can import rather than redefine.
+
+Three paths the factorization-sweep freshness check watches changed
+without touching the `ZPoly.factorize` call graph: the new module, the
+`All.lean` import that reaches it, and the service's
+`quadraticNormProbe` body. They are registered in
+`scripts/bench/proof_only_runtime_exemptions.json` by exact blob pair,
+so each exemption expires the moment its file changes again.
+
+## Current frontier
+
+The two Mathlib-facing pieces the certificate still needs are the field
+theory: #9167 (multiquadratic tower degree from independent square
+classes) and its follow-up on `ℚ(α) = K` and `minpoly α = F(c; d)`.
+Neither is touched here.
+
+## Next step
+
+Production integration (#9170): the checker on the singleton
+irreducibility path with a budget gate, so a success returns the same
+`Factorization` as every other proof and a failure falls through.
+
+## Blockers
+
+None.

--- a/progress/20260805T002817Z_issue-9168.md
+++ b/progress/20260805T002817Z_issue-9168.md
@@ -17,8 +17,10 @@ Mathlib-free operation on `ZPoly`:
 
 `HexBerlekampZassenhausMathlib/SquareClass.lean` states
 `Hex.SquareClass.Independent` over nonempty sublists and proves
-`independentSquareClasses_eq_true_iff`, through `Nat.exists_mul_self`
-and `Rat.isSquare_intCast_iff`.
+`independentSquareClasses_iff`, through `Nat.exists_mul_self` and
+`Rat.isSquare_intCast_iff`, with `Independent.sublist`,
+`Independent.perm`, and `length_squareClassProducts` as the API the tower
+proof will consume.
 
 `HexBerlekampZassenhausMathlib/QuadraticNorm.lean` proves the
 correspondence: `quadShift_spec` (the synthetic shift really is

--- a/progress/20260805T002817Z_issue-9168.md
+++ b/progress/20260805T002817Z_issue-9168.md
@@ -15,14 +15,11 @@ Mathlib-free operation on `ZPoly`:
 - `QuadraticNormCertificate` and its `check`, whose identification half
   compares against `ZPoly.normalizePrimitiveSign`.
 
-`HexBerlekampZassenhausMathlib/SquareClass.lean` states
-`Hex.SquareClass.Independent` over nonempty sublists and proves
-`independentSquareClasses_iff`, through `Nat.exists_mul_self` and
-`Rat.isSquare_intCast_iff`, with `Independent.sublist`,
-`Independent.perm`, and `length_squareClassProducts` as the API the tower
-proof will consume.
-
-`HexBerlekampZassenhausMathlib/QuadraticNorm.lean` proves the
+`HexBerlekampZassenhausMathlib/QuadraticNorm.lean` proves that the
+executable subproduct test decides `Hex.SquareClass.Independent`, which
+#9174 landed while this was in flight: `isPerfectSquare_eq_true_iff`,
+`mem_squareClassProducts`, `length_squareClassProducts`, and
+`independentSquareClasses_iff`. The same file proves the norm
 correspondence: `quadShift_spec` (the synthetic shift really is
 `g(X - r)`), `map_quadNorm`, `map_foldl_quadNorm`, `map_iteratedNorm`
 landing on `signPatternPoly`, `toPolynomial_inj`, and the certificate
@@ -55,12 +52,12 @@ rather than `g²` for a constant `g`. That branch is mathematically wrong
 and unreachable from `iteratedNorm`, and keeping it would make
 `map_quadNorm` false.
 
-`Independent` is stated over `List.Sublist` rather than `2 ^ n` subsets
-of `Fin n`, per #9167's request: sublists are what the executable
-enumeration recurses on, and the predicate stays symmetric under
-permuting the radicands, which the tower argument needs after
-reordering. It lives in `SquareClass.lean`, which is the home #9167
-suggests for it, so that issue can import rather than redefine.
+`Hex.SquareClass.Independent` was written twice, here and in #9174, with
+the same `List.Sublist` statement. #9174 landed first with the whole
+tower degree theorem behind it, so this branch dropped its copy and kept
+only the decision half, which #9174 does not have. The decision lemmas
+sit in `QuadraticNorm.lean` rather than in `SquareClass.lean` so the
+field-theory file does not gain a dependency on the executable module.
 
 Three paths the factorization-sweep freshness check watches changed
 without touching the `ZPoly.factorize` call graph: the new module, the

--- a/progress/20260805T004618Z_pr-9175-second-opinion.md
+++ b/progress/20260805T004618Z_pr-9175-second-opinion.md
@@ -1,0 +1,37 @@
+# PR #9175 second-opinion review
+
+## Accomplished
+
+Reviewed the final `dc56a680` PR diff for mathematical correctness, executable
+agreement, certificate normalization, square-class enumeration, and Lean/API
+hazards. Checked the Horner recurrence and sign conventions directly, compared
+the structural norm with the prototype on 19,000 arbitrary polynomials of
+positive degree, and verified that `squareClassProducts` has the prototype's
+mask order through length 10.
+
+The targeted quadratic-norm builds and the root `lake build` passed. The full
+quadratic-norm witness driver passed all 15 named cases and all 250 randomized
+independence/certificate/factorization comparisons. The bench Mathlib-free check
+and factor-sweep freshness check also passed.
+
+No blocker or should-fix mathematical defect was found. The correspondence has
+the intended signs and fold order; the final degree/length lemmas make the
+`2^n` and `2^n - 1` claims explicit; the successful-check theorems really yield
+equality up to `-1` and hence `Associated` polynomials.
+
+## Current frontier
+
+Two non-blocking review nits remain: `independentSquareClasses` materializes its
+entire exponential product list before `List.all`, and the public
+`toPolynomial_inj` lemma is weaker/more indirect than its coefficient-equality
+docstring suggests. Neither affects soundness or the measured target sizes.
+
+## Next step
+
+Merge after ordinary CI. A later hardening pass may stream the square-class
+products or add a cheap degree/budget guard, and may expose an equality `iff`
+for the dense/Mathlib polynomial bridge.
+
+## Blockers
+
+None.

--- a/progress/20260805T004618Z_pr-9175-second-opinion.md
+++ b/progress/20260805T004618Z_pr-9175-second-opinion.md
@@ -2,35 +2,58 @@
 
 ## Accomplished
 
-Reviewed the final `dc56a680` PR diff for mathematical correctness, executable
-agreement, certificate normalization, square-class enumeration, and Lean/API
-hazards. Checked the Horner recurrence and sign conventions directly, compared
-the structural norm with the prototype on 19,000 arbitrary polynomials of
-positive degree, and verified that `squareClassProducts` has the prototype's
-mask order through length 10.
+Reviewed the quadratic-norm correspondence for mathematical correctness,
+agreement with the prototype, certificate normalization, square-class
+enumeration, and Lean hazards.
 
-The targeted quadratic-norm builds and the root `lake build` passed. The full
-quadratic-norm witness driver passed all 15 named cases and all 250 randomized
-independence/certificate/factorization comparisons. The bench Mathlib-free check
-and factor-sweep freshness check also passed.
+No blocker or should-fix mathematical defect. Confirmed: `quadShift_spec`
+is a substantive Horner statement at `X - r`, not a tautology;
+`map_quadNorm` gets the conjugate by instantiating it at `-r`;
+`map_iteratedNorm` has the fold order the executable `iteratedNorm` uses,
+so after `r₁, r₂` the signed sums are `r₁+r₂, r₁-r₂, -r₁+r₂, -r₁-r₂`;
+`squareClassProducts` enumerates exactly the positional nonempty
+sublists, in the prototype's own increasing-mask order; and `check = true`
+rules out every degenerate input, since a zero or constant `f` cannot
+equal the positive-degree monic iterate, a negative-leading `f` becomes
+exactly `-F`, and a non-primitive `f` fails because no content is divided
+out.
 
-No blocker or should-fix mathematical defect was found. The correspondence has
-the intended signs and fold order; the final degree/length lemmas make the
-`2^n` and `2^n - 1` claims explicit; the successful-check theorems really yield
-equality up to `-1` and hence `Associated` polynomials.
+Two differential checks back the executable side. 2000 random
+`quadNorm d g` cases over sizes 1 to 8 with radicands in `[-10, 10]` and
+coefficients in `[-20, 20]` agree exactly with the independent Python
+implementation in `scripts/bench/quadratic_norm_witnesses.py`, size 1
+included, which is where the prototype's `n ≤ 1` early return disagrees
+with the mathematics. The witness driver itself passes all 15 named cases
+and all 250 randomized independence/certificate/factorization
+comparisons.
+
+## Changed in response
+
+Named equation lemmas `quadShift_nil`, `quadShift_cons`, and
+`quadNorm_eq` replace the bare `rfl` unfoldings the correspondence proof
+used, so an implementation change surfaces next to the definition rather
+than inside a proof. `length_squareClassProducts` records that the
+enumeration really has `2ⁿ - 1` entries, and `length_signedSums`,
+`monic_signPatternPoly`, and `natDegree_signPatternPoly` record that the
+sign-pattern product is monic of degree `2ⁿ`. The executable module's
+docstring now points at the multiquadratic tower theorem for the
+field-theory half instead of at the correspondence module, which does not
+contain it.
 
 ## Current frontier
 
-Two non-blocking review nits remain: `independentSquareClasses` materializes its
-entire exponential product list before `List.all`, and the public
-`toPolynomial_inj` lemma is weaker/more indirect than its coefficient-equality
-docstring suggests. Neither affects soundness or the measured target sizes.
+Two non-blocking observations remain. `independentSquareClasses`
+materializes its `2ⁿ - 1` product list before `List.all` rather than
+short-circuiting; at the certificate sizes the class admits, that list is
+exponentially smaller than the polynomial being checked, and the measured
+degree-1024 case is 305 ms against the prototype's 318 ms. And the
+correspondence stops at `Associated`; irreducibility needs the
+minimal-polynomial half of the tower theorem, which is not this issue.
 
 ## Next step
 
-Merge after ordinary CI. A later hardening pass may stream the square-class
-products or add a cheap degree/budget guard, and may expose an equality `iff`
-for the dense/Mathlib polynomial bridge.
+The minimal-polynomial half of the tower theorem, then production
+integration (#9170).
 
 ## Blockers
 

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -32,7 +32,7 @@
   {
     "path": "HexBerlekampZassenhaus/QuadraticNorm.lean",
     "baseline_blob": null,
-    "current_blob": "b1a1bcdc734736a673f23e90fcc8b8991b4979ec",
+    "current_blob": "1e390cb2985f73ee45c4892dac543dcebbb8f178",
     "reason": "Adds the iterated quadratic norm and its certificate as a new module; nothing on the ZPoly.factorize path imports it, so the compiled factorization call graph is unchanged."
   },
   {

--- a/scripts/bench/proof_only_runtime_exemptions.json
+++ b/scripts/bench/proof_only_runtime_exemptions.json
@@ -28,5 +28,23 @@
     "baseline_blob": "e43de53cbeced2ebe811ff1a6a6fa6ceaf843c14",
     "current_blob": "ba568b38f9482f906439858ac72b823d2b933be7",
     "reason": "Adds an unused rational-reflection helper and supporting theorems for NumberField certificate transport; existing factorization definitions and their call graph are unchanged."
+  },
+  {
+    "path": "HexBerlekampZassenhaus/QuadraticNorm.lean",
+    "baseline_blob": null,
+    "current_blob": "b1a1bcdc734736a673f23e90fcc8b8991b4979ec",
+    "reason": "Adds the iterated quadratic norm and its certificate as a new module; nothing on the ZPoly.factorize path imports it, so the compiled factorization call graph is unchanged."
+  },
+  {
+    "path": "HexBerlekampZassenhaus/All.lean",
+    "baseline_blob": "a0c52128e63d3dcbb6e7b9cf522cd36304508e1a",
+    "current_blob": "6d80de18acfc61947485068478df1f28c1be044d",
+    "reason": "Adds one import of the new quadratic-norm module to the development umbrella; the released umbrella the factorization service imports is unchanged."
+  },
+  {
+    "path": "bench/HexBench/FactorService.lean",
+    "baseline_blob": "13d9e7609cc4e528012ea23e7dce7a05ad0a35f5",
+    "current_blob": "f203ec23f03eced0a8e22fe1eee53983fcacd6eb",
+    "reason": "Repoints the quadraticNormCertificate entry's three checked spans at the production definitions and adds its import; the factor entry the sweep measures is unchanged."
   }
 ]


### PR DESCRIPTION
This PR adds the iterated quadratic norm to the Mathlib-free production layer and proves its `Polynomial` correspondence, so the certificate prototyped in #9133 rests on definitions the Mathlib side can reason about.

`Hex.quadShift` carries the coefficient pair of `g(X - t)` in `ℤ[t]/(t² - d)` through the synthetic Taylor shift with shift constant `-t`, `Hex.quadNorm` materializes only the rational part `p² - d q²` of the product with the conjugate, and `Hex.iteratedNorm` folds the radicands from `X - c`. `Hex.independentSquareClasses` runs the `2ⁿ - 1` subproduct square tests over the nonempty-sublist products, and `Hex.QuadraticNormCertificate.check` conjoins that with coefficient equality against the unit-normalized input.

On the Mathlib side, `map_quadNorm` says the executable norm maps to `g(X - r) · g(X + r)` over any commutative ring carrying `r` with `r² = d`, through `quadShift_spec`: the carried pair really is `g(X - t)`. `map_iteratedNorm` iterates that to the sign-pattern product `F(c; d) = ∏_ε (X - c - ∑ᵢ εᵢ rᵢ)`, which is what the multiquadratic tower theorem is stated about, and `monic_signPatternPoly` / `natDegree_signPatternPoly` pin it monic of degree `2ⁿ`. `independentSquareClasses_iff` shows the executable test decides the `Hex.SquareClass.Independent` that #9174 landed, through `Nat.sqrt` correctness and the fact that an integer that is a rational square is a perfect square. `toPolynomial_inj` and `associated_toPolynomial_of_check` close the identification half.

The prototype's in-place double-loop shift became a structural Horner recursion on the ascending coefficient list. Same shift constant and same conjugate-product cancellation, but the recursion admits a correspondence proof where the in-place loop does not. `quadNorm` drops the prototype's `n ≤ 1` early return, which answers `g` rather than `g²` for a constant `g`; that branch is unreachable from `iteratedNorm` and keeping it would make `map_quadNorm` false.

The certificate service entry now prices the production definitions on its independence, construction, and equality spans; recovery stays the bench prototype's dense-array search, which carries no proof obligation. `scripts/bench/quadratic_norm_witnesses.py` passes against those production definitions: all 15 off-corpus cases, including degree 1024, negative radicands, and the perturbed-coefficient refusal, plus the 250-case randomized agreement against the production factorizer. Degree 1024 costs 305 ms against the prototype's 318 ms. A separate differential run agrees with the same script's independent Python implementation on 2000 random `quadNorm` cases over sizes 1 to 8, size 1 included. The committed witness record is left alone, since `reports/hexbz-quadratic-norm-certificate.md` pins it by SHA-256 as one of a set measured together at one revision under `taskset -c 0`, and these runs were neither.

Three paths the factorization-sweep freshness check watches changed without touching the `ZPoly.factorize` call graph: the new module, the `All.lean` import that reaches it, and the service's `quadraticNormProbe` body. They are registered in `scripts/bench/proof_only_runtime_exemptions.json` by exact blob pair, so each exemption expires the moment its file changes again.

Closes #9168.

🤖 Prepared with Claude Code